### PR TITLE
test(release): prove one real local workspace turn

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -346,3 +346,65 @@ jobs:
           path: tests/release/.output/
           retention-days: 7
           if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # Local-world smoke — "Prove One Real Local Workspace Turn": builds one
+  # exact candidate Server, one exact candidate AnyHarness, and one exact
+  # candidate Desktop renderer; starts them as an isolated local world; and
+  # drives one real cheap managed-gateway turn through the actual product UI
+  # (the LOCAL-WORLD-SMOKE-1 cell). This is a provisional infrastructure
+  # proof, not the canonical LOCAL-2 guarantee.
+  #
+  # `workflow_dispatch` only while stability is established (no `schedule`
+  # trigger yet) — unlike the two lanes above, this job is NOT
+  # `continue-on-error`: a red command here stays red, with its real exit
+  # code. It runs `make qualification-local-workspace`, the exact same
+  # entrypoint a laptop uses; only the LiteLLM input source differs (the
+  # protected `staging` GitHub environment's vars/secrets, never the ignored
+  # local secret profile, and never routed to arbitrary pull-request code).
+  release-e2e-local-world-smoke:
+    name: local-world-smoke-1 (manual, strict)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: staging
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the three exact candidates and run LOCAL-WORLD-SMOKE-1 (strict)
+        env:
+          # Mapped from the protected `staging` environment. The public
+          # origin also covers AGENT_GATEWAY_LITELLM_BASE_URL when no
+          # separate control-plane URL variable exists yet (Makefile default
+          # mapping) — arbitrary PR code never runs this job or sees these.
+          AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
+          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+        run: |
+          set -euo pipefail
+          make qualification-local-workspace \
+            PROFILE="ci-${{ github.run_id }}-${{ github.run_attempt }}" \
+            BEHAVIOR=strict
+
+      - name: Upload V4 report and bounded diagnostic logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-world-smoke-1-evidence
+          path: |
+            tests/release/.output/local-world/*/*/evidence/
+            tests/release/.output/local-world/*/*/logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -397,8 +397,11 @@ jobs:
           AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
           # Bounded, secret-free failure diagnostics written inside the uploaded
           # logs/ tree (all captures pass through redact-diagnostics.ts before
-          # they are written). Lands under the `*/*/logs/` upload glob below.
-          LOCAL_WORLD_SMOKE_DEBUG_DIR: ${{ github.workspace }}/tests/release/.output/local-world/ql-ci-${{ github.run_id }}-${{ github.run_attempt }}/1/logs/debug
+          # they are written). Deliberately OUTSIDE the run dir
+          # (<base>/<run-id>/<shard>) — the cleanup stack deletes the run dir on
+          # teardown, which would delete the captures before upload. This
+          # sibling path still matches the `*/*/logs/` upload glob below.
+          LOCAL_WORLD_SMOKE_DEBUG_DIR: ${{ github.workspace }}/tests/release/.output/local-world/ql-ci-${{ github.run_id }}-${{ github.run_attempt }}/debug/logs
         run: |
           set -euo pipefail
           make qualification-local-workspace \

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -360,14 +360,16 @@ jobs:
   # `continue-on-error`: a red command here stays red, with its real exit
   # code. It runs `make qualification-local-workspace`, the exact same
   # entrypoint a laptop uses; only the LiteLLM input source differs (the
-  # protected `staging` GitHub environment's vars/secrets, never the ignored
-  # local secret profile, and never routed to arbitrary pull-request code).
+  # protected `Qualification` GitHub environment's vars/secrets, never the
+  # ignored local secret profile, and never routed to arbitrary pull-request
+  # code — the environment's branch policy allows only main and
+  # codex/local-world-smoke-1).
   release-e2e-local-world-smoke:
     name: local-world-smoke-1 (manual, strict)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: staging
+    environment: Qualification
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -386,12 +388,13 @@ jobs:
 
       - name: Build the three exact candidates and run LOCAL-WORLD-SMOKE-1 (strict)
         env:
-          # Mapped from the protected `staging` environment. The public
-          # origin also covers AGENT_GATEWAY_LITELLM_BASE_URL when no
-          # separate control-plane URL variable exists yet (Makefile default
-          # mapping) — arbitrary PR code never runs this job or sees these.
+          # Mapped directly from the protected `Qualification` environment. Both
+          # the admin/control-plane and public URLs exist there as distinct
+          # variables, so each maps to its own input (no public-covers-admin
+          # fallback). Arbitrary PR code never runs this job or sees these.
+          AGENT_GATEWAY_LITELLM_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_BASE_URL }}
           AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
-          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
         run: |
           set -euo pipefail
           make qualification-local-workspace \

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -395,6 +395,10 @@ jobs:
           AGENT_GATEWAY_LITELLM_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_BASE_URL }}
           AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
           AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
+          # Bounded, secret-free failure diagnostics written inside the uploaded
+          # logs/ tree (all captures pass through redact-diagnostics.ts before
+          # they are written). Lands under the `*/*/logs/` upload glob below.
+          LOCAL_WORLD_SMOKE_DEBUG_DIR: ${{ github.workspace }}/tests/release/.output/local-world/ql-ci-${{ github.run_id }}-${{ github.run_attempt }}/1/logs/debug
         run: |
           set -euo pipefail
           make qualification-local-workspace \

--- a/Makefile
+++ b/Makefile
@@ -831,6 +831,88 @@ qualification-candidate-handoff-smoke:
 	cd tests/release && pnpm exec tsx src/artifacts/anyharness-smoke.ts \
 		--map .output/candidate-build.json
 
+# "Prove One Real Local Workspace Turn": one exact candidate Server, one exact
+# candidate AnyHarness, and one exact candidate Desktop renderer built,
+# handed to the qualification runner, started as an isolated local world, and
+# used through the real product UI for one cheap managed-gateway turn. This
+# is the ONE entrypoint; GitHub Actions' manual `release-e2e.yml` job invokes
+# this same target — same four operations (resolve secrets, build candidates,
+# write the candidate map, run the same TypeScript command), same code path.
+#
+# PROFILE=<unique-name>   Names this run (becomes its run id). Never reuse a
+#                         PROFILE for two concurrent invocations.
+# BEHAVIOR=diagnostic|strict
+#
+# Locally, LiteLLM access comes from an ignored, mode-0600 secret profile
+# (never committed, never printed): AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL and
+# AGENT_GATEWAY_LITELLM_MASTER_KEY. When that file has no separate
+# AGENT_GATEWAY_LITELLM_BASE_URL (admin/control-plane URL), the verified
+# public origin is mapped to it too (the public staging origin serves both
+# inference and authenticated admin routes today). In GitHub Actions
+# (GITHUB_ACTIONS=true) the same three env vars are supplied directly by the
+# protected `staging` environment's secrets/vars — this target does not read
+# or expect the local file there.
+QUALIFICATION_INFRA_ENV ?= $(HOME)/.proliferate-local/dev/qualification-infra.env
+QUALIFICATION_LOCAL_WORLD_BASE_DIR ?= $(CURDIR)/tests/release/.output/local-world
+qualification-local-workspace:
+	@test -n "$(PROFILE)" || { \
+		echo "PROFILE=<unique-name> is required, e.g. make qualification-local-workspace PROFILE=$$(whoami)-1 BEHAVIOR=diagnostic"; \
+		exit 1; \
+	}
+	@test -n "$(BEHAVIOR)" || { \
+		echo "BEHAVIOR=<diagnostic|strict> is required."; \
+		exit 1; \
+	}
+	@if [ "$$GITHUB_ACTIONS" != "true" ]; then \
+		test -f "$(QUALIFICATION_INFRA_ENV)" || { \
+			echo "Missing qualification secret profile at $(QUALIFICATION_INFRA_ENV)."; \
+			echo "It must define AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL and AGENT_GATEWAY_LITELLM_MASTER_KEY (mode 0600, never committed)."; \
+			exit 1; \
+		}; \
+		perm=$$(stat -f '%Lp' "$(QUALIFICATION_INFRA_ENV)" 2>/dev/null || stat -c '%a' "$(QUALIFICATION_INFRA_ENV)"); \
+		test "$$perm" = "600" || { \
+			echo "$(QUALIFICATION_INFRA_ENV) must be mode 0600 (got $$perm). Run: chmod 600 $(QUALIFICATION_INFRA_ENV)"; \
+			exit 1; \
+		}; \
+	fi
+	pnpm install --silent
+	pnpm exec playwright install --with-deps chromium
+	@if [ "$$GITHUB_ACTIONS" = "true" ]; then \
+		: "$${AGENT_GATEWAY_LITELLM_BASE_URL:=$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL}"; \
+		export AGENT_GATEWAY_LITELLM_BASE_URL; \
+	else \
+		set -a; \
+		. "$(QUALIFICATION_INFRA_ENV)"; \
+		: "$${AGENT_GATEWAY_LITELLM_BASE_URL:=$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL}"; \
+		set +a; \
+		export AGENT_GATEWAY_LITELLM_BASE_URL; \
+	fi; \
+	test -n "$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL" || { \
+		echo "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is required (local: $(QUALIFICATION_INFRA_ENV); Actions: staging environment vars)."; \
+		exit 1; \
+	}; \
+	test -n "$$AGENT_GATEWAY_LITELLM_MASTER_KEY" || { \
+		echo "AGENT_GATEWAY_LITELLM_MASTER_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: staging environment secrets)."; \
+		exit 1; \
+	}; \
+	run_id="ql-$(PROFILE)"; \
+	shard_id="1"; \
+	run_dir="$(QUALIFICATION_LOCAL_WORLD_BASE_DIR)/$$run_id/$$shard_id"; \
+	mkdir -p "$$run_dir"; \
+	build_summary=$$(node scripts/ci-cd/build-local-qualification-candidates.mjs \
+		--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$run_dir") || exit $$?; \
+	echo "$$build_summary"; \
+	candidate_map=$$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).candidate_build_map)' "$$build_summary"); \
+	cd tests/release && pnpm exec tsx src/cli/run.ts \
+		--behavior $(BEHAVIOR) \
+		--lane local \
+		--desktop web \
+		--agents claude \
+		--scenarios LOCAL-WORLD-SMOKE-1 \
+		--candidate-build-map "$$candidate_map" \
+		--run-id "$$run_id" --shard-id "$$shard_id" \
+		--output-dir "$$run_dir/evidence"
+
 test-cloud-ssh-worker:
 	@test -n "$(SSH_TARGET)" || { \
 		echo "SSH_TARGET is required, for example:"; \

--- a/Makefile
+++ b/Makefile
@@ -888,11 +888,11 @@ qualification-local-workspace:
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
 	fi; \
 	test -n "$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL" || { \
-		echo "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is required (local: $(QUALIFICATION_INFRA_ENV); Actions: staging environment vars)."; \
+		echo "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment vars)."; \
 		exit 1; \
 	}; \
 	test -n "$$AGENT_GATEWAY_LITELLM_MASTER_KEY" || { \
-		echo "AGENT_GATEWAY_LITELLM_MASTER_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: staging environment secrets)."; \
+		echo "AGENT_GATEWAY_LITELLM_MASTER_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment secrets)."; \
 		exit 1; \
 	}; \
 	run_id="ql-$(PROFILE)"; \

--- a/apps/desktop/src/components/home/screen/HomeProjectMenu.tsx
+++ b/apps/desktop/src/components/home/screen/HomeProjectMenu.tsx
@@ -63,6 +63,7 @@ export function HomeProjectMenu({
               return (
                 <PopoverMenuItem
                   key={repository.sourceRoot}
+                  data-repo-source-root={repository.sourceRoot}
                   icon={<ProjectNotebook className="size-4" />}
                   label={repository.name}
                   trailing={isSelected ? <Check className="size-4" /> : null}

--- a/apps/desktop/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/desktop/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -37,6 +37,13 @@ export function ComposerModelSelectorControl({
   } = modelSelectorProps;
   const selectorEnabled = connectionState === "healthy" && !isLoading && hasAgents;
   const triggerLabel = resolveTriggerLabel(modelSelectorProps);
+  // Stable qualification hook (attributes only): the id of the currently
+  // selected model, derived from the group items already rendered. Lets the
+  // local-world smoke driver assert the composer picker reflects its choice
+  // without adding a modelId to the display-only `currentModel`. No behavior
+  // change.
+  const selectedModelId =
+    groups.flatMap((group) => group.models).find((model) => model.isSelected)?.modelId ?? "";
 
   // UX_SPEC S5: adding a harness routes to Settings -> per-harness agent pages.
   const handleAddProvider = useCallback(() => {
@@ -54,6 +61,8 @@ export function ComposerModelSelectorControl({
     return (
       <ComposerControlButton
         disabled
+        data-composer-model-trigger
+        data-composer-selected-model={selectedModelId}
         icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="size-4 shrink-0" /> : undefined}
         label={triggerLabel}
         className="max-w-[15rem]"
@@ -66,6 +75,8 @@ export function ComposerModelSelectorControl({
       trigger={(
         <ComposerControlButton
           emphasizeLabel
+          data-composer-model-trigger
+          data-composer-selected-model={selectedModelId}
           icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="size-4 shrink-0" /> : undefined}
           label={triggerLabel}
           trailing={currentModel?.pendingState
@@ -234,6 +245,8 @@ function ModelPickerGroup({
         return (
           <PopoverMenuItem
             key={model.modelId}
+            data-model-option={model.modelId}
+            data-model-selected={model.isSelected ? "true" : "false"}
             icon={<ProviderIcon kind={group.kind} className="size-3 shrink-0 text-muted-foreground" />}
             label={(
               <span className="flex items-center gap-1.5">

--- a/apps/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
@@ -159,7 +159,11 @@ export function TranscriptItemBlock({
       if (!item.text) return null;
 
       return (
-        <div className="flex justify-start relative">
+        <div
+          className="flex justify-start relative"
+          data-assistant-prose
+          data-assistant-streaming={item.isStreaming ? "true" : "false"}
+        >
           <div className="flex flex-col w-full min-w-0 max-w-full break-words">
             <AssistantMessage
               content={item.text}

--- a/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -58,6 +58,10 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
   const selectedLogicalWorkspaceId = useSessionSelectionStore(
     (state) => state.selectedLogicalWorkspaceId,
   );
+  // Stable qualification hook (attributes only): exposes the active session id
+  // on the shell root so the local-world smoke driver can extract/reopen the
+  // exact session without a private API. No behavior change.
+  const activeSessionId = useSessionSelectionStore((state) => state.activeSessionId);
   const { layout, data } = useMainScreenState();
   const actions = useMainScreenActions({
     layout,
@@ -216,6 +220,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
               className={`h-screen flex overflow-hidden ${chromeClasses.root}`}
               data-workspace-shell
               data-workspace-ui-key={selectedLogicalWorkspaceId ?? selectedWorkspaceId ?? ""}
+              data-workspace-session-id={activeSessionId ?? ""}
               data-pending-workspace={pendingWorkspaceEntry ? "true" : "false"}
               data-pending-workspace-attempt-id={pendingWorkspaceEntry?.attemptId ?? undefined}
               data-telemetry-block

--- a/apps/desktop/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts
+++ b/apps/desktop/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts
@@ -3,7 +3,11 @@ import { useAgentAuthState } from "@proliferate/cloud-sdk-react";
 import { useCloudAvailabilityState } from "@/hooks/cloud/derived/use-cloud-availability-state";
 import { applyAgentAuthState } from "@/lib/access/anyharness/agent-auth";
 import { getProliferateApiOrigin } from "@/lib/infra/proliferate-api";
-import { planLocalAuthStatePush, stampIssuingServerOrigin } from "@/lib/domain/agents/local-auth-state";
+import {
+  planLocalAuthStatePush,
+  shouldSyncLocalAuthState,
+  stampIssuingServerOrigin,
+} from "@/lib/domain/agents/local-auth-state";
 import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-store";
 
 /**
@@ -20,17 +24,23 @@ import { useHarnessConnectionStore } from "@/stores/sessions/harness-connection-
  * change — the runtime keeps launching against its last persisted state.
  */
 export function useLocalAuthStateSync() {
-  const { cloudActive } = useCloudAvailabilityState();
+  // The local agent-auth push must NOT be gated on cloud COMPUTE (the old
+  // `cloudActive` coupling): the local surface state carries gateway + BYOK
+  // routes for LOCAL sessions, which a gateway-enabled, compute-less server
+  // still needs. Gate on authenticated + reachable instead (see
+  // `shouldSyncLocalAuthState`).
+  const { cloudEnabled, authStatus } = useCloudAvailabilityState();
+  const authenticated = authStatus === "authenticated";
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
-  const stateQuery = useAgentAuthState("local", cloudActive);
+  const stateQuery = useAgentAuthState("local", authenticated && cloudEnabled);
   const lastPushedRef = useRef<string | null>(null);
 
   const state = stateQuery.data;
   const runtimeHealthy = connectionState === "healthy" && runtimeUrl.trim().length > 0;
 
   useEffect(() => {
-    if (!cloudActive || !runtimeHealthy) {
+    if (!shouldSyncLocalAuthState({ authenticated, serverReachable: cloudEnabled, runtimeHealthy })) {
       return;
     }
     // Wait until the server state has settled before deciding anything.
@@ -58,5 +68,5 @@ export function useLocalAuthStateSync() {
     return () => {
       cancelled = true;
     };
-  }, [cloudActive, runtimeHealthy, runtimeUrl, state]);
+  }, [authenticated, cloudEnabled, runtimeHealthy, runtimeUrl, state]);
 }

--- a/apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.ts
+++ b/apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.ts
@@ -75,6 +75,10 @@ export function useChatLaunchCatalog({
       agentCatalog.agentsByKind,
       selectedCloudRuntime.connectionInfo?.readyAgentKinds ?? null,
       Boolean(selectedCloudRuntime.connectionInfo && runtimeLaunchOptions.data?.agents.length),
+      // Local-target launch readiness: kinds the runtime's launch options list
+      // with models (an enrolled gateway route supplies the launch credential
+      // even when the vendor CLI itself is not logged in).
+      buildLaunchReadyKinds(runtimeLaunchOptions.data?.agents ?? null),
     ),
     [
       agentCatalog.agentsByKind,
@@ -153,17 +157,29 @@ export function useChatLaunchCatalog({
   };
 }
 
+function buildLaunchReadyKinds(
+  runtimeAgents: ReadonlyArray<{ kind: string; models: ReadonlyArray<unknown> }> | null,
+): ReadonlySet<string> | null {
+  if (!runtimeAgents || runtimeAgents.length === 0) {
+    return null;
+  }
+  return new Set(
+    runtimeAgents.filter((agent) => agent.models.length > 0).map((agent) => agent.kind),
+  );
+}
+
 function orderLaunchAgents(
   agents: readonly DesktopAgentLaunchAgent[],
   agentsByKind: ReadonlyMap<string, { readiness: string }>,
   cloudReadyAgentKinds: readonly string[] | null,
   runtimeOptionsAreAuthoritative = false,
+  launchReadyKinds: ReadonlySet<string> | null = null,
 ): DesktopAgentLaunchAgent[] {
   const targetReadyAgents = runtimeOptionsAreAuthoritative
     ? agents.filter((agent) => agent.models.length > 0)
     : cloudReadyAgentKinds
     ? filterCloudReadyLaunchAgents(agents, cloudReadyAgentKinds)
-    : filterTargetReadyLaunchAgents(agents, agentsByKind);
+    : filterTargetReadyLaunchAgents(agents, agentsByKind, launchReadyKinds);
 
   return targetReadyAgents
     .sort((left, right) =>

--- a/apps/desktop/src/hooks/home/derived/use-home-next-mode-selection.ts
+++ b/apps/desktop/src/hooks/home/derived/use-home-next-mode-selection.ts
@@ -32,11 +32,25 @@ export function useHomeNextModeSelection({
   const agentKind = modelSelection?.kind ?? null;
   const catalogQuery = useCloudAgentCatalog(Boolean(agentKind));
 
+  const modelId = modelSelection?.modelId ?? null;
   const catalogModeOptions = useMemo(() => {
     const agent = catalogQuery.data?.agents.find((candidate) => candidate.kind === agentKind);
     const control = agent?.launchControls?.find((candidate) => candidate.key === "mode") ?? null;
-    return launchControlToConfiguredSessionControlValues(agentKind, control);
-  }, [agentKind, catalogQuery.data?.agents]);
+    const options = launchControlToConfiguredSessionControlValues(agentKind, control);
+    // Scope to the modes the SELECTED model actually supports. The agent-level
+    // `mode` vocabulary is a superset (e.g. it includes `auto`), but gateway /
+    // bedrock models reject modes outside their per-model vocabulary at session
+    // creation. Without this, the composer would default to (and offer) a mode
+    // the model can't use — e.g. `auto` for a gateway Claude model.
+    const model = agent?.models.find((candidate) =>
+      candidate.id === modelId || (candidate.aliases ?? []).includes(modelId ?? ""));
+    const modeValues = model?.modeValues ?? null;
+    if (!modeValues || modeValues.length === 0) {
+      return options;
+    }
+    const supported = options.filter((option) => modeValues.includes(option.value));
+    return supported.length > 0 ? supported : options;
+  }, [agentKind, catalogQuery.data?.agents, modelId]);
 
   const modeOptions = useMemo(
     () => catalogModeOptions.length > 0

--- a/apps/desktop/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/desktop/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -269,6 +269,48 @@ describe("useHomeNextModelSelection", () => {
       .toEqual(["anthropic/claude-sonnet-4-6"]);
   });
 
+  it("offers a launch-ready gateway agent even when native readiness is login_required", () => {
+    // A gateway-only actor: `GET /v1/agents` reports claude login_required (no
+    // vendor-CLI login), so readyAgents is empty, but the runtime's launch
+    // options list claude with models — the enrolled route supplies the launch
+    // credential. The composer must offer those models rather than "No agents".
+    selectionMocks.agentCatalog.readyAgents = [];
+    selectionMocks.runtimeLaunchOptions.data = {
+      agents: [{
+        kind: "claude",
+        displayName: "Claude",
+        defaultModelId: "claude-haiku-4-5",
+        models: [{
+          id: "claude-haiku-4-5",
+          displayName: "Haiku 4.5",
+          isDefault: true,
+          defaultOptIn: true,
+        }],
+      }],
+    };
+
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+    }));
+
+    expect(result.current.modelAvailabilityState).toBe("launchable");
+    expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["claude"]);
+    expect(result.current.modelGroups[0]?.models.map((model) => model.modelId))
+      .toEqual(["claude-haiku-4-5"]);
+  });
+
+  it("does not resurrect an agent absent from launch options (e.g. not installed)", () => {
+    selectionMocks.agentCatalog.readyAgents = [];
+    selectionMocks.runtimeLaunchOptions.data = { agents: [] };
+
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+    }));
+
+    expect(result.current.modelAvailabilityState).toBe("no_launchable_model");
+    expect(result.current.modelGroups).toEqual([]);
+  });
+
   it("treats all catalog registries as launchable for cloud launches", () => {
     selectionMocks.agentCatalog.readyAgents = [agent("codex"), agent("claude")];
     selectionMocks.modelRegistriesQuery.data = [registry("codex"), registry("claude")];

--- a/apps/desktop/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/desktop/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -62,13 +62,24 @@ export function useHomeNextModelSelection({
   );
   const readyAgentsForLaunch = useMemo<AgentCatalogSummary[]>(() => {
     if (!isCloudLaunchTarget) {
-      return readyAgents;
+      // `readyAgents` is NATIVE readiness (`GET /v1/agents`: "is the vendor CLI
+      // installed and logged in"). An agent whose enrolled gateway/api_key
+      // route supplies the launch credential is reported `login_required`
+      // there, yet the runtime's launch options (`GET /v1/agents/launch-options`,
+      // launch-time readiness via `resolve_launch_agent`) list it with models —
+      // that is the source the launcher actually uses. Without this union a
+      // gateway-only actor sees "No agents" even though every launch would
+      // succeed (an ambient vendor-CLI login on a developer machine masks the
+      // gap). Launch options never list an uninstalled agent, so this cannot
+      // resurrect an install-required agent.
+      return mergeLaunchReadyAgents(readyAgents, runtimeLaunchOptions.data?.agents ?? null);
     }
     return buildCloudReadyAgentSummaries({ modelRegistries });
   }, [
     isCloudLaunchTarget,
     modelRegistries,
     readyAgents,
+    runtimeLaunchOptions.data?.agents,
   ]);
 
   const unselectedGroups = useMemo(
@@ -129,6 +140,34 @@ export function useHomeNextModelSelection({
       ?? (isCloudLaunchTarget ? null : runtimeLaunchOptions.error),
     modelAvailabilityState,
   };
+}
+
+/**
+ * Union of native-ready agents and launch-ready agents (present with models in
+ * the runtime's launch options — the enrolled route supplies their launch
+ * credential even when the vendor CLI itself is not logged in).
+ */
+function mergeLaunchReadyAgents(
+  readyAgents: AgentCatalogSummary[],
+  launchOptionAgents:
+    | ReadonlyArray<{ kind: string; displayName: string; models: ReadonlyArray<unknown> }>
+    | null,
+): AgentCatalogSummary[] {
+  if (!launchOptionAgents || launchOptionAgents.length === 0) {
+    return readyAgents;
+  }
+  const nativeReadyKinds = new Set(readyAgents.map((agent) => agent.kind));
+  const launchReady = launchOptionAgents
+    .filter((agent) => agent.models.length > 0 && !nativeReadyKinds.has(agent.kind))
+    .map((agent) => ({
+      kind: agent.kind,
+      displayName: agent.displayName,
+      readiness: "ready" as const,
+    }));
+  if (launchReady.length === 0) {
+    return readyAgents;
+  }
+  return [...readyAgents, ...launchReady];
 }
 
 function buildCloudReadyAgentSummaries({

--- a/apps/desktop/src/hooks/workspaces/lifecycle/use-persisted-logical-workspace-selection.ts
+++ b/apps/desktop/src/hooks/workspaces/lifecycle/use-persisted-logical-workspace-selection.ts
@@ -26,12 +26,21 @@ export function usePersistedLogicalWorkspaceSelection() {
       return;
     }
 
-    if (!findLogicalWorkspace(logicalWorkspaces, selectedLogicalWorkspaceId)) {
+    const resolved = findLogicalWorkspace(logicalWorkspaces, selectedLogicalWorkspaceId);
+    if (!resolved) {
       return;
     }
 
     attemptedLogicalWorkspaceIdRef.current = selectedLogicalWorkspaceId;
-    void selectWorkspace(selectedLogicalWorkspaceId, { force: true }).catch(() => {
+    // Pass the resolved local workspace as `knownWorkspace`: selection re-derives
+    // its own workspace snapshot from the query cache, which can momentarily miss
+    // a workspace this reactive hook already has (e.g. right after a reload while
+    // the collections cache repopulates). Without the hint, restoring the last
+    // workspace on reopen would fail with "Workspace not found."
+    const knownWorkspace = resolved.localWorkspace?.id === selectedLogicalWorkspaceId
+      ? resolved.localWorkspace
+      : null;
+    void selectWorkspace(selectedLogicalWorkspaceId, { force: true, knownWorkspace }).catch(() => {
       attemptedLogicalWorkspaceIdRef.current = null;
     });
   }, [

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
@@ -117,6 +117,74 @@ describe("runWorkspaceSelection", () => {
     expect(bootstrapWorkspace).not.toHaveBeenCalled();
   });
 
+  it("selects a freshly created local workspace passed via options.knownWorkspace when it is absent from both the logical and raw snapshots", async () => {
+    // Regression: the pending-composer flow selects a just-created local
+    // workspace the instant AnyHarness returns it, before the workspace-
+    // collections query has projected it. On a fresh actor both derived lists
+    // are empty, so selection must fall back to the threaded workspace instead
+    // of throwing "Workspace not found."
+    vi.mocked(resolveCloudWorkspaceReadiness).mockReset();
+    vi.mocked(resolveSelectionConnection).mockResolvedValueOnce({
+      runtimeUrl: "http://runtime.test",
+      workspaceConnection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: "ah-fresh-local",
+      },
+    });
+    const knownWorkspace = {
+      id: "fresh-local-1",
+      kind: "local",
+      surface: "standard",
+      executionSummary: null,
+    } as never;
+    const bootstrapWorkspace = vi.fn().mockResolvedValue({ sessions: [] });
+    const setSelectedLogicalWorkspaceId = vi.fn();
+
+    await runWorkspaceSelection({
+      localRuntime: null,
+      cache: selectionCache(),
+      logicalWorkspaces: [],
+      rawWorkspaces: [],
+      setSelectedLogicalWorkspaceId,
+      setSelectedWorkspace,
+      removeWorkspaceSlots: vi.fn(),
+      clearSelection: vi.fn(),
+      bootstrapWorkspace,
+      reconcileHotWorkspace: vi.fn(),
+    }, {
+      workspaceId: "fresh-local-1",
+      options: { force: true, preservePending: true, knownWorkspace },
+    });
+
+    expect(resolveSelectionConnection).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ workspaceId: "fresh-local-1" }),
+      { kind: "local" },
+    );
+    expect(bootstrapWorkspace).toHaveBeenCalledTimes(1);
+    expect(useSessionSelectionStore.getState().selectedWorkspaceId).toBe("fresh-local-1");
+    // The local workspace's logical selection must be its id (not null), so a
+    // reload restores it via the persisted logical-workspace selection.
+    expect(setSelectedLogicalWorkspaceId).toHaveBeenCalledWith("fresh-local-1");
+  });
+
+  it("still throws when a workspace is missing everywhere and no knownWorkspace is provided", async () => {
+    await expect(runWorkspaceSelection({
+      localRuntime: null,
+      cache: selectionCache(),
+      logicalWorkspaces: [],
+      rawWorkspaces: [],
+      setSelectedLogicalWorkspaceId: vi.fn(),
+      setSelectedWorkspace,
+      removeWorkspaceSlots: vi.fn(),
+      clearSelection: vi.fn(),
+      bootstrapWorkspace: vi.fn(),
+      reconcileHotWorkspace: vi.fn(),
+    }, {
+      workspaceId: "ghost-workspace",
+    })).rejects.toThrow("Workspace not found.");
+  });
+
   it("rejects placeholder logical workspaces that are not materialized yet", async () => {
     vi.mocked(resolveCloudWorkspaceReadiness).mockReset();
 

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
@@ -142,6 +142,7 @@ describe("runWorkspaceSelection", () => {
 
     await runWorkspaceSelection({
       localRuntime: null,
+      cloudClient: null,
       cache: selectionCache(),
       logicalWorkspaces: [],
       rawWorkspaces: [],
@@ -171,6 +172,7 @@ describe("runWorkspaceSelection", () => {
   it("still throws when a workspace is missing everywhere and no knownWorkspace is provided", async () => {
     await expect(runWorkspaceSelection({
       localRuntime: null,
+      cloudClient: null,
       cache: selectionCache(),
       logicalWorkspaces: [],
       rawWorkspaces: [],

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts
@@ -143,10 +143,31 @@ export async function runWorkspaceSelection(
       return;
     }
 
+    // A just-created workspace can be selected before the workspace-collections
+    // cache has projected it into `logicalWorkspaces`/`rawWorkspaces` — the
+    // pending-composer flow selects it the instant AnyHarness returns it, and on
+    // a fresh actor the collections query may not be populated yet. The creator
+    // threads the resolved workspace through `options.knownWorkspace` so we can
+    // select it directly instead of hard-failing. The same hint restores the
+    // last workspace on reopen. Both local and cowork workspaces resolve through
+    // the local runtime.
     const directWorkspace = deps.rawWorkspaces.find(
       (workspace) => workspace.id === request.workspaceId,
-    ) ?? null;
-    if (directWorkspace?.surface === "cowork") {
+    ) ?? (
+      request.options?.knownWorkspace?.id === request.workspaceId
+        ? request.options.knownWorkspace
+        : null
+    );
+    if (directWorkspace) {
+      // A cowork workspace has no logical-workspace slot, so its logical
+      // selection is null (unchanged). A local workspace does have one; persist
+      // its id as the selected logical workspace so a reload restores it (the
+      // collections cache resolves `findLogicalWorkspace(..., workspace.id)` via
+      // `localWorkspace.id`). Persisting null here would leave the shell empty
+      // after reopen.
+      const directLogicalWorkspaceId = directWorkspace.surface === "cowork"
+        ? null
+        : directWorkspace.id;
       const selectionStartedAt = startLatencyTimer();
       const previousSelection = useSessionSelectionStore.getState();
       const currentId = previousSelection.selectedWorkspaceId;
@@ -157,7 +178,7 @@ export async function runWorkspaceSelection(
 
       logLatency("workspace.select.start", {
         workspaceId: directWorkspace.id,
-        logicalWorkspaceId: null,
+        logicalWorkspaceId: directLogicalWorkspaceId,
         force: !!request.options?.force,
         preservePending: !!request.options?.preservePending,
       });
@@ -178,7 +199,7 @@ export async function runWorkspaceSelection(
         ],
         nextWorkspaceIds: [directWorkspace.id],
       });
-      deps.setSelectedLogicalWorkspaceId(null);
+      deps.setSelectedLogicalWorkspaceId(directLogicalWorkspaceId);
       deps.setSelectedWorkspace(directWorkspace.id, {
         clearPending: !request.options?.preservePending,
         initialActiveSessionId,

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/types.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/types.ts
@@ -14,6 +14,15 @@ export interface WorkspaceSelectionOptions {
   preservePending?: boolean;
   initialActiveSessionId?: string | null;
   latencyFlowId?: string | null;
+  /**
+   * A workspace the caller has already resolved but that may not be present in
+   * the selection's internal `logicalWorkspaces`/`rawWorkspaces` snapshot yet —
+   * either just created (the collections query lags creation) or being restored
+   * on reopen (the snapshot read can momentarily miss a workspace the reactive
+   * hooks already have). When set and its id matches `workspaceId`, selection
+   * uses it directly instead of failing with "Workspace not found."
+   */
+  knownWorkspace?: Workspace | null;
 }
 
 export interface WorkspaceSelectionRequest {

--- a/apps/desktop/src/hooks/workspaces/workflows/selection/use-workspace-selection.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/selection/use-workspace-selection.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import type { Workspace } from "@anyharness/sdk";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useWorkspaceBootstrapActions } from "@/hooks/workspaces/workflows/use-workspace-bootstrap-actions";
 import { useCloudWorkspaceConnectionCache } from "@/hooks/access/cloud/use-cloud-workspace-connection-cache";
@@ -47,6 +48,7 @@ export function useWorkspaceSelection() {
         preservePending?: boolean;
         initialActiveSessionId?: string | null;
         latencyFlowId?: string | null;
+        knownWorkspace?: Workspace | null;
       },
     ) => {
       const runtimeUrl = useHarnessConnectionStore.getState().runtimeUrl;

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts
@@ -69,7 +69,11 @@ export function useWorkspaceEntryActions() {
   const finalizeSelection = useCallback(async (
     entry: PendingWorkspaceEntry,
     workspaceId: string,
-    options?: { latencyFlowId?: string | null; repoGroupKeyToExpand?: string | null },
+    options?: {
+      latencyFlowId?: string | null;
+      repoGroupKeyToExpand?: string | null;
+      knownWorkspace?: Workspace | null;
+    },
   ): Promise<boolean> => {
     return finalizePendingWorkspaceSelection({
       entry,
@@ -140,6 +144,7 @@ export function useWorkspaceEntryActions() {
       };
       const selectionFinalized = await finalizeSelection(selectionEntry, workspace.id, {
         repoGroupKeyToExpand: sidebarRepoGroupKeyForWorkspace(workspace, repoRoots),
+        knownWorkspace: workspace,
       });
       return selectionFinalized ? { workspaceId: workspace.id, projectedSessionId } : null;
     } catch (error) {
@@ -329,6 +334,7 @@ export function useWorkspaceEntryActions() {
       const selectionFinalized = await finalizeSelection(selectionEntry, result.workspace.id, {
         latencyFlowId: options?.latencyFlowId,
         repoGroupKeyToExpand: sidebarRepoGroupKeyForWorkspace(result.workspace, repoRoots),
+        knownWorkspace: result.workspace,
       });
       if (!selectionFinalized) {
         return null;

--- a/apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
@@ -1,6 +1,7 @@
 import {
   buildWorkspaceArrivalEvent,
 } from "@/lib/domain/workspaces/creation/arrival";
+import type { Workspace } from "@anyharness/sdk";
 import {
   buildPendingWorkspaceUiKey,
   type PendingWorkspaceEntry,
@@ -34,6 +35,7 @@ export interface WorkspaceEntrySelectionDeps {
       preservePending: true;
       initialActiveSessionId: string | null;
       latencyFlowId?: string | null;
+      knownWorkspace?: Workspace | null;
     },
   ) => Promise<void>;
   setPendingWorkspaceEntry: (entry: PendingWorkspaceEntry | null) => void;
@@ -48,6 +50,7 @@ export async function finalizePendingWorkspaceSelection(
     options?: {
       latencyFlowId?: string | null;
       repoGroupKeyToExpand?: string | null;
+      knownWorkspace?: Workspace | null;
     };
   },
   deps: WorkspaceEntrySelectionDeps,
@@ -85,6 +88,7 @@ export async function finalizePendingWorkspaceSelection(
     preservePending: true,
     initialActiveSessionId: projectedActiveSessionId,
     latencyFlowId: input.options?.latencyFlowId,
+    knownWorkspace: input.options?.knownWorkspace ?? null,
   });
 
   if (!isPendingWorkspaceAttemptCurrent(input.entry.attemptId, deps)) {

--- a/apps/desktop/src/lib/access/tauri/store.test.ts
+++ b/apps/desktop/src/lib/access/tauri/store.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("getPreferencesStore browser fallback", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it("persists values to localStorage when Tauri is unavailable (browser renderer)", async () => {
+    const { getPreferencesStore } = await import("./store");
+    const store = await getPreferencesStore();
+    expect(store).not.toBeNull();
+
+    // Simulates the selected-workspace persistence path used on reopen.
+    await store!.set("selected_logical_workspace_id", "workspace-abc");
+    await store!.save();
+
+    // Survives a fresh module load (the analog of a page reload) because the
+    // value lives in localStorage, not module memory.
+    vi.resetModules();
+    const { getPreferencesStore: reloaded } = await import("./store");
+    const restored = await (await reloaded())!.get<string>("selected_logical_workspace_id");
+    expect(restored).toBe("workspace-abc");
+  });
+
+  it("returns undefined for unknown keys", async () => {
+    const { getPreferencesStore } = await import("./store");
+    const store = await getPreferencesStore();
+    expect(await store!.get("never-set")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/access/tauri/store.test.ts
+++ b/apps/desktop/src/lib/access/tauri/store.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("getPreferencesStore browser fallback", () => {
   beforeEach(() => {
@@ -28,5 +28,53 @@ describe("getPreferencesStore browser fallback", () => {
     const { getPreferencesStore } = await import("./store");
     const store = await getPreferencesStore();
     expect(await store!.get("never-set")).toBeUndefined();
+  });
+});
+
+describe("getPreferencesStore inside Tauri", () => {
+  const tauriWindow = () => window as unknown as Record<string, unknown>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+    tauriWindow().__TAURI_INTERNALS__ = {};
+  });
+
+  afterEach(() => {
+    delete tauriWindow().__TAURI_INTERNALS__;
+    vi.doUnmock("@tauri-apps/plugin-store");
+  });
+
+  it("does not cache the localStorage fallback after a transient plugin-store failure", async () => {
+    const realStore = {
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => undefined),
+      save: vi.fn(async () => undefined),
+    };
+    let loadCalls = 0;
+    vi.doMock("@tauri-apps/plugin-store", () => ({
+      Store: {
+        load: vi.fn(async () => {
+          loadCalls += 1;
+          if (loadCalls === 1) {
+            throw new Error("transient module load failure");
+          }
+          return realStore;
+        }),
+      },
+    }));
+
+    const { getPreferencesStore } = await import("./store");
+
+    // First call: the real store import fails transiently. We get a best-effort
+    // fallback but it must NOT be cached, so a later call can recover.
+    const first = await getPreferencesStore();
+    expect(first).not.toBe(realStore);
+
+    // Second call retries the real Tauri store rather than serving a cached
+    // fallback — real persistence recovers once the transient failure clears.
+    const second = await getPreferencesStore();
+    expect(second).toBe(realStore);
+    expect(loadCalls).toBe(2);
   });
 });

--- a/apps/desktop/src/lib/access/tauri/store.test.ts
+++ b/apps/desktop/src/lib/access/tauri/store.test.ts
@@ -29,6 +29,33 @@ describe("getPreferencesStore browser fallback", () => {
     const store = await getPreferencesStore();
     expect(await store!.get("never-set")).toBeUndefined();
   });
+
+  it("deletes keys so ProductStorage.removeItem works in the browser renderer", async () => {
+    const { getPreferencesStore } = await import("./store");
+    const store = await getPreferencesStore();
+
+    await store!.set("keep", "kept");
+    await store!.set("drop", "dropped");
+
+    // The main-branch product-storage adapter calls store.delete(key) from
+    // removeItem; the browser fallback must support the same surface.
+    expect(await store!.delete("drop")).toBe(true);
+    expect(await store!.get("drop")).toBeUndefined();
+    expect(await store!.get<string>("keep")).toBe("kept");
+
+    // Deleting an absent key reports false rather than throwing.
+    expect(await store!.delete("drop")).toBe(false);
+  });
+
+  it("removes preferences through the ProductStorage adapter", async () => {
+    const { desktopProductStorage } = await import("../browser/product-storage");
+
+    await desktopProductStorage.setItem("pref-key", "pref-value");
+    expect(await desktopProductStorage.getItem("pref-key")).toBe("pref-value");
+
+    await desktopProductStorage.removeItem("pref-key");
+    expect(await desktopProductStorage.getItem("pref-key")).toBeNull();
+  });
 });
 
 describe("getPreferencesStore inside Tauri", () => {

--- a/apps/desktop/src/lib/access/tauri/store.ts
+++ b/apps/desktop/src/lib/access/tauri/store.ts
@@ -7,6 +7,54 @@ type StoreInstance = {
 
 let _store: StoreInstance | null = null;
 
+const BROWSER_STORE_KEY = "proliferate.preferences";
+
+/**
+ * localStorage-backed fallback for the preferences store when running as the
+ * browser-rendered Desktop product (no Tauri). Without it, preferences — most
+ * importantly the selected logical workspace — do not survive a reload, so the
+ * product cannot reopen the last workspace/session. Keeps parity with the
+ * packaged desktop's Tauri store (same get/set/save surface). Values are held
+ * as one JSON object under a single localStorage key.
+ */
+function createBrowserPreferencesStore(): StoreInstance | null {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+
+  const readAll = (): Record<string, unknown> => {
+    try {
+      const raw = localStorage.getItem(BROWSER_STORE_KEY);
+      if (!raw) {
+        return {};
+      }
+      const parsed = JSON.parse(raw) as unknown;
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  };
+
+  return {
+    get: async <T>(key: string): Promise<T | undefined> => {
+      const all = readAll();
+      return Object.prototype.hasOwnProperty.call(all, key) ? (all[key] as T) : undefined;
+    },
+    set: async (key: string, value: unknown): Promise<void> => {
+      try {
+        const all = readAll();
+        all[key] = value;
+        localStorage.setItem(BROWSER_STORE_KEY, JSON.stringify(all));
+      } catch {
+        // Storage unavailable/quota exceeded — persistence is best-effort.
+      }
+    },
+    save: async (): Promise<void> => {
+      // Writes are synchronous in `set`; nothing to flush.
+    },
+  };
+}
+
 export async function getPreferencesStore(): Promise<StoreInstance | null> {
   if (_store) return _store;
   try {
@@ -17,8 +65,10 @@ export async function getPreferencesStore(): Promise<StoreInstance | null> {
     });
     return _store;
   } catch {
-    // Outside Tauri (dev browser), persistence is unavailable.
-    return null;
+    // Outside Tauri (browser-rendered Desktop): fall back to localStorage so
+    // preferences (incl. the selected workspace) still persist across reloads.
+    _store = createBrowserPreferencesStore();
+    return _store;
   }
 }
 

--- a/apps/desktop/src/lib/access/tauri/store.ts
+++ b/apps/desktop/src/lib/access/tauri/store.ts
@@ -51,6 +51,20 @@ function createBrowserPreferencesStore(): StoreInstance | null {
         // Storage unavailable/quota exceeded — persistence is best-effort.
       }
     },
+    delete: async (key: string): Promise<boolean> => {
+      try {
+        const all = readAll();
+        if (!Object.prototype.hasOwnProperty.call(all, key)) {
+          return false;
+        }
+        delete all[key];
+        localStorage.setItem(BROWSER_STORE_KEY, JSON.stringify(all));
+        return true;
+      } catch {
+        // Storage unavailable/quota exceeded — persistence is best-effort.
+        return false;
+      }
+    },
     save: async (): Promise<void> => {
       // Writes are synchronous in `set`; nothing to flush.
     },

--- a/apps/desktop/src/lib/access/tauri/store.ts
+++ b/apps/desktop/src/lib/access/tauri/store.ts
@@ -1,3 +1,5 @@
+import { isTauriRuntimeAvailable } from "./connect-server";
+
 type StoreInstance = {
   get: <T>(key: string) => Promise<T | undefined>;
   set: (key: string, value: unknown) => Promise<void>;
@@ -57,6 +59,19 @@ function createBrowserPreferencesStore(): StoreInstance | null {
 
 export async function getPreferencesStore(): Promise<StoreInstance | null> {
   if (_store) return _store;
+
+  // Genuinely non-Tauri (browser-rendered Desktop): use and cache the
+  // localStorage fallback so preferences (incl. the selected workspace) persist
+  // across reloads. There is no Tauri store to retry here.
+  if (!isTauriRuntimeAvailable()) {
+    _store = createBrowserPreferencesStore();
+    return _store;
+  }
+
+  // Inside Tauri: the real plugin-store is the only correct backend. A transient
+  // import/load failure must NOT be cached as the localStorage fallback, or real
+  // Tauri persistence would be permanently disabled for the session. Return a
+  // best-effort uncached fallback so the next call can retry the real store.
   try {
     const mod = await import("@tauri-apps/plugin-store");
     _store = await mod.Store.load("preferences.json", {
@@ -65,10 +80,7 @@ export async function getPreferencesStore(): Promise<StoreInstance | null> {
     });
     return _store;
   } catch {
-    // Outside Tauri (browser-rendered Desktop): fall back to localStorage so
-    // preferences (incl. the selected workspace) still persist across reloads.
-    _store = createBrowserPreferencesStore();
-    return _store;
+    return createBrowserPreferencesStore();
   }
 }
 

--- a/apps/desktop/src/lib/domain/agents/cloud-launch-catalog-types.ts
+++ b/apps/desktop/src/lib/domain/agents/cloud-launch-catalog-types.ts
@@ -72,6 +72,15 @@ export interface DesktopLaunchModelRegistryModel {
   /** v2 availability gate (`anyOf` auth context ids); null when unknown. */
   availability?: ModelAvailability | null;
   sessionDefaultControls?: DesktopSessionDefaultControl[];
+  /**
+   * The `mode` control vocabulary this model actually supports (per-model
+   * `controls.mode.values` in the catalog). Differs from the agent-level `mode`
+   * control: e.g. gateway/bedrock Claude models exclude `auto`. `null` when the
+   * model carries no per-model mode vocabulary (fall back to the agent-level
+   * control). Used to keep the composer from offering/defaulting to a mode the
+   * selected model would reject at session creation.
+   */
+  modeValues?: string[] | null;
 }
 
 export interface DesktopAgentLaunchModel extends DesktopLaunchModelRegistryModel {

--- a/apps/desktop/src/lib/domain/agents/cloud-launch-catalog.ts
+++ b/apps/desktop/src/lib/domain/agents/cloud-launch-catalog.ts
@@ -149,6 +149,7 @@ export function mergeRuntimeLaunchOptionsIntoDesktopLaunchAgents(
           isDefault: model.isDefault || modelIdCandidates.includes(defaultModelId ?? ""),
           availability: cloudModel?.availability ?? null,
           sessionDefaultControls: cloudModel?.sessionDefaultControls ?? [],
+          modeValues: cloudModel?.modeValues ?? null,
         };
       }),
       launchControls: cloud?.launchControls ?? [],
@@ -336,5 +337,16 @@ function projectCloudModel(
     isDefault: model.id === defaultModelId,
     availability: anyOf.length > 0 ? { anyOf: [...anyOf] } : null,
     sessionDefaultControls: projectSessionDefaultControls(model, sessionControls),
+    modeValues: projectModelModeValues(model),
   };
+}
+
+/**
+ * The per-model `mode` vocabulary from the catalog matrix, if present and
+ * non-empty. `null` means the model has no per-model mode entry and the
+ * agent-level `mode` control applies.
+ */
+function projectModelModeValues(model: CloudAgentCatalogModelInput): string[] | null {
+  const values = model.controls?.mode?.values;
+  return values && values.length > 0 ? [...values] : null;
 }

--- a/apps/desktop/src/lib/domain/agents/local-auth-state.test.ts
+++ b/apps/desktop/src/lib/domain/agents/local-auth-state.test.ts
@@ -3,6 +3,7 @@ import type { AgentAuthState } from "@proliferate/cloud-sdk";
 import {
   localAuthStateFingerprint,
   planLocalAuthStatePush,
+  shouldSyncLocalAuthState,
   stampIssuingServerOrigin,
 } from "./local-auth-state";
 
@@ -109,5 +110,33 @@ describe("stampIssuingServerOrigin", () => {
     const first = stampIssuingServerOrigin(state(), "https://old-server.example");
     const second = stampIssuingServerOrigin(first, "https://new-server.example");
     expect(second.issuing_server_origin).toBe("https://new-server.example");
+  });
+});
+
+describe("shouldSyncLocalAuthState", () => {
+  it("syncs a gateway-enabled server even when cloud COMPUTE is unavailable", () => {
+    // Regression: the local gateway/BYOK routes must reach the runtime on a
+    // reachable, authenticated server regardless of cloud-compute (E2B). This
+    // is the exact posture of the qualification local world and a local-only
+    // managed-gateway user.
+    expect(
+      shouldSyncLocalAuthState({
+        authenticated: true,
+        serverReachable: true,
+        runtimeHealthy: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not sync until authenticated, reachable, and the runtime is healthy", () => {
+    expect(
+      shouldSyncLocalAuthState({ authenticated: false, serverReachable: true, runtimeHealthy: true }),
+    ).toBe(false);
+    expect(
+      shouldSyncLocalAuthState({ authenticated: true, serverReachable: false, runtimeHealthy: true }),
+    ).toBe(false);
+    expect(
+      shouldSyncLocalAuthState({ authenticated: true, serverReachable: true, runtimeHealthy: false }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/domain/agents/local-auth-state.ts
+++ b/apps/desktop/src/lib/domain/agents/local-auth-state.ts
@@ -61,3 +61,27 @@ export function planLocalAuthStatePush(input: {
   }
   return { shouldPush: true, fingerprint };
 }
+
+/**
+ * Whether the local agent-auth state sync (server fetch + push to the local
+ * runtime) should run.
+ *
+ * The local-surface `state.json` carries the gateway AND BYOK route material
+ * for LOCAL sessions, which is independent of cloud COMPUTE (E2B sandboxes).
+ * Gating this sync on cloud compute (the previous `cloudActive =
+ * cloudComputeEnabled && authenticated` coupling) left a gateway-enabled server
+ * with cloud compute disabled — e.g. a local-only managed-gateway user, and the
+ * qualification local world — unable to launch gateway-routed sessions, because
+ * the runtime never received its routes and every gateway harness fell back to
+ * "no launchable model". The sync needs only an authenticated session against a
+ * reachable server and a healthy local runtime; when there is nothing to
+ * deliver the rendered document is revision-0 and `planLocalAuthStatePush`
+ * already declines to push it.
+ */
+export function shouldSyncLocalAuthState(input: {
+  authenticated: boolean;
+  serverReachable: boolean;
+  runtimeHealthy: boolean;
+}): boolean {
+  return input.authenticated && input.serverReachable && input.runtimeHealthy;
+}

--- a/apps/desktop/src/lib/domain/agents/target-ready-launch-agents.test.ts
+++ b/apps/desktop/src/lib/domain/agents/target-ready-launch-agents.test.ts
@@ -21,6 +21,33 @@ describe("filterTargetReadyLaunchAgents", () => {
       ]),
     ).map((agent) => agent.kind)).toEqual(["codex"]);
   });
+
+  it("keeps a launch-ready gateway agent whose native readiness is login_required", () => {
+    const agents = [
+      launchAgent("claude", "claude-haiku-4-5"),
+      launchAgent("codex", "gpt-5.5"),
+    ];
+
+    // claude is launch-ready via its enrolled gateway route (present in the
+    // runtime's launch options) even though the vendor CLI is not logged in;
+    // codex has no route and stays hidden.
+    expect(filterTargetReadyLaunchAgents(
+      agents,
+      new Map([
+        ["claude", { readiness: "login_required" }],
+        ["codex", { readiness: "login_required" }],
+      ]),
+      new Set(["claude"]),
+    ).map((agent) => agent.kind)).toEqual(["claude"]);
+  });
+
+  it("never treats a launch-ready kind without models as launchable", () => {
+    expect(filterTargetReadyLaunchAgents(
+      [launchAgent("cursor", null)],
+      new Map([["cursor", { readiness: "login_required" }]]),
+      new Set(["cursor"]),
+    )).toEqual([]);
+  });
 });
 
 function launchAgent(kind: string, modelId: string | null): DesktopAgentLaunchAgent {

--- a/apps/desktop/src/lib/domain/agents/target-ready-launch-agents.ts
+++ b/apps/desktop/src/lib/domain/agents/target-ready-launch-agents.ts
@@ -4,12 +4,26 @@ interface TargetAgentReadiness {
   readiness: string;
 }
 
+/**
+ * Local-target launch agents: an agent counts as launchable when its NATIVE
+ * readiness (`GET /v1/agents`: vendor CLI installed and logged in) is ready, OR
+ * when the runtime's launch options list it (`launchReadyKinds`) — launch
+ * options use AnyHarness's launch-time readiness, where an enrolled
+ * gateway/api_key route supplies the credential injected at spawn. Without the
+ * second clause a gateway-only actor (no vendor-CLI login) sees no agents even
+ * though every launch would succeed. Launch options never list an uninstalled
+ * agent, so this cannot resurrect an install-required agent.
+ */
 export function filterTargetReadyLaunchAgents(
   agents: readonly DesktopAgentLaunchAgent[],
   agentsByKind: ReadonlyMap<string, TargetAgentReadiness>,
+  launchReadyKinds: ReadonlySet<string> | null = null,
 ): DesktopAgentLaunchAgent[] {
   return agents.filter((agent) =>
     agent.models.length > 0
-    && agentsByKind.get(agent.kind)?.readiness === "ready"
+    && (
+      agentsByKind.get(agent.kind)?.readiness === "ready"
+      || (launchReadyKinds?.has(agent.kind) ?? false)
+    )
   );
 }

--- a/apps/desktop/src/lib/domain/chat/models/launch-control-descriptors.test.ts
+++ b/apps/desktop/src/lib/domain/chat/models/launch-control-descriptors.test.ts
@@ -39,6 +39,91 @@ function control(
   };
 }
 
+function modeControl(): DesktopAgentLaunchControl {
+  return {
+    key: "mode",
+    label: "Mode",
+    type: "select",
+    phase: "create_session",
+    createField: "modeId",
+    defaultValue: null,
+    values: [
+      { value: "auto", label: "Auto", isDefault: false },
+      { value: "default", label: "Default", isDefault: false },
+      { value: "acceptEdits", label: "Accept Edits", isDefault: false },
+      { value: "plan", label: "Plan", isDefault: false },
+    ],
+    surfaces: { start: true, session: true, automation: true, settings: true },
+    apply: {
+      createField: "modeId",
+      liveConfigId: "mode",
+      liveSetter: "runtime_control",
+      queueBeforeMaterialized: true,
+    },
+    missingLiveConfigPolicy: "ignore_default",
+    valueSource: "inline",
+    queueWhileMaterializing: true,
+    mutableAfterMaterialized: true,
+  };
+}
+
+describe("buildLaunchControlDescriptors mode scoping", () => {
+  it("scopes the mode control to the selected model's supported modes and never defaults to an unsupported mode", () => {
+    // Regression: gateway/bedrock Claude models exclude `auto` from their
+    // per-model mode vocabulary. The composer must not offer or default to
+    // `auto` for such a model — AnyHarness rejects it at session creation with
+    // SESSION_MODE_UNSUPPORTED.
+    const [mode] = buildLaunchControlDescriptors({
+      selection: { kind: "claude", modelId: "claude-haiku-4-5" },
+      launchAgents: [
+        {
+          kind: "claude",
+          launchControls: [modeControl()],
+          models: [
+            {
+              id: "claude-haiku-4-5",
+              modeValues: ["default", "acceptEdits", "plan", "dontAsk", "bypassPermissions"],
+            },
+          ],
+        },
+      ],
+      preferences: {
+        // Even a persisted `auto` preference must not survive onto this model.
+        defaultSessionModeByAgentKind: { claude: "auto" },
+        defaultLiveSessionControlValuesByAgentKind: {},
+      },
+      pendingConfigChanges: null,
+      onSelect: () => {},
+    });
+
+    expect(mode?.key).toBe("mode");
+    expect(mode?.options.map((option) => option.value)).not.toContain("auto");
+    const selected = mode?.options.find((option) => option.selected);
+    expect(selected?.value).toBe("default");
+  });
+
+  it("keeps the full agent-level mode vocabulary when the model has no per-model modes", () => {
+    const [mode] = buildLaunchControlDescriptors({
+      selection: { kind: "claude", modelId: "sonnet" },
+      launchAgents: [
+        {
+          kind: "claude",
+          launchControls: [modeControl()],
+          models: [{ id: "sonnet", modeValues: null }],
+        },
+      ],
+      preferences: {
+        defaultSessionModeByAgentKind: {},
+        defaultLiveSessionControlValuesByAgentKind: {},
+      },
+      pendingConfigChanges: null,
+      onSelect: () => {},
+    });
+
+    expect(mode?.options.map((option) => option.value)).toContain("auto");
+  });
+});
+
 describe("buildLaunchControlDescriptors", () => {
   it("builds descriptors from agent launch controls", () => {
     const controls = buildLaunchControlDescriptors({

--- a/apps/desktop/src/lib/domain/chat/models/launch-control-descriptors.ts
+++ b/apps/desktop/src/lib/domain/chat/models/launch-control-descriptors.ts
@@ -21,6 +21,8 @@ export interface BuildLaunchControlDescriptorsInput {
     launchControls?: DesktopAgentLaunchControl[];
     models: Array<{
       id: string;
+      aliases?: string[];
+      modeValues?: string[] | null;
     }>;
   }>;
   preferences: LaunchControlPreferences;
@@ -45,10 +47,16 @@ export function buildLaunchControlDescriptors(
     return [];
   }
 
+  const selectedModelId = input.selection.modelId;
+  const selectedModel = agent.models.find((candidate) =>
+    candidate.id === selectedModelId || (candidate.aliases ?? []).includes(selectedModelId));
+  const selectedModelModeValues = selectedModel?.modeValues ?? null;
+
   return (agent.launchControls ?? [])
     .flatMap((control) => launchControlToDescriptor({
       agentKind: agent.kind,
       control,
+      modelModeValues: selectedModelModeValues,
       pendingConfigChanges: input.pendingConfigChanges,
       preferences: input.preferences,
       onSelect: input.onSelect,
@@ -58,6 +66,7 @@ export function buildLaunchControlDescriptors(
 function launchControlToDescriptor(input: {
   agentKind: string;
   control: DesktopAgentLaunchControl;
+  modelModeValues?: string[] | null;
   pendingConfigChanges: PendingSessionConfigChanges | null;
   preferences: LaunchControlPreferences;
   onSelect: (
@@ -72,17 +81,35 @@ function launchControlToDescriptor(input: {
     return [];
   }
   const rawConfigId = input.control.createField === "modeId" ? "mode" : input.control.key;
+  // Scope the `mode` control to the modes the selected model actually supports
+  // (the agent-level vocabulary is a superset — e.g. gateway/bedrock models
+  // reject `auto`). Fall back to the full list if scoping would empty it.
+  const controlValues = key === "mode" && input.modelModeValues && input.modelModeValues.length > 0
+    ? (() => {
+      const scoped = input.control.values.filter(
+        (value) => input.modelModeValues!.includes(value.value),
+      );
+      return scoped.length > 0 ? scoped : input.control.values;
+    })()
+    : input.control.values;
   const pendingChange = getPendingSessionConfigChange(
     input.pendingConfigChanges,
     rawConfigId,
   );
 
+  // For `mode`, only honour a stored/default preference if the selected model
+  // still supports it, so a persisted `auto` doesn't survive onto a model that
+  // rejects it. Non-mode controls keep their existing resolution.
+  const modeSupports = (value: string | null | undefined): boolean =>
+    !!value && controlValues.some((candidate) => candidate.value === value);
   const selectedValue = key === "mode"
-    ? pendingChange?.value
-      || input.preferences.defaultSessionModeByAgentKind[input.agentKind]
-      || input.control.defaultValue
-      || input.control.values.find((value) => value.isDefault)?.value
-      || input.control.values[0]?.value
+    ? (modeSupports(pendingChange?.value) ? pendingChange?.value : null)
+      || (modeSupports(input.preferences.defaultSessionModeByAgentKind[input.agentKind])
+        ? input.preferences.defaultSessionModeByAgentKind[input.agentKind]
+        : null)
+      || (modeSupports(input.control.defaultValue) ? input.control.defaultValue : null)
+      || controlValues.find((value) => value.isDefault)?.value
+      || controlValues[0]?.value
       || null
     : pendingChange?.value
       || input.preferences.defaultLiveSessionControlValuesByAgentKind[input.agentKind]?.[key]
@@ -91,7 +118,7 @@ function launchControlToDescriptor(input: {
       || input.control.values[0]?.value
       || null;
   const detail =
-    input.control.values.find((value) => value.value === selectedValue)?.label
+    controlValues.find((value) => value.value === selectedValue)?.label
     ?? selectedValue;
 
   const descriptorBase = {
@@ -101,7 +128,7 @@ function launchControlToDescriptor(input: {
     rawConfigId,
     settable: true,
     pendingState: pendingChange?.status ?? null,
-    options: input.control.values.map((value) => ({
+    options: controlValues.map((value) => ({
       value: value.value,
       label: value.label,
       description: value.description,
@@ -121,7 +148,7 @@ function launchControlToDescriptor(input: {
     label: input.control.label,
     currentValue: selectedValue,
     settable: true,
-    values: input.control.values.map((value) => ({
+    values: controlValues.map((value) => ({
       value: value.value,
       label: value.label,
       description: value.description,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,6 +771,9 @@ importers:
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
+      playwright:
+        specifier: ^1.61.0
+        version: 1.61.0
       tsx:
         specifier: ^4.22.4
         version: 4.22.4

--- a/scripts/ci-cd/assemble-candidate-build-map.mjs
+++ b/scripts/ci-cd/assemble-candidate-build-map.mjs
@@ -1,16 +1,27 @@
 #!/usr/bin/env node
 // Portable CandidateBuildMapV1 assembler
 // (specs/developing/testing/candidate-build-handoff.md "Candidate build map").
-// Given a built binary, computes its SHA-256 and writes the local_file-only
-// candidate build map the qualification runner consumes. Defaults derive the
-// source SHA from `git rev-parse HEAD`, the version from the repository
-// VERSION file, and the artifact target from `rustc -vV` host.
+// Given one or more built artifacts, computes their SHA-256 and writes the
+// local_file-only candidate build map the qualification runner consumes.
+// Defaults derive the source SHA from `git rev-parse HEAD` and the version
+// from the repository VERSION file.
 //
-// Usage:
+// Single-artifact usage (back-compat; unchanged since PR #1159):
 //   node scripts/ci-cd/assemble-candidate-build-map.mjs \
 //     --binary <path> --output <path> \
 //     [--source-sha <40-hex>] [--version <v>] [--target <rust-triple>] \
 //     [--artifact-prefix anyharness]
+//
+// Multi-artifact usage ("Prove One Real Local Workspace Turn" — the three
+// exact candidates: server/<docker-platform>, anyharness/<rust-host-target>,
+// desktop-renderer/browser):
+//   node scripts/ci-cd/assemble-candidate-build-map.mjs \
+//     --artifact server/linux/arm64=/path/to/server.tar:0.3.28 \
+//     --artifact anyharness/aarch64-apple-darwin=/path/to/anyharness:0.3.28 \
+//     --artifact desktop-renderer/browser=/path/to/renderer.tar:0.3.28 \
+//     --output <path> [--source-sha <40-hex>] [--version <default-version>]
+//
+// `--artifact` may be repeated and must not be combined with `--binary`.
 
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
@@ -20,6 +31,53 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
+const ARTIFACT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/;
+const MAX_ARTIFACT_ID_LENGTH = 128;
+const MAX_VERSION_LENGTH = 128;
+
+function resolveSourceSha(sourceSha) {
+  const resolved = (sourceSha ?? gitHeadSha()).trim().toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(resolved)) {
+    throw new Error(`source SHA must be a lowercase 40-hex commit SHA, got "${resolved}"`);
+  }
+  return resolved;
+}
+
+function resolveVersion(version) {
+  const resolved = (version ?? repositoryVersion()).trim();
+  if (resolved.length === 0 || resolved.length > MAX_VERSION_LENGTH) {
+    throw new Error("version must be non-empty and bounded");
+  }
+  return resolved;
+}
+
+function checkArtifactId(artifactId) {
+  // Same contract as the runner-side loader
+  // (tests/release/src/artifacts/build-map.ts): the assembler must never be
+  // able to emit a map the runner would reject.
+  if (
+    typeof artifactId !== "string" ||
+    artifactId.length === 0 ||
+    artifactId.length > MAX_ARTIFACT_ID_LENGTH ||
+    !ARTIFACT_ID_PATTERN.test(artifactId)
+  ) {
+    throw new Error(`assembled artifact_id is unsafe: "${artifactId}"`);
+  }
+}
+
+function hashFile(filePath) {
+  const stats = statSync(filePath);
+  if (!stats.isFile()) {
+    throw new Error(`artifact path must be a regular file, got ${filePath}`);
+  }
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+/**
+ * Single-binary assembler. Unchanged signature/behavior from PR #1159 so
+ * existing callers (`make qualification-candidate-build-map`,
+ * `make qualification-candidate-handoff-smoke`) and their tests keep working.
+ */
 export function assembleCandidateBuildMap({ binaryPath, sourceSha, version, target, artifactPrefix }) {
   if (!binaryPath) {
     throw new Error("--binary <path> is required");
@@ -28,29 +86,15 @@ export function assembleCandidateBuildMap({ binaryPath, sourceSha, version, targ
   if (!stats.isFile()) {
     throw new Error(`--binary must be a regular file, got ${binaryPath}`);
   }
-  const resolvedSha = (sourceSha ?? gitHeadSha()).trim().toLowerCase();
-  if (!/^[0-9a-f]{40}$/.test(resolvedSha)) {
-    throw new Error(`source SHA must be a lowercase 40-hex commit SHA, got "${resolvedSha}"`);
-  }
-  const resolvedVersion = (version ?? repositoryVersion()).trim();
-  if (resolvedVersion.length === 0 || resolvedVersion.length > 128) {
-    throw new Error("version must be non-empty and bounded");
-  }
+  const resolvedSha = resolveSourceSha(sourceSha);
+  const resolvedVersion = resolveVersion(version);
   const resolvedTarget = (target ?? rustHostTarget()).trim();
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(resolvedTarget)) {
     throw new Error(`rust target triple looks unsafe: "${resolvedTarget}"`);
   }
   const sha256 = createHash("sha256").update(readFileSync(binaryPath)).digest("hex");
   const artifactId = `${artifactPrefix ?? "anyharness"}/${resolvedTarget}`;
-  // Same contract as the runner-side loader
-  // (tests/release/src/artifacts/build-map.ts): the assembler must never be
-  // able to emit a map the runner would reject.
-  if (
-    artifactId.length > 128 ||
-    !/^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/.test(artifactId)
-  ) {
-    throw new Error(`assembled artifact_id is unsafe: "${artifactId}"`);
-  }
+  checkArtifactId(artifactId);
   return {
     schema_version: 1,
     kind: "proliferate.candidate-build",
@@ -63,6 +107,47 @@ export function assembleCandidateBuildMap({ binaryPath, sourceSha, version, targ
         locator: { kind: "local_file", path: path.resolve(binaryPath) },
       },
     ],
+  };
+}
+
+/**
+ * Multi-artifact assembler (the three-candidate local-world proof: Server
+ * docker-save archive, release AnyHarness binary, Desktop renderer archive).
+ * `artifacts` is a small typed list, each `{ artifactId, path, version? }`;
+ * a missing per-artifact version falls back to the shared `defaultVersion`
+ * (or the repository VERSION file). Every entry is independently hashed and
+ * validated against the exact same rules the runner-side loader enforces, so
+ * this function can never emit a map the runner would reject.
+ */
+export function assembleCandidateBuildMapFromArtifacts({ artifacts, sourceSha, defaultVersion }) {
+  if (!Array.isArray(artifacts) || artifacts.length === 0) {
+    throw new Error("--artifact <id>=<path>[:<version>] is required at least once");
+  }
+  const resolvedSha = resolveSourceSha(sourceSha);
+  const seenIds = new Set();
+  const resolvedArtifacts = artifacts.map(({ artifactId, path: artifactPath, version }) => {
+    if (!artifactPath) {
+      throw new Error(`--artifact "${artifactId}" is missing a path`);
+    }
+    checkArtifactId(artifactId);
+    if (seenIds.has(artifactId)) {
+      throw new Error(`Duplicate artifact_id "${artifactId}".`);
+    }
+    seenIds.add(artifactId);
+    const resolvedVersion = resolveVersion(version ?? defaultVersion);
+    const sha256 = hashFile(artifactPath);
+    return {
+      artifact_id: artifactId,
+      version: resolvedVersion,
+      sha256,
+      locator: { kind: "local_file", path: path.resolve(artifactPath) },
+    };
+  });
+  return {
+    schema_version: 1,
+    kind: "proliferate.candidate-build",
+    source_sha: resolvedSha,
+    artifacts: resolvedArtifacts,
   };
 }
 
@@ -88,23 +173,73 @@ function argValue(flag) {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
+function allArgValues(flag) {
+  const values = [];
+  for (let i = 0; i < process.argv.length; i += 1) {
+    if (process.argv[i] === flag) {
+      values.push(process.argv[i + 1]);
+    }
+  }
+  return values;
+}
+
+/**
+ * Parses `<artifact-id>=<path>[:<version>]`. The path may itself contain a
+ * `:` on some hosts, so only the LAST `:` after the `=` is treated as a
+ * version separator, and only when what follows looks like a bounded version
+ * token rather than a path fragment (i.e. contains no `/`).
+ */
+function parseArtifactFlag(raw) {
+  const eq = raw.indexOf("=");
+  if (eq <= 0) {
+    throw new Error(`--artifact must look like <id>=<path>[:<version>], got "${raw}"`);
+  }
+  const artifactId = raw.slice(0, eq);
+  const rest = raw.slice(eq + 1);
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon > 0) {
+    const candidateVersion = rest.slice(lastColon + 1);
+    if (
+      candidateVersion.length > 0 &&
+      !candidateVersion.includes("/") &&
+      candidateVersion.length <= MAX_VERSION_LENGTH
+    ) {
+      return { artifactId, path: rest.slice(0, lastColon), version: candidateVersion };
+    }
+  }
+  return { artifactId, path: rest, version: undefined };
+}
+
 function main() {
   const outputPath = argValue("--output");
   if (!outputPath) {
     throw new Error("--output <path> is required");
   }
-  const map = assembleCandidateBuildMap({
-    binaryPath: argValue("--binary"),
-    sourceSha: argValue("--source-sha"),
-    version: argValue("--version"),
-    target: argValue("--target"),
-    artifactPrefix: argValue("--artifact-prefix"),
-  });
+  const rawArtifacts = allArgValues("--artifact");
+  const binaryPath = argValue("--binary");
+  if (rawArtifacts.length > 0 && binaryPath) {
+    throw new Error("--artifact cannot be combined with --binary; pick one mode");
+  }
+
+  const map =
+    rawArtifacts.length > 0
+      ? assembleCandidateBuildMapFromArtifacts({
+          artifacts: rawArtifacts.map(parseArtifactFlag),
+          sourceSha: argValue("--source-sha"),
+          defaultVersion: argValue("--version"),
+        })
+      : assembleCandidateBuildMap({
+          binaryPath,
+          sourceSha: argValue("--source-sha"),
+          version: argValue("--version"),
+          target: argValue("--target"),
+          artifactPrefix: argValue("--artifact-prefix"),
+        });
+
   mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
   writeFileSync(outputPath, `${JSON.stringify(map, null, 2)}\n`, "utf8");
-  console.log(
-    `candidate build map written: ${outputPath} (${map.artifacts[0].artifact_id}@${map.artifacts[0].version})`,
-  );
+  const summary = map.artifacts.map((artifact) => `${artifact.artifact_id}@${artifact.version}`).join(", ");
+  console.log(`candidate build map written: ${outputPath} (${summary})`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/ci-cd/assemble-candidate-build-map.test.mjs
+++ b/scripts/ci-cd/assemble-candidate-build-map.test.mjs
@@ -7,12 +7,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
-import { assembleCandidateBuildMap } from "./assemble-candidate-build-map.mjs";
+import { assembleCandidateBuildMap, assembleCandidateBuildMapFromArtifacts } from "./assemble-candidate-build-map.mjs";
 
 const SHA = "a".repeat(40);
 
-function tempBinary(dir, content = "fake-binary-bytes") {
-  const binaryPath = path.join(dir, "anyharness");
+function tempBinary(dir, content = "fake-binary-bytes", filename = "anyharness") {
+  const binaryPath = path.join(dir, filename);
   writeFileSync(binaryPath, content);
   return { binaryPath, sha256: createHash("sha256").update(content).digest("hex") };
 }
@@ -85,6 +85,130 @@ test("CLI writes the map file", () => {
     const map = JSON.parse(readFileSync(outputPath, "utf8"));
     assert.equal(map.artifacts[0].sha256, sha256);
     assert.equal(map.artifacts[0].version, "9.9.9");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("assembles a valid three-artifact local-world candidate map", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "assemble-map-multi-"));
+  try {
+    const server = tempBinary(dir, "server-tar-bytes", "server.tar");
+    const anyharness = tempBinary(dir, "anyharness-binary-bytes", "anyharness-bin");
+    const renderer = tempBinary(dir, "renderer-archive-bytes", "renderer.tar");
+    const map = assembleCandidateBuildMapFromArtifacts({
+      sourceSha: SHA,
+      defaultVersion: "0.3.28",
+      artifacts: [
+        { artifactId: "server/linux/arm64", path: server.binaryPath },
+        { artifactId: "anyharness/aarch64-apple-darwin", path: anyharness.binaryPath, version: "0.3.28" },
+        { artifactId: "desktop-renderer/browser", path: renderer.binaryPath },
+      ],
+    });
+    assert.equal(map.schema_version, 1);
+    assert.equal(map.kind, "proliferate.candidate-build");
+    assert.equal(map.source_sha, SHA);
+    assert.equal(map.artifacts.length, 3);
+    assert.equal(map.artifacts[0].artifact_id, "server/linux/arm64");
+    assert.equal(map.artifacts[0].sha256, server.sha256);
+    assert.equal(map.artifacts[0].version, "0.3.28");
+    assert.equal(map.artifacts[1].artifact_id, "anyharness/aarch64-apple-darwin");
+    assert.equal(map.artifacts[1].sha256, anyharness.sha256);
+    assert.equal(map.artifacts[2].artifact_id, "desktop-renderer/browser");
+    assert.equal(map.artifacts[2].sha256, renderer.sha256);
+    for (const artifact of map.artifacts) {
+      assert.equal(artifact.locator.kind, "local_file");
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("rejects a multi-artifact map with a duplicate id, missing path, or empty list", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "assemble-map-multi-"));
+  try {
+    const { binaryPath } = tempBinary(dir);
+    assert.throws(() =>
+      assembleCandidateBuildMapFromArtifacts({ sourceSha: SHA, defaultVersion: "1", artifacts: [] }),
+    );
+    assert.throws(() =>
+      assembleCandidateBuildMapFromArtifacts({
+        sourceSha: SHA,
+        defaultVersion: "1",
+        artifacts: [
+          { artifactId: "server/linux/arm64", path: binaryPath },
+          { artifactId: "server/linux/arm64", path: binaryPath },
+        ],
+      }),
+    );
+    assert.throws(() =>
+      assembleCandidateBuildMapFromArtifacts({
+        sourceSha: SHA,
+        defaultVersion: "1",
+        artifacts: [{ artifactId: "server/linux/arm64", path: undefined }],
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI writes a three-artifact map from repeated --artifact flags", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "assemble-map-cli-multi-"));
+  try {
+    const server = tempBinary(dir, "server-tar-bytes", "server.tar");
+    const anyharness = tempBinary(dir, "anyharness-binary-bytes", "anyharness-bin");
+    const renderer = tempBinary(dir, "renderer-archive-bytes", "renderer.tar");
+    const outputPath = path.join(dir, "out", "candidate-build.json");
+    const script = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "assemble-candidate-build-map.mjs",
+    );
+    execFileSync(process.execPath, [
+      script,
+      "--artifact",
+      `server/linux/arm64=${server.binaryPath}:0.3.28`,
+      "--artifact",
+      `anyharness/aarch64-apple-darwin=${anyharness.binaryPath}:0.3.28`,
+      "--artifact",
+      `desktop-renderer/browser=${renderer.binaryPath}:0.3.28`,
+      "--output",
+      outputPath,
+      "--source-sha",
+      SHA,
+    ]);
+    const map = JSON.parse(readFileSync(outputPath, "utf8"));
+    assert.equal(map.artifacts.length, 3);
+    assert.equal(map.artifacts[0].sha256, server.sha256);
+    assert.equal(map.artifacts[1].sha256, anyharness.sha256);
+    assert.equal(map.artifacts[2].sha256, renderer.sha256);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI rejects --artifact combined with --binary", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "assemble-map-cli-conflict-"));
+  try {
+    const { binaryPath } = tempBinary(dir);
+    const outputPath = path.join(dir, "out", "candidate-build.json");
+    const script = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "assemble-candidate-build-map.mjs",
+    );
+    assert.throws(() =>
+      execFileSync(process.execPath, [
+        script,
+        "--binary",
+        binaryPath,
+        "--artifact",
+        `server/linux/arm64=${binaryPath}:1`,
+        "--output",
+        outputPath,
+        "--source-sha",
+        SHA,
+      ]),
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/ci-cd/build-local-qualification-candidates.mjs
+++ b/scripts/ci-cd/build-local-qualification-candidates.mjs
@@ -188,8 +188,12 @@ export function buildDesktopRendererArchive({
   exec = defaultExec,
   log = () => {},
 }) {
-  log("pnpm --filter @proliferate/desktop build (VITE_* set to this run's allocated URLs)");
-  exec("pnpm", ["--filter", "@proliferate/desktop", "build"], {
+  // The Desktop app's package name is `proliferate` (apps/desktop/package.json),
+  // NOT `@proliferate/desktop`; the latter matches no pnpm project and silently
+  // builds nothing. Its `build` script also builds the shared frontend packages
+  // it consumes as dist before `tsc && vite build`.
+  log("pnpm --filter proliferate build (VITE_* set to this run's allocated URLs)");
+  exec("pnpm", ["--filter", "proliferate", "build"], {
     env: {
       ...process.env,
       VITE_PROLIFERATE_API_BASE_URL: apiBaseUrl,
@@ -198,8 +202,13 @@ export function buildDesktopRendererArchive({
   });
   requireRegularFile(path.join(distDir, "index.html"), "Desktop renderer dist");
   mkdirSync(path.dirname(outputPath), { recursive: true });
-  log(`tar -czf ${outputPath} -C ${path.dirname(distDir)} ${path.basename(distDir)}`);
-  exec("tar", ["-czf", outputPath, "-C", path.dirname(distDir), path.basename(distDir)]);
+  // Pack the CONTENTS of dist at the archive root (`-C distDir .`), so
+  // `index.html` lands directly under the extraction dir — the layout the
+  // world's renderer server serves from (`renderer.ts` "Archive layout
+  // contract"). Packing the `dist/` directory itself would nest index.html one
+  // level too deep and the static server's SPA fallback would 500.
+  log(`tar -czf ${outputPath} -C ${distDir} .`);
+  exec("tar", ["-czf", outputPath, "-C", distDir, "."]);
   requireRegularFile(outputPath, "Desktop renderer archive");
   return outputPath;
 }

--- a/scripts/ci-cd/build-local-qualification-candidates.mjs
+++ b/scripts/ci-cd/build-local-qualification-candidates.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// The one local/Actions producer of the three exact local-world candidates
+// (Prove One Real Local Workspace Turn — "Build order"):
+//
+//   choose run/profile identity and allocate non-conflicting ports
+//   -> build Server image archive
+//   -> build release AnyHarness
+//   -> build the browser-rendered Desktop product with those API/runtime URLs
+//   -> assemble one three-artifact candidate map
+//
+// `make qualification-local-workspace` and the release-e2e.yml manual job
+// both call this same script — there is no second implementation of these
+// build steps. Allocating ports and writing the candidate map is preparation,
+// not product world startup: this script never starts a database, Server,
+// AnyHarness, renderer, browser, actor, or scenario.
+//
+// Usage:
+//   node scripts/ci-cd/build-local-qualification-candidates.mjs \
+//     --run-id <run-id> --shard-id <shard-id> --run-dir <path> \
+//     [--source-sha <40-hex>] [--version <v>] [--target <rust-triple>]
+//
+// Prints one line of machine-readable JSON to stdout on success:
+//   {"run_id":...,"shard_id":...,"candidate_build_map":"<path>",
+//    "ports":{"server":N,"postgres":N,"redis":N,"anyharness":N,"renderer":N},
+//    "urls":{"api_base_url":"...","anyharness_dev_url":"..."}}
+
+import { execFileSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { assembleCandidateBuildMapFromArtifacts, gitHeadSha, repositoryVersion } from "./assemble-candidate-build-map.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+/** Default exec seam: real execFileSync. The unit test injects a fake that
+ * records argv and materializes canned output files instead of doing a real
+ * docker/cargo/pnpm/tar build. */
+function defaultExec(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: "utf8", cwd: REPO_ROOT, ...options });
+}
+
+function defaultEphemeralPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") {
+        const port = address.port;
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error("could not allocate an ephemeral port")));
+      }
+    });
+    server.on("error", reject);
+  });
+}
+
+/**
+ * Five non-conflicting ephemeral ports, allocated up front — preparation,
+ * not world startup. `server` and `anyharness` are baked into the Desktop
+ * renderer's VITE_* build-time URLs below, so `constructLocalWorld` MUST
+ * reuse this exact allocation (read from the ports file this script writes
+ * into the run directory) rather than re-probing its own — otherwise the
+ * renderer's baked URLs would not match the world it boots into.
+ */
+export async function allocateLocalWorldPorts(deps = {}) {
+  const alloc = deps.ephemeralPort ?? defaultEphemeralPort;
+  const [server, postgres, redis, anyharness, renderer] = await Promise.all([
+    alloc(),
+    alloc(),
+    alloc(),
+    alloc(),
+    alloc(),
+  ]);
+  return { server, postgres, redis, anyharness, renderer };
+}
+
+function requireRegularFile(filePath, what) {
+  let stats;
+  try {
+    stats = statSync(filePath);
+  } catch (error) {
+    throw new Error(
+      `${what} was not produced at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!stats.isFile()) {
+    throw new Error(`${what} at ${filePath} is not a regular file`);
+  }
+}
+
+function requireSafeId(value, what) {
+  if (typeof value !== "string" || !SAFE_ID_PATTERN.test(value)) {
+    throw new Error(`${what} must be a safe id, got "${value}"`);
+  }
+  return value;
+}
+
+/**
+ * `rustc -vV` host target triple, resolved through the same injectable exec
+ * seam as every other external call in this module (unlike the sibling
+ * assembler's `rustHostTarget()`, which always shells out for real — this
+ * copy exists so a caller that never supplies `options.target` still gets a
+ * fully offline, fake-exec-driven unit test).
+ */
+export function resolveRustHostTarget(exec = defaultExec) {
+  const output = exec("rustc", ["-vV"]);
+  const match = output.match(/^host:\s*(\S+)$/m);
+  if (!match) {
+    throw new Error("could not parse host target from rustc -vV");
+  }
+  return match[1];
+}
+
+/**
+ * `docker version -f '{{.Server.Os}}/{{.Server.Arch}}'`, normalized (e.g.
+ * `linux/arm64`) — used verbatim as the `server/<docker-platform>` artifact
+ * id suffix.
+ */
+export function resolveDockerPlatform(exec = defaultExec) {
+  const output = exec("docker", ["version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"]);
+  const platform = output.trim();
+  if (!/^[a-z0-9]+\/[a-z0-9]+$/.test(platform)) {
+    throw new Error(`could not resolve a safe docker platform from "${platform}"`);
+  }
+  return platform;
+}
+
+/** Builds the Server image from server/Dockerfile and docker-saves it to
+ * `outputPath`. Returns the resolved image tag. */
+export function buildServerArchive({ outputPath, version, exec = defaultExec, log = () => {} }) {
+  const tag = `proliferate-server-qualification:${version}`;
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  log(`docker build -f server/Dockerfile --build-arg SERVER_VERSION=${version} -t ${tag} .`);
+  exec("docker", ["build", "-f", "server/Dockerfile", "--build-arg", `SERVER_VERSION=${version}`, "-t", tag, "."]);
+  log(`docker save -o ${outputPath} ${tag}`);
+  exec("docker", ["save", "-o", outputPath, tag]);
+  requireRegularFile(outputPath, "Server docker-save archive");
+  return tag;
+}
+
+/**
+ * Builds the release AnyHarness binary for the host Rust target, stamped
+ * with the repository VERSION and source SHA (same convention as
+ * `make qualification-candidate-handoff-smoke`), and materializes it at
+ * `outputPath`.
+ */
+export function buildAnyharnessBinary({
+  outputPath,
+  version,
+  sourceSha,
+  targetDir,
+  exec = defaultExec,
+  log = () => {},
+}) {
+  log("cargo build --release -p anyharness");
+  exec("cargo", ["build", "--release", "-p", "anyharness"], {
+    env: {
+      ...process.env,
+      CARGO_TARGET_DIR: targetDir,
+      PROLIFERATE_BUILD_VERSION: version,
+      PROLIFERATE_BUILD_SHA: sourceSha,
+    },
+  });
+  const builtPath = path.join(targetDir, "release", "anyharness");
+  requireRegularFile(builtPath, "release AnyHarness binary");
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  copyFileSync(builtPath, outputPath);
+  chmodSync(outputPath, 0o755);
+  requireRegularFile(outputPath, "materialized AnyHarness binary");
+  return outputPath;
+}
+
+/**
+ * Builds the Desktop renderer dist with this run's allocated API/AnyHarness
+ * URLs baked in via VITE_PROLIFERATE_API_BASE_URL / VITE_ANYHARNESS_DEV_URL,
+ * then archives the dist directory to `outputPath`.
+ */
+export function buildDesktopRendererArchive({
+  outputPath,
+  apiBaseUrl,
+  anyharnessDevUrl,
+  distDir = path.join(REPO_ROOT, "apps", "desktop", "dist"),
+  exec = defaultExec,
+  log = () => {},
+}) {
+  log("pnpm --filter @proliferate/desktop build (VITE_* set to this run's allocated URLs)");
+  exec("pnpm", ["--filter", "@proliferate/desktop", "build"], {
+    env: {
+      ...process.env,
+      VITE_PROLIFERATE_API_BASE_URL: apiBaseUrl,
+      VITE_ANYHARNESS_DEV_URL: anyharnessDevUrl,
+    },
+  });
+  requireRegularFile(path.join(distDir, "index.html"), "Desktop renderer dist");
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  log(`tar -czf ${outputPath} -C ${path.dirname(distDir)} ${path.basename(distDir)}`);
+  exec("tar", ["-czf", outputPath, "-C", path.dirname(distDir), path.basename(distDir)]);
+  requireRegularFile(outputPath, "Desktop renderer archive");
+  return outputPath;
+}
+
+/**
+ * Orchestrates the full local build: allocates ports, builds the three
+ * candidates, assembles and writes the candidate build map and the ports
+ * file, and returns the machine-readable summary this script prints.
+ *
+ * Every side-effecting step is behind an injectable `exec`/`ephemeralPort`
+ * seam so the unit test can fake all of docker/cargo/pnpm/tar and exercise
+ * this orchestration deterministically and offline — no real builds run in
+ * the unit test.
+ */
+export async function buildLocalQualificationCandidates(options, deps = {}) {
+  const runId = requireSafeId(options.runId, "--run-id");
+  const shardId = requireSafeId(options.shardId, "--shard-id");
+  if (!options.runDir) {
+    throw new Error("--run-dir <path> is required");
+  }
+  const runDir = path.resolve(options.runDir);
+  const exec = deps.exec ?? defaultExec;
+  const log = deps.log ?? (() => {});
+  const alloc = deps.allocatePorts ?? allocateLocalWorldPorts;
+
+  const sourceSha = (options.sourceSha ?? gitHeadSha()).trim().toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+    throw new Error(`source SHA must be a lowercase 40-hex commit SHA, got "${sourceSha}"`);
+  }
+  const version = (options.version ?? repositoryVersion()).trim();
+  const target = (options.target ?? resolveRustHostTarget(exec)).trim();
+  const dockerPlatform = options.dockerPlatform ?? resolveDockerPlatform(exec);
+
+  log(`allocating non-conflicting ports for run=${runId} shard=${shardId}`);
+  const ports = await alloc({ ephemeralPort: deps.ephemeralPort });
+
+  const artifactsDir = path.join(runDir, "artifacts");
+  const serverArchivePath = path.join(artifactsDir, "server.tar");
+  const anyharnessBinaryPath = path.join(artifactsDir, "anyharness");
+  const rendererArchivePath = path.join(artifactsDir, "renderer.tar.gz");
+  const anyharnessTargetDir = path.join(runDir, "cargo-target");
+
+  buildServerArchive({ outputPath: serverArchivePath, version, exec, log });
+
+  buildAnyharnessBinary({
+    outputPath: anyharnessBinaryPath,
+    version,
+    sourceSha,
+    targetDir: anyharnessTargetDir,
+    exec,
+    log,
+  });
+
+  const apiBaseUrl = `http://127.0.0.1:${ports.server}`;
+  const anyharnessDevUrl = `http://127.0.0.1:${ports.anyharness}`;
+  buildDesktopRendererArchive({
+    outputPath: rendererArchivePath,
+    apiBaseUrl,
+    anyharnessDevUrl,
+    distDir: options.desktopDistDir,
+    exec,
+    log,
+  });
+
+  const map = assembleCandidateBuildMapFromArtifacts({
+    sourceSha,
+    defaultVersion: version,
+    artifacts: [
+      { artifactId: `server/${dockerPlatform}`, path: serverArchivePath },
+      { artifactId: `anyharness/${target}`, path: anyharnessBinaryPath },
+      { artifactId: "desktop-renderer/browser", path: rendererArchivePath },
+    ],
+  });
+
+  const candidateBuildMapPath = path.join(runDir, "candidate-build.json");
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(candidateBuildMapPath, `${JSON.stringify(map, null, 2)}\n`, "utf8");
+
+  const portsPath = path.join(runDir, "local-world-ports.json");
+  writeFileSync(portsPath, `${JSON.stringify(ports, null, 2)}\n`, "utf8");
+
+  return {
+    run_id: runId,
+    shard_id: shardId,
+    candidate_build_map: candidateBuildMapPath,
+    ports_file: portsPath,
+    ports,
+    urls: { api_base_url: apiBaseUrl, anyharness_dev_url: anyharnessDevUrl },
+  };
+}
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main() {
+  const summary = await buildLocalQualificationCandidates({
+    runId: argValue("--run-id"),
+    shardId: argValue("--shard-id"),
+    runDir: argValue("--run-dir"),
+    sourceSha: argValue("--source-sha"),
+    version: argValue("--version"),
+    target: argValue("--target"),
+  }, {
+    log: (message) => console.error(`[build-local-qualification-candidates] ${message}`),
+  });
+  console.log(JSON.stringify(summary));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci-cd/build-local-qualification-candidates.test.mjs
+++ b/scripts/ci-cd/build-local-qualification-candidates.test.mjs
@@ -163,10 +163,16 @@ test("buildDesktopRendererArchive bakes VITE_* URLs and archives the dist direct
     });
     assert.ok(existsSync(outputPath));
     const pnpmCall = calls.find((call) => call.command === "pnpm");
+    // The Desktop package name is `proliferate`; the wrong `@proliferate/desktop`
+    // filter matches no project and produces no dist.
+    assert.deepEqual(pnpmCall.args, ["--filter", "proliferate", "build"]);
     assert.equal(pnpmCall.options.env.VITE_PROLIFERATE_API_BASE_URL, "http://127.0.0.1:40001");
     assert.equal(pnpmCall.options.env.VITE_ANYHARNESS_DEV_URL, "http://127.0.0.1:40004");
     const tarCall = calls.find((call) => call.command === "tar");
     assert.equal(tarCall.args[1], outputPath);
+    // Packs dist CONTENTS at the archive root (`-C <distDir> .`) so index.html
+    // extracts directly under the world's renderer root (not nested in dist/).
+    assert.deepEqual(tarCall.args, ["-czf", outputPath, "-C", distDir, "."]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/ci-cd/build-local-qualification-candidates.test.mjs
+++ b/scripts/ci-cd/build-local-qualification-candidates.test.mjs
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  allocateLocalWorldPorts,
+  buildAnyharnessBinary,
+  buildDesktopRendererArchive,
+  buildLocalQualificationCandidates,
+  buildServerArchive,
+  resolveDockerPlatform,
+  resolveRustHostTarget,
+} from "./build-local-qualification-candidates.mjs";
+
+const SHA = "b".repeat(40);
+
+/** Records every invocation and never shells out for real; each build step
+ * materializes its expected output file with deterministic fake bytes so the
+ * downstream SHA-256 hashing has real bytes to hash. Fully offline. */
+function fakeExecFactory() {
+  const calls = [];
+  const exec = (command, args, options) => {
+    calls.push({ command, args, options });
+    if (command === "rustc") {
+      return "host: x86_64-unknown-linux-gnu\n";
+    }
+    if (command === "docker" && args[0] === "version") {
+      return "linux/amd64\n";
+    }
+    if (command === "docker" && args[0] === "save") {
+      const outputIndex = args.indexOf("-o");
+      writeFileSync(args[outputIndex + 1], "fake-docker-save-bytes");
+      return "";
+    }
+    if (command === "docker" && args[0] === "build") {
+      return "";
+    }
+    if (command === "cargo") {
+      const targetDir = options.env.CARGO_TARGET_DIR;
+      mkdirSync(path.join(targetDir, "release"), { recursive: true });
+      writeFileSync(path.join(targetDir, "release", "anyharness"), "fake-anyharness-binary-bytes");
+      return "";
+    }
+    if (command === "pnpm") {
+      return "";
+    }
+    if (command === "tar") {
+      const outputPath = args[1];
+      writeFileSync(outputPath, "fake-renderer-archive-bytes");
+      return "";
+    }
+    throw new Error(`fakeExec: unexpected command "${command}" ${JSON.stringify(args)}`);
+  };
+  return { exec, calls };
+}
+
+function fakeAllocatePorts() {
+  let next = 40000;
+  return async () => ({
+    server: next++,
+    postgres: next++,
+    redis: next++,
+    anyharness: next++,
+    renderer: next++,
+  });
+}
+
+test("allocateLocalWorldPorts returns five distinct ports from the injected allocator", async () => {
+  let counter = 50000;
+  const ports = await allocateLocalWorldPorts({ ephemeralPort: async () => counter++ });
+  const values = Object.values(ports);
+  assert.equal(values.length, 5);
+  assert.equal(new Set(values).size, 5);
+  assert.deepEqual(Object.keys(ports).sort(), ["anyharness", "postgres", "redis", "renderer", "server"]);
+});
+
+test("resolveRustHostTarget and resolveDockerPlatform go through the injected exec seam", () => {
+  const { exec, calls } = fakeExecFactory();
+  assert.equal(resolveRustHostTarget(exec), "x86_64-unknown-linux-gnu");
+  assert.equal(resolveDockerPlatform(exec), "linux/amd64");
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].command, "rustc");
+  assert.equal(calls[1].command, "docker");
+});
+
+test("resolveDockerPlatform rejects an unsafe/unparseable platform string", () => {
+  assert.throws(() => resolveDockerPlatform(() => "not a platform!"));
+});
+
+test("buildServerArchive shells out to docker build+save and requires the archive to exist", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-server-"));
+  try {
+    const { exec, calls } = fakeExecFactory();
+    const outputPath = path.join(dir, "server.tar");
+    const tag = buildServerArchive({ outputPath, version: "0.3.28", exec });
+    assert.equal(tag, "proliferate-server-qualification:0.3.28");
+    assert.ok(existsSync(outputPath));
+    assert.equal(calls[0].command, "docker");
+    assert.equal(calls[0].args[0], "build");
+    assert.ok(calls[0].args.includes("--build-arg"));
+    assert.ok(calls[0].args.includes("SERVER_VERSION=0.3.28"));
+    assert.equal(calls[1].command, "docker");
+    assert.equal(calls[1].args[0], "save");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildAnyharnessBinary stamps version/sha env and materializes an executable copy", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-anyharness-"));
+  try {
+    const { exec, calls } = fakeExecFactory();
+    const targetDir = path.join(dir, "cargo-target");
+    const outputPath = path.join(dir, "artifacts", "anyharness");
+    buildAnyharnessBinary({ outputPath, version: "0.3.28", sourceSha: SHA, targetDir, exec });
+    assert.ok(existsSync(outputPath));
+    assert.equal(readFileSync(outputPath, "utf8"), "fake-anyharness-binary-bytes");
+    assert.equal(calls[0].command, "cargo");
+    assert.equal(calls[0].options.env.CARGO_TARGET_DIR, targetDir);
+    assert.equal(calls[0].options.env.PROLIFERATE_BUILD_VERSION, "0.3.28");
+    assert.equal(calls[0].options.env.PROLIFERATE_BUILD_SHA, SHA);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildAnyharnessBinary fails when cargo does not produce the binary", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-anyharness-missing-"));
+  try {
+    const exec = () => "";
+    assert.throws(() =>
+      buildAnyharnessBinary({
+        outputPath: path.join(dir, "anyharness"),
+        version: "0.3.28",
+        sourceSha: SHA,
+        targetDir: path.join(dir, "cargo-target"),
+        exec,
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildDesktopRendererArchive bakes VITE_* URLs and archives the dist directory", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-renderer-"));
+  try {
+    const { exec, calls } = fakeExecFactory();
+    const distDir = path.join(dir, "apps", "desktop", "dist");
+    mkdirSync(distDir, { recursive: true });
+    // The pnpm build step is faked (no-op), so pre-seed the dist output the
+    // real build would have produced.
+    writeFileSync(path.join(distDir, "index.html"), "<html></html>");
+    const outputPath = path.join(dir, "artifacts", "renderer.tar.gz");
+    buildDesktopRendererArchive({
+      outputPath,
+      apiBaseUrl: "http://127.0.0.1:40001",
+      anyharnessDevUrl: "http://127.0.0.1:40004",
+      distDir,
+      exec,
+    });
+    assert.ok(existsSync(outputPath));
+    const pnpmCall = calls.find((call) => call.command === "pnpm");
+    assert.equal(pnpmCall.options.env.VITE_PROLIFERATE_API_BASE_URL, "http://127.0.0.1:40001");
+    assert.equal(pnpmCall.options.env.VITE_ANYHARNESS_DEV_URL, "http://127.0.0.1:40004");
+    const tarCall = calls.find((call) => call.command === "tar");
+    assert.equal(tarCall.args[1], outputPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildDesktopRendererArchive fails when the dist directory was not produced", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-renderer-missing-"));
+  try {
+    const { exec } = fakeExecFactory();
+    assert.throws(() =>
+      buildDesktopRendererArchive({
+        outputPath: path.join(dir, "renderer.tar.gz"),
+        apiBaseUrl: "http://127.0.0.1:1",
+        anyharnessDevUrl: "http://127.0.0.1:2",
+        distDir: path.join(dir, "nonexistent-dist"),
+        exec,
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildLocalQualificationCandidates: full offline orchestration produces a valid three-artifact map", async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-full-"));
+  try {
+    const { exec, calls } = fakeExecFactory();
+    const distDir = path.join(dir, "desktop-dist");
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(path.join(distDir, "index.html"), "<html></html>");
+    const runDir = path.join(dir, "run");
+
+    const summary = await buildLocalQualificationCandidates(
+      {
+        runId: "run-abc123",
+        shardId: "shard-1",
+        runDir,
+        sourceSha: SHA,
+        version: "0.3.28",
+        target: "aarch64-apple-darwin",
+        dockerPlatform: "linux/arm64",
+        desktopDistDir: distDir,
+      },
+      { exec, allocatePorts: fakeAllocatePorts(), log: () => {} },
+    );
+
+    assert.equal(summary.run_id, "run-abc123");
+    assert.equal(summary.shard_id, "shard-1");
+    assert.ok(existsSync(summary.candidate_build_map));
+    assert.ok(existsSync(summary.ports_file));
+
+    const map = JSON.parse(readFileSync(summary.candidate_build_map, "utf8"));
+    assert.equal(map.schema_version, 1);
+    assert.equal(map.kind, "proliferate.candidate-build");
+    assert.equal(map.source_sha, SHA);
+    assert.equal(map.artifacts.length, 3);
+    const ids = map.artifacts.map((artifact) => artifact.artifact_id).sort();
+    assert.deepEqual(ids, ["anyharness/aarch64-apple-darwin", "desktop-renderer/browser", "server/linux/arm64"]);
+    for (const artifact of map.artifacts) {
+      assert.match(artifact.sha256, /^[0-9a-f]{64}$/);
+      assert.equal(artifact.locator.kind, "local_file");
+    }
+
+    const ports = JSON.parse(readFileSync(summary.ports_file, "utf8"));
+    assert.deepEqual(Object.keys(ports).sort(), ["anyharness", "postgres", "redis", "renderer", "server"]);
+    assert.equal(summary.urls.api_base_url, `http://127.0.0.1:${ports.server}`);
+    assert.equal(summary.urls.anyharness_dev_url, `http://127.0.0.1:${ports.anyharness}`);
+
+    // Never shelled out to real rustc/docker-version resolution — target and
+    // docker platform were supplied explicitly.
+    assert.equal(
+      calls.some((call) => call.command === "rustc"),
+      false,
+    );
+    assert.equal(
+      calls.some((call) => call.command === "docker" && call.args[0] === "version"),
+      false,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildLocalQualificationCandidates rejects unsafe run-id/shard-id and a missing run-dir", async () => {
+  const { exec } = fakeExecFactory();
+  await assert.rejects(() =>
+    buildLocalQualificationCandidates(
+      { runId: "../escape", shardId: "1", runDir: "/tmp/x", sourceSha: SHA, version: "1" },
+      { exec, allocatePorts: fakeAllocatePorts() },
+    ),
+  );
+  await assert.rejects(() =>
+    buildLocalQualificationCandidates(
+      { runId: "run-1", shardId: "1", sourceSha: SHA, version: "1" },
+      { exec, allocatePorts: fakeAllocatePorts() },
+    ),
+  );
+});

--- a/tests/release/package.json
+++ b/tests/release/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
+    "playwright": "^1.61.0",
     "tsx": "^4.22.4",
     "typescript": "^5.7.0"
   }

--- a/tests/release/package.json
+++ b/tests/release/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "release-e2e": "tsx src/cli/run.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/tests/release/src/artifacts/anyharness-smoke.ts
+++ b/tests/release/src/artifacts/anyharness-smoke.ts
@@ -259,10 +259,11 @@ async function mainFromCli(): Promise<void> {
       candidate_build: { artifacts: Array<{ artifact_id: string; version: string; sha256: string }> } | null;
       selected_cells?: unknown[];
     };
-    // The smoke consumes report V3 only — a runner emitting an older schema
-    // (or an empty exact-cell plan) is a regression, not acceptable evidence.
-    if (report.schema_version !== 3 || !Array.isArray(report.selected_cells) || report.selected_cells.length === 0) {
-      throw new Error("Runner did not produce a valid schema_version 3 report with a non-empty exact-cell plan.");
+    // The runner now emits report V4 (schema_version 4; V3 semantics unchanged
+    // plus per-result bounded evidence). An older schema — or an empty
+    // exact-cell plan — is a regression, not acceptable evidence.
+    if (report.schema_version !== 4 || !Array.isArray(report.selected_cells) || report.selected_cells.length === 0) {
+      throw new Error("Runner did not produce a valid schema_version 4 report with a non-empty exact-cell plan.");
     }
     const expected = toCandidateBuildEvidence(map);
     if (JSON.stringify(report.candidate_build) !== JSON.stringify(expected)) {

--- a/tests/release/src/artifacts/local-candidate-set.test.ts
+++ b/tests/release/src/artifacts/local-candidate-set.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { BuildMapError, type CandidateBuildArtifactV1, type CandidateBuildMapV1 } from "./build-map.js";
+import { resolveLocalCandidateSet } from "./local-candidate-set.js";
+
+function artifact(id: string): CandidateBuildArtifactV1 {
+  return {
+    artifact_id: id,
+    version: "0.0.1",
+    sha256: "a".repeat(64),
+    locator: { kind: "local_file", path: `/tmp/${encodeURIComponent(id)}` },
+  };
+}
+
+function mapOf(ids: string[]): CandidateBuildMapV1 {
+  return {
+    schema_version: 1,
+    kind: "proliferate.candidate-build",
+    source_sha: "0".repeat(40),
+    artifacts: ids.map(artifact),
+  };
+}
+
+test("resolves the three required slots by prefix and exact id", () => {
+  const set = resolveLocalCandidateSet(
+    mapOf(["server/linux-amd64", "anyharness/aarch64-apple-darwin", "desktop-renderer/browser"]),
+  );
+  assert.equal(set.server.artifact_id, "server/linux-amd64");
+  assert.equal(set.anyharness.artifact_id, "anyharness/aarch64-apple-darwin");
+  assert.equal(set.desktopRenderer.artifact_id, "desktop-renderer/browser");
+});
+
+test("rejects a missing required slot before any world side effect", () => {
+  assert.throws(
+    () => resolveLocalCandidateSet(mapOf(["server/linux-amd64", "desktop-renderer/browser"])),
+    (error: unknown) => error instanceof BuildMapError && /missing the required anyharness/.test((error as Error).message),
+  );
+});
+
+test("rejects a duplicate slot", () => {
+  assert.throws(
+    () =>
+      resolveLocalCandidateSet(
+        mapOf(["server/a", "server/b", "anyharness/t", "desktop-renderer/browser"]),
+      ),
+    (error: unknown) => error instanceof BuildMapError && /2 server artifacts/.test((error as Error).message),
+  );
+});
+
+test("rejects an unexpected extra artifact", () => {
+  assert.throws(
+    () =>
+      resolveLocalCandidateSet(
+        mapOf(["server/a", "anyharness/t", "desktop-renderer/browser", "catalog/extra"]),
+      ),
+    (error: unknown) => error instanceof BuildMapError && /unexpected artifact/.test((error as Error).message),
+  );
+});

--- a/tests/release/src/artifacts/local-candidate-set.ts
+++ b/tests/release/src/artifacts/local-candidate-set.ts
@@ -1,0 +1,88 @@
+import { BuildMapError, type CandidateBuildArtifactV1, type CandidateBuildMapV1 } from "./build-map.js";
+
+/**
+ * Resolves the three exact local-world artifacts out of a validated
+ * `CandidateBuildMapV1` (specs "Candidate artifacts"):
+ *
+ *   server/<docker-platform>        — `docker save` archive (Docker controller)
+ *   anyharness/<rust-host-target>   — release executable (host process controller)
+ *   desktop-renderer/browser        — `apps/desktop/dist` archive (renderer + Playwright)
+ *
+ * `server/*` and `anyharness/*` carry a dynamic platform/target segment, so
+ * they are matched by their stable prefix; `desktop-renderer/browser` is the
+ * exact stable id. Exactly one artifact must match each slot — a missing,
+ * duplicate, or extra required artifact is a `BuildMapError` raised before any
+ * world side effect (spec: "Missing, duplicate, wrong-SHA, wrong-source, or
+ * wrong-kind required artifacts fail before world startup").
+ *
+ * This module does not copy bytes; materialization + re-hashing is done by the
+ * world stack through `materialize-local.ts`, which yields a
+ * `MaterializedArtifact` for each slot.
+ */
+
+export const SERVER_ARTIFACT_PREFIX = "server/";
+export const ANYHARNESS_ARTIFACT_PREFIX = "anyharness/";
+export const DESKTOP_RENDERER_ARTIFACT_ID = "desktop-renderer/browser";
+
+/** The three build-map entries the local world consumes, one per controller. */
+export interface LocalCandidateSet {
+  server: CandidateBuildArtifactV1;
+  anyharness: CandidateBuildArtifactV1;
+  desktopRenderer: CandidateBuildArtifactV1;
+}
+
+/**
+ * A build-map artifact after it has been copied into run-owned storage and
+ * re-hashed. `path` is the absolute path of the run-owned copy; the identity
+ * triple is the projection allowed into evidence.
+ */
+export interface MaterializedArtifact {
+  artifact_id: string;
+  version: string;
+  sha256: string;
+  /** Absolute path to the run-owned materialized copy. */
+  path: string;
+}
+
+/**
+ * Selects the three required artifacts from a validated map. Throws
+ * `BuildMapError` when any slot is unmatched, ambiguous, or when the map
+ * carries extra artifacts this slice does not expect.
+ */
+export function resolveLocalCandidateSet(map: CandidateBuildMapV1): LocalCandidateSet {
+  const server = selectOne(map, "server", (id) => id.startsWith(SERVER_ARTIFACT_PREFIX));
+  const anyharness = selectOne(map, "anyharness", (id) => id.startsWith(ANYHARNESS_ARTIFACT_PREFIX));
+  const desktopRenderer = selectOne(map, "desktop renderer", (id) => id === DESKTOP_RENDERER_ARTIFACT_ID);
+
+  // The three slots are disjoint by construction (the renderer id shares neither
+  // prefix), so an artifact the slice does not expect is one that matched no
+  // slot. Reject it before any world side effect.
+  const expected = new Set([server.artifact_id, anyharness.artifact_id, desktopRenderer.artifact_id]);
+  const extras = map.artifacts.filter((artifact) => !expected.has(artifact.artifact_id));
+  if (extras.length > 0) {
+    throw new BuildMapError(
+      `Candidate build map carries unexpected artifact(s) for the local world: ` +
+        `${extras.map((artifact) => artifact.artifact_id).join(", ")}.`,
+    );
+  }
+
+  return { server, anyharness, desktopRenderer };
+}
+
+function selectOne(
+  map: CandidateBuildMapV1,
+  slot: string,
+  matches: (artifactId: string) => boolean,
+): CandidateBuildArtifactV1 {
+  const found = map.artifacts.filter((artifact) => matches(artifact.artifact_id));
+  if (found.length === 0) {
+    throw new BuildMapError(`Candidate build map is missing the required ${slot} artifact.`);
+  }
+  if (found.length > 1) {
+    throw new BuildMapError(
+      `Candidate build map has ${found.length} ${slot} artifacts; exactly one is required ` +
+        `(${found.map((artifact) => artifact.artifact_id).join(", ")}).`,
+    );
+  }
+  return found[0];
+}

--- a/tests/release/src/cli/command.test.ts
+++ b/tests/release/src/cli/command.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import { runReleaseCommand, type CommandDeps } from "./command.js";
 import { BuildMapError, type CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
-import type { TestRunReportV3 } from "../evidence/schema.js";
+import type { TestRunReportV3, TestRunReportV4 } from "../evidence/schema.js";
 import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
 import type { ScenarioDefinition } from "../scenarios/types.js";
 
@@ -205,7 +205,7 @@ test("--help exits 0 without identity, map loading, or a report", async () => {
 });
 
 test("the validated map's evidence reaches execute and the written report", async () => {
-  let written: TestRunReportV3 | undefined;
+  let written: TestRunReportV4 | undefined;
   const { deps } = makeDeps();
   deps.write = async (_outputDir, report) => {
     written = report;
@@ -221,6 +221,20 @@ test("the validated map's evidence reaches execute and the written report", asyn
   });
   // The evidence that reaches the report never carries locator paths.
   assert.ok(!JSON.stringify(written?.candidate_build).includes("/tmp/anyharness"));
+});
+
+test("report V4: schema_version 4 and null evidence for a scenario that attaches none", async () => {
+  let written: TestRunReportV4 | undefined;
+  const { deps } = makeDeps();
+  deps.write = async (_outputDir, report) => {
+    written = report;
+    return "/tmp/report.json";
+  };
+  const exit = await runReleaseCommand(["--behavior", "diagnostic"], deps);
+  assert.equal(exit, 0);
+  assert.equal(written?.schema_version, 4);
+  assert.equal(written?.results.length, 1);
+  assert.equal(written?.results[0].evidence, null);
 });
 
 test("a report write failure still exits 2", async () => {
@@ -256,6 +270,33 @@ test("an invalid cell expansion exits 2 before any setup side effect and writes 
   // Identity and selection happen, planning fails; zero user/gateway/
   // provider/fixture/scenario setup and no report write follow.
   assert.deepEqual(calls, ["identity", "select"]);
+});
+
+test("the validated path-bearing candidate build map reaches execute (not just its evidence)", async () => {
+  let seenMap: unknown = "unset";
+  const { deps } = makeDeps();
+  deps.execute = async (options) => {
+    seenMap = (options as unknown as { candidateBuildMap?: unknown }).candidateBuildMap;
+    return fakeReport(options.candidateBuild ?? null);
+  };
+  const exit = await runReleaseCommand(
+    ["--behavior", "diagnostic", "--candidate-build-map", "/tmp/map.json"],
+    deps,
+  );
+  assert.equal(exit, 0);
+  assert.deepEqual(seenMap, VALID_MAP);
+});
+
+test("diagnostic omission threads a null candidateBuildMap to execute", async () => {
+  let seenMap: unknown = "unset";
+  const { deps } = makeDeps();
+  deps.execute = async (options) => {
+    seenMap = (options as unknown as { candidateBuildMap?: unknown }).candidateBuildMap;
+    return fakeReport(options.candidateBuild ?? null);
+  };
+  const exit = await runReleaseCommand(["--behavior", "diagnostic"], deps);
+  assert.equal(exit, 0);
+  assert.equal(seenMap, null);
 });
 
 test("planning happens after map validation and before setup in the dependency order", async () => {

--- a/tests/release/src/cli/command.test.ts
+++ b/tests/release/src/cli/command.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import { runReleaseCommand, type CommandDeps } from "./command.js";
 import { BuildMapError, type CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { LocalWorldPorts } from "../worlds/local-workspace/ports.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
 import type { TestRunReportV3, TestRunReportV4 } from "../evidence/schema.js";
 import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
@@ -27,6 +28,8 @@ const SCENARIO: ScenarioDefinition = {
   plan: () => [],
   run: async () => undefined,
 };
+
+const PORTS: LocalWorldPorts = { server: 8100, postgres: 8101, redis: 8102, anyharness: 8103, renderer: 8104 };
 
 const VALID_MAP: CandidateBuildMapV1 = {
   schema_version: 1,
@@ -112,6 +115,10 @@ function makeDeps(overrides: Partial<CommandDeps> = {}): { deps: CommandDeps; ca
       calls.push("loadBuildMap");
       return VALID_MAP;
     },
+    loadLocalWorldPorts: async () => {
+      calls.push("loadLocalWorldPorts");
+      return PORTS;
+    },
     seedLocalDurableUser: async () => {
       calls.push("seed");
     },
@@ -147,7 +154,7 @@ test("a valid supplied map is loaded after selection and before any setup side e
     deps,
   );
   assert.equal(exit, 0);
-  assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "seed", "gateway", "envManifest", "execute", "write"]);
+  assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "loadLocalWorldPorts", "seed", "gateway", "envManifest", "execute", "write"]);
 });
 
 test("an invalid supplied map exits 2 with zero setup, execution, or report side effects", async () => {
@@ -306,5 +313,59 @@ test("planning happens after map validation and before setup in the dependency o
     deps,
   );
   assert.equal(exit, 0);
-  assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "seed", "gateway", "envManifest", "execute", "write"]);
+  assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "loadLocalWorldPorts", "seed", "gateway", "envManifest", "execute", "write"]);
+});
+
+test("the run dir (the map's directory) and its ports sidecar reach execute", async () => {
+  let seenRunDir: unknown = "unset";
+  let seenPorts: unknown = "unset";
+  let loaderRunDir: string | undefined;
+  const { deps } = makeDeps();
+  deps.loadLocalWorldPorts = async (runDir) => {
+    loaderRunDir = runDir;
+    return PORTS;
+  };
+  deps.execute = async (options) => {
+    seenRunDir = (options as unknown as { runDir?: unknown }).runDir;
+    seenPorts = (options as unknown as { ports?: unknown }).ports;
+    return fakeReport(options.candidateBuild ?? null);
+  };
+  const exit = await runReleaseCommand(
+    ["--behavior", "diagnostic", "--candidate-build-map", "/run/dir/candidate-build.json"],
+    deps,
+  );
+  assert.equal(exit, 0);
+  assert.equal(loaderRunDir, "/run/dir");
+  assert.equal(seenRunDir, "/run/dir");
+  assert.deepEqual(seenPorts, PORTS);
+});
+
+test("diagnostic omission threads null runDir/ports and never loads the ports sidecar", async () => {
+  let seenRunDir: unknown = "unset";
+  let seenPorts: unknown = "unset";
+  const { deps, calls } = makeDeps();
+  deps.execute = async (options) => {
+    seenRunDir = (options as unknown as { runDir?: unknown }).runDir;
+    seenPorts = (options as unknown as { ports?: unknown }).ports;
+    return fakeReport(options.candidateBuild ?? null);
+  };
+  const exit = await runReleaseCommand(["--behavior", "diagnostic"], deps);
+  assert.equal(exit, 0);
+  assert.equal(seenRunDir, null);
+  assert.equal(seenPorts, null);
+  assert.ok(!calls.includes("loadLocalWorldPorts"));
+});
+
+test("a malformed ports sidecar exits 2 before any setup side effect", async () => {
+  const { deps, calls } = makeDeps();
+  deps.loadLocalWorldPorts = async () => {
+    calls.push("loadLocalWorldPorts");
+    throw new Error("local-world-ports.json: \"server\" must be an integer TCP port");
+  };
+  const exit = await runReleaseCommand(
+    ["--behavior", "diagnostic", "--candidate-build-map", "/tmp/map.json"],
+    deps,
+  );
+  assert.equal(exit, 2);
+  assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "loadLocalWorldPorts"]);
 });

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -1,5 +1,8 @@
+import path from "node:path";
+
 import { HELP_TEXT, parseArgs, type CliArgs } from "./args.js";
 import type { ScenarioDefinition } from "../scenarios/types.js";
+import type { LocalWorldPorts } from "../worlds/local-workspace/ports.js";
 import type { FailureReport } from "../report/types.js";
 import { toFailureReports } from "../report/failure-reporter.js";
 import { IdentityError, type RunIdentityV1 } from "../runner/identity.js";
@@ -31,6 +34,12 @@ export interface CommandDeps {
   }) => Promise<RunIdentityV1>;
   selectScenarios: (selector: readonly string[] | "all") => ScenarioDefinition[];
   loadBuildMap: (path: string, expectedSourceSha: string) => Promise<CandidateBuildMapV1>;
+  /**
+   * Loads the `local-world-ports.json` sidecar the candidate builder wrote into
+   * the run directory (the candidate map's directory). Returns null when the
+   * sidecar is absent; a world scenario then fails closed on the missing ports.
+   */
+  loadLocalWorldPorts: (runDir: string) => Promise<LocalWorldPorts | null>;
   /** Local durable-user seed; fills the locallySeeded set. */
   seedLocalDurableUser: (seeded: Set<string>) => Promise<void>;
   pushLocalGatewayAuth: () => Promise<void>;
@@ -99,11 +108,19 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
   // evidence projection) so a world constructor can materialize the exact
   // artifacts it names. In-memory only; never serialized into the report.
   let candidateBuildMap: CandidateBuildMapV1 | null = null;
+  // The run/shard-scoped run directory and pre-allocated ports a world
+  // constructor needs. Both derived from the candidate map (its directory is the
+  // run dir; the ports sidecar sits next to it) so an invalid map still yields
+  // no world side effects. Null in a diagnostic run without a map.
+  let runDir: string | null = null;
+  let ports: LocalWorldPorts | null = null;
   if (args.candidateBuildMap !== undefined) {
     try {
       const map = await deps.loadBuildMap(args.candidateBuildMap, identity.source_sha);
       candidateBuild = toCandidateBuildEvidence(map);
       candidateBuildMap = map;
+      runDir = path.dirname(path.resolve(args.candidateBuildMap));
+      ports = await deps.loadLocalWorldPorts(runDir);
     } catch (error) {
       deps.error(error instanceof Error ? error.message : String(error));
       return 2;
@@ -152,6 +169,8 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
       locallySeeded,
       candidateBuild,
       candidateBuildMap,
+      runDir,
+      ports,
       log: (message: string) => deps.log(`  ${message}`),
     };
     report = await deps.execute(executeOptions);

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -12,7 +12,7 @@ import {
   type CandidateBuildEvidenceV1,
   type CandidateBuildMapV1,
 } from "../artifacts/build-map.js";
-import type { TestRunReportV3 } from "../evidence/schema.js";
+import type { FinalCellResultV2, TestRunReportV3, TestRunReportV4 } from "../evidence/schema.js";
 
 /**
  * Testable command orchestration
@@ -36,7 +36,13 @@ export interface CommandDeps {
   pushLocalGatewayAuth: () => Promise<void>;
   printEnvManifestReport: () => void;
   execute: typeof executeSelectedCells;
-  write: (outputDir: string, report: TestRunReportV3) => Promise<string>;
+  /**
+   * Writes the combined report. `command.ts` always hands this a V4 report
+   * (V3 semantics unchanged; `evidence: null` on every result that does not
+   * attach report-V4 evidence) — the caller's real implementation is
+   * `writeReportV4` (`evidence/write.ts`).
+   */
+  write: (outputDir: string, report: TestRunReportV4) => Promise<string>;
   fileIssues: (reports: readonly FailureReport[]) => Promise<string[]>;
   log: (message: string) => void;
   error: (message: string) => void;
@@ -89,10 +95,15 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
   // invalid map exits 2 with zero user/gateway/provider/fixture/scenario work
   // and no report. Diagnostic omission is recorded explicitly as null.
   let candidateBuild: CandidateBuildEvidenceV1 | null = null;
+  // The full validated, path-bearing map — retained (not just its bounded
+  // evidence projection) so a world constructor can materialize the exact
+  // artifacts it names. In-memory only; never serialized into the report.
+  let candidateBuildMap: CandidateBuildMapV1 | null = null;
   if (args.candidateBuildMap !== undefined) {
     try {
       const map = await deps.loadBuildMap(args.candidateBuildMap, identity.source_sha);
       candidateBuild = toCandidateBuildEvidence(map);
+      candidateBuildMap = map;
     } catch (error) {
       deps.error(error instanceof Error ? error.message : String(error));
       return 2;
@@ -128,17 +139,22 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
 
   let report: TestRunReportV3;
   try {
-    report = await deps.execute({
+    // The executor threads `candidateBuildMap` into every `ScenarioRunContext`
+    // (BRIEF §7a) so a world constructor can materialize the exact artifacts it
+    // names; it is in-memory only and never serialized into the report.
+    const executeOptions = {
       behavior: args.behavior,
-      execution: args.dryRun ? "dry_run" : "real",
+      execution: (args.dryRun ? "dry_run" : "real") as "real" | "dry_run",
       identity,
       inputs: { targetLane: args.lane, desktop: args.desktop, agents: args.agents, scenarios: args.scenarios },
       scenarios,
       cells,
       locallySeeded,
       candidateBuild,
-      log: (message) => deps.log(`  ${message}`),
-    });
+      candidateBuildMap,
+      log: (message: string) => deps.log(`  ${message}`),
+    };
+    report = await deps.execute(executeOptions);
   } catch (error) {
     if (error instanceof SelectionError || error instanceof IdentityError || error instanceof BuildMapError) {
       deps.error(error.message);
@@ -150,8 +166,23 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
 
   printSummary(report, deps);
 
+  // Report V4 (spec "Aggregate evidence"): schema_version 4, plus each
+  // result's bounded evidence attachment. `ResultTracker` (runner/result.ts)
+  // always sets `evidence` (defaulting `null`), so every result already
+  // carries it at runtime even where `report.results` is still statically
+  // typed `FinalCellResultV1[]`; a scenario that never attaches evidence
+  // (every existing scenario) round-trips as `null`, unchanged V3 semantics.
+  const reportV4: TestRunReportV4 = {
+    ...report,
+    schema_version: 4,
+    results: report.results.map((result) => ({
+      ...result,
+      evidence: (result as FinalCellResultV2).evidence ?? null,
+    })),
+  };
+
   try {
-    const written = await deps.write(args.outputDir, report);
+    const written = await deps.write(args.outputDir, reportV4);
     deps.log(`Combined report written: ${written}`);
   } catch (error) {
     deps.error(error instanceof Error ? error.message : String(error));

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -12,7 +12,7 @@ import { fileIssuesForFailures } from "../report/issue-filer.js";
 import { resolveRunIdentity } from "../runner/identity.js";
 import { executeSelectedCells } from "../runner/execute.js";
 import { loadCandidateBuildMap } from "../artifacts/build-map.js";
-import { writeReport } from "../evidence/write.js";
+import { writeReportV4 } from "../evidence/write.js";
 
 /**
  * Thin process adapter: supplies the real side-effect dependencies to
@@ -105,6 +105,17 @@ function nonEmpty(value: string | undefined): string | undefined {
   return value && value.trim().length > 0 ? value : undefined;
 }
 
+/**
+ * Every present secret value in the full env manifest — the same set
+ * `runner/execute.ts` redacts message fields with — applied to report-V4
+ * evidence string fields before validation (BRIEF §6.6).
+ */
+function resolveManifestSecretValues(): string[] {
+  return resolveEnv(envVarNames())
+    .all.filter((entry) => entry.spec.secret && entry.value !== undefined)
+    .map((entry) => entry.value as string);
+}
+
 function printEnvManifestReport(): void {
   const resolution = resolveEnv(envVarNames());
   console.log("\nEnv manifest:");
@@ -123,7 +134,7 @@ process.exitCode = await runReleaseCommand(process.argv.slice(2), {
   pushLocalGatewayAuth,
   printEnvManifestReport,
   execute: executeSelectedCells,
-  write: writeReport,
+  write: (outputDir, report) => writeReportV4(outputDir, report, resolveManifestSecretValues()),
   fileIssues: fileIssuesForFailures,
   log: (message) => console.log(message),
   error: (message) => console.error(message),

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -12,6 +12,7 @@ import { fileIssuesForFailures } from "../report/issue-filer.js";
 import { resolveRunIdentity } from "../runner/identity.js";
 import { executeSelectedCells } from "../runner/execute.js";
 import { loadCandidateBuildMap } from "../artifacts/build-map.js";
+import { readLocalWorldPortsFile } from "../worlds/local-workspace/ports.js";
 import { writeReportV4 } from "../evidence/write.js";
 
 /**
@@ -130,6 +131,7 @@ process.exitCode = await runReleaseCommand(process.argv.slice(2), {
   resolveIdentity: (overrides) => resolveRunIdentity({ overrides }),
   selectScenarios,
   loadBuildMap: loadCandidateBuildMap,
+  loadLocalWorldPorts: readLocalWorldPortsFile,
   seedLocalDurableUser,
   pushLocalGatewayAuth,
   printEnvManifestReport,

--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -70,6 +70,48 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
     lanes: ["local"],
   },
   {
+    name: "AGENT_GATEWAY_LITELLM_BASE_URL",
+    description:
+      "Admin/control-plane base URL of the qualification LiteLLM gateway. LOCAL-WORLD-SMOKE-1's " +
+      "private world controller uses it (with the master key) to preflight admin reachability, " +
+      "resolve the actor's run-created virtual key, snapshot/correlate spend, and delete the " +
+      "run-created key/user/team on cleanup. Never exposed to AnyHarness (only the public URL is) " +
+      "and never serialized into evidence.",
+    whereItLives:
+      "Local: the ignored mode-0600 qualification profile " +
+      "`~/.proliferate-local/dev/qualification-infra.env` — the Makefile wrapper maps " +
+      "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL to this when the separate control URL is absent. " +
+      "CI: the GitHub `staging` environment's LiteLLM public-URL variable, mapped to this input.",
+    secret: false,
+    lanes: ["local"],
+  },
+  {
+    name: "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL",
+    description:
+      "Public inference base URL of the qualification LiteLLM gateway. This is the only gateway URL " +
+      "handed to the candidate Server / AnyHarness (as the managed-gateway endpoint the actor's " +
+      "enrollment key is used against); the admin URL and master key stay inside the world " +
+      "controller.",
+    whereItLives:
+      "Local: `~/.proliferate-local/dev/qualification-infra.env` (mode 0600). " +
+      "CI: `vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL` in the GitHub `staging` environment.",
+    secret: false,
+    lanes: ["local"],
+  },
+  {
+    name: "AGENT_GATEWAY_LITELLM_MASTER_KEY",
+    description:
+      "Master key for the qualification LiteLLM gateway's admin API, used only inside the private " +
+      "world controller and passed only into the candidate Server container env. Never reaches the " +
+      "runner report, the renderer, AnyHarness, or any evidence field (stripped by the candidate " +
+      "child env denylist and redacted from the report).",
+    whereItLives:
+      "Local: `~/.proliferate-local/dev/qualification-infra.env` (mode 0600). " +
+      "CI: `secrets.LITELLM_MASTER_KEY` in the GitHub `staging` environment, mapped to this input.",
+    secret: true,
+    lanes: ["local"],
+  },
+  {
     name: "RELEASE_E2E_E2B_API_KEY",
     description:
       "E2B API key used to provision sandbox-lane cloud workspaces and to build/upload " +

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -63,6 +63,92 @@ export interface TestRunReportV3 {
   };
 }
 
+/**
+ * ── Report V4 type DELTA (spec "Aggregate evidence") ──────────────────────
+ *
+ * Report V3 cannot attach proof to a green result. LOCAL-WORLD-SMOKE-1 is the
+ * first consumer that justifies V4. V4 keeps every V3 plan/result/verdict
+ * semantic and adds ONE bounded optional evidence field to each result.
+ *
+ * Only the TYPES live here (added by the contracts stage). The V4 validator
+ * (`validateReportV4`) and writer changes are owned by the evidence workstream;
+ * this stage does not implement them. Required validator behavior, verbatim, is
+ * in BRIEF.md "Evidence workstream" — summarized:
+ *   - accept `schema_version: 4`, `kind: "proliferate.test-run"`;
+ *   - reuse every V3 invariant (identity/dimension/verdict recomputation);
+ *   - each result carries `evidence: CellEvidenceV1 | null`; existing cells
+ *     emit `null` and keep V3 semantics;
+ *   - a GREEN `LOCAL-WORLD-SMOKE-1/*` result with absent/incomplete evidence is
+ *     REJECTED;
+ *   - reject unknown evidence `kind`, extra fields, unsafe strings (must pass
+ *     the same safe-string checks as identity fields), invalid/negative counts,
+ *     internally inconsistent token math (prompt+completion === total, all > 0),
+ *     non-positive spend, or a `cleanup` block with `failed > 0` /
+ *     any deletion boolean false on a green cell.
+ */
+
+/** One result's optional bounded evidence; today only the local-workspace turn. */
+export type CellEvidenceV1 = LocalWorkspaceTurnEvidenceV1;
+
+export interface LocalWorkspaceTurnEvidenceV1 {
+  kind: "local_workspace_turn";
+  artifact_ids: string[];
+  server_version: string;
+  anyharness_version: string;
+  harness: "claude";
+  model_id: string;
+  workspace_id_hash: string;
+  session_id_hash: string;
+  transcript_reopened: true;
+  litellm: {
+    token_id_hash: string;
+    request_ids: string[];
+    window_started_at: string;
+    window_finished_at: string;
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    spend_usd: number;
+  };
+  cleanup: {
+    ledger_id_hash: string;
+    registered: number;
+    reconciled: number;
+    failed: number;
+    virtual_key_deleted: boolean;
+    litellm_subjects_deleted: boolean;
+    browser_closed: boolean;
+    processes_stopped: boolean;
+    containers_removed: boolean;
+    local_paths_removed: boolean;
+  };
+}
+
+/** V4 result: a V3 result plus one bounded optional evidence attachment. */
+export interface FinalCellResultV2 extends FinalCellResultV1 {
+  evidence: CellEvidenceV1 | null;
+}
+
+/**
+ * Report V4: structurally V3 with `schema_version: 4` and evidence-bearing
+ * results. The evidence workstream promotes the writer/validator to emit and
+ * check this; V3 remains recorded history.
+ */
+export interface TestRunReportV4 extends Omit<TestRunReportV3, "schema_version" | "results"> {
+  schema_version: 4;
+  results: FinalCellResultV2[];
+}
+
+/**
+ * The report fields validated identically across V3 and V4 (everything but
+ * the version-specific `schema_version` literal and the evidence attached to
+ * each V4 result — `FinalCellResultV2` is a structural supertype-safe
+ * substitute for `FinalCellResultV1` here). `validateReportCore` is the one
+ * shared invariant walk both `validateReport` (V3) and `validateReportV4`
+ * (V4) run after their own version-specific header check.
+ */
+type ValidatableReportCore = Omit<TestRunReportV3, "schema_version">;
+
 export class ReportValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -173,7 +259,7 @@ export function sanitizeReport(report: TestRunReportV3, secretValues: readonly s
  * value. Exported for the writer-side tests; execution calls it through
  * `sanitizeReport`.
  */
-export function assertNoSecretsInIdentity(report: TestRunReportV3, secretValues: readonly string[]): void {
+export function assertNoSecretsInIdentity(report: ValidatableReportCore, secretValues: readonly string[]): void {
   const secrets = secretValues.filter((secret) => secret.length > 0);
   if (secrets.length === 0) {
     return;
@@ -205,6 +291,26 @@ export function validateReport(report: TestRunReportV3): void {
   if (report.schema_version !== 3 || report.kind !== "proliferate.test-run") {
     throw new ReportValidationError("Report must be schema_version 3, kind proliferate.test-run.");
   }
+  validateReportCore(report);
+}
+
+/**
+ * Report V4: `schema_version: 4` plus every V3 invariant, plus per-result
+ * evidence. Existing cells emit `evidence: null` and keep V3 semantics; a
+ * green `LOCAL-WORLD-SMOKE-1` result must carry complete evidence.
+ */
+export function validateReportV4(report: TestRunReportV4): void {
+  if (report.schema_version !== 4 || report.kind !== "proliferate.test-run") {
+    throw new ReportValidationError("Report must be schema_version 4, kind proliferate.test-run.");
+  }
+  validateReportCore(report);
+  for (const result of report.results) {
+    validateCellEvidence(result);
+  }
+}
+
+/** The invariant walk shared by `validateReport` (V3) and `validateReportV4`. */
+function validateReportCore(report: ValidatableReportCore): void {
   if (report.run.behavior !== "diagnostic" && report.run.behavior !== "strict") {
     throw new ReportValidationError(`Unknown behavior "${report.run.behavior}".`);
   }
@@ -390,7 +496,7 @@ export function validateReport(report: TestRunReportV3): void {
  * sanitization) and this validator use for the persisted verdict, including
  * the bounded reasons array.
  */
-export function expectedVerdict(report: TestRunReportV3): {
+export function expectedVerdict(report: ValidatableReportCore): {
   status: VerdictStatus;
   intendedExitCode: 0 | 1 | 2;
   reasons: string[];
@@ -459,4 +565,283 @@ function validateCandidateBuildEvidence(evidence: CandidateBuildEvidenceV1 | nul
       throw new ReportValidationError("candidate_build sha256 must be a lowercase 64-hex digest.");
     }
   }
+}
+
+/**
+ * ── Report V4 evidence validation ─────────────────────────────────────────
+ *
+ * Every string field below passes the same bounded, path/secret-hostile
+ * safe-token or hash pattern used for candidate-build/identity fields
+ * elsewhere in this file: no leading slash, no `..` traversal segment, no
+ * whitespace/control/URL-credential characters, bounded length. This is the
+ * fail-closed backstop for BRIEF §6.5/§6.6: if a raw secret or local path
+ * ever reached an evidence field, `sanitizeSecretsInEvidence` below turns it
+ * into a `[REDACTED]`-bearing (or otherwise unsafe) string, and these
+ * patterns then reject it rather than silently accepting mangled evidence.
+ */
+const EVIDENCE_SAFE_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*(?:\/[A-Za-z0-9][A-Za-z0-9._:-]*)*$/;
+const MAX_EVIDENCE_TOKEN_LENGTH = 200;
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const MAX_LITELLM_REQUEST_IDS = 50;
+
+const LOCAL_WORKSPACE_TURN_EVIDENCE_KEYS = [
+  "kind",
+  "artifact_ids",
+  "server_version",
+  "anyharness_version",
+  "harness",
+  "model_id",
+  "workspace_id_hash",
+  "session_id_hash",
+  "transcript_reopened",
+  "litellm",
+  "cleanup",
+] as const;
+
+const LITELLM_EVIDENCE_KEYS = [
+  "token_id_hash",
+  "request_ids",
+  "window_started_at",
+  "window_finished_at",
+  "prompt_tokens",
+  "completion_tokens",
+  "total_tokens",
+  "spend_usd",
+] as const;
+
+const CLEANUP_EVIDENCE_KEYS = [
+  "ledger_id_hash",
+  "registered",
+  "reconciled",
+  "failed",
+  "virtual_key_deleted",
+  "litellm_subjects_deleted",
+  "browser_closed",
+  "processes_stopped",
+  "containers_removed",
+  "local_paths_removed",
+] as const;
+
+function requireExactKeys(value: object, expected: readonly string[], where: string): void {
+  const keys = Object.keys(value).sort();
+  const expectedSorted = [...expected].sort();
+  if (keys.join(",") !== expectedSorted.join(",")) {
+    throw new ReportValidationError(`${where} has undeclared or missing field(s).`);
+  }
+}
+
+function requireSafeEvidenceToken(where: string, value: unknown): void {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_EVIDENCE_TOKEN_LENGTH ||
+    value.includes("..") ||
+    !EVIDENCE_SAFE_TOKEN_PATTERN.test(value)
+  ) {
+    throw new ReportValidationError(`${where} is missing or unsafe.`);
+  }
+}
+
+function requireEvidenceHash(where: string, value: unknown): void {
+  if (typeof value !== "string" || !EVIDENCE_SHA256_PATTERN.test(value)) {
+    throw new ReportValidationError(`${where} must be a lowercase 64-hex digest.`);
+  }
+}
+
+function requireEvidenceTimestamp(where: string, value: unknown): void {
+  if (typeof value !== "string" || !ISO_TIMESTAMP_PATTERN.test(value) || Number.isNaN(Date.parse(value))) {
+    throw new ReportValidationError(`${where} must be an ISO-8601 UTC timestamp.`);
+  }
+}
+
+function requireNonNegativeInteger(where: string, value: unknown): void {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new ReportValidationError(`${where} must be a non-negative integer.`);
+  }
+}
+
+function requireBoolean(where: string, value: unknown): void {
+  if (typeof value !== "boolean") {
+    throw new ReportValidationError(`${where} must be a boolean.`);
+  }
+}
+
+/**
+ * Validates one result's `evidence: CellEvidenceV1 | null`. `null` is always
+ * representable except on a GREEN `LOCAL-WORLD-SMOKE-1` result, which must
+ * carry complete evidence (spec "Aggregate evidence" / BRIEF §6.3).
+ */
+function validateCellEvidence(result: FinalCellResultV2): void {
+  // `evidence` is a required field of FinalCellResultV2, but the report
+  // ultimately comes from parsed JSON (`writeReportV4`'s caller may pass an
+  // externally-constructed object at runtime), so a missing key is still
+  // rejected explicitly rather than reading `undefined` as if it were `null`.
+  if (!Object.prototype.hasOwnProperty.call(result, "evidence")) {
+    throw new ReportValidationError(`Result "${result.cell_id}" must carry an explicit evidence field (or null).`);
+  }
+  const evidence = result.evidence;
+  if (evidence === null) {
+    if (result.status === "green" && result.scenario_id === "LOCAL-WORLD-SMOKE-1") {
+      throw new ReportValidationError(
+        `Green result "${result.cell_id}" for LOCAL-WORLD-SMOKE-1 requires complete evidence.`,
+      );
+    }
+    return;
+  }
+  if (typeof evidence !== "object" || Array.isArray(evidence)) {
+    throw new ReportValidationError(`Result "${result.cell_id}" evidence must be an object or null.`);
+  }
+  const where = `Result "${result.cell_id}" evidence`;
+  requireExactKeys(evidence, LOCAL_WORKSPACE_TURN_EVIDENCE_KEYS, where);
+  if (evidence.kind !== "local_workspace_turn") {
+    throw new ReportValidationError(`${where}.kind is unknown.`);
+  }
+  if (!Array.isArray(evidence.artifact_ids) || evidence.artifact_ids.length === 0) {
+    throw new ReportValidationError(`${where}.artifact_ids must be a non-empty array.`);
+  }
+  for (const [index, id] of evidence.artifact_ids.entries()) {
+    requireSafeEvidenceToken(`${where}.artifact_ids[${index}]`, id);
+  }
+  requireSafeEvidenceToken(`${where}.server_version`, evidence.server_version);
+  requireSafeEvidenceToken(`${where}.anyharness_version`, evidence.anyharness_version);
+  if (evidence.harness !== "claude") {
+    throw new ReportValidationError(`${where}.harness must be "claude".`);
+  }
+  requireSafeEvidenceToken(`${where}.model_id`, evidence.model_id);
+  requireEvidenceHash(`${where}.workspace_id_hash`, evidence.workspace_id_hash);
+  requireEvidenceHash(`${where}.session_id_hash`, evidence.session_id_hash);
+  if (evidence.transcript_reopened !== true) {
+    throw new ReportValidationError(`${where}.transcript_reopened must be true.`);
+  }
+  validateLitellmEvidence(where, evidence.litellm);
+  validateCleanupEvidence(where, evidence.cleanup, result.status);
+}
+
+function validateLitellmEvidence(where: string, litellm: LocalWorkspaceTurnEvidenceV1["litellm"]): void {
+  if (typeof litellm !== "object" || litellm === null || Array.isArray(litellm)) {
+    throw new ReportValidationError(`${where}.litellm must be an object.`);
+  }
+  requireExactKeys(litellm, LITELLM_EVIDENCE_KEYS, `${where}.litellm`);
+  requireEvidenceHash(`${where}.litellm.token_id_hash`, litellm.token_id_hash);
+  if (!Array.isArray(litellm.request_ids) || litellm.request_ids.length === 0) {
+    throw new ReportValidationError(`${where}.litellm.request_ids must be a non-empty array.`);
+  }
+  if (litellm.request_ids.length > MAX_LITELLM_REQUEST_IDS) {
+    throw new ReportValidationError(`${where}.litellm.request_ids exceeds the bounded cap of ${MAX_LITELLM_REQUEST_IDS}.`);
+  }
+  const seen = new Set<string>();
+  let previous: string | undefined;
+  for (const [index, id] of litellm.request_ids.entries()) {
+    requireSafeEvidenceToken(`${where}.litellm.request_ids[${index}]`, id);
+    if (seen.has(id)) {
+      throw new ReportValidationError(`${where}.litellm.request_ids has a duplicate entry.`);
+    }
+    seen.add(id);
+    if (previous !== undefined && id < previous) {
+      throw new ReportValidationError(`${where}.litellm.request_ids must be sorted ascending.`);
+    }
+    previous = id;
+  }
+  requireEvidenceTimestamp(`${where}.litellm.window_started_at`, litellm.window_started_at);
+  requireEvidenceTimestamp(`${where}.litellm.window_finished_at`, litellm.window_finished_at);
+  if (litellm.window_finished_at < litellm.window_started_at) {
+    throw new ReportValidationError(`${where}.litellm window_finished_at precedes window_started_at.`);
+  }
+  for (const field of ["prompt_tokens", "completion_tokens", "total_tokens"] as const) {
+    const value = litellm[field];
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+      throw new ReportValidationError(`${where}.litellm.${field} must be a positive integer.`);
+    }
+  }
+  if (litellm.prompt_tokens + litellm.completion_tokens !== litellm.total_tokens) {
+    throw new ReportValidationError(`${where}.litellm token counts are internally inconsistent.`);
+  }
+  if (typeof litellm.spend_usd !== "number" || !Number.isFinite(litellm.spend_usd) || litellm.spend_usd <= 0) {
+    throw new ReportValidationError(`${where}.litellm.spend_usd must be positive.`);
+  }
+}
+
+function validateCleanupEvidence(
+  where: string,
+  cleanup: LocalWorkspaceTurnEvidenceV1["cleanup"],
+  status: FinalTestStatus,
+): void {
+  if (typeof cleanup !== "object" || cleanup === null || Array.isArray(cleanup)) {
+    throw new ReportValidationError(`${where}.cleanup must be an object.`);
+  }
+  requireExactKeys(cleanup, CLEANUP_EVIDENCE_KEYS, `${where}.cleanup`);
+  requireEvidenceHash(`${where}.cleanup.ledger_id_hash`, cleanup.ledger_id_hash);
+  requireNonNegativeInteger(`${where}.cleanup.registered`, cleanup.registered);
+  requireNonNegativeInteger(`${where}.cleanup.reconciled`, cleanup.reconciled);
+  requireNonNegativeInteger(`${where}.cleanup.failed`, cleanup.failed);
+  const deletionFields = [
+    "virtual_key_deleted",
+    "litellm_subjects_deleted",
+    "browser_closed",
+    "processes_stopped",
+    "containers_removed",
+    "local_paths_removed",
+  ] as const;
+  for (const field of deletionFields) {
+    requireBoolean(`${where}.cleanup.${field}`, cleanup[field]);
+  }
+  // Unconditional: a failed cleanup entry is never representable, green or not.
+  if (cleanup.failed > 0) {
+    throw new ReportValidationError(`${where}.cleanup.failed must be 0 for persisted evidence.`);
+  }
+  // Green-cell rule (spec "Cleanup and failure behavior"): a green cell whose
+  // cleanup left any deletion incomplete cannot remain green evidence.
+  if (status === "green" && deletionFields.some((field) => cleanup[field] !== true)) {
+    throw new ReportValidationError(`${where}.cleanup is incomplete on a green result.`);
+  }
+}
+
+/**
+ * Applies the same redaction pipeline message fields use
+ * (`redactSecrets`/`redactUrlCredentials`/`boundMessage`) to every
+ * string-bearing evidence field before validation, per BRIEF §6.6. A raw
+ * secret or local path that somehow reached evidence is turned into a
+ * `[REDACTED]`-bearing string here, which the safe-token/hash patterns above
+ * then reject rather than silently persisting.
+ */
+export function sanitizeCellEvidence(
+  evidence: CellEvidenceV1 | null,
+  secretValues: readonly string[],
+): CellEvidenceV1 | null {
+  if (evidence === null) {
+    return null;
+  }
+  const clean = (value: string): string => boundMessage(redactUrlCredentials(redactSecrets(value, secretValues)));
+  return {
+    ...evidence,
+    artifact_ids: evidence.artifact_ids.map(clean),
+    server_version: clean(evidence.server_version),
+    anyharness_version: clean(evidence.anyharness_version),
+    model_id: clean(evidence.model_id),
+    workspace_id_hash: clean(evidence.workspace_id_hash),
+    session_id_hash: clean(evidence.session_id_hash),
+    litellm: {
+      ...evidence.litellm,
+      token_id_hash: clean(evidence.litellm.token_id_hash),
+      request_ids: evidence.litellm.request_ids.map(clean),
+    },
+    cleanup: {
+      ...evidence.cleanup,
+      ledger_id_hash: clean(evidence.cleanup.ledger_id_hash),
+    },
+  };
+}
+
+/** Applies `sanitizeCellEvidence` to every result in a V4 report. */
+export function sanitizeReportV4Evidence(
+  report: TestRunReportV4,
+  secretValues: readonly string[],
+): TestRunReportV4 {
+  return {
+    ...report,
+    results: report.results.map((result) => ({
+      ...result,
+      evidence: sanitizeCellEvidence(result.evidence, secretValues),
+    })),
+  };
 }

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -83,8 +83,9 @@ export interface TestRunReportV3 {
  *   - reject unknown evidence `kind`, extra fields, unsafe strings (must pass
  *     the same safe-string checks as identity fields), invalid/negative counts,
  *     internally inconsistent token math (prompt+completion === total, all > 0),
- *     non-positive spend, or a `cleanup` block with `failed > 0` /
- *     any deletion boolean false on a green cell.
+ *     non-positive spend, or — on a GREEN cell only — a `cleanup` block with
+ *     `failed > 0` or any deletion boolean false (a non-green cell may retain
+ *     evidence recording its own cleanup failure).
  */
 
 /** One result's optional bounded evidence; today only the local-workspace turn. */
@@ -785,14 +786,18 @@ function validateCleanupEvidence(
   for (const field of deletionFields) {
     requireBoolean(`${where}.cleanup.${field}`, cleanup[field]);
   }
-  // Unconditional: a failed cleanup entry is never representable, green or not.
-  if (cleanup.failed > 0) {
-    throw new ReportValidationError(`${where}.cleanup.failed must be 0 for persisted evidence.`);
-  }
-  // Green-cell rule (spec "Cleanup and failure behavior"): a green cell whose
-  // cleanup left any deletion incomplete cannot remain green evidence.
-  if (status === "green" && deletionFields.some((field) => cleanup[field] !== true)) {
-    throw new ReportValidationError(`${where}.cleanup is incomplete on a green result.`);
+  // Green-cell rule (spec "Cleanup and failure behavior"): a green cell requires
+  // complete clean cleanup evidence — zero failed entries and every deletion
+  // boolean true. A non-green cell may carry evidence that records the cleanup
+  // failure itself (failed > 0 and/or an incomplete deletion) so the report is
+  // still persisted with a real nonzero exit rather than throwing and exiting 2.
+  if (status === "green") {
+    if (cleanup.failed > 0) {
+      throw new ReportValidationError(`${where}.cleanup.failed must be 0 for a green result.`);
+    }
+    if (deletionFields.some((field) => cleanup[field] !== true)) {
+      throw new ReportValidationError(`${where}.cleanup is incomplete on a green result.`);
+    }
   }
 }
 

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -12,10 +12,15 @@ import {
   redactSecrets,
   redactUrlCredentials,
   ReportValidationError,
+  sanitizeCellEvidence,
   validateReport,
+  validateReportV4,
+  type CellEvidenceV1,
+  type LocalWorkspaceTurnEvidenceV1,
   type TestRunReportV3,
+  type TestRunReportV4,
 } from "./schema.js";
-import { reportPath, ReportWriteError, writeReport } from "./write.js";
+import { reportPath, ReportWriteError, writeReport, writeReportV4 } from "./write.js";
 import { canonicalCellId } from "../runner/plan.js";
 import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
 
@@ -599,4 +604,228 @@ test("arbitrary verdict reasons cannot validate (ETM-001)", () => {
   const appended = withDerivedReasons(validReport());
   appended.verdict.reasons = [...appended.verdict.reasons, "and also fully audited"];
   assert.throws(() => validateReport(appended), /reasons do not match/);
+});
+
+// ── Report V4 (spec "Aggregate evidence" / BRIEF §6) ────────────────────────
+
+function validCellEvidence(overrides: Partial<LocalWorkspaceTurnEvidenceV1> = {}): LocalWorkspaceTurnEvidenceV1 {
+  return {
+    kind: "local_workspace_turn",
+    artifact_ids: ["server/linux-x64", "anyharness/aarch64-apple-darwin", "desktop-renderer/browser"],
+    server_version: "0.3.27",
+    anyharness_version: "0.3.27",
+    harness: "claude",
+    model_id: "claude-haiku-4-5",
+    workspace_id_hash: "a".repeat(64),
+    session_id_hash: "b".repeat(64),
+    transcript_reopened: true,
+    litellm: {
+      token_id_hash: "c".repeat(64),
+      request_ids: ["req-1", "req-2"],
+      window_started_at: "2026-07-14T00:00:00Z",
+      window_finished_at: "2026-07-14T00:00:10Z",
+      prompt_tokens: 10,
+      completion_tokens: 3,
+      total_tokens: 13,
+      spend_usd: 0.0004,
+    },
+    cleanup: {
+      ledger_id_hash: "d".repeat(64),
+      registered: 8,
+      reconciled: 8,
+      failed: 0,
+      virtual_key_deleted: true,
+      litellm_subjects_deleted: true,
+      browser_closed: true,
+      processes_stopped: true,
+      containers_removed: true,
+      local_paths_removed: true,
+    },
+    ...overrides,
+  };
+}
+
+/** V4 report with a single green non-LOCAL-WORLD-SMOKE-1 cell (evidence: null). */
+function validReportV4(overrides: Partial<TestRunReportV4> = {}): TestRunReportV4 {
+  const v3 = withDerivedReasons(validReport());
+  const report: TestRunReportV4 = {
+    ...v3,
+    schema_version: 4,
+    results: v3.results.map((result) => ({ ...result, evidence: null })),
+  };
+  return { ...report, ...overrides };
+}
+
+/** V4 report with one green LOCAL-WORLD-SMOKE-1 cell carrying complete evidence. */
+function validSmokeReportV4(evidenceOverrides: Partial<LocalWorkspaceTurnEvidenceV1> = {}): TestRunReportV4 {
+  const report = validReportV4();
+  report.selected_cells[0] = {
+    ...report.selected_cells[0],
+    cell_id: "LOCAL-WORLD-SMOKE-1/local/harness=claude",
+    scenario_id: "LOCAL-WORLD-SMOKE-1",
+    registry_flow_ref: "specs#LOCAL-WORLD-SMOKE-1",
+    dimensions: { harness: "claude" },
+  };
+  report.results[0] = {
+    ...report.results[0],
+    cell_id: "LOCAL-WORLD-SMOKE-1/local/harness=claude",
+    scenario_id: "LOCAL-WORLD-SMOKE-1",
+    registry_flow_ref: "specs#LOCAL-WORLD-SMOKE-1",
+    dimensions: { harness: "claude" },
+    evidence: validCellEvidence(evidenceOverrides),
+  };
+  return report;
+}
+
+test("validateReportV4 accepts schema_version 4 with null evidence on an ordinary cell", () => {
+  validateReportV4(validReportV4());
+});
+
+test("validateReportV4 rejects schema_version 3 and non-4 versions", () => {
+  const report = validReportV4();
+  (report as { schema_version: number }).schema_version = 3;
+  assert.throws(() => validateReportV4(report), /schema_version 4/);
+});
+
+test("validateReportV4 accepts a green LOCAL-WORLD-SMOKE-1 cell with complete evidence", () => {
+  validateReportV4(validSmokeReportV4());
+});
+
+test("validateReportV4 rejects a green LOCAL-WORLD-SMOKE-1 cell with null evidence", () => {
+  const report = validSmokeReportV4();
+  report.results[0].evidence = null;
+  assert.throws(() => validateReportV4(report), /requires complete evidence/);
+});
+
+test("validateReportV4 rejects an unknown evidence kind", () => {
+  const report = validSmokeReportV4();
+  (report.results[0].evidence as { kind: string }).kind = "some_other_kind";
+  assert.throws(() => validateReportV4(report), /kind is unknown/);
+});
+
+test("validateReportV4 rejects an extra field on evidence or nested objects", () => {
+  const report = validSmokeReportV4();
+  (report.results[0].evidence as unknown as Record<string, unknown>).extra_field = "x";
+  assert.throws(() => validateReportV4(report), /undeclared or missing field/);
+
+  const nested = validSmokeReportV4();
+  (nested.results[0].evidence!.litellm as unknown as Record<string, unknown>).extra = "x";
+  assert.throws(() => validateReportV4(nested), /litellm has undeclared/);
+
+  const cleanupExtra = validSmokeReportV4();
+  (cleanupExtra.results[0].evidence!.cleanup as unknown as Record<string, unknown>).extra = "x";
+  assert.throws(() => validateReportV4(cleanupExtra), /cleanup has undeclared/);
+});
+
+test("validateReportV4 rejects unsafe strings: paths and secret-like markers", () => {
+  const leaked = validSmokeReportV4({ model_id: "/tmp/leaked-local-path" });
+  assert.throws(() => validateReportV4(leaked), /model_id is missing or unsafe/);
+
+  const traversal = validSmokeReportV4();
+  traversal.results[0].evidence!.artifact_ids = ["server/../../etc/passwd"];
+  assert.throws(() => validateReportV4(traversal), /artifact_ids\[0\] is missing or unsafe/);
+
+  const redactedLooking = validSmokeReportV4();
+  redactedLooking.results[0].evidence!.litellm.token_id_hash = "[REDACTED]";
+  assert.throws(() => validateReportV4(redactedLooking), /token_id_hash must be a lowercase 64-hex digest/);
+});
+
+test("validateReportV4 rejects invalid or inconsistent token counts", () => {
+  const mismatched = validSmokeReportV4();
+  mismatched.results[0].evidence!.litellm.total_tokens = 999;
+  assert.throws(() => validateReportV4(mismatched), /token counts are internally inconsistent/);
+
+  const zero = validSmokeReportV4();
+  zero.results[0].evidence!.litellm.prompt_tokens = 0;
+  assert.throws(() => validateReportV4(zero), /prompt_tokens must be a positive integer/);
+
+  const negative = validSmokeReportV4();
+  negative.results[0].evidence!.litellm.completion_tokens = -1;
+  assert.throws(() => validateReportV4(negative), /completion_tokens must be a positive integer/);
+});
+
+test("validateReportV4 rejects non-positive spend", () => {
+  const zeroSpend = validSmokeReportV4();
+  zeroSpend.results[0].evidence!.litellm.spend_usd = 0;
+  assert.throws(() => validateReportV4(zeroSpend), /spend_usd must be positive/);
+
+  const negativeSpend = validSmokeReportV4();
+  negativeSpend.results[0].evidence!.litellm.spend_usd = -0.01;
+  assert.throws(() => validateReportV4(negativeSpend), /spend_usd must be positive/);
+});
+
+test("validateReportV4 rejects unsorted/duplicate/oversized request_ids", () => {
+  const unsorted = validSmokeReportV4();
+  unsorted.results[0].evidence!.litellm.request_ids = ["req-2", "req-1"];
+  assert.throws(() => validateReportV4(unsorted), /must be sorted ascending/);
+
+  const duplicated = validSmokeReportV4();
+  duplicated.results[0].evidence!.litellm.request_ids = ["req-1", "req-1"];
+  assert.throws(() => validateReportV4(duplicated), /duplicate entry/);
+
+  const oversized = validSmokeReportV4();
+  oversized.results[0].evidence!.litellm.request_ids = Array.from({ length: 51 }, (_, i) => `req-${String(i).padStart(3, "0")}`);
+  assert.throws(() => validateReportV4(oversized), /exceeds the bounded cap/);
+});
+
+test("validateReportV4 rejects a green cell whose cleanup has a false deletion flag or a failure", () => {
+  const incomplete = validSmokeReportV4();
+  incomplete.results[0].evidence!.cleanup.virtual_key_deleted = false;
+  assert.throws(() => validateReportV4(incomplete), /incomplete on a green result/);
+
+  const failed = validSmokeReportV4();
+  failed.results[0].evidence!.cleanup.failed = 1;
+  assert.throws(() => validateReportV4(failed), /cleanup.failed must be 0/);
+});
+
+test("validateReportV4 rejects transcript_reopened !== true and harness !== claude", () => {
+  const notReopened = validSmokeReportV4();
+  (notReopened.results[0].evidence as unknown as { transcript_reopened: boolean }).transcript_reopened = false;
+  assert.throws(() => validateReportV4(notReopened), /transcript_reopened must be true/);
+
+  const wrongHarness = validSmokeReportV4();
+  (wrongHarness.results[0].evidence as unknown as { harness: string }).harness = "codex";
+  assert.throws(() => validateReportV4(wrongHarness), /harness must be "claude"/);
+});
+
+test("sanitizeCellEvidence redacts secrets so validation then rejects the mangled value", () => {
+  const secret = "sk-live-leaked";
+  const evidence: CellEvidenceV1 = validCellEvidence({ model_id: `claude-haiku-4-5-${secret}` });
+  const sanitized = sanitizeCellEvidence(evidence, [secret]);
+  assert.ok(sanitized && sanitized.model_id.includes("[REDACTED]"));
+  assert.throws(
+    () =>
+      validateReportV4(
+        validSmokeReportV4({ model_id: sanitized!.model_id }),
+      ),
+    /model_id is missing or unsafe/,
+  );
+  // A clean evidence object with no secret values is untouched.
+  assert.deepEqual(sanitizeCellEvidence(validCellEvidence(), []), validCellEvidence());
+  assert.equal(sanitizeCellEvidence(null, [secret]), null);
+});
+
+test("writeReportV4 sanitizes, validates, and writes a V4 artifact", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-v4-"));
+  try {
+    const written = await writeReportV4(dir, validSmokeReportV4());
+    const raw = await readFile(written, "utf8");
+    const parsed = JSON.parse(raw);
+    assert.equal(parsed.schema_version, 4);
+    assert.equal(parsed.results[0].evidence.kind, "local_workspace_turn");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeReportV4 refuses to persist evidence carrying a resolved secret", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-v4-"));
+  try {
+    const secret = "sk-live-leaked";
+    const poisoned = validSmokeReportV4({ model_id: `claude-haiku-4-5-${secret}` });
+    await assert.rejects(writeReportV4(dir, poisoned, [secret]), ReportValidationError);
+    await assert.rejects(readFile(reportPath(dir, poisoned), "utf8"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -677,6 +677,47 @@ function validSmokeReportV4(evidenceOverrides: Partial<LocalWorkspaceTurnEvidenc
   return report;
 }
 
+/**
+ * V4 report with one FAILED LOCAL-WORLD-SMOKE-1 cell whose cleanup did not fully
+ * reconcile: the cell records `cleanup.failed > 0` and an incomplete deletion.
+ * Per the spec failure table a cleanup failure makes the aggregate non-qualifying
+ * and nonzero; the report must still persist (exit 1) rather than throw (exit 2).
+ */
+function failedCleanupSmokeReportV4(): TestRunReportV4 {
+  const report = validSmokeReportV4();
+  report.run.behavior = "strict";
+  report.candidate_build = STRICT_CB;
+  report.results[0] = {
+    ...report.results[0],
+    status: "failed",
+    reason: { code: "scenario_failure", message: "cleanup did not fully reconcile (failed=1)" },
+    evidence: validCellEvidence({
+      cleanup: {
+        ledger_id_hash: "d".repeat(64),
+        registered: 8,
+        reconciled: 7,
+        failed: 1,
+        virtual_key_deleted: false,
+        litellm_subjects_deleted: true,
+        browser_closed: true,
+        processes_stopped: true,
+        containers_removed: true,
+        local_paths_removed: true,
+      },
+    }),
+  };
+  const byStatus = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
+    FinalTestStatus,
+    number
+  >;
+  byStatus.failed = 1;
+  report.summary.by_status = byStatus;
+  report.summary.intended_exit_code = 1;
+  report.verdict.status = "selected_cells_failed";
+  withDerivedReasons(report);
+  return report;
+}
+
 test("validateReportV4 accepts schema_version 4 with null evidence on an ordinary cell", () => {
   validateReportV4(validReportV4());
 });
@@ -813,6 +854,31 @@ test("writeReportV4 sanitizes, validates, and writes a V4 artifact", async () =>
     const parsed = JSON.parse(raw);
     assert.equal(parsed.schema_version, 4);
     assert.equal(parsed.results[0].evidence.kind, "local_workspace_turn");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("validateReportV4 accepts a failed cell whose cleanup evidence records failed>0", () => {
+  // The sibling green case (failed>0 on a green cell) is still rejected — see
+  // "validateReportV4 rejects a green cell whose cleanup has a false deletion
+  // flag or a failure" above. Here the same evidence is valid because the cell
+  // is non-green and merely records its own cleanup failure.
+  validateReportV4(failedCleanupSmokeReportV4());
+});
+
+test("writeReportV4 persists a failed cleanup-failure cell (exit 1, report written, not throw→exit 2)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "q1-evidence-v4-"));
+  try {
+    const written = await writeReportV4(dir, failedCleanupSmokeReportV4());
+    const parsed = JSON.parse(await readFile(written, "utf8"));
+    assert.equal(parsed.schema_version, 4);
+    assert.equal(parsed.results[0].status, "failed");
+    assert.equal(parsed.results[0].evidence.cleanup.failed, 1);
+    assert.equal(parsed.results[0].evidence.cleanup.virtual_key_deleted, false);
+    // The report IS persisted with a real nonzero intended exit, so the CLI
+    // returns exit 1 rather than throwing on write and returning exit 2.
+    assert.equal(parsed.summary.intended_exit_code, 1);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -714,7 +714,9 @@ function failedCleanupSmokeReportV4(): TestRunReportV4 {
   report.summary.by_status = byStatus;
   report.summary.intended_exit_code = 1;
   report.verdict.status = "selected_cells_failed";
-  withDerivedReasons(report);
+  // withDerivedReasons mutates verdict.reasons in place; the V3 parameter type is
+  // structurally satisfied (V4 only adds schema_version 4 + per-result evidence).
+  withDerivedReasons(report as unknown as TestRunReportV3);
   return report;
 }
 

--- a/tests/release/src/evidence/write.ts
+++ b/tests/release/src/evidence/write.ts
@@ -2,7 +2,13 @@ import { link, mkdir, unlink, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 
-import { validateReport, type TestRunReportV3 } from "./schema.js";
+import {
+  sanitizeReportV4Evidence,
+  validateReport,
+  validateReportV4,
+  type TestRunReportV3,
+  type TestRunReportV4,
+} from "./schema.js";
 
 export class ReportWriteError extends Error {
   constructor(message: string) {
@@ -11,7 +17,11 @@ export class ReportWriteError extends Error {
   }
 }
 
-export function reportPath(outputDir: string, report: TestRunReportV3): string {
+interface ReportPathIdentity {
+  run: { run_id: string; shard_id: string; attempt: number };
+}
+
+export function reportPath(outputDir: string, report: ReportPathIdentity): string {
   return path.join(
     outputDir,
     report.run.run_id,
@@ -30,6 +40,27 @@ export function reportPath(outputDir: string, report: TestRunReportV3): string {
  */
 export async function writeReport(outputDir: string, report: TestRunReportV3): Promise<string> {
   validateReport(report);
+  return writeValidatedReport(outputDir, report);
+}
+
+/**
+ * V4 counterpart of `writeReport`: sanitizes every evidence string field
+ * through the same redaction pipeline message fields use (BRIEF §6.6), then
+ * validates and writes with the same atomic, no-overwrite semantics.
+ * `secretValues` are the same resolved manifest secrets the V3 producer
+ * (`runner/execute.ts`) redacts message fields with.
+ */
+export async function writeReportV4(
+  outputDir: string,
+  report: TestRunReportV4,
+  secretValues: readonly string[] = [],
+): Promise<string> {
+  const sanitized = sanitizeReportV4Evidence(report, secretValues);
+  validateReportV4(sanitized);
+  return writeValidatedReport(outputDir, sanitized);
+}
+
+async function writeValidatedReport(outputDir: string, report: ReportPathIdentity): Promise<string> {
   const destination = reportPath(outputDir, report);
   try {
     await mkdir(path.dirname(destination), { recursive: true });

--- a/tests/release/src/fixtures/authenticated-actor.test.ts
+++ b/tests/release/src/fixtures/authenticated-actor.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  authenticatedActor,
+  toStoredSession,
+  type AuthenticatedActorTransport,
+} from "./authenticated-actor.js";
+import { ApiClient } from "./http.js";
+import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+import type { ActorKeyIdentity } from "../services/qualification-litellm.js";
+
+function fakeWorld(): ReadyLocalWorld {
+  return {
+    kind: "local-workspace",
+    run: {
+      run_id: "local-run-1",
+      shard_id: "local-0",
+      attempt: 1,
+      source_sha: "a".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+    },
+    artifacts: {
+      server: { artifact_id: "server/linux-amd64", version: "1", sha256: "s".repeat(64), path: "/tmp/server" },
+      anyharness: { artifact_id: "anyharness/x86_64", version: "1", sha256: "a".repeat(64), path: "/tmp/anyharness" },
+      desktopRenderer: {
+        artifact_id: "desktop-renderer/browser",
+        version: "1",
+        sha256: "d".repeat(64),
+        path: "/tmp/renderer",
+      },
+    },
+    api: { baseUrl: "http://127.0.0.1:9001", client: new ApiClient({ baseUrl: "http://127.0.0.1:9001" }) },
+    runtime: { baseUrl: "http://127.0.0.1:9002", client: undefined as never },
+    renderer: { baseUrl: "http://127.0.0.1:9003", browser: undefined as never },
+    gateway: {
+      resolveActorKey: async ({ userId, enrollmentId }: { userId: string; enrollmentId: string }) =>
+        ({
+          userId,
+          enrollmentId,
+          teamId: "team-1",
+          litellmUserId: "litellm-user-1",
+          keyAlias: `vk-user-${userId}-${enrollmentId.slice(0, 8)}`,
+          tokenId: "token-1",
+          tokenIdHash: "hash-1",
+        }) satisfies ActorKeyIdentity,
+    } as unknown as ReadyLocalWorld["gateway"],
+    paths: { runDir: "/tmp/run-1", runtimeHome: "/tmp/run-1/runtime-home", repositoriesDir: "/tmp/run-1/repositories" },
+    close: async () => {
+      throw new Error("not used in this test");
+    },
+  };
+}
+
+function fakeTransport(overrides: Partial<AuthenticatedActorTransport> = {}): {
+  transport: AuthenticatedActorTransport;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  let enrollmentCallCount = 0;
+  const transport: AuthenticatedActorTransport = {
+    readSetupToken: async (setupTokenPath) => {
+      calls.push(`readSetupToken:${setupTokenPath}`);
+      return "the-setup-token";
+    },
+    claimSetup: async (params) => {
+      calls.push(`claimSetup:${params.email}`);
+    },
+    loginWithPassword: async (apiBaseUrl, email) => {
+      calls.push(`loginWithPassword:${email}`);
+      return {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        token_type: "bearer",
+        expires_in: 3600,
+        user: { id: "user-1", email, display_name: "Owner", github_login: null, avatar_url: null },
+      };
+    },
+    listOrganizations: async () => {
+      calls.push("listOrganizations");
+      return { organizations: [{ id: "org-1" }] };
+    },
+    getEnrollment: async () => {
+      enrollmentCallCount += 1;
+      calls.push(`getEnrollment:${enrollmentCallCount}`);
+      return {
+        id: "enrollment-1",
+        subjectKind: "user",
+        litellmTeamId: "team-1",
+        syncStatus: enrollmentCallCount < 2 ? "pending" : "synced",
+        lastErrorCode: null,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+    },
+    putGatewaySelection: async (_api, harnessKind) => {
+      calls.push(`putGatewaySelection:${harnessKind}`);
+    },
+    ...overrides,
+  };
+  return { transport, calls };
+}
+
+test("toStoredSession maps the desktop token response onto the snake_case StoredAuthSession the client persists", () => {
+  const session = toStoredSession({
+    access_token: "a",
+    refresh_token: "r",
+    token_type: "bearer",
+    expires_in: 60,
+    user: { id: "u1", email: "owner@example.com", display_name: "Owner", github_login: "owner", avatar_url: null },
+  });
+  assert.equal(session.access_token, "a");
+  assert.equal(session.refresh_token, "r");
+  assert.equal(session.user_id, "u1");
+  assert.equal(session.email, "owner@example.com");
+  assert.equal(session.display_name, "Owner");
+  assert.equal(session.github_login, "owner");
+  assert.ok(!Number.isNaN(Date.parse(session.expires_at)));
+});
+
+test("authenticatedActor drives claim -> login -> org lookup -> enrollment poll -> gateway selection -> key resolution, in order", async () => {
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+
+  const actor = await authenticatedActor(world, "owner", {}, transport);
+
+  assert.equal(actor.role, "owner");
+  assert.equal(actor.userId, "user-1");
+  assert.equal(actor.organizationId, "org-1");
+  assert.equal(actor.enrollmentId, "enrollment-1");
+  assert.equal(actor.gatewayKey.keyAlias, "vk-user-user-1-enrollme");
+  assert.equal(actor.session.access_token, "access-1");
+  // Never persists the raw password anywhere on the returned actor.
+  assert.equal(JSON.stringify(actor).includes(actor.session.access_token), true);
+  assert.equal("password" in (actor as unknown as Record<string, unknown>), false);
+
+  assert.deepEqual(calls, [
+    "readSetupToken:/tmp/run-1/setup-token",
+    "claimSetup:qual-owner-local-run-1-local-0@local-world-smoke.invalid",
+    "loginWithPassword:qual-owner-local-run-1-local-0@local-world-smoke.invalid",
+    "listOrganizations",
+    "getEnrollment:1",
+    "getEnrollment:2",
+    "putGatewaySelection:claude",
+  ]);
+});
+
+test("authenticatedActor rejects non-owner roles", async () => {
+  const world = fakeWorld();
+  const { transport } = fakeTransport();
+  await assert.rejects(
+    () => authenticatedActor(world, "admin" as unknown as "owner", {}, transport),
+    /unsupported role/,
+  );
+});
+
+test("authenticatedActor skips gateway-selection PUT when selectGatewayRoute is false", async () => {
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  await authenticatedActor(world, "owner", { selectGatewayRoute: false }, transport);
+  assert.ok(!calls.some((call) => call.startsWith("putGatewaySelection")));
+});
+
+test("authenticatedActor propagates a bounded timeout when enrollment never syncs", async () => {
+  const world = fakeWorld();
+  const { transport } = fakeTransport({
+    getEnrollment: async () => ({
+      id: "enrollment-1",
+      subjectKind: "user",
+      litellmTeamId: null,
+      syncStatus: "pending",
+      lastErrorCode: "gateway_unreachable",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    }),
+  });
+  await assert.rejects(
+    () => authenticatedActor(world, "owner", { enrollmentTimeoutMs: 5, enrollmentPollMs: 1 }, transport),
+    /did not reach "synced"/,
+  );
+});
+
+test("authenticatedActor propagates claim failures without masking them", async () => {
+  const world = fakeWorld();
+  const { transport } = fakeTransport({
+    claimSetup: async () => {
+      throw new Error("POST /setup -> 400: invalid setup token");
+    },
+  });
+  await assert.rejects(() => authenticatedActor(world, "owner", {}, transport), /invalid setup token/);
+});

--- a/tests/release/src/fixtures/authenticated-actor.test.ts
+++ b/tests/release/src/fixtures/authenticated-actor.test.ts
@@ -136,8 +136,8 @@ test("authenticatedActor drives claim -> login -> org lookup -> enrollment poll 
 
   assert.deepEqual(calls, [
     "readSetupToken:/tmp/run-1/setup-token",
-    "claimSetup:qual-owner-local-run-1-local-0@local-world-smoke.invalid",
-    "loginWithPassword:qual-owner-local-run-1-local-0@local-world-smoke.invalid",
+    "claimSetup:qual-owner-local-run-1-local-0@example.com",
+    "loginWithPassword:qual-owner-local-run-1-local-0@example.com",
     "listOrganizations",
     "getEnrollment:1",
     "getEnrollment:2",

--- a/tests/release/src/fixtures/authenticated-actor.ts
+++ b/tests/release/src/fixtures/authenticated-actor.ts
@@ -1,0 +1,311 @@
+import { randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { ApiClient } from "./http.js";
+import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+import type { ActorKeyIdentity } from "../services/qualification-litellm.js";
+
+/**
+ * `authenticatedActor("owner")` (spec "Fixtures"). Only prerequisites are
+ * fixtures; workspace/session creation and the turn remain behavior under test.
+ * This fixture:
+ *
+ *   - claims the fresh Server through the real one-time `/setup` path
+ *     (mounted only with SINGLE_ORG_MODE=true);
+ *   - logs in through `/auth/desktop/password/login` and maps the response
+ *     through the same stored-session shape the Desktop client uses;
+ *   - relies on eager personal gateway enrollment scheduled from the first-run
+ *     claim (a narrowly tested product fix), and still polls the PUBLIC
+ *     enrollment endpoint so eventual recovery stays covered;
+ *   - waits for the real gateway enrollment to become `synced`;
+ *   - returns actor/user/organization identity and a product API session; and
+ *   - never persists the generated password or raw virtual key in evidence.
+ *
+ * It MAY use the authenticated gateway-selection API
+ * (`PUT {api_prefix}/v1/cloud/agent-gateway/selections/{harness_kind}`) to
+ * select `gateway` for the representative harness — prerequisite state only.
+ * It MUST NOT call `PUT /v1/agent-auth/state` itself; Desktop pushes that.
+ *
+ * Verified against `origin/main` `0eab251fd`:
+ *   - `POST /setup` is a FORM post (`email`, `password`, `setup_token`,
+ *     `organization_name` — `server/proliferate/server/setup/api.py`), gated by
+ *     a token written to `settings.setup_token_file`
+ *     (`PROLIFERATE_SETUP_TOKEN_FILE`/`SETUP_TOKEN_FILE`, default
+ *     `/var/lib/proliferate/setup/setup-token`). The world/Docker controller
+ *     (workstream A) must bind-mount that file to a run-owned path readable by
+ *     this fixture; this module assumes the convention `<runDir>/setup-token`,
+ *     overridable via `setupTokenPath` — flagged for the integrator to confirm
+ *     against `docker.ts`.
+ *   - `POST /auth/desktop/password/login`
+ *     (`server/proliferate/auth/desktop/api.py`) returns `DesktopTokenResponse
+ *     { access_token, refresh_token, token_type, expires_in, user: {...} }`;
+ *     the real Desktop `toStoredSession()`
+ *     (`apps/desktop/src/lib/integrations/auth/proliferate-auth.ts`) maps it to
+ *     the SNAKE_CASE `StoredAuthSession` in
+ *     `apps/desktop/src/lib/domain/auth/stored-auth-session.ts` — not the
+ *     camelCase placeholder shape the contracts-stage skeleton sketched.
+ *     Corrected here since this type is owned by this workstream's file (see
+ *     final report for the disclosed deviation).
+ *   - `GET {api_prefix}/v1/cloud/agent-gateway/enrollment` returns
+ *     `syncStatus` (`AgentGatewayEnrollmentResponse`,
+ *     `server/proliferate/server/cloud/agent_gateway/models.py`); the synced
+ *     value is `AGENT_GATEWAY_SYNC_STATUS_SYNCED = "synced"`
+ *     (`server/proliferate/constants/agent_gateway.py`).
+ *   - `PUT {api_prefix}/v1/cloud/agent-gateway/selections/{harness_kind}?surface=local`
+ *     body `{ sources: [{ sourceKind: "gateway", enabled: true }] }`
+ *     (`AgentAuthSelectionsPutRequest`/`AgentAuthSourceInput`, same file).
+ *   - Organization identity comes from `GET {api_prefix}/v1/organizations`
+ *     (`{ organizations: [{ id, ... }] }`), same pattern
+ *     `RELEASE_E2E_DURABLE_ORG_ID` documents for the durable-user fixtures.
+ */
+
+export type ActorRole = "owner";
+
+/**
+ * The stored-session shape the Desktop client persists under
+ * `proliferate.auth.session`
+ * (`apps/desktop/src/lib/domain/auth/stored-auth-session.ts`, mapped by
+ * `toStoredSession()` in
+ * `apps/desktop/src/lib/integrations/auth/proliferate-auth.ts`). The
+ * product-page fixture installs exactly this into browser storage before boot.
+ */
+export interface StoredAuthSession {
+  access_token: string;
+  refresh_token: string;
+  expires_at: string;
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  github_login?: string | null;
+  avatar_url?: string | null;
+}
+
+export interface AuthenticatedActor {
+  role: ActorRole;
+  userId: string;
+  organizationId: string;
+  enrollmentId: string;
+  /** Authenticated product API client (bearer set). */
+  api: ApiClient;
+  /** Browser-installable stored session (no raw password persisted). */
+  session: StoredAuthSession;
+  /** The actor's resolved LiteLLM key identity (token id stays in memory). */
+  gatewayKey: ActorKeyIdentity;
+}
+
+export interface AuthenticatedActorOptions {
+  /** Overrides the derived organization name (defaults to a run-scoped name). */
+  organizationName?: string;
+  /** Overrides the derived claim email (defaults to a run-scoped local address). */
+  email?: string;
+  /** Path to the plaintext setup-token file; defaults to `<runDir>/setup-token`. */
+  setupTokenPath?: string;
+  /** Bounded wait for enrollment sync (default 60s). */
+  enrollmentTimeoutMs?: number;
+  /** Poll interval while waiting for enrollment sync (default 2s). */
+  enrollmentPollMs?: number;
+  /** Harness to select the gateway route for (default "claude"). */
+  harnessKind?: string;
+  /** Set false to skip the gateway-selection PUT (default true). */
+  selectGatewayRoute?: boolean;
+}
+
+interface DesktopTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_in: number;
+  user: {
+    id: string;
+    email: string;
+    display_name: string | null;
+    github_login?: string | null;
+    avatar_url?: string | null;
+  };
+}
+
+interface EnrollmentResponse {
+  id: string;
+  subjectKind: string;
+  litellmTeamId: string | null;
+  syncStatus: string;
+  lastErrorCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface OrganizationsListResponse {
+  organizations: Array<{ id: string }>;
+}
+
+export const SYNCED_ENROLLMENT_STATUS = "synced";
+
+/**
+ * Every network/filesystem side effect this fixture performs, factored out so
+ * unit tests can fake the transport without a real Server/filesystem. The
+ * default (`defaultAuthenticatedActorTransport`) is what production wiring
+ * uses.
+ */
+export interface AuthenticatedActorTransport {
+  readSetupToken(setupTokenPath: string): Promise<string>;
+  claimSetup(params: {
+    apiBaseUrl: string;
+    email: string;
+    password: string;
+    setupToken: string;
+    organizationName: string;
+  }): Promise<void>;
+  loginWithPassword(apiBaseUrl: string, email: string, password: string): Promise<DesktopTokenResponse>;
+  listOrganizations(api: ApiClient): Promise<OrganizationsListResponse>;
+  getEnrollment(api: ApiClient): Promise<EnrollmentResponse>;
+  putGatewaySelection(api: ApiClient, harnessKind: string): Promise<void>;
+}
+
+export const defaultAuthenticatedActorTransport: AuthenticatedActorTransport = {
+  async readSetupToken(setupTokenPath) {
+    return (await readFile(setupTokenPath, "utf8")).trim();
+  },
+  async claimSetup({ apiBaseUrl, email, password, setupToken, organizationName }) {
+    const body = new URLSearchParams({
+      email,
+      password,
+      setup_token: setupToken,
+      organization_name: organizationName,
+    });
+    const response = await fetch(`${apiBaseUrl}/setup`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`POST /setup -> ${response.status}: ${text.slice(0, 2000)}`);
+    }
+  },
+  async loginWithPassword(apiBaseUrl, email, password) {
+    const response = await fetch(`${apiBaseUrl}/auth/desktop/password/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`POST /auth/desktop/password/login -> ${response.status}: ${text.slice(0, 2000)}`);
+    }
+    return (await response.json()) as DesktopTokenResponse;
+  },
+  async listOrganizations(api) {
+    return api.get<OrganizationsListResponse>("/v1/organizations");
+  },
+  async getEnrollment(api) {
+    return api.get<EnrollmentResponse>("/v1/cloud/agent-gateway/enrollment");
+  },
+  async putGatewaySelection(api, harnessKind) {
+    await api.put(`/v1/cloud/agent-gateway/selections/${encodeURIComponent(harnessKind)}?surface=local`, {
+      sources: [{ sourceKind: "gateway", enabled: true }],
+    });
+  },
+};
+
+/** Maps the real `/auth/desktop/password/login` response onto the browser-installable session. */
+export function toStoredSession(response: DesktopTokenResponse): StoredAuthSession {
+  const expiresAt = new Date(Date.now() + response.expires_in * 1000).toISOString();
+  return {
+    access_token: response.access_token,
+    refresh_token: response.refresh_token,
+    expires_at: expiresAt,
+    user_id: response.user.id,
+    email: response.user.email,
+    display_name: response.user.display_name,
+    github_login: response.user.github_login ?? null,
+    avatar_url: response.user.avatar_url ?? null,
+  };
+}
+
+/**
+ * Creates the fresh owner actor against a ready world: setup claim → desktop
+ * password login → wait for gateway enrollment `synced` → resolve the actor
+ * LiteLLM key → optionally select the `gateway` route for the harness.
+ */
+export async function authenticatedActor(
+  world: ReadyLocalWorld,
+  role: ActorRole,
+  options: AuthenticatedActorOptions = {},
+  transport: AuthenticatedActorTransport = defaultAuthenticatedActorTransport,
+): Promise<AuthenticatedActor> {
+  if (role !== "owner") {
+    throw new Error(`authenticatedActor: unsupported role "${role}" (only "owner" is implemented).`);
+  }
+
+  const setupTokenPath = options.setupTokenPath ?? path.join(world.paths.runDir, "setup-token");
+  const setupToken = await transport.readSetupToken(setupTokenPath);
+
+  const email = options.email ?? `qual-owner-${world.run.run_id}-${world.run.shard_id}@local-world-smoke.invalid`;
+  const password = randomBytes(24).toString("hex");
+  const organizationName = options.organizationName ?? `local-world-smoke-${world.run.run_id}`;
+
+  await transport.claimSetup({ apiBaseUrl: world.api.baseUrl, email, password, setupToken, organizationName });
+
+  const tokenResponse = await transport.loginWithPassword(world.api.baseUrl, email, password);
+  const session = toStoredSession(tokenResponse);
+  const api = world.api.client.withBearerToken(session.access_token);
+
+  const organizations = await transport.listOrganizations(api);
+  const organization = organizations.organizations[0];
+  if (!organization) {
+    throw new Error("authenticatedActor: claimed owner has no organization membership.");
+  }
+
+  const harnessKind = options.harnessKind ?? "claude";
+  const enrollment = await waitForSyncedEnrollment(api, transport, {
+    timeoutMs: options.enrollmentTimeoutMs ?? 60_000,
+    pollMs: options.enrollmentPollMs ?? 2_000,
+  });
+
+  if (options.selectGatewayRoute !== false) {
+    await transport.putGatewaySelection(api, harnessKind);
+  }
+
+  const gatewayKey = await world.gateway.resolveActorKey({
+    userId: session.user_id,
+    enrollmentId: enrollment.id,
+  });
+
+  return {
+    role,
+    userId: session.user_id,
+    organizationId: organization.id,
+    enrollmentId: enrollment.id,
+    api,
+    session,
+    gatewayKey,
+  };
+}
+
+async function waitForSyncedEnrollment(
+  api: ApiClient,
+  transport: AuthenticatedActorTransport,
+  options: { timeoutMs: number; pollMs: number },
+): Promise<EnrollmentResponse> {
+  const deadline = Date.now() + options.timeoutMs;
+  let last: EnrollmentResponse | undefined;
+  for (;;) {
+    last = await transport.getEnrollment(api);
+    if (last.syncStatus === SYNCED_ENROLLMENT_STATUS) {
+      return last;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `authenticatedActor: gateway enrollment did not reach "${SYNCED_ENROLLMENT_STATUS}" within ` +
+          `${options.timeoutMs}ms (last status "${last.syncStatus}", lastErrorCode ` +
+          `"${last.lastErrorCode ?? "none"}").`,
+      );
+    }
+    await sleep(options.pollMs);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/release/src/fixtures/authenticated-actor.ts
+++ b/tests/release/src/fixtures/authenticated-actor.ts
@@ -241,7 +241,11 @@ export async function authenticatedActor(
   const setupTokenPath = options.setupTokenPath ?? path.join(world.paths.runDir, "setup-token");
   const setupToken = await transport.readSetupToken(setupTokenPath);
 
-  const email = options.email ?? `qual-owner-${world.run.run_id}-${world.run.shard_id}@local-world-smoke.invalid`;
+  // NOTE: a real, non-reserved TLD is required. `normalize_account_email`
+  // (server/proliferate/server/setup/accounts.py) rejects the special-use TLDs
+  // `.invalid`/`.test`/`.local`/`.localhost` with a 400, so the claim uses a
+  // syntactically valid `example.com` address (no mail is ever sent).
+  const email = options.email ?? `qual-owner-${world.run.run_id}-${world.run.shard_id}@example.com`;
   const password = randomBytes(24).toString("hex");
   const organizationName = options.organizationName ?? `local-world-smoke-${world.run.run_id}`;
 
@@ -290,20 +294,38 @@ async function waitForSyncedEnrollment(
 ): Promise<EnrollmentResponse> {
   const deadline = Date.now() + options.timeoutMs;
   let last: EnrollmentResponse | undefined;
+  let lastStatusNote = "no enrollment row yet";
   for (;;) {
-    last = await transport.getEnrollment(api);
-    if (last.syncStatus === SYNCED_ENROLLMENT_STATUS) {
-      return last;
+    try {
+      last = await transport.getEnrollment(api);
+      lastStatusNote = `status "${last.syncStatus}", lastErrorCode "${last.lastErrorCode ?? "none"}"`;
+      if (last.syncStatus === SYNCED_ENROLLMENT_STATUS) {
+        return last;
+      }
+    } catch (error) {
+      // The enrollment row is created asynchronously by the server's backfill
+      // loop (server/proliferate/server/cloud/agent_gateway/enrollment.py); the
+      // setup-claim account path does not eagerly enrol. Until the first
+      // backfill pass runs, `GET .../enrollment` returns 404 — a transient
+      // not-yet-enrolled state to poll through, not a hard failure.
+      if (!isNotFound(error)) {
+        throw error;
+      }
+      lastStatusNote = "enrollment row not created yet (404)";
     }
     if (Date.now() >= deadline) {
       throw new Error(
         `authenticatedActor: gateway enrollment did not reach "${SYNCED_ENROLLMENT_STATUS}" within ` +
-          `${options.timeoutMs}ms (last status "${last.syncStatus}", lastErrorCode ` +
-          `"${last.lastErrorCode ?? "none"}").`,
+          `${options.timeoutMs}ms (last: ${lastStatusNote}).`,
       );
     }
     await sleep(options.pollMs);
   }
+}
+
+/** True for a 404 from the enrollment endpoint (ApiRequestError.status === 404). */
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && (error as { status?: unknown }).status === 404;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/tests/release/src/fixtures/authenticated-actor.ts
+++ b/tests/release/src/fixtures/authenticated-actor.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -251,7 +252,18 @@ export async function authenticatedActor(
 
   await transport.claimSetup({ apiBaseUrl: world.api.baseUrl, email, password, setupToken, organizationName });
 
-  const tokenResponse = await transport.loginWithPassword(world.api.baseUrl, email, password);
+  let tokenResponse: DesktopTokenResponse;
+  try {
+    tokenResponse = await transport.loginWithPassword(world.api.baseUrl, email, password);
+  } catch (error) {
+    // Env-gated (LOCAL_WORLD_SMOKE_DEBUG_DIR) secret-free diagnostics for the
+    // CI-only `POST /auth/desktop/password/login -> 401`. Distinguishes "claim
+    // never persisted the owner" (setup still open) from "owner exists but the
+    // password/verify path fails" (setup closed). Never writes the password,
+    // setup token, access/refresh tokens, or any credential.
+    await captureAuthFailureDiagnostics(world.api.baseUrl, email).catch(() => undefined);
+    throw error;
+  }
   const session = toStoredSession(tokenResponse);
   const api = world.api.client.withBearerToken(session.access_token);
 
@@ -330,4 +342,52 @@ function isNotFound(error: unknown): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Env-gated (`LOCAL_WORLD_SMOKE_DEBUG_DIR`) secret-free capture of why the
+ * setup-claim → password-login handshake failed. Only read-only, credential-free
+ * signals are recorded:
+ *
+ *   - `GET /setup`: 404/"nothing to set up" means the claim DID consume setup
+ *     (owner exists → the 401 is a verify/state problem); a 200 setup form means
+ *     the claim did NOT persist (commit/visibility problem);
+ *   - `GET /auth/desktop/methods`: whether password login is enabled at all.
+ *
+ * The setup page HTML is reduced to a boolean marker; no page body, password,
+ * setup token, or session token is ever written.
+ */
+async function captureAuthFailureDiagnostics(apiBaseUrl: string, email: string): Promise<void> {
+  const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  if (!dir) {
+    return;
+  }
+  const diag: Record<string, unknown> = { emailLocalPartLength: email.split("@")[0]?.length ?? 0 };
+
+  try {
+    const setup = await fetch(`${apiBaseUrl}/setup`, { method: "GET" });
+    const body = await setup.text().catch(() => "");
+    diag.setupGet = {
+      status: setup.status,
+      // Boolean markers only — never the page body.
+      setupStillOpen: /name="setup_token"/.test(body),
+      nothingToSetUp: /nothing to set up/i.test(body),
+    };
+  } catch (error) {
+    diag.setupGet = `err: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  try {
+    const methods = await fetch(`${apiBaseUrl}/auth/desktop/methods`, { method: "GET" });
+    diag.authMethods = { status: methods.status, body: await methods.json().catch(() => null) };
+  } catch (error) {
+    diag.authMethods = `err: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, `auth-failure-diag-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+  } catch {
+    // Best-effort diagnostics.
+  }
 }

--- a/tests/release/src/fixtures/local-runtime.ts
+++ b/tests/release/src/fixtures/local-runtime.ts
@@ -160,8 +160,29 @@ export class LocalRuntimeClient {
     return response.models;
   }
 
+  /**
+   * The runtime's per-agent launch options (`GET /v1/agents/launch-options`) —
+   * the exact source Desktop's composer reads for local launch. An agent only
+   * appears here (with a non-empty `models` list) once its process is installed
+   * and its credentials resolve, so it is the authoritative "is this harness
+   * launchable in the UI yet" signal.
+   */
+  async getAgentLaunchOptions(): Promise<Array<{ kind: string; models: Array<{ id: string }> }>> {
+    const response = await this.request<{ agents: Array<{ kind: string; models: Array<{ id: string }> }> }>(
+      "GET",
+      "/v1/agents/launch-options",
+    );
+    return response.agents;
+  }
+
   async createLocalWorkspace(path: string): Promise<CreateWorkspaceResponse> {
     return this.request<CreateWorkspaceResponse>("POST", "/v1/workspaces", { path });
+  }
+
+  /** All workspaces the runtime currently knows about (diagnostic use). */
+  async listWorkspaces(): Promise<Workspace[]> {
+    const response = await this.request<{ workspaces?: Workspace[] } | Workspace[]>("GET", "/v1/workspaces");
+    return Array.isArray(response) ? response : (response.workspaces ?? []);
   }
 
   async createWorktree(params: {
@@ -199,6 +220,12 @@ export class LocalRuntimeClient {
 
   async getSession(sessionId: string): Promise<SessionSummary> {
     return this.request<SessionSummary>("GET", `/v1/sessions/${sessionId}`);
+  }
+
+  /** All sessions the runtime currently knows about (diagnostic use). */
+  async listSessions(): Promise<SessionSummary[]> {
+    const response = await this.request<{ sessions?: SessionSummary[] } | SessionSummary[]>("GET", "/v1/sessions");
+    return Array.isArray(response) ? response : (response.sessions ?? []);
   }
 
   async prompt(sessionId: string, text: string): Promise<void> {

--- a/tests/release/src/fixtures/prepared-repository.test.ts
+++ b/tests/release/src/fixtures/prepared-repository.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { preparedRepository, type PreparedRepositoryTransport } from "./prepared-repository.js";
+import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+
+function fakeWorld(): ReadyLocalWorld {
+  return {
+    kind: "local-workspace",
+    run: {
+      run_id: "local-run-1",
+      shard_id: "local-0",
+      attempt: 1,
+      source_sha: "a".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+    },
+    artifacts: undefined as never,
+    api: undefined as never,
+    runtime: { baseUrl: "http://127.0.0.1:9002", client: undefined as never },
+    renderer: undefined as never,
+    gateway: undefined as never,
+    paths: {
+      runDir: "/tmp/run-1",
+      runtimeHome: "/tmp/run-1/runtime-home",
+      repositoriesDir: "/tmp/run-1/repositories",
+    },
+    close: async () => {
+      throw new Error("not used in this test");
+    },
+  };
+}
+
+function fakeActor(): AuthenticatedActor {
+  return {
+    role: "owner",
+    userId: "user-1",
+    organizationId: "org-1",
+    enrollmentId: "enrollment-1",
+    api: undefined as never,
+    session: undefined as never,
+    gatewayKey: undefined as never,
+  };
+}
+
+function fakeTransport(): { transport: PreparedRepositoryTransport; calls: string[] } {
+  const calls: string[] = [];
+  const transport: PreparedRepositoryTransport = {
+    ensureCleanDir: async (dirPath) => {
+      calls.push(`ensureCleanDir:${dirPath}`);
+    },
+    cloneAndCheckout: async (repoUrl, commit, destDir) => {
+      calls.push(`cloneAndCheckout:${repoUrl}:${commit}:${destDir}`);
+    },
+    resolveRepoRoot: async (runtimeBaseUrl, repoPath) => {
+      calls.push(`resolveRepoRoot:${runtimeBaseUrl}:${repoPath}`);
+      return { id: "repo-root-1" };
+    },
+  };
+  return { transport, calls };
+}
+
+test("preparedRepository clones into a cell-scoped subdirectory of the world's repositoriesDir, checks out the pinned commit, and resolves the repo root", async () => {
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+
+  const repo = await preparedRepository(
+    world,
+    fakeActor(),
+    { repoUrl: "https://github.com/example/fixture.git", commit: "deadbeef", cellId: "harness=claude" },
+    transport,
+  );
+
+  assert.equal(repo.repoUrl, "https://github.com/example/fixture.git");
+  assert.equal(repo.commit, "deadbeef");
+  assert.equal(repo.repoRootId, "repo-root-1");
+  assert.equal(repo.path, "/tmp/run-1/repositories/harness%3Dclaude");
+
+  assert.deepEqual(calls, [
+    "ensureCleanDir:/tmp/run-1/repositories/harness%3Dclaude",
+    "cloneAndCheckout:https://github.com/example/fixture.git:deadbeef:/tmp/run-1/repositories/harness%3Dclaude",
+    "resolveRepoRoot:http://127.0.0.1:9002:/tmp/run-1/repositories/harness%3Dclaude",
+  ]);
+});
+
+test("preparedRepository defaults cellId so two calls without one collide on the same directory (caller must pass distinct cellIds for concurrency)", async () => {
+  const world = fakeWorld();
+  const { transport } = fakeTransport();
+  const repo = await preparedRepository(world, fakeActor(), undefined, transport);
+  assert.equal(repo.path, "/tmp/run-1/repositories/default");
+});
+
+test("preparedRepository propagates a clone failure without masking it", async () => {
+  const world = fakeWorld();
+  const { transport } = fakeTransport();
+  transport.cloneAndCheckout = async () => {
+    throw new Error("git clone ... failed (128): Repository not found.");
+  };
+  await assert.rejects(() => preparedRepository(world, fakeActor(), {}, transport), /Repository not found/);
+});
+
+test("preparedRepository propagates a repo-root resolution failure without masking it", async () => {
+  const world = fakeWorld();
+  const { transport } = fakeTransport();
+  transport.resolveRepoRoot = async () => {
+    throw new Error("POST /v1/repo-roots/resolve -> 400: REPO_ROOT_NOT_GIT_REPO");
+  };
+  await assert.rejects(() => preparedRepository(world, fakeActor(), {}, transport), /REPO_ROOT_NOT_GIT_REPO/);
+});

--- a/tests/release/src/fixtures/prepared-repository.test.ts
+++ b/tests/release/src/fixtures/prepared-repository.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { test } from "node:test";
 
 import { preparedRepository, type PreparedRepositoryTransport } from "./prepared-repository.js";
+
+function sha8(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 8);
+}
 import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
 import type { AuthenticatedActor } from "./authenticated-actor.js";
 
@@ -74,12 +79,16 @@ test("preparedRepository clones into a cell-scoped subdirectory of the world's r
   assert.equal(repo.repoUrl, "https://github.com/example/fixture.git");
   assert.equal(repo.commit, "deadbeef");
   assert.equal(repo.repoRootId, "repo-root-1");
-  assert.equal(repo.path, "/tmp/run-1/repositories/harness%3Dclaude");
+  // Filesystem-safe, unique clone dir: sanitized cell id + short cell-id hash
+  // (no literal `%2F`/`%3D`, which the desktop workspace-entry path mishandled).
+  const expectedDir = `/tmp/run-1/repositories/harness-claude-${sha8("harness=claude")}`;
+  assert.equal(repo.path, expectedDir);
+  assert.match(repo.path, /^\/tmp\/run-1\/repositories\/[A-Za-z0-9._-]+$/);
 
   assert.deepEqual(calls, [
-    "ensureCleanDir:/tmp/run-1/repositories/harness%3Dclaude",
-    "cloneAndCheckout:https://github.com/example/fixture.git:deadbeef:/tmp/run-1/repositories/harness%3Dclaude",
-    "resolveRepoRoot:http://127.0.0.1:9002:/tmp/run-1/repositories/harness%3Dclaude",
+    `ensureCleanDir:${expectedDir}`,
+    `cloneAndCheckout:https://github.com/example/fixture.git:deadbeef:${expectedDir}`,
+    `resolveRepoRoot:http://127.0.0.1:9002:${expectedDir}`,
   ]);
 });
 
@@ -87,7 +96,7 @@ test("preparedRepository defaults cellId so two calls without one collide on the
   const world = fakeWorld();
   const { transport } = fakeTransport();
   const repo = await preparedRepository(world, fakeActor(), undefined, transport);
-  assert.equal(repo.path, "/tmp/run-1/repositories/default");
+  assert.equal(repo.path, `/tmp/run-1/repositories/default-${sha8("default")}`);
 });
 
 test("preparedRepository propagates a clone failure without masking it", async () => {

--- a/tests/release/src/fixtures/prepared-repository.ts
+++ b/tests/release/src/fixtures/prepared-repository.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
@@ -115,7 +116,13 @@ export async function preparedRepository(
   const repoUrl = options?.repoUrl ?? defaultRepoUrl();
   const commit = options?.commit ?? DEFAULT_BASELINE_COMMIT;
   const cellId = options?.cellId ?? "default";
-  const destDir = path.join(world.paths.repositoriesDir, encodeURIComponent(cellId));
+  // Filesystem-safe, still-unique clone directory. `encodeURIComponent(cellId)`
+  // produced literal `%2F`/`%3D` in the path (cell id "…/local/harness=claude"),
+  // an unusual workspace path that the desktop workspace-entry / agent launch
+  // path can mishandle. Sanitize to `[A-Za-z0-9._-]` and append a short cellId
+  // hash so distinct cells still clone into disjoint directories.
+  const safeCellDir = `${cellId.replace(/[^A-Za-z0-9._-]+/g, "-")}-${cellIdHash(cellId)}`;
+  const destDir = path.join(world.paths.repositoriesDir, safeCellDir);
 
   await transport.ensureCleanDir(destDir);
   await transport.cloneAndCheckout(repoUrl, commit, destDir);
@@ -144,4 +151,9 @@ function runGit(args: string[], cwd: string): Promise<void> {
       resolve();
     });
   });
+}
+
+/** Short, stable hash of a cell id so distinct cells clone into disjoint dirs. */
+function cellIdHash(cellId: string): string {
+  return createHash("sha256").update(cellId).digest("hex").slice(0, 8);
 }

--- a/tests/release/src/fixtures/prepared-repository.ts
+++ b/tests/release/src/fixtures/prepared-repository.ts
@@ -24,11 +24,10 @@ import type { AuthenticatedActor } from "./authenticated-actor.js";
  * `ensureLocalClone()` helper in `src/fixtures/git.ts` — that helper
  * deliberately reuses one mutable clone across runs, which the spec's
  * "no shared mutable clone is reused between runs" requirement rules out here.
- * `DEFAULT_BASELINE_COMMIT` should be a real, verifiable commit on that repo's
- * default branch; override via `PreparedRepositoryOptions.commit` (or the
- * scenario's typed input) if that repository's history changes — flagged for
- * the integrator to confirm the exact pinned SHA against the live fixture
- * repo before the first real run.
+ * `DEFAULT_BASELINE_COMMIT` is a real, durable commit on that repo's default
+ * branch (`main`), pinned to a full SHA; override via
+ * `PreparedRepositoryOptions.commit` (or the scenario's typed input) if that
+ * repository's history changes.
  *
  * `POST /v1/repo-roots/resolve` on the local AnyHarness runtime
  * (`anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs`) is not yet
@@ -59,14 +58,13 @@ export interface PreparedRepositoryOptions {
 }
 
 /**
- * Placeholder pinned baseline commit on the durable qualification repo's
- * default branch. This MUST be confirmed against the live
- * `RELEASE_E2E_GITHUB_TEST_REPO` fixture (`proliferate-e2e/e2e-fixture`)
- * before the first real run — a wrong/absent SHA fails the clone loudly
- * rather than silently, so this is safe to ship unverified but is flagged in
- * the final report as a must-confirm item.
+ * Pinned baseline commit on the durable qualification repo's default branch
+ * (`proliferate-e2e/e2e-fixture` @ `main`). Pinned to a full, durable SHA
+ * (confirmed live via `gh api repos/proliferate-e2e/e2e-fixture/commits/main`
+ * on 2026-07-14) so every run checks out the exact same bytes; a
+ * wrong/absent SHA fails the clone loudly rather than silently.
  */
-export const DEFAULT_BASELINE_COMMIT = "HEAD";
+export const DEFAULT_BASELINE_COMMIT = "b70a83eda743a4ad615e33483bc8943055d3aa7d";
 
 function defaultRepoUrl(): string {
   return `https://github.com/${DEFAULT_GITHUB_TEST_REPO}.git`;

--- a/tests/release/src/fixtures/prepared-repository.ts
+++ b/tests/release/src/fixtures/prepared-repository.ts
@@ -1,0 +1,149 @@
+import { spawn } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+import { DEFAULT_GITHUB_TEST_REPO } from "../config/env-manifest.js";
+import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+
+/**
+ * `preparedRepository(actor)` (spec "Fixtures"). Prerequisite state only:
+ *
+ *   - clones the durable public qualification repository into a unique
+ *     `run/shard/cell` directory (no shared mutable clone is reused);
+ *   - checks out the pinned baseline commit;
+ *   - calls the real AnyHarness `POST /v1/repo-roots/resolve` path used after
+ *     the Desktop folder picker; and
+ *   - returns the path, repository identity, commit, and runtime repo-root id.
+ *
+ * Native folder-picker behavior is out of scope for this browser-renderer slice.
+ *
+ * Repo/commit resolution follows the existing `RELEASE_E2E_GITHUB_TEST_REPO`
+ * pattern (`src/config/env-manifest.ts`, default
+ * `proliferate-e2e/e2e-fixture`), NOT the shared-scratch-path
+ * `ensureLocalClone()` helper in `src/fixtures/git.ts` — that helper
+ * deliberately reuses one mutable clone across runs, which the spec's
+ * "no shared mutable clone is reused between runs" requirement rules out here.
+ * `DEFAULT_BASELINE_COMMIT` should be a real, verifiable commit on that repo's
+ * default branch; override via `PreparedRepositoryOptions.commit` (or the
+ * scenario's typed input) if that repository's history changes — flagged for
+ * the integrator to confirm the exact pinned SHA against the live fixture
+ * repo before the first real run.
+ *
+ * `POST /v1/repo-roots/resolve` on the local AnyHarness runtime
+ * (`anyharness/crates/anyharness-lib/src/api/http/repo_roots.rs`) is not yet
+ * exposed on `LocalRuntimeClient` (`src/fixtures/local-runtime.ts`, owned by
+ * workstream A / reused-not-edited by this workstream) — this module calls it
+ * directly via `fetch` against `world.runtime.baseUrl`. Flagged for the
+ * integrator: `resolveRepoRoot` belongs on `LocalRuntimeClient` long-term.
+ */
+
+export interface PreparedRepository {
+  /** Absolute path to the run/shard/cell-scoped clone. */
+  path: string;
+  /** Public qualification repo URL that was cloned. */
+  repoUrl: string;
+  /** Pinned baseline commit that was checked out. */
+  commit: string;
+  /** Runtime repo-root id returned by `POST /v1/repo-roots/resolve`. */
+  repoRootId: string;
+}
+
+export interface PreparedRepositoryOptions {
+  /** Overrides the default durable public qualification repo. */
+  repoUrl?: string;
+  /** Overrides the default pinned baseline commit. */
+  commit?: string;
+  /** Cell id, so concurrent cells clone into disjoint directories. */
+  cellId?: string;
+}
+
+/**
+ * Placeholder pinned baseline commit on the durable qualification repo's
+ * default branch. This MUST be confirmed against the live
+ * `RELEASE_E2E_GITHUB_TEST_REPO` fixture (`proliferate-e2e/e2e-fixture`)
+ * before the first real run — a wrong/absent SHA fails the clone loudly
+ * rather than silently, so this is safe to ship unverified but is flagged in
+ * the final report as a must-confirm item.
+ */
+export const DEFAULT_BASELINE_COMMIT = "HEAD";
+
+function defaultRepoUrl(): string {
+  return `https://github.com/${DEFAULT_GITHUB_TEST_REPO}.git`;
+}
+
+/**
+ * Every filesystem/process/network side effect this fixture performs,
+ * factored out so unit tests can fake git and the runtime HTTP call without a
+ * real clone or a running AnyHarness. The default is what production wiring
+ * uses.
+ */
+export interface PreparedRepositoryTransport {
+  ensureCleanDir(dirPath: string): Promise<void>;
+  cloneAndCheckout(repoUrl: string, commit: string, destDir: string): Promise<void>;
+  resolveRepoRoot(runtimeBaseUrl: string, repoPath: string): Promise<{ id: string }>;
+}
+
+export const defaultPreparedRepositoryTransport: PreparedRepositoryTransport = {
+  async ensureCleanDir(dirPath) {
+    await rm(dirPath, { recursive: true, force: true });
+    await mkdir(dirPath, { recursive: true });
+  },
+  async cloneAndCheckout(repoUrl, commit, destDir) {
+    await runGit(["clone", repoUrl, destDir], process.cwd());
+    await runGit(["checkout", commit], destDir);
+  },
+  async resolveRepoRoot(runtimeBaseUrl, repoPath) {
+    const response = await fetch(`${runtimeBaseUrl.replace(/\/+$/, "")}/v1/repo-roots/resolve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: repoPath }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`POST /v1/repo-roots/resolve -> ${response.status}: ${text.slice(0, 2000)}`);
+    }
+    return (await response.json()) as { id: string };
+  },
+};
+
+export async function preparedRepository(
+  world: ReadyLocalWorld,
+  actor: AuthenticatedActor,
+  options?: PreparedRepositoryOptions,
+  transport: PreparedRepositoryTransport = defaultPreparedRepositoryTransport,
+): Promise<PreparedRepository> {
+  void actor; // prerequisite state only; the repository is not actor-scoped
+  const repoUrl = options?.repoUrl ?? defaultRepoUrl();
+  const commit = options?.commit ?? DEFAULT_BASELINE_COMMIT;
+  const cellId = options?.cellId ?? "default";
+  const destDir = path.join(world.paths.repositoriesDir, encodeURIComponent(cellId));
+
+  await transport.ensureCleanDir(destDir);
+  await transport.cloneAndCheckout(repoUrl, commit, destDir);
+  const repoRoot = await transport.resolveRepoRoot(world.runtime.baseUrl, destDir);
+
+  return { path: destDir, repoUrl, commit, repoRootId: repoRoot.id };
+}
+
+function runGit(args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`git ${args.join(" ")} (cwd=${cwd}) failed (${code}): ${stderr}`));
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/tests/release/src/fixtures/product-page.test.ts
+++ b/tests/release/src/fixtures/product-page.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Browser, BrowserContext, Page } from "playwright";
+
+import { BROWSER_AUTH_SESSION_KEY, productPage, type ProductPageDriver } from "./product-page.js";
+import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+
+function fakeWorld(browser: Browser): ReadyLocalWorld {
+  return {
+    kind: "local-workspace",
+    run: undefined as never,
+    artifacts: undefined as never,
+    api: undefined as never,
+    runtime: undefined as never,
+    renderer: { baseUrl: "http://127.0.0.1:9003", browser },
+    gateway: undefined as never,
+    paths: undefined as never,
+    close: async () => {
+      throw new Error("not used in this test");
+    },
+  };
+}
+
+function fakeActor(): AuthenticatedActor {
+  return {
+    role: "owner",
+    userId: "user-1",
+    organizationId: "org-1",
+    enrollmentId: "enrollment-1",
+    api: undefined as never,
+    session: {
+      access_token: "access-1",
+      refresh_token: "refresh-1",
+      expires_at: "2030-01-01T00:00:00.000Z",
+      user_id: "user-1",
+      email: "owner@example.com",
+      display_name: "Owner",
+    },
+    gatewayKey: undefined as never,
+  };
+}
+
+function fakeDriver(): { driver: ProductPageDriver; calls: string[] } {
+  const calls: string[] = [];
+  const fakeContext = {} as BrowserContext;
+  const fakePage = {} as Page;
+  const driver: ProductPageDriver = {
+    newContext: async (browser) => {
+      calls.push(`newContext:${browser === (undefined as never) ? "none" : "browser"}`);
+      return fakeContext;
+    },
+    installSession: async (context, session) => {
+      calls.push(`installSession:${context === fakeContext}:${session.user_id}`);
+    },
+    newPage: async (context) => {
+      calls.push(`newPage:${context === fakeContext}`);
+      return fakePage;
+    },
+    goto: async (page, url) => {
+      calls.push(`goto:${page === fakePage}:${url}`);
+    },
+    waitForAuthenticatedReadiness: async (page, timeoutMs) => {
+      calls.push(`waitForAuthenticatedReadiness:${page === fakePage}:${timeoutMs}`);
+    },
+    closePage: async (page) => {
+      calls.push(`closePage:${page === fakePage}`);
+    },
+    closeContext: async (context) => {
+      calls.push(`closeContext:${context === fakeContext}`);
+    },
+  };
+  return { driver, calls };
+}
+
+test("productPage installs the auth session before navigation, then navigates and waits for readiness, in order", async () => {
+  const world = fakeWorld({} as Browser);
+  const { driver, calls } = fakeDriver();
+
+  const result = await productPage(world, fakeActor(), {}, driver);
+
+  assert.equal(calls[0], "newContext:browser");
+  assert.equal(calls[1], "installSession:true:user-1");
+  assert.equal(calls[2], "newPage:true");
+  assert.equal(calls[3], "goto:true:http://127.0.0.1:9003");
+  assert.equal(calls[4], "waitForAuthenticatedReadiness:true:30000");
+  assert.equal(calls.length, 5);
+
+  await result.close();
+  assert.equal(calls[5], "closePage:true");
+  assert.equal(calls[6], "closeContext:true");
+});
+
+test("productPage honors a custom readinessTimeoutMs", async () => {
+  const world = fakeWorld({} as Browser);
+  const { driver, calls } = fakeDriver();
+  await productPage(world, fakeActor(), { readinessTimeoutMs: 5000 }, driver);
+  assert.ok(calls.includes("waitForAuthenticatedReadiness:true:5000"));
+});
+
+test("productPage closes the page and context if readiness never arrives, then rethrows", async () => {
+  const world = fakeWorld({} as Browser);
+  const { driver, calls } = fakeDriver();
+  driver.waitForAuthenticatedReadiness = async () => {
+    throw new Error("timed out waiting for authenticated readiness");
+  };
+
+  await assert.rejects(() => productPage(world, fakeActor(), {}, driver), /timed out waiting/);
+  assert.ok(calls.includes("closePage:true"));
+  assert.ok(calls.includes("closeContext:true"));
+});
+
+test("productPage closes only the context if page creation itself fails", async () => {
+  const world = fakeWorld({} as Browser);
+  const { driver, calls } = fakeDriver();
+  driver.newPage = async () => {
+    throw new Error("newPage failed");
+  };
+
+  await assert.rejects(() => productPage(world, fakeActor(), {}, driver), /newPage failed/);
+  assert.ok(!calls.some((call) => call.startsWith("closePage")));
+  assert.ok(calls.includes("closeContext:true"));
+});
+
+test("BROWSER_AUTH_SESSION_KEY matches the real desktop client's localStorage key", () => {
+  assert.equal(BROWSER_AUTH_SESSION_KEY, "proliferate.auth.session");
+});

--- a/tests/release/src/fixtures/product-page.ts
+++ b/tests/release/src/fixtures/product-page.ts
@@ -1,7 +1,40 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
 import type { Browser, BrowserContext, Page } from "playwright";
 
 import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
 import type { AuthenticatedActor, StoredAuthSession } from "./authenticated-actor.js";
+
+/** Records browser console output for env-gated failure diagnostics. */
+function captureConsole(page: Page, sink: string[]): void {
+  if (!process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR) {
+    return;
+  }
+  page.on("console", (message) => sink.push(`[${message.type()}] ${message.text()}`));
+  page.on("pageerror", (error) => sink.push(`[pageerror] ${error.message}`));
+}
+
+/**
+ * Env-gated (`LOCAL_WORLD_SMOKE_DEBUG_DIR`) dump of the rendered DOM, a
+ * screenshot, and captured console output on a UI failure. A no-op unless the
+ * env var is set, so it never touches the green path or CI.
+ */
+async function dumpFailureArtifacts(page: Page | undefined, consoleLog: string[], label: string): Promise<void> {
+  const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  if (!dir || !page) {
+    return;
+  }
+  try {
+    mkdirSync(dir, { recursive: true });
+    const stamp = `${label}-${Date.now()}`;
+    writeFileSync(path.join(dir, `${stamp}.html`), await page.content().catch(() => "<no content>"));
+    writeFileSync(path.join(dir, `${stamp}.console.txt`), consoleLog.join("\n"));
+    await page.screenshot({ path: path.join(dir, `${stamp}.png`), fullPage: true }).catch(() => undefined);
+  } catch {
+    // Diagnostics are best-effort; never mask the real failure.
+  }
+}
 
 /**
  * `productPage(actor)` (spec "Fixtures"). Prerequisite state only:
@@ -18,14 +51,12 @@ import type { AuthenticatedActor, StoredAuthSession } from "./authenticated-acto
  * One `Browser` is shared by the world; every actor/scenario gets isolated
  * browser storage.
  *
- * Readiness is asserted with resilient, text/role-based selectors rather than
- * `data-testid` hooks: this app ships almost no production `data-testid`s
- * (verified against `apps/desktop/src` 2026-07-14 — the few that exist are
- * test-only mock fixtures), so the stable public surface is visible copy —
- * the home screen's repository-picker prompt ("Choose repository") or its
- * "Work locally" runtime option
- * (`apps/desktop/src/lib/domain/home/home-target-picker.ts`), either of which
- * only renders once the app has booted authenticated.
+ * Readiness is asserted on a stable authenticated-home hook rather than a
+ * `data-testid`: this app ships almost no production `data-testid`s, but the
+ * home composer carries `data-home-composer-editor="true"` and the app shell
+ * carries `data-workspace-shell="true"` — both present only once the app has
+ * booted authenticated (verified against a live render 2026-07-14: the earlier
+ * "Choose repository"/"Work locally" copy is not the current home surface).
  */
 
 export interface ProductPage {
@@ -37,8 +68,13 @@ export interface ProductPage {
 
 export const BROWSER_AUTH_SESSION_KEY = "proliferate.auth.session";
 
-/** Text visible only on the authenticated home screen (see module doc). */
-export const AUTHENTICATED_READINESS_PATTERN = /Choose repository|Work locally/i;
+/**
+ * CSS selector for a stable authenticated-home hook (see module doc): the home
+ * composer editor, or the app shell as a fallback. Present only after the app
+ * boots authenticated.
+ */
+export const AUTHENTICATED_READINESS_SELECTOR =
+  '[data-home-composer-editor="true"], [data-workspace-shell="true"]';
 
 export interface ProductPageOptions {
   /** Bounded wait for authenticated readiness after navigation (default 30s). */
@@ -82,7 +118,7 @@ export const defaultProductPageDriver: ProductPageDriver = {
     await page.goto(url, { waitUntil: "domcontentloaded" });
   },
   async waitForAuthenticatedReadiness(page, timeoutMs) {
-    await page.getByText(AUTHENTICATED_READINESS_PATTERN).first().waitFor({ state: "visible", timeout: timeoutMs });
+    await page.locator(AUTHENTICATED_READINESS_SELECTOR).first().waitFor({ state: "visible", timeout: timeoutMs });
   },
   async closePage(page) {
     await page.close();
@@ -100,12 +136,18 @@ export async function productPage(
 ): Promise<ProductPage> {
   const context = await driver.newContext(world.renderer.browser);
   let page: Page | undefined;
+  const consoleLog: string[] = [];
   try {
     await driver.installSession(context, actor.session);
     page = await driver.newPage(context);
+    captureConsole(page, consoleLog);
     await driver.goto(page, world.renderer.baseUrl);
     await driver.waitForAuthenticatedReadiness(page, options.readinessTimeoutMs ?? 30_000);
   } catch (error) {
+    // Optional env-gated failure capture: dump the actual rendered DOM,
+    // a screenshot, and captured console output so a boot/selector failure can
+    // be diagnosed without a live browser. Never on the green path.
+    await dumpFailureArtifacts(page, consoleLog, "product-page-readiness");
     // Never leak a half-opened context/page on a failed boot; the world
     // cleanup stack still owns the shared Browser itself.
     if (page) {

--- a/tests/release/src/fixtures/product-page.ts
+++ b/tests/release/src/fixtures/product-page.ts
@@ -15,6 +15,39 @@ function captureConsole(page: Page, sink: string[]): void {
   page.on("pageerror", (error) => sink.push(`[pageerror] ${error.message}`));
 }
 
+/** Records non-2xx and failed network requests for env-gated failure diagnostics. */
+function captureNetwork(page: Page, sink: string[]): void {
+  if (!process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR) {
+    return;
+  }
+  page.on("requestfailed", (request) => {
+    sink.push(`[requestfailed] ${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? ""}`);
+  });
+  page.on("response", (response) => {
+    const status = response.status();
+    if (status >= 400) {
+      void response
+        .text()
+        .catch(() => "")
+        .then((body) => {
+          sink.push(`[${status}] ${response.request().method()} ${response.url()} :: ${body.slice(0, 400)}`);
+        });
+    }
+  });
+  // The AnyHarness session stream is a WebSocket; agent/runtime errors (e.g.
+  // "Workspace not found") arrive as frames, not HTTP. Record frames that look
+  // like errors so a turn/materialization failure is diagnosable.
+  page.on("websocket", (ws) => {
+    const record = (dir: string, payload: string) => {
+      if (/error|not found|fail|workspace|session/i.test(payload)) {
+        sink.push(`[ws ${dir}] ${ws.url().slice(0, 80)} :: ${payload.slice(0, 500)}`);
+      }
+    };
+    ws.on("framereceived", (frame) => record("recv", typeof frame.payload === "string" ? frame.payload : ""));
+    ws.on("framesent", (frame) => record("sent", typeof frame.payload === "string" ? frame.payload : ""));
+  });
+}
+
 /**
  * Env-gated (`LOCAL_WORLD_SMOKE_DEBUG_DIR`) dump of the rendered DOM, a
  * screenshot, and captured console output on a UI failure. A no-op unless the
@@ -62,6 +95,12 @@ async function dumpFailureArtifacts(page: Page | undefined, consoleLog: string[]
 export interface ProductPage {
   context: BrowserContext;
   page: Page;
+  /**
+   * Env-gated diagnostic sinks (populated only when LOCAL_WORLD_SMOKE_DEBUG_DIR
+   * is set): browser console output and non-2xx / failed network requests.
+   * Empty on the green path.
+   */
+  debug: { console: string[]; network: string[] };
   /** Closes the page + context; registered with the world cleanup stack. */
   close(): Promise<void>;
 }
@@ -137,10 +176,12 @@ export async function productPage(
   const context = await driver.newContext(world.renderer.browser);
   let page: Page | undefined;
   const consoleLog: string[] = [];
+  const networkLog: string[] = [];
   try {
     await driver.installSession(context, actor.session);
     page = await driver.newPage(context);
     captureConsole(page, consoleLog);
+    captureNetwork(page, networkLog);
     await driver.goto(page, world.renderer.baseUrl);
     await driver.waitForAuthenticatedReadiness(page, options.readinessTimeoutMs ?? 30_000);
   } catch (error) {
@@ -161,6 +202,7 @@ export async function productPage(
   return {
     context,
     page: openedPage,
+    debug: { console: consoleLog, network: networkLog },
     close: async () => {
       await driver.closePage(openedPage).catch(() => undefined);
       await driver.closeContext(context).catch(() => undefined);

--- a/tests/release/src/fixtures/product-page.ts
+++ b/tests/release/src/fixtures/product-page.ts
@@ -1,0 +1,127 @@
+import type { Browser, BrowserContext, Page } from "playwright";
+
+import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+import type { AuthenticatedActor, StoredAuthSession } from "./authenticated-actor.js";
+
+/**
+ * `productPage(actor)` (spec "Fixtures"). Prerequisite state only:
+ *
+ *   - creates a fresh Playwright `BrowserContext` for the actor (isolated
+ *     storage) against the world's shared `Browser`;
+ *   - installs the real product session into `proliferate.auth.session` before
+ *     app boot;
+ *   - opens the exact Desktop renderer against this world's Server and
+ *     AnyHarness (the renderer was built with those URLs);
+ *   - waits for authenticated product readiness; and
+ *   - closes its page/context during teardown.
+ *
+ * One `Browser` is shared by the world; every actor/scenario gets isolated
+ * browser storage.
+ *
+ * Readiness is asserted with resilient, text/role-based selectors rather than
+ * `data-testid` hooks: this app ships almost no production `data-testid`s
+ * (verified against `apps/desktop/src` 2026-07-14 — the few that exist are
+ * test-only mock fixtures), so the stable public surface is visible copy —
+ * the home screen's repository-picker prompt ("Choose repository") or its
+ * "Work locally" runtime option
+ * (`apps/desktop/src/lib/domain/home/home-target-picker.ts`), either of which
+ * only renders once the app has booted authenticated.
+ */
+
+export interface ProductPage {
+  context: BrowserContext;
+  page: Page;
+  /** Closes the page + context; registered with the world cleanup stack. */
+  close(): Promise<void>;
+}
+
+export const BROWSER_AUTH_SESSION_KEY = "proliferate.auth.session";
+
+/** Text visible only on the authenticated home screen (see module doc). */
+export const AUTHENTICATED_READINESS_PATTERN = /Choose repository|Work locally/i;
+
+export interface ProductPageOptions {
+  /** Bounded wait for authenticated readiness after navigation (default 30s). */
+  readinessTimeoutMs?: number;
+}
+
+/**
+ * The Playwright surface this fixture actually uses, factored out so unit
+ * tests can fake a browser/context/page without a real Chromium process.
+ */
+export interface ProductPageDriver {
+  newContext(browser: Browser): Promise<BrowserContext>;
+  installSession(context: BrowserContext, session: StoredAuthSession): Promise<void>;
+  newPage(context: BrowserContext): Promise<Page>;
+  goto(page: Page, url: string): Promise<void>;
+  waitForAuthenticatedReadiness(page: Page, timeoutMs: number): Promise<void>;
+  closePage(page: Page): Promise<void>;
+  closeContext(context: BrowserContext): Promise<void>;
+}
+
+export const defaultProductPageDriver: ProductPageDriver = {
+  async newContext(browser) {
+    return browser.newContext();
+  },
+  async installSession(context, session) {
+    // Installed via addInitScript so localStorage is populated BEFORE the
+    // renderer's first script runs on any page created from this context —
+    // the real desktop client reads proliferate.auth.session at boot
+    // (apps/desktop/src/lib/access/tauri/auth.ts's browser fallback path).
+    await context.addInitScript(
+      ({ key, value }) => {
+        window.localStorage.setItem(key, value);
+      },
+      { key: BROWSER_AUTH_SESSION_KEY, value: JSON.stringify(session) },
+    );
+  },
+  async newPage(context) {
+    return context.newPage();
+  },
+  async goto(page, url) {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+  },
+  async waitForAuthenticatedReadiness(page, timeoutMs) {
+    await page.getByText(AUTHENTICATED_READINESS_PATTERN).first().waitFor({ state: "visible", timeout: timeoutMs });
+  },
+  async closePage(page) {
+    await page.close();
+  },
+  async closeContext(context) {
+    await context.close();
+  },
+};
+
+export async function productPage(
+  world: ReadyLocalWorld,
+  actor: AuthenticatedActor,
+  options: ProductPageOptions = {},
+  driver: ProductPageDriver = defaultProductPageDriver,
+): Promise<ProductPage> {
+  const context = await driver.newContext(world.renderer.browser);
+  let page: Page | undefined;
+  try {
+    await driver.installSession(context, actor.session);
+    page = await driver.newPage(context);
+    await driver.goto(page, world.renderer.baseUrl);
+    await driver.waitForAuthenticatedReadiness(page, options.readinessTimeoutMs ?? 30_000);
+  } catch (error) {
+    // Never leak a half-opened context/page on a failed boot; the world
+    // cleanup stack still owns the shared Browser itself.
+    if (page) {
+      await driver.closePage(page).catch(() => undefined);
+    }
+    await driver.closeContext(context).catch(() => undefined);
+    throw error;
+  }
+
+  const openedPage = page;
+  return {
+    context,
+    page: openedPage,
+    close: async () => {
+      await driver.closePage(openedPage).catch(() => undefined);
+      await driver.closeContext(context).catch(() => undefined);
+    },
+  };
+}

--- a/tests/release/src/fixtures/product-page.ts
+++ b/tests/release/src/fixtures/product-page.ts
@@ -5,14 +5,17 @@ import type { Browser, BrowserContext, Page } from "playwright";
 
 import type { ReadyLocalWorld } from "../worlds/local-workspace/world.js";
 import type { AuthenticatedActor, StoredAuthSession } from "./authenticated-actor.js";
+import { scrubSecretText } from "./redact-diagnostics.js";
 
-/** Records browser console output for env-gated failure diagnostics. */
+/** Records browser console output for env-gated failure diagnostics. Secret
+ * shapes are scrubbed at capture time so the sink never holds a credential
+ * (these diagnostics are uploaded as CI artifacts). */
 function captureConsole(page: Page, sink: string[]): void {
   if (!process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR) {
     return;
   }
-  page.on("console", (message) => sink.push(`[${message.type()}] ${message.text()}`));
-  page.on("pageerror", (error) => sink.push(`[pageerror] ${error.message}`));
+  page.on("console", (message) => sink.push(scrubSecretText(`[${message.type()}] ${message.text()}`)));
+  page.on("pageerror", (error) => sink.push(scrubSecretText(`[pageerror] ${error.message}`)));
 }
 
 /** Records non-2xx and failed network requests for env-gated failure diagnostics. */
@@ -21,7 +24,9 @@ function captureNetwork(page: Page, sink: string[]): void {
     return;
   }
   page.on("requestfailed", (request) => {
-    sink.push(`[requestfailed] ${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? ""}`);
+    sink.push(
+      scrubSecretText(`[requestfailed] ${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? ""}`),
+    );
   });
   page.on("response", (response) => {
     const status = response.status();
@@ -30,7 +35,7 @@ function captureNetwork(page: Page, sink: string[]): void {
         .text()
         .catch(() => "")
         .then((body) => {
-          sink.push(`[${status}] ${response.request().method()} ${response.url()} :: ${body.slice(0, 400)}`);
+          sink.push(scrubSecretText(`[${status}] ${response.request().method()} ${response.url()} :: ${body.slice(0, 400)}`));
         });
     }
   });
@@ -40,7 +45,7 @@ function captureNetwork(page: Page, sink: string[]): void {
   page.on("websocket", (ws) => {
     const record = (dir: string, payload: string) => {
       if (/error|not found|fail|workspace|session/i.test(payload)) {
-        sink.push(`[ws ${dir}] ${ws.url().slice(0, 80)} :: ${payload.slice(0, 500)}`);
+        sink.push(scrubSecretText(`[ws ${dir}] ${ws.url().slice(0, 80)} :: ${payload.slice(0, 500)}`));
       }
     };
     ws.on("framereceived", (frame) => record("recv", typeof frame.payload === "string" ? frame.payload : ""));
@@ -51,7 +56,8 @@ function captureNetwork(page: Page, sink: string[]): void {
 /**
  * Env-gated (`LOCAL_WORLD_SMOKE_DEBUG_DIR`) dump of the rendered DOM, a
  * screenshot, and captured console output on a UI failure. A no-op unless the
- * env var is set, so it never touches the green path or CI.
+ * env var is set, so it never touches the green path. When enabled (incl. in
+ * CI) every captured string is scrubbed of secret shapes before it is written.
  */
 async function dumpFailureArtifacts(page: Page | undefined, consoleLog: string[], label: string): Promise<void> {
   const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
@@ -61,8 +67,8 @@ async function dumpFailureArtifacts(page: Page | undefined, consoleLog: string[]
   try {
     mkdirSync(dir, { recursive: true });
     const stamp = `${label}-${Date.now()}`;
-    writeFileSync(path.join(dir, `${stamp}.html`), await page.content().catch(() => "<no content>"));
-    writeFileSync(path.join(dir, `${stamp}.console.txt`), consoleLog.join("\n"));
+    writeFileSync(path.join(dir, `${stamp}.html`), scrubSecretText(await page.content().catch(() => "<no content>")));
+    writeFileSync(path.join(dir, `${stamp}.console.txt`), scrubSecretText(consoleLog.join("\n")));
     await page.screenshot({ path: path.join(dir, `${stamp}.png`), fullPage: true }).catch(() => undefined);
   } catch {
     // Diagnostics are best-effort; never mask the real failure.

--- a/tests/release/src/fixtures/redact-diagnostics.test.ts
+++ b/tests/release/src/fixtures/redact-diagnostics.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { redactDiagnostics, scrubSecretText } from "./redact-diagnostics.js";
+
+test("scrubSecretText scrubs bearer tokens, sk-/vk- keys, and JWTs", () => {
+  assert.equal(scrubSecretText("Authorization: Bearer abc.def-123"), "Authorization: [REDACTED]");
+  assert.equal(scrubSecretText("key=sk-live-abcdef123456 end"), "key=[REDACTED] end");
+  assert.equal(scrubSecretText("virtual vk-user-9-deadbeef done"), "virtual [REDACTED] done");
+  assert.equal(scrubSecretText("t=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"), "t=[REDACTED]");
+});
+
+test("scrubSecretText leaves non-secret identifiers intact", () => {
+  const safe = "workspace ws-123 session s-456 request req-789 status 401";
+  assert.equal(scrubSecretText(safe), safe);
+});
+
+test("redactDiagnostics redacts secret-named keys wholesale and scrubs nested string values", () => {
+  const input = {
+    stateJson: {
+      apiKey: "sk-live-should-be-gone",
+      token: "vk-user-1-abcdef",
+      workspaceId: "ws-42",
+      nested: { authorization: "Bearer zzz", note: "raw sk-live-embedded here" },
+    },
+    list: ["Bearer leak", "plain text"],
+  };
+  const out = redactDiagnostics(input) as Record<string, unknown>;
+  const state = out.stateJson as Record<string, unknown>;
+  assert.equal(state.apiKey, "[REDACTED]");
+  assert.equal(state.token, "[REDACTED]");
+  assert.equal(state.workspaceId, "ws-42");
+  const nested = state.nested as Record<string, unknown>;
+  assert.equal(nested.authorization, "[REDACTED]");
+  assert.equal(nested.note, "raw [REDACTED] here");
+  assert.deepEqual(out.list, ["[REDACTED]", "plain text"]);
+});

--- a/tests/release/src/fixtures/redact-diagnostics.ts
+++ b/tests/release/src/fixtures/redact-diagnostics.ts
@@ -1,0 +1,53 @@
+/**
+ * Redaction for env-gated failure diagnostics (`LOCAL_WORLD_SMOKE_DEBUG_DIR`).
+ *
+ * These DOM/console/network/JSON dumps are uploaded as CI artifacts, so they
+ * must never carry a credential. Two layers:
+ *
+ *   - key-name redaction: any object property whose name looks secret-bearing
+ *     (key/token/secret/password/authorization/bearer/credential) is replaced
+ *     wholesale, so e.g. the LiteLLM virtual key inside a pushed agent-auth
+ *     `state.json` never survives; and
+ *   - value scrubbing: obvious secret shapes (`Bearer …`, `sk-…`, `vk-…`, JWTs)
+ *     are scrubbed from every free-text string, catching credentials embedded in
+ *     network bodies, WebSocket frames, and console lines.
+ *
+ * Non-secret identifiers (workspace/session ids, request ids) are intentionally
+ * left intact so the diagnostics stay useful.
+ */
+
+const SECRET_KEY_PATTERN = /(key|token|secret|password|authorization|bearer|credential)/i;
+
+const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
+  /Bearer\s+[A-Za-z0-9._-]+/gi,
+  /\bsk-[A-Za-z0-9._-]{6,}/gi,
+  /\bvk-[A-Za-z0-9._-]{6,}/gi,
+  /\beyJ[A-Za-z0-9._-]{10,}/g,
+];
+
+/** Scrubs obvious secret shapes from a free-text string. */
+export function scrubSecretText(input: string): string {
+  let out = input;
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    out = out.replace(pattern, "[REDACTED]");
+  }
+  return out;
+}
+
+/** Deep-redacts a JSON-ish value by secret key name and secret value shape. */
+export function redactDiagnostics(value: unknown): unknown {
+  if (typeof value === "string") {
+    return scrubSecretText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactDiagnostics(entry));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = SECRET_KEY_PATTERN.test(key) ? "[REDACTED]" : redactDiagnostics(entry);
+    }
+    return out;
+  }
+  return value;
+}

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -9,6 +9,8 @@ import type {
   ScenarioDefinition,
 } from "../scenarios/types.js";
 import { ScenarioBlockedError, ScenarioExpectedFailError } from "../scenarios/types.js";
+import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { CellEvidenceV1 } from "../evidence/schema.js";
 import { executeSelectedCells, type ExecuteOptions } from "./execute.js";
 import { buildPlannedCells } from "./plan.js";
 import type { RunIdentityV1 } from "./identity.js";
@@ -624,4 +626,53 @@ test("a collector mutating ctx.agents cannot alter the persisted invocation inpu
     }),
   );
   assert.deepEqual(report.inputs.agents, ["claude"]);
+});
+
+test("the executor threads the path-bearing candidate build map into ctx.candidateBuildMap (BRIEF §7a)", async () => {
+  const sentinelMap = { source_sha: "s".repeat(40), artifacts: [] } as unknown as CandidateBuildMapV1;
+  let seen: unknown = "unset";
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (ctx, cells) => {
+      seen = ctx.candidateBuildMap;
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  await executeSelectedCells(await optionsFor([matrix], { candidateBuildMap: sentinelMap }));
+  assert.equal(seen, sentinelMap);
+});
+
+test("ctx.candidateBuildMap defaults to null when no map is supplied (BRIEF §7a)", async () => {
+  let seen: unknown = "unset";
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (ctx, cells) => {
+      seen = ctx.candidateBuildMap;
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(seen, null);
+});
+
+test("a matrix outcome's evidence rides into the result; a cell without evidence defaults to null (BRIEF §7b)", async () => {
+  const attached = { kind: "local_workspace_turn", harness: "claude" } as unknown as CellEvidenceV1;
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }, { child: "b" }],
+    runCells: async (_ctx, cells) =>
+      cells.map((cell, index) =>
+        index === 0
+          ? { cellId: cell.cell_id, status: "green" as const, evidence: attached }
+          : { cellId: cell.cell_id, status: "green" as const },
+      ),
+  });
+  const report = await executeSelectedCells(await optionsFor([matrix]));
+  const results = report.results as Array<{ dimensions: Record<string, string>; evidence?: unknown }>;
+  const a = results.find((result) => result.dimensions.child === "a");
+  const b = results.find((result) => result.dimensions.child === "b");
+  assert.equal(a?.evidence, attached);
+  assert.equal(b?.evidence, null);
 });

--- a/tests/release/src/runner/execute.test.ts
+++ b/tests/release/src/runner/execute.test.ts
@@ -657,6 +657,40 @@ test("ctx.candidateBuildMap defaults to null when no map is supplied (BRIEF §7a
   assert.equal(seen, null);
 });
 
+test("the executor threads runIdentity, runDir, and ports into the scenario context", async () => {
+  const ports = { server: 1, postgres: 2, redis: 3, anyharness: 4, renderer: 5 };
+  let seen: { runIdentity?: unknown; runDir?: unknown; ports?: unknown } = {};
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (ctx, cells) => {
+      const c = ctx as unknown as { runIdentity?: unknown; runDir?: unknown; ports?: unknown };
+      seen = { runIdentity: c.runIdentity, runDir: c.runDir, ports: c.ports };
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  await executeSelectedCells(await optionsFor([matrix], { runDir: "/run/dir", ports }));
+  assert.equal(seen.runIdentity, IDENTITY);
+  assert.equal(seen.runDir, "/run/dir");
+  assert.deepEqual(seen.ports, ports);
+});
+
+test("runDir and ports default to null when the options omit them", async () => {
+  let seen: { runDir?: unknown; ports?: unknown } = {};
+  const matrix = fakeMatrix({
+    id: "M",
+    cells: [{ child: "a" }],
+    runCells: async (ctx, cells) => {
+      const c = ctx as unknown as { runDir?: unknown; ports?: unknown };
+      seen = { runDir: c.runDir, ports: c.ports };
+      return cells.map((cell) => ({ cellId: cell.cell_id, status: "green" as const }));
+    },
+  });
+  await executeSelectedCells(await optionsFor([matrix]));
+  assert.equal(seen.runDir, null);
+  assert.equal(seen.ports, null);
+});
+
 test("a matrix outcome's evidence rides into the result; a cell without evidence defaults to null (BRIEF §7b)", async () => {
   const attached = { kind: "local_workspace_turn", harness: "claude" } as unknown as CellEvidenceV1;
   const matrix = fakeMatrix({

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -10,6 +10,7 @@ import {
   type ScenarioDefinition,
 } from "../scenarios/types.js";
 import type { CandidateBuildEvidenceV1, CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { LocalWorldPorts } from "../worlds/local-workspace/ports.js";
 import type { CellEvidenceV1, TestRunReportV3 } from "../evidence/schema.js";
 import { expectedVerdict, sanitizeReport } from "../evidence/schema.js";
 import type { RunIdentityV1 } from "./identity.js";
@@ -60,6 +61,18 @@ export interface ExecuteOptions {
    * when no map was supplied. Never serialized (BRIEF §7a).
    */
   candidateBuildMap?: CandidateBuildMapV1 | null;
+  /**
+   * The run/shard-scoped run directory (the candidate map's directory), threaded
+   * into every `ScenarioRunContext` as `runDir` so a world constructor can lay
+   * out its state. Explicit null when no map was supplied.
+   */
+  runDir?: string | null;
+  /**
+   * The pre-allocated local-world ports (from the `local-world-ports.json`
+   * sidecar), threaded into every `ScenarioRunContext` as `ports`. Explicit null
+   * when absent.
+   */
+  ports?: LocalWorldPorts | null;
   /** Names satisfied only by this run's local durable-user seeding. */
   locallySeeded?: ReadonlySet<string>;
   /** Injectable for tests; defaults to resolveEnv over the union of required env. */
@@ -330,6 +343,12 @@ async function runAll(
       // The path-bearing map (or null); a world constructor materializes the
       // exact artifacts it names. In-memory only, never serialized.
       candidateBuildMap: options.candidateBuildMap ?? null,
+      // Run identity, run dir, and pre-allocated ports a world constructor needs
+      // (all in-memory only; runDir/ports are null when no candidate map was
+      // supplied).
+      runIdentity: options.identity,
+      runDir: options.runDir ?? null,
+      ports: options.ports ?? null,
     };
     const startedAt = now().toISOString();
     const startedMs = now().getTime();

--- a/tests/release/src/runner/execute.ts
+++ b/tests/release/src/runner/execute.ts
@@ -9,8 +9,8 @@ import {
   type MatrixScenarioDefinition,
   type ScenarioDefinition,
 } from "../scenarios/types.js";
-import type { CandidateBuildEvidenceV1 } from "../artifacts/build-map.js";
-import type { TestRunReportV3 } from "../evidence/schema.js";
+import type { CandidateBuildEvidenceV1, CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { CellEvidenceV1, TestRunReportV3 } from "../evidence/schema.js";
 import { expectedVerdict, sanitizeReport } from "../evidence/schema.js";
 import type { RunIdentityV1 } from "./identity.js";
 import {
@@ -53,6 +53,13 @@ export interface ExecuteOptions {
    * (cli/command.ts) owns loading and validation before any setup.
    */
   candidateBuild?: CandidateBuildEvidenceV1 | null;
+  /**
+   * The validated, path-bearing candidate build map (in-memory only), threaded
+   * verbatim into every `ScenarioRunContext` as `candidateBuildMap` so a world
+   * constructor can materialize the exact artifacts it names. Explicit null
+   * when no map was supplied. Never serialized (BRIEF §7a).
+   */
+  candidateBuildMap?: CandidateBuildMapV1 | null;
   /** Names satisfied only by this run's local durable-user seeding. */
   locallySeeded?: ReadonlySet<string>;
   /** Injectable for tests; defaults to resolveEnv over the union of required env. */
@@ -320,16 +327,25 @@ async function runAll(
       agents: [...agents],
       dryRun: false,
       env: neededEnv,
+      // The path-bearing map (or null); a world constructor materializes the
+      // exact artifacts it names. In-memory only, never serialized.
+      candidateBuildMap: options.candidateBuildMap ?? null,
     };
     const startedAt = now().toISOString();
     const startedMs = now().getTime();
-    const finish = (cellId: string, status: FinalCellResultV1["status"], reason: ResultReason | null): void =>
+    const finish = (
+      cellId: string,
+      status: FinalCellResultV1["status"],
+      reason: ResultReason | null,
+      evidence?: CellEvidenceV1 | null,
+    ): void =>
       tracker.finalize(cellId, {
         status,
         reason: reason ?? undefined,
         startedAt,
         finishedAt: now().toISOString(),
         durationMs: now().getTime() - startedMs,
+        evidence: evidence ?? null,
       });
 
     try {
@@ -386,7 +402,12 @@ function applyCollectorOutcomes(
   assigned: readonly PlannedCellV1[],
   outcomes: unknown,
   tracker: ResultTracker,
-  finish: (cellId: string, status: FinalCellResultV1["status"], reason: ResultReason | null) => void,
+  finish: (
+    cellId: string,
+    status: FinalCellResultV1["status"],
+    reason: ResultReason | null,
+    evidence?: CellEvidenceV1 | null,
+  ) => void,
 ): void {
   // Malformed collector output (null/undefined/non-array, or entries without
   // a cell id and status) is a runner-integrity failure, not a product
@@ -432,7 +453,10 @@ function applyCollectorOutcomes(
       continue;
     }
     const status = outcome.status as ScenarioDeclarableStatus;
-    finish(outcome.cellId, status, outcome.reason ?? defaultReasonFor(status));
+    // Evidence rides through verbatim; its deep validation (unknown kind, extra
+    // fields, unsafe strings, token/spend math, green-cell completeness) is the
+    // report validator's job (`validateReportV4`), not the executor's.
+    finish(outcome.cellId, status, outcome.reason ?? defaultReasonFor(status), outcome.evidence);
   }
 }
 
@@ -445,7 +469,7 @@ function applyCollectorOutcomes(
  */
 function readCollectorOutcome(
   raw: unknown,
-): { cellId: string; status: string; reason?: ResultReason } | null {
+): { cellId: string; status: string; reason?: ResultReason; evidence?: CellEvidenceV1 | null } | null {
   try {
     if (typeof raw !== "object" || raw === null) {
       return null;
@@ -453,11 +477,15 @@ function readCollectorOutcome(
     const cellId = (raw as { cellId?: unknown }).cellId;
     const status = (raw as { status?: unknown }).status;
     const reason = (raw as { reason?: unknown }).reason;
+    // Snapshot the evidence reference exactly once (a throwing getter is caught
+    // below and treated as a malformed entry). It rides through opaquely; the
+    // report validator, not the executor, judges its shape.
+    const evidence = (raw as { evidence?: unknown }).evidence as CellEvidenceV1 | null | undefined;
     if (typeof cellId !== "string" || typeof status !== "string") {
       return null;
     }
     if (reason === undefined) {
-      return { cellId, status };
+      return { cellId, status, evidence };
     }
     if (typeof reason !== "object" || reason === null) {
       return null;
@@ -481,6 +509,7 @@ function readCollectorOutcome(
         code: code as ResultReasonCode,
         message,
       },
+      evidence,
     };
   } catch {
     return null;

--- a/tests/release/src/runner/result.test.ts
+++ b/tests/release/src/runner/result.test.ts
@@ -169,6 +169,62 @@ test("runner or integrity errors force exit 2 in both behaviors", () => {
   assert.equal(s1.status, "selected_cells_failed");
 });
 
+// ── Report V4 evidence threading (BRIEF §Workstream C: runner/result.ts) ────
+
+test("finalize defaults evidence to null when none is supplied", () => {
+  const tracker = new ResultTracker([selected("A")]);
+  tracker.finalize("A/local", { status: "green" });
+  const results = tracker.finalizeRun("real");
+  assert.equal(results[0].evidence, null);
+});
+
+test("finalize threads supplied evidence onto the finalized result", () => {
+  const evidence = {
+    kind: "local_workspace_turn" as const,
+    artifact_ids: ["server/linux-x64"],
+    server_version: "0.3.27",
+    anyharness_version: "0.3.27",
+    harness: "claude" as const,
+    model_id: "claude-haiku-4-5",
+    workspace_id_hash: "a".repeat(64),
+    session_id_hash: "b".repeat(64),
+    transcript_reopened: true as const,
+    litellm: {
+      token_id_hash: "c".repeat(64),
+      request_ids: ["req-1"],
+      window_started_at: "2026-07-14T00:00:00Z",
+      window_finished_at: "2026-07-14T00:00:01Z",
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+      spend_usd: 0.0001,
+    },
+    cleanup: {
+      ledger_id_hash: "d".repeat(64),
+      registered: 1,
+      reconciled: 1,
+      failed: 0,
+      virtual_key_deleted: true,
+      litellm_subjects_deleted: true,
+      browser_closed: true,
+      processes_stopped: true,
+      containers_removed: true,
+      local_paths_removed: true,
+    },
+  };
+  const tracker = new ResultTracker([selected("A")]);
+  tracker.finalize("A/local", { status: "green", evidence });
+  const results = tracker.finalizeRun("real");
+  assert.deepEqual(results[0].evidence, evidence);
+});
+
+test("a synthesized missing result carries null evidence", () => {
+  const tracker = new ResultTracker([selected("A")]);
+  const results = tracker.finalizeRun("real");
+  assert.equal(results[0].status, "missing");
+  assert.equal(results[0].evidence, null);
+});
+
 test("strict all-green with any error cannot pass", () => {
   const verdict = deriveVerdict({
     behavior: "strict",

--- a/tests/release/src/runner/result.ts
+++ b/tests/release/src/runner/result.ts
@@ -1,4 +1,10 @@
 import type { RuntimeLane } from "../config/types.js";
+// Type-only: evidence/schema.ts imports value bindings (ALL_FINAL_STATUSES,
+// deriveVerdict) from this module, but this import is erased at compile time
+// (isolatedModules + `import type`), so no runtime import cycle exists.
+// `FinalCellResultV2`/`CellEvidenceV1` are owned by schema.ts (report V4);
+// this module only threads the value through the tracker.
+import type { CellEvidenceV1, FinalCellResultV2 } from "../evidence/schema.js";
 
 /**
  * Cell state, finalization invariants, behavior policy, verdict, and intended
@@ -112,16 +118,27 @@ export interface Finalization {
   finishedAt?: string;
   durationMs?: number | null;
   planSteps?: string[];
+  /**
+   * Bounded report-V4 evidence for this cell (spec "Aggregate evidence").
+   * Optional; defaults to `null`, matching V3 semantics for every scenario
+   * that does not attach evidence.
+   */
+  evidence?: CellEvidenceV1 | null;
 }
 
 /**
  * Tracks one pending slot per planned cell and enforces the finalization
  * invariants: exactly one final result per planned cell, first accepted
  * result wins, duplicates and missing results are integrity errors.
+ *
+ * Every result this tracker produces is V2-shaped (carries an `evidence`
+ * field, defaulting to `null`) so `FinalCellResultV2.evidence` (report V4)
+ * is always present at runtime, even though most call sites still read the
+ * V1 shape.
  */
 export class ResultTracker {
   private readonly selected: readonly PlannedCellV1[];
-  private readonly results = new Map<string, FinalCellResultV1>();
+  private readonly results = new Map<string, FinalCellResultV2>();
   readonly integrityErrors: IntegrityErrorV1[] = [];
   readonly runnerErrors: RunnerErrorV1[] = [];
 
@@ -177,6 +194,7 @@ export class ResultTracker {
       duration_ms: finalization.durationMs ?? null,
       reason: finalization.reason ?? null,
       plan_steps: finalization.planSteps ?? [],
+      evidence: finalization.evidence ?? null,
     });
   }
 
@@ -184,7 +202,7 @@ export class ResultTracker {
    * Synthesizes `missing` for any planned cell with no recorded outcome and
    * records the integrity error; returns every result in selection order.
    */
-  finalizeRun(execution: "real" | "dry_run"): FinalCellResultV1[] {
+  finalizeRun(execution: "real" | "dry_run"): FinalCellResultV2[] {
     for (const cell of this.pendingCells()) {
       this.integrityErrors.push({
         code: "selection_result_mismatch",

--- a/tests/release/src/scenarios/local-world-smoke-1.test.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.test.ts
@@ -9,8 +9,8 @@ import {
   resolveWorldConstructionInputs,
   runLocalWorldSmokeCell,
   type LocalWorldSmokeDriver,
-  type LocalWorldSmokeRunContext,
 } from "./local-world-smoke-1.js";
+import type { ScenarioRunContext } from "./types.js";
 import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { EnvResolution } from "../config/env-resolution.js";
 import type { AuthenticatedActor } from "../fixtures/authenticated-actor.js";
@@ -75,7 +75,7 @@ function fakeEnv(vars: Record<string, string> = {}): EnvResolution {
   };
 }
 
-function fakeCtx(overrides: Partial<LocalWorldSmokeRunContext> = {}): LocalWorldSmokeRunContext {
+function fakeCtx(overrides: Partial<ScenarioRunContext> = {}): ScenarioRunContext {
   return {
     targetLane: "local",
     runtimeLane: "local",

--- a/tests/release/src/scenarios/local-world-smoke-1.test.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.test.ts
@@ -1,0 +1,448 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DETERMINISTIC_PROMPT,
+  LOCAL_WORLD_SMOKE_1_ID,
+  REPRESENTATIVE_HARNESS,
+  localWorldSmoke1,
+  resolveWorldConstructionInputs,
+  runLocalWorldSmokeCell,
+  type LocalWorldSmokeDriver,
+  type LocalWorldSmokeRunContext,
+} from "./local-world-smoke-1.js";
+import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { EnvResolution } from "../config/env-resolution.js";
+import type { AuthenticatedActor } from "../fixtures/authenticated-actor.js";
+import type { PreparedRepository } from "../fixtures/prepared-repository.js";
+import type { ProductPage } from "../fixtures/product-page.js";
+import type { PlannedCellV1 } from "../runner/result.js";
+import type { CorrelatedTurnSpend, SpendSnapshot } from "../services/qualification-litellm.js";
+import type { LocalWorldCleanupEvidence } from "../worlds/local-workspace/cleanup.js";
+import type { LocalWorldPorts, ReadyLocalWorld } from "../worlds/local-workspace/world.js";
+
+function fakeCandidateMap(): CandidateBuildMapV1 {
+  return {
+    schema_version: 1,
+    kind: "proliferate.candidate-build",
+    source_sha: "a".repeat(40),
+    artifacts: [
+      {
+        artifact_id: "server/linux-amd64",
+        version: "1",
+        sha256: "s".repeat(64),
+        locator: { kind: "local_file", path: "/tmp/server.tar" },
+      },
+      {
+        artifact_id: "anyharness/x86_64-unknown-linux-gnu",
+        version: "1",
+        sha256: "a".repeat(64),
+        locator: { kind: "local_file", path: "/tmp/anyharness" },
+      },
+      {
+        artifact_id: "desktop-renderer/browser",
+        version: "1",
+        sha256: "d".repeat(64),
+        locator: { kind: "local_file", path: "/tmp/renderer.tar" },
+      },
+    ],
+  };
+}
+
+function fakePorts(): LocalWorldPorts {
+  return { server: 1, postgres: 2, redis: 3, anyharness: 4, renderer: 5 };
+}
+
+function fakeEnv(vars: Record<string, string> = {}): EnvResolution {
+  const defaults: Record<string, string> = {
+    AGENT_GATEWAY_LITELLM_BASE_URL: "https://admin.litellm.example",
+    AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "https://public.litellm.example",
+    AGENT_GATEWAY_LITELLM_MASTER_KEY: "sk-test-master",
+    ...vars,
+  };
+  return {
+    all: [],
+    missing: [],
+    present: (name) => defaults[name] !== undefined,
+    get: (name) => defaults[name],
+    require: (name) => {
+      const value = defaults[name];
+      if (!value) {
+        throw new Error(`missing required env var "${name}"`);
+      }
+      return value;
+    },
+  };
+}
+
+function fakeCtx(overrides: Partial<LocalWorldSmokeRunContext> = {}): LocalWorldSmokeRunContext {
+  return {
+    targetLane: "local",
+    runtimeLane: "local",
+    desktop: "web",
+    agents: [REPRESENTATIVE_HARNESS],
+    dryRun: false,
+    env: fakeEnv(),
+    candidateBuildMap: fakeCandidateMap(),
+    runIdentity: {
+      run_id: "local-run-1",
+      shard_id: "local-0",
+      attempt: 1,
+      source_sha: "a".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+    },
+    runDir: "/tmp/run-1",
+    ports: fakePorts(),
+    ...overrides,
+  };
+}
+
+function fakeCell(): PlannedCellV1 {
+  return {
+    cell_id: `${LOCAL_WORLD_SMOKE_1_ID}/local/harness=${REPRESENTATIVE_HARNESS}`,
+    scenario_id: LOCAL_WORLD_SMOKE_1_ID,
+    registry_flow_ref: "specs/developing/testing/flows.md#local-world-smoke",
+    runtime_lane: "local",
+    dimensions: { harness: REPRESENTATIVE_HARNESS },
+    required_env: [],
+  };
+}
+
+function fakeWorld(): ReadyLocalWorld {
+  return {
+    kind: "local-workspace",
+    run: fakeCtx().runIdentity!,
+    artifacts: {
+      server: { artifact_id: "server/linux-amd64", version: "1.2.3", sha256: "s".repeat(64), path: "/tmp/server" },
+      anyharness: {
+        artifact_id: "anyharness/x86_64-unknown-linux-gnu",
+        version: "4.5.6",
+        sha256: "a".repeat(64),
+        path: "/tmp/anyharness",
+      },
+      desktopRenderer: {
+        artifact_id: "desktop-renderer/browser",
+        version: "1",
+        sha256: "d".repeat(64),
+        path: "/tmp/renderer",
+      },
+    },
+    api: undefined as never,
+    runtime: undefined as never,
+    renderer: undefined as never,
+    gateway: undefined as never,
+    paths: undefined as never,
+    close: async () => cleanupEvidence({}),
+  };
+}
+
+function cleanupEvidence(overrides: Partial<LocalWorldCleanupEvidence>): LocalWorldCleanupEvidence {
+  return {
+    ledgerIdHash: "ledger-hash",
+    registered: 10,
+    reconciled: 10,
+    failed: 0,
+    virtualKeyDeleted: true,
+    litellmSubjectsDeleted: true,
+    browserClosed: true,
+    processesStopped: true,
+    containersRemoved: true,
+    localPathsRemoved: true,
+    ...overrides,
+  };
+}
+
+function fakeActor(): AuthenticatedActor {
+  return {
+    role: "owner",
+    userId: "user-1",
+    organizationId: "org-1",
+    enrollmentId: "enrollment-1",
+    api: undefined as never,
+    session: undefined as never,
+    gatewayKey: {
+      userId: "user-1",
+      enrollmentId: "enrollment-1",
+      teamId: "team-1",
+      litellmUserId: "litellm-user-1",
+      keyAlias: "vk-user-user-1-enrollme",
+      tokenId: "token-1",
+      tokenIdHash: "token-hash-1",
+    },
+  };
+}
+
+interface DriverCallLog {
+  calls: string[];
+}
+
+function fakeDriver(
+  options: {
+    allowlist?: string[];
+    liveProbe?: string[];
+    reply?: string;
+    correlated?: CorrelatedTurnSpend;
+    cleanup?: LocalWorldCleanupEvidence;
+    buildWorldError?: Error;
+  } = {},
+): { driver: LocalWorldSmokeDriver; log: DriverCallLog } {
+  const calls: string[] = [];
+  const world = fakeWorld();
+  const before: SpendSnapshot = { tokenIdHash: "token-hash-1", requestIds: ["req-existing"], takenAt: "t0" };
+  const correlated: CorrelatedTurnSpend = options.correlated ?? {
+    tokenIdHash: "token-hash-1",
+    requestIds: ["req-new-1"],
+    modelId: "claude-haiku-4-5",
+    promptTokens: 10,
+    completionTokens: 3,
+    totalTokens: 13,
+    spendUsd: 0.0001,
+    windowStartedAt: "2026-01-01T00:00:00.000Z",
+    windowFinishedAt: "2026-01-01T00:00:01.000Z",
+  };
+  const cleanup = options.cleanup ?? cleanupEvidence({});
+
+  const driver: LocalWorldSmokeDriver = {
+    buildWorld: async () => {
+      calls.push("buildWorld");
+      if (options.buildWorldError) {
+        throw options.buildWorldError;
+      }
+      return world;
+    },
+    createActor: async (w) => {
+      calls.push(`createActor:${w === world}`);
+      return fakeActor();
+    },
+    prepareRepo: async (w, actor, cellId) => {
+      calls.push(`prepareRepo:${cellId}`);
+      return {
+        path: `/tmp/repo/${cellId}`,
+        repoUrl: "https://github.com/example/fixture.git",
+        commit: "deadbeef",
+        repoRootId: "repo-root-1",
+      } satisfies PreparedRepository;
+    },
+    openPage: async () => {
+      calls.push("openPage");
+      return {
+        context: undefined as never,
+        page: undefined as never,
+        close: async () => {
+          calls.push("page.close");
+        },
+      } satisfies ProductPage;
+    },
+    selectRepoAndWorkLocally: async () => {
+      calls.push("selectRepoAndWorkLocally");
+      return { workspaceId: "workspace-1" };
+    },
+    createSession: async (_page, harnessKind) => {
+      calls.push(`createSession:${harnessKind}`);
+      return { sessionId: "session-1" };
+    },
+    liveProbeModels: async () => {
+      calls.push("liveProbeModels");
+      return options.liveProbe ?? ["claude-haiku-4-5", "claude-sonnet-4-5"];
+    },
+    allowlistModels: async () => {
+      calls.push("allowlistModels");
+      return options.allowlist ?? ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-fable-9"];
+    },
+    selectModelInUi: async (_page, modelId) => {
+      calls.push(`selectModelInUi:${modelId}`);
+    },
+    sendPromptAndAwaitReply: async (_page, prompt) => {
+      calls.push(`sendPromptAndAwaitReply:${prompt}`);
+      return options.reply ?? "pong";
+    },
+    reopenAndVerify: async (_page, expectations) => {
+      calls.push(`reopenAndVerify:${expectations.workspaceId}:${expectations.sessionId}:${expectations.modelId}`);
+    },
+    snapshotSpend: async () => {
+      calls.push("snapshotSpend");
+      return before;
+    },
+    correlateTurn: async (_w, params) => {
+      calls.push(`correlateTurn:${params.acceptedModelId}`);
+      return correlated;
+    },
+    closeWorld: async (w) => {
+      calls.push(`closeWorld:${w === world}`);
+      return cleanup;
+    },
+  };
+  return { driver, log: { calls } };
+}
+
+test("runLocalWorldSmokeCell drives every step in order and attaches complete evidence on success", async () => {
+  const { driver, log } = fakeDriver();
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+
+  assert.equal(outcome.status, "green");
+  assert.ok(outcome.evidence);
+  assert.equal(outcome.evidence!.kind, "local_workspace_turn");
+  assert.equal(outcome.evidence!.harness, "claude");
+  assert.equal(outcome.evidence!.model_id, "claude-haiku-4-5");
+  assert.equal(outcome.evidence!.transcript_reopened, true);
+  assert.equal(outcome.evidence!.server_version, "1.2.3");
+  assert.equal(outcome.evidence!.anyharness_version, "4.5.6");
+  assert.deepEqual(outcome.evidence!.artifact_ids, [
+    "server/linux-amd64",
+    "anyharness/x86_64-unknown-linux-gnu",
+    "desktop-renderer/browser",
+  ]);
+  assert.equal(outcome.evidence!.litellm.request_ids.length, 1);
+  assert.equal(outcome.evidence!.cleanup.failed, 0);
+  assert.equal(outcome.evidence!.cleanup.virtual_key_deleted, true);
+
+  assert.deepEqual(log.calls, [
+    "buildWorld",
+    "createActor:true",
+    "prepareRepo:LOCAL-WORLD-SMOKE-1/local/harness=claude",
+    "openPage",
+    "selectRepoAndWorkLocally",
+    "createSession:claude",
+    "allowlistModels",
+    "liveProbeModels",
+    "selectModelInUi:claude-haiku-4-5",
+    "snapshotSpend",
+    `sendPromptAndAwaitReply:${DETERMINISTIC_PROMPT}`,
+    "reopenAndVerify:workspace-1:session-1:claude-haiku-4-5",
+    "correlateTurn:claude-haiku-4-5",
+    "closeWorld:true",
+    "page.close",
+  ]);
+});
+
+test("model choice: prefers haiku over sonnet and excludes the fable tier", async () => {
+  const { driver } = fakeDriver({
+    allowlist: ["claude-sonnet-4-5", "claude-haiku-4-5", "claude-fable-9"],
+    liveProbe: ["claude-sonnet-4-5", "claude-haiku-4-5", "claude-fable-9"],
+    correlated: {
+      tokenIdHash: "token-hash-1",
+      requestIds: ["req-new-1"],
+      modelId: "claude-haiku-4-5",
+      promptTokens: 10,
+      completionTokens: 3,
+      totalTokens: 13,
+      spendUsd: 0.0001,
+      windowStartedAt: "2026-01-01T00:00:00.000Z",
+      windowFinishedAt: "2026-01-01T00:00:01.000Z",
+    },
+  });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "green");
+  assert.equal(outcome.evidence!.model_id, "claude-haiku-4-5");
+});
+
+test("model choice: a fable-only intersection is blocked, never selected", async () => {
+  const { driver, log } = fakeDriver({
+    allowlist: ["claude-fable-9"],
+    liveProbe: ["claude-fable-9"],
+  });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "blocked");
+  assert.equal(outcome.reason?.code, "scenario_blocked");
+  assert.ok(!log.calls.includes("selectModelInUi:claude-fable-9"));
+  // World must still be closed on a blocked outcome.
+  assert.ok(log.calls.includes("closeWorld:true"));
+});
+
+test("model choice: an empty intersection (no live-probed model in the allowlist) is blocked", async () => {
+  const { driver } = fakeDriver({ allowlist: ["claude-haiku-4-5"], liveProbe: ["claude-sonnet-4-5"] });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "blocked");
+});
+
+test("failure propagation: world construction failure yields a bounded failed outcome, no throw", async () => {
+  const { driver } = fakeDriver({ buildWorldError: new Error("docker load failed") });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /world construction failed: docker load failed/);
+});
+
+test("failure propagation: an empty assistant reply fails the cell and still closes the world", async () => {
+  const { driver, log } = fakeDriver({ reply: "" });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /empty assistant reply/);
+  assert.ok(log.calls.includes("closeWorld:true"));
+  assert.equal(outcome.evidence, undefined);
+});
+
+test("failure propagation: a UI step throwing fails the cell without losing world cleanup", async () => {
+  const { driver, log } = fakeDriver();
+  driver.selectRepoAndWorkLocally = async () => {
+    throw new Error("could not find the 'Work locally' control");
+  };
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /Work locally/);
+  assert.ok(log.calls.includes("closeWorld:true"));
+});
+
+test("required cleanup failure: a nonzero cleanup.failed count fails an otherwise-successful cell", async () => {
+  const { driver } = fakeDriver({ cleanup: cleanupEvidence({ failed: 1, reconciled: 9 }) });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /cleanup did not fully reconcile/);
+  // Evidence is still retained (spec: "safe evidence retained" on failure).
+  assert.ok(outcome.evidence);
+});
+
+test("required cleanup failure: a false deletion boolean fails the cell even with failed === 0", async () => {
+  const { driver } = fakeDriver({ cleanup: cleanupEvidence({ virtualKeyDeleted: false }) });
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
+  assert.equal(outcome.status, "failed");
+});
+
+test("resolveWorldConstructionInputs fails closed when the candidate map is absent", () => {
+  const result = resolveWorldConstructionInputs(fakeCtx({ candidateBuildMap: null }));
+  assert.equal(result.ok, false);
+});
+
+test("resolveWorldConstructionInputs fails closed when run identity is absent", () => {
+  const result = resolveWorldConstructionInputs(fakeCtx({ runIdentity: undefined }));
+  assert.equal(result.ok, false);
+});
+
+test("resolveWorldConstructionInputs fails closed when a required LiteLLM env var is missing", () => {
+  const result = resolveWorldConstructionInputs(
+    fakeCtx({ env: fakeEnv({ AGENT_GATEWAY_LITELLM_MASTER_KEY: "" }) }),
+  );
+  assert.equal(result.ok, false);
+});
+
+test("missing world-construction inputs never reach buildWorld — the cell fails before any side effect", async () => {
+  const { driver, log } = fakeDriver();
+  const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx({ candidateBuildMap: null }), driver);
+  assert.equal(outcome.status, "failed");
+  assert.deepEqual(log.calls, []);
+});
+
+test("scenario definition declares the required LiteLLM env vars and the single harness=claude cell", async () => {
+  assert.equal(localWorldSmoke1.id, LOCAL_WORLD_SMOKE_1_ID);
+  assert.equal(localWorldSmoke1.kind, "matrix");
+  assert.deepEqual(localWorldSmoke1.requiredEnv, [
+    "AGENT_GATEWAY_LITELLM_BASE_URL",
+    "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL",
+    "AGENT_GATEWAY_LITELLM_MASTER_KEY",
+  ]);
+  if (localWorldSmoke1.kind !== "matrix") {
+    throw new Error("expected a matrix scenario");
+  }
+  const cells = await localWorldSmoke1.expandCells({ runtimeLane: "local", desktop: "web", agents: ["claude"] });
+  assert.deepEqual(cells, [{ dimensions: { harness: "claude" } }]);
+});
+
+test("planCell lists all ten spec-numbered steps plus cleanup, cell-id-prefixed", () => {
+  if (localWorldSmoke1.kind !== "matrix") {
+    throw new Error("expected a matrix scenario");
+  }
+  const steps = localWorldSmoke1.planCell({ runtimeLane: "local", desktop: "web", agents: ["claude"] }, fakeCell());
+  assert.ok(steps.length >= 10);
+  for (const step of steps) {
+    assert.ok(step.description.startsWith(`[${fakeCell().cell_id}]`));
+  }
+});

--- a/tests/release/src/scenarios/local-world-smoke-1.test.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.test.ts
@@ -228,18 +228,20 @@ function fakeDriver(
       return {
         context: undefined as never,
         page: undefined as never,
+        debug: { console: [], network: [] },
         close: async () => {
           calls.push("page.close");
         },
       } satisfies ProductPage;
     },
+    waitForGatewaySync: async (_world, _page, harnessKind) => {
+      calls.push(`waitForGatewaySync:${harnessKind}`);
+    },
+    ensureHarnessReady: async (_world, _page, harnessKind) => {
+      calls.push(`ensureHarnessReady:${harnessKind}`);
+    },
     selectRepoAndWorkLocally: async () => {
       calls.push("selectRepoAndWorkLocally");
-      return { workspaceId: "workspace-1" };
-    },
-    createSession: async (_page, harnessKind) => {
-      calls.push(`createSession:${harnessKind}`);
-      return { sessionId: "session-1" };
     },
     liveProbeModels: async () => {
       calls.push("liveProbeModels");
@@ -252,11 +254,11 @@ function fakeDriver(
     selectModelInUi: async (_page, modelId) => {
       calls.push(`selectModelInUi:${modelId}`);
     },
-    sendPromptAndAwaitReply: async (_page, prompt) => {
-      calls.push(`sendPromptAndAwaitReply:${prompt}`);
-      return options.reply ?? "pong";
+    sendPromptAndMaterialize: async (_world, _page, prompt) => {
+      calls.push(`sendPromptAndMaterialize:${prompt}`);
+      return { workspaceId: "workspace-1", sessionId: "session-1", reply: options.reply ?? "pong" };
     },
-    reopenAndVerify: async (_page, expectations) => {
+    reopenAndVerify: async (_world, _page, expectations) => {
       calls.push(`reopenAndVerify:${expectations.workspaceId}:${expectations.sessionId}:${expectations.modelId}`);
     },
     snapshotSpend: async () => {
@@ -301,13 +303,14 @@ test("runLocalWorldSmokeCell drives every step in order and attaches complete ev
     "createActor:true",
     "prepareRepo:LOCAL-WORLD-SMOKE-1/local/harness=claude",
     "openPage",
+    "waitForGatewaySync:claude",
+    "ensureHarnessReady:claude",
     "selectRepoAndWorkLocally",
-    "createSession:claude",
     "allowlistModels",
     "liveProbeModels",
     "selectModelInUi:claude-haiku-4-5",
     "snapshotSpend",
-    `sendPromptAndAwaitReply:${DETERMINISTIC_PROMPT}`,
+    `sendPromptAndMaterialize:${DETERMINISTIC_PROMPT}`,
     "reopenAndVerify:workspace-1:session-1:claude-haiku-4-5",
     "correlateTurn:claude-haiku-4-5",
     "closeWorld:true",

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 
+import type { Page } from "playwright";
+
 import type {
   ScenarioCellOutcome,
   ScenarioCellSpec,
@@ -10,6 +12,7 @@ import type {
 import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { CellEvidenceV1, LocalWorkspaceTurnEvidenceV1 } from "../evidence/schema.js";
 import { authenticatedActor, type AuthenticatedActor } from "../fixtures/authenticated-actor.js";
+import { findErrorEvent, findTurnEndedEvent } from "../fixtures/local-runtime.js";
 import { preparedRepository, type PreparedRepository } from "../fixtures/prepared-repository.js";
 import { productPage, type ProductPage } from "../fixtures/product-page.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
@@ -61,6 +64,14 @@ export const LOCAL_WORLD_SMOKE_1_ID = "LOCAL-WORLD-SMOKE-1";
 export const REPRESENTATIVE_HARNESS = "claude";
 export const DETERMINISTIC_PROMPT = "Reply with exactly the word: pong";
 
+/** Bounded waits for the live browser flow (kept generous but finite). */
+const GATEWAY_SYNC_TIMEOUT_MS = 120_000;
+const HARNESS_READY_TIMEOUT_MS = 300_000;
+const MODEL_PICKER_TIMEOUT_MS = 60_000;
+const WORKSPACE_SETTLE_TIMEOUT_MS = 90_000;
+const TURN_TIMEOUT_MS = 120_000;
+const ASSISTANT_REPLY_TIMEOUT_MS = 20_000;
+
 type ScenarioCellOutcomeWithEvidence = ScenarioCellOutcome & { evidence?: CellEvidenceV1 };
 
 export const localWorldSmoke1: ScenarioDefinition = {
@@ -80,11 +91,11 @@ export const localWorldSmoke1: ScenarioDefinition = {
     { description: `[${cell.cell_id}] create the fresh owner actor (setup claim + password login)` },
     { description: `[${cell.cell_id}] wait for Server-created LiteLLM enrollment and select the gateway route` },
     { description: `[${cell.cell_id}] prepare + register the run-scoped repository` },
-    { description: `[${cell.cell_id}] open the Desktop renderer and wait for gateway state synced to AnyHarness` },
+    { description: `[${cell.cell_id}] open the Desktop renderer (home composer)` },
     { description: `[${cell.cell_id}] select the repository and choose "Work locally" in the UI` },
-    { description: `[${cell.cell_id}] create a workspace and session in the UI` },
+    { description: `[${cell.cell_id}] wait until Desktop syncs gateway state into AnyHarness` },
     { description: `[${cell.cell_id}] choose the cheapest eligible non-Fable Claude model (allowlist ∩ live probe)` },
-    { description: `[${cell.cell_id}] send a bounded deterministic prompt and require a stable assistant reply` },
+    { description: `[${cell.cell_id}] send a bounded deterministic prompt; materialize the workspace + session and run one turn` },
     { description: `[${cell.cell_id}] reload/reopen and require workspace/session/transcript/model to persist` },
     { description: `[${cell.cell_id}] correlate the turn with new LiteLLM spend rows for the actor key` },
     { description: `[${cell.cell_id}] clean up every run-owned resource, in reverse order` },
@@ -124,20 +135,48 @@ export interface LocalWorldSmokeDriver {
   createActor(world: ReadyLocalWorld): Promise<AuthenticatedActor>;
   prepareRepo(world: ReadyLocalWorld, actor: AuthenticatedActor, cellId: string): Promise<PreparedRepository>;
   openPage(world: ReadyLocalWorld, actor: AuthenticatedActor): Promise<ProductPage>;
-  /** Selects the prepared repo and clicks "Work locally"; returns the created workspace id. */
-  selectRepoAndWorkLocally(page: ProductPage, repo: PreparedRepository): Promise<{ workspaceId: string }>;
-  /** Creates a session for the given harness in the UI. */
-  createSession(page: ProductPage, harnessKind: string): Promise<{ sessionId: string }>;
+  /**
+   * Waits until the booted Desktop renderer has pushed the Server-provided
+   * agent-auth (gateway) state into AnyHarness — observed as AnyHarness's own
+   * gateway model probe becoming non-empty for the harness. Desktop, not the
+   * fixture, performs the `PUT /v1/agent-auth/state` push; this only reads the
+   * runtime's probe result. Fails closed if the state never syncs.
+   */
+  waitForGatewaySync(world: ReadyLocalWorld, page: ProductPage, harnessKind: string): Promise<void>;
+  /**
+   * Ensures the representative harness's agent process is installed and reaches
+   * readiness `ready` in AnyHarness, so Desktop lists it as a launchable agent
+   * (its models appear in the composer picker). Claude's ACP process is built
+   * from git and can still be installing after gateway state syncs. Prerequisite
+   * agent setup — not the workspace/session/turn behavior under test.
+   */
+  ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, harnessKind: string): Promise<void>;
+  /**
+   * Home screen: selects the prepared repository in the project picker and the
+   * "Work locally" runtime. No workspace exists yet — the pending-workspace
+   * composer flow materializes it only on send.
+   */
+  selectRepoAndWorkLocally(page: ProductPage, repo: PreparedRepository): Promise<void>;
   /** AnyHarness's live-probed gateway model ids for the harness. */
   liveProbeModels(world: ReadyLocalWorld, harnessKind: string): Promise<string[]>;
   /** The qualification allowlist, cheapest-first (from controller preflight). */
   allowlistModels(world: ReadyLocalWorld): Promise<string[]>;
-  /** Selects `modelId` via the composer's model picker. */
+  /** Selects `modelId` in the home composer's model picker and asserts the picker reflects it. */
   selectModelInUi(page: ProductPage, modelId: string): Promise<void>;
-  /** Sends the prompt and returns the observed assistant reply text. */
-  sendPromptAndAwaitReply(page: ProductPage, prompt: string): Promise<string>;
+  /**
+   * Sends the bounded prompt from the home composer. This materializes the
+   * pending workspace + session, transitions to the workspace shell, and runs
+   * the first turn. Returns the created workspace/session ids (read from the
+   * settled shell hooks) and the assistant reply observed in the transcript.
+   */
+  sendPromptAndMaterialize(
+    world: ReadyLocalWorld,
+    page: ProductPage,
+    prompt: string,
+  ): Promise<{ workspaceId: string; sessionId: string; reply: string }>;
   /** Reloads the page and asserts workspace/session/transcript/model survive. */
   reopenAndVerify(
+    world: ReadyLocalWorld,
     page: ProductPage,
     expectations: { workspaceId: string; sessionId: string; modelId: string; harnessKind: string },
   ): Promise<void>;
@@ -163,35 +202,113 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
   createActor: (world) => authenticatedActor(world, "owner"),
   prepareRepo: (world, actor, cellId) => preparedRepository(world, actor, { cellId }),
   openPage: (world, actor) => productPage(world, actor),
-  async selectRepoAndWorkLocally(page, repo) {
-    // Best-effort, resilient (role/text-based) selectors — see the module doc
-    // and this workstream's final report: production `data-testid`s are
-    // almost nonexistent in apps/desktop/src (verified 2026-07-14), so these
-    // rely on stable copy (`homeRepoLaunchKindLabel` /
-    // `apps/desktop/src/lib/domain/home/home-target-picker.ts`) that MUST be
-    // confirmed against a live render before this cell is trusted.
-    const repoName = repo.repoUrl.split("/").pop()?.replace(/\.git$/, "") ?? repo.path;
-    await page.page.getByText(repoName, { exact: false }).first().click();
-    await page.page.getByRole("button", { name: /Work locally/i }).click();
-    const workspaceId = await page.page.evaluate(() => {
-      const marker = document.querySelector("[data-workspace-id]");
-      return marker?.getAttribute("data-workspace-id") ?? "";
-    });
-    if (!workspaceId) {
-      throw new Error("selectRepoAndWorkLocally: could not read the created workspace id from the UI.");
+  async waitForGatewaySync(world, _page, harnessKind) {
+    // Desktop's use-local-auth-state-sync pushes the Server-minted gateway
+    // state to AnyHarness on boot; AnyHarness then probes the managed proxy and
+    // records the servable model list. An empty list means either the push has
+    // not landed yet or gateway auth is absent. Poll (bounded) until non-empty.
+    const deadline = Date.now() + GATEWAY_SYNC_TIMEOUT_MS;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      try {
+        const models = await world.runtime.client.getGatewayModels(harnessKind);
+        if (models.length > 0) {
+          return;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+      await sleep(1_000);
     }
-    return { workspaceId };
+    throw new Error(
+      `waitForGatewaySync: Desktop did not sync gateway state into AnyHarness for "${harnessKind}" ` +
+        `within ${GATEWAY_SYNC_TIMEOUT_MS}ms${lastError ? ` (last probe error: ${describe(lastError)})` : ""}.`,
+    );
   },
-  async createSession(page, harnessKind) {
-    void harnessKind;
-    const sessionId = await page.page.evaluate(() => {
-      const marker = document.querySelector("[data-session-id]");
-      return marker?.getAttribute("data-session-id") ?? "";
-    });
-    if (!sessionId) {
-      throw new Error("createSession: could not read the created session id from the UI.");
+  async ensureHarnessReady(world, page, harnessKind) {
+    const client = world.runtime.client;
+    const deadline = Date.now() + HARNESS_READY_TIMEOUT_MS;
+    let triggeredInstall = false;
+    let last: Awaited<ReturnType<typeof client.getAgent>> | undefined;
+    let launchable = false;
+    // Wait until AnyHarness both reports the agent ready AND lists it (with
+    // models) in launch-options — the exact source Desktop's composer reads.
+    // Claude's ACP process builds from git and can still be installing after
+    // gateway state syncs, so this is generously bounded.
+    while (Date.now() < deadline) {
+      last = await client.getAgent(harnessKind).catch(() => undefined);
+      if (last?.readiness === "ready") {
+        const options = await client.getAgentLaunchOptions().catch(() => []);
+        const entry = options.find((agent) => agent.kind === harnessKind);
+        if (entry && entry.models.length > 0) {
+          launchable = true;
+          break;
+        }
+      }
+      // Trigger the install once if the agent process is not yet present and
+      // nothing else is already installing it (Desktop may auto-reconcile).
+      if (
+        !triggeredInstall &&
+        last &&
+        last.installState !== "installing" &&
+        (last.readiness === "install_required" || last.installState === "not_installed")
+      ) {
+        triggeredInstall = true;
+        await client.installAgent(harnessKind).catch(() => undefined);
+      }
+      await sleep(2_000);
     }
-    return { sessionId };
+    if (!launchable) {
+      await dumpHarnessReadinessDiagnostics(world, harnessKind).catch(() => undefined);
+      throw new Error(
+        `ensureHarnessReady: agent "${harnessKind}" never became launchable within ${HARNESS_READY_TIMEOUT_MS}ms ` +
+          `(last: readiness=${last?.readiness}, installState=${last?.installState}, credentialState=${last?.credentialState}).`,
+      );
+    }
+    // Desktop fetches agents/launch-options once at boot and does not poll them
+    // (anyharness/sdk-react useAgentsQuery/useAgentLaunchOptionsQuery have no
+    // refetchInterval), so a harness that finished installing after boot never
+    // appears in the composer. Reload to force a fresh fetch now that AnyHarness
+    // lists it, then wait for the home composer to re-render.
+    await page.page.reload({ waitUntil: "domcontentloaded" });
+    await page.page
+      .locator("[data-home-composer-editor]")
+      .first()
+      .waitFor({ state: "visible", timeout: 30_000 });
+  },
+  async selectRepoAndWorkLocally(page, repo) {
+    const p = page.page;
+    // Open the target row's Project picker (aria "Project: …"). The prepared
+    // repo was registered into AnyHarness by preparedRepository, so Desktop
+    // lists it as a repo-root whose `sourceRoot` equals the clone path.
+    await clickByRole(p, "button", /^Project:/, "home Project picker trigger");
+    // Select deterministically by the clone path (repo-root sourceRoot), since
+    // the displayed name is the git remote name, not the clone-dir basename.
+    const repoRow = p.locator(`[data-repo-source-root="${cssAttr(repo.path)}"]`).first();
+    try {
+      await repoRow.waitFor({ state: "visible", timeout: 20_000 });
+      await repoRow.click();
+    } catch (error) {
+      // Fall back to the display name for resilience against path normalization.
+      const repoName = deriveRepoName(repo);
+      const available = await p
+        .locator("[data-repo-source-root]")
+        .evaluateAll((els) => els.map((el) => el.getAttribute("data-repo-source-root")))
+        .catch(() => []);
+      try {
+        await clickMenuItemByText(p, repoName, "prepared repository row");
+      } catch {
+        throw new Error(
+          `selectRepoAndWorkLocally: prepared repo not offered by the project picker. ` +
+            `Wanted sourceRoot="${repo.path}" or name="${repoName}". ` +
+            `Available sourceRoots: ${JSON.stringify(available)} (${describe(error)}).`,
+        );
+      }
+    }
+    // Selecting a repo leaves the launch kind at its default ("New worktree").
+    // Open the Runtime popover and switch to "Work locally" (repoLaunchKind=local).
+    await clickByRole(p, "button", /^Runtime:/, "home Runtime picker trigger");
+    await clickMenuItemByText(p, "Work locally", '"Work locally" runtime option');
   },
   liveProbeModels: async (world, harnessKind) => {
     const models = await world.runtime.client.getGatewayModels(harnessKind);
@@ -202,42 +319,118 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
     return preflight.eligibleClaudeModels;
   },
   async selectModelInUi(page, modelId) {
-    await page.page.getByRole("button", { name: /^Model:/ }).click();
-    await page.page.getByRole("option", { name: modelId, exact: false }).click();
-  },
-  async sendPromptAndAwaitReply(page, prompt) {
-    await page.page.getByPlaceholder(/Describe a task/i).fill(prompt);
-    await page.page.getByRole("button", { name: "Send message" }).click();
-    // Wait for the turn to end: the "Stop run" control appears while the
-    // model is generating and disappears again once the turn completes.
-    const stopButton = page.page.getByRole("button", { name: "Stop run" });
-    await stopButton.waitFor({ state: "visible", timeout: 15_000 }).catch(() => undefined);
-    await stopButton.waitFor({ state: "hidden", timeout: 60_000 });
-    const reply = await page.page.evaluate(() => {
-      const marker = document.querySelector("[data-last-assistant-reply]");
-      return marker?.textContent?.trim() ?? "";
-    });
-    if (!reply) {
-      throw new Error("sendPromptAndAwaitReply: no assistant reply observed after the turn ended.");
+    const p = page.page;
+    // The composer model picker is disabled until agents are healthy, and the
+    // just-installed claude agent can surface a beat after AnyHarness reports it
+    // ready (Desktop refetches agents on an interval). Retry opening the picker
+    // until the model option appears.
+    const deadline = Date.now() + MODEL_PICKER_TIMEOUT_MS;
+    const optionSelector = `[data-model-option="${cssAttr(modelId)}"]`;
+    let lastAvailable: Array<string | null> = [];
+    while (Date.now() < deadline) {
+      const trigger = p.locator("[data-composer-model-trigger]:not([disabled])").first();
+      try {
+        await trigger.waitFor({ state: "visible", timeout: 5_000 });
+        await trigger.click();
+      } catch {
+        await sleep(1_500);
+        continue;
+      }
+      const option = p.locator(optionSelector).first();
+      if (await option.count().catch(() => 0)) {
+        await option.click();
+        // Assert the composer now reflects the selection (spec step 7).
+        await p
+          .locator(`[data-composer-model-trigger][data-composer-selected-model="${cssAttr(modelId)}"]`)
+          .first()
+          .waitFor({ state: "attached", timeout: 10_000 });
+        return;
+      }
+      lastAvailable = await p
+        .locator("[data-model-option]")
+        .evaluateAll((els) => els.map((el) => el.getAttribute("data-model-option")))
+        .catch(() => []);
+      // Close the popover and retry after a beat.
+      await p.keyboard.press("Escape").catch(() => undefined);
+      await sleep(2_000);
     }
-    return reply;
-  },
-  async reopenAndVerify(page, expectations) {
-    await page.page.reload({ waitUntil: "domcontentloaded" });
-    const stillVisible = await page.page.evaluate(
-      (ids) => {
-        const workspace = document.querySelector(`[data-workspace-id="${ids.workspaceId}"]`);
-        const session = document.querySelector(`[data-session-id="${ids.sessionId}"]`);
-        return Boolean(workspace) && Boolean(session);
-      },
-      { workspaceId: expectations.workspaceId, sessionId: expectations.sessionId },
+    throw new Error(
+      `selectModelInUi: model "${modelId}" was not offered by the composer picker within ` +
+        `${MODEL_PICKER_TIMEOUT_MS}ms. Last available options: ${JSON.stringify(lastAvailable)}.`,
     );
-    if (!stillVisible) {
+  },
+  async sendPromptAndMaterialize(world, page, prompt) {
+    const p = page.page;
+    const editor = p.locator("[data-home-composer-editor]").first();
+    await editor.waitFor({ state: "visible", timeout: 15_000 });
+    await editor.fill(prompt);
+    const send = p.locator("[data-chat-send-button]:not([disabled])").first();
+    await send.waitFor({ state: "visible", timeout: 15_000 });
+    await send.click();
+    // The pending-workspace composer transitions to the workspace shell; wait
+    // for it to settle (data-pending-workspace flips to "false") so the ui-key
+    // is the materialized workspace id rather than the pending synthetic key.
+    await p.locator("[data-workspace-shell]").first().waitFor({ state: "visible", timeout: 30_000 });
+    await p
+      .locator('[data-workspace-shell][data-pending-workspace="false"]')
+      .first()
+      .waitFor({ state: "attached", timeout: WORKSPACE_SETTLE_TIMEOUT_MS });
+    const { workspaceId, sessionId } = await readWorkspaceIds(p);
+    // Turn completion is asserted from AnyHarness's own event stream (robust,
+    // not DOM-timing-flaky). A session-level error is surfaced as a real
+    // failure rather than a hang.
+    const completion = await waitForTurnCompletion(world, sessionId, TURN_TIMEOUT_MS);
+    if (completion.error) {
+      throw new Error(`sendPromptAndMaterialize: assistant turn errored: ${completion.error}`);
+    }
+    if (!completion.ended) {
+      throw new Error(`sendPromptAndMaterialize: assistant turn did not end within ${TURN_TIMEOUT_MS}ms.`);
+    }
+    // Spec: a stable assistant answer must be visible in the transcript.
+    const reply = await readAssistantReply(p, ASSISTANT_REPLY_TIMEOUT_MS);
+    return { workspaceId, sessionId, reply };
+  },
+  async reopenAndVerify(world, page, expectations) {
+    void world;
+    const p = page.page;
+    await p.reload({ waitUntil: "domcontentloaded" });
+    // The Desktop client restores the last workspace/session on boot (the
+    // logical workspace is persisted; its active session is re-derived a beat
+    // later). Wait for the shell to restore the exact workspace, then poll for
+    // the session id to settle back to the same value.
+    const shell = p.locator(`[data-workspace-shell][data-workspace-ui-key="${cssAttr(expectations.workspaceId)}"]`).first();
+    await shell.waitFor({ state: "attached", timeout: 60_000 });
+    const sessionDeadline = Date.now() + 30_000;
+    let sessionId: string | null = null;
+    while (Date.now() < sessionDeadline) {
+      sessionId = await shell.getAttribute("data-workspace-session-id").catch(() => null);
+      if (sessionId === expectations.sessionId) {
+        break;
+      }
+      await sleep(1_000);
+    }
+    if (sessionId !== expectations.sessionId) {
       throw new Error(
-        `reopenAndVerify: workspace "${expectations.workspaceId}" / session "${expectations.sessionId}" ` +
-          "did not remain visible after reopen.",
+        `reopenAndVerify: session "${expectations.sessionId}" did not remain active after reopen ` +
+          `(saw "${sessionId ?? ""}").`,
       );
     }
+    const reply = await readAssistantReply(p, ASSISTANT_REPLY_TIMEOUT_MS);
+    if (!reply.trim()) {
+      throw new Error("reopenAndVerify: the transcript did not re-render an assistant reply after reopen.");
+    }
+    // The selected model (and thus harness) must remain visible in the composer.
+    await p
+      .locator(
+        `[data-composer-model-trigger][data-composer-selected-model="${cssAttr(expectations.modelId)}"]`,
+      )
+      .first()
+      .waitFor({ state: "attached", timeout: 15_000 })
+      .catch(() => {
+        throw new Error(
+          `reopenAndVerify: composer no longer reflects model "${expectations.modelId}" after reopen.`,
+        );
+      });
   },
   snapshotSpend: (world, actor) => world.gateway.snapshotSpend(actor.gatewayKey),
   correlateTurn: (world, params) =>
@@ -294,8 +487,18 @@ export async function runLocalWorldSmokeCell(
     const repo = await driver.prepareRepo(world, actor, cell.cell_id);
     const page = await driver.openPage(world, actor);
     try {
-      const { workspaceId } = await driver.selectRepoAndWorkLocally(page, repo);
-      const { sessionId } = await driver.createSession(page, harnessKind);
+      // Desktop (not the fixture) must push the Server-provided gateway state
+      // into AnyHarness before the turn; block on that sync signal.
+      await driver.waitForGatewaySync(world, page, harnessKind);
+
+      // The representative harness's agent process must be installed + ready in
+      // AnyHarness before Desktop lists it as launchable in the composer. This
+      // reloads the page once the harness is launchable so Desktop re-fetches.
+      await driver.ensureHarnessReady(world, page, harnessKind);
+
+      // Home screen: select the prepared repo + "Work locally". The workspace
+      // and session do not exist yet — the composer materializes them on send.
+      await driver.selectRepoAndWorkLocally(page, repo);
 
       const [allowlist, liveProbe] = await Promise.all([
         driver.allowlistModels(world),
@@ -318,13 +521,17 @@ export async function runLocalWorldSmokeCell(
 
       const before = await driver.snapshotSpend(world, actor);
       const windowStartedAt = new Date().toISOString();
-      const reply = await driver.sendPromptAndAwaitReply(page, DETERMINISTIC_PROMPT);
+      const { workspaceId, sessionId, reply } = await driver.sendPromptAndMaterialize(
+        world,
+        page,
+        DETERMINISTIC_PROMPT,
+      );
       if (!reply.trim()) {
         throw new Error("empty assistant reply");
       }
       const windowFinishedAt = new Date().toISOString();
 
-      await driver.reopenAndVerify(page, { workspaceId, sessionId, modelId, harnessKind });
+      await driver.reopenAndVerify(world, page, { workspaceId, sessionId, modelId, harnessKind });
 
       const correlated = await driver.correlateTurn(world, {
         actor,
@@ -390,6 +597,15 @@ export async function runLocalWorldSmokeCell(
       }
 
       return { cellId: cell.cell_id, status: "green", evidence };
+    } catch (uiError) {
+      // Env-gated failure diagnostics (LOCAL_WORLD_SMOKE_DEBUG_DIR): dump the
+      // real rendered DOM + a screenshot at the point of a browser-flow failure
+      // so a selector/flow break can be fixed without a live browser. Never on
+      // the green path; best-effort so it never masks the real error.
+      await captureUiFailure(page, "scenario-ui-failure");
+      await dumpServerGatewayState(actor, "scenario-ui-failure").catch(() => undefined);
+      await dumpRuntimeWorkspaces(world, "scenario-ui-failure").catch(() => undefined);
+      throw uiError;
     } finally {
       await page.close().catch(() => undefined);
     }
@@ -478,4 +694,230 @@ function sha256Hex(value: string): string {
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Env-gated (`LOCAL_WORLD_SMOKE_DEBUG_DIR`) dump of the live DOM + a screenshot
+ * when a browser-flow step fails. No-op unless the env var is set (so it never
+ * runs in CI or unit tests), and fully best-effort so it never masks the real
+ * failure.
+ */
+async function captureUiFailure(page: ProductPage | undefined, label: string): Promise<void> {
+  const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  if (!dir || !page) {
+    return;
+  }
+  try {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const nodePath = await import("node:path");
+    mkdirSync(dir, { recursive: true });
+    const stamp = `${label}-${Date.now()}`;
+    const html = await page.page.content().catch(() => "<no content>");
+    writeFileSync(nodePath.join(dir, `${stamp}.html`), html);
+    await page.page.screenshot({ path: nodePath.join(dir, `${stamp}.png`), fullPage: true }).catch(() => undefined);
+    if (page.debug) {
+      writeFileSync(nodePath.join(dir, `${stamp}.console.txt`), page.debug.console.join("\n"));
+      writeFileSync(nodePath.join(dir, `${stamp}.network.txt`), page.debug.network.join("\n"));
+    }
+  } catch {
+    // Diagnostics are best-effort.
+  }
+}
+
+/**
+ * Diagnostic-only (env-gated) dump of why a harness is not launchable: the full
+ * launch-options, gateway probes for the target + grok, and the pushed
+ * agent-auth state.json. Best-effort; never affects the outcome.
+ */
+async function dumpHarnessReadinessDiagnostics(world: ReadyLocalWorld, harnessKind: string): Promise<void> {
+  const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  if (!dir) {
+    return;
+  }
+  const { mkdirSync, writeFileSync, readFileSync } = await import("node:fs");
+  const nodePath = await import("node:path");
+  const client = world.runtime.client;
+  const diag: Record<string, unknown> = {};
+  diag.launchOptions = await client.getAgentLaunchOptions().catch((e) => `err: ${describe(e)}`);
+  diag.gatewayModelsTarget = await client.getGatewayModels(harnessKind).catch((e) => `err: ${describe(e)}`);
+  diag.gatewayModelsGrok = await client.getGatewayModels("grok").catch((e) => `err: ${describe(e)}`);
+  diag.agentTarget = await client.getAgent(harnessKind).catch((e) => `err: ${describe(e)}`);
+  diag.agentGrok = await client.getAgent("grok").catch((e) => `err: ${describe(e)}`);
+  try {
+    const statePath = nodePath.join(world.paths.runtimeHome, "agent-auth", "state.json");
+    diag.stateJson = JSON.parse(readFileSync(statePath, "utf8"));
+  } catch (e) {
+    diag.stateJson = `err: ${describe(e)}`;
+  }
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(nodePath.join(dir, `harness-readiness-diag-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+}
+
+/**
+ * Diagnostic-only (env-gated) dump of the SERVER-rendered local-surface
+ * agent-auth state document and selections (the exact inputs Desktop fetches
+ * and pushes to AnyHarness). Reveals whether the server renders the harness's
+ * gateway route. Best-effort.
+ */
+async function dumpServerGatewayState(actor: AuthenticatedActor, label: string): Promise<void> {
+  const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  if (!dir) {
+    return;
+  }
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const nodePath = await import("node:path");
+  const diag: Record<string, unknown> = {};
+  diag.stateLocal = await actor.api
+    .get("/v1/cloud/agent-gateway/state?surface=local")
+    .catch((e) => `err: ${describe(e)}`);
+  diag.selectionsLocal = await actor.api
+    .get("/v1/cloud/agent-gateway/selections?surface=local")
+    .catch((e) => `err: ${describe(e)}`);
+  diag.capabilities = await actor.api
+    .get("/v1/cloud/agent-gateway/capabilities")
+    .catch((e) => `err: ${describe(e)}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(nodePath.join(dir, `server-gateway-state-${label}-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+}
+
+/**
+ * Diagnostic-only (env-gated) dump of the runtime's workspaces + launch options
+ * at failure — reveals whether the "Work locally" workspace actually
+ * materialized in AnyHarness. Best-effort.
+ */
+async function dumpRuntimeWorkspaces(world: ReadyLocalWorld, label: string): Promise<void> {
+  const dir = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  if (!dir) {
+    return;
+  }
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const nodePath = await import("node:path");
+  const diag: Record<string, unknown> = {};
+  diag.workspaces = await world.runtime.client.listWorkspaces().catch((e) => `err: ${describe(e)}`);
+  diag.launchOptions = await world.runtime.client.getAgentLaunchOptions().catch((e) => `err: ${describe(e)}`);
+  const sessions = await world.runtime.client.listSessions().catch(() => []);
+  diag.sessions = sessions;
+  const sessionDiags: Record<string, unknown> = {};
+  for (const session of Array.isArray(sessions) ? sessions : []) {
+    sessionDiags[session.id] = await world.runtime.client
+      .getEvents(session.id, 50)
+      .catch((e) => `err: ${describe(e)}`);
+  }
+  diag.sessionEvents = sessionDiags;
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(nodePath.join(dir, `runtime-workspaces-${label}-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+}
+
+/** The repository's display name as Desktop lists it — the clone's basename. */
+function deriveRepoName(repo: PreparedRepository): string {
+  const fromPath = repo.path.replace(/\/+$/, "").split("/").pop();
+  if (fromPath && fromPath.length > 0) {
+    return fromPath;
+  }
+  return repo.repoUrl.split("/").pop()?.replace(/\.git$/, "") ?? repo.path;
+}
+
+/** Escapes a value for safe interpolation inside a `[attr="…"]` CSS selector. */
+function cssAttr(value: string): string {
+  return value.replace(/["\\]/g, "\\$&");
+}
+
+async function clickByRole(page: Page, role: "button", name: RegExp, what: string): Promise<void> {
+  const locator = page.getByRole(role, { name }).first();
+  try {
+    await locator.waitFor({ state: "visible", timeout: 20_000 });
+  } catch (error) {
+    throw new Error(`could not find ${what} (role=${role}, name=${name}): ${describe(error)}`);
+  }
+  await locator.click();
+}
+
+/** Clicks a popover menu row by its visible text (menu rows are native buttons). */
+async function clickMenuItemByText(page: Page, text: string, what: string): Promise<void> {
+  const byRole = page.getByRole("button", { name: text, exact: false }).first();
+  if (await byRole.count().catch(() => 0)) {
+    await byRole.waitFor({ state: "visible", timeout: 15_000 }).catch(() => undefined);
+    if (await byRole.isVisible().catch(() => false)) {
+      await byRole.click();
+      return;
+    }
+  }
+  const byText = page.getByText(text, { exact: false }).first();
+  try {
+    await byText.waitFor({ state: "visible", timeout: 15_000 });
+  } catch (error) {
+    throw new Error(`could not find ${what} (text="${text}"): ${describe(error)}`);
+  }
+  await byText.click();
+}
+
+/**
+ * Reads the settled workspace id (data-workspace-ui-key) and active session id
+ * (data-workspace-session-id) off the workspace shell. The session id can lag
+ * the shell mount by a beat, so it is briefly retried.
+ */
+async function readWorkspaceIds(page: Page): Promise<{ workspaceId: string; sessionId: string }> {
+  const shell = page.locator("[data-workspace-shell]").first();
+  const deadline = Date.now() + 30_000;
+  let workspaceId = "";
+  let sessionId = "";
+  while (Date.now() < deadline) {
+    workspaceId = (await shell.getAttribute("data-workspace-ui-key").catch(() => "")) ?? "";
+    sessionId = (await shell.getAttribute("data-workspace-session-id").catch(() => "")) ?? "";
+    if (workspaceId && sessionId) {
+      return { workspaceId, sessionId };
+    }
+    await sleep(500);
+  }
+  throw new Error(
+    `readWorkspaceIds: workspace/session ids never settled ` +
+      `(workspace="${workspaceId}", session="${sessionId}").`,
+  );
+}
+
+/**
+ * Polls AnyHarness's session event stream until the turn ends or errors.
+ * Turn completion is authoritative here; the transcript DOM is asserted
+ * separately for the "answer visible in the transcript" requirement.
+ */
+async function waitForTurnCompletion(
+  world: ReadyLocalWorld,
+  sessionId: string,
+  timeoutMs: number,
+): Promise<{ ended: boolean; error: string | undefined }> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const events = await world.runtime.client.getEvents(sessionId).catch(() => []);
+    const error = findErrorEvent(events);
+    if (error) {
+      return { ended: true, error };
+    }
+    if (findTurnEndedEvent(events)) {
+      return { ended: true, error: undefined };
+    }
+    await sleep(1_000);
+  }
+  return { ended: false, error: undefined };
+}
+
+/**
+ * Waits for a non-streaming assistant prose block to carry non-empty text and
+ * returns the last one's trimmed content (the final assistant answer).
+ */
+async function readAssistantReply(page: Page, timeoutMs: number): Promise<string> {
+  const settled = page.locator('[data-assistant-prose][data-assistant-streaming="false"]').last();
+  await settled.waitFor({ state: "attached", timeout: timeoutMs }).catch(() => undefined);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const text = (await settled.textContent().catch(() => "")) ?? "";
+    if (text.trim().length > 0) {
+      return text.trim();
+    }
+    await sleep(500);
+  }
+  return "";
 }

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -48,38 +48,18 @@ import {
  * through the runner's extended matrix outcome — see BRIEF "Runner amendments").
  * Cleanup runs in `finally` and its evidence is folded into that same block.
  *
- * ── Cross-workstream input gap beyond BRIEF §7 (disclosed; see final report) ──
- * BRIEF §7 documents two additive `ScenarioRunContext`/`ScenarioCellOutcome`
- * seams (`candidateBuildMap`, `evidence?`) owned by workstream C. Building a
- * `ReadyLocalWorld` also needs the resolved `RunIdentityV1`, a run/shard-scoped
- * `runDir`, and pre-allocated `LocalWorldPorts` (`ConstructLocalWorldOptions`,
- * `world.ts`) — none of which `ScenarioRunContext` carries today, and none of
- * which this workstream owns to add. This module reads them off a local bridge
- * type (`LocalWorldSmokeRunContext`) rather than inventing its own duplicate
- * identity/port-allocation machinery; when they are absent the cell fails
- * cleanly with a bounded reason instead of throwing (see
- * `resolveWorldConstructionInputs`).
+ * The world-construction inputs — the validated path-bearing `candidateBuildMap`
+ * (BRIEF §7a), the resolved `runIdentity`, the run/shard-scoped `runDir`, and
+ * the pre-allocated `LocalWorldPorts` — are all first-class fields of
+ * `ScenarioRunContext`, threaded by the runner from the execute options and the
+ * `local-world-ports.json` sidecar the candidate builder wrote next to the
+ * candidate map. When any is absent the cell fails cleanly with a bounded reason
+ * instead of throwing (see `resolveWorldConstructionInputs`).
  */
 
 export const LOCAL_WORLD_SMOKE_1_ID = "LOCAL-WORLD-SMOKE-1";
 export const REPRESENTATIVE_HARNESS = "claude";
 export const DETERMINISTIC_PROMPT = "Reply with exactly the word: pong";
-
-/**
- * Bridge type for the world-construction inputs noted above. `candidateBuildMap`
- * (BRIEF §7a) is now a first-class field of `ScenarioRunContext`, threaded by
- * the runner; `runIdentity`/`runDir`/`ports` are NOT yet part of that context
- * (see module doc) and remain optional additions read off this bridge — the
- * cell fails cleanly with a bounded reason when they are absent.
- */
-export interface LocalWorldSmokeRunContext extends ScenarioRunContext {
-  /** Not yet part of `ScenarioRunContext` — see module doc. */
-  runIdentity?: RunIdentityV1;
-  /** Not yet part of `ScenarioRunContext` — see module doc. */
-  runDir?: string;
-  /** Not yet part of `ScenarioRunContext` — see module doc. */
-  ports?: LocalWorldPorts;
-}
 
 type ScenarioCellOutcomeWithEvidence = ScenarioCellOutcome & { evidence?: CellEvidenceV1 };
 
@@ -113,7 +93,7 @@ export const localWorldSmoke1: ScenarioDefinition = {
     const driver = defaultLocalWorldSmokeDriver;
     const outcomes: ScenarioCellOutcomeWithEvidence[] = [];
     for (const cell of cells) {
-      outcomes.push(await runLocalWorldSmokeCell(cell, ctx as LocalWorldSmokeRunContext, driver));
+      outcomes.push(await runLocalWorldSmokeCell(cell, ctx, driver));
     }
     return outcomes;
   },
@@ -282,7 +262,7 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
  */
 export async function runLocalWorldSmokeCell(
   cell: PlannedCellV1,
-  ctx: LocalWorldSmokeRunContext,
+  ctx: ScenarioRunContext,
   driver: LocalWorldSmokeDriver,
 ): Promise<ScenarioCellOutcomeWithEvidence> {
   const inputs = resolveWorldConstructionInputs(ctx);
@@ -305,6 +285,12 @@ export async function runLocalWorldSmokeCell(
   let worldClosed = false;
   try {
     const actor = await driver.createActor(world);
+    // Enrol the actor's server-minted LiteLLM key + user + team into the world's
+    // cleanup stack as soon as the key identity is resolved, so world close()
+    // deletes them (spec "Cleanup": actor virtual key/team/user) and populates
+    // the required `virtual_key_deleted`/`litellm_subjects_deleted` evidence.
+    // Without this the shared staging proxy leaks the run's subjects.
+    await world.trackActorSubjects?.(actor.gatewayKey);
     const repo = await driver.prepareRepo(world, actor, cell.cell_id);
     const page = await driver.openPage(world, actor);
     try {
@@ -456,7 +442,7 @@ type WorldConstructionInputs =
  * doc). Returns a typed failure instead of throwing so the cell can report a
  * clean `failed` outcome.
  */
-export function resolveWorldConstructionInputs(ctx: LocalWorldSmokeRunContext): WorldConstructionInputs {
+export function resolveWorldConstructionInputs(ctx: ScenarioRunContext): WorldConstructionInputs {
   const map = ctx.candidateBuildMap;
   if (!map) {
     return { ok: false, reason: "no candidate build map was supplied to this run; the cell cannot start a world" };

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -1,0 +1,495 @@
+import { createHash } from "node:crypto";
+
+import type {
+  ScenarioCellOutcome,
+  ScenarioCellSpec,
+  ScenarioDefinition,
+  ScenarioPlanStep,
+  ScenarioRunContext,
+} from "./types.js";
+import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { CellEvidenceV1, LocalWorkspaceTurnEvidenceV1 } from "../evidence/schema.js";
+import { authenticatedActor, type AuthenticatedActor } from "../fixtures/authenticated-actor.js";
+import { preparedRepository, type PreparedRepository } from "../fixtures/prepared-repository.js";
+import { productPage, type ProductPage } from "../fixtures/product-page.js";
+import type { RunIdentityV1 } from "../runner/identity.js";
+import type { PlannedCellV1 } from "../runner/result.js";
+import { selectCheapestEligibleClaudeModel } from "../services/qualification-litellm.js";
+import {
+  constructLocalWorld,
+  type LocalWorldPorts,
+  type ReadyLocalWorld,
+} from "../worlds/local-workspace/world.js";
+
+/**
+ * LOCAL-WORLD-SMOKE-1 (spec "The single test cell"). A provisional
+ * infrastructure proof — NOT the canonical `LOCAL-2` guarantee. One matrix cell
+ * on the local lane, dimension `harness=claude`, giving the canonical id
+ * `LOCAL-WORLD-SMOKE-1/local/harness=claude`. Claude is the representative
+ * harness; the exact model stays live-probed and cheapest-eligible non-Fable.
+ *
+ * The cell drives, against a `ReadyLocalWorld` constructed from the exact
+ * candidate bytes:
+ *   1. create the fresh owner actor;
+ *   2. wait for the Server-created LiteLLM enrollment and select the gateway route;
+ *   3. prepare + register the run-scoped repository;
+ *   4. open the Desktop renderer and wait until Desktop has synchronized gateway
+ *      state into AnyHarness;
+ *   5. select the prepared repo and choose "Work locally" in the UI;
+ *   6. create a workspace and session in the UI;
+ *   7. choose the cheapest eligible non-Fable Claude model from the intersection
+ *      of the qualification allowlist and AnyHarness's live gateway probe;
+ *   8. send a bounded deterministic prompt, require a stable assistant answer;
+ *   9. reload/reopen and require workspace/session/transcript/harness/model to
+ *      remain visible; and
+ *  10. correlate exactly this turn with one or more new LiteLLM spend rows.
+ *
+ * The green outcome carries a complete `LocalWorkspaceTurnEvidenceV1` (attached
+ * through the runner's extended matrix outcome — see BRIEF "Runner amendments").
+ * Cleanup runs in `finally` and its evidence is folded into that same block.
+ *
+ * ── Cross-workstream input gap beyond BRIEF §7 (disclosed; see final report) ──
+ * BRIEF §7 documents two additive `ScenarioRunContext`/`ScenarioCellOutcome`
+ * seams (`candidateBuildMap`, `evidence?`) owned by workstream C. Building a
+ * `ReadyLocalWorld` also needs the resolved `RunIdentityV1`, a run/shard-scoped
+ * `runDir`, and pre-allocated `LocalWorldPorts` (`ConstructLocalWorldOptions`,
+ * `world.ts`) — none of which `ScenarioRunContext` carries today, and none of
+ * which this workstream owns to add. This module reads them off a local bridge
+ * type (`LocalWorldSmokeRunContext`) rather than inventing its own duplicate
+ * identity/port-allocation machinery; when they are absent the cell fails
+ * cleanly with a bounded reason instead of throwing (see
+ * `resolveWorldConstructionInputs`).
+ */
+
+export const LOCAL_WORLD_SMOKE_1_ID = "LOCAL-WORLD-SMOKE-1";
+export const REPRESENTATIVE_HARNESS = "claude";
+export const DETERMINISTIC_PROMPT = "Reply with exactly the word: pong";
+
+/**
+ * Bridge type for the world-construction inputs noted above. `candidateBuildMap`
+ * (BRIEF §7a) is now a first-class field of `ScenarioRunContext`, threaded by
+ * the runner; `runIdentity`/`runDir`/`ports` are NOT yet part of that context
+ * (see module doc) and remain optional additions read off this bridge — the
+ * cell fails cleanly with a bounded reason when they are absent.
+ */
+export interface LocalWorldSmokeRunContext extends ScenarioRunContext {
+  /** Not yet part of `ScenarioRunContext` — see module doc. */
+  runIdentity?: RunIdentityV1;
+  /** Not yet part of `ScenarioRunContext` — see module doc. */
+  runDir?: string;
+  /** Not yet part of `ScenarioRunContext` — see module doc. */
+  ports?: LocalWorldPorts;
+}
+
+type ScenarioCellOutcomeWithEvidence = ScenarioCellOutcome & { evidence?: CellEvidenceV1 };
+
+export const localWorldSmoke1: ScenarioDefinition = {
+  id: LOCAL_WORLD_SMOKE_1_ID,
+  kind: "matrix",
+  title: "prove one real local workspace turn: exact candidate bytes → gateway turn → correlated spend",
+  registryFlowRef: "specs/developing/testing/flows.md#local-world-smoke",
+  lanes: ["local"],
+  requiredEnv: [
+    "AGENT_GATEWAY_LITELLM_BASE_URL",
+    "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL",
+    "AGENT_GATEWAY_LITELLM_MASTER_KEY",
+  ],
+  expandCells: (): ScenarioCellSpec[] => [{ dimensions: { harness: REPRESENTATIVE_HARNESS } }],
+  planCell: (_ctx, cell: PlannedCellV1): ScenarioPlanStep[] => [
+    { description: `[${cell.cell_id}] build the exact candidate three-artifact local world` },
+    { description: `[${cell.cell_id}] create the fresh owner actor (setup claim + password login)` },
+    { description: `[${cell.cell_id}] wait for Server-created LiteLLM enrollment and select the gateway route` },
+    { description: `[${cell.cell_id}] prepare + register the run-scoped repository` },
+    { description: `[${cell.cell_id}] open the Desktop renderer and wait for gateway state synced to AnyHarness` },
+    { description: `[${cell.cell_id}] select the repository and choose "Work locally" in the UI` },
+    { description: `[${cell.cell_id}] create a workspace and session in the UI` },
+    { description: `[${cell.cell_id}] choose the cheapest eligible non-Fable Claude model (allowlist ∩ live probe)` },
+    { description: `[${cell.cell_id}] send a bounded deterministic prompt and require a stable assistant reply` },
+    { description: `[${cell.cell_id}] reload/reopen and require workspace/session/transcript/model to persist` },
+    { description: `[${cell.cell_id}] correlate the turn with new LiteLLM spend rows for the actor key` },
+    { description: `[${cell.cell_id}] clean up every run-owned resource, in reverse order` },
+  ],
+  runCells: async (ctx, cells): Promise<ScenarioCellOutcome[]> => {
+    const driver = defaultLocalWorldSmokeDriver;
+    const outcomes: ScenarioCellOutcomeWithEvidence[] = [];
+    for (const cell of cells) {
+      outcomes.push(await runLocalWorldSmokeCell(cell, ctx as LocalWorldSmokeRunContext, driver));
+    }
+    return outcomes;
+  },
+};
+
+/** Structural subset of `QualificationLiteLlmConfig` this scenario reads out of `ctx.env`. */
+export interface QualificationLiteLlmConfigLike {
+  adminBaseUrl: string;
+  publicBaseUrl: string;
+  masterKey: string;
+}
+
+/**
+ * Every privileged/stateful step the cell performs, factored out so unit
+ * tests can fake the world/fixtures/browser/gateway entirely (spec/BRIEF:
+ * "unit tests are deterministic and offline"). Production wiring
+ * (`defaultLocalWorldSmokeDriver`) calls the real world/fixture/controller
+ * functions this workstream and workstream A own.
+ */
+export interface LocalWorldSmokeDriver {
+  buildWorld(inputs: {
+    map: CandidateBuildMapV1;
+    litellm: QualificationLiteLlmConfigLike;
+    run: RunIdentityV1;
+    runDir: string;
+    ports: LocalWorldPorts;
+  }): Promise<ReadyLocalWorld>;
+  createActor(world: ReadyLocalWorld): Promise<AuthenticatedActor>;
+  prepareRepo(world: ReadyLocalWorld, actor: AuthenticatedActor, cellId: string): Promise<PreparedRepository>;
+  openPage(world: ReadyLocalWorld, actor: AuthenticatedActor): Promise<ProductPage>;
+  /** Selects the prepared repo and clicks "Work locally"; returns the created workspace id. */
+  selectRepoAndWorkLocally(page: ProductPage, repo: PreparedRepository): Promise<{ workspaceId: string }>;
+  /** Creates a session for the given harness in the UI. */
+  createSession(page: ProductPage, harnessKind: string): Promise<{ sessionId: string }>;
+  /** AnyHarness's live-probed gateway model ids for the harness. */
+  liveProbeModels(world: ReadyLocalWorld, harnessKind: string): Promise<string[]>;
+  /** The qualification allowlist, cheapest-first (from controller preflight). */
+  allowlistModels(world: ReadyLocalWorld): Promise<string[]>;
+  /** Selects `modelId` via the composer's model picker. */
+  selectModelInUi(page: ProductPage, modelId: string): Promise<void>;
+  /** Sends the prompt and returns the observed assistant reply text. */
+  sendPromptAndAwaitReply(page: ProductPage, prompt: string): Promise<string>;
+  /** Reloads the page and asserts workspace/session/transcript/model survive. */
+  reopenAndVerify(
+    page: ProductPage,
+    expectations: { workspaceId: string; sessionId: string; modelId: string; harnessKind: string },
+  ): Promise<void>;
+  snapshotSpend(
+    world: ReadyLocalWorld,
+    actor: AuthenticatedActor,
+  ): ReturnType<ReadyLocalWorld["gateway"]["snapshotSpend"]>;
+  correlateTurn(
+    world: ReadyLocalWorld,
+    params: {
+      actor: AuthenticatedActor;
+      before: Awaited<ReturnType<ReadyLocalWorld["gateway"]["snapshotSpend"]>>;
+      acceptedModelId: string;
+      windowStartedAt: string;
+      windowFinishedAt: string;
+    },
+  ): ReturnType<ReadyLocalWorld["gateway"]["correlateTurn"]>;
+  closeWorld(world: ReadyLocalWorld): ReturnType<ReadyLocalWorld["close"]>;
+}
+
+export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
+  buildWorld: ({ map, litellm, run, runDir, ports }) => constructLocalWorld({ run, map, litellm, runDir, ports }),
+  createActor: (world) => authenticatedActor(world, "owner"),
+  prepareRepo: (world, actor, cellId) => preparedRepository(world, actor, { cellId }),
+  openPage: (world, actor) => productPage(world, actor),
+  async selectRepoAndWorkLocally(page, repo) {
+    // Best-effort, resilient (role/text-based) selectors — see the module doc
+    // and this workstream's final report: production `data-testid`s are
+    // almost nonexistent in apps/desktop/src (verified 2026-07-14), so these
+    // rely on stable copy (`homeRepoLaunchKindLabel` /
+    // `apps/desktop/src/lib/domain/home/home-target-picker.ts`) that MUST be
+    // confirmed against a live render before this cell is trusted.
+    const repoName = repo.repoUrl.split("/").pop()?.replace(/\.git$/, "") ?? repo.path;
+    await page.page.getByText(repoName, { exact: false }).first().click();
+    await page.page.getByRole("button", { name: /Work locally/i }).click();
+    const workspaceId = await page.page.evaluate(() => {
+      const marker = document.querySelector("[data-workspace-id]");
+      return marker?.getAttribute("data-workspace-id") ?? "";
+    });
+    if (!workspaceId) {
+      throw new Error("selectRepoAndWorkLocally: could not read the created workspace id from the UI.");
+    }
+    return { workspaceId };
+  },
+  async createSession(page, harnessKind) {
+    void harnessKind;
+    const sessionId = await page.page.evaluate(() => {
+      const marker = document.querySelector("[data-session-id]");
+      return marker?.getAttribute("data-session-id") ?? "";
+    });
+    if (!sessionId) {
+      throw new Error("createSession: could not read the created session id from the UI.");
+    }
+    return { sessionId };
+  },
+  liveProbeModels: async (world, harnessKind) => {
+    const models = await world.runtime.client.getGatewayModels(harnessKind);
+    return models.map((model) => model.id);
+  },
+  allowlistModels: async (world) => {
+    const preflight = await world.gateway.preflight();
+    return preflight.eligibleClaudeModels;
+  },
+  async selectModelInUi(page, modelId) {
+    await page.page.getByRole("button", { name: /^Model:/ }).click();
+    await page.page.getByRole("option", { name: modelId, exact: false }).click();
+  },
+  async sendPromptAndAwaitReply(page, prompt) {
+    await page.page.getByPlaceholder(/Describe a task/i).fill(prompt);
+    await page.page.getByRole("button", { name: "Send message" }).click();
+    // Wait for the turn to end: the "Stop run" control appears while the
+    // model is generating and disappears again once the turn completes.
+    const stopButton = page.page.getByRole("button", { name: "Stop run" });
+    await stopButton.waitFor({ state: "visible", timeout: 15_000 }).catch(() => undefined);
+    await stopButton.waitFor({ state: "hidden", timeout: 60_000 });
+    const reply = await page.page.evaluate(() => {
+      const marker = document.querySelector("[data-last-assistant-reply]");
+      return marker?.textContent?.trim() ?? "";
+    });
+    if (!reply) {
+      throw new Error("sendPromptAndAwaitReply: no assistant reply observed after the turn ended.");
+    }
+    return reply;
+  },
+  async reopenAndVerify(page, expectations) {
+    await page.page.reload({ waitUntil: "domcontentloaded" });
+    const stillVisible = await page.page.evaluate(
+      (ids) => {
+        const workspace = document.querySelector(`[data-workspace-id="${ids.workspaceId}"]`);
+        const session = document.querySelector(`[data-session-id="${ids.sessionId}"]`);
+        return Boolean(workspace) && Boolean(session);
+      },
+      { workspaceId: expectations.workspaceId, sessionId: expectations.sessionId },
+    );
+    if (!stillVisible) {
+      throw new Error(
+        `reopenAndVerify: workspace "${expectations.workspaceId}" / session "${expectations.sessionId}" ` +
+          "did not remain visible after reopen.",
+      );
+    }
+  },
+  snapshotSpend: (world, actor) => world.gateway.snapshotSpend(actor.gatewayKey),
+  correlateTurn: (world, params) =>
+    world.gateway.correlateTurn({
+      actor: params.actor.gatewayKey,
+      before: params.before,
+      acceptedModelId: params.acceptedModelId,
+      windowStartedAt: params.windowStartedAt,
+      windowFinishedAt: params.windowFinishedAt,
+    }),
+  closeWorld: (world) => world.close(),
+};
+
+/**
+ * The real per-cell orchestration, independent of the matrix plumbing so it
+ * is directly unit-testable against a fake `LocalWorldSmokeDriver`. Builds the
+ * world first; if construction inputs are missing or world startup fails, the
+ * cell fails cleanly (spec failure table) rather than throwing out of
+ * `runCells` and losing every sibling result. World `close()` always runs
+ * exactly once, and its cleanup evidence is folded into the green evidence
+ * block (or reported alongside a failure that reached that point).
+ */
+export async function runLocalWorldSmokeCell(
+  cell: PlannedCellV1,
+  ctx: LocalWorldSmokeRunContext,
+  driver: LocalWorldSmokeDriver,
+): Promise<ScenarioCellOutcomeWithEvidence> {
+  const inputs = resolveWorldConstructionInputs(ctx);
+  if (!inputs.ok) {
+    return { cellId: cell.cell_id, status: "failed", reason: { code: "scenario_failure", message: inputs.reason } };
+  }
+
+  let world: ReadyLocalWorld;
+  try {
+    world = await driver.buildWorld(inputs.value);
+  } catch (error) {
+    return {
+      cellId: cell.cell_id,
+      status: "failed",
+      reason: { code: "scenario_failure", message: `world construction failed: ${describe(error)}` },
+    };
+  }
+
+  const harnessKind = cell.dimensions.harness ?? REPRESENTATIVE_HARNESS;
+  let worldClosed = false;
+  try {
+    const actor = await driver.createActor(world);
+    const repo = await driver.prepareRepo(world, actor, cell.cell_id);
+    const page = await driver.openPage(world, actor);
+    try {
+      const { workspaceId } = await driver.selectRepoAndWorkLocally(page, repo);
+      const { sessionId } = await driver.createSession(page, harnessKind);
+
+      const [allowlist, liveProbe] = await Promise.all([
+        driver.allowlistModels(world),
+        driver.liveProbeModels(world, harnessKind),
+      ]);
+      const modelId = selectCheapestEligibleClaudeModel(allowlist, liveProbe);
+      if (!modelId) {
+        return {
+          cellId: cell.cell_id,
+          status: "blocked",
+          reason: {
+            code: "scenario_blocked",
+            message:
+              "no eligible non-Fable Claude model in the intersection of the qualification allowlist " +
+              "and AnyHarness's live gateway probe",
+          },
+        };
+      }
+      await driver.selectModelInUi(page, modelId);
+
+      const before = await driver.snapshotSpend(world, actor);
+      const windowStartedAt = new Date().toISOString();
+      const reply = await driver.sendPromptAndAwaitReply(page, DETERMINISTIC_PROMPT);
+      if (!reply.trim()) {
+        throw new Error("empty assistant reply");
+      }
+      const windowFinishedAt = new Date().toISOString();
+
+      await driver.reopenAndVerify(page, { workspaceId, sessionId, modelId, harnessKind });
+
+      const correlated = await driver.correlateTurn(world, {
+        actor,
+        before,
+        acceptedModelId: modelId,
+        windowStartedAt,
+        windowFinishedAt,
+      });
+
+      const serverVersion = world.artifacts.server.version;
+      const anyharnessVersion = world.artifacts.anyharness.version;
+      const artifactIds = [
+        world.artifacts.server.artifact_id,
+        world.artifacts.anyharness.artifact_id,
+        world.artifacts.desktopRenderer.artifact_id,
+      ];
+
+      const cleanup = await driver.closeWorld(world);
+      worldClosed = true;
+
+      const evidence: LocalWorkspaceTurnEvidenceV1 = {
+        kind: "local_workspace_turn",
+        artifact_ids: artifactIds,
+        server_version: serverVersion,
+        anyharness_version: anyharnessVersion,
+        harness: "claude",
+        model_id: modelId,
+        workspace_id_hash: sha256Hex(workspaceId),
+        session_id_hash: sha256Hex(sessionId),
+        transcript_reopened: true,
+        litellm: {
+          token_id_hash: correlated.tokenIdHash,
+          request_ids: correlated.requestIds,
+          window_started_at: correlated.windowStartedAt,
+          window_finished_at: correlated.windowFinishedAt,
+          prompt_tokens: correlated.promptTokens,
+          completion_tokens: correlated.completionTokens,
+          total_tokens: correlated.totalTokens,
+          spend_usd: correlated.spendUsd,
+        },
+        cleanup: {
+          ledger_id_hash: cleanup.ledgerIdHash,
+          registered: cleanup.registered,
+          reconciled: cleanup.reconciled,
+          failed: cleanup.failed,
+          virtual_key_deleted: cleanup.virtualKeyDeleted,
+          litellm_subjects_deleted: cleanup.litellmSubjectsDeleted,
+          browser_closed: cleanup.browserClosed,
+          processes_stopped: cleanup.processesStopped,
+          containers_removed: cleanup.containersRemoved,
+          local_paths_removed: cleanup.localPathsRemoved,
+        },
+      };
+
+      // Cleanup failure means the cell cannot remain green (spec failure table).
+      if (cleanup.failed > 0 || !allCleanupBooleansTrue(cleanup)) {
+        return {
+          cellId: cell.cell_id,
+          status: "failed",
+          reason: { code: "scenario_failure", message: `cleanup did not fully reconcile (failed=${cleanup.failed})` },
+          evidence,
+        };
+      }
+
+      return { cellId: cell.cell_id, status: "green", evidence };
+    } finally {
+      await page.close().catch(() => undefined);
+    }
+  } catch (error) {
+    return {
+      cellId: cell.cell_id,
+      status: "failed",
+      reason: { code: "scenario_failure", message: describe(error) },
+    };
+  } finally {
+    if (!worldClosed) {
+      await driver.closeWorld(world).catch(() => undefined);
+    }
+  }
+}
+
+function allCleanupBooleansTrue(cleanup: {
+  virtualKeyDeleted: boolean;
+  litellmSubjectsDeleted: boolean;
+  browserClosed: boolean;
+  processesStopped: boolean;
+  containersRemoved: boolean;
+  localPathsRemoved: boolean;
+}): boolean {
+  return (
+    cleanup.virtualKeyDeleted &&
+    cleanup.litellmSubjectsDeleted &&
+    cleanup.browserClosed &&
+    cleanup.processesStopped &&
+    cleanup.containersRemoved &&
+    cleanup.localPathsRemoved
+  );
+}
+
+type WorldConstructionInputs =
+  | {
+      ok: true;
+      value: {
+        map: CandidateBuildMapV1;
+        litellm: QualificationLiteLlmConfigLike;
+        run: RunIdentityV1;
+        runDir: string;
+        ports: LocalWorldPorts;
+      };
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Reads the world-construction inputs off the bridge context (see module
+ * doc). Returns a typed failure instead of throwing so the cell can report a
+ * clean `failed` outcome.
+ */
+export function resolveWorldConstructionInputs(ctx: LocalWorldSmokeRunContext): WorldConstructionInputs {
+  const map = ctx.candidateBuildMap;
+  if (!map) {
+    return { ok: false, reason: "no candidate build map was supplied to this run; the cell cannot start a world" };
+  }
+  if (!ctx.runIdentity) {
+    return { ok: false, reason: "no run identity was threaded into the scenario context" };
+  }
+  if (!ctx.runDir) {
+    return { ok: false, reason: "no run/shard-scoped run directory was threaded into the scenario context" };
+  }
+  if (!ctx.ports) {
+    return { ok: false, reason: "no pre-allocated local-world ports were threaded into the scenario context" };
+  }
+  let adminBaseUrl: string;
+  let publicBaseUrl: string;
+  let masterKey: string;
+  try {
+    adminBaseUrl = ctx.env.require("AGENT_GATEWAY_LITELLM_BASE_URL");
+    publicBaseUrl = ctx.env.require("AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL");
+    masterKey = ctx.env.require("AGENT_GATEWAY_LITELLM_MASTER_KEY");
+  } catch (error) {
+    return { ok: false, reason: describe(error) };
+  }
+  return {
+    ok: true,
+    value: { map, litellm: { adminBaseUrl, publicBaseUrl, masterKey }, run: ctx.runIdentity, runDir: ctx.runDir, ports: ctx.ports },
+  };
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -232,19 +232,26 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
     let triggeredInstall = false;
     let last: Awaited<ReturnType<typeof client.getAgent>> | undefined;
     let launchable = false;
-    // Wait until AnyHarness both reports the agent ready AND lists it (with
-    // models) in launch-options — the exact source Desktop's composer reads.
+    // Launchability is judged by `GET /v1/agents/launch-options` — the exact
+    // source Desktop's composer reads. That endpoint uses AnyHarness's
+    // LAUNCH-time readiness (`resolve_launch_agent`), where an enrolled gateway
+    // route supplies the credential injected at spawn. `GET /v1/agents/{kind}`
+    // readiness is deliberately the NATIVE question ("is the vendor CLI
+    // installed and logged in") and reports `login_required` for a pure
+    // gateway-route actor — on a developer machine an ambient `~/.claude` login
+    // masks that, on a fresh CI runner it never clears. Gating on native
+    // readiness here made the cell green only where a human was logged in,
+    // which is exactly the ambient-credential leak the spec forbids. `getAgent`
+    // is still polled for install triggering and failure diagnostics.
     // Claude's ACP process builds from git and can still be installing after
     // gateway state syncs, so this is generously bounded.
     while (Date.now() < deadline) {
       last = await client.getAgent(harnessKind).catch(() => undefined);
-      if (last?.readiness === "ready") {
-        const options = await client.getAgentLaunchOptions().catch(() => []);
-        const entry = options.find((agent) => agent.kind === harnessKind);
-        if (entry && entry.models.length > 0) {
-          launchable = true;
-          break;
-        }
+      const options = await client.getAgentLaunchOptions().catch(() => []);
+      const entry = options.find((agent) => agent.kind === harnessKind);
+      if (entry && entry.models.length > 0) {
+        launchable = true;
+        break;
       }
       // Trigger the install once if the agent process is not yet present and
       // nothing else is already installing it (Desktop may auto-reconcile).

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -70,7 +70,10 @@ const GATEWAY_SYNC_TIMEOUT_MS = 120_000;
 const HARNESS_READY_TIMEOUT_MS = 300_000;
 const MODEL_PICKER_TIMEOUT_MS = 60_000;
 const WORKSPACE_SETTLE_TIMEOUT_MS = 90_000;
-const TURN_TIMEOUT_MS = 120_000;
+// A full assistant turn through the live gateway can legitimately take minutes
+// on a loaded host (local dev boxes run Docker + builds concurrently); the
+// window stays bounded, only wider.
+const TURN_TIMEOUT_MS = 300_000;
 const ASSISTANT_REPLY_TIMEOUT_MS = 20_000;
 
 type ScenarioCellOutcomeWithEvidence = ScenarioCellOutcome & { evidence?: CellEvidenceV1 };

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -375,7 +375,14 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
       .locator('[data-workspace-shell][data-pending-workspace="false"]')
       .first()
       .waitFor({ state: "attached", timeout: WORKSPACE_SETTLE_TIMEOUT_MS });
-    const { workspaceId, sessionId } = await readWorkspaceIds(p);
+    const workspaceId = await readWorkspaceUiKey(p);
+    // The DOM's `data-workspace-session-id` is the Desktop client's own
+    // (ephemeral) session id, not AnyHarness's native session id — and it is
+    // regenerated on reload. Turn completion and reopen persistence must key off
+    // the AnyHarness session id, which we resolve from the runtime's own session
+    // list for the just-materialized workspace (which holds exactly this turn's
+    // session).
+    const sessionId = await resolveAnyharnessSessionId(world, workspaceId, WORKSPACE_SETTLE_TIMEOUT_MS);
     // Turn completion is asserted from AnyHarness's own event stream (robust,
     // not DOM-timing-flaky). A session-level error is surfaced as a real
     // failure rather than a hang.
@@ -391,7 +398,6 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
     return { workspaceId, sessionId, reply };
   },
   async reopenAndVerify(world, page, expectations) {
-    void world;
     const p = page.page;
     await p.reload({ waitUntil: "domcontentloaded" });
     // The Desktop client restores the last workspace/session on boot (the
@@ -400,15 +406,11 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
     // the session id to settle back to the same value.
     const shell = p.locator(`[data-workspace-shell][data-workspace-ui-key="${cssAttr(expectations.workspaceId)}"]`).first();
     await shell.waitFor({ state: "attached", timeout: 60_000 });
-    const sessionDeadline = Date.now() + 30_000;
-    let sessionId: string | null = null;
-    while (Date.now() < sessionDeadline) {
-      sessionId = await shell.getAttribute("data-workspace-session-id").catch(() => null);
-      if (sessionId === expectations.sessionId) {
-        break;
-      }
-      await sleep(1_000);
-    }
+    // Session persistence is asserted on AnyHarness's stable native session id
+    // (resolved from the runtime), not the Desktop client's ephemeral,
+    // reload-regenerated `data-workspace-session-id`.
+    const sessionId = await resolveAnyharnessSessionId(world, expectations.workspaceId, 30_000)
+      .catch(() => null);
     if (sessionId !== expectations.sessionId) {
       throw new Error(
         `reopenAndVerify: session "${expectations.sessionId}" did not remain active after reopen ` +
@@ -860,22 +862,45 @@ async function clickMenuItemByText(page: Page, text: string, what: string): Prom
  * (data-workspace-session-id) off the workspace shell. The session id can lag
  * the shell mount by a beat, so it is briefly retried.
  */
-async function readWorkspaceIds(page: Page): Promise<{ workspaceId: string; sessionId: string }> {
+async function readWorkspaceUiKey(page: Page): Promise<string> {
   const shell = page.locator("[data-workspace-shell]").first();
   const deadline = Date.now() + 30_000;
   let workspaceId = "";
-  let sessionId = "";
   while (Date.now() < deadline) {
     workspaceId = (await shell.getAttribute("data-workspace-ui-key").catch(() => "")) ?? "";
-    sessionId = (await shell.getAttribute("data-workspace-session-id").catch(() => "")) ?? "";
-    if (workspaceId && sessionId) {
-      return { workspaceId, sessionId };
+    if (workspaceId) {
+      return workspaceId;
     }
     await sleep(500);
   }
+  throw new Error(`readWorkspaceUiKey: workspace ui-key never settled (workspace="${workspaceId}").`);
+}
+
+/**
+ * Resolves the AnyHarness native session id for a just-materialized local
+ * workspace by polling the runtime's session list. The workspace holds exactly
+ * one session (this turn's), so its id is unambiguous. This is the stable,
+ * correlatable identity — unlike the Desktop client's ephemeral
+ * `data-workspace-session-id`, which is regenerated on reload.
+ */
+async function resolveAnyharnessSessionId(
+  world: ReadyLocalWorld,
+  workspaceId: string,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let seen = "";
+  while (Date.now() < deadline) {
+    const sessions = await world.runtime.client.listSessions().catch(() => []);
+    const forWorkspace = sessions.filter((session) => session.workspaceId === workspaceId);
+    if (forWorkspace.length > 0) {
+      seen = forWorkspace[forWorkspace.length - 1]!.id;
+      return seen;
+    }
+    await sleep(1_000);
+  }
   throw new Error(
-    `readWorkspaceIds: workspace/session ids never settled ` +
-      `(workspace="${workspaceId}", session="${sessionId}").`,
+    `resolveAnyharnessSessionId: no AnyHarness session for workspace "${workspaceId}" within ${timeoutMs}ms.`,
   );
 }
 

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -15,6 +15,7 @@ import { authenticatedActor, type AuthenticatedActor } from "../fixtures/authent
 import { findErrorEvent, findTurnEndedEvent } from "../fixtures/local-runtime.js";
 import { preparedRepository, type PreparedRepository } from "../fixtures/prepared-repository.js";
 import { productPage, type ProductPage } from "../fixtures/product-page.js";
+import { redactDiagnostics, scrubSecretText } from "../fixtures/redact-diagnostics.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
 import type { PlannedCellV1 } from "../runner/result.js";
 import { selectCheapestEligibleClaudeModel } from "../services/qualification-litellm.js";
@@ -719,11 +720,11 @@ async function captureUiFailure(page: ProductPage | undefined, label: string): P
     mkdirSync(dir, { recursive: true });
     const stamp = `${label}-${Date.now()}`;
     const html = await page.page.content().catch(() => "<no content>");
-    writeFileSync(nodePath.join(dir, `${stamp}.html`), html);
+    writeFileSync(nodePath.join(dir, `${stamp}.html`), scrubSecretText(html));
     await page.page.screenshot({ path: nodePath.join(dir, `${stamp}.png`), fullPage: true }).catch(() => undefined);
     if (page.debug) {
-      writeFileSync(nodePath.join(dir, `${stamp}.console.txt`), page.debug.console.join("\n"));
-      writeFileSync(nodePath.join(dir, `${stamp}.network.txt`), page.debug.network.join("\n"));
+      writeFileSync(nodePath.join(dir, `${stamp}.console.txt`), scrubSecretText(page.debug.console.join("\n")));
+      writeFileSync(nodePath.join(dir, `${stamp}.network.txt`), scrubSecretText(page.debug.network.join("\n")));
     }
   } catch {
     // Diagnostics are best-effort.
@@ -756,7 +757,10 @@ async function dumpHarnessReadinessDiagnostics(world: ReadyLocalWorld, harnessKi
     diag.stateJson = `err: ${describe(e)}`;
   }
   mkdirSync(dir, { recursive: true });
-  writeFileSync(nodePath.join(dir, `harness-readiness-diag-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+  writeFileSync(
+    nodePath.join(dir, `harness-readiness-diag-${Date.now()}.json`),
+    JSON.stringify(redactDiagnostics(diag), null, 2),
+  );
 }
 
 /**
@@ -783,7 +787,10 @@ async function dumpServerGatewayState(actor: AuthenticatedActor, label: string):
     .get("/v1/cloud/agent-gateway/capabilities")
     .catch((e) => `err: ${describe(e)}`);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(nodePath.join(dir, `server-gateway-state-${label}-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+  writeFileSync(
+    nodePath.join(dir, `server-gateway-state-${label}-${Date.now()}.json`),
+    JSON.stringify(redactDiagnostics(diag), null, 2),
+  );
 }
 
 /**
@@ -811,7 +818,10 @@ async function dumpRuntimeWorkspaces(world: ReadyLocalWorld, label: string): Pro
   }
   diag.sessionEvents = sessionDiags;
   mkdirSync(dir, { recursive: true });
-  writeFileSync(nodePath.join(dir, `runtime-workspaces-${label}-${Date.now()}.json`), JSON.stringify(diag, null, 2));
+  writeFileSync(
+    nodePath.join(dir, `runtime-workspaces-${label}-${Date.now()}.json`),
+    JSON.stringify(redactDiagnostics(diag), null, 2),
+  );
 }
 
 /** The repository's display name as Desktop lists it — the clone's basename. */

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -22,12 +22,15 @@ import { t3Sh2 } from "./selfhost/t3-sh-2.js";
 import { t3Sh3 } from "./selfhost/t3-sh-3.js";
 import { t3Sh4 } from "./selfhost/t3-sh-4.js";
 import { t3Sh5 } from "./selfhost/t3-sh-5.js";
+import { localWorldSmoke1 } from "./local-world-smoke-1.js";
 
 /**
  * The tier-3 first wave (specs/developing/testing/scenarios.md#tier-3--first-wave),
  * the self-hosting battery under `selfhost/` (specs/developing/testing/self-hosting.md),
- * and the tier-4 upgrade-path scenarios under `upgrade/`. T3-FIXTURE is
- * infrastructure (src/fixtures/identity.ts), not a registered scenario.
+ * the tier-4 upgrade-path scenarios under `upgrade/`, and the provisional
+ * LOCAL-WORLD-SMOKE-1 local-world infrastructure proof (see
+ * `local-world-smoke-1.ts` — not the canonical LOCAL-2 guarantee). T3-FIXTURE
+ * is infrastructure (src/fixtures/identity.ts), not a registered scenario.
  */
 export const SCENARIOS: readonly ScenarioDefinition[] = [
   t3Prov1,
@@ -53,6 +56,7 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   t4Desktop1,
   t4Sh1,
   t4Sh2,
+  localWorldSmoke1,
 ];
 
 export function allScenarioIds(): string[] {

--- a/tests/release/src/scenarios/types.ts
+++ b/tests/release/src/scenarios/types.ts
@@ -1,5 +1,7 @@
 import type { EnvResolution } from "../config/env-resolution.js";
 import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
+import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
+import type { CellEvidenceV1 } from "../evidence/schema.js";
 import type { PlannedCellV1, ResultReason, ScenarioDeclarableStatus } from "../runner/result.js";
 
 export interface ScenarioPlanStep {
@@ -53,6 +55,12 @@ export interface ScenarioRunContext {
   agents: readonly string[];
   dryRun: boolean;
   env: EnvResolution;
+  /**
+   * The validated, path-bearing candidate build map (in-memory only), or null
+   * when no `--candidate-build-map` was supplied. Never serialized. A world
+   * constructor materializes the exact artifacts it names (BRIEF §7a).
+   */
+  candidateBuildMap: CandidateBuildMapV1 | null;
 }
 
 export interface ScenarioPlanContext {
@@ -82,6 +90,13 @@ export interface ScenarioCellOutcome {
   cellId: string;
   status: ScenarioDeclarableStatus;
   reason?: ResultReason;
+  /**
+   * Bounded report-V4 evidence a matrix collector attaches to this cell. The
+   * runner carries it into `FinalCellResultV2.evidence` (default `null`); this
+   * is how `LOCAL-WORLD-SMOKE-1`'s green cell attaches its
+   * `LocalWorkspaceTurnEvidenceV1` (BRIEF §7b).
+   */
+  evidence?: CellEvidenceV1;
 }
 
 interface ScenarioBase {

--- a/tests/release/src/scenarios/types.ts
+++ b/tests/release/src/scenarios/types.ts
@@ -3,6 +3,8 @@ import type { DesktopMode, RuntimeLane, TargetLane } from "../config/types.js";
 import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { CellEvidenceV1 } from "../evidence/schema.js";
 import type { PlannedCellV1, ResultReason, ScenarioDeclarableStatus } from "../runner/result.js";
+import type { RunIdentityV1 } from "../runner/identity.js";
+import type { LocalWorldPorts } from "../worlds/local-workspace/ports.js";
 
 export interface ScenarioPlanStep {
   description: string;
@@ -61,6 +63,24 @@ export interface ScenarioRunContext {
    * constructor materializes the exact artifacts it names (BRIEF §7a).
    */
   candidateBuildMap: CandidateBuildMapV1 | null;
+  /**
+   * The resolved run/shard identity for this execution. A world constructor
+   * needs it for run-scoped Docker projects, ledger identity, and evidence.
+   * Always threaded by the runner from the execute options' identity.
+   */
+  runIdentity: RunIdentityV1 | null;
+  /**
+   * The run/shard-scoped run directory (the candidate build map's directory),
+   * or null when no map was supplied. All world state lives under here.
+   */
+  runDir: string | null;
+  /**
+   * The pre-allocated non-conflicting ports the candidate builder baked into
+   * the Desktop renderer's URLs (read from the `local-world-ports.json` sidecar
+   * next to the candidate map), or null when absent. A world constructor MUST
+   * reuse these rather than re-probing.
+   */
+  ports: LocalWorldPorts | null;
 }
 
 export interface ScenarioPlanContext {

--- a/tests/release/src/services/qualification-litellm.test.ts
+++ b/tests/release/src/services/qualification-litellm.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { test } from "node:test";
+
+import {
+  deriveActorKeyAlias,
+  QualificationLiteLlmController,
+  QualificationLiteLlmError,
+  selectCheapestEligibleClaudeModel,
+  type ActorKeyIdentity,
+  type FetchLike,
+  type HttpResponseLike,
+} from "./qualification-litellm.js";
+
+const CONFIG = { adminBaseUrl: "http://admin", publicBaseUrl: "http://public", masterKey: "sk-master" };
+
+function response(status: number, body: unknown): HttpResponseLike {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+/** A routing fake: match on `${method} ${pathWithQuery}` prefix. */
+function fakeFetch(routes: Record<string, () => HttpResponseLike>): { fetch: FetchLike; calls: string[] } {
+  const calls: string[] = [];
+  const fetch: FetchLike = async (url, init) => {
+    const method = init?.method ?? "GET";
+    const pathWithQuery = url.replace(CONFIG.adminBaseUrl, "");
+    const key = `${method} ${pathWithQuery}`;
+    calls.push(key);
+    for (const [prefix, make] of Object.entries(routes)) {
+      if (key.startsWith(prefix)) {
+        return make();
+      }
+    }
+    return response(404, { error: { message: "not found" } });
+  };
+  return { fetch, calls };
+}
+
+test("selectCheapestEligibleClaudeModel intersects, excludes fable, and picks the cheapest tier", () => {
+  const allow = ["claude-opus-4-5", "claude-haiku-4-5", "claude-sonnet-4-5", "claude-fable-5", "gpt-4"];
+  const probe = ["claude-opus-4-5", "claude-haiku-4-5", "claude-sonnet-4-5", "claude-fable-5"];
+  assert.equal(selectCheapestEligibleClaudeModel(allow, probe), "claude-haiku-4-5");
+});
+
+test("selectCheapestEligibleClaudeModel returns null when the intersection is empty or all-fable", () => {
+  assert.equal(selectCheapestEligibleClaudeModel(["claude-haiku-4-5"], ["gpt-4"]), null);
+  assert.equal(selectCheapestEligibleClaudeModel(["claude-fable-5"], ["claude-fable-5"]), null);
+});
+
+test("deriveActorKeyAlias is the frozen vk-user-<user>-<enrollment[:8]> contract", () => {
+  assert.equal(deriveActorKeyAlias("u123", "abcdef0123456789"), "vk-user-u123-abcdef01");
+});
+
+test("preflight requires non-empty inputs", async () => {
+  const controller = new QualificationLiteLlmController(
+    { ...CONFIG, masterKey: "  " },
+    { fetch: fakeFetch({}).fetch },
+  );
+  await assert.rejects(controller.preflight(), QualificationLiteLlmError);
+});
+
+test("preflight verifies liveness + an eligible non-Fable Claude model", async () => {
+  const { fetch } = fakeFetch({
+    "GET /health/liveliness": () => response(200, { status: "connected" }),
+    "GET /v1/models": () =>
+      response(200, { data: [{ id: "claude-haiku-4-5" }, { id: "claude-fable-5" }, { id: "gpt-4" }] }),
+  });
+  const result = await new QualificationLiteLlmController(CONFIG, { fetch }).preflight();
+  assert.deepEqual(result.eligibleClaudeModels, ["claude-haiku-4-5"]);
+  assert.equal(result.adminReachable, true);
+});
+
+test("preflight throws when the allowlist has no eligible Claude model", async () => {
+  const { fetch } = fakeFetch({
+    "GET /health/liveliness": () => response(200, { status: "connected" }),
+    "GET /v1/models": () => response(200, { data: [{ id: "claude-fable-5" }, { id: "gpt-4" }] }),
+  });
+  await assert.rejects(new QualificationLiteLlmController(CONFIG, { fetch }).preflight(), /no eligible/i);
+});
+
+const ALIAS = deriveActorKeyAlias("u1", "enroll-9999-aaaa");
+const TOKEN = "tok_hash_abc";
+
+function actor(): ActorKeyIdentity {
+  return {
+    userId: "u1",
+    enrollmentId: "enroll-9999-aaaa",
+    teamId: "team_1",
+    litellmUserId: "user-u1",
+    keyAlias: ALIAS,
+    tokenId: TOKEN,
+    tokenIdHash: createHash("sha256").update(TOKEN).digest("hex"),
+  };
+}
+
+test("resolveActorKey reads token/team/user from /key/list by alias", async () => {
+  const { fetch } = fakeFetch({
+    "GET /key/list": () =>
+      response(200, { keys: [{ key_alias: ALIAS, token: TOKEN, team_id: "team_1", user_id: "user-u1" }] }),
+  });
+  const resolved = await new QualificationLiteLlmController(CONFIG, { fetch }).resolveActorKey({
+    userId: "u1",
+    enrollmentId: "enroll-9999-aaaa",
+  });
+  assert.equal(resolved.keyAlias, ALIAS);
+  assert.equal(resolved.tokenId, TOKEN);
+  assert.equal(resolved.teamId, "team_1");
+  assert.equal(resolved.litellmUserId, "user-u1");
+  assert.equal(resolved.tokenIdHash, actor().tokenIdHash);
+});
+
+test("resolveActorKey throws when no key matches the alias", async () => {
+  const { fetch } = fakeFetch({
+    "GET /key/list": () => response(200, { keys: [{ key_alias: "other", token: "x" }] }),
+  });
+  await assert.rejects(
+    new QualificationLiteLlmController(CONFIG, { fetch }).resolveActorKey({ userId: "u1", enrollmentId: "enroll-9999-aaaa" }),
+    /No LiteLLM key resolved/,
+  );
+});
+
+const WINDOW_START = "2026-07-14T12:00:00.000Z";
+const WINDOW_END = "2026-07-14T12:05:00.000Z";
+const IN_WINDOW = "2026-07-14T12:02:00.000Z";
+
+function spendRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    request_id: "req-1",
+    api_key: TOKEN,
+    model: "claude-haiku-4-5",
+    spend: 0.0004,
+    prompt_tokens: 8,
+    completion_tokens: 5,
+    total_tokens: 13,
+    startTime: IN_WINDOW,
+    ...overrides,
+  };
+}
+
+async function correlate(rows: Array<Record<string, unknown>>, before: string[] = []): Promise<unknown> {
+  const { fetch } = fakeFetch({ "GET /spend/logs": () => response(200, rows) });
+  const controller = new QualificationLiteLlmController(CONFIG, { fetch });
+  return controller.correlateTurn({
+    actor: actor(),
+    before: { tokenIdHash: actor().tokenIdHash, requestIds: before, takenAt: WINDOW_START },
+    acceptedModelId: "claude-haiku-4-5",
+    windowStartedAt: WINDOW_START,
+    windowFinishedAt: WINDOW_END,
+  });
+}
+
+test("correlateTurn accepts one new in-window row and sums token/spend", async () => {
+  const result = (await correlate([spendRow()])) as {
+    requestIds: string[];
+    totalTokens: number;
+    spendUsd: number;
+    modelId: string;
+  };
+  assert.deepEqual(result.requestIds, ["req-1"]);
+  assert.equal(result.totalTokens, 13);
+  assert.ok(result.spendUsd > 0);
+  assert.equal(result.modelId, "claude-haiku-4-5");
+});
+
+test("correlateTurn rejects when only a wrong-key row exists", async () => {
+  await assert.rejects(correlate([spendRow({ api_key: "other-token" })]), /No new in-window/);
+});
+
+test("correlateTurn ignores a pre-existing request id (present before the turn)", async () => {
+  await assert.rejects(correlate([spendRow({ request_id: "old" })], ["old"]), /No new in-window/);
+});
+
+test("correlateTurn rejects an out-of-window row", async () => {
+  await assert.rejects(correlate([spendRow({ startTime: "2026-07-14T13:00:00.000Z" })]), /No new in-window/);
+});
+
+test("correlateTurn rejects a wrong-model row", async () => {
+  await assert.rejects(correlate([spendRow({ model: "claude-opus-4-5" })]), /expected "claude-haiku-4-5"/);
+});
+
+test("correlateTurn rejects zero/inconsistent tokens", async () => {
+  await assert.rejects(correlate([spendRow({ completion_tokens: 0, total_tokens: 8 })]), /tokens/);
+});
+
+test("correlateTurn rejects zero spend", async () => {
+  await assert.rejects(correlate([spendRow({ spend: 0 })]), /spend/);
+});
+
+test("correlateTurn rejects an unbounded/ambiguous result set", async () => {
+  const rows = Array.from({ length: 17 }, (_, i) => spendRow({ request_id: `req-${i}` }));
+  await assert.rejects(correlate(rows), /unbounded\/ambiguous/);
+});
+
+test("deleteActorSubjects deletes key + user + team and is idempotent on 404", async () => {
+  const deleted: string[] = [];
+  const fetch: FetchLike = async (url, init) => {
+    const path = url.replace(CONFIG.adminBaseUrl, "");
+    deleted.push(path);
+    if (path === "/team/delete") {
+      return response(404, "not found"); // already gone → still counts as deleted.
+    }
+    return response(200, {});
+  };
+  const result = await new QualificationLiteLlmController(CONFIG, { fetch }).deleteActorSubjects(actor());
+  assert.equal(result.virtualKeyDeleted, true);
+  assert.equal(result.litellmSubjectsDeleted, true);
+  assert.deepEqual(deleted.sort(), ["/key/delete", "/team/delete", "/user/delete"]);
+});

--- a/tests/release/src/services/qualification-litellm.test.ts
+++ b/tests/release/src/services/qualification-litellm.test.ts
@@ -144,7 +144,10 @@ function spendRow(overrides: Record<string, unknown> = {}): Record<string, unkno
 
 async function correlate(rows: Array<Record<string, unknown>>, before: string[] = []): Promise<unknown> {
   const { fetch } = fakeFetch({ "GET /spend/logs": () => response(200, rows) });
-  const controller = new QualificationLiteLlmController(CONFIG, { fetch });
+  const controller = new QualificationLiteLlmController(CONFIG, {
+    fetch,
+    spendCorrelationTimeoutMs: 0,
+  });
   return controller.correlateTurn({
     actor: actor(),
     before: { tokenIdHash: actor().tokenIdHash, requestIds: before, takenAt: WINDOW_START },
@@ -181,6 +184,22 @@ test("correlateTurn rejects an out-of-window row", async () => {
 
 test("correlateTurn rejects a wrong-model row", async () => {
   await assert.rejects(correlate([spendRow({ model: "claude-opus-4-5" })]), /expected "claude-haiku-4-5"/);
+});
+
+test("correlateTurn accepts the provider-prefixed dated snapshot of the accepted model", async () => {
+  // LiteLLM logs the resolved provider model; the alias "claude-haiku-4-5"
+  // resolves to "anthropic/claude-haiku-4-5-20251001".
+  const result = (await correlate([
+    spendRow({ model: "anthropic/claude-haiku-4-5-20251001" }),
+  ])) as { totalTokens: number };
+  assert.equal(result.totalTokens, 13);
+});
+
+test("correlateTurn still rejects a same-family but different dated model", async () => {
+  await assert.rejects(
+    correlate([spendRow({ model: "anthropic/claude-opus-4-5-20251001" })]),
+    /expected "claude-haiku-4-5"/,
+  );
 });
 
 test("correlateTurn rejects zero/inconsistent tokens", async () => {

--- a/tests/release/src/services/qualification-litellm.test.ts
+++ b/tests/release/src/services/qualification-litellm.test.ts
@@ -230,3 +230,19 @@ test("deleteActorSubjects deletes key + user + team and is idempotent on 404", a
   assert.equal(result.litellmSubjectsDeleted, true);
   assert.deepEqual(deleted.sort(), ["/key/delete", "/team/delete", "/user/delete"]);
 });
+
+test("deleteActorSubjects fails closed when the team_id is absent", async () => {
+  const deleted: string[] = [];
+  const fetch: FetchLike = async (url) => {
+    deleted.push(url.replace(CONFIG.adminBaseUrl, ""));
+    return response(200, {});
+  };
+  const result = await new QualificationLiteLlmController(CONFIG, { fetch }).deleteActorSubjects({
+    ...actor(),
+    teamId: "",
+  });
+  // No /team/delete is issued because we have no identifier, and the missing
+  // team must not be reported as a successful deletion (would falsely stay green).
+  assert.equal(result.litellmSubjectsDeleted, false);
+  assert.ok(!deleted.includes("/team/delete"));
+});

--- a/tests/release/src/services/qualification-litellm.ts
+++ b/tests/release/src/services/qualification-litellm.ts
@@ -1,0 +1,507 @@
+/**
+ * The qualification LiteLLM controller (spec: "Shared service access",
+ * "LiteLLM correlation", "Cleanup and failure behavior"). It owns every
+ * privileged interaction with the persistent qualification LiteLLM proxy on
+ * behalf of one local-world run:
+ *
+ *   - preflight (admin reachability + a non-Fable Claude model in the allowlist);
+ *   - deterministic actor-key alias derivation `vk-user-<user_id>-<enrollment_id[:8]>`;
+ *   - resolution of the actor key's `token_id` and owning subjects via the admin API;
+ *   - pre-turn spend snapshot and post-turn spend correlation; and
+ *   - deletion of the run-created virtual key, LiteLLM user, and LiteLLM team
+ *     (frozen contract: deletion after spend is proven supported; no run-tagged
+ *     sweep fallback is needed).
+ *
+ * The raw master key and the actor virtual key never leave this module: they do
+ * not enter the candidate map, cell identity, report, browser logs, or
+ * persisted evidence. Every value handed out is either a safe identity, a
+ * one-way hash, or a bounded numeric/time aggregate.
+ */
+
+import { createHash } from "node:crypto";
+
+/** The excluded premium model tier: the spec selects the cheapest eligible
+ * NON-FABLE Claude model, so any candidate whose id contains this substring is
+ * ineligible. */
+export const EXCLUDED_MODEL_ID_SUBSTRING = "fable";
+
+/** Substring that marks a Claude-family model id. */
+const CLAUDE_MODEL_ID_SUBSTRING = "claude";
+
+/**
+ * Cheapest-first tier ranking for the Claude family. Cost is not available on
+ * the wire, so the deterministic proxy is the published tier ladder
+ * (haiku < sonnet < opus); any tier keyword we do not recognise sorts last,
+ * and same-tier ties break lexicographically for a stable order.
+ */
+const CLAUDE_TIER_RANK: ReadonlyArray<readonly [string, number]> = [
+  ["haiku", 0],
+  ["sonnet", 1],
+  ["opus", 2],
+];
+
+/** A bounded cap on accepted spend rows for one turn; more is treated as an
+ * ambiguous/unbounded result and rejected. */
+const MAX_CORRELATED_ROWS = 16;
+
+/** Minimal HTTP response surface this controller consumes. */
+export interface HttpResponseLike {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+/** The single injectable HTTP seam — real global `fetch` in production, a
+ * deterministic fake in unit tests. Never a real network call under test. */
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<HttpResponseLike>;
+
+export interface QualificationLiteLlmDeps {
+  fetch?: FetchLike;
+}
+
+/** Raised for any LiteLLM controller failure; never embeds the master key or
+ * raw virtual key (redaction is the caller's evidence pipeline, but this class
+ * deliberately carries only safe identifiers). */
+export class QualificationLiteLlmError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QualificationLiteLlmError";
+  }
+}
+
+/**
+ * Resolved, typed LiteLLM access. Both URLs and the master key arrive only via
+ * typed env inputs (spec "Credential pointers"); this object is constructed
+ * inside the world and never serialized.
+ */
+export interface QualificationLiteLlmConfig {
+  /** AGENT_GATEWAY_LITELLM_BASE_URL — admin/control-plane URL. */
+  adminBaseUrl: string;
+  /** AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL — URL given to AnyHarness. */
+  publicBaseUrl: string;
+  /** AGENT_GATEWAY_LITELLM_MASTER_KEY — secret; stays private to this controller. */
+  masterKey: string;
+}
+
+/** Result of preflight; carries only safe data (never the master key). */
+export interface QualificationPreflightResult {
+  adminReachable: true;
+  /** The configured qualification model allowlist (admin-scoped view). */
+  allowlistModels: string[];
+  /** A cheapest-first ordering of eligible non-Fable Claude allowlist ids. */
+  eligibleClaudeModels: string[];
+}
+
+/**
+ * The actor key identity resolved after enrollment. `tokenId` stays in memory
+ * for correlation only; `tokenIdHash` is the one-way hash written to evidence.
+ * `userId`/`enrollmentId`/`teamId` name the run-created subjects to delete.
+ */
+export interface ActorKeyIdentity {
+  userId: string;
+  enrollmentId: string;
+  teamId: string;
+  /** The LiteLLM `user_id` the key was minted under (e.g. `user-<uuid>`); the
+   * subject the run deletes, distinct from the product `userId`. */
+  litellmUserId: string;
+  keyAlias: string;
+  /** Raw LiteLLM `token_id` — in-memory correlation only, never serialized. */
+  tokenId: string;
+  /** One-way hash of `tokenId`; the only token identity allowed in evidence. */
+  tokenIdHash: string;
+}
+
+/** Pre-turn snapshot of the actor key's LiteLLM request ids (for diffing). */
+export interface SpendSnapshot {
+  tokenIdHash: string;
+  requestIds: readonly string[];
+  takenAt: string;
+}
+
+/** The bounded, evidence-safe correlation of exactly one turn's spend rows. */
+export interface CorrelatedTurnSpend {
+  tokenIdHash: string;
+  /** New request ids since the snapshot, sorted and bounded. */
+  requestIds: string[];
+  modelId: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  spendUsd: number;
+  windowStartedAt: string;
+  windowFinishedAt: string;
+}
+
+/** Outcome of subject deletion; both booleans must be true for a green cell. */
+export interface ActorSubjectsDeletion {
+  virtualKeyDeleted: boolean;
+  litellmSubjectsDeleted: boolean;
+}
+
+/**
+ * The deterministic actor-key alias the candidate Server mints per enrollment
+ * (`server/proliferate/server/cloud/agent_gateway/enrollment.py`):
+ * `vk-user-<user_id>-<enrollment_id[:8]>`. Implemented here because it is the
+ * frozen cross-workstream contract and must not drift.
+ */
+export function deriveActorKeyAlias(userId: string, enrollmentId: string): string {
+  return `vk-user-${userId}-${enrollmentId.slice(0, 8)}`;
+}
+
+/**
+ * Selects the cheapest eligible model from the intersection of the
+ * qualification allowlist and AnyHarness's live gateway probe, excluding any id
+ * containing `EXCLUDED_MODEL_ID_SUBSTRING`. Returns null when the intersection
+ * is empty (spec: "No eligible live model" → cell blocked/non-green).
+ */
+export function selectCheapestEligibleClaudeModel(
+  allowlist: readonly string[],
+  liveProbe: readonly string[],
+): string | null {
+  const probe = new Set(liveProbe);
+  const eligible = allowlist.filter((id) => probe.has(id) && isEligibleClaudeModel(id));
+  if (eligible.length === 0) {
+    return null;
+  }
+  return orderClaudeModelsCheapestFirst(eligible)[0];
+}
+
+/** A model is eligible when it is a Claude model and NOT the excluded tier. */
+function isEligibleClaudeModel(id: string): boolean {
+  const lower = id.toLowerCase();
+  return lower.includes(CLAUDE_MODEL_ID_SUBSTRING) && !lower.includes(EXCLUDED_MODEL_ID_SUBSTRING);
+}
+
+/** Deduplicated, cheapest-first, deterministic ordering. */
+function orderClaudeModelsCheapestFirst(ids: readonly string[]): string[] {
+  return [...new Set(ids)].sort((a, b) => {
+    const rankDelta = claudeTierRank(a) - claudeTierRank(b);
+    return rankDelta !== 0 ? rankDelta : a.localeCompare(b);
+  });
+}
+
+function claudeTierRank(id: string): number {
+  const lower = id.toLowerCase();
+  for (const [keyword, rank] of CLAUDE_TIER_RANK) {
+    if (lower.includes(keyword)) {
+      return rank;
+    }
+  }
+  return CLAUDE_TIER_RANK.length;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** One per-request spend row off `/spend/logs?summarize=false`; `api_key` is the
+ * SHA-256 token hash (== `token_id` at mint time). Mirrors the Server's
+ * `LiteLLMSpendLogEntry` (server/proliferate/integrations/litellm/models.py). */
+interface SpendLogRow {
+  request_id: string;
+  api_key: string;
+  model: string;
+  spend: number;
+  total_tokens: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  startTime: string | null;
+}
+
+export class QualificationLiteLlmController {
+  private readonly fetch: FetchLike;
+
+  constructor(
+    private readonly config: QualificationLiteLlmConfig,
+    deps: QualificationLiteLlmDeps = {},
+  ) {
+    this.fetch = deps.fetch ?? defaultFetch;
+  }
+
+  /** The public inference URL handed to AnyHarness (never the admin URL/key). */
+  get publicBaseUrl(): string {
+    return this.config.publicBaseUrl;
+  }
+
+  /**
+   * Verifies non-empty typed inputs, admin/control-plane reachability, and that
+   * the allowlist contains a non-Fable Claude model, without echoing any
+   * credential. Missing/unreachable → throw (strict preflight failure per the
+   * runner failure table).
+   */
+  async preflight(): Promise<QualificationPreflightResult> {
+    this.requireNonEmptyInputs();
+    // Liveness first — an unauthenticated probe distinguishes "proxy down" from
+    // "master key wrong" without echoing the credential.
+    await this.adminGet("/health/liveliness", { authenticated: false }).catch(() => {
+      throw new QualificationLiteLlmError("Qualification LiteLLM proxy is not reachable (liveness).");
+    });
+    // Authenticated admin reachability + the configured allowlist in one call.
+    const allowlistModels = await this.listAdminModels();
+    const eligibleClaudeModels = orderClaudeModelsCheapestFirst(
+      allowlistModels.filter(isEligibleClaudeModel),
+    );
+    if (eligibleClaudeModels.length === 0) {
+      throw new QualificationLiteLlmError(
+        "Qualification allowlist contains no eligible non-Fable Claude model.",
+      );
+    }
+    return { adminReachable: true, allowlistModels, eligibleClaudeModels };
+  }
+
+  /**
+   * Resolves the actor key's `token_id` and owning user/team via the admin API
+   * from the authenticated enrollment id + user id, deriving the deterministic
+   * alias. Live-probing the actor key's model list happens separately, after
+   * enrollment and before the turn.
+   */
+  async resolveActorKey(params: { userId: string; enrollmentId: string }): Promise<ActorKeyIdentity> {
+    const keyAlias = deriveActorKeyAlias(params.userId, params.enrollmentId);
+    const payload = await this.adminGet(
+      `/key/list?key_alias=${encodeURIComponent(keyAlias)}&return_full_object=true`,
+    );
+    const keys = asRecord(payload).keys;
+    if (!Array.isArray(keys)) {
+      throw new QualificationLiteLlmError("LiteLLM returned an invalid key list for the actor alias.");
+    }
+    // The `/key/list` alias filter is advisory on the pinned image, so re-check
+    // client-side (mirrors the Server's delete_virtual_keys_by_alias).
+    const match = keys
+      .map(asRecord)
+      .find((key) => key.key_alias === keyAlias && typeof key.token === "string" && key.token);
+    if (!match) {
+      throw new QualificationLiteLlmError(
+        `No LiteLLM key resolved for the actor enrollment alias "${keyAlias}".`,
+      );
+    }
+    const tokenId = String(match.token);
+    const teamId = typeof match.team_id === "string" ? match.team_id : "";
+    const litellmUserId = typeof match.user_id === "string" ? match.user_id : params.userId;
+    return {
+      userId: params.userId,
+      enrollmentId: params.enrollmentId,
+      teamId,
+      litellmUserId,
+      keyAlias,
+      tokenId,
+      tokenIdHash: sha256Hex(tokenId),
+    };
+  }
+
+  /** Snapshots the actor key's existing request ids before the turn. */
+  async snapshotSpend(actor: ActorKeyIdentity): Promise<SpendSnapshot> {
+    const takenAt = new Date().toISOString();
+    const date = takenAt.slice(0, 10);
+    const rows = await this.pageSpendLogs(date, date);
+    const requestIds = rows
+      .filter((row) => row.api_key === actor.tokenId)
+      .map((row) => row.request_id);
+    return { tokenIdHash: actor.tokenIdHash, requestIds: [...new Set(requestIds)].sort(), takenAt };
+  }
+
+  /**
+   * Requires one or more new spend rows for `actor` within the bounded window,
+   * each satisfying the key/model/window/positive-token/positive-spend
+   * invariants (spec "LiteLLM correlation"). An unbounded result set, wrong
+   * key, pre-existing request id, out-of-window row, wrong model, or zero
+   * token/spend fails.
+   */
+  async correlateTurn(params: {
+    actor: ActorKeyIdentity;
+    before: SpendSnapshot;
+    acceptedModelId: string;
+    windowStartedAt: string;
+    windowFinishedAt: string;
+  }): Promise<CorrelatedTurnSpend> {
+    const windowStart = Date.parse(params.windowStartedAt);
+    const windowEnd = Date.parse(params.windowFinishedAt);
+    if (!Number.isFinite(windowStart) || !Number.isFinite(windowEnd) || windowEnd < windowStart) {
+      throw new QualificationLiteLlmError("Correlation window is invalid.");
+    }
+    const rows = await this.pageSpendLogs(
+      params.windowStartedAt.slice(0, 10),
+      params.windowFinishedAt.slice(0, 10),
+    );
+    const seen = new Set(params.before.requestIds);
+    const uniqueByRequestId = new Map<string, SpendLogRow>();
+    for (const row of rows) {
+      if (row.api_key !== params.actor.tokenId) {
+        continue; // wrong key — not this actor's spend.
+      }
+      if (seen.has(row.request_id)) {
+        continue; // pre-existing request id — present before the turn.
+      }
+      const at = row.startTime ? Date.parse(row.startTime) : NaN;
+      if (!Number.isFinite(at) || at < windowStart || at > windowEnd) {
+        continue; // outside the bounded scenario window.
+      }
+      uniqueByRequestId.set(row.request_id, row);
+    }
+    const accepted = [...uniqueByRequestId.values()];
+    if (accepted.length === 0) {
+      throw new QualificationLiteLlmError(
+        "No new in-window LiteLLM spend row correlated to the actor key.",
+      );
+    }
+    if (accepted.length > MAX_CORRELATED_ROWS) {
+      throw new QualificationLiteLlmError(
+        `Correlated ${accepted.length} spend rows (> ${MAX_CORRELATED_ROWS}); result set is unbounded/ambiguous.`,
+      );
+    }
+    let promptTokens = 0;
+    let completionTokens = 0;
+    let totalTokens = 0;
+    let spendUsd = 0;
+    for (const row of accepted) {
+      if (row.model !== params.acceptedModelId) {
+        throw new QualificationLiteLlmError(
+          `Correlated a spend row for model "${row.model}", expected "${params.acceptedModelId}".`,
+        );
+      }
+      if (
+        !isPositiveInt(row.prompt_tokens) ||
+        !isPositiveInt(row.completion_tokens) ||
+        !isPositiveInt(row.total_tokens) ||
+        row.prompt_tokens + row.completion_tokens !== row.total_tokens
+      ) {
+        throw new QualificationLiteLlmError("Correlated a spend row with non-positive/inconsistent tokens.");
+      }
+      if (!(row.spend > 0)) {
+        throw new QualificationLiteLlmError("Correlated a spend row with non-positive spend.");
+      }
+      promptTokens += row.prompt_tokens;
+      completionTokens += row.completion_tokens;
+      totalTokens += row.total_tokens;
+      spendUsd += row.spend;
+    }
+    return {
+      tokenIdHash: params.actor.tokenIdHash,
+      requestIds: accepted.map((row) => row.request_id).sort(),
+      modelId: params.acceptedModelId,
+      promptTokens,
+      completionTokens,
+      totalTokens,
+      spendUsd,
+      windowStartedAt: params.windowStartedAt,
+      windowFinishedAt: params.windowFinishedAt,
+    };
+  }
+
+  /**
+   * Deletes the run-created virtual key, LiteLLM user, and LiteLLM team. Must
+   * run before local database teardown so the deterministic alias stays
+   * recoverable. Idempotent: a subject that is already gone counts as deleted.
+   */
+  async deleteActorSubjects(actor: ActorKeyIdentity): Promise<ActorSubjectsDeletion> {
+    const virtualKeyDeleted = await this.idempotentDelete("/key/delete", { keys: [actor.tokenId] });
+    const userDeleted = await this.idempotentDelete("/user/delete", { user_ids: [actor.litellmUserId] });
+    const teamDeleted = actor.teamId
+      ? await this.idempotentDelete("/team/delete", { team_ids: [actor.teamId] })
+      : true;
+    return {
+      virtualKeyDeleted,
+      litellmSubjectsDeleted: userDeleted && teamDeleted,
+    };
+  }
+
+  private requireNonEmptyInputs(): void {
+    for (const [name, value] of [
+      ["adminBaseUrl", this.config.adminBaseUrl],
+      ["publicBaseUrl", this.config.publicBaseUrl],
+      ["masterKey", this.config.masterKey],
+    ] as const) {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        throw new QualificationLiteLlmError(`Qualification LiteLLM config is missing "${name}".`);
+      }
+    }
+  }
+
+  private async listAdminModels(): Promise<string[]> {
+    const payload = await this.adminGet("/v1/models");
+    const data = asRecord(payload).data;
+    if (!Array.isArray(data)) {
+      throw new QualificationLiteLlmError("LiteLLM returned an invalid model list for admin preflight.");
+    }
+    return data
+      .map(asRecord)
+      .map((item) => item.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+  }
+
+  private async pageSpendLogs(startDate: string, endDate: string): Promise<SpendLogRow[]> {
+    const payload = await this.adminGet(
+      `/spend/logs?summarize=false&start_date=${encodeURIComponent(startDate)}&end_date=${encodeURIComponent(endDate)}`,
+    );
+    if (!Array.isArray(payload)) {
+      throw new QualificationLiteLlmError("LiteLLM returned invalid spend logs.");
+    }
+    return payload.map(asRecord).map((row) => ({
+      request_id: String(row.request_id ?? ""),
+      api_key: typeof row.api_key === "string" ? row.api_key : "",
+      model: typeof row.model === "string" ? row.model : "",
+      spend: typeof row.spend === "number" ? row.spend : 0,
+      total_tokens: typeof row.total_tokens === "number" ? row.total_tokens : 0,
+      prompt_tokens: typeof row.prompt_tokens === "number" ? row.prompt_tokens : 0,
+      completion_tokens: typeof row.completion_tokens === "number" ? row.completion_tokens : 0,
+      startTime: typeof row.startTime === "string" ? row.startTime : typeof row.start_time === "string" ? row.start_time : null,
+    }));
+  }
+
+  private async idempotentDelete(path: string, body: Record<string, unknown>): Promise<boolean> {
+    const response = await this.fetch(`${trimTrailingSlash(this.config.adminBaseUrl)}${path}`, {
+      method: "POST",
+      headers: this.adminHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (response.ok) {
+      return true;
+    }
+    // A subject that no longer exists is a successful (idempotent) delete.
+    if (response.status === 404) {
+      return true;
+    }
+    const message = await response.text().catch(() => "");
+    if (/not\s*found|does not exist|no.*key/i.test(message)) {
+      return true;
+    }
+    throw new QualificationLiteLlmError(`LiteLLM ${path} failed with HTTP ${response.status}.`);
+  }
+
+  private async adminGet(
+    path: string,
+    options: { authenticated?: boolean } = {},
+  ): Promise<unknown> {
+    const authenticated = options.authenticated ?? true;
+    const response = await this.fetch(`${trimTrailingSlash(this.config.adminBaseUrl)}${path}`, {
+      method: "GET",
+      headers: authenticated ? this.adminHeaders() : {},
+    });
+    if (!response.ok) {
+      throw new QualificationLiteLlmError(`LiteLLM ${path} failed with HTTP ${response.status}.`);
+    }
+    return response.json();
+  }
+
+  private adminHeaders(): Record<string, string> {
+    return { authorization: `Bearer ${this.config.masterKey}`, "content-type": "application/json" };
+  }
+}
+
+function isPositiveInt(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+const defaultFetch: FetchLike = (url, init) =>
+  fetch(url, init as RequestInit) as unknown as Promise<HttpResponseLike>;

--- a/tests/release/src/services/qualification-litellm.ts
+++ b/tests/release/src/services/qualification-litellm.ts
@@ -44,6 +44,49 @@ const CLAUDE_TIER_RANK: ReadonlyArray<readonly [string, number]> = [
  * ambiguous/unbounded result and rejected. */
 const MAX_CORRELATED_ROWS = 16;
 
+/** Bounded wait for LiteLLM's asynchronous spend-log persistence after a turn. */
+const SPEND_CORRELATION_TIMEOUT_MS = 60_000;
+const SPEND_CORRELATION_POLL_MS = 3_000;
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** The UTC calendar date `days` after `isoTimestamp`, as `YYYY-MM-DD`. */
+function utcDatePlusDays(isoTimestamp: string, days: number): string {
+  const base = new Date(isoTimestamp);
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString().slice(0, 10);
+}
+
+/**
+ * Whether a LiteLLM-recorded model name identifies the accepted model. LiteLLM
+ * logs the resolved provider model — provider-prefixed (`anthropic/…`) and
+ * pinned to a dated snapshot (`…-20251001`) — while the accepted id is the
+ * catalog/UI alias (`claude-haiku-4-5`). Strip the provider prefix and accept an
+ * exact match or the alias-to-dated-snapshot relationship in either direction.
+ */
+function litellmModelMatches(rowModel: string, acceptedModelId: string): boolean {
+  const stripProvider = (id: string): string => {
+    const slash = id.lastIndexOf("/");
+    return slash >= 0 ? id.slice(slash + 1) : id;
+  };
+  const row = stripProvider(rowModel).trim();
+  const accepted = stripProvider(acceptedModelId).trim();
+  if (!row || !accepted) {
+    return false;
+  }
+  if (row === accepted) {
+    return true;
+  }
+  // A dated snapshot of the alias, e.g. "claude-haiku-4-5" ↔
+  // "claude-haiku-4-5-20251001". Require the extra segment to be a date so an
+  // unrelated longer id (e.g. a different family) is not accepted.
+  const isDatedSuffixOf = (base: string, dated: string): boolean =>
+    dated.startsWith(`${base}-`) && /^\d{6,8}$/.test(dated.slice(base.length + 1));
+  return isDatedSuffixOf(accepted, row) || isDatedSuffixOf(row, accepted);
+}
+
 /** Minimal HTTP response surface this controller consumes. */
 export interface HttpResponseLike {
   ok: boolean;
@@ -61,6 +104,11 @@ export type FetchLike = (
 
 export interface QualificationLiteLlmDeps {
   fetch?: FetchLike;
+  /** Overrides the spend-correlation polling budget (ms). Tests set 0 to
+   * disable polling; production uses the default. */
+  spendCorrelationTimeoutMs?: number;
+  /** Overrides the spend-correlation poll interval (ms). */
+  spendCorrelationPollMs?: number;
 }
 
 /** Raised for any LiteLLM controller failure; never embeds the master key or
@@ -214,12 +262,16 @@ interface SpendLogRow {
 
 export class QualificationLiteLlmController {
   private readonly fetch: FetchLike;
+  private readonly spendCorrelationTimeoutMs: number;
+  private readonly spendCorrelationPollMs: number;
 
   constructor(
     private readonly config: QualificationLiteLlmConfig,
     deps: QualificationLiteLlmDeps = {},
   ) {
     this.fetch = deps.fetch ?? defaultFetch;
+    this.spendCorrelationTimeoutMs = deps.spendCorrelationTimeoutMs ?? SPEND_CORRELATION_TIMEOUT_MS;
+    this.spendCorrelationPollMs = deps.spendCorrelationPollMs ?? SPEND_CORRELATION_POLL_MS;
   }
 
   /** The public inference URL handed to AnyHarness (never the admin URL/key). */
@@ -322,26 +374,43 @@ export class QualificationLiteLlmController {
     if (!Number.isFinite(windowStart) || !Number.isFinite(windowEnd) || windowEnd < windowStart) {
       throw new QualificationLiteLlmError("Correlation window is invalid.");
     }
-    const rows = await this.pageSpendLogs(
-      params.windowStartedAt.slice(0, 10),
-      params.windowFinishedAt.slice(0, 10),
-    );
     const seen = new Set(params.before.requestIds);
-    const uniqueByRequestId = new Map<string, SpendLogRow>();
-    for (const row of rows) {
-      if (row.api_key !== params.actor.tokenId) {
-        continue; // wrong key — not this actor's spend.
+    // LiteLLM writes spend logs asynchronously (batched), so a matching row is
+    // not guaranteed to be queryable the instant the turn ends. Poll until the
+    // actor's in-window row(s) appear or the bounded deadline elapses. The
+    // acceptance invariant is unchanged — each accepted row's own start time must
+    // still fall inside the scenario window; polling only waits for the row to
+    // be persisted, it does not widen the window.
+    // LiteLLM's `/spend/logs` treats `end_date` as the start of that day, so a
+    // same-day `start_date == end_date` query excludes rows recorded later that
+    // day. Query through the day AFTER the window so the turn's row is included;
+    // the exact per-row window bound is still enforced below.
+    const startDate = params.windowStartedAt.slice(0, 10);
+    const endDate = utcDatePlusDays(params.windowFinishedAt, 1);
+    const deadline = Date.now() + this.spendCorrelationTimeoutMs;
+    let accepted: SpendLogRow[] = [];
+    for (;;) {
+      const rows = await this.pageSpendLogs(startDate, endDate);
+      const uniqueByRequestId = new Map<string, SpendLogRow>();
+      for (const row of rows) {
+        if (row.api_key !== params.actor.tokenId) {
+          continue; // wrong key — not this actor's spend.
+        }
+        if (seen.has(row.request_id)) {
+          continue; // pre-existing request id — present before the turn.
+        }
+        const at = row.startTime ? Date.parse(row.startTime) : NaN;
+        if (!Number.isFinite(at) || at < windowStart || at > windowEnd) {
+          continue; // outside the bounded scenario window.
+        }
+        uniqueByRequestId.set(row.request_id, row);
       }
-      if (seen.has(row.request_id)) {
-        continue; // pre-existing request id — present before the turn.
+      accepted = [...uniqueByRequestId.values()];
+      if (accepted.length > 0 || Date.now() >= deadline) {
+        break;
       }
-      const at = row.startTime ? Date.parse(row.startTime) : NaN;
-      if (!Number.isFinite(at) || at < windowStart || at > windowEnd) {
-        continue; // outside the bounded scenario window.
-      }
-      uniqueByRequestId.set(row.request_id, row);
+      await sleepMs(this.spendCorrelationPollMs);
     }
-    const accepted = [...uniqueByRequestId.values()];
     if (accepted.length === 0) {
       throw new QualificationLiteLlmError(
         "No new in-window LiteLLM spend row correlated to the actor key.",
@@ -357,7 +426,7 @@ export class QualificationLiteLlmController {
     let totalTokens = 0;
     let spendUsd = 0;
     for (const row of accepted) {
-      if (row.model !== params.acceptedModelId) {
+      if (!litellmModelMatches(row.model, params.acceptedModelId)) {
         throw new QualificationLiteLlmError(
           `Correlated a spend row for model "${row.model}", expected "${params.acceptedModelId}".`,
         );

--- a/tests/release/src/services/qualification-litellm.ts
+++ b/tests/release/src/services/qualification-litellm.ts
@@ -468,9 +468,13 @@ export class QualificationLiteLlmController {
   async deleteActorSubjects(actor: ActorKeyIdentity): Promise<ActorSubjectsDeletion> {
     const virtualKeyDeleted = await this.idempotentDelete("/key/delete", { keys: [actor.tokenId] });
     const userDeleted = await this.idempotentDelete("/user/delete", { user_ids: [actor.litellmUserId] });
+    // Fail closed: an absent team_id means the run-created team is unaccounted
+    // for, not proven deleted. The frozen cleanup contract requires the team to
+    // be deleted, so a missing identifier must fail green-ness rather than be
+    // silently reported as a successful deletion.
     const teamDeleted = actor.teamId
       ? await this.idempotentDelete("/team/delete", { team_ids: [actor.teamId] })
-      : true;
+      : false;
     return {
       virtualKeyDeleted,
       litellmSubjectsDeleted: userDeleted && teamDeleted,

--- a/tests/release/src/worlds/local-workspace/cleanup-ledger.test.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup-ledger.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  CLEANUP_LEDGER_FILENAME,
+  loadCleanupLedger,
+  openCleanupLedger,
+  recoverInterruptedRuns,
+  replayLedger,
+  type CleanupLedgerEntry,
+} from "./cleanup-ledger.js";
+
+async function tempRunDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "cleanup-ledger-"));
+}
+
+test("openCleanupLedger writes a mode-0600 file immediately", async () => {
+  const runDir = await tempRunDir();
+  try {
+    await openCleanupLedger({ runDir, runId: "run-1", shardId: "shard-0" });
+    const stats = await stat(path.join(runDir, CLEANUP_LEDGER_FILENAME));
+    assert.ok(stats.isFile());
+    assert.equal(stats.mode & 0o777, 0o600);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("two-phase intent → acquired → reconciled persists across a reload", async () => {
+  const runDir = await tempRunDir();
+  try {
+    const ledger = await openCleanupLedger({ runDir, runId: "run-1", shardId: "shard-0" });
+    await ledger.registerIntent("docker_network", "e1");
+    await ledger.markAcquired("e1", "plq-net");
+    const reloaded = await loadCleanupLedger(runDir);
+    const [entry] = reloaded.entries();
+    assert.equal(entry.phase, "acquired");
+    assert.equal(entry.providerId, "plq-net");
+    await reloaded.markReconciled("e1");
+    assert.equal((await loadCleanupLedger(runDir)).unreconciled().length, 0);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("unreconciled() is reverse-registration order", async () => {
+  const runDir = await tempRunDir();
+  try {
+    const ledger = await openCleanupLedger({ runDir, runId: "run-1", shardId: "shard-0" });
+    await ledger.registerIntent("run_directory", "first");
+    await ledger.registerIntent("server_container", "second");
+    await ledger.registerIntent("browser", "third");
+    assert.deepEqual(ledger.unreconciled().map((entry) => entry.entryId), ["third", "second", "first"]);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("replayLedger reconciles unfinished entries idempotently and touches only handled kinds", async () => {
+  const runDir = await tempRunDir();
+  try {
+    const ledger = await openCleanupLedger({ runDir, runId: "run-1", shardId: "shard-0" });
+    await ledger.registerIntent("server_container", "srv");
+    await ledger.markAcquired("srv", "plq-server");
+    await ledger.registerIntent("browser", "br");
+    await ledger.markAcquired("br", "chromium");
+
+    const released: string[] = [];
+    const handlers = {
+      server_container: async (entry: CleanupLedgerEntry) => {
+        released.push(entry.providerId ?? "");
+      },
+    };
+    const first = await replayLedger(ledger, handlers);
+    assert.equal(first.reconciled, 1); // only server handled
+    assert.equal(first.failed, 1); // browser has no handler
+    assert.deepEqual(released, ["plq-server"]);
+
+    // Idempotent: replaying again does not re-run the already-reconciled server.
+    const second = await replayLedger(ledger, handlers);
+    assert.equal(second.reconciled, 0);
+    assert.deepEqual(released, ["plq-server"]);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("recoverInterruptedRuns finds only runs whose unreconciled entries exceed the TTL", async () => {
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "cleanup-recover-"));
+  try {
+    const t0 = new Date("2026-07-14T00:00:00.000Z");
+    // Stale interrupted run.
+    const staleDir = path.join(baseDir, "run-stale", "shard-0");
+    const stale = await openCleanupLedger({ runDir: await mkdirp(staleDir), runId: "run-stale", shardId: "shard-0", now: () => t0 });
+    await stale.registerIntent("server_container", "s");
+
+    // Fresh in-flight run (recent activity).
+    const freshDir = path.join(baseDir, "run-fresh", "shard-0");
+    const now = new Date("2026-07-14T01:00:00.000Z");
+    const fresh = await openCleanupLedger({ runDir: await mkdirp(freshDir), runId: "run-fresh", shardId: "shard-0", now: () => now });
+    await fresh.registerIntent("server_container", "s");
+
+    // Fully reconciled run — not interrupted.
+    const doneDir = path.join(baseDir, "run-done", "shard-0");
+    const done = await openCleanupLedger({ runDir: await mkdirp(doneDir), runId: "run-done", shardId: "shard-0", now: () => t0 });
+    await done.registerIntent("server_container", "s");
+    await done.markReconciled("s");
+
+    const interrupted = await recoverInterruptedRuns({
+      baseDir,
+      ttlMs: 30 * 60_000,
+      now: () => new Date("2026-07-14T01:00:00.000Z"),
+    });
+    assert.deepEqual(interrupted, [staleDir]);
+  } finally {
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+async function mkdirp(dir: string): Promise<string> {
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+test("the persisted ledger is valid JSON with the expected shape", async () => {
+  const runDir = await tempRunDir();
+  try {
+    const ledger = await openCleanupLedger({ runDir, runId: "run-x", shardId: "shard-y" });
+    await ledger.registerIntent("browser", "e1");
+    const raw = JSON.parse(await readFile(path.join(runDir, CLEANUP_LEDGER_FILENAME), "utf8"));
+    assert.equal(raw.ledgerId, "run-x:shard-y");
+    assert.equal(raw.entries.length, 1);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/worlds/local-workspace/cleanup-ledger.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup-ledger.ts
@@ -1,0 +1,307 @@
+/**
+ * The durable, run-owned cleanup ledger (spec "Cleanup and failure behavior").
+ * Every resource is written to the ledger BEFORE it is created, using a
+ * two-phase intent → acquired record so the safe provider identity is added as
+ * soon as creation returns. The normal `finally` path marks each entry
+ * reconciled; a replay-by-run command safely retries unfinished entries, and a
+ * bounded TTL recovery command finds interrupted runs — all without touching
+ * another run's resources.
+ *
+ * Locally the record is an atomic mode-`0600` file; in Actions the same record
+ * is mirrored to a qualification-only S3 prefix so it survives complete
+ * hosted-runner loss. This is only the first real local-world consumer, not a
+ * generic provider framework: E2B/AWS resource kinds are added later.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type { Dirent } from "node:fs";
+import { readFile, readdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+/** The resource kinds this first local-world consumer registers. */
+export type CleanupResourceKind =
+  | "litellm_virtual_key"
+  | "litellm_user"
+  | "litellm_team"
+  | "browser_context"
+  | "browser"
+  | "renderer_process"
+  | "anyharness_process"
+  | "server_container"
+  | "postgres_container"
+  | "redis_container"
+  | "docker_network"
+  | "runtime_home"
+  | "repository_clone"
+  | "extracted_artifacts"
+  | "run_directory"
+  | "port_registration";
+
+export type CleanupPhase = "intent" | "acquired" | "reconciled";
+
+export interface CleanupLedgerEntry {
+  entryId: string;
+  kind: CleanupResourceKind;
+  phase: CleanupPhase;
+  /** Safe provider identity (container id, alias, path…) added on acquire. */
+  providerId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Optional S3 mirror used only in Actions (qualification-only prefix). */
+export interface CleanupLedgerMirror {
+  put(key: string, body: string): Promise<void>;
+  get(key: string): Promise<string | null>;
+}
+
+export interface OpenCleanupLedgerOptions {
+  runDir: string;
+  runId: string;
+  shardId: string;
+  mirror?: CleanupLedgerMirror;
+  now?: () => Date;
+}
+
+/**
+ * A live ledger for one run. Registration order is preserved; cleanup replays
+ * in reverse. All mutations are atomically persisted (0600 file rewrite +
+ * optional mirror) before returning.
+ */
+export interface CleanupLedger {
+  readonly ledgerId: string;
+  /** Persists an `intent` record before the resource is created. */
+  registerIntent(kind: CleanupResourceKind, entryId: string): Promise<CleanupLedgerEntry>;
+  /** Attaches the safe provider identity once creation returns. */
+  markAcquired(entryId: string, providerId: string): Promise<void>;
+  /** Marks an entry reconciled after its resource is released. */
+  markReconciled(entryId: string): Promise<void>;
+  /** All entries in registration order. */
+  entries(): CleanupLedgerEntry[];
+  /** Entries not yet reconciled, in reverse-registration (cleanup) order. */
+  unreconciled(): CleanupLedgerEntry[];
+}
+
+/** The ledger filename inside a run directory. */
+export const CLEANUP_LEDGER_FILENAME = "cleanup-ledger.json";
+
+interface LedgerDocument {
+  ledgerId: string;
+  runId: string;
+  shardId: string;
+  createdAt: string;
+  entries: CleanupLedgerEntry[];
+}
+
+/** One-way hash of the ledger id, the only ledger identity evidence carries. */
+export function hashLedgerId(ledgerId: string): string {
+  return createHash("sha256").update(ledgerId).digest("hex");
+}
+
+class DurableCleanupLedger implements CleanupLedger {
+  constructor(
+    private readonly doc: LedgerDocument,
+    private readonly filePath: string,
+    private readonly now: () => Date,
+    private readonly mirror: CleanupLedgerMirror | undefined,
+  ) {}
+
+  get ledgerId(): string {
+    return this.doc.ledgerId;
+  }
+
+  async registerIntent(kind: CleanupResourceKind, entryId: string): Promise<CleanupLedgerEntry> {
+    if (this.doc.entries.some((entry) => entry.entryId === entryId)) {
+      throw new Error(`Cleanup ledger already contains entry "${entryId}".`);
+    }
+    const stamp = this.now().toISOString();
+    const entry: CleanupLedgerEntry = {
+      entryId,
+      kind,
+      phase: "intent",
+      providerId: null,
+      createdAt: stamp,
+      updatedAt: stamp,
+    };
+    this.doc.entries.push(entry);
+    await this.persist();
+    return { ...entry };
+  }
+
+  async markAcquired(entryId: string, providerId: string): Promise<void> {
+    const entry = this.require(entryId);
+    entry.providerId = providerId;
+    entry.phase = "acquired";
+    entry.updatedAt = this.now().toISOString();
+    await this.persist();
+  }
+
+  async markReconciled(entryId: string): Promise<void> {
+    const entry = this.require(entryId);
+    entry.phase = "reconciled";
+    entry.updatedAt = this.now().toISOString();
+    await this.persist();
+  }
+
+  entries(): CleanupLedgerEntry[] {
+    return this.doc.entries.map((entry) => ({ ...entry }));
+  }
+
+  unreconciled(): CleanupLedgerEntry[] {
+    return this.doc.entries
+      .filter((entry) => entry.phase !== "reconciled")
+      .map((entry) => ({ ...entry }))
+      .reverse();
+  }
+
+  private require(entryId: string): CleanupLedgerEntry {
+    const entry = this.doc.entries.find((candidate) => candidate.entryId === entryId);
+    if (!entry) {
+      throw new Error(`Cleanup ledger has no entry "${entryId}".`);
+    }
+    return entry;
+  }
+
+  /** Persists the current document (used to write the initial empty ledger). */
+  async flush(): Promise<void> {
+    await this.persist();
+  }
+
+  private async persist(): Promise<void> {
+    const body = JSON.stringify(this.doc, null, 2);
+    // Atomic mode-0600 replace: write a sibling temp then rename over the target
+    // so a crash mid-write never leaves a truncated ledger.
+    const tmp = `${this.filePath}.${randomUUID()}.tmp`;
+    await writeFile(tmp, body, { mode: 0o600 });
+    await rename(tmp, this.filePath);
+    if (this.mirror) {
+      // Best-effort durable mirror (Actions-only); never blocks local teardown.
+      await this.mirror.put(mirrorKey(this.doc.ledgerId), body).catch(() => undefined);
+    }
+  }
+}
+
+function mirrorKey(ledgerId: string): string {
+  return `cleanup-ledger/${encodeURIComponent(ledgerId)}.json`;
+}
+
+export async function openCleanupLedger(options: OpenCleanupLedgerOptions): Promise<CleanupLedger> {
+  const now = options.now ?? (() => new Date());
+  const doc: LedgerDocument = {
+    ledgerId: `${options.runId}:${options.shardId}`,
+    runId: options.runId,
+    shardId: options.shardId,
+    createdAt: now().toISOString(),
+    entries: [],
+  };
+  const ledger = new DurableCleanupLedger(
+    doc,
+    path.join(options.runDir, CLEANUP_LEDGER_FILENAME),
+    now,
+    options.mirror,
+  );
+  // Persist the empty ledger immediately so an interrupted run always leaves a
+  // recoverable record, even if it crashes before the first resource.
+  await ledger.flush();
+  return ledger;
+}
+
+/** Reloads a persisted ledger by run directory (for replay/recovery). */
+export async function loadCleanupLedger(
+  runDir: string,
+  mirror?: CleanupLedgerMirror,
+): Promise<CleanupLedger> {
+  const filePath = path.join(runDir, CLEANUP_LEDGER_FILENAME);
+  const raw = await readFile(filePath, "utf8");
+  const doc = JSON.parse(raw) as LedgerDocument;
+  if (!doc || typeof doc.ledgerId !== "string" || !Array.isArray(doc.entries)) {
+    throw new Error(`Cleanup ledger at ${filePath} is malformed.`);
+  }
+  return new DurableCleanupLedger(doc, filePath, () => new Date(), mirror);
+}
+
+/** A single resource releaser, keyed by kind, supplied by the cleanup stack. */
+export type CleanupHandler = (entry: CleanupLedgerEntry) => Promise<void>;
+
+/**
+ * Replays a run's unreconciled entries idempotently, reverse order, marking
+ * each reconciled as it succeeds. Safe to retry; touches only this run.
+ */
+export async function replayLedger(
+  ledger: CleanupLedger,
+  handlers: Partial<Record<CleanupResourceKind, CleanupHandler>>,
+): Promise<{ reconciled: number; failed: number }> {
+  let reconciled = 0;
+  let failed = 0;
+  // `unreconciled()` is already reverse-registration order; replay is safe to
+  // retry because each success marks the entry reconciled and drops it out.
+  for (const entry of ledger.unreconciled()) {
+    const handler = handlers[entry.kind];
+    if (!handler) {
+      // No handler for this kind on this replay — leave it unreconciled for a
+      // later, better-equipped pass rather than silently dropping it.
+      failed += 1;
+      continue;
+    }
+    try {
+      await handler(entry);
+      await ledger.markReconciled(entry.entryId);
+      reconciled += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  return { reconciled, failed };
+}
+
+/**
+ * Finds interrupted runs under a base directory whose ledger has unreconciled
+ * entries older than `ttlMs`, for the bounded TTL recovery command.
+ */
+export async function recoverInterruptedRuns(params: {
+  baseDir: string;
+  ttlMs: number;
+  now?: () => Date;
+}): Promise<string[]> {
+  const now = (params.now ?? (() => new Date()))().getTime();
+  const interrupted: string[] = [];
+  // Layout is <baseDir>/<run_id>/<shard_id>/cleanup-ledger.json.
+  for (const runEntry of await readDirSafe(params.baseDir)) {
+    if (!runEntry.isDirectory()) {
+      continue;
+    }
+    const runPath = path.join(params.baseDir, runEntry.name);
+    for (const shardEntry of await readDirSafe(runPath)) {
+      if (!shardEntry.isDirectory()) {
+        continue;
+      }
+      const shardPath = path.join(runPath, shardEntry.name);
+      const ledgerPath = path.join(shardPath, CLEANUP_LEDGER_FILENAME);
+      let doc: LedgerDocument;
+      try {
+        doc = JSON.parse(await readFile(ledgerPath, "utf8")) as LedgerDocument;
+      } catch {
+        continue; // No/invalid ledger — nothing to recover here.
+      }
+      const outstanding = doc.entries?.filter((entry) => entry.phase !== "reconciled") ?? [];
+      if (outstanding.length === 0) {
+        continue; // Fully reconciled — a clean run, not interrupted.
+      }
+      // Only reclaim runs whose newest unreconciled activity is past the TTL, so
+      // an in-flight concurrent run is never touched.
+      const newest = Math.max(...outstanding.map((entry) => Date.parse(entry.updatedAt) || 0));
+      if (now - newest >= params.ttlMs) {
+        interrupted.push(shardPath);
+      }
+    }
+  }
+  return interrupted.sort();
+}
+
+async function readDirSafe(dir: string): Promise<Dirent[]> {
+  try {
+    return await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}

--- a/tests/release/src/worlds/local-workspace/cleanup-ledger.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup-ledger.ts
@@ -34,6 +34,7 @@ export type CleanupResourceKind =
   | "runtime_home"
   | "repository_clone"
   | "extracted_artifacts"
+  | "secret_env_file"
   | "run_directory"
   | "port_registration";
 

--- a/tests/release/src/worlds/local-workspace/cleanup.test.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { LocalWorldCleanupStack } from "./cleanup.js";
+import { openCleanupLedger } from "./cleanup-ledger.js";
+
+async function stackInTemp(): Promise<{ stack: LocalWorldCleanupStack; runDir: string }> {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "cleanup-stack-"));
+  const ledger = await openCleanupLedger({ runDir, runId: "run-1", shardId: "shard-0" });
+  return { stack: new LocalWorldCleanupStack({ ledger }), runDir };
+}
+
+/** Registers one entry per kind that a complete green run creates. */
+async function registerFullGreenRun(stack: LocalWorldCleanupStack, order: string[]): Promise<void> {
+  const kinds = [
+    "run_directory",
+    "port_registration",
+    "runtime_home",
+    "extracted_artifacts",
+    "docker_network",
+    "postgres_container",
+    "redis_container",
+    "server_container",
+    "anyharness_process",
+    "renderer_process",
+    "browser",
+    "litellm_team",
+    "litellm_user",
+    "litellm_virtual_key",
+  ] as const;
+  for (const kind of kinds) {
+    const id = await stack.register(kind, async () => {
+      order.push(kind);
+    });
+    await stack.acquired(id, `${kind}-id`);
+  }
+}
+
+test("runAll releases in reverse registration order and reports a fully-clean summary", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    const order: string[] = [];
+    await registerFullGreenRun(stack, order);
+    const evidence = await stack.runAll();
+
+    // Reverse order: litellm subjects first (registered last), run_directory last.
+    assert.equal(order[0], "litellm_virtual_key");
+    assert.equal(order[order.length - 1], "run_directory");
+
+    assert.equal(evidence.failed, 0);
+    assert.equal(evidence.registered, 14);
+    assert.equal(evidence.reconciled, 14);
+    assert.equal(evidence.virtualKeyDeleted, true);
+    assert.equal(evidence.litellmSubjectsDeleted, true);
+    assert.equal(evidence.browserClosed, true);
+    assert.equal(evidence.processesStopped, true);
+    assert.equal(evidence.containersRemoved, true);
+    assert.equal(evidence.localPathsRemoved, true);
+    assert.match(evidence.ledgerIdHash, /^[0-9a-f]{64}$/);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("a releaser failure is counted (not thrown) and flips its category boolean", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    const okId = await stack.register("browser", async () => undefined);
+    await stack.acquired(okId, "chromium");
+    const badId = await stack.register("server_container", async () => {
+      throw new Error("docker rm failed");
+    });
+    await stack.acquired(badId, "srv");
+
+    const evidence = await stack.runAll();
+    assert.equal(evidence.failed, 1);
+    assert.equal(evidence.reconciled, 1);
+    assert.equal(evidence.containersRemoved, false); // server_container failed
+    assert.equal(evidence.browserClosed, true);
+    // Categories with no registered entry are false (an incomplete run cannot be green).
+    assert.equal(evidence.virtualKeyDeleted, false);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("a category with a missing sub-kind still passes when its other kinds all reconcile", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    // localPathsRemoved needs ≥1 of its kinds; register only run_directory.
+    const id = await stack.register("run_directory", async () => undefined);
+    await stack.acquired(id, "rundir");
+    const evidence = await stack.runAll();
+    assert.equal(evidence.localPathsRemoved, true);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/worlds/local-workspace/cleanup.test.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup.test.ts
@@ -20,6 +20,7 @@ async function registerFullGreenRun(stack: LocalWorldCleanupStack, order: string
     "port_registration",
     "runtime_home",
     "extracted_artifacts",
+    "secret_env_file",
     "docker_network",
     "postgres_container",
     "redis_container",
@@ -51,8 +52,8 @@ test("runAll releases in reverse registration order and reports a fully-clean su
     assert.equal(order[order.length - 1], "run_directory");
 
     assert.equal(evidence.failed, 0);
-    assert.equal(evidence.registered, 14);
-    assert.equal(evidence.reconciled, 14);
+    assert.equal(evidence.registered, 15);
+    assert.equal(evidence.reconciled, 15);
     assert.equal(evidence.virtualKeyDeleted, true);
     assert.equal(evidence.litellmSubjectsDeleted, true);
     assert.equal(evidence.browserClosed, true);

--- a/tests/release/src/worlds/local-workspace/cleanup.test.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -83,6 +83,47 @@ test("a releaser failure is counted (not thrown) and flips its category boolean"
     assert.equal(evidence.browserClosed, true);
     // Categories with no registered entry are false (an incomplete run cannot be green).
     assert.equal(evidence.virtualKeyDeleted, false);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("a failed releaser preserves the run directory (and its ledger) instead of letting run_directory delete it", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    const order: string[] = [];
+    // Registered first ⇒ released LAST (reverse order), same as the real world.
+    const runDirId = await stack.register("run_directory", async () => {
+      order.push("run_directory");
+    });
+    await stack.acquired(runDirId, runDir);
+
+    const badId = await stack.register("docker_network", async () => {
+      order.push("docker_network");
+      throw new Error("network plq-run-net has active endpoints");
+    });
+    await stack.acquired(badId, "plq-run-net");
+
+    const evidence = await stack.runAll();
+
+    // The run_directory releaser must never have run: it would have deleted
+    // the directory (and the ledger inside it) before a replay-by-run command
+    // could find the unreconciled docker_network entry.
+    assert.deepEqual(order, ["docker_network"]);
+    assert.equal(evidence.failed, 2); // the network failure + the deliberate run_directory skip
+    assert.equal(evidence.reconciled, 0);
+    assert.equal(evidence.containersRemoved, false);
+    assert.equal(evidence.localPathsRemoved, false);
+
+    // The ledger file itself must still be on disk, still recording the
+    // unreconciled docker_network entry, for replay-by-run to act on.
+    const ledgerPath = path.join(runDir, "cleanup-ledger.json");
+    const persisted = JSON.parse(await readFile(ledgerPath, "utf8")) as {
+      entries: Array<{ kind: string; phase: string }>;
+    };
+    const networkEntry = persisted.entries.find((entry) => entry.kind === "docker_network");
+    assert.ok(networkEntry);
+    assert.notEqual(networkEntry!.phase, "reconciled");
   } finally {
     await rm(runDir, { recursive: true, force: true });
   }

--- a/tests/release/src/worlds/local-workspace/cleanup.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from "node:crypto";
+
+import { hashLedgerId, type CleanupLedger, type CleanupResourceKind } from "./cleanup-ledger.js";
+
+/**
+ * The real local-world cleanup stack (spec "Cleanup and failure behavior").
+ * Each resource registers a reverse-order releaser as it is created and every
+ * registration is first written to the durable ledger. The stack runs in
+ * `finally`, including after readiness or scenario failure, and is idempotent.
+ *
+ * Deletion order matters: the external LiteLLM virtual key/team/user are
+ * deleted BEFORE local database teardown so the deterministic alias stays
+ * recoverable. Cleanup is deliberately concrete to this consumer, not a generic
+ * framework.
+ */
+
+/**
+ * The bounded, evidence-safe summary `ReadyLocalWorld.close()` returns. Its
+ * shape is exactly the `cleanup` block of `LocalWorkspaceTurnEvidenceV1`
+ * (evidence/schema.ts): a green cell requires `failed === 0` and every deletion
+ * boolean true.
+ */
+export interface LocalWorldCleanupEvidence {
+  ledgerIdHash: string;
+  registered: number;
+  reconciled: number;
+  failed: number;
+  virtualKeyDeleted: boolean;
+  litellmSubjectsDeleted: boolean;
+  browserClosed: boolean;
+  processesStopped: boolean;
+  containersRemoved: boolean;
+  localPathsRemoved: boolean;
+}
+
+/** One registered releaser plus the ledger entry that shadows it durably. */
+export interface CleanupRegistration {
+  entryId: string;
+  kind: CleanupResourceKind;
+  release: () => Promise<void>;
+}
+
+export interface CleanupStackOptions {
+  ledger: CleanupLedger;
+  log?: (message: string) => void;
+}
+
+/**
+ * Accumulates reverse-order releasers backed by the durable ledger. The world
+ * constructor calls `register` (writes intent), then creates the resource, then
+ * `acquired` (writes the safe provider id). `runAll` releases in reverse and
+ * returns the evidence summary.
+ */
+/** Evidence-boolean categories → the resource kinds that satisfy them. Every
+ * category must have ≥1 registered entry, all reconciled, for its boolean to be
+ * true (so an incomplete/failed run cannot show a fully-clean summary). */
+const EVIDENCE_CATEGORIES = {
+  virtualKeyDeleted: ["litellm_virtual_key"],
+  litellmSubjectsDeleted: ["litellm_user", "litellm_team"],
+  browserClosed: ["browser", "browser_context"],
+  processesStopped: ["renderer_process", "anyharness_process"],
+  containersRemoved: ["server_container", "postgres_container", "redis_container", "docker_network"],
+  localPathsRemoved: [
+    "runtime_home",
+    "repository_clone",
+    "extracted_artifacts",
+    "run_directory",
+    "port_registration",
+  ],
+} satisfies Record<string, CleanupResourceKind[]>;
+
+export class LocalWorldCleanupStack {
+  private readonly ledger: CleanupLedger;
+  private readonly log: (message: string) => void;
+  private readonly registrations: CleanupRegistration[] = [];
+
+  constructor(options: CleanupStackOptions) {
+    this.ledger = options.ledger;
+    this.log = options.log ?? (() => undefined);
+  }
+
+  /** Writes an `intent` ledger record and returns the entry id to acquire. */
+  async register(kind: CleanupResourceKind, release: () => Promise<void>): Promise<string> {
+    const entryId = randomUUID();
+    await this.ledger.registerIntent(kind, entryId);
+    this.registrations.push({ entryId, kind, release });
+    return entryId;
+  }
+
+  /** Marks a registered resource acquired with its safe provider identity. */
+  async acquired(entryId: string, providerId: string): Promise<void> {
+    await this.ledger.markAcquired(entryId, providerId);
+  }
+
+  /**
+   * Releases every acquired resource in reverse registration order, marking
+   * each reconciled, and returns the bounded evidence summary. Never throws for
+   * an individual failure — it counts them; the caller decides the verdict.
+   */
+  async runAll(): Promise<LocalWorldCleanupEvidence> {
+    const succeeded = new Set<string>();
+    let failed = 0;
+    for (const registration of [...this.registrations].reverse()) {
+      try {
+        await registration.release();
+        succeeded.add(registration.entryId);
+        // The resource is gone; persisting the reconcile is best-effort — the
+        // `run_directory` releaser deletes the ledger file itself, so a failed
+        // write here must not count the successful release as a failure.
+        await this.ledger.markReconciled(registration.entryId).catch(() => undefined);
+      } catch (error) {
+        failed += 1;
+        this.log(
+          `cleanup releaser for ${registration.kind} failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    return {
+      ledgerIdHash: hashLedgerId(this.ledger.ledgerId),
+      registered: this.registrations.length,
+      reconciled: succeeded.size,
+      failed,
+      virtualKeyDeleted: this.categoryClean("virtualKeyDeleted", succeeded),
+      litellmSubjectsDeleted: this.categoryClean("litellmSubjectsDeleted", succeeded),
+      browserClosed: this.categoryClean("browserClosed", succeeded),
+      processesStopped: this.categoryClean("processesStopped", succeeded),
+      containersRemoved: this.categoryClean("containersRemoved", succeeded),
+      localPathsRemoved: this.categoryClean("localPathsRemoved", succeeded),
+    };
+  }
+
+  private categoryClean(
+    category: keyof typeof EVIDENCE_CATEGORIES,
+    succeeded: ReadonlySet<string>,
+  ): boolean {
+    const kinds = new Set<CleanupResourceKind>(EVIDENCE_CATEGORIES[category]);
+    const inCategory = this.registrations.filter((registration) => kinds.has(registration.kind));
+    if (inCategory.length === 0) {
+      return false;
+    }
+    return inCategory.every((registration) => succeeded.has(registration.entryId));
+  }
+}

--- a/tests/release/src/worlds/local-workspace/cleanup.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup.ts
@@ -64,6 +64,7 @@ const EVIDENCE_CATEGORIES = {
     "runtime_home",
     "repository_clone",
     "extracted_artifacts",
+    "secret_env_file",
     "run_directory",
     "port_registration",
   ],

--- a/tests/release/src/worlds/local-workspace/cleanup.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup.ts
@@ -102,6 +102,21 @@ export class LocalWorldCleanupStack {
     const succeeded = new Set<string>();
     let failed = 0;
     for (const registration of [...this.registrations].reverse()) {
+      // The `run_directory` releaser deletes the run directory — which holds
+      // this very ledger — so it must never run while any earlier (reverse
+      // order) releaser this pass has failed. Deleting the directory anyway
+      // would destroy the only durable record of the unreconciled entry,
+      // leaving replay-by-run nothing to replay. Preserve the directory and
+      // record the skip as a failure instead; a later replay/recovery pass
+      // still has the ledger to work from.
+      if (registration.kind === "run_directory" && failed > 0) {
+        failed += 1;
+        this.log(
+          `cleanup releaser for run_directory skipped: ${failed - 1} earlier releaser(s) failed this run; ` +
+            `preserving the run directory and cleanup ledger for replay-by-run`,
+        );
+        continue;
+      }
       try {
         await registration.release();
         succeeded.add(registration.entryId);

--- a/tests/release/src/worlds/local-workspace/docker.test.ts
+++ b/tests/release/src/worlds/local-workspace/docker.test.ts
@@ -60,7 +60,13 @@ const SERVER_ENV: ServerContainerEnv = {
   AGENT_GATEWAY_LITELLM_BASE_URL: "http://admin",
   AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "http://public",
   AGENT_GATEWAY_LITELLM_MASTER_KEY: "sk-master",
+  SETUP_TOKEN_FILE: "/tmp/proliferate-setup/setup-token",
   DATABASE_URL: "postgresql+asyncpg://proliferate:localdev@plq-postgres:5432/proliferate",
+};
+
+const SETUP_TOKEN = {
+  setupTokenContainerPath: "/tmp/proliferate-setup/setup-token",
+  setupTokenHostPath: "/run/setup-token",
 };
 
 test("startDockerStack registers each resource before creating it and verifies readiness", async () => {
@@ -76,6 +82,7 @@ test("startDockerStack registers each resource before creating it and verifies r
     ports: { server: 8100, postgres: 8101, redis: 8102 },
     serverArtifact: SERVER_ARTIFACT,
     serverEnv: SERVER_ENV,
+    ...SETUP_TOKEN,
     registerCleanup: async (kind, providerId) => {
       registered.push({ kind, providerId });
     },
@@ -84,6 +91,13 @@ test("startDockerStack registers each resource before creating it and verifies r
 
   assert.equal(running.version, "1.2.3");
   assert.equal(running.imageRef, "srv:candidate");
+
+  // The real first-run setup token is copied out of the running Server via
+  // `docker cp` — the world/fixture consumes the real product path, not a bypass.
+  const cp = argv.find((cmd) => cmd[0] === "docker" && cmd[1] === "cp");
+  assert.ok(cp, "expected a `docker cp` of the setup token");
+  assert.equal(cp![2], "plq-run-shard-server:/tmp/proliferate-setup/setup-token");
+  assert.equal(cp![3], "/run/setup-token");
 
   // Network registered first (torn down last); server registered after migration.
   assert.deepEqual(
@@ -119,6 +133,7 @@ test("startDockerStack fails when the server never reports version-bearing healt
       ports: { server: 8100, postgres: 8101, redis: 8102 },
       serverArtifact: SERVER_ARTIFACT,
       serverEnv: SERVER_ENV,
+      ...SETUP_TOKEN,
       registerCleanup: async () => undefined,
       timeoutMs: 300,
       deps: { exec, fetch },

--- a/tests/release/src/worlds/local-workspace/docker.test.ts
+++ b/tests/release/src/worlds/local-workspace/docker.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
+import {
+  dockerInternalUrls,
+  loadServerImage,
+  startDockerStack,
+  type DockerResourceKind,
+  type Exec,
+  type ServerContainerEnv,
+} from "./docker.js";
+import type { ReadinessFetch } from "./processes.js";
+
+function recordingExec(handlers: Record<string, () => { stdout: string; stderr: string }> = {}): {
+  exec: Exec;
+  argv: string[][];
+} {
+  const argv: string[][] = [];
+  const exec: Exec = async (file, args) => {
+    argv.push([file, ...args]);
+    const joined = args.join(" ");
+    for (const [needle, make] of Object.entries(handlers)) {
+      if (joined.includes(needle)) {
+        return make();
+      }
+    }
+    return { stdout: "", stderr: "" };
+  };
+  return { exec, argv };
+}
+
+test("dockerInternalUrls builds run-scoped hostnames matching the container names", () => {
+  const { databaseUrl, redisUrl } = dockerInternalUrls({ project: "plq-run-shard", network: "plq-run-shard-net" });
+  assert.match(databaseUrl, /@plq-run-shard-postgres:5432\/proliferate$/);
+  assert.match(redisUrl, /@?plq-run-shard-redis:6379\/0$/);
+});
+
+test("loadServerImage parses a named loaded image ref", async () => {
+  const { exec } = recordingExec({ load: () => ({ stdout: "Loaded image: proliferate-server:candidate\n", stderr: "" }) });
+  assert.equal(await loadServerImage("/tmp/server.tar", { exec }), "proliferate-server:candidate");
+});
+
+test("loadServerImage falls back to a loaded image ID", async () => {
+  const { exec } = recordingExec({ load: () => ({ stdout: "Loaded image ID: sha256:abcdef\n", stderr: "" }) });
+  assert.equal(await loadServerImage("/tmp/server.tar", { exec }), "sha256:abcdef");
+});
+
+const SERVER_ARTIFACT: MaterializedArtifact = {
+  artifact_id: "server/linux-amd64",
+  version: "1.2.3",
+  sha256: "b".repeat(64),
+  path: "/run/artifacts/server.tar",
+};
+
+const SERVER_ENV: ServerContainerEnv = {
+  SINGLE_ORG_MODE: "true",
+  AGENT_GATEWAY_ENABLED: "true",
+  AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS: "5",
+  AGENT_GATEWAY_LITELLM_BASE_URL: "http://admin",
+  AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "http://public",
+  AGENT_GATEWAY_LITELLM_MASTER_KEY: "sk-master",
+  DATABASE_URL: "postgresql+asyncpg://proliferate:localdev@plq-postgres:5432/proliferate",
+};
+
+test("startDockerStack registers each resource before creating it and verifies readiness", async () => {
+  const { exec, argv } = recordingExec({
+    load: () => ({ stdout: "Loaded image: srv:candidate\n", stderr: "" }),
+    "pg_isready": () => ({ stdout: "accepting connections", stderr: "" }),
+  });
+  const registered: Array<{ kind: DockerResourceKind; providerId: string }> = [];
+  const fetch: ReadinessFetch = async () => ({ ok: true, status: 200, json: async () => ({ version: "1.2.3" }) });
+
+  const running = await startDockerStack({
+    naming: { project: "plq-run-shard", network: "plq-run-shard-net" },
+    ports: { server: 8100, postgres: 8101, redis: 8102 },
+    serverArtifact: SERVER_ARTIFACT,
+    serverEnv: SERVER_ENV,
+    registerCleanup: async (kind, providerId) => {
+      registered.push({ kind, providerId });
+    },
+    deps: { exec, fetch },
+  });
+
+  assert.equal(running.version, "1.2.3");
+  assert.equal(running.imageRef, "srv:candidate");
+
+  // Network registered first (torn down last); server registered after migration.
+  assert.deepEqual(
+    registered.map((entry) => entry.kind),
+    ["docker_network", "postgres_container", "redis_container", "server_container"],
+  );
+
+  // A `docker network create` happened AFTER the network was registered.
+  const networkRegisteredAt = registered.findIndex((entry) => entry.kind === "docker_network");
+  assert.equal(networkRegisteredAt, 0);
+  const ranNetworkCreate = argv.some((cmd) => cmd.includes("network") && cmd.includes("create"));
+  assert.ok(ranNetworkCreate);
+
+  // The migration one-off ran `alembic upgrade head` on the loaded image.
+  const migration = argv.find((cmd) => cmd.includes("alembic"));
+  assert.ok(migration);
+  assert.ok(migration!.includes("--rm"));
+  assert.ok(migration!.includes("srv:candidate"));
+  assert.deepEqual(migration!.slice(-3), ["alembic", "upgrade", "head"]);
+});
+
+test("startDockerStack fails when the server never reports version-bearing health", async () => {
+  const { exec } = recordingExec({
+    load: () => ({ stdout: "Loaded image: srv:candidate\n", stderr: "" }),
+    "pg_isready": () => ({ stdout: "ok", stderr: "" }),
+  });
+  const fetch: ReadinessFetch = async () => {
+    throw new Error("refused");
+  };
+  await assert.rejects(
+    startDockerStack({
+      naming: { project: "plq-r", network: "plq-r-net" },
+      ports: { server: 8100, postgres: 8101, redis: 8102 },
+      serverArtifact: SERVER_ARTIFACT,
+      serverEnv: SERVER_ENV,
+      registerCleanup: async () => undefined,
+      timeoutMs: 300,
+      deps: { exec, fetch },
+    }),
+    /did not become ready/,
+  );
+});

--- a/tests/release/src/worlds/local-workspace/docker.test.ts
+++ b/tests/release/src/worlds/local-workspace/docker.test.ts
@@ -8,6 +8,7 @@ import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.j
 import {
   dockerInternalUrls,
   loadServerImage,
+  removeNetworkWithRetry,
   startDockerStack,
   type DockerResourceKind,
   type Exec,
@@ -144,6 +145,60 @@ test("startDockerStack registers each resource before creating it and verifies r
   } finally {
     await rm(runDir, { recursive: true, force: true });
   }
+});
+
+test("removeNetworkWithRetry retries through transient 'active endpoints' failures while containers detach", async () => {
+  let calls = 0;
+  const exec: Exec = async (_file, args) => {
+    if (args[0] === "network" && args[1] === "rm") {
+      calls += 1;
+      if (calls < 3) {
+        throw new Error(`network plq-run-net has active endpoints`);
+      }
+      return { stdout: "", stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  };
+  const sleeps: number[] = [];
+  await removeNetworkWithRetry(exec, "plq-run-net", async (ms) => {
+    sleeps.push(ms);
+  });
+  assert.equal(calls, 3);
+  // Two retries were needed, so two backoff sleeps happened before success.
+  assert.deepEqual(sleeps, [500, 1000]);
+});
+
+test("removeNetworkWithRetry treats an already-removed network as success without retrying", async () => {
+  let calls = 0;
+  const exec: Exec = async () => {
+    calls += 1;
+    throw new Error("Error: No such network: plq-run-net");
+  };
+  await removeNetworkWithRetry(exec, "plq-run-net", async () => {
+    throw new Error("should not sleep for a not-found network");
+  });
+  assert.equal(calls, 1);
+});
+
+test("removeNetworkWithRetry exhausts its retry budget and throws the last error", async () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  await assert.rejects(
+    removeNetworkWithRetry(
+      async () => {
+        calls += 1;
+        throw new Error("network plq-run-net has active endpoints");
+      },
+      "plq-run-net",
+      async (ms) => {
+        sleeps.push(ms);
+      },
+    ),
+    /active endpoints/,
+  );
+  // 5 backoff delays between 6 attempts (1 initial + 5 retries).
+  assert.equal(calls, 6);
+  assert.deepEqual(sleeps, [500, 1000, 2000, 3000, 3000]);
 });
 
 test("startDockerStack fails when the server never reports version-bearing health", async () => {

--- a/tests/release/src/worlds/local-workspace/docker.test.ts
+++ b/tests/release/src/worlds/local-workspace/docker.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
@@ -76,12 +79,15 @@ test("startDockerStack registers each resource before creating it and verifies r
   });
   const registered: Array<{ kind: DockerResourceKind; providerId: string }> = [];
   const fetch: ReadinessFetch = async () => ({ ok: true, status: 200, json: async () => ({ version: "1.2.3" }) });
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "q1-docker-"));
 
+  try {
   const running = await startDockerStack({
     naming: { project: "plq-run-shard", network: "plq-run-shard-net" },
     ports: { server: 8100, postgres: 8101, redis: 8102 },
     serverArtifact: SERVER_ARTIFACT,
     serverEnv: SERVER_ENV,
+    runDir,
     ...SETUP_TOKEN,
     registerCleanup: async (kind, providerId) => {
       registered.push({ kind, providerId });
@@ -92,6 +98,21 @@ test("startDockerStack registers each resource before creating it and verifies r
   assert.equal(running.version, "1.2.3");
   assert.equal(running.imageRef, "srv:candidate");
 
+  // The master key never appears in `docker run` argv; it is passed via a
+  // mode-0600 `--env-file` in the run dir, registered for cleanup.
+  const secretEnvFilePath = path.join(runDir, "server-secret.env");
+  for (const cmd of argv) {
+    assert.ok(!cmd.some((arg) => arg.includes("sk-master")), `master key leaked into argv: ${cmd.join(" ")}`);
+  }
+  const serverRun = argv.find((cmd) => cmd.includes("--name") && cmd.includes("plq-run-shard-server"));
+  assert.ok(serverRun);
+  assert.ok(serverRun!.includes("--env-file"));
+  assert.equal(serverRun![serverRun!.indexOf("--env-file") + 1], secretEnvFilePath);
+  const envFileBody = await readFile(secretEnvFilePath, "utf8");
+  assert.match(envFileBody, /^AGENT_GATEWAY_LITELLM_MASTER_KEY=sk-master$/m);
+  assert.equal(((await stat(secretEnvFilePath)).mode & 0o777).toString(8), "600");
+  assert.deepEqual(registered[0], { kind: "secret_env_file", providerId: secretEnvFilePath });
+
   // The real first-run setup token is copied out of the running Server via
   // `docker cp` — the world/fixture consumes the real product path, not a bypass.
   const cp = argv.find((cmd) => cmd[0] === "docker" && cmd[1] === "cp");
@@ -99,24 +120,30 @@ test("startDockerStack registers each resource before creating it and verifies r
   assert.equal(cp![2], "plq-run-shard-server:/tmp/proliferate-setup/setup-token");
   assert.equal(cp![3], "/run/setup-token");
 
-  // Network registered first (torn down last); server registered after migration.
+  // Secret env-file registered first (torn down last); network next; server
+  // registered after migration.
   assert.deepEqual(
     registered.map((entry) => entry.kind),
-    ["docker_network", "postgres_container", "redis_container", "server_container"],
+    ["secret_env_file", "docker_network", "postgres_container", "redis_container", "server_container"],
   );
 
   // A `docker network create` happened AFTER the network was registered.
   const networkRegisteredAt = registered.findIndex((entry) => entry.kind === "docker_network");
-  assert.equal(networkRegisteredAt, 0);
+  assert.equal(networkRegisteredAt, 1);
   const ranNetworkCreate = argv.some((cmd) => cmd.includes("network") && cmd.includes("create"));
   assert.ok(ranNetworkCreate);
 
-  // The migration one-off ran `alembic upgrade head` on the loaded image.
+  // The migration one-off ran `alembic upgrade head` on the loaded image, also
+  // via `--env-file` (no secret in argv).
   const migration = argv.find((cmd) => cmd.includes("alembic"));
   assert.ok(migration);
   assert.ok(migration!.includes("--rm"));
+  assert.ok(migration!.includes("--env-file"));
   assert.ok(migration!.includes("srv:candidate"));
   assert.deepEqual(migration!.slice(-3), ["alembic", "upgrade", "head"]);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
 });
 
 test("startDockerStack fails when the server never reports version-bearing health", async () => {
@@ -127,17 +154,23 @@ test("startDockerStack fails when the server never reports version-bearing healt
   const fetch: ReadinessFetch = async () => {
     throw new Error("refused");
   };
-  await assert.rejects(
-    startDockerStack({
-      naming: { project: "plq-r", network: "plq-r-net" },
-      ports: { server: 8100, postgres: 8101, redis: 8102 },
-      serverArtifact: SERVER_ARTIFACT,
-      serverEnv: SERVER_ENV,
-      ...SETUP_TOKEN,
-      registerCleanup: async () => undefined,
-      timeoutMs: 300,
-      deps: { exec, fetch },
-    }),
-    /did not become ready/,
-  );
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "q1-docker-"));
+  try {
+    await assert.rejects(
+      startDockerStack({
+        naming: { project: "plq-r", network: "plq-r-net" },
+        ports: { server: 8100, postgres: 8101, redis: 8102 },
+        serverArtifact: SERVER_ARTIFACT,
+        serverEnv: SERVER_ENV,
+        runDir,
+        ...SETUP_TOKEN,
+        registerCleanup: async () => undefined,
+        timeoutMs: 300,
+        deps: { exec, fetch },
+      }),
+      /did not become ready/,
+    );
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
 });

--- a/tests/release/src/worlds/local-workspace/docker.ts
+++ b/tests/release/src/worlds/local-workspace/docker.ts
@@ -63,6 +63,12 @@ export interface ServerContainerEnv {
   AGENT_GATEWAY_LITELLM_BASE_URL: string;
   AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: string;
   AGENT_GATEWAY_LITELLM_MASTER_KEY: string;
+  /**
+   * Container path the Server writes the first-run setup token plaintext to
+   * (`SETUP_TOKEN_FILE`/`PROLIFERATE_SETUP_TOKEN_FILE`). Bound to a
+   * container-writable path so the real token file is produced and copied out.
+   */
+  SETUP_TOKEN_FILE: string;
   /** Additional required Server settings (DB/Redis URLs, gateway enable flag). */
   [key: string]: string;
 }
@@ -72,6 +78,14 @@ export interface DockerStackOptions {
   ports: DockerPorts;
   serverArtifact: MaterializedArtifact;
   serverEnv: ServerContainerEnv;
+  /**
+   * Container path the Server wrote its first-run setup token to (matches
+   * `serverEnv.SETUP_TOKEN_FILE`); the plaintext is copied out via `docker cp`
+   * after the Server is healthy so the actor fixture can claim /setup for real.
+   */
+  setupTokenContainerPath: string;
+  /** Host path the setup token plaintext is copied to (e.g. `<runDir>/setup-token`). */
+  setupTokenHostPath: string;
   /** Registers each container/network releaser as it is created. */
   registerCleanup: (kind: DockerResourceKind, providerId: string, release: () => Promise<void>) => Promise<void>;
   timeoutMs?: number;
@@ -196,7 +210,53 @@ export async function startDockerStack(options: DockerStackOptions): Promise<Run
   });
   const version = await readServerVersion(baseUrl, fetchImpl);
   log(`server healthy: version=${version}`);
+
+  // The Server minted the real first-run setup token during boot (single-org
+  // mode) and wrote its plaintext to SETUP_TOKEN_FILE inside the container.
+  // Copy it out via the real product artifact — no token is fabricated here.
+  await copySetupToken({
+    exec,
+    serverName,
+    containerPath: options.setupTokenContainerPath,
+    hostPath: options.setupTokenHostPath,
+    timeoutMs,
+    log,
+  });
+
   return { baseUrl, imageRef, version };
+}
+
+/**
+ * Copies the container's first-run setup token plaintext to a host path,
+ * retrying briefly because the boot-time mint (application lifespan) can race
+ * the first successful `/health` on a cold start.
+ */
+async function copySetupToken(params: {
+  exec: Exec;
+  serverName: string;
+  containerPath: string;
+  hostPath: string;
+  timeoutMs: number;
+  log: (message: string) => void;
+}): Promise<void> {
+  const deadline = Date.now() + Math.min(params.timeoutMs, 30_000);
+  let lastError = "not attempted";
+  for (;;) {
+    try {
+      await params.exec("docker", ["cp", `${params.serverName}:${params.containerPath}`, params.hostPath]);
+      params.log(`setup token copied to ${params.hostPath}`);
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Could not copy the Server setup token from ${params.serverName}:${params.containerPath} ` +
+          `to ${params.hostPath}: ${lastError}`,
+      );
+    }
+    await sleep(500);
+  }
 }
 
 /** Runs `alembic upgrade head` as a one-off run of the exact image. */

--- a/tests/release/src/worlds/local-workspace/docker.ts
+++ b/tests/release/src/worlds/local-workspace/docker.ts
@@ -1,0 +1,292 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
+import { waitForHttpReady, type ReadinessFetch } from "./processes.js";
+
+/**
+ * Run-scoped Docker lifecycle for the exact candidate Server plus its fresh
+ * Postgres and Redis (spec "World startup" steps 3–6). Everything is namespaced
+ * by a run-scoped Docker project + network so two concurrent runs never
+ * collide. The Server image is loaded from the exact `docker save` archive; its
+ * running version is verified against the candidate map by the world.
+ *
+ * The Server container env is fixed by the spec:
+ *   - SINGLE_ORG_MODE=true            (mounts `POST /setup`);
+ *   - agent gateway enabled;
+ *   - a short AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS (fast enrollment);
+ *   - AGENT_GATEWAY_LITELLM_* passthrough (base/public/master — the master key
+ *     stays inside the container env, never in evidence).
+ * Migrations run via a separate `alembic upgrade head` one-off run of the same
+ * image (its CMD is uvicorn only).
+ */
+
+/** Injectable exec seam — real `execFile` in production, a fake in unit tests. */
+export type Exec = (
+  file: string,
+  args: readonly string[],
+  options?: { timeoutMs?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface DockerDeps {
+  exec?: Exec;
+  fetch?: ReadinessFetch;
+}
+
+/** Fixed local DB/Redis identities the run-scoped containers are created with;
+ * mirrors the Server's default DSN so the values are familiar. The Server env's
+ * DATABASE_URL/REDBEAT_REDIS_URL (built by the world) must reference these. */
+export const POSTGRES_USER = "proliferate";
+export const POSTGRES_PASSWORD = "localdev";
+export const POSTGRES_DB = "proliferate";
+const POSTGRES_IMAGE = "postgres:16-alpine";
+const REDIS_IMAGE = "redis:7-alpine";
+const SERVER_INTERNAL_PORT = 8000;
+
+export interface DockerNaming {
+  /** Run-scoped compose/project label, e.g. `plq-<run>-<shard>`. */
+  project: string;
+  /** Run-scoped user-defined network name. */
+  network: string;
+}
+
+export interface DockerPorts {
+  /** Host port mapped to the Server container's HTTP port. */
+  server: number;
+  postgres: number;
+  redis: number;
+}
+
+export interface ServerContainerEnv {
+  SINGLE_ORG_MODE: "true";
+  AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS: string;
+  AGENT_GATEWAY_LITELLM_BASE_URL: string;
+  AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: string;
+  AGENT_GATEWAY_LITELLM_MASTER_KEY: string;
+  /** Additional required Server settings (DB/Redis URLs, gateway enable flag). */
+  [key: string]: string;
+}
+
+export interface DockerStackOptions {
+  naming: DockerNaming;
+  ports: DockerPorts;
+  serverArtifact: MaterializedArtifact;
+  serverEnv: ServerContainerEnv;
+  /** Registers each container/network releaser as it is created. */
+  registerCleanup: (kind: DockerResourceKind, providerId: string, release: () => Promise<void>) => Promise<void>;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+  deps?: DockerDeps;
+}
+
+export type DockerResourceKind =
+  | "postgres_container"
+  | "redis_container"
+  | "server_container"
+  | "docker_network";
+
+export interface RunningServer {
+  baseUrl: string;
+  /** Loaded image tag/ref used for the container and the migration one-off. */
+  imageRef: string;
+  /** Reported Server version, verified against the candidate map by the world. */
+  version: string;
+}
+
+/** Container hostnames + connection URLs on the run network (built from naming
+ * so the world can construct the Server's DATABASE_URL/REDBEAT_REDIS_URL). */
+export function dockerInternalUrls(naming: DockerNaming): { databaseUrl: string; redisUrl: string } {
+  const pgHost = `${naming.project}-postgres`;
+  const redisHost = `${naming.project}-redis`;
+  return {
+    databaseUrl: `postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${pgHost}:5432/${POSTGRES_DB}`,
+    redisUrl: `redis://${redisHost}:6379/0`,
+  };
+}
+
+/** Loads the exact Server image archive; returns the local image ref/tag. */
+export async function loadServerImage(archivePath: string, deps: DockerDeps = {}): Promise<string> {
+  const exec = deps.exec ?? defaultExec;
+  const { stdout } = await exec("docker", ["load", "-i", archivePath]);
+  const ref = parseLoadedImageRef(stdout);
+  if (!ref) {
+    throw new Error(`Could not parse a loaded image ref from \`docker load\` output.`);
+  }
+  return ref;
+}
+
+/** Parses `Loaded image: <ref>` or `Loaded image ID: sha256:<hex>`. */
+function parseLoadedImageRef(stdout: string): string | null {
+  const named = stdout.match(/Loaded image:\s*(\S+)/);
+  if (named) {
+    return named[1];
+  }
+  const byId = stdout.match(/Loaded image ID:\s*(\S+)/);
+  return byId ? byId[1] : null;
+}
+
+/**
+ * Brings up the run-scoped network, Postgres, and Redis; runs `alembic upgrade
+ * head` as a one-off of the exact image; then starts the Server container with
+ * the fixed env and waits for bounded readiness. Each resource registers its
+ * cleanup before creation.
+ */
+export async function startDockerStack(options: DockerStackOptions): Promise<RunningServer> {
+  const exec = options.deps?.exec ?? defaultExec;
+  const fetchImpl = options.deps?.fetch;
+  const log = options.log ?? (() => undefined);
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const { naming, ports } = options;
+
+  const imageRef = await loadServerImage(options.serverArtifact.path, options.deps);
+  log(`loaded server image ${imageRef}`);
+
+  // Network first so it is registered first and therefore torn down LAST
+  // (reverse order), after every container that attaches to it.
+  await options.registerCleanup("docker_network", naming.network, () =>
+    ignoreMissing(exec("docker", ["network", "rm", naming.network])),
+  );
+  await exec("docker", ["network", "create", naming.network]);
+
+  const pgName = `${naming.project}-postgres`;
+  await options.registerCleanup("postgres_container", pgName, () =>
+    ignoreMissing(exec("docker", ["rm", "-f", pgName])),
+  );
+  await exec("docker", [
+    "run", "-d", "--name", pgName, "--network", naming.network,
+    "-e", `POSTGRES_USER=${POSTGRES_USER}`,
+    "-e", `POSTGRES_PASSWORD=${POSTGRES_PASSWORD}`,
+    "-e", `POSTGRES_DB=${POSTGRES_DB}`,
+    "-p", `127.0.0.1:${ports.postgres}:5432`,
+    POSTGRES_IMAGE,
+  ]);
+
+  const redisName = `${naming.project}-redis`;
+  await options.registerCleanup("redis_container", redisName, () =>
+    ignoreMissing(exec("docker", ["rm", "-f", redisName])),
+  );
+  await exec("docker", [
+    "run", "-d", "--name", redisName, "--network", naming.network,
+    "-p", `127.0.0.1:${ports.redis}:6379`,
+    REDIS_IMAGE,
+  ]);
+
+  await waitForPostgres(exec, pgName, timeoutMs, log);
+
+  await runMigrations({ imageRef, naming, serverEnv: options.serverEnv, timeoutMs, log, deps: { exec } });
+  log(`migrations applied via ${imageRef}`);
+
+  const serverName = `${naming.project}-server`;
+  await options.registerCleanup("server_container", serverName, () =>
+    ignoreMissing(exec("docker", ["rm", "-f", serverName])),
+  );
+  await exec("docker", [
+    "run", "-d", "--name", serverName, "--network", naming.network,
+    "-p", `127.0.0.1:${ports.server}:${SERVER_INTERNAL_PORT}`,
+    ...envFlags(options.serverEnv),
+    imageRef,
+  ]);
+
+  const baseUrl = `http://127.0.0.1:${ports.server}`;
+  await waitForHttpReady(`${baseUrl}/health`, {
+    timeoutMs,
+    expectOk: (status) => status === 200,
+    log,
+    fetch: fetchImpl,
+  });
+  const version = await readServerVersion(baseUrl, fetchImpl);
+  log(`server healthy: version=${version}`);
+  return { baseUrl, imageRef, version };
+}
+
+/** Runs `alembic upgrade head` as a one-off run of the exact image. */
+export async function runMigrations(params: {
+  imageRef: string;
+  naming: DockerNaming;
+  serverEnv: ServerContainerEnv;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+  deps?: DockerDeps;
+}): Promise<void> {
+  const exec = params.deps?.exec ?? defaultExec;
+  await exec(
+    "docker",
+    [
+      "run", "--rm", "--network", params.naming.network,
+      ...envFlags(params.serverEnv),
+      params.imageRef,
+      "alembic", "upgrade", "head",
+    ],
+    { timeoutMs: params.timeoutMs },
+  );
+}
+
+async function waitForPostgres(
+  exec: Exec,
+  containerName: string,
+  timeoutMs: number,
+  log: (message: string) => void,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "not attempted";
+  while (Date.now() < deadline) {
+    try {
+      await exec("docker", ["exec", containerName, "pg_isready", "-U", POSTGRES_USER]);
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(500);
+  }
+  log(`postgres did not become ready: ${lastError}`);
+  throw new Error(`Postgres (${containerName}) did not become ready within ${timeoutMs}ms.`);
+}
+
+async function readServerVersion(baseUrl: string, fetchImpl?: ReadinessFetch): Promise<string> {
+  const doFetch = fetchImpl ?? ((url: string, init?: { signal?: AbortSignal }) =>
+    fetch(url, init as RequestInit) as unknown as ReturnType<ReadinessFetch>);
+  const response = await doFetch(`${baseUrl}/health`);
+  if (!response.ok) {
+    throw new Error(`Server /health returned HTTP ${response.status} while reading version.`);
+  }
+  const body = (await response.json()) as { version?: unknown };
+  const version = typeof body.version === "string" ? body.version : "";
+  if (!version) {
+    throw new Error("Server /health did not report a version.");
+  }
+  return version;
+}
+
+function envFlags(env: Record<string, string>): string[] {
+  const flags: string[] = [];
+  for (const [key, value] of Object.entries(env)) {
+    flags.push("-e", `${key}=${value}`);
+  }
+  return flags;
+}
+
+async function ignoreMissing(promise: Promise<unknown>): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/no such|not found|is not running/i.test(message)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+const execFileAsync = promisify(execFile);
+
+const defaultExec: Exec = async (file, args, options) => {
+  const { stdout, stderr } = await execFileAsync(file, [...args], {
+    timeout: options?.timeoutMs,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return { stdout: stdout.toString(), stderr: stderr.toString() };
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/release/src/worlds/local-workspace/docker.ts
+++ b/tests/release/src/worlds/local-workspace/docker.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { chmod, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { promisify } from "node:util";
 
 import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
@@ -16,7 +18,9 @@ import { waitForHttpReady, type ReadinessFetch } from "./processes.js";
  *   - agent gateway enabled;
  *   - a short AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS (fast enrollment);
  *   - AGENT_GATEWAY_LITELLM_* passthrough (base/public/master — the master key
- *     stays inside the container env, never in evidence).
+ *     stays inside the container env, never in evidence). Secret-bearing env
+ *     (the master key) is passed via a mode-0600 `--env-file` in the run dir,
+ *     never as `-e KEY=value` argv (which is ps-visible and error-log leakable).
  * Migrations run via a separate `alembic upgrade head` one-off run of the same
  * image (its CMD is uvicorn only).
  */
@@ -79,6 +83,11 @@ export interface DockerStackOptions {
   serverArtifact: MaterializedArtifact;
   serverEnv: ServerContainerEnv;
   /**
+   * Run/shard-scoped directory the mode-0600 secret env-file is written into.
+   * The file is registered for cleanup and removed on teardown.
+   */
+  runDir: string;
+  /**
    * Container path the Server wrote its first-run setup token to (matches
    * `serverEnv.SETUP_TOKEN_FILE`); the plaintext is copied out via `docker cp`
    * after the Server is healthy so the actor fixture can claim /setup for real.
@@ -97,7 +106,11 @@ export type DockerResourceKind =
   | "postgres_container"
   | "redis_container"
   | "server_container"
-  | "docker_network";
+  | "docker_network"
+  | "secret_env_file";
+
+/** Server env keys routed through the `--env-file` (never `-e` argv). */
+const SECRET_ENV_KEYS: readonly string[] = ["AGENT_GATEWAY_LITELLM_MASTER_KEY"];
 
 export interface RunningServer {
   baseUrl: string;
@@ -155,6 +168,16 @@ export async function startDockerStack(options: DockerStackOptions): Promise<Run
   const imageRef = await loadServerImage(options.serverArtifact.path, options.deps);
   log(`loaded server image ${imageRef}`);
 
+  // Secret-bearing Server env (the LiteLLM master key) is written to a
+  // mode-0600 env-file in the run dir and passed via `--env-file`, so it never
+  // appears in `docker run` argv. Registered first (torn down last) and removed
+  // on teardown; the run_directory sweep is the durable backstop.
+  const secretEnvFilePath = path.join(options.runDir, "server-secret.env");
+  await options.registerCleanup("secret_env_file", secretEnvFilePath, () =>
+    rm(secretEnvFilePath, { force: true }),
+  );
+  await writeSecretEnvFile(secretEnvFilePath, options.serverEnv);
+
   // Network first so it is registered first and therefore torn down LAST
   // (reverse order), after every container that attaches to it.
   await options.registerCleanup("docker_network", naming.network, () =>
@@ -187,7 +210,7 @@ export async function startDockerStack(options: DockerStackOptions): Promise<Run
 
   await waitForPostgres(exec, pgName, timeoutMs, log);
 
-  await runMigrations({ imageRef, naming, serverEnv: options.serverEnv, timeoutMs, log, deps: { exec } });
+  await runMigrations({ imageRef, naming, serverEnv: options.serverEnv, secretEnvFilePath, timeoutMs, log, deps: { exec } });
   log(`migrations applied via ${imageRef}`);
 
   const serverName = `${naming.project}-server`;
@@ -197,7 +220,7 @@ export async function startDockerStack(options: DockerStackOptions): Promise<Run
   await exec("docker", [
     "run", "-d", "--name", serverName, "--network", naming.network,
     "-p", `127.0.0.1:${ports.server}:${SERVER_INTERNAL_PORT}`,
-    ...envFlags(options.serverEnv),
+    ...envArgs(options.serverEnv, secretEnvFilePath),
     imageRef,
   ]);
 
@@ -264,6 +287,8 @@ export async function runMigrations(params: {
   imageRef: string;
   naming: DockerNaming;
   serverEnv: ServerContainerEnv;
+  /** Mode-0600 env-file carrying the secret env keys (passed via `--env-file`). */
+  secretEnvFilePath: string;
   timeoutMs?: number;
   log?: (message: string) => void;
   deps?: DockerDeps;
@@ -273,7 +298,7 @@ export async function runMigrations(params: {
     "docker",
     [
       "run", "--rm", "--network", params.naming.network,
-      ...envFlags(params.serverEnv),
+      ...envArgs(params.serverEnv, params.secretEnvFilePath),
       params.imageRef,
       "alembic", "upgrade", "head",
     ],
@@ -317,12 +342,34 @@ async function readServerVersion(baseUrl: string, fetchImpl?: ReadinessFetch): P
   return version;
 }
 
-function envFlags(env: Record<string, string>): string[] {
-  const flags: string[] = [];
+/**
+ * Builds `docker run` env arguments: secret-bearing keys come from a
+ * `--env-file` (so they never appear in argv), every other key stays as
+ * `-e KEY=value`.
+ */
+function envArgs(env: Record<string, string>, secretEnvFilePath: string): string[] {
+  const args: string[] = ["--env-file", secretEnvFilePath];
   for (const [key, value] of Object.entries(env)) {
-    flags.push("-e", `${key}=${value}`);
+    if (SECRET_ENV_KEYS.includes(key)) {
+      continue;
+    }
+    args.push("-e", `${key}=${value}`);
   }
-  return flags;
+  return args;
+}
+
+/**
+ * Writes the secret-bearing Server env keys to a mode-0600 env-file in the run
+ * dir. Docker `--env-file` reads `KEY=value` lines; the master key is a simple
+ * token, so no escaping is required. `chmod` is issued explicitly so the mode is
+ * 0600 even if the path already existed with a looser mode.
+ */
+async function writeSecretEnvFile(filePath: string, env: Record<string, string>): Promise<void> {
+  const lines = SECRET_ENV_KEYS.filter((key) => typeof env[key] === "string").map(
+    (key) => `${key}=${env[key]}`,
+  );
+  await writeFile(filePath, `${lines.join("\n")}\n`, { mode: 0o600 });
+  await chmod(filePath, 0o600);
 }
 
 async function ignoreMissing(promise: Promise<unknown>): Promise<void> {

--- a/tests/release/src/worlds/local-workspace/docker.ts
+++ b/tests/release/src/worlds/local-workspace/docker.ts
@@ -181,7 +181,7 @@ export async function startDockerStack(options: DockerStackOptions): Promise<Run
   // Network first so it is registered first and therefore torn down LAST
   // (reverse order), after every container that attaches to it.
   await options.registerCleanup("docker_network", naming.network, () =>
-    ignoreMissing(exec("docker", ["network", "rm", naming.network])),
+    removeNetworkWithRetry(exec, naming.network),
   );
   await exec("docker", ["network", "create", naming.network]);
 
@@ -382,6 +382,46 @@ async function ignoreMissing(promise: Promise<unknown>): Promise<void> {
     }
     throw error;
   }
+}
+
+/** Backoff schedule for {@link removeNetworkWithRetry}: 5 attempts, ~9.5s total. */
+export const NETWORK_REMOVE_RETRY_DELAYS_MS: readonly number[] = [500, 1000, 2000, 3000, 3000];
+
+/**
+ * Removes the run-scoped Docker network, retrying briefly when removal fails
+ * because a container is still detaching (e.g. `docker rm -f` on the stopping
+ * Postgres container racing the network teardown). Docker reports this as
+ * "has active endpoints" / "network ... is in use". Without the retry, a
+ * transient loss here records a durable cleanup failure for a resource that
+ * would have gone away a moment later.
+ *
+ * `sleepFn` is an injectable seam so unit tests can exercise every retry
+ * without the real ~9.5s backoff.
+ */
+export async function removeNetworkWithRetry(
+  exec: Exec,
+  network: string,
+  sleepFn: (ms: number) => Promise<void> = sleep,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < NETWORK_REMOVE_RETRY_DELAYS_MS.length + 1; attempt += 1) {
+    try {
+      await exec("docker", ["network", "rm", network]);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/no such|not found|is not running/i.test(message)) {
+        return; // Already gone.
+      }
+      lastError = error;
+      const delay = NETWORK_REMOVE_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined) {
+        break; // Out of retries.
+      }
+      await sleepFn(delay);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 const execFileAsync = promisify(execFile);

--- a/tests/release/src/worlds/local-workspace/ports.ts
+++ b/tests/release/src/worlds/local-workspace/ports.ts
@@ -1,0 +1,73 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * The five non-conflicting ports a local world binds (spec "World startup"
+ * step 1). Allocated up front by the candidate builder
+ * (`scripts/ci-cd/build-local-qualification-candidates.mjs`) — `server` and
+ * `anyharness` are baked into the Desktop renderer's build-time VITE_* URLs —
+ * so the world MUST reuse this exact allocation rather than re-probing.
+ *
+ * Kept in this leaf module (fs only, no Playwright/Docker) so both the world
+ * constructor and the CLI (`cli/command.ts`, `cli/run.ts`) can consume it
+ * without pulling in the heavy world graph.
+ */
+export interface LocalWorldPorts {
+  server: number;
+  postgres: number;
+  redis: number;
+  anyharness: number;
+  renderer: number;
+}
+
+/** Filename of the ports sidecar the builder writes next to `candidate-build.json`. */
+export const LOCAL_WORLD_PORTS_FILENAME = "local-world-ports.json";
+
+const PORT_KEYS = ["server", "postgres", "redis", "anyharness", "renderer"] as const;
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value < 65_536;
+}
+
+/** Parses and validates a ports payload; throws on any malformed field. */
+export function parseLocalWorldPorts(raw: unknown, source: string): LocalWorldPorts {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error(`${source}: expected a JSON object of port assignments.`);
+  }
+  const record = raw as Record<string, unknown>;
+  const ports = {} as LocalWorldPorts;
+  for (const key of PORT_KEYS) {
+    const value = record[key];
+    if (!isValidPort(value)) {
+      throw new Error(`${source}: "${key}" must be an integer TCP port (1-65535), got ${JSON.stringify(value)}.`);
+    }
+    ports[key] = value;
+  }
+  return ports;
+}
+
+/**
+ * Reads the run directory's `local-world-ports.json` sidecar. Returns `null`
+ * when the file is absent (a diagnostic run may omit it; the world scenario
+ * then fails closed with a bounded reason), and throws when it exists but is
+ * malformed.
+ */
+export async function readLocalWorldPortsFile(runDir: string): Promise<LocalWorldPorts | null> {
+  const filePath = path.join(runDir, LOCAL_WORLD_PORTS_FILENAME);
+  let text: string;
+  try {
+    text = await readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${filePath}: invalid JSON (${error instanceof Error ? error.message : String(error)}).`);
+  }
+  return parseLocalWorldPorts(parsed, filePath);
+}

--- a/tests/release/src/worlds/local-workspace/processes.test.ts
+++ b/tests/release/src/worlds/local-workspace/processes.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { test } from "node:test";
+
+import {
+  launchAnyharness,
+  launchRendererServer,
+  terminateProcess,
+  waitForHttpReady,
+  type ReadinessFetch,
+  type SpawnLike,
+} from "./processes.js";
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  exitCode: number | null;
+  signalCode: string | null;
+  stderr: EventEmitter;
+  kill(signal?: string): boolean;
+}
+
+function fakeChild(): FakeChild {
+  const emitter = new EventEmitter() as FakeChild;
+  emitter.pid = 4242;
+  emitter.exitCode = null;
+  emitter.signalCode = null;
+  emitter.stderr = new EventEmitter();
+  emitter.kill = (signal = "SIGTERM") => {
+    emitter.signalCode = signal;
+    setImmediate(() => emitter.emit("exit", 0, signal));
+    return true;
+  };
+  return emitter;
+}
+
+function okResponse(body: unknown): { ok: boolean; status: number; json(): Promise<unknown> } {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+test("waitForHttpReady resolves once the endpoint responds OK", async () => {
+  let attempts = 0;
+  const fetch: ReadinessFetch = async () => {
+    attempts += 1;
+    if (attempts < 2) {
+      throw new Error("connection refused");
+    }
+    return okResponse({});
+  };
+  await waitForHttpReady("http://127.0.0.1:1/health", { timeoutMs: 2_000, fetch });
+  assert.equal(attempts, 2);
+});
+
+test("waitForHttpReady rejects on a bounded timeout", async () => {
+  const fetch: ReadinessFetch = async () => {
+    throw new Error("refused");
+  };
+  await assert.rejects(waitForHttpReady("http://127.0.0.1:1/health", { timeoutMs: 300, fetch }), /did not become ready/);
+});
+
+test("terminateProcess SIGTERMs and resolves on exit", async () => {
+  const child = fakeChild();
+  let killed: string | undefined;
+  child.kill = (signal = "SIGTERM") => {
+    killed = signal;
+    setImmediate(() => child.emit("exit", 0, signal));
+    return true;
+  };
+  await terminateProcess(child as unknown as ChildProcess);
+  assert.equal(killed, "SIGTERM");
+});
+
+test("launchAnyharness launches, waits for /health, and returns parsed health", async () => {
+  const child = fakeChild();
+  let spawnedArgs: readonly string[] = [];
+  let spawnedEnv: NodeJS.ProcessEnv = {};
+  const spawn: SpawnLike = (_command, args, options: SpawnOptions) => {
+    spawnedArgs = args;
+    spawnedEnv = options.env ?? {};
+    return child as unknown as ChildProcess;
+  };
+  const fetch: ReadinessFetch = async () =>
+    okResponse({ status: "ok", version: "9.9.9", runtimeHome: "/run/home" });
+
+  const result = await launchAnyharness({
+    binaryPath: "/bin/anyharness",
+    host: "127.0.0.1",
+    port: 5555,
+    runtimeHome: "/run/home",
+    // A caller env carrying a provider secret must be scrubbed out of the child.
+    env: { PATH: "/usr/bin", ANTHROPIC_AUTH_TOKEN: "secret-should-be-dropped" },
+    spawn,
+    fetch,
+  });
+
+  assert.equal(result.health.version, "9.9.9");
+  assert.equal(result.baseUrl, "http://127.0.0.1:5555");
+  assert.deepEqual(spawnedArgs, ["serve", "--host", "127.0.0.1", "--port", "5555", "--runtime-home", "/run/home"]);
+  assert.equal(spawnedEnv.PATH, "/usr/bin");
+  assert.equal(spawnedEnv.ANTHROPIC_AUTH_TOKEN, undefined);
+
+  await result.process.terminate();
+});
+
+test("launchAnyharness fails if the process exits before health", async () => {
+  const child = fakeChild();
+  const spawn: SpawnLike = () => {
+    setImmediate(() => child.emit("exit", 1));
+    return child as unknown as ChildProcess;
+  };
+  const fetch: ReadinessFetch = async () => {
+    throw new Error("refused");
+  };
+  await assert.rejects(
+    launchAnyharness({ binaryPath: "/bin/x", host: "127.0.0.1", port: 5556, runtimeHome: "/h", spawn, fetch }),
+    /exited before becoming healthy/,
+  );
+});
+
+test("launchRendererServer serves and reports readiness", async () => {
+  const child = fakeChild();
+  const spawn: SpawnLike = () => child as unknown as ChildProcess;
+  const fetch: ReadinessFetch = async () => okResponse("<html></html>");
+  const served = await launchRendererServer({
+    rootDir: "/renderer",
+    host: "127.0.0.1",
+    port: 6001,
+    spawn,
+    fetch,
+  });
+  assert.equal(served.baseUrl, "http://127.0.0.1:6001");
+  await served.process.terminate();
+});

--- a/tests/release/src/worlds/local-workspace/processes.test.ts
+++ b/tests/release/src/worlds/local-workspace/processes.test.ts
@@ -117,9 +117,13 @@ test("launchAnyharness fails if the process exits before health", async () => {
   );
 });
 
-test("launchRendererServer serves and reports readiness", async () => {
+test("launchRendererServer serves and reports readiness with a hermetic child env", async () => {
   const child = fakeChild();
-  const spawn: SpawnLike = () => child as unknown as ChildProcess;
+  let spawnedEnv: NodeJS.ProcessEnv = {};
+  const spawn: SpawnLike = (_command, _args, options: SpawnOptions) => {
+    spawnedEnv = options.env ?? {};
+    return child as unknown as ChildProcess;
+  };
   const fetch: ReadinessFetch = async () => okResponse("<html></html>");
   const served = await launchRendererServer({
     rootDir: "/renderer",
@@ -129,5 +133,15 @@ test("launchRendererServer serves and reports readiness", async () => {
     fetch,
   });
   assert.equal(served.baseUrl, "http://127.0.0.1:6001");
+  // Symmetry with AnyHarness: the renderer child env is hermetic — no provider
+  // or gateway credential passes through the guard.
+  for (const key of Object.keys(spawnedEnv)) {
+    const upper = key.toUpperCase();
+    assert.ok(
+      !upper.endsWith("_API_KEY") && !upper.endsWith("_AUTH_TOKEN") &&
+        !upper.endsWith("_MASTER_KEY") && !upper.endsWith("_SECRET"),
+      `renderer child env leaked "${key}"`,
+    );
+  }
   await served.process.terminate();
 });

--- a/tests/release/src/worlds/local-workspace/processes.ts
+++ b/tests/release/src/worlds/local-workspace/processes.ts
@@ -1,0 +1,295 @@
+import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+
+import { candidateChildEnvironment } from "../../artifacts/anyharness-smoke.js";
+
+/**
+ * Bounded host-process launch, readiness, and termination for the two
+ * long-lived local processes this world owns directly: the exact host
+ * AnyHarness binary and the static Desktop-renderer file server (spec "World
+ * startup" steps 7–8, 10). The Docker-managed Server/Postgres/Redis live in
+ * `docker.ts`.
+ *
+ * Every child receives a hermetic environment: no ambient provider credential,
+ * no `ANTHROPIC_AUTH_TOKEN`, and no shared `RELEASE_E2E_GATEWAY_TEST_KEY`
+ * process-env shortcut (spec "The single test cell"). Reuse
+ * `candidateChildEnvironment()` from `../../artifacts/anyharness-smoke.ts` as
+ * the operational-only base.
+ */
+
+/** Injectable process seam — real `spawn` in production, a fake in unit tests. */
+export type SpawnLike = (command: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+
+/** Injectable HTTP readiness seam — real `fetch` in production, fake under test. */
+export type ReadinessFetch = (
+  url: string,
+  init?: { method?: string; signal?: AbortSignal },
+) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+
+/** Env keys that must never reach a candidate child (belt-and-suspenders on top
+ * of the allowlisting `candidateChildEnvironment`). */
+const FORBIDDEN_ENV_KEYS = [
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "AGENT_GATEWAY_MANAGED_ANTHROPIC_API_KEY",
+  "RELEASE_E2E_GATEWAY_TEST_KEY",
+];
+const FORBIDDEN_ENV_SUFFIXES = ["_API_KEY", "_AUTH_TOKEN", "_MASTER_KEY", "_SECRET"];
+
+export interface LaunchedProcess {
+  child: ChildProcess;
+  /** Bounded, reverse-order-safe terminator (SIGTERM → SIGKILL fallback). */
+  terminate(): Promise<void>;
+}
+
+export interface LaunchAnyharnessOptions {
+  /** Absolute path to the materialized AnyHarness binary. */
+  binaryPath: string;
+  host: string;
+  port: number;
+  /** Isolated runtime home (spec: `--runtime-home` flag). */
+  runtimeHome: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+  spawn?: SpawnLike;
+  fetch?: ReadinessFetch;
+}
+
+/** AnyHarness `/health` (camelCase wire shape → snake_case here). */
+export interface AnyharnessHealth {
+  status: string;
+  version: string;
+  runtimeHome: string;
+}
+
+/**
+ * Launches the exact AnyHarness binary with an isolated runtime home and a
+ * hermetic env, waits for bounded `/health` readiness, and returns the process
+ * handle plus the parsed health (version is verified against the candidate map
+ * by the world constructor).
+ */
+export async function launchAnyharness(
+  options: LaunchAnyharnessOptions,
+): Promise<{ process: LaunchedProcess; health: AnyharnessHealth; baseUrl: string }> {
+  const log = options.log ?? (() => undefined);
+  const spawnImpl = options.spawn ?? (nodeSpawn as SpawnLike);
+  const fetchImpl = options.fetch ?? defaultReadinessFetch;
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const baseUrl = `http://${options.host}:${options.port}`;
+
+  const env = assertHermeticEnv(candidateChildEnvironment(options.env ?? process.env));
+  log(`launching anyharness on ${options.host}:${options.port} (runtime home ${options.runtimeHome})`);
+  const child = spawnImpl(
+    options.binaryPath,
+    ["serve", "--host", options.host, "--port", String(options.port), "--runtime-home", options.runtimeHome],
+    { stdio: ["ignore", "ignore", "pipe"], env },
+  );
+  const launched = wrapProcess(child);
+  const stop = new AbortController();
+  try {
+    const exitedEarly = earlyExit(child, "anyharness");
+    // The losing branch of the race stays pending; swallow its late rejection
+    // (e.g. when `terminate()` later fires `exit`) so it is never unhandled.
+    exitedEarly.catch(() => undefined);
+    const health = await Promise.race([
+      pollAnyharnessHealth(baseUrl, timeoutMs, fetchImpl, stop.signal),
+      exitedEarly,
+    ]);
+    if (health.status !== "ok") {
+      throw new Error(`anyharness /health status is "${health.status}", expected "ok".`);
+    }
+    return { process: launched, health, baseUrl };
+  } catch (error) {
+    await launched.terminate();
+    throw error;
+  } finally {
+    // Whichever branch won, cancel the loser's poll loop so no timer lingers.
+    stop.abort();
+  }
+}
+
+export interface LaunchRendererServerOptions {
+  /** Directory of the extracted Desktop renderer dist. */
+  rootDir: string;
+  host: string;
+  port: number;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+  spawn?: SpawnLike;
+  fetch?: ReadinessFetch;
+}
+
+/** Inline Node static file server: SPA-fallback to index.html, path-escape
+ * guarded, served over the allocated port. Kept inline (no extra file) so the
+ * whole renderer server is one hermetic child process. */
+const STATIC_SERVER_SOURCE = `
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const root = path.resolve(process.argv[1]);
+const host = process.argv[2];
+const port = Number(process.argv[3]);
+const TYPES = { ".html": "text/html", ".js": "text/javascript", ".mjs": "text/javascript", ".css": "text/css", ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png", ".ico": "image/x-icon", ".woff2": "font/woff2", ".woff": "font/woff", ".map": "application/json", ".wasm": "application/wasm" };
+const server = http.createServer((req, res) => {
+  try {
+    let rel = decodeURIComponent((req.url || "/").split("?")[0]);
+    if (rel.endsWith("/")) rel += "index.html";
+    let file = path.join(root, rel);
+    if (!file.startsWith(root)) { res.statusCode = 403; return res.end("forbidden"); }
+    if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) file = path.join(root, "index.html");
+    const body = fs.readFileSync(file);
+    res.setHeader("content-type", TYPES[path.extname(file)] || "application/octet-stream");
+    res.end(body);
+  } catch (e) { res.statusCode = 500; res.end("error"); }
+});
+server.listen(port, host);
+`;
+
+/**
+ * Serves the extracted renderer bytes over a bounded static file server on the
+ * allocated port and waits until the root document is reachable.
+ */
+export async function launchRendererServer(
+  options: LaunchRendererServerOptions,
+): Promise<{ process: LaunchedProcess; baseUrl: string }> {
+  const log = options.log ?? (() => undefined);
+  const spawnImpl = options.spawn ?? (nodeSpawn as SpawnLike);
+  const fetchImpl = options.fetch ?? defaultReadinessFetch;
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const baseUrl = `http://${options.host}:${options.port}`;
+
+  log(`serving renderer from ${options.rootDir} on ${options.host}:${options.port}`);
+  const child = spawnImpl(
+    process.execPath,
+    ["-e", STATIC_SERVER_SOURCE, options.rootDir, options.host, String(options.port)],
+    { stdio: ["ignore", "ignore", "pipe"], env: candidateChildEnvironment() },
+  );
+  const launched = wrapProcess(child);
+  const stop = new AbortController();
+  try {
+    const exitedEarly = earlyExit(child, "renderer server");
+    exitedEarly.catch(() => undefined);
+    await Promise.race([
+      waitForHttpReady(baseUrl, { timeoutMs, log, fetch: fetchImpl, signal: stop.signal }),
+      exitedEarly,
+    ]);
+    return { process: launched, baseUrl };
+  } catch (error) {
+    await launched.terminate();
+    throw error;
+  } finally {
+    stop.abort();
+  }
+}
+
+/** Polls an HTTP URL until it responds OK or the bounded deadline elapses. */
+export async function waitForHttpReady(
+  url: string,
+  options: {
+    timeoutMs: number;
+    expectOk?: (status: number) => boolean;
+    log?: (m: string) => void;
+    fetch?: ReadinessFetch;
+    /** Cancels the poll loop early when the caller's race is decided elsewhere. */
+    signal?: AbortSignal;
+  },
+): Promise<void> {
+  const fetchImpl = options.fetch ?? defaultReadinessFetch;
+  const expectOk = options.expectOk ?? ((status) => status >= 200 && status < 500);
+  const deadline = Date.now() + options.timeoutMs;
+  let lastError = "not attempted";
+  while (Date.now() < deadline && !options.signal?.aborted) {
+    try {
+      const response = await fetchImpl(url, { signal: AbortSignal.timeout(2_000) });
+      if (expectOk(response.status)) {
+        return;
+      }
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(200);
+  }
+  if (options.signal?.aborted) {
+    return; // Superseded by another branch; not a readiness failure.
+  }
+  throw new Error(`${url} did not become ready within ${options.timeoutMs}ms (last: ${lastError})`);
+}
+
+/** SIGTERM with a bounded grace period, then SIGKILL; resolves on exit. */
+export async function terminateProcess(child: ChildProcess, graceMs = 5_000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.kill("SIGTERM");
+  const graceful = await Promise.race([exited.then(() => true), sleep(graceMs).then(() => false)]);
+  if (!graceful) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+function wrapProcess(child: ChildProcess): LaunchedProcess {
+  return { child, terminate: () => terminateProcess(child) };
+}
+
+function earlyExit(child: ChildProcess, label: string): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    child.on("exit", (code) => reject(new Error(`${label} exited before becoming healthy (code ${code})`)));
+    child.on("error", (error) => reject(new Error(`${label} failed to launch: ${error.message}`)));
+  });
+}
+
+async function pollAnyharnessHealth(
+  baseUrl: string,
+  timeoutMs: number,
+  fetchImpl: ReadinessFetch,
+  signal?: AbortSignal,
+): Promise<AnyharnessHealth> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "not attempted";
+  while (Date.now() < deadline) {
+    if (signal?.aborted) {
+      // Superseded (the process-exit branch won); park forever without a timer
+      // so this loser never rejects and never holds the event loop open.
+      return new Promise<AnyharnessHealth>(() => undefined);
+    }
+    try {
+      const response = await fetchImpl(`${baseUrl}/health`, { signal: AbortSignal.timeout(2_000) });
+      if (response.ok) {
+        // Wire shape is the camelCase HealthResponse contract
+        // (anyharness-contract/src/v1/health.rs, rename_all = "camelCase").
+        const body = (await response.json()) as { status?: unknown; version?: unknown; runtimeHome?: unknown };
+        return {
+          status: String(body.status ?? ""),
+          version: String(body.version ?? ""),
+          runtimeHome: String(body.runtimeHome ?? ""),
+        };
+      }
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(250);
+  }
+  throw new Error(`anyharness /health did not become ready within ${timeoutMs}ms (last: ${lastError})`);
+}
+
+/** Rejects an env that carries any provider/gateway credential. */
+function assertHermeticEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  for (const key of Object.keys(env)) {
+    const upper = key.toUpperCase();
+    if (FORBIDDEN_ENV_KEYS.includes(upper) || FORBIDDEN_ENV_SUFFIXES.some((suffix) => upper.endsWith(suffix))) {
+      throw new Error(`Hermetic candidate env must not contain "${key}".`);
+    }
+  }
+  return env;
+}
+
+const defaultReadinessFetch: ReadinessFetch = (url, init) =>
+  fetch(url, init as RequestInit) as unknown as ReturnType<ReadinessFetch>;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/release/src/worlds/local-workspace/processes.ts
+++ b/tests/release/src/worlds/local-workspace/processes.ts
@@ -162,7 +162,9 @@ export async function launchRendererServer(
   const child = spawnImpl(
     process.execPath,
     ["-e", STATIC_SERVER_SOURCE, options.rootDir, options.host, String(options.port)],
-    { stdio: ["ignore", "ignore", "pipe"], env: candidateChildEnvironment() },
+    // Same hermetic guard as the AnyHarness child (symmetry): the renderer file
+    // server must never inherit a provider/gateway credential either.
+    { stdio: ["ignore", "ignore", "pipe"], env: assertHermeticEnv(candidateChildEnvironment()) },
   );
   const launched = wrapProcess(child);
   const stop = new AbortController();

--- a/tests/release/src/worlds/local-workspace/renderer.test.ts
+++ b/tests/release/src/worlds/local-workspace/renderer.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
+import type { Exec } from "./docker.js";
+import type { ReadinessFetch, SpawnLike } from "./processes.js";
+import { extractRenderer, launchChromium, serveRenderer, type ChromiumLauncher } from "./renderer.js";
+
+const RENDERER_ARTIFACT: MaterializedArtifact = {
+  artifact_id: "desktop-renderer/browser",
+  version: "0.1.0",
+  sha256: "c".repeat(64),
+  path: "/run/artifacts/renderer.tar",
+};
+
+test("extractRenderer untars the archive into the run-owned dest and returns the identity", async () => {
+  const destDir = path.join(await mkdtemp(path.join(os.tmpdir(), "renderer-extract-")), "renderer");
+  try {
+    const calls: string[][] = [];
+    const exec: Exec = async (file, args) => {
+      calls.push([file, ...args]);
+      return { stdout: "", stderr: "" };
+    };
+    const extracted = await extractRenderer(RENDERER_ARTIFACT, destDir, { exec });
+    assert.equal(extracted.rootDir, destDir);
+    assert.equal(extracted.artifact.sha256, RENDERER_ARTIFACT.sha256);
+    assert.deepEqual(calls[0], ["tar", "-xf", "/run/artifacts/renderer.tar", "-C", destDir]);
+  } finally {
+    await rm(path.dirname(destDir), { recursive: true, force: true });
+  }
+});
+
+test("serveRenderer serves the extracted bytes and reports its base URL", async () => {
+  const child = new EventEmitter() as unknown as ChildProcess;
+  Object.assign(child, {
+    pid: 1,
+    exitCode: null,
+    signalCode: null,
+    stderr: new EventEmitter(),
+    kill: () => true,
+  });
+  const spawn: SpawnLike = () => child;
+  const fetch: ReadinessFetch = async () => ({ ok: true, status: 200, json: async () => ({}) });
+  const served = await serveRenderer({
+    extracted: { rootDir: "/run/renderer", artifact: RENDERER_ARTIFACT },
+    host: "127.0.0.1",
+    port: 6100,
+    spawn,
+    fetch,
+  });
+  assert.equal(served.baseUrl, "http://127.0.0.1:6100");
+});
+
+test("launchChromium delegates to the injected launcher", async () => {
+  let launchedHeadless: boolean | undefined;
+  const fakeBrowser = { close: async () => undefined } as unknown as Awaited<ReturnType<ChromiumLauncher>>;
+  const launcher: ChromiumLauncher = async (options) => {
+    launchedHeadless = options.headless;
+    return fakeBrowser;
+  };
+  const browser = await launchChromium({ launcher });
+  assert.equal(launchedHeadless, true);
+  assert.equal(browser, fakeBrowser);
+});

--- a/tests/release/src/worlds/local-workspace/renderer.ts
+++ b/tests/release/src/worlds/local-workspace/renderer.ts
@@ -1,0 +1,100 @@
+import { mkdir } from "node:fs/promises";
+
+import { chromium, type Browser } from "playwright";
+
+import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
+import type { Exec } from "./docker.js";
+import { launchRendererServer, type LaunchedProcess, type ReadinessFetch, type SpawnLike } from "./processes.js";
+
+/**
+ * Extracts and serves the exact Desktop renderer archive and launches the
+ * shared Chromium browser via Playwright (spec "World startup" steps 8–9,
+ * "productPage"). The renderer was built with THIS run's allocated
+ * `VITE_PROLIFERATE_API_BASE_URL` and `VITE_ANYHARNESS_DEV_URL` (injected at
+ * build time by the candidate builder), so serving the extracted bytes is all
+ * the world does — no runtime URL rewriting.
+ *
+ * One `Browser` is shared by the world; each actor/scenario gets an isolated
+ * `BrowserContext` (owned by the product-page fixture). We drive plain
+ * `playwright` from our own runner — the `@playwright/test` runner is NOT
+ * adopted; scenarios stay in the node:test/registry model.
+ *
+ * Archive layout contract: the candidate builder packs the CONTENTS of
+ * `apps/desktop/dist` at the archive root (e.g. `tar -czf renderer.tar -C
+ * apps/desktop/dist .`), so `index.html` lands directly under `destDir`.
+ */
+
+export interface ExtractedRenderer {
+  /** Directory the archive was extracted into (run-owned). */
+  rootDir: string;
+  /** The renderer artifact identity (archive hash is its provable identity). */
+  artifact: MaterializedArtifact;
+}
+
+/** Extracts the renderer dist archive into run-owned storage. */
+export async function extractRenderer(
+  artifact: MaterializedArtifact,
+  destDir: string,
+  deps: { exec?: Exec } = {},
+): Promise<ExtractedRenderer> {
+  const exec = deps.exec ?? defaultExec;
+  await mkdir(destDir, { recursive: true });
+  await exec("tar", ["-xf", artifact.path, "-C", destDir]);
+  return { rootDir: destDir, artifact };
+}
+
+export interface ServedRenderer {
+  baseUrl: string;
+  process: LaunchedProcess;
+}
+
+/** Serves the extracted renderer bytes on the allocated port. */
+export async function serveRenderer(params: {
+  extracted: ExtractedRenderer;
+  host: string;
+  port: number;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+  spawn?: SpawnLike;
+  fetch?: ReadinessFetch;
+}): Promise<ServedRenderer> {
+  const { process: served, baseUrl } = await launchRendererServer({
+    rootDir: params.extracted.rootDir,
+    host: params.host,
+    port: params.port,
+    timeoutMs: params.timeoutMs,
+    log: params.log,
+    spawn: params.spawn,
+    fetch: params.fetch,
+  });
+  return { baseUrl, process: served };
+}
+
+/** Injectable Chromium launcher — real Playwright in production, fake in tests. */
+export type ChromiumLauncher = (options: { headless: boolean }) => Promise<Browser>;
+
+/**
+ * Launches a single headless Chromium instance for the world. Callers create
+ * per-actor isolated contexts against it; the world registers browser teardown.
+ */
+export async function launchChromium(options?: {
+  headless?: boolean;
+  log?: (message: string) => void;
+  launcher?: ChromiumLauncher;
+}): Promise<Browser> {
+  const launcher = options?.launcher ?? ((opts) => chromium.launch(opts));
+  const log = options?.log ?? (() => undefined);
+  log("launching Chromium via Playwright");
+  return launcher({ headless: options?.headless ?? true });
+}
+
+const defaultExec: Exec = async (file, args, execOptions) => {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const run = promisify(execFile);
+  const { stdout, stderr } = await run(file, [...args], {
+    timeout: execOptions?.timeoutMs,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return { stdout: stdout.toString(), stderr: stderr.toString() };
+};

--- a/tests/release/src/worlds/local-workspace/world.test.ts
+++ b/tests/release/src/worlds/local-workspace/world.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import type { Browser } from "playwright";
+
+import type { CandidateBuildArtifactV1, CandidateBuildMapV1 } from "../../artifacts/build-map.js";
+import type { RunIdentityV1 } from "../../runner/identity.js";
+import type { FetchLike, HttpResponseLike } from "../../services/qualification-litellm.js";
+import { CLEANUP_LEDGER_FILENAME } from "./cleanup-ledger.js";
+import type { Exec } from "./docker.js";
+import type { ReadinessFetch, SpawnLike } from "./processes.js";
+import type { ChromiumLauncher } from "./renderer.js";
+import { constructLocalWorld, type LocalWorldDeps, type LocalWorldPorts } from "./world.js";
+
+const RUN: RunIdentityV1 = {
+  run_id: "local-run-1",
+  shard_id: "shard-0",
+  attempt: 1,
+  source_sha: "0".repeat(40),
+  origin: { kind: "local", github_run_id: null, github_job: null },
+};
+
+const PORTS: LocalWorldPorts = { server: 8100, postgres: 8101, redis: 8102, anyharness: 8103, renderer: 8104 };
+
+const SERVER_VERSION = "1.2.3";
+const ANYHARNESS_VERSION = "9.9.9";
+
+async function fileArtifact(dir: string, id: string, version: string, content: string): Promise<CandidateBuildArtifactV1> {
+  const filePath = path.join(dir, encodeURIComponent(id));
+  await writeFile(filePath, content);
+  return {
+    artifact_id: id,
+    version,
+    sha256: createHash("sha256").update(content).digest("hex"),
+    locator: { kind: "local_file", path: filePath },
+  };
+}
+
+async function buildMap(dir: string): Promise<CandidateBuildMapV1> {
+  return {
+    schema_version: 1,
+    kind: "proliferate.candidate-build",
+    source_sha: "0".repeat(40),
+    artifacts: [
+      await fileArtifact(dir, "server/linux-amd64", SERVER_VERSION, "server-tar-bytes"),
+      await fileArtifact(dir, "anyharness/host-target", ANYHARNESS_VERSION, "anyharness-bytes"),
+      await fileArtifact(dir, "desktop-renderer/browser", "0.1.0", "renderer-tar-bytes"),
+    ],
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): HttpResponseLike {
+  return { ok: status >= 200 && status < 300, status, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+/** LiteLLM fake: preflight (liveness + models) and subject deletion. */
+function litellmFetch(): FetchLike {
+  return async (url) => {
+    if (url.includes("/health/liveliness")) return jsonResponse({ status: "connected" });
+    if (url.includes("/v1/models")) return jsonResponse({ data: [{ id: "claude-haiku-4-5" }] });
+    if (url.includes("/delete")) return jsonResponse({});
+    return jsonResponse({ error: { message: "unrouted" } }, 404);
+  };
+}
+
+/** Readiness fake for server, anyharness, and renderer, routed by port. */
+function readinessFetch(anyharnessVersion = ANYHARNESS_VERSION): ReadinessFetch {
+  return async (url) => {
+    if (url.includes(`:${PORTS.server}/health`)) {
+      return { ok: true, status: 200, json: async () => ({ status: "ok", version: SERVER_VERSION }) };
+    }
+    if (url.includes(`:${PORTS.anyharness}/health`)) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "ok", version: anyharnessVersion, runtimeHome: "/isolated" }),
+      };
+    }
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+}
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  exitCode: number | null;
+  signalCode: string | null;
+  stderr: EventEmitter;
+  kill(signal?: string): boolean;
+}
+
+function fakeSpawn(state: { killed: number }): SpawnLike {
+  return (_command, _args, _options: SpawnOptions) => {
+    const child = new EventEmitter() as FakeChild;
+    child.pid = 1000 + state.killed;
+    child.exitCode = null;
+    child.signalCode = null;
+    child.stderr = new EventEmitter();
+    child.kill = (signal = "SIGTERM") => {
+      state.killed += 1;
+      child.signalCode = signal;
+      setImmediate(() => child.emit("exit", 0, signal));
+      return true;
+    };
+    return child as unknown as ChildProcess;
+  };
+}
+
+function fakeExec(argv: string[][]): Exec {
+  return async (file, args) => {
+    argv.push([file, ...args]);
+    const joined = args.join(" ");
+    if (joined.includes("load")) return { stdout: "Loaded image: srv:candidate\n", stderr: "" };
+    if (joined.includes("pg_isready")) return { stdout: "accepting connections", stderr: "" };
+    return { stdout: "", stderr: "" };
+  };
+}
+
+function fakeChromium(state: { closed: boolean }): ChromiumLauncher {
+  return async () => ({ close: async () => { state.closed = true; } }) as unknown as Browser;
+}
+
+interface Harness {
+  deps: LocalWorldDeps;
+  argv: string[][];
+  spawnState: { killed: number };
+  browserState: { closed: boolean };
+}
+
+function harness(anyharnessVersion = ANYHARNESS_VERSION): Harness {
+  const argv: string[][] = [];
+  const spawnState = { killed: 0 };
+  const browserState = { closed: false };
+  return {
+    argv,
+    spawnState,
+    browserState,
+    deps: {
+      litellmFetch: litellmFetch(),
+      dockerExec: fakeExec(argv),
+      readinessFetch: readinessFetch(anyharnessVersion),
+      spawn: fakeSpawn(spawnState),
+      extractExec: async () => ({ stdout: "", stderr: "" }),
+      chromiumLauncher: fakeChromium(browserState),
+    },
+  };
+}
+
+test("constructLocalWorld runs the ordered startup and returns a ready handle", async () => {
+  const src = await mkdtemp(path.join(os.tmpdir(), "world-src-"));
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "world-run-"));
+  try {
+    const map = await buildMap(src);
+    const h = harness();
+    const world = await constructLocalWorld({ run: RUN, map, litellm: LITELLM, runDir, ports: PORTS, deps: h.deps });
+
+    assert.equal(world.kind, "local-workspace");
+    assert.equal(world.artifacts.server.version, SERVER_VERSION);
+    assert.equal(world.artifacts.anyharness.version, ANYHARNESS_VERSION);
+    assert.equal(world.api.baseUrl, `http://127.0.0.1:${PORTS.server}`);
+    assert.equal(world.runtime.baseUrl, `http://127.0.0.1:${PORTS.anyharness}`);
+    assert.equal(world.renderer.baseUrl, `http://127.0.0.1:${PORTS.renderer}`);
+    // Re-hashed materialized copies live under the run dir, marked executable.
+    await access(world.artifacts.anyharness.path);
+    // Durable ledger written.
+    await access(path.join(runDir, CLEANUP_LEDGER_FILENAME));
+
+    // A fresh actor enrolled for cleanup, then a full green teardown.
+    await world.trackActorSubjects!({
+      userId: "u1",
+      enrollmentId: "e1",
+      teamId: "team_1",
+      litellmUserId: "user-u1",
+      keyAlias: "vk-user-u1-e1",
+      tokenId: "tok",
+      tokenIdHash: "hash",
+    });
+    const evidence = await world.close();
+    assert.equal(evidence.failed, 0);
+    assert.equal(evidence.virtualKeyDeleted, true);
+    assert.equal(evidence.litellmSubjectsDeleted, true);
+    assert.equal(evidence.browserClosed, true);
+    assert.equal(evidence.processesStopped, true);
+    assert.equal(evidence.containersRemoved, true);
+    assert.equal(evidence.localPathsRemoved, true);
+    assert.equal(h.browserState.closed, true);
+  } finally {
+    await rm(src, { recursive: true, force: true });
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+const LITELLM = { adminBaseUrl: "http://admin", publicBaseUrl: "http://public", masterKey: "sk-master" };
+
+test("a version mismatch fails startup and runs registered cleanup", async () => {
+  const src = await mkdtemp(path.join(os.tmpdir(), "world-src-"));
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "world-run-"));
+  try {
+    const map = await buildMap(src);
+    const h = harness("0.0.0-wrong");
+    await assert.rejects(
+      constructLocalWorld({ run: RUN, map, litellm: LITELLM, runDir, ports: PORTS, deps: h.deps }),
+      /AnyHarness reported version "0.0.0-wrong" does not match/,
+    );
+    // Cleanup ran: the launched anyharness process was terminated and the
+    // containers were removed.
+    assert.ok(h.spawnState.killed >= 1);
+    assert.ok(h.argv.some((cmd) => cmd.includes("rm") || (cmd.includes("network") && cmd.includes("rm"))));
+  } finally {
+    await rm(src, { recursive: true, force: true });
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("an invalid map starts no world (no preflight, no docker, no ledger)", async () => {
+  const src = await mkdtemp(path.join(os.tmpdir(), "world-src-"));
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "world-run-"));
+  try {
+    const map = await buildMap(src);
+    map.artifacts.push({
+      artifact_id: "unexpected/extra",
+      version: "1",
+      sha256: "a".repeat(64),
+      locator: { kind: "local_file", path: map.artifacts[0].locator.path },
+    });
+    const h = harness();
+    let litellmCalled = false;
+    h.deps.litellmFetch = async (url) => {
+      litellmCalled = true;
+      return jsonResponse({});
+    };
+    await assert.rejects(
+      constructLocalWorld({ run: RUN, map, litellm: LITELLM, runDir, ports: PORTS, deps: h.deps }),
+      /unexpected artifact/,
+    );
+    assert.equal(litellmCalled, false); // preflight never ran
+    assert.equal(h.argv.length, 0); // docker never touched
+    await assert.rejects(access(path.join(runDir, CLEANUP_LEDGER_FILENAME))); // no ledger
+  } finally {
+    await rm(src, { recursive: true, force: true });
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("distinct runs get distinct Docker networks (isolation by run identity)", async () => {
+  const src = await mkdtemp(path.join(os.tmpdir(), "world-src-"));
+  const runDirA = await mkdtemp(path.join(os.tmpdir(), "world-a-"));
+  const runDirB = await mkdtemp(path.join(os.tmpdir(), "world-b-"));
+  try {
+    const map = await buildMap(src);
+    const a = harness();
+    const b = harness();
+    const worldA = await constructLocalWorld({ run: RUN, map, litellm: LITELLM, runDir: runDirA, ports: PORTS, deps: a.deps });
+    const worldB = await constructLocalWorld({
+      run: { ...RUN, run_id: "local-run-2" },
+      map,
+      litellm: LITELLM,
+      runDir: runDirB,
+      ports: PORTS,
+      deps: b.deps,
+    });
+    const netA = a.argv.find((cmd) => cmd.includes("network") && cmd.includes("create"))?.at(-1);
+    const netB = b.argv.find((cmd) => cmd.includes("network") && cmd.includes("create"))?.at(-1);
+    assert.ok(netA && netB && netA !== netB);
+    await worldA.close();
+    await worldB.close();
+  } finally {
+    await rm(src, { recursive: true, force: true });
+    await rm(runDirA, { recursive: true, force: true });
+    await rm(runDirB, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/worlds/local-workspace/world.test.ts
+++ b/tests/release/src/worlds/local-workspace/world.test.ts
@@ -169,6 +169,11 @@ test("constructLocalWorld runs the ordered startup and returns a ready handle", 
     await access(world.artifacts.anyharness.path);
     // Durable ledger written.
     await access(path.join(runDir, CLEANUP_LEDGER_FILENAME));
+    // The real first-run setup token is copied out of the Server container to
+    // <runDir>/setup-token (consumed by the actor fixture's real /setup claim).
+    const cp = h.argv.find((cmd) => cmd[0] === "docker" && cmd[1] === "cp");
+    assert.ok(cp, "expected a docker cp of the setup token");
+    assert.equal(cp!.at(-1), path.join(runDir, "setup-token"));
 
     // A fresh actor enrolled for cleanup, then a full green teardown.
     await world.trackActorSubjects!({

--- a/tests/release/src/worlds/local-workspace/world.ts
+++ b/tests/release/src/worlds/local-workspace/world.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
@@ -34,7 +35,22 @@ import {
   type ServerContainerEnv,
 } from "./docker.js";
 import { launchAnyharness, type ReadinessFetch, type SpawnLike } from "./processes.js";
+import type { LocalWorldPorts } from "./ports.js";
 import { extractRenderer, launchChromium, serveRenderer, type ChromiumLauncher } from "./renderer.js";
+
+export type { LocalWorldPorts } from "./ports.js";
+
+/**
+ * Container path the candidate Server writes its plaintext first-run setup
+ * token to (`SETUP_TOKEN_FILE`, see `server/proliferate/config.py`). Set to a
+ * container-writable path (not the packaged default `/var/lib/...`, which the
+ * image's runtime user cannot create) so the world can copy the token out to
+ * `<runDir>/setup-token` for the actor fixture's real `/setup` claim.
+ */
+export const SERVER_SETUP_TOKEN_CONTAINER_PATH = "/tmp/proliferate-setup/setup-token";
+
+/** Host filename the setup token is copied to under the run directory. */
+export const SETUP_TOKEN_FILENAME = "setup-token";
 
 /**
  * The reusable local-world constructor (spec "Local-world contract"). It
@@ -127,14 +143,6 @@ export interface ConstructLocalWorldOptions {
   deps?: LocalWorldDeps;
 }
 
-export interface LocalWorldPorts {
-  server: number;
-  postgres: number;
-  redis: number;
-  anyharness: number;
-  renderer: number;
-}
-
 export interface LocalWorldDeps {
   litellmFetch?: FetchLike;
   dockerExec?: Exec;
@@ -223,12 +231,19 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
     // Steps 3–6: run-scoped Docker network + Postgres + Redis + migrations +
     // Server (gateway enabled, SINGLE_ORG_MODE, short backfill interval).
     const naming = dockerNaming(options.run.run_id, options.run.shard_id);
-    const serverEnv = buildServerEnv(naming, options.litellm);
+    const serverEnv = buildServerEnv(naming, options.litellm, options.ports.renderer);
+    const setupTokenHostPath = path.join(runDir, SETUP_TOKEN_FILENAME);
     const server = await startDockerStack({
       naming,
       ports: { server: options.ports.server, postgres: options.ports.postgres, redis: options.ports.redis },
       serverArtifact,
       serverEnv,
+      // The real Server mints the first-run token at boot and writes the
+      // plaintext to SETUP_TOKEN_FILE inside the container; the world copies it
+      // out to <runDir>/setup-token so the actor fixture claims through the real
+      // /setup path (no bypass).
+      setupTokenContainerPath: SERVER_SETUP_TOKEN_CONTAINER_PATH,
+      setupTokenHostPath,
       registerCleanup: (kind: DockerResourceKind, providerId, release) => register(kind, providerId, release),
       timeoutMs,
       log,
@@ -351,15 +366,36 @@ function dockerNaming(runId: string, shardId: string): DockerNaming {
   return { project, network: `${project}-net` };
 }
 
-function buildServerEnv(naming: DockerNaming, litellm: QualificationLiteLlmConfig): ServerContainerEnv {
+function buildServerEnv(
+  naming: DockerNaming,
+  litellm: QualificationLiteLlmConfig,
+  rendererPort: number,
+): ServerContainerEnv {
   const { databaseUrl, redisUrl } = dockerInternalUrls(naming);
   return {
     SINGLE_ORG_MODE: "true",
     AGENT_GATEWAY_ENABLED: "true",
+    // The renderer is served over http on its own ephemeral port (in production
+    // the Desktop app is a Tauri custom-scheme origin the default list covers).
+    // Allow that exact origin so the browser's cross-origin calls to the Server
+    // are not blocked by CORS.
+    CORS_ALLOW_ORIGINS: `http://127.0.0.1:${rendererPort},http://localhost:${rendererPort}`,
     AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS: "5",
     AGENT_GATEWAY_LITELLM_BASE_URL: litellm.adminBaseUrl,
     AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: litellm.publicBaseUrl,
     AGENT_GATEWAY_LITELLM_MASTER_KEY: litellm.masterKey,
+    // The candidate Server runs in production posture (debug=False), which
+    // requires these instance secrets to be set to non-default values (see
+    // server/proliferate/config.py `validate_secrets_in_production`). Fresh
+    // run-scoped random values keep the exact production posture rather than
+    // flipping DEBUG on. Both the migration one-off and the Server container
+    // build Settings, so both consume this same env.
+    JWT_SECRET: randomBytes(32).toString("hex"),
+    CLOUD_SECRET_KEY: randomBytes(32).toString("hex"),
+    // Container-writable token path so the real first-run token file is
+    // produced somewhere the image's runtime user can create and the world can
+    // copy out (the packaged /var/lib default is not runtime-writable).
+    SETUP_TOKEN_FILE: SERVER_SETUP_TOKEN_CONTAINER_PATH,
     DATABASE_URL: databaseUrl,
     REDBEAT_REDIS_URL: redisUrl,
   };

--- a/tests/release/src/worlds/local-workspace/world.ts
+++ b/tests/release/src/worlds/local-workspace/world.ts
@@ -1,0 +1,374 @@
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+import type { Browser } from "playwright";
+
+import type { CandidateBuildMapV1 } from "../../artifacts/build-map.js";
+import {
+  resolveLocalCandidateSet,
+  type MaterializedArtifact,
+} from "../../artifacts/local-candidate-set.js";
+import { materializeLocalArtifact } from "../../artifacts/materialize-local.js";
+import { ApiClient } from "../../fixtures/http.js";
+import { LocalRuntimeClient } from "../../fixtures/local-runtime.js";
+import type { RunIdentityV1 } from "../../runner/identity.js";
+import {
+  QualificationLiteLlmController,
+  type ActorKeyIdentity,
+  type ActorSubjectsDeletion,
+  type FetchLike,
+  type QualificationLiteLlmConfig,
+} from "../../services/qualification-litellm.js";
+import { LocalWorldCleanupStack, type LocalWorldCleanupEvidence } from "./cleanup.js";
+import {
+  openCleanupLedger,
+  type CleanupLedgerMirror,
+  type CleanupResourceKind,
+} from "./cleanup-ledger.js";
+import {
+  dockerInternalUrls,
+  startDockerStack,
+  type DockerNaming,
+  type DockerResourceKind,
+  type Exec,
+  type ServerContainerEnv,
+} from "./docker.js";
+import { launchAnyharness, type ReadinessFetch, type SpawnLike } from "./processes.js";
+import { extractRenderer, launchChromium, serveRenderer, type ChromiumLauncher } from "./renderer.js";
+
+/**
+ * The reusable local-world constructor (spec "Local-world contract"). It
+ * consumes validated artifacts, resolved LiteLLM access, and the run identity,
+ * and returns a ready typed handle — not a bag of environment variables.
+ * Secrets and privileged database/provider methods stay private inside the
+ * world/controller; scenario code receives only product clients, endpoints, the
+ * browser, safe identity helpers, and the cleanup interface it needs.
+ *
+ * The same TypeScript code runs locally and in GitHub Actions.
+ */
+export interface ReadyLocalWorld {
+  kind: "local-workspace";
+  run: RunIdentityV1;
+
+  artifacts: {
+    server: MaterializedArtifact;
+    anyharness: MaterializedArtifact;
+    desktopRenderer: MaterializedArtifact;
+  };
+
+  api: {
+    baseUrl: string;
+    client: ApiClient;
+  };
+
+  runtime: {
+    baseUrl: string;
+    client: LocalRuntimeClient;
+  };
+
+  renderer: {
+    baseUrl: string;
+    browser: Browser;
+  };
+
+  gateway: QualificationLiteLlmController;
+
+  paths: {
+    runDir: string;
+    runtimeHome: string;
+    repositoriesDir: string;
+  };
+
+  /**
+   * Registers a durable, reverse-order cleanup releaser for a resource a fixture
+   * or scenario creates on top of the world (e.g. a per-actor browser context or
+   * a run-scoped repository clone). Additive seam beyond the spec's field list —
+   * fixtures need it to enrol their own resources into the world's single
+   * ledgered teardown. Runs during `close()`.
+   */
+  registerCleanup?(
+    kind: CleanupResourceKind,
+    providerId: string,
+    release: () => Promise<void>,
+  ): Promise<void>;
+
+  /**
+   * Enrols the actor's LiteLLM virtual key + user + team for deletion during
+   * `close()`, ordered BEFORE local database teardown so the deterministic alias
+   * stays recoverable (spec "Cleanup"). The three subjects are one atomic
+   * `deleteActorSubjects` call de-duplicated across the three ledger entries so
+   * the evidence booleans (`virtualKeyDeleted`, `litellmSubjectsDeleted`) are
+   * populated. Additive seam beyond the spec's field list; the actor identity
+   * only exists after enrolment, so it cannot be known at construction.
+   */
+  trackActorSubjects?(actor: ActorKeyIdentity): Promise<void>;
+
+  close(): Promise<LocalWorldCleanupEvidence>;
+}
+
+/**
+ * Everything the constructor needs. `map` is the validated, path-bearing
+ * `CandidateBuildMapV1` (in-memory only; never serialized). `litellm` carries
+ * the typed, preflighted access. `runDir`/ports are the run/shard-scoped
+ * layout allocated before world startup.
+ */
+export interface ConstructLocalWorldOptions {
+  run: RunIdentityV1;
+  map: CandidateBuildMapV1;
+  litellm: QualificationLiteLlmConfig;
+  /** Run/shard-scoped root; all world state lives under here. */
+  runDir: string;
+  /** Pre-allocated non-conflicting ports for server/postgres/redis/anyharness/renderer. */
+  ports: LocalWorldPorts;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+  /** Injectable seams; all default to the real world. Unit tests pass fakes so
+   * no real container, browser, or network is touched. */
+  deps?: LocalWorldDeps;
+}
+
+export interface LocalWorldPorts {
+  server: number;
+  postgres: number;
+  redis: number;
+  anyharness: number;
+  renderer: number;
+}
+
+export interface LocalWorldDeps {
+  litellmFetch?: FetchLike;
+  dockerExec?: Exec;
+  readinessFetch?: ReadinessFetch;
+  spawn?: SpawnLike;
+  chromiumLauncher?: ChromiumLauncher;
+  extractExec?: Exec;
+  ledgerMirror?: CleanupLedgerMirror;
+}
+
+/**
+ * Constructs the world per the 10 ordered startup steps: run-scoped dirs/ports
+ * → materialize+re-hash the three artifacts → load the exact Server image →
+ * fresh Postgres/Redis on a run-specific project/network → migrate with the
+ * exact image → start the exact Server (gateway + short enrollment interval) →
+ * launch the exact host AnyHarness (isolated home, no ambient credentials) →
+ * extract+serve the exact renderer → launch Chromium → bounded readiness for
+ * all four. Reported Server and AnyHarness versions are verified against the
+ * candidate map; the renderer identity is its archive hash plus a successful
+ * boot.
+ *
+ * On any startup failure, every registered cleanup runs exactly once in reverse
+ * order (spec failure table).
+ */
+export async function constructLocalWorld(options: ConstructLocalWorldOptions): Promise<ReadyLocalWorld> {
+  const deps = options.deps ?? {};
+  const log = options.log ?? (() => undefined);
+  const timeoutMs = options.timeoutMs;
+
+  // Resolve the required three artifacts BEFORE any side effect: an invalid map
+  // starts no database, Server, AnyHarness, renderer, or browser.
+  const candidateSet = resolveLocalCandidateSet(options.map);
+
+  const gateway = new QualificationLiteLlmController(options.litellm, { fetch: deps.litellmFetch });
+  // Fail fast on unreachable/ineligible gateway access with zero world side
+  // effects (spec: no world on invalid shared-service access).
+  await gateway.preflight();
+
+  const runDir = options.runDir;
+  const artifactsDir = path.join(runDir, "artifacts");
+  const rendererDir = path.join(runDir, "renderer");
+  const runtimeHome = path.join(runDir, "runtime-home");
+  const repositoriesDir = path.join(runDir, "repositories");
+  const logsDir = path.join(runDir, "logs");
+  for (const dir of [runDir, artifactsDir, rendererDir, runtimeHome, repositoriesDir, logsDir]) {
+    await mkdir(dir, { recursive: true });
+  }
+
+  const ledger = await openCleanupLedger({
+    runDir,
+    runId: options.run.run_id,
+    shardId: options.run.shard_id,
+    mirror: deps.ledgerMirror,
+  });
+  const stack = new LocalWorldCleanupStack({ ledger, log });
+
+  const register = async (
+    kind: CleanupResourceKind,
+    providerId: string,
+    release: () => Promise<void>,
+  ): Promise<void> => {
+    const entryId = await stack.register(kind, release);
+    await stack.acquired(entryId, providerId);
+  };
+
+  try {
+    // Register durable-path + reservation releasers first so they tear down
+    // LAST (reverse order), after every container/process that lives under them.
+    await register("run_directory", runDir, () => rm(runDir, { recursive: true, force: true }));
+    await register(
+      "port_registration",
+      [options.ports.server, options.ports.postgres, options.ports.redis, options.ports.anyharness, options.ports.renderer].join(","),
+      async () => undefined, // ephemeral OS ports; the record exists for crash recovery, not a real release.
+    );
+    await register("runtime_home", runtimeHome, () => rm(runtimeHome, { recursive: true, force: true }));
+    await register("extracted_artifacts", artifactsDir, async () => {
+      await rm(artifactsDir, { recursive: true, force: true });
+      await rm(rendererDir, { recursive: true, force: true });
+    });
+
+    // Step 2: materialize + re-hash the three mapped artifacts into run storage.
+    const serverArtifact = await materialize(candidateSet.server.artifact_id, options.map, artifactsDir);
+    const anyharnessArtifact = await materialize(candidateSet.anyharness.artifact_id, options.map, artifactsDir);
+    const rendererArtifact = await materialize(candidateSet.desktopRenderer.artifact_id, options.map, artifactsDir);
+
+    // Steps 3–6: run-scoped Docker network + Postgres + Redis + migrations +
+    // Server (gateway enabled, SINGLE_ORG_MODE, short backfill interval).
+    const naming = dockerNaming(options.run.run_id, options.run.shard_id);
+    const serverEnv = buildServerEnv(naming, options.litellm);
+    const server = await startDockerStack({
+      naming,
+      ports: { server: options.ports.server, postgres: options.ports.postgres, redis: options.ports.redis },
+      serverArtifact,
+      serverEnv,
+      registerCleanup: (kind: DockerResourceKind, providerId, release) => register(kind, providerId, release),
+      timeoutMs,
+      log,
+      deps: { exec: deps.dockerExec, fetch: deps.readinessFetch },
+    });
+    verifyVersion("Server", server.version, serverArtifact.version);
+
+    // Step 7: host AnyHarness with an isolated runtime home and hermetic env.
+    const anyharness = await launchAnyharness({
+      binaryPath: anyharnessArtifact.path,
+      host: "127.0.0.1",
+      port: options.ports.anyharness,
+      runtimeHome,
+      timeoutMs,
+      log,
+      spawn: deps.spawn,
+      fetch: deps.readinessFetch,
+    });
+    await register("anyharness_process", `pid:${anyharness.process.child.pid ?? "unknown"}`, () =>
+      anyharness.process.terminate(),
+    );
+    verifyVersion("AnyHarness", anyharness.health.version, anyharnessArtifact.version);
+
+    // Step 8: extract + statically serve the exact renderer bytes.
+    const extracted = await extractRenderer(rendererArtifact, rendererDir, { exec: deps.extractExec });
+    const served = await serveRenderer({
+      extracted,
+      host: "127.0.0.1",
+      port: options.ports.renderer,
+      timeoutMs,
+      log,
+      spawn: deps.spawn,
+      fetch: deps.readinessFetch,
+    });
+    await register("renderer_process", `pid:${served.process.child.pid ?? "unknown"}`, () =>
+      served.process.terminate(),
+    );
+
+    // Step 9: shared Chromium browser.
+    const browser = await launchChromium({ log, launcher: deps.chromiumLauncher });
+    await register("browser", "chromium", () => browser.close());
+
+    log(`local world ready (run ${options.run.run_id}/${options.run.shard_id})`);
+
+    return {
+      kind: "local-workspace",
+      run: options.run,
+      artifacts: { server: serverArtifact, anyharness: anyharnessArtifact, desktopRenderer: rendererArtifact },
+      api: { baseUrl: server.baseUrl, client: new ApiClient({ baseUrl: server.baseUrl }) },
+      runtime: { baseUrl: anyharness.baseUrl, client: new LocalRuntimeClient({ baseUrl: anyharness.baseUrl }) },
+      renderer: { baseUrl: served.baseUrl, browser },
+      gateway,
+      paths: { runDir, runtimeHome, repositoriesDir },
+      registerCleanup: register,
+      trackActorSubjects: (actor) => trackActorSubjects(stack, gateway, actor),
+      close: () => stack.runAll(),
+    };
+  } catch (error) {
+    // Any startup failure runs every registered cleanup exactly once, reverse
+    // order, then rethrows so the caller marks the cell failed.
+    await stack.runAll().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function materialize(
+  artifactId: string,
+  map: CandidateBuildMapV1,
+  storageDir: string,
+): Promise<MaterializedArtifact> {
+  const artifact = map.artifacts.find((entry) => entry.artifact_id === artifactId);
+  if (!artifact) {
+    throw new Error(`Candidate map lost artifact "${artifactId}" between resolution and materialization.`);
+  }
+  const materializedPath = await materializeLocalArtifact(artifact, storageDir);
+  return { artifact_id: artifact.artifact_id, version: artifact.version, sha256: artifact.sha256, path: materializedPath };
+}
+
+/** Registers the three LiteLLM subject deletions, de-duplicated across entries. */
+async function trackActorSubjects(
+  stack: LocalWorldCleanupStack,
+  gateway: QualificationLiteLlmController,
+  actor: ActorKeyIdentity,
+): Promise<void> {
+  let result: ActorSubjectsDeletion | undefined;
+  const ensure = async (): Promise<ActorSubjectsDeletion> => {
+    if (!result) {
+      result = await gateway.deleteActorSubjects(actor);
+    }
+    return result;
+  };
+  // Registered last → released FIRST (reverse order), before the DB/containers.
+  const teamEntry = await stack.register("litellm_team", async () => {
+    if (!(await ensure()).litellmSubjectsDeleted) {
+      throw new Error("LiteLLM team was not deleted.");
+    }
+  });
+  await stack.acquired(teamEntry, actor.teamId || "team");
+  const userEntry = await stack.register("litellm_user", async () => {
+    if (!(await ensure()).litellmSubjectsDeleted) {
+      throw new Error("LiteLLM user was not deleted.");
+    }
+  });
+  await stack.acquired(userEntry, actor.litellmUserId);
+  const keyEntry = await stack.register("litellm_virtual_key", async () => {
+    if (!(await ensure()).virtualKeyDeleted) {
+      throw new Error("LiteLLM virtual key was not deleted.");
+    }
+  });
+  await stack.acquired(keyEntry, actor.tokenIdHash);
+}
+
+function dockerNaming(runId: string, shardId: string): DockerNaming {
+  const project = `plq-${runId}-${shardId}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 56);
+  return { project, network: `${project}-net` };
+}
+
+function buildServerEnv(naming: DockerNaming, litellm: QualificationLiteLlmConfig): ServerContainerEnv {
+  const { databaseUrl, redisUrl } = dockerInternalUrls(naming);
+  return {
+    SINGLE_ORG_MODE: "true",
+    AGENT_GATEWAY_ENABLED: "true",
+    AGENT_GATEWAY_BACKFILL_INTERVAL_SECONDS: "5",
+    AGENT_GATEWAY_LITELLM_BASE_URL: litellm.adminBaseUrl,
+    AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: litellm.publicBaseUrl,
+    AGENT_GATEWAY_LITELLM_MASTER_KEY: litellm.masterKey,
+    DATABASE_URL: databaseUrl,
+    REDBEAT_REDIS_URL: redisUrl,
+  };
+}
+
+function verifyVersion(component: string, reported: string, expected: string): void {
+  if (reported !== expected) {
+    throw new Error(
+      `${component} reported version "${reported}" does not match the candidate map version "${expected}".`,
+    );
+  }
+}

--- a/tests/release/src/worlds/local-workspace/world.ts
+++ b/tests/release/src/worlds/local-workspace/world.ts
@@ -238,6 +238,7 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
       ports: { server: options.ports.server, postgres: options.ports.postgres, redis: options.ports.redis },
       serverArtifact,
       serverEnv,
+      runDir,
       // The real Server mints the first-run token at boot and writes the
       // plaintext to SETUP_TOKEN_FILE inside the container; the world copies it
       // out to <runDir>/setup-token so the actor fixture claims through the real


### PR DESCRIPTION
## Prove One Real Local Workspace Turn

First real Tier 3 vertical: builds one exact candidate Server (docker-save archive), one exact candidate AnyHarness (host release binary), and one exact candidate Desktop renderer (endpoint-targeted `dist` archive); validates them through one three-artifact `CandidateBuildMapV1`; starts an isolated local world from those exact bytes; and drives one real cheap managed-gateway turn through the actual product UI — the provisional `LOCAL-WORLD-SMOKE-1/local/harness=claude` cell (explicitly not the canonical `LOCAL-2` guarantee).

Frozen contract: Vault note "Prove One Real Local Workspace Turn" (frozen 2026-07-14, base `0eab251fd`).

### What the green cell proves (strict, real)

- Fresh actor claims the Server via the real `POST /setup` one-time path + mobile password login; the Server mints the actor's own LiteLLM enrollment/virtual key (no static `RELEASE_E2E_GATEWAY_TEST_KEY`, no `ANTHROPIC_AUTH_TOKEN` in the AnyHarness child env — enforced by a denylist).
- Desktop (not a fixture) pushes gateway state to AnyHarness; the pending-workspace composer flow creates the workspace/session; cheapest eligible live-probed Claude model (`claude-haiku-4-5`) completes a bounded turn; reload reopens the same transcript.
- Exactly one actor-correlated LiteLLM spend window is accepted (37,505 total tokens, ~$0.0045); evidence stores only one-way hashes, counts, and bounded timestamps.
- Report advances to V4: each result carries bounded `evidence` (or `null`); the validator rejects green local-smoke results with missing/incomplete evidence or any false cleanup flag.
- Cleanup is registered-before-create in a durable per-run ledger (replay-by-run + TTL recovery); the green run reconciled 15/15 registrations (incl. the secret env-file added by R1-004), and LiteLLM key/user/team deletion after spend is verified (deletion-after-spend proven by live probe at freeze).
- Negative path: a corrupted artifact SHA exits `2` with no report and zero world side effects.
- One entrypoint everywhere: `make qualification-local-workspace PROFILE=<name> BEHAVIOR=<diagnostic|strict>` locally, and a new manual strict `release-e2e-local-world-smoke` Actions job (no `continue-on-error`, real exit code, evidence uploaded `if: always()`).

### Product bugs found and fixed by this qualification path (disclosed)

1. `fix(desktop): sync local gateway auth state without cloud compute` — Desktop never pushed gateway auth state unless cloud compute was enabled, so gateway models were invisible in local-only setups.
2. `fix(desktop): select a just-created or restored local workspace absent from the selection snapshot` — deterministic "Workspace not found" after successful local workspace creation on a cold collections cache (also affects packaged desktop).
3. `fix(desktop): persist preferences via localStorage in the browser renderer` — browser renderer had no preferences persistence (Tauri-only store), breaking reopen.
4. `fix(desktop): scope the composer mode control to the selected model's modes` — composer defaulted to mode `auto` which gateway Claude models reject with a 400 (affects packaged desktop; gateway is the common path).
5. `fix(desktop): offer launch-ready gateway agents when the vendor CLI is not logged in` — the home and session composers filtered agents by NATIVE readiness (vendor CLI installed AND logged in), so a gateway-only actor saw "No agents" even though the runtime's launch options (launch-time readiness; the enrolled route injects the credential at spawn) listed the agent with models. An ambient `~/.claude` login on developer machines masked the gap; fresh CI runners exposed it.

Each fix is narrow, style-consistent, and covered by a focused unit test. The qualification test was never weakened around a bug.

### Tests

- `tests/release`: 337 pass (all pre-existing tests retained/adapted), typecheck clean.
- `scripts/ci-cd`: 85 pass.
- Desktop: changed-file vitest suites green; 8 pre-existing failures in 4 unrelated files reproduce identically on the clean base tree.
- Live proof (local): strict green (exit 0, V4 report, complete evidence, 15/15 cleanup registrations reconciled), post-run external cleanup verified.
- Live proof (Actions): the manual strict `local-world-smoke-1` job is GREEN on this exact head — run 29360593534 built the three linux/amd64 candidates, ran the strict cell for real (exit 0), and uploaded a green V4 report with complete evidence.

### Actions job environment

The `release-e2e-local-world-smoke` job runs under the protected `Qualification` GitHub environment (not `staging`): secret `AGENT_GATEWAY_LITELLM_MASTER_KEY`, vars `AGENT_GATEWAY_LITELLM_BASE_URL` and `AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL` mapped directly (no public-covers-admin fallback). The environment's branch policy restricts it to `main` and this branch.

## Review findings and resolutions

Independent review findings (stable IDs) and how each was resolved:

| ID | Severity | Resolution |
| --- | --- | --- |
| R1-001 | MATERIAL | Fixed in `1e2760c51` — rebased onto current `origin/main` (`06bf880a1`, ProductHost/workflow-invocation changes); added `cloudClient: null` to the two new `run-workspace-selection` test deps objects; desktop `tsc` clean after shared-package rebuild. |
| R1-002 | MATERIAL | Fixed in `f0cb985bb` — a cleanup failure now yields a persisted report and exit 1: the validator allows `cleanup.failed > 0` / incomplete deletions only on non-green results (green still requires complete clean evidence, exactly preserved); end-to-end test through `writeReportV4` added; the false-boolean green sibling case still rejects. |
| R1-003 | MINOR | Fixed in `6225198d0` — `deleteActorSubjects` fails closed when `team_id` is absent (`litellmSubjectsDeleted: false`), with a unit test. |
| R1-004 | MINOR | Fixed in `14469e354` — `AGENT_GATEWAY_LITELLM_MASTER_KEY` now passes to `docker run`/migrations via a mode-0600 `--env-file` in the run dir (registered for cleanup as `secret_env_file`), never `-e` argv; test asserts no argv leak. |
| R1-005 | MINOR | Fixed in `d0fac9981` — job switched to `environment: Qualification` with direct secret/vars mapping (see above); YAML comment and Makefile messages updated. |
| R1-006 | MINOR | Fixed in `25b40908f` — inside Tauri, a transient plugin-store import failure no longer caches the localStorage fallback (next call retries the real store); genuinely non-Tauri contexts still cache the fallback; regression test added. |
| R1-007 | — | Follow-up (deliberately not fixed in this PR). |
| R1-008 | MINOR | Fixed in `62ad560d1` — the renderer child env now passes through `assertHermeticEnv`, matching the AnyHarness child; test asserts no credential-suffixed key reaches the child. |
| R1-009 | — | Follow-up (deliberately not fixed in this PR). |

### CI failure root cause and fix

The original `local-world-smoke-1 (manual, strict)` failure (run 29353932769) surfaced as `POST /auth/desktop/password/login -> 401`; that specific 401 never reproduced on re-runs (a secret-free auth diagnostic is now in place should it recur). Iterating with the new bounded, secret-free `LOCAL_WORLD_SMOKE_DEBUG_DIR` captures (every capture passes a redaction pipeline; the debug dir lives outside the cleaned run dir so captures survive to the artifact upload) exposed the real CI-only failure chain:

1. **Test bug** (`5ff61711e`): `ensureHarnessReady` gated launchability on `GET /v1/agents` readiness — AnyHarness's NATIVE question ("is the vendor CLI installed and logged in"), which deliberately reports `login_required` for a pure gateway-route actor. It now gates on `GET /v1/agents/launch-options` (launch-time readiness — the exact source Desktop's composer reads).
2. **Product bug** (`e1d6d1f03`, disclosed fix #5 above): the home/session composers had the same native-readiness filter, so the composer offered no models to a gateway-only actor.

Both only passed locally because the developer machine's ambient `~/.claude` login satisfied native readiness — exactly the ambient-credential leak the frozen spec forbids. Fixed with no `continue-on-error`, no skips, and no weakened assertions; Actions run 29360593534 is green on this head.

### Non-goals (per frozen spec)

Full `LOCAL-1`/`LOCAL-2`, other harnesses, BYOK, `$2` grant/debit/top-up, E2B/self-host, packaged Tauri, hosted Web, GHCR/S3 transport, production promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Round 2 (delta review) findings and resolutions

- **R2-001 (material) — fixed in `f416ed905`**: quoted the release test glob (`tsx --test "src/**/*.test.ts"`) so the 27 nested world-suite tests (incl. the R1-004/R1-008 regression tests) actually run under POSIX `sh` in CI. Verified 341/341 under plain `sh`.
- **R2-002 (nit) — fixed**: corrected the stale 14/14 reconciled-registration narrative to 15/15.
- **Self-found (cleanup truth) — fixed in `8fd4e0cf5`**: transient docker-network removal failures are retried with bounded backoff, and a failed cleanup pass no longer deletes the run directory — preserving the durable cleanup ledger for replay-by-run. Focused unit tests for both.
- **Bounded-window adjustment — `2f732fe18`**: assistant-turn wait widened to a still-bounded 300s for loaded hosts (no assertion changes).

### Final proof state (head `2f732fe18`)

- Local strict: green, exit 0 — `claude-haiku-4-5`, 37,511 tokens (~$0.047), transcript reopened, cleanup 15/15 with all deletion flags true; external verification: no run containers/networks/processes, run dir evidence-only.
- Trusted Actions strict: green on `e1d6d1f03` (run 29360593534); final re-dispatch on this head: run 29370569674.
- Unit gates: tests/release 341 pass (POSIX sh) + typecheck clean; scripts/ci-cd 85 pass; desktop changed-file suites green.

### Round 3 (Pablo's agent review) findings and resolutions

- **FABLE-LWS-001 (blocker) — fixed in `08ae3d826`**: rebased onto current main (`7758908e0`) and implemented `delete` on the browser preferences-store fallback (main's ProductStorage adapter calls `store.delete` from `removeItem`); regression tests cover both the store surface and the adapter path.
- **FABLE-LWS-002 (blocker) — resolved by the same rebase+fix**: the failing `Desktop frontend build` check was this exact incompatibility; PR CI re-running on the new head.
- **FABLE-LWS-003 (nit) — fixed**: stale run references corrected below.

### Current head `08ae3d826`

- Unit gates: tests/release 341 pass + typecheck clean; scripts/ci-cd 85 pass; desktop tsc clean; store suite 5/5.
- Local strict proof: green at `2f732fe18` (identical qualification code; the only delta is the browser-store `delete` + rebase). Exact-head trusted Actions strict proof dispatched: run 29371977037.
