### PR TITLE
refactor(desktop): trim session creation follow-up

### DIFF
--- a/apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
@@ -5,7 +5,40 @@ import type { ProductHost } from "@proliferate/product-client/host/product-host"
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import { FileChangeCall } from "./FileChangeCall";
 
-const webTestHost = { desktop: null } as ProductHost;
+const webTestHost = {
+  surface: "web",
+  deployment: { apiBaseUrl: "https://app.test" },
+  auth: {
+    authRequired: true,
+    state: { status: "loading" },
+    restoreSession: async () => {},
+    startLogin: async () => ({ provider: "password", source: "password_form" }),
+    finishLogin: async () => {},
+    cancelLogin: async () => {},
+    logout: async () => ({ provider: "password" }),
+  },
+  cloud: { client: null },
+  storage: {
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+  },
+  links: {
+    openExternal: async () => {},
+    buildReturnUrl: () => "https://app.test",
+    observeInboundEntries: () => () => {},
+  },
+  clipboard: { writeText: async () => {} },
+  telemetry: {
+    track: () => {},
+    captureException: () => {},
+    setUser: () => {},
+    setTag: () => {},
+    routeChanged: () => {},
+    getSupportContext: () => ({ clientReleaseId: "test" }),
+  },
+  desktop: null,
+} satisfies ProductHost;
 
 function renderToStaticMarkup(ui: ReactElement) {
   return renderReactToStaticMarkup(

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-empty-options.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-empty-options.ts
@@ -1,0 +1,22 @@
+import type {
+  CreateEmptySessionWithResolvedConfigOptions,
+  CreateSessionWithResolvedConfigOptions,
+} from "@/hooks/sessions/workflows/session-creation-types";
+
+export function toEmptySessionCreateOptions(
+  options: CreateEmptySessionWithResolvedConfigOptions,
+): CreateSessionWithResolvedConfigOptions {
+  return {
+    text: "",
+    agentKind: options.agentKind,
+    modelId: options.modelId,
+    modeId: options.modeId,
+    launchControlValues: options.launchControlValues,
+    workspaceId: options.workspaceId,
+    latencyFlowId: options.latencyFlowId,
+    clientSessionId: options.clientSessionId,
+    reuseInFlightEmptySession: options.reuseInFlightEmptySession,
+    preserveProjectedSessionOnCreateFailure: options.preserveProjectedSessionOnCreateFailure,
+    replacesSessionId: options.replacesSessionId,
+  };
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.ts
@@ -1,0 +1,44 @@
+import {
+  shouldDiscardSupersededSessionCreation,
+} from "@/hooks/sessions/workflows/session-creation-supersession";
+
+export interface MaterializationLifecycle {
+  discardCreatedSession: (() => Promise<boolean>) | null;
+  retainCreatedSession: (() => void) | null;
+}
+
+export async function discardMaterializationIfSuperseded(
+  sessionId: string,
+  lifecycle: MaterializationLifecycle,
+): Promise<boolean> {
+  if (!await shouldDiscardSupersededSessionCreation(sessionId)) {
+    return false;
+  }
+  const discardCreatedSession = lifecycle.discardCreatedSession;
+  lifecycle.discardCreatedSession = null;
+  if (!discardCreatedSession || await discardCreatedSession()) {
+    lifecycle.retainCreatedSession = null;
+    return true;
+  }
+  // The successor already committed, but this created runtime could not be
+  // retired safely. Publish it honestly and stop this older materializer here.
+  const retainCreatedSession = lifecycle.retainCreatedSession;
+  lifecycle.retainCreatedSession = null;
+  retainCreatedSession?.();
+  return true;
+}
+
+export async function discardCreatedRuntimeSession(
+  lifecycle: MaterializationLifecycle,
+): Promise<boolean> {
+  const discardCreatedSession = lifecycle.discardCreatedSession;
+  lifecycle.discardCreatedSession = null;
+  if (!discardCreatedSession || await discardCreatedSession()) {
+    lifecycle.retainCreatedSession = null;
+    return true;
+  }
+  const retainCreatedSession = lifecycle.retainCreatedSession;
+  lifecycle.retainCreatedSession = null;
+  retainCreatedSession?.();
+  return false;
+}

--- a/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -50,8 +50,10 @@ import { resolveDesktopRuntimeUrlForWorkspace } from "@/hooks/sessions/workflows
 import { annotateLatencyFlow } from "@/lib/infra/measurement/latency-flow";
 import { logLatency } from "@/lib/infra/measurement/debug-latency";
 import {
-  shouldDiscardSupersededSessionCreation,
-} from "@/hooks/sessions/workflows/session-creation-supersession";
+  discardCreatedRuntimeSession,
+  discardMaterializationIfSuperseded,
+  type MaterializationLifecycle,
+} from "@/hooks/sessions/workflows/session-creation-materialization-cleanup";
 import { filterReplacedSessionTombstones } from "@/hooks/sessions/workflows/session-replacement-tombstones";
 import { scheduleCreatedRuntimeSessionCleanup } from "@/hooks/sessions/workflows/session-created-runtime-cleanup";
 import { runInterruptibleSessionCreationStep } from "@/hooks/sessions/workflows/session-creation-materialization-interruption";
@@ -88,11 +90,6 @@ interface MaterializeSessionCreationInput {
   workspaceId: string;
 }
 
-interface MaterializationLifecycle {
-  discardCreatedSession: (() => Promise<boolean>) | null;
-  retainCreatedSession: (() => void) | null;
-}
-
 export async function materializeSessionCreation(
   input: MaterializeSessionCreationInput,
 ): Promise<string> {
@@ -103,7 +100,7 @@ export async function materializeSessionCreation(
   try {
     return await runSessionCreationMaterialization(input, lifecycle);
   } catch (error) {
-    if (await discardIfSuperseded(input.pendingSessionId, lifecycle)) {
+    if (await discardMaterializationIfSuperseded(input.pendingSessionId, lifecycle)) {
       return input.pendingSessionId;
     }
     if (!await discardCreatedRuntimeSession(lifecycle)) {
@@ -163,7 +160,7 @@ async function runSessionCreationMaterialization({
     ...targetConnection,
     anyharnessWorkspaceId: target.anyharnessWorkspaceId,
   };
-  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+  if (await discardMaterializationIfSuperseded(pendingSessionId, lifecycle)) {
     return pendingSessionId;
   }
   if (shouldProbeCompatibleRuntimeSessions({
@@ -179,9 +176,9 @@ async function runSessionCreationMaterialization({
         agentKind: options.agentKind,
         modelId: options.modelId,
       }))
-      .catch(() => null);
+    .catch(() => null);
     if (existingSession) {
-      if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+      if (await discardMaterializationIfSuperseded(pendingSessionId, lifecycle)) {
         return pendingSessionId;
       }
       return materializeExistingSession({
@@ -246,7 +243,7 @@ async function runSessionCreationMaterialization({
       workspaceId,
     });
   };
-  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+  if (await discardMaterializationIfSuperseded(pendingSessionId, lifecycle)) {
     return pendingSessionId;
   }
   logLatency("session.create.materialize.session_created", {
@@ -266,7 +263,7 @@ async function runSessionCreationMaterialization({
   const catalogStep = await runInterruptibleSessionCreationStep({
     sessionId: pendingSessionId,
     step: ensureCloudAgentCatalog().catch(() => null),
-    onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
+    onSuperseded: () => discardMaterializationIfSuperseded(pendingSessionId, lifecycle),
   });
   if (catalogStep.discarded) {
     return pendingSessionId;
@@ -289,7 +286,7 @@ async function runSessionCreationMaterialization({
       modelRegistries,
       defaultLiveSessionControlValuesByAgentKind: liveDefaultsForLaunch,
     }),
-    onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
+    onSuperseded: () => discardMaterializationIfSuperseded(pendingSessionId, lifecycle),
   });
   if (launchDefaultsStep.discarded) {
     return pendingSessionId;
@@ -303,7 +300,7 @@ async function runSessionCreationMaterialization({
     ...launchedSession,
     liveConfig: launchedLiveConfig,
   };
-  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+  if (await discardMaterializationIfSuperseded(pendingSessionId, lifecycle)) {
     return pendingSessionId;
   }
   const realRecord: SessionRuntimeRecord = {
@@ -376,40 +373,4 @@ async function runSessionCreationMaterialization({
   lifecycle.discardCreatedSession = null;
   lifecycle.retainCreatedSession = null;
   return pendingSessionId;
-}
-
-async function discardIfSuperseded(
-  sessionId: string,
-  lifecycle: MaterializationLifecycle,
-): Promise<boolean> {
-  if (!await shouldDiscardSupersededSessionCreation(sessionId)) {
-    return false;
-  }
-  const discardCreatedSession = lifecycle.discardCreatedSession;
-  lifecycle.discardCreatedSession = null;
-  if (!discardCreatedSession || await discardCreatedSession()) {
-    lifecycle.retainCreatedSession = null;
-    return true;
-  }
-  // The successor already committed, but this created runtime could not be
-  // retired safely. Publish it honestly and stop this older materializer here.
-  const retainCreatedSession = lifecycle.retainCreatedSession;
-  lifecycle.retainCreatedSession = null;
-  retainCreatedSession?.();
-  return true;
-}
-
-async function discardCreatedRuntimeSession(
-  lifecycle: MaterializationLifecycle,
-): Promise<boolean> {
-  const discardCreatedSession = lifecycle.discardCreatedSession;
-  lifecycle.discardCreatedSession = null;
-  if (!discardCreatedSession || await discardCreatedSession()) {
-    lifecycle.retainCreatedSession = null;
-    return true;
-  }
-  const retainCreatedSession = lifecycle.retainCreatedSession;
-  lifecycle.retainCreatedSession = null;
-  retainCreatedSession?.();
-  return false;
 }

--- a/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -56,6 +56,7 @@ import {
 } from "@/hooks/sessions/workflows/session-replacement-shell-preferences";
 import { cleanupSessionCreationFailure } from "@/hooks/sessions/workflows/session-creation-failure-cleanup";
 import { resolveWorkspaceUiKey } from "@/lib/domain/workspaces/selection/workspace-ui-key";
+import { toEmptySessionCreateOptions } from "@/hooks/sessions/workflows/session-creation-empty-options";
 
 export function useSessionCreationActions() {
   const host = useProductHost();
@@ -387,19 +388,7 @@ export function useSessionCreationActions() {
   const createEmptySessionWithResolvedConfig = useCallback(async (
     options: CreateEmptySessionWithResolvedConfigOptions,
   ): Promise<string> => {
-    return createSessionWithResolvedConfig({
-      text: "",
-      agentKind: options.agentKind,
-      modelId: options.modelId,
-      modeId: options.modeId,
-      launchControlValues: options.launchControlValues,
-      workspaceId: options.workspaceId,
-      latencyFlowId: options.latencyFlowId,
-      clientSessionId: options.clientSessionId,
-      reuseInFlightEmptySession: options.reuseInFlightEmptySession,
-      preserveProjectedSessionOnCreateFailure: options.preserveProjectedSessionOnCreateFailure,
-      replacesSessionId: options.replacesSessionId,
-    });
+    return createSessionWithResolvedConfig(toEmptySessionCreateOptions(options));
   }, [createSessionWithResolvedConfig]);
 
   return { createEmptySessionWithResolvedConfig, createSessionWithResolvedConfig };

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -23,6 +23,4 @@ apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx 404 git review fi
 apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 414 workspace sidebar item pending indicator/menu split
 apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-domain/src/chats/transcript/transcript-row-model.ts 946 transcript row model pending row-kind module split
-apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts 415 injected typed telemetry deps threaded from the calling hook; split deferred
 apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model
-apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts 406 product telemetry facade threading into session-creation workflows; split deferred


### PR DESCRIPTION
## Summary

This is the small follow-up to the already-merged ProductHost persistence/telemetry work. It does not republish the duplicate implementation branch; it only ports the remaining cleanup that still applies on current `main`.

- extracts session-creation materialization cleanup helpers out of the large workflow file
- extracts empty-session option mapping out of `use-session-creation-actions`
- removes now-stale frontend structure allowlist entries after both files fall below the limit
- replaces the partial `ProductHost` cast in `FileChangeCall.test.tsx` with a real web host fixture, including clipboard support

## Why

PR #1182 already merged the core persistence/telemetry slice. On current `main`, two session-creation workflow files were still over/near the frontend structure threshold via stale allowlist entries, and one test still used an unsafe partial ProductHost cast. This keeps the merged foundation tidy without changing product behavior.

## Validation

- `pnpm --filter @proliferate/ui build`
- `pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/product-surfaces build && pnpm --filter @proliferate/product-client build`
- `cd apps/desktop && pnpm exec vitest run src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts src/hooks/sessions/workflows/use-session-creation-actions.test.ts`
- `cd apps/desktop && pnpm exec tsc --noEmit --pretty false`
- `python3 scripts/report_frontend_structure.py --strict`
- `python3 scripts/check_frontend_boundaries.py`
- `git diff --check`

