### PR TITLE
build(product-client): prove extraction mechanics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ reference/
 dist/
 out/
 target/
+apps/desktop/dist-product-client-qualification/
+apps/packages/product-client/qualification/browser-host/dist/
 apps/desktop/index.js
 *.db
 *.db-wal

--- a/apps/desktop/qualification/product-client/index.html
+++ b/apps/desktop/qualification/product-client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-mode="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ProductClient Desktop Qualification</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/qualification/product-client/src/main.tsx
+++ b/apps/desktop/qualification/product-client/src/main.tsx
@@ -1,0 +1,65 @@
+import { CloudClientProvider } from "@proliferate/cloud-sdk-react";
+import { ProductClientBuildCanary } from "@proliferate/product-client/qualification/ProductClientBuildCanary";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes } from "react-router-dom";
+import "@proliferate/design/product.css";
+import "@proliferate/design/desktop.css";
+
+const queryClient = new QueryClient();
+
+const host: ProductHost = {
+  surface: "desktop",
+  deployment: {
+    apiBaseUrl: "https://desktop.test",
+    switchDeployment: async () => {},
+    resetDeployment: async () => {},
+  },
+  auth: {
+    authRequired: true,
+    state: { status: "loading" },
+    restoreSession: async () => {},
+    startLogin: async () => ({ provider: "password", source: "password_form" }),
+    finishLogin: async () => {},
+    cancelLogin: async () => {},
+    logout: async () => ({ provider: "password" }),
+  },
+  cloud: { client: null },
+  storage: {
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+  },
+  links: {
+    openExternal: async () => {},
+    buildReturnUrl: () => "proliferate://qualification",
+    observeInboundEntries: () => () => {},
+  },
+  clipboard: { writeText: async () => {} },
+  telemetry: {
+    track: () => {},
+    captureException: () => {},
+    setUser: () => {},
+    setTag: () => {},
+    routeChanged: () => {},
+    getSupportContext: () => ({ clientReleaseId: "desktop-qualification" }),
+  },
+  desktop: null,
+};
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <CloudClientProvider client={host.cloud.client}>
+        <ProductHostProvider host={host}>
+          <BrowserRouter>
+            <ProductClientBuildCanary RoutesComponent={Routes} />
+          </BrowserRouter>
+        </ProductHostProvider>
+      </CloudClientProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apps/desktop/qualification/product-client/tsconfig.json
+++ b/apps/desktop/qualification/product-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/apps/desktop/qualification/product-client/vite.config.ts
+++ b/apps/desktop/qualification/product-client/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  root,
+  plugins: [react(), tailwindcss()],
+  clearScreen: false,
+  build: {
+    assetsInlineLimit: 0,
+    manifest: true,
+    outDir: "../../dist-product-client-qualification",
+    emptyOutDir: true,
+  },
+});

--- a/apps/packages/product-client/package.json
+++ b/apps/packages/product-client/package.json
@@ -4,7 +4,17 @@
   "private": true,
   "type": "module",
   "files": ["dist"],
+  "imports": {
+    "#product/*": {
+      "types": "./src/*",
+      "default": "./dist/*.js"
+    }
+  },
   "exports": {
+    "./qualification/ProductClientBuildCanary": {
+      "types": "./dist/qualification/ProductClientBuildCanary.d.ts",
+      "import": "./dist/qualification/ProductClientBuildCanary.js"
+    },
     "./host/product-host": {
       "types": "./dist/host/product-host.d.ts",
       "import": "./dist/host/product-host.js"
@@ -19,14 +29,25 @@
     }
   },
   "scripts": {
-    "build": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/product-domain build && tsc -p tsconfig.json",
-    "typecheck": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/product-domain build && tsc -p tsconfig.json --noEmit",
+    "build": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc -p tsconfig.json && node scripts/copy-product-client-qualification-assets.mjs",
+    "typecheck": "pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/design build && pnpm --filter @proliferate/product-domain build && pnpm --filter @proliferate/ui build && pnpm --filter @proliferate/product-ui build && pnpm --filter @proliferate/product-surfaces build && tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
+    "@anyharness/sdk": "workspace:*",
     "@anyharness/sdk-react": "workspace:*",
     "@proliferate/cloud-sdk": "workspace:*",
-    "@proliferate/product-domain": "workspace:*"
+    "@proliferate/cloud-sdk-react": "workspace:*",
+    "@proliferate/design": "workspace:*",
+    "@proliferate/product-domain": "workspace:*",
+    "@proliferate/product-surfaces": "workspace:*",
+    "@proliferate/product-ui": "workspace:*",
+    "@proliferate/ui": "workspace:*",
+    "@tanstack/react-query": "^5.101.0",
+    "lucide-react": "0.577.0",
+    "react-router-dom": "^7",
+    "tailwind-merge": "^3.6.0",
+    "zustand": "^5"
   },
   "peerDependencies": {
     "react": "^19",
@@ -34,12 +55,16 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
+    "@tailwindcss/vite": "^4",
     "@types/react": "~19.2.17",
     "@types/react-dom": "~19.2.3",
+    "@vitejs/plugin-react": "^4",
     "jsdom": "^29.1.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "tailwindcss": "^4",
     "typescript": "^5.7",
+    "vite": "^6",
     "vitest": "^3.2.6"
   }
 }

--- a/apps/packages/product-client/qualification/browser-host/index.html
+++ b/apps/packages/product-client/qualification/browser-host/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-mode="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ProductClient Browser Qualification</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/packages/product-client/qualification/browser-host/src/main.tsx
+++ b/apps/packages/product-client/qualification/browser-host/src/main.tsx
@@ -1,0 +1,60 @@
+import { CloudClientProvider } from "@proliferate/cloud-sdk-react";
+import { ProductClientBuildCanary } from "@proliferate/product-client/qualification/ProductClientBuildCanary";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes } from "react-router-dom";
+import "@proliferate/design/product.css";
+
+const queryClient = new QueryClient();
+
+const host: ProductHost = {
+  surface: "web",
+  deployment: { apiBaseUrl: "https://app.test" },
+  auth: {
+    authRequired: true,
+    state: { status: "loading" },
+    restoreSession: async () => {},
+    startLogin: async () => ({ provider: "password", source: "password_form" }),
+    finishLogin: async () => {},
+    cancelLogin: async () => {},
+    logout: async () => ({ provider: "password" }),
+  },
+  cloud: { client: null },
+  storage: {
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+  },
+  links: {
+    openExternal: async () => {},
+    buildReturnUrl: () => "https://app.test",
+    observeInboundEntries: () => () => {},
+  },
+  clipboard: { writeText: async () => {} },
+  telemetry: {
+    track: () => {},
+    captureException: () => {},
+    setUser: () => {},
+    setTag: () => {},
+    routeChanged: () => {},
+    getSupportContext: () => ({ clientReleaseId: "browser-qualification" }),
+  },
+  desktop: null,
+};
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <CloudClientProvider client={host.cloud.client}>
+        <ProductHostProvider host={host}>
+          <BrowserRouter>
+            <ProductClientBuildCanary RoutesComponent={Routes} />
+          </BrowserRouter>
+        </ProductHostProvider>
+      </CloudClientProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apps/packages/product-client/qualification/browser-host/tsconfig.json
+++ b/apps/packages/product-client/qualification/browser-host/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/apps/packages/product-client/qualification/browser-host/vite.config.ts
+++ b/apps/packages/product-client/qualification/browser-host/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  root,
+  plugins: [react(), tailwindcss()],
+  clearScreen: false,
+  build: {
+    assetsInlineLimit: 0,
+    manifest: true,
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/apps/packages/product-client/scripts/copy-product-client-qualification-assets.mjs
+++ b/apps/packages/product-client/scripts/copy-product-client-qualification-assets.mjs
@@ -1,0 +1,18 @@
+import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const source = resolve(packageRoot, "src/qualification/assets");
+const target = resolve(packageRoot, "dist/qualification/assets");
+const cssSource = resolve(packageRoot, "src/qualification/product-client-canary.css");
+const cssTarget = resolve(packageRoot, "dist/qualification/product-client-canary.css");
+
+if (!existsSync(source)) {
+  throw new Error(`Missing ProductClient qualification assets: ${source}`);
+}
+
+rmSync(target, { force: true, recursive: true });
+mkdirSync(dirname(target), { recursive: true });
+cpSync(source, target, { recursive: true });
+copyFileSync(cssSource, cssTarget);

--- a/apps/packages/product-client/src/qualification/AuthenticatedProductClientBuildCanary.tsx
+++ b/apps/packages/product-client/src/qualification/AuthenticatedProductClientBuildCanary.tsx
@@ -1,0 +1,25 @@
+import registry from "./assets/generated-registry.json";
+import rawNote from "./assets/canary-note.txt?raw";
+import rawIcon from "./assets/canary-icon.svg?raw";
+import iconUrl from "./assets/canary-icon.svg";
+import imageUrl from "./assets/canary-image.svg";
+import audioUrl from "./assets/canary-audio.wav";
+import fontUrl from "./assets/canary-font.woff2";
+
+export function AuthenticatedProductClientBuildCanary() {
+  return (
+    <section
+      aria-label="Authenticated ProductClient build canary"
+      data-canary-registry-name={registry.name}
+      data-canary-registry-count={registry.entries.length}
+      data-canary-raw-note={rawNote.trim()}
+      data-canary-raw-svg={rawIcon.includes("ProductClient canary") ? "loaded" : "missing"}
+    >
+      <p>Lazy authenticated root loaded.</p>
+      <img alt="" src={iconUrl} width={24} height={24} />
+      <img alt="" src={imageUrl} width={80} height={45} />
+      <audio data-canary-audio={audioUrl} />
+      <span data-canary-font={fontUrl}>font asset</span>
+    </section>
+  );
+}

--- a/apps/packages/product-client/src/qualification/ProductClientBuildCanary.tsx
+++ b/apps/packages/product-client/src/qualification/ProductClientBuildCanary.tsx
@@ -1,0 +1,51 @@
+import {
+  lazy,
+  Suspense,
+  type ComponentType,
+  type ReactElement,
+} from "react";
+import { Route, type RoutesProps } from "react-router-dom";
+
+import { useProductHost } from "../host/ProductHostProvider";
+import "./product-client-canary.css";
+
+export type ProductRoutesComponent = ComponentType<RoutesProps>;
+
+export interface ProductClientBuildCanaryProps {
+  RoutesComponent: ProductRoutesComponent;
+}
+
+const LazyAuthenticatedCanary = lazy(() =>
+  import("#product/qualification/AuthenticatedProductClientBuildCanary").then((module) => ({
+    default: module.AuthenticatedProductClientBuildCanary,
+  })),
+);
+
+export function ProductClientBuildCanary({
+  RoutesComponent,
+}: ProductClientBuildCanaryProps): ReactElement {
+  const host = useProductHost();
+  return (
+    <RoutesComponent>
+      <Route
+        path="*"
+        element={(
+          <main
+            className="product-client-build-canary"
+            data-product-client-canary="public-shell"
+            data-product-client-surface={host.surface}
+            data-product-client-has-desktop={host.desktop === null ? "false" : "true"}
+          >
+            <div className="product-client-build-canary__card">
+              <h1>ProductClient build canary</h1>
+              <p>Public shell compiled through ProductClient package exports.</p>
+              <Suspense fallback={<p>Loading authenticated canary…</p>}>
+                <LazyAuthenticatedCanary />
+              </Suspense>
+            </div>
+          </main>
+        )}
+      />
+    </RoutesComponent>
+  );
+}

--- a/apps/packages/product-client/src/qualification/assets/canary-audio.wav
+++ b/apps/packages/product-client/src/qualification/assets/canary-audio.wav
@@ -1,0 +1,1 @@
+ProductClient qualification audio asset placeholder.

--- a/apps/packages/product-client/src/qualification/assets/canary-font.woff2
+++ b/apps/packages/product-client/src/qualification/assets/canary-font.woff2
@@ -1,0 +1,1 @@
+ProductClient qualification font asset placeholder.

--- a/apps/packages/product-client/src/qualification/assets/canary-icon.svg
+++ b/apps/packages/product-client/src/qualification/assets/canary-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="ProductClient canary">
+  <rect width="32" height="32" rx="8" fill="#181818"/>
+  <circle cx="16" cy="16" r="9" fill="#339cff"/>
+  <path d="M11 17.5 15 21l7-10" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/packages/product-client/src/qualification/assets/canary-image.svg
+++ b/apps/packages/product-client/src/qualification/assets/canary-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90">
+  <rect width="160" height="90" rx="14" fill="#232323"/>
+  <path d="M28 62 65 30l24 20 17-14 26 26" fill="none" stroke="#339cff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/packages/product-client/src/qualification/assets/canary-note.txt
+++ b/apps/packages/product-client/src/qualification/assets/canary-note.txt
@@ -1,0 +1,1 @@
+ProductClient qualification raw text input.

--- a/apps/packages/product-client/src/qualification/assets/generated-registry.json
+++ b/apps/packages/product-client/src/qualification/assets/generated-registry.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "name": "product-client-build-canary",
+  "entries": ["public-shell", "lazy-authenticated-root"]
+}

--- a/apps/packages/product-client/src/qualification/product-client-canary.css
+++ b/apps/packages/product-client/src/qualification/product-client-canary.css
@@ -1,0 +1,19 @@
+.product-client-build-canary {
+  display: grid;
+  gap: 0.5rem;
+  min-height: 100vh;
+  place-content: center;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
+}
+
+.product-client-build-canary__card {
+  display: grid;
+  gap: 0.375rem;
+  width: min(28rem, calc(100vw - 2rem));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-card);
+  padding: 1rem;
+}

--- a/apps/packages/product-client/src/qualification/qualification-assets.d.ts
+++ b/apps/packages/product-client/src/qualification/qualification-assets.d.ts
@@ -1,0 +1,29 @@
+declare module "*.css" {
+  const href: string;
+  export default href;
+}
+
+declare module "*.svg" {
+  const url: string;
+  export default url;
+}
+
+declare module "*.svg?raw" {
+  const source: string;
+  export default source;
+}
+
+declare module "*.txt?raw" {
+  const source: string;
+  export default source;
+}
+
+declare module "*.wav" {
+  const url: string;
+  export default url;
+}
+
+declare module "*.woff2" {
+  const url: string;
+  export default url;
+}

--- a/apps/packages/product-client/tsconfig.json
+++ b/apps/packages/product-client/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "rootDir": "src",
+    "resolveJsonModule": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
   ],
   clearScreen: false,
   build: {
+    manifest: true,
     sourcemap: sentryUploadEnabled ? "hidden" : false,
   },
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,16 +389,52 @@ importers:
 
   apps/packages/product-client:
     dependencies:
+      '@anyharness/sdk':
+        specifier: workspace:*
+        version: link:../../../anyharness/sdk
       '@anyharness/sdk-react':
         specifier: workspace:*
         version: link:../../../anyharness/sdk-react
       '@proliferate/cloud-sdk':
         specifier: workspace:*
         version: link:../../../cloud/sdk
+      '@proliferate/cloud-sdk-react':
+        specifier: workspace:*
+        version: link:../../../cloud/sdk-react
+      '@proliferate/design':
+        specifier: workspace:*
+        version: link:../design
       '@proliferate/product-domain':
         specifier: workspace:*
         version: link:../product-domain
+      '@proliferate/product-surfaces':
+        specifier: workspace:*
+        version: link:../product-surfaces
+      '@proliferate/product-ui':
+        specifier: workspace:*
+        version: link:../product-ui
+      '@proliferate/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
+      lucide-react:
+        specifier: 0.577.0
+        version: 0.577.0(react@19.2.7)
+      react-router-dom:
+        specifier: ^7
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      zustand:
+        specifier: ^5
+        version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4
+        version: 4.3.1(vite@6.4.3(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -408,6 +444,9 @@ importers:
       '@types/react-dom':
         specifier: ~19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4
+        version: 4.7.0(vite@6.4.3(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -417,9 +456,15 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: ^4
+        version: 4.3.1
       typescript:
         specifier: ^5.7
         version: 5.9.3
+      vite:
+        specifier: ^6
+        version: 6.4.3(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0)

--- a/scripts/collect-web-bundle-baseline.mjs
+++ b/scripts/collect-web-bundle-baseline.mjs
@@ -1,0 +1,57 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+
+function parseArgs() {
+  const args = new Map();
+  for (let index = 2; index < process.argv.length; index += 2) {
+    args.set(process.argv[index], process.argv[index + 1]);
+  }
+  return {
+    dist: resolve(args.get("--dist") ?? "apps/web/dist"),
+    out: resolve(args.get("--out") ?? "specs/codebase/features/web-desktop-product-client-web-baseline.json"),
+  };
+}
+
+const { dist, out } = parseArgs();
+const manifestPath = join(dist, ".vite", "manifest.json");
+if (!existsSync(manifestPath)) {
+  throw new Error(`Missing Vite manifest at ${manifestPath}. Build Web with manifest enabled before collecting.`);
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const files = new Map();
+for (const entry of Object.values(manifest)) {
+  if (entry.file) files.set(entry.file, "js");
+  for (const css of entry.css ?? []) files.set(css, "css");
+  for (const asset of entry.assets ?? []) files.set(asset, asset.split(".").at(-1) ?? "asset");
+}
+
+const totals = {};
+const entries = [];
+for (const [file, kind] of [...files].sort()) {
+  const bytes = readFileSync(join(dist, file));
+  const gzipBytes = gzipSync(bytes).byteLength;
+  totals[kind] = (totals[kind] ?? 0) + gzipBytes;
+  entries.push({
+    file,
+    name: basename(file),
+    kind,
+    bytes: bytes.byteLength,
+    gzipBytes,
+  });
+}
+
+const baseline = {
+  schemaVersion: 1,
+  collectedAt: new Date().toISOString(),
+  dist,
+  metric: "gzip_bytes",
+  note: "Provisional legacy Web baseline. The Web replacement PR reruns this on its exact base for the binding budget.",
+  totals,
+  entries,
+};
+
+mkdirSync(dirname(out), { recursive: true });
+writeFileSync(out, `${JSON.stringify(baseline, null, 2)}\n`);
+console.log(`Wrote Web bundle baseline to ${out}`);

--- a/scripts/migrate-desktop-product-client.mjs
+++ b/scripts/migrate-desktop-product-client.mjs
@@ -1,0 +1,222 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const desktopSrc = resolve(repoRoot, "apps/desktop/src");
+const ledgerPath = resolve(repoRoot, "specs/codebase/features/web-desktop-product-client-move-ledger.json");
+
+function walk(dir) {
+  const entries = [];
+  for (const name of readdirSync(dir).sort()) {
+    const path = resolve(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      entries.push(...walk(path));
+    } else {
+      entries.push(path);
+    }
+  }
+  return entries;
+}
+
+function rel(path) {
+  return relative(repoRoot, path).replaceAll("\\", "/");
+}
+
+function classify(path) {
+  const source = rel(path);
+  const srcRelative = source.slice("apps/desktop/src/".length);
+  if (
+    srcRelative === "main.tsx"
+    || srcRelative === "index.css"
+    || srcRelative === "assets.d.ts"
+    || srcRelative.startsWith("lib/access/tauri/")
+    || srcRelative.startsWith("lib/access/browser/")
+    || srcRelative.startsWith("providers/Desktop")
+    || srcRelative === "providers/desktop-product-host.ts"
+    || srcRelative === "providers/desktop-product-host.test.ts"
+    || srcRelative.startsWith("test/")
+  ) {
+    return {
+      action: "retain",
+      source,
+      reason: "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app.",
+    };
+  }
+  if (
+    srcRelative === "App.tsx"
+    || srcRelative === "providers/ProductProviderRoot.tsx"
+    || srcRelative === "providers/ProductLifecycleRoot.tsx"
+    || srcRelative === "providers/ProductLifecycleRoot.test.tsx"
+  ) {
+    return {
+      action: "split",
+      source,
+      target: `apps/packages/product-client/src/${srcRelative}`,
+      reason: "Root composition splits into a host shell plus shared ProductClient route/provider ownership.",
+    };
+  }
+  return {
+    action: "move",
+    source,
+    target: `apps/packages/product-client/src/${srcRelative}`,
+    reason: "Desktop product source moves mechanically into ProductClient.",
+  };
+}
+
+function buildLedger() {
+  return {
+    schemaVersion: 1,
+    generatedFrom: "scripts/migrate-desktop-product-client.mjs",
+    desktopSourceRoot: "apps/desktop/src",
+    productClientTargetRoot: "apps/packages/product-client/src",
+    entries: walk(desktopSrc)
+      .filter((path) => /\.(ts|tsx|css|json|svg|png|jpg|jpeg|webp|wav|mp3|woff2)$/.test(path))
+      .map(classify),
+  };
+}
+
+function writeLedger() {
+  const ledger = buildLedger();
+  mkdirSync(dirname(ledgerPath), { recursive: true });
+  writeFileSync(ledgerPath, `${JSON.stringify(ledger, null, 2)}\n`);
+  console.log(`Wrote ${ledger.entries.length} move-ledger entries to ${rel(ledgerPath)}`);
+}
+
+function checkLedger() {
+  const expected = JSON.stringify(buildLedger(), null, 2) + "\n";
+  const actual = existsSync(ledgerPath) ? readFileSync(ledgerPath, "utf8") : "";
+  if (actual !== expected) {
+    throw new Error(`Move ledger is stale. Run: node scripts/migrate-desktop-product-client.mjs ledger`);
+  }
+  const ledger = JSON.parse(actual);
+  const targets = new Map();
+  for (const entry of ledger.entries) {
+    if (!existsSync(resolve(repoRoot, entry.source))) {
+      throw new Error(`Ledger source is missing: ${entry.source}`);
+    }
+    if (entry.target) {
+      const previous = targets.get(entry.target);
+      if (previous) {
+        throw new Error(`Ledger maps two sources to ${entry.target}: ${previous} and ${entry.source}`);
+      }
+      targets.set(entry.target, entry.source);
+    }
+  }
+  console.log(`Checked ${ledger.entries.length} move-ledger entries.`);
+}
+
+function loadMovedMap(root) {
+  const ledger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+  const moved = new Map();
+  for (const entry of ledger.entries) {
+    if (entry.action === "move" || entry.action === "split") {
+      moved.set(entry.source, entry.target);
+    }
+  }
+  return { ledger, moved, root };
+}
+
+function resolveDesktopAlias(importer, specifier) {
+  if (specifier.startsWith("@/")) {
+    return `apps/desktop/src/${specifier.slice(2)}`;
+  }
+  if (!specifier.startsWith(".")) {
+    return null;
+  }
+  const importerDir = dirname(importer);
+  const candidate = resolve(repoRoot, importerDir, specifier);
+  for (const extension of ["", ".ts", ".tsx", ".css", ".json"]) {
+    const full = `${candidate}${extension}`;
+    if (existsSync(full)) {
+      return rel(full);
+    }
+  }
+  return null;
+}
+
+function productSpecifierFor(target) {
+  return `#product/${target.slice("apps/packages/product-client/src/".length).replace(/\.(ts|tsx)$/, "")}`;
+}
+
+function rewriteSource(importer, source, moved) {
+  return source.replace(
+    /from\s+["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g,
+    (match, staticSpecifier, dynamicSpecifier) => {
+      const specifier = staticSpecifier ?? dynamicSpecifier;
+      const resolved = resolveDesktopAlias(importer, specifier);
+      if (!resolved || !moved.has(resolved)) {
+        return match;
+      }
+      const next = productSpecifierFor(moved.get(resolved));
+      return staticSpecifier ? `from "${next}"` : `import("${next}")`;
+    },
+  );
+}
+
+function codemod({ root, apply }) {
+  const { moved } = loadMovedMap(root);
+  const files = walk(resolve(repoRoot, root)).filter((path) => /\.(ts|tsx)$/.test(path));
+  const changes = [];
+  for (const file of files) {
+    const path = rel(file);
+    const source = readFileSync(file, "utf8");
+    const next = rewriteSource(path, source, moved);
+    if (source !== next) {
+      changes.push(path);
+      if (apply) {
+        writeFileSync(file, next);
+      }
+    }
+  }
+  if (!apply && changes.length > 0) {
+    console.log(changes.join("\n"));
+    throw new Error(`Codemod would update ${changes.length} files.`);
+  }
+  console.log(`${apply ? "Updated" : "Checked"} ${files.length} files; ${changes.length} changes.`);
+}
+
+function proveCodemod() {
+  checkLedger();
+  const tmp = resolve(repoRoot, ".tmp/product-client-codemod-proof");
+  rmSync(tmp, { force: true, recursive: true });
+  mkdirSync(dirname(tmp), { recursive: true });
+  cpSync(desktopSrc, resolve(tmp, "apps/desktop/src"), { recursive: true });
+  const proofRoot = relative(repoRoot, resolve(tmp, "apps/desktop/src")).replaceAll("\\", "/");
+  codemod({ root: proofRoot, apply: true });
+  codemod({ root: proofRoot, apply: false });
+  rmSync(tmp, { force: true, recursive: true });
+}
+
+const command = process.argv[2];
+switch (command) {
+  case "ledger":
+    writeLedger();
+    break;
+  case "check-ledger":
+    checkLedger();
+    break;
+  case "codemod-check":
+    checkLedger();
+    codemod({ root: process.argv[3] ?? "apps/desktop/src", apply: false });
+    break;
+  case "codemod-apply":
+    checkLedger();
+    codemod({ root: process.argv[3] ?? "apps/desktop/src", apply: true });
+    break;
+  case "prove-codemod":
+    proveCodemod();
+    break;
+  default:
+    throw new Error("Usage: node scripts/migrate-desktop-product-client.mjs <ledger|check-ledger|codemod-check|codemod-apply|prove-codemod> [root]");
+}

--- a/scripts/verify-product-client-qualification-assets.mjs
+++ b/scripts/verify-product-client-qualification-assets.mjs
@@ -1,0 +1,54 @@
+import { createServer } from "node:http";
+import { existsSync, readFileSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
+
+const root = resolve(process.argv[2] ?? "");
+if (!root || !existsSync(root)) {
+  throw new Error(`Usage: node scripts/verify-product-client-qualification-assets.mjs <dist-dir>; missing ${root}`);
+}
+
+const manifestPath = join(root, ".vite", "manifest.json");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const urls = new Set(["/index.html"]);
+for (const entry of Object.values(manifest)) {
+  if (entry.file) urls.add(`/${entry.file}`);
+  for (const css of entry.css ?? []) urls.add(`/${css}`);
+  for (const asset of entry.assets ?? []) urls.add(`/${asset}`);
+}
+
+const mimeTypes = new Map([
+  [".html", "text/html"],
+  [".js", "text/javascript"],
+  [".css", "text/css"],
+  [".svg", "image/svg+xml"],
+  [".wav", "audio/wav"],
+  [".woff2", "font/woff2"],
+]);
+
+const server = createServer((request, response) => {
+  const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+  const pathname = requestUrl.pathname === "/" ? "/index.html" : requestUrl.pathname;
+  const filePath = join(root, decodeURIComponent(pathname));
+  if (!filePath.startsWith(root) || !existsSync(filePath)) {
+    response.statusCode = 404;
+    response.end("not found");
+    return;
+  }
+  response.setHeader("content-type", mimeTypes.get(extname(filePath)) ?? "application/octet-stream");
+  response.end(readFileSync(filePath));
+});
+
+await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+const { port } = server.address();
+
+try {
+  for (const url of [...urls].sort()) {
+    const response = await fetch(`http://127.0.0.1:${port}${url}`);
+    if (!response.ok) {
+      throw new Error(`${url} returned HTTP ${response.status}`);
+    }
+  }
+  console.log(`Verified ${urls.size} ProductClient qualification URLs from ${root}`);
+} finally {
+  await new Promise((resolveClose) => server.close(resolveClose));
+}

--- a/specs/codebase/features/web-desktop-product-client-extraction-mechanics.md
+++ b/specs/codebase/features/web-desktop-product-client-extraction-mechanics.md
@@ -1,0 +1,96 @@
+# ProductClient Extraction Mechanics
+
+Status: qualification artifact for the Web/Desktop client unification migration.
+
+This PR proves the mechanics needed by the next source-move PR without moving
+Desktop product source.
+
+## Future application entry
+
+The real shared product entry remains reserved for the mechanical move:
+
+```text
+apps/packages/product-client/src/ProductClient.tsx
+  -> @proliferate/product-client/ProductClient
+```
+
+Its approved signature is:
+
+```ts
+export type ProductRoutesComponent = ComponentType<RoutesProps>;
+
+export interface ProductClientProps {
+  RoutesComponent: ProductRoutesComponent;
+}
+
+export function ProductClient({
+  RoutesComponent,
+}: ProductClientProps): ReactElement;
+```
+
+The real entry is not created in this mechanics PR. The temporary public
+qualification export is:
+
+```text
+@proliferate/product-client/qualification/ProductClientBuildCanary
+```
+
+It proves the same host envelope, package export resolution, lazy authenticated
+chunk shape, product CSS, generated JSON, raw text/SVG imports, and emitted
+image/audio/font assets.
+
+## Qualification builds
+
+Two production canary builds import the compiled ProductClient package:
+
+```text
+apps/desktop/qualification/product-client
+apps/packages/product-client/qualification/browser-host
+```
+
+Both mount:
+
+```text
+Router
+  -> QueryClientProvider
+  -> CloudClientProvider
+  -> ProductHostProvider
+  -> ProductClientBuildCanary(RoutesComponent)
+```
+
+The browser host passes `surface: "web"` and `desktop: null`. The Desktop
+qualification host passes `surface: "desktop"` and imports Desktop CSS, but it
+does not mount a local runtime or native lifecycle.
+
+## Move ledger and codemod
+
+The exact Desktop source ledger is generated and checked by:
+
+```bash
+node scripts/migrate-desktop-product-client.mjs ledger
+node scripts/migrate-desktop-product-client.mjs check-ledger
+node scripts/migrate-desktop-product-client.mjs prove-codemod
+```
+
+The checked-in ledger lives at:
+
+```text
+specs/codebase/features/web-desktop-product-client-move-ledger.json
+```
+
+The codemod rewrites only ledger-approved moved/split Desktop-local imports to
+`#product/*`. The proof command runs against a disposable copy and verifies a
+second pass is empty.
+
+## Legacy Web bundle baseline
+
+The provisional legacy Web bundle collector is:
+
+```bash
+node scripts/collect-web-bundle-baseline.mjs \
+  --dist apps/web/dist \
+  --out specs/codebase/features/web-desktop-product-client-web-baseline.json
+```
+
+The Web replacement PR reruns this on its exact base and records the binding
+budget baseline before deleting the legacy Web product.

--- a/specs/codebase/features/web-desktop-product-client-move-ledger.json
+++ b/specs/codebase/features/web-desktop-product-client-move-ledger.json
@@ -1,0 +1,13290 @@
+{
+  "schemaVersion": 1,
+  "generatedFrom": "scripts/migrate-desktop-product-client.mjs",
+  "desktopSourceRoot": "apps/desktop/src",
+  "productClientTargetRoot": "apps/packages/product-client/src",
+  "entries": [
+    {
+      "action": "split",
+      "source": "apps/desktop/src/App.tsx",
+      "target": "apps/packages/product-client/src/App.tsx",
+      "reason": "Root composition splits into a host shell plus shared ProductClient route/provider ownership."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/axiom-dark.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/axiom-dark.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/axiom.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/axiom.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/context7.jpeg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/context7.jpeg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/exa.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/exa.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/filesystem.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/filesystem.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/gitlab.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/gitlab.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/gmail.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/gmail.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/huggingface.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/huggingface.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/neon.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/neon.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/notion.png",
+      "target": "apps/packages/product-client/src/assets/connector-icons/notion.png",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/playwright.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/playwright.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/posthog.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/posthog.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/render-dark.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/render-dark.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/render.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/render.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/sentry-dark.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/sentry-dark.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/sentry.svg",
+      "target": "apps/packages/product-client/src/assets/connector-icons/sentry.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/connector-icons/supabase.png",
+      "target": "apps/packages/product-client/src/assets/connector-icons/supabase.png",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/biome.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/biome.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/c.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/c.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/console.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/console.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/cpp.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/cpp.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/css.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/css.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/database.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/database.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/docker.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/docker.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/document.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/document.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/editorconfig.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/editorconfig.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/eslint.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/eslint.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/file.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/file.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-config-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-config-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-config.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-config.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-docs-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-docs-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-docs.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-docs.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-git-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-git-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-git.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-git.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-images-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-images-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-images.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-images.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-src-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-src-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-src.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-src.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-test-open.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-test-open.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder-test.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder-test.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/folder.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/folder.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/git.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/git.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/go-mod.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/go-mod.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/go.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/go.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/html.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/html.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/image.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/image.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/java.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/java.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/javascript.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/javascript.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/json.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/json.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/key.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/key.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/kotlin.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/kotlin.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/license.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/license.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/lock.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/lock.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/makefile.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/makefile.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/markdown.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/markdown.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/npm.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/npm.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/php.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/php.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/pnpm.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/pnpm.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/prettier.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/prettier.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/python.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/python.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/react.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/react.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/react_ts.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/react_ts.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/readme.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/readme.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/ruby.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/ruby.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/rust.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/rust.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/sass.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/sass.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/settings.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/settings.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/svg.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/svg.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/swift.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/swift.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/table.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/table.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/test-js.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/test-js.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/test-jsx.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/test-jsx.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/test-ts.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/test-ts.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/toml.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/toml.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/tsconfig.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/tsconfig.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/typescript-def.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/typescript-def.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/typescript.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/typescript.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/xml.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/xml.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/yaml.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/yaml.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/file-icons/material/yarn.svg",
+      "target": "apps/packages/product-client/src/assets/file-icons/material/yarn.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/assets/sounds/ding.mp3",
+      "target": "apps/packages/product-client/src/assets/sounds/ding.mp3",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/assets.d.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/agents/AgentHarnessModelSelector.tsx",
+      "target": "apps/packages/product-client/src/components/agents/AgentHarnessModelSelector.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/agents/AgentLoginTerminalPanel.tsx",
+      "target": "apps/packages/product-client/src/components/agents/AgentLoginTerminalPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/agents/AgentSetupModal.tsx",
+      "target": "apps/packages/product-client/src/components/agents/AgentSetupModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/AppErrorBoundary.tsx",
+      "target": "apps/packages/product-client/src/components/app/AppErrorBoundary.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/OfflineIndicator.tsx",
+      "target": "apps/packages/product-client/src/components/app/OfflineIndicator.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/UserPreferencesGate.test.tsx",
+      "target": "apps/packages/product-client/src/components/app/UserPreferencesGate.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/UserPreferencesGate.tsx",
+      "target": "apps/packages/product-client/src/components/app/UserPreferencesGate.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/chrome/MacWindowControlsSafeArea.tsx",
+      "target": "apps/packages/product-client/src/components/app/chrome/MacWindowControlsSafeArea.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/OrganizationSwitchDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/OrganizationSwitchDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/OrganizationSwitchDialog.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/OrganizationSwitchDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/SidebarAccountFooter.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/SidebarAccountFooter.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/SidebarAppVersionRow.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/SidebarAppVersionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/SidebarConsumptionCard.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/SidebarHelpSection.test.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/app/sidebar/SidebarHelpSection.tsx",
+      "target": "apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/AuthAppearanceBoundary.tsx",
+      "target": "apps/packages/product-client/src/components/auth/AuthAppearanceBoundary.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/AuthGate.test.tsx",
+      "target": "apps/packages/product-client/src/components/auth/AuthGate.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/AuthGate.tsx",
+      "target": "apps/packages/product-client/src/components/auth/AuthGate.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/AuthScreenLayout.tsx",
+      "target": "apps/packages/product-client/src/components/auth/AuthScreenLayout.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/AuthShell.tsx",
+      "target": "apps/packages/product-client/src/components/auth/AuthShell.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/ConnectServerDialog.tsx",
+      "target": "apps/packages/product-client/src/components/auth/ConnectServerDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/LoginScreen.tsx",
+      "target": "apps/packages/product-client/src/components/auth/LoginScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/OrgSsoLoginLink.tsx",
+      "target": "apps/packages/product-client/src/components/auth/OrgSsoLoginLink.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/PasswordSignInForm.tsx",
+      "target": "apps/packages/product-client/src/components/auth/PasswordSignInForm.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/auth/SessionCheckScreen.tsx",
+      "target": "apps/packages/product-client/src/components/auth/SessionCheckScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/controls/AutomationAgentRunConfigPicker.tsx",
+      "target": "apps/packages/product-client/src/components/automations/controls/AutomationAgentRunConfigPicker.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/controls/AutomationRunLocationSelector.test.tsx",
+      "target": "apps/packages/product-client/src/components/automations/controls/AutomationRunLocationSelector.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/controls/AutomationRunLocationSelector.tsx",
+      "target": "apps/packages/product-client/src/components/automations/controls/AutomationRunLocationSelector.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/controls/run-location/AutomationRunLocationMenu.tsx",
+      "target": "apps/packages/product-client/src/components/automations/controls/run-location/AutomationRunLocationMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/editor/AutomationAgentHarnessControls.tsx",
+      "target": "apps/packages/product-client/src/components/automations/editor/AutomationAgentHarnessControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/editor/AutomationEditorControls.tsx",
+      "target": "apps/packages/product-client/src/components/automations/editor/AutomationEditorControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/editor/AutomationEditorDialog.tsx",
+      "target": "apps/packages/product-client/src/components/automations/editor/AutomationEditorDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/editor/AutomationEditorModal.tsx",
+      "target": "apps/packages/product-client/src/components/automations/editor/AutomationEditorModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/automations/screen/AutomationsScreen.tsx",
+      "target": "apps/packages/product-client/src/components/automations/screen/AutomationsScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/billing/UpgradeGateDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/billing/UpgradeGateDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/billing/UpgradeGateDialog.tsx",
+      "target": "apps/packages/product-client/src/components/billing/UpgradeGateDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/brand/ProliferateLogo.tsx",
+      "target": "apps/packages/product-client/src/components/brand/ProliferateLogo.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/cloud/CloudGuard.test.tsx",
+      "target": "apps/packages/product-client/src/components/cloud/CloudGuard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/cloud/CloudGuard.tsx",
+      "target": "apps/packages/product-client/src/components/cloud/CloudGuard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/compute/ComputeTargetSwatch.tsx",
+      "target": "apps/packages/product-client/src/components/compute/ComputeTargetSwatch.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/DiffViewer.test.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/DiffViewer.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/DiffViewer.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/DiffViewer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/FileChangeStats.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/FileChangeStats.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/FileChangesCard.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/FileChangesCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/FileDiffCard.test.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/FileDiffCard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/FileDiffCard.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/FileDiffCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/FilePathLink.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/FilePathLink.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/HighlightedCodeBlock.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/HighlightedCodeBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/desktop-markdown-code-block.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/desktop-markdown-code-block.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/ChatDiffLineWrapContextMenu.test.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/ChatDiffLineWrapContextMenu.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/ChatDiffLineWrapContextMenu.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/ChatDiffLineWrapContextMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/DiffContextExpander.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/DiffContextExpander.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/DiffLineContent.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/DiffLineContent.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/HunkActionPill.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/HunkActionPill.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/SplitDiffViewer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/content/ui/search/ContentSearchMarks.tsx",
+      "target": "apps/packages/product-client/src/components/content/ui/search/ContentSearchMarks.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/diagnostics/DebugProfiler.test.tsx",
+      "target": "apps/packages/product-client/src/components/diagnostics/DebugProfiler.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/diagnostics/DebugProfiler.tsx",
+      "target": "apps/packages/product-client/src/components/diagnostics/DebugProfiler.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/LoadingIllustration.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/LoadingIllustration.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/Skeleton.test.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/Skeleton.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/Skeleton.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/Skeleton.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/ThinkingText.test.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/ThinkingText.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/ThinkingText.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/ThinkingText.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/Toast.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/Toast.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/UpdateDialogContent.test.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/UpdateDialogContent.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/UpdateDialogContent.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/UpdateDialogContent.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/UpdateRestartDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/UpdateRestartDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/UpdateRestartDialog.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/UpdateRestartDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/UpdateToastPresenter.test.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/UpdateToastPresenter.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/feedback/UpdateToastPresenter.tsx",
+      "target": "apps/packages/product-client/src/components/feedback/UpdateToastPresenter.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeComposerForm.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeNextScreen.test.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeNextScreen.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeOnboardingCards.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeOnboardingCards.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeProjectMenu.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeProjectMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeTargetPicker.test.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeTargetPicker.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeTargetPicker.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/home/screen/HomeTargetPickerParts.tsx",
+      "target": "apps/packages/product-client/src/components/home/screen/HomeTargetPickerParts.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/organizations/OrganizationAvatar.tsx",
+      "target": "apps/packages/product-client/src/components/organizations/OrganizationAvatar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/AuthOnboardingPlayground.tsx",
+      "target": "apps/packages/product-client/src/components/playground/AuthOnboardingPlayground.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/PlaygroundComposer.tsx",
+      "target": "apps/packages/product-client/src/components/playground/PlaygroundComposer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/PlaygroundComposerActions.tsx",
+      "target": "apps/packages/product-client/src/components/playground/PlaygroundComposerActions.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/PlaygroundComposerSurfaces.tsx",
+      "target": "apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/PlaygroundScenarioBar.tsx",
+      "target": "apps/packages/product-client/src/components/playground/PlaygroundScenarioBar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/PlaygroundSidebarGitDiff.test.tsx",
+      "target": "apps/packages/product-client/src/components/playground/PlaygroundSidebarGitDiff.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/PlaygroundSidebarGitDiff.tsx",
+      "target": "apps/packages/product-client/src/components/playground/PlaygroundSidebarGitDiff.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/UpdateUiPlayground.tsx",
+      "target": "apps/packages/product-client/src/components/playground/UpdateUiPlayground.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/UpdateUiPlaygroundControls.tsx",
+      "target": "apps/packages/product-client/src/components/playground/UpdateUiPlaygroundControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/WorkspaceStatusPlayground.tsx",
+      "target": "apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/activity/ActivityFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/activity/ActivityFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/activity/GoalBarFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/activity/GoalBarFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/composer-slots/PlaygroundActiveSlotFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/composer-slots/PlaygroundActiveSlotFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/composer-slots/PlaygroundAttachedSlotFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/composer-slots/PlaygroundAttachedSlotFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/composer-slots/PlaygroundInteractionMotionFixture.tsx",
+      "target": "apps/packages/product-client/src/components/playground/composer-slots/PlaygroundInteractionMotionFixture.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/composer-slots/PlaygroundOutboundSlotFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/composer-slots/PlaygroundOutboundSlotFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/composer-slots/PlaygroundPanelSlotFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/composer-slots/PlaygroundPanelSlotFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/delegation/PlaygroundComposerDelegation.tsx",
+      "target": "apps/packages/product-client/src/components/playground/delegation/PlaygroundComposerDelegation.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/delegation/PlaygroundDelegatedWorkViewModel.tsx",
+      "target": "apps/packages/product-client/src/components/playground/delegation/PlaygroundDelegatedWorkViewModel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/loading/PlaygroundLoadingStates.tsx",
+      "target": "apps/packages/product-client/src/components/playground/loading/PlaygroundLoadingStates.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/loading/PlaygroundThinkingTimingControls.tsx",
+      "target": "apps/packages/product-client/src/components/playground/loading/PlaygroundThinkingTimingControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/SubagentsUxPlayground.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/SubagentsUxPlayground.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowChatViews.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/full-flow/FullFlowChatViews.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/full-flow/FullFlowFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowPrototype.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/full-flow/FullFlowPrototype.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/full-flow/FullFlowTabs.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/full-flow/FullFlowTabs.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/identity-receipts/IdentityReceiptsPrototype.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/identity-receipts/IdentityReceiptsPrototype.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/identity-receipts/SubagentCreationReceipt.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/identity-receipts/SubagentCreationReceipt.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/identity-receipts/SubagentIdentityGlyph.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/identity-receipts/SubagentIdentityGlyph.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/navigation-close/NavigationClosePaneRow.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/navigation-close/NavigationClosePaneRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/navigation-close/NavigationClosePrototype.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/navigation-close/NavigationClosePrototype.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/navigation-close/NavigationCloseTabs.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/navigation-close/NavigationCloseTabs.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/ActivityAggregatePopover.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/ActivityAggregatePopover.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/AgentGlyph.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/AgentGlyph.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/GlobalAgentsPanePrototype.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/GlobalAgentsPanePrototype.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPaneActivityFacts.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/PopoverPaneActivityFacts.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPaneFixtures.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/PopoverPaneFixtures.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/PopoverPanePrototype.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/PopoverPanePrototype.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/subagents-ux/popover-pane/SubagentsPanePrototype.tsx",
+      "target": "apps/packages/product-client/src/components/playground/subagents-ux/popover-pane/SubagentsPanePrototype.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/transcript/PlaygroundPlanTranscript.tsx",
+      "target": "apps/packages/product-client/src/components/playground/transcript/PlaygroundPlanTranscript.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/transcript/PlaygroundRecordingTranscript.tsx",
+      "target": "apps/packages/product-client/src/components/playground/transcript/PlaygroundRecordingTranscript.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/transcript/PlaygroundStatusTranscript.tsx",
+      "target": "apps/packages/product-client/src/components/playground/transcript/PlaygroundStatusTranscript.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/transcript/PlaygroundToolTranscript.tsx",
+      "target": "apps/packages/product-client/src/components/playground/transcript/PlaygroundToolTranscript.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/transcript/PlaygroundTranscript.tsx",
+      "target": "apps/packages/product-client/src/components/playground/transcript/PlaygroundTranscript.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/playground/transcript/PlaygroundTranscriptShell.tsx",
+      "target": "apps/packages/product-client/src/components/playground/transcript/PlaygroundTranscriptShell.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/session-controls/SessionControlIcon.test.tsx",
+      "target": "apps/packages/product-client/src/components/session-controls/SessionControlIcon.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/session-controls/SessionControlIcon.tsx",
+      "target": "apps/packages/product-client/src/components/session-controls/SessionControlIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/AccountPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/AccountPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/AppearancePane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/AppearancePane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/BillingPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/BillingPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/CloudAuthUnavailablePane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/CloudAuthUnavailablePane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/CloudSignInRequiredPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/CloudSignInRequiredPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/CloudUnavailablePane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/CloudUnavailablePane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/GeneralPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/GeneralPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationBudgetsPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationBudgetsPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationIntegrationsPane.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationIntegrationsPane.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationIntegrationsPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationIntegrationsPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationLimitsEditor.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationLimitsEditor.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationMembersPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationMembersPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationModelPolicyPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationModelPolicyPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationSecretsPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationSecretsPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/OrganizationSsoPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/OrganizationSsoPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/PersonalSecretsPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/PersonalSecretsPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/SettingsScaffoldPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/SettingsScaffoldPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/UserIntegrationsPane.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/UserIntegrationsPane.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/UserIntegrationsPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/UserIntegrationsPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/WorktreesPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/WorktreesPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/account/GitHubAppUserAuthorizationService.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/account/GitHubAppUserAuthorizationService.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agent-auth/ApiKeyCreatorModal.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agent-auth/ApiKeyCreatorModal.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agent-auth/ApiKeyCreatorModal.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agent-auth/ApiKeyCreatorModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agent-auth/KeyPicker.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agent-auth/KeyPicker.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agent-auth/KeyPicker.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agent-auth/KeyPicker.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/api-keys/ApiKeysPane.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/api-keys/ApiKeysPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthApiKeyDetails.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthApiKeyDetails.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthApiKeyRow.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthApiKeyRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthCliDetails.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthCliDetails.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthDetailsSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthDetailsSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthGatewayDetails.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthGatewayDetails.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessPanelBlock.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPanelBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/ProviderPickerModal.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderPickerModal.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/agents/harness/ProviderPickerModal.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderPickerModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/environments/WorktreeStorageSection.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/environments/WorktreeStorageSection.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/environments/WorktreeStorageSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/environments/WorktreeStorageSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/AddCustomIntegrationDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/AddCustomIntegrationDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/AddCustomIntegrationDialog.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/AddCustomIntegrationDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/IntegrationConnectDialog.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/IntegrationConnectDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/IntegrationIcon.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/IntegrationIcon.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/IntegrationIcon.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/IntegrationIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/IntegrationRow.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/IntegrationRow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/integrations/IntegrationRow.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/integrations/IntegrationRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/CurrentUserInvitationsSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/CurrentUserInvitationsSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/GitHubAppInstallationSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/GitHubAppInstallationSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationBillingLinkSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationBillingLinkSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationInvitationsSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationInvitationsSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationLogo.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationLogo.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationMembersList.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationMembersList.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationMembersList.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationMembersList.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationMembersSection.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationMembersSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationSelectMenu.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationSelectMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/organization/OrganizationSettingsCard.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/organization/OrganizationSettingsCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/repo/RepoActionsPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/repo/RepoActionsPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/repo/RepoCloudGate.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/repo/RepoCloudGate.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/repo/RepoConfigurePane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/repo/RepoConfigurePane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/repo/RepoEnvironmentPane.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/repo/RepoEnvironmentPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/panes/repo/RepoScopeStates.tsx",
+      "target": "apps/packages/product-client/src/components/settings/panes/repo/RepoScopeStates.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/screen/AgentScopeHeaderControls.tsx",
+      "target": "apps/packages/product-client/src/components/settings/screen/AgentScopeHeaderControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/screen/RepoScopeHeaderControls.tsx",
+      "target": "apps/packages/product-client/src/components/settings/screen/RepoScopeHeaderControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/screen/SettingsContentBoundary.tsx",
+      "target": "apps/packages/product-client/src/components/settings/screen/SettingsContentBoundary.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/screen/SettingsScreen.tsx",
+      "target": "apps/packages/product-client/src/components/settings/screen/SettingsScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/screen/render-settings-section.tsx",
+      "target": "apps/packages/product-client/src/components/settings/screen/render-settings-section.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/shared/AdminOnlyPlaceholder.tsx",
+      "target": "apps/packages/product-client/src/components/settings/shared/AdminOnlyPlaceholder.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/shared/AgentHarnessConfigComposer.tsx",
+      "target": "apps/packages/product-client/src/components/settings/shared/AgentHarnessConfigComposer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/shared/RunCommandHelp.tsx",
+      "target": "apps/packages/product-client/src/components/settings/shared/RunCommandHelp.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/sidebar/HarnessStatusDot.tsx",
+      "target": "apps/packages/product-client/src/components/settings/sidebar/HarnessStatusDot.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx",
+      "target": "apps/packages/product-client/src/components/settings/sidebar/SettingsSidebar.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/settings/sidebar/SettingsSidebar.tsx",
+      "target": "apps/packages/product-client/src/components/settings/sidebar/SettingsSidebar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/support/SendFeedbackModal.tsx",
+      "target": "apps/packages/product-client/src/components/support/SendFeedbackModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/support/SubmitPromptModal.tsx",
+      "target": "apps/packages/product-client/src/components/support/SubmitPromptModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/support/SupportCheckboxRow.tsx",
+      "target": "apps/packages/product-client/src/components/support/SupportCheckboxRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/support/SupportCreditField.tsx",
+      "target": "apps/packages/product-client/src/components/support/SupportCreditField.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/support/SupportModalFooter.tsx",
+      "target": "apps/packages/product-client/src/components/support/SupportModalFooter.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/support/SupportModalHost.tsx",
+      "target": "apps/packages/product-client/src/components/support/SupportModalHost.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workflows/definitions/WorkflowDefinitionsAccessScreen.tsx",
+      "target": "apps/packages/product-client/src/components/workflows/definitions/WorkflowDefinitionsAccessScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/activity/LiveTerminalsRosterPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/activity/LiveTerminalsRosterPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/activity/SessionActivityBar.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/activity/SessionActivityBar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/ChatView.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/ChatView.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/content/PlanReferenceAttachmentCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/content/PlanReferenceAttachmentCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ApprovalCard.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ApprovalCard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ApprovalCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ApprovalCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ChatComposerActions.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ChatComposerActions.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ChatComposerDock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ChatComposerDock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ChatInput.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ChatInputControlRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ChatInputDraftArea.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerAttachedPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerAttachedPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerCommandEditor.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerFastModeToggle.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerFastModeToggle.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerIntegrationsControl.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerIntegrationsControl.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerIntegrationsControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerIntegrationsControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerOptionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerOverflowControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerOverflowControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/ComposerSlashHighlight.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/ComposerSlashHighlight.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/DelegatedWorkComposerPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/DelegatedWorkComposerPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/McpElicitationCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/McpElicitationCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/McpElicitationFieldControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/McpElicitationFieldControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/McpElicitationFormPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/McpElicitationFormPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/McpElicitationInlineError.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/McpElicitationInlineError.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/McpElicitationUrlPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/McpElicitationUrlPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/PendingConfigIndicator.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/PendingConfigIndicator.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/PendingPromptList.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/PendingPromptList.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/PlanPickerContentBody.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/PlanPickerContentBody.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/PromptRecoveryPanel.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/PromptRecoveryPanel.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/PromptRecoveryPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/PromptRecoveryPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/QueuedPromptEditBanner.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/QueuedPromptEditBanner.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/RuntimePressureDetailsDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/RuntimePressureDetailsDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/RuntimePressureDetailsDialog.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/RuntimePressureDetailsDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/RuntimePressureIndicator.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/RuntimePressureIndicator.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/RuntimePressureWorktreeTable.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/RuntimePressureWorktreeTable.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/RuntimePressureWorktreeTable.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/RuntimePressureWorktreeTable.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/SessionConfigControls.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/SessionConfigControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/SessionModeControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/TodoTrackerPanel.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/TodoTrackerPanel.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/TodoTrackerPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/TodoTrackerPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/UserInputCard.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/UserInputCard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/UserInputCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/UserInputCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/WorkspaceOpenInWebFooterControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/WorkspaceOpenInWebFooterControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/WorkspaceRemoteAccessFooterControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/WorkspaceRemoteAccessFooterControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/delegated-work/AgentsPopoverSubagentSection.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/delegated-work/AgentsPopoverSubagentSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/delegated-work/DelegatedWorkComposerControl.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/delegated-work/PopoverSection.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/delegated-work/PopoverSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/plans/ConnectedPlanHandoffDialog.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/plans/ConnectedPlanHandoffDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/plans/PlanHandoffDialog.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/plans/PlanHandoffDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/plans/PlanHandoffModePicker.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/plans/PlanHandoffModePicker.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/plans/PlanReferencePreviewDialog.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/plans/PlanReferencePreviewDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/ChatLaunchIntentPane.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/ChatLaunchIntentPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/ChatLoadingHero.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/ChatLoadingHero.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/ChatPreMessageCanvas.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/ChatPreMessageCanvas.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/ChatReadyHero.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/ChatReadyHero.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/ChatSurfaceCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/ChatSurfaceCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/CloudRuntimeAttachedPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/CloudRuntimeAttachedPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/CloudStatusCompactHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/CloudStatusCompactHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/NoWorkspaceState.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/NoWorkspaceState.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/SessionContentSearchOverlay.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/SessionContentSearchOverlay.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/SessionContentSearchOverlay.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/SessionContentSearchOverlay.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/SessionTranscriptPane.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/WorkspaceArrivalAttachedPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/surface/WorkspaceArrivalCloudPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/surface/WorkspaceArrivalCloudPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/BashCommandCall.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/BashCommandCall.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/BashCommandCall.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/BashCommandCall.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActionIcon.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedActions.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CollapsedGenericActionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedGenericActionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CoworkArtifactToolActionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CoworkArtifactToolActionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/CoworkArtifactTurnCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/CoworkArtifactTurnCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/FileChangeCall.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/FileReadCall.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/GenericToolResultRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/GenericToolResultRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/ReasoningBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/ReasoningBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/SubagentToolActionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/SubagentToolActionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/ToolActionDetailsPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionDetailsPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/ToolActionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/ToolFileChip.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolActionRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolActionRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/AssistantMessage.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/CarryOutPlanRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/CarryOutPlanRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ClaudePlanCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ClaudePlanCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ConnectedProposedPlanItem.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ConnectedProposedPlanItem.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/CopyMessageButton.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/CopyMessageButton.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/CopyMessageButton.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/CopyMessageButton.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/DelegatedAgentReceiptName.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/DelegatedAgentReceiptName.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/GoalTranscriptEventRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/GoalTranscriptEventRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ModeTransitionDivider.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ModeTransitionDivider.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ProposedPlanCard.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ProposedPlanCard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ProposedPlanCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ProposedPlanCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ProposedPlanToolCallIdsContext.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ProposedPlanToolCallIdsContext.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SessionErrorItem.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SessionErrorItem.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/StreamingIndicator.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/StreamingIndicator.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SubagentWakeBadge.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SubagentWakeBadge.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SubagentWakeBadge.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/SystemMessage.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/SystemMessage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptActivityBlock.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptActivityBlock.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptActivityBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptActivityBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptContexts.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptContexts.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptEntryMotionContext.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptEntryMotionContext.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptPatchTurnDiffPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPatchTurnDiffPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptToolGroupUtils.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolGroupUtils.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptToolKindIcon.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolKindIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnDiffFileCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffFileCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnDiffPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnDiffPanelHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanelHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnItemSequence.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnMetadata.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnMetadata.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnSeparator.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnSeparator.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/TurnSeparator.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/TurnSeparator.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/UserMessage.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/UserMessage.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/UserMessageProvenanceChrome.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/UserMessageProvenanceChrome.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/chat/transcript/transcript-markdown.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/chat/transcript/transcript-markdown.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/CoworkArtifactRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/CoworkArtifactViewer.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactViewer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/CoworkArtifactsPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactsPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/CoworkWorkspaceHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/CoworkWorkspaceShell.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/sidebar/CoworkManagedWorkspaceList.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkManagedWorkspaceList.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/sidebar/CoworkSessionActionsMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkSessionActionsMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/sidebar/CoworkThreadItem.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadItem.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/file-references/FileReferenceBadge.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/file-references/FileReferenceMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/FileEditorView.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/FileEditorView.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/FileViewerContent.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/FileViewerContent.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/file-icon-assets.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/file-icon-assets.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/file-icons.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/file-icons.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/tree/FileSearchResultsTree.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/tree/FileSearchResultsTree.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/tree/FileTreeOverlay.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/tree/FileTreeOverlay.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/tree/FileTreeRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/tree/FileTreeRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/viewer/CenterMessage.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/viewer/CenterMessage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/viewer/FileDiffPane.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/viewer/FileDiffPane.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/viewer/FileSourceView.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/files/viewer/FileViewerFrame.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitPanel.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitPanelHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitPanelHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitPanelReviewBody.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitPanelReviewBody.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitPanelReviewChrome.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitPanelReviewChrome.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitPanelReviewSections.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitPanelReviewSections.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewBaseSelector.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewBaseSelector.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewEmptyState.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewEmptyState.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewFileRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewFileTree.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewFileTree.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewInlineState.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewInlineState.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewOptionsMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewOptionsMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewStageAction.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewStageAction.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewStatusBadge.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewStatusBadge.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/GitReviewTargetSelector.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/GitReviewTargetSelector.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/PublishDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/PublishDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/git/PublishDialog.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/git/PublishDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/open-target/FilePathContextMenuContent.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/open-target/OpenTargetIcon.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/open-target/OpenTargetIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/open-target/OpenTargetMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/open-target/OpenTargetMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/open-target/SplitButton.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/open-target/SplitButton.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/open-target/app-icons.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/open-target/app-icons.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/pane/AttachedPaneShell.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/pane/AttachedPaneShell.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/pane/PaneFileTree.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/pane/PaneFileTree.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/pane/PaneHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/pane/PaneHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/pane/PaneOptionsMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/pane/PaneOptionsMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/pane/PaneSideOverlay.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/pane/PaneSideOverlay.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/repo-setup/AddRepoFlowHost.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/repo-setup/RepoSetupModal.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/repo-setup/RepoSetupModal.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/repo-setup/RepoSetupModal.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/repo-setup/RepoSetupModal.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/repo-setup/RepoSetupModalHost.test.ts",
+      "target": "apps/packages/product-client/src/components/workspace/repo-setup/RepoSetupModalHost.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/repo-setup/RepoSetupModalHost.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/repo-setup/RepoSetupModalHost.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/scratch/ScratchCodeMirrorEditor.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/scratch/ScratchCodeMirrorEditor.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/scratch/ScratchCodeMirrorEditor.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/scratch/ScratchPadPanel.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/scratch/ScratchPadPanel.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/scratch/ScratchPadPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/scratch/ScratchPadPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/command-palette/WorkspaceCommandPalette.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/command-palette/WorkspaceCommandPalette.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/providers/WorkspaceHeaderTabsViewModelContext.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/providers/WorkspaceShellActionsContext.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/providers/WorkspaceShellActionsContext.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelContent.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelContent.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelFrame.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelFrame.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderEntryDropZone.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/RightPanelPlaceholder.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelPlaceholder.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/TerminalHeaderButton.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/TerminalHeaderButton.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/TerminalHeaderIcon.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/TerminalHeaderIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/ToolHeaderButton.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/ToolHeaderButton.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/right-panel/ViewerHeaderButton.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/right-panel/ViewerHeaderButton.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/MainScreen.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/MainScreen.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/MainSidebarPageShell.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/WorkspaceContentView.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceContentView.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/WorkspaceResizeSeparator.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceResizeSeparator.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/screen/WorkspaceShellShortcuts.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellShortcuts.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/KeyboardShortcutsDialog.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/KeyboardShortcutsDialog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/KeyboardShortcutsDialog.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/KeyboardShortcutsDialog.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/MainSidebar.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/ReleaseNoticeCard.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/ReleaseNoticeCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/RepoGroup.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarIndicators.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarRepositoriesHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarShowToggleRow.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarShowToggleRow.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarUpdatePill.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceVariantIcon.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceCleanupAttentionSection.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceCleanupAttentionSection.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceRenamePopover.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceRenamePopover.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ChatTabWithMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ChatTabWithMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ChatTabsMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ChatTabsMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ChromeWorkspaceTab.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ChromeWorkspaceTab.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ChromeWorkspaceTab.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ChromeWorkspaceTab.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/DelegatedAgentHoverCard.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/DelegatedAgentHoverCard.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ManualChatGroupEditorPopover.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ManualChatGroupEditorPopover.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/ManualChatGroupEditorPopover.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/ManualChatGroupEditorPopover.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/SessionTitleRenamePopover.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/SessionTitleRenamePopover.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/TabContextMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/TabContextMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/TabGroupPill.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/TabGroupPill.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/TabGroupPillWithMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/TabGroupPillWithMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/WorkspaceTabStrip.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/WorkspaceTabStrip.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/tab-rendering.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/tab-rendering.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/tabs/tab-rendering.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/tabs/tab-rendering.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/GlobalHeader.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/GlobalHeader.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/HeaderChatTab.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/HeaderChatTab.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/HeaderChatTab.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/HeaderChatTab.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/HeaderGroupPillTab.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/HeaderGroupPillTab.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/HeaderTabs.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabs.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/HeaderTabsActions.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/HeaderTabsStripRows.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsStripRows.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenu.test.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenu.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenu.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenu.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/shell/topbar/WorkspaceActionsMenuContainer.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenuContainer.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/terminals/TerminalCommandFloatingAction.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/terminals/TerminalCommandFloatingAction.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/terminals/TerminalErrorBoundary.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/terminals/TerminalErrorBoundary.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/terminals/TerminalPanel.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/terminals/TerminalPanel.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/terminals/TerminalTopBar.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/terminals/TerminalTopBar.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/components/workspace/terminals/TerminalViewport.tsx",
+      "target": "apps/packages/product-client/src/components/workspace/terminals/TerminalViewport.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/app-routes.test.ts",
+      "target": "apps/packages/product-client/src/config/app-routes.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/app-routes.ts",
+      "target": "apps/packages/product-client/src/config/app-routes.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/automations.ts",
+      "target": "apps/packages/product-client/src/config/automations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/capabilities.ts",
+      "target": "apps/packages/product-client/src/config/capabilities.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/chat-launch.ts",
+      "target": "apps/packages/product-client/src/config/chat-launch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/chat-layout.test.ts",
+      "target": "apps/packages/product-client/src/config/chat-layout.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/chat-layout.ts",
+      "target": "apps/packages/product-client/src/config/chat-layout.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/chat.ts",
+      "target": "apps/packages/product-client/src/config/chat.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/cloud-providers.ts",
+      "target": "apps/packages/product-client/src/config/cloud-providers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/cloud-sidebar.ts",
+      "target": "apps/packages/product-client/src/config/cloud-sidebar.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/cowork-session-mode-defaults.ts",
+      "target": "apps/packages/product-client/src/config/cowork-session-mode-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/harness-env-vars.ts",
+      "target": "apps/packages/product-client/src/config/harness-env-vars.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/open-target-defaults.ts",
+      "target": "apps/packages/product-client/src/config/open-target-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/open-target-icon-assets.ts",
+      "target": "apps/packages/product-client/src/config/open-target-icon-assets.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/open-targets.test.ts",
+      "target": "apps/packages/product-client/src/config/open-targets.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/open-targets.ts",
+      "target": "apps/packages/product-client/src/config/open-targets.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/plan-handoff-session-mode-defaults.ts",
+      "target": "apps/packages/product-client/src/config/plan-handoff-session-mode-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/plans.ts",
+      "target": "apps/packages/product-client/src/config/plans.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/playground.test.ts",
+      "target": "apps/packages/product-client/src/config/playground.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/playground.ts",
+      "target": "apps/packages/product-client/src/config/playground.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/provider-registry.generated.json",
+      "target": "apps/packages/product-client/src/config/provider-registry.generated.json",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/release-notice.ts",
+      "target": "apps/packages/product-client/src/config/release-notice.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/review-session-mode-defaults.ts",
+      "target": "apps/packages/product-client/src/config/review-session-mode-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/runtime.ts",
+      "target": "apps/packages/product-client/src/config/runtime.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/session-controls.ts",
+      "target": "apps/packages/product-client/src/config/session-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/settings.ts",
+      "target": "apps/packages/product-client/src/config/settings.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/shortcuts/app-shortcuts.ts",
+      "target": "apps/packages/product-client/src/config/shortcuts/app-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/shortcuts/composer-shortcuts.ts",
+      "target": "apps/packages/product-client/src/config/shortcuts/composer-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/shortcuts/groups.ts",
+      "target": "apps/packages/product-client/src/config/shortcuts/groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/shortcuts/registry.ts",
+      "target": "apps/packages/product-client/src/config/shortcuts/registry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/shortcuts/types.ts",
+      "target": "apps/packages/product-client/src/config/shortcuts/types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/shortcuts/workspace-shortcuts.ts",
+      "target": "apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/theme.ts",
+      "target": "apps/packages/product-client/src/config/theme.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/config/update-playground.ts",
+      "target": "apps/packages/product-client/src/config/update-playground.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/agents/agents-copy.ts",
+      "target": "apps/packages/product-client/src/copy/agents/agents-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/auth/auth-copy.ts",
+      "target": "apps/packages/product-client/src/copy/auth/auth-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/automations/automation-copy.ts",
+      "target": "apps/packages/product-client/src/copy/automations/automation-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/billing/upgrade-gate-copy.ts",
+      "target": "apps/packages/product-client/src/copy/billing/upgrade-gate-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/capabilities/capability-copy.ts",
+      "target": "apps/packages/product-client/src/copy/capabilities/capability-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/chat/chat-copy.ts",
+      "target": "apps/packages/product-client/src/copy/chat/chat-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/cloud/cloud-status-copy.ts",
+      "target": "apps/packages/product-client/src/copy/cloud/cloud-status-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/cloud/desktop-worker-copy.ts",
+      "target": "apps/packages/product-client/src/copy/cloud/desktop-worker-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/home/home-screen-copy.ts",
+      "target": "apps/packages/product-client/src/copy/home/home-screen-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/plans/plan-picker-copy.ts",
+      "target": "apps/packages/product-client/src/copy/plans/plan-picker-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/plans/plan-prompts.ts",
+      "target": "apps/packages/product-client/src/copy/plans/plan-prompts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/settings/agent-api-keys-copy.ts",
+      "target": "apps/packages/product-client/src/copy/settings/agent-api-keys-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/settings/agent-auth-copy.ts",
+      "target": "apps/packages/product-client/src/copy/settings/agent-auth-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/settings/harness-pane.ts",
+      "target": "apps/packages/product-client/src/copy/settings/harness-pane.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/settings/settings-copy.ts",
+      "target": "apps/packages/product-client/src/copy/settings/settings-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/settings/settings-scaffold-copy.ts",
+      "target": "apps/packages/product-client/src/copy/settings/settings-scaffold-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/workflows/workflow-copy.ts",
+      "target": "apps/packages/product-client/src/copy/workflows/workflow-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/copy/workspaces/workspace-arrival-copy.ts",
+      "target": "apps/packages/product-client/src/copy/workspaces/workspace-arrival-copy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/agents/use-agent-resources-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/agents/use-agent-resources-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/automations/use-local-automation-runtime-client.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/automations/use-local-automation-runtime-client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-artifact-detail.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-artifact-detail.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-artifact-manifest.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-artifact-manifest.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-managed-workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-status.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-status.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/cowork/use-cowork-threads.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/cowork/use-cowork-threads.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/files/use-workspace-files-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/files/use-workspace-files-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/sessions/use-workspace-session-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/sessions/use-workspace-session-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/terminals/use-terminal-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/terminals/use-terminal-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-retire-preflights.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-retire-preflights.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-setup-status-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/worktrees/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/worktrees/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/worktrees/use-worktree-retention-policy.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/worktrees/use-worktree-retention-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/worktrees/use-worktree-target-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/worktrees/use-worktree-target-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/worktrees/use-worktree-target-health.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/worktrees/use-worktree-target-health.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/anyharness/worktrees/use-worktree-target-inventories.ts",
+      "target": "apps/packages/product-client/src/hooks/access/anyharness/worktrees/use-worktree-target-inventories.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/agent-catalog/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/agent-catalog/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/agent-run-configs/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/agent-run-configs/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/agent-run-configs/use-agent-run-config-mutations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/agent-run-configs/use-agent-run-config-mutations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/agent-run-configs/use-agent-run-configs.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/agent-run-configs/use-agent-run-configs.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/auth/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/auth/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/auth/use-auth-methods.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/auth/use-auth-methods.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/auth/use-auth-methods.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/auth/use-auth-methods.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/auth/use-auth-viewer.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/auth/use-auth-viewer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/auth/use-github-auth-availability.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/auth/use-github-auth-availability.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/auth/use-sso-discovery.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/auth/use-sso-discovery.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/automations/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/automations/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/automations/use-automation-mutations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/automations/use-automation-mutations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/automations/use-automations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/automations/use-automations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/automations/use-local-automation-run-claims.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/automations/use-local-automation-run-claims.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/billing/use-team-checkout.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/billing/use-team-checkout.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/cloud-connection-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/cloud-connection-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/integrations/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/integrations/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/integrations/use-admin-integration-definitions.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/integrations/use-admin-integration-definitions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/integrations/use-integration-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/integrations/use-integration-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/integrations/use-integration-catalog.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/integrations/use-integration-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/integrations/use-integration-health.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/integrations/use-integration-health.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/integrations/use-integration-oauth-flow.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/integrations/use-integration-oauth-flow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-current-user-organization-invitations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-current-user-organization-invitations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-is-admin.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-is-admin.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-organization-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-organization-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-organization-invitations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-organization-invitations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-organization-join-link.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-organization-join-link.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-organization-members.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-organization-members.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/organizations/use-organizations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/organizations/use-organizations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/query-keys.test.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/query-keys.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/server-capabilities/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/server-capabilities/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/server-capabilities/use-server-capabilities.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/server-capabilities/use-server-capabilities.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-cloud-billing.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-cloud-billing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-cloud-repo-branches.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-cloud-repo-branches.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-cloud-workspace-connection-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-cloud-workspace-connection-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-cloud-workspace-connection.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-cloud-workspace-connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-cloud-workspace-lifecycle-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-cloud-workspace-lifecycle-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-cloud-worktree-retention-policy.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-cloud-worktree-retention-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/use-control-plane-health.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/use-control-plane-health.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/workspaces/use-cloud-exposed-workspaces.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/workspaces/use-cloud-exposed-workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/cloud/workspaces/use-cloud-visible-workspaces.ts",
+      "target": "apps/packages/product-client/src/hooks/access/cloud/workspaces/use-cloud-visible-workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/downloads/desktop-releases/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/downloads/desktop-releases/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.ts",
+      "target": "apps/packages/product-client/src/hooks/access/downloads/desktop-releases/use-desktop-release-manifest.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/app/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/app/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/app/use-app-version.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/app/use-app-version.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/credentials/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/credentials/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/credentials/use-local-agent-credentials.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/credentials/use-local-agent-credentials.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/credentials/use-local-agent-credentials.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/credentials/use-local-agent-credentials.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/shell/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/shell/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/shell/use-available-editors.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/shell/use-available-editors.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/updater-dev-mock.test.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/updater-dev-mock.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/updater-dev-mock.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/updater-dev-mock.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/use-update-restart-watcher.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/use-update-restart-watcher.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/use-update-restart-watcher.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/use-update-restart-watcher.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/use-updater.test.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/use-updater.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/use-updater.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/use-updater.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/use-window-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/use-window-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/workspace-scratch/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/workspace-scratch/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.ts",
+      "target": "apps/packages/product-client/src/hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/feed-content-buffer.test.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/feed-content-buffer.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/feed-content-buffer.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/feed-content-buffer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/use-activity-now-ms.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/use-activity-now-ms.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/use-feed-stream.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/use-feed-stream.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/use-session-activity-chips.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/use-session-activity-chips.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/use-session-activity.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/use-session-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/use-session-goal.test.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/use-session-goal.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/derived/use-session-goal.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/derived/use-session-goal.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/workflows/use-session-goal-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/workflows/use-session-goal-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/activity/workflows/use-session-loop-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/activity/workflows/use-session-loop-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/derived/use-agent-catalog.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/derived/use-agent-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-agent-auto-reconcile.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-agent-auto-reconcile.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-agent-auto-reconcile.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-agent-auto-reconcile.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-agent-login-terminal-viewport.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-agent-login-terminal-viewport.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-gateway-catalog-mirror-sync.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-gateway-catalog-mirror-sync.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/workflows/use-agent-installation-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/workflows/use-agent-installation-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/workflows/use-agent-login-terminal-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/workflows/use-agent-login-terminal-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/workflows/use-agent-setup-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/workflows/use-agent-setup-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/workflows/use-harness-auth-editor.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/workflows/use-harness-auth-editor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/workflows/use-harness-install-action.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/agents/workflows/use-harness-install-action.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/agents/workflows/use-harness-install-action.ts",
+      "target": "apps/packages/product-client/src/hooks/agents/workflows/use-harness-install-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-app-shortcuts.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-connectivity-listeners.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-connectivity-listeners.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-debug-session-activity.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-debug-session-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-dev-desktop-handoff.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-dev-desktop-handoff.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-dev-desktop-handoff.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-dev-desktop-handoff.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-export-running-agent-count.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-export-running-agent-count.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-export-running-agent-count.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-product-entry-routing.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-product-entry-routing.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-product-entry-routing.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-product-entry-routing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-running-agent-count.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-running-agent-count.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-workspace-activity-indicator.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-activity-indicator.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/lifecycle/use-workspace-activity-indicator.ts",
+      "target": "apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-activity-indicator.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/app-command-action-types.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/app-command-action-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-add-repository-command-action.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-add-repository-command-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-command-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-command-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-command-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-command-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-navigation-command-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-navigation-command-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-navigation-command-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-new-workspace-command-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-new-workspace-command-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-sidebar-sign-out-action.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-sidebar-sign-out-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/app/workflows/use-app-workspace-copy-command-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/app/workflows/use-app-workspace-copy-command-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/facade/use-audited-auth.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/facade/use-login-page.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/facade/use-login-page.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/facade/use-product-auth.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/facade/use-product-auth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/lifecycle/use-auth-bootstrap.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/lifecycle/use-auth-bootstrap.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-auth-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-auth-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-auth-orchestration-effects.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-auth-orchestration-effects.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-connect-server.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-connect-server.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-connect-server.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-connect-server.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-github-sign-in.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-github-sign-in.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-org-slug-sso-sign-in.test.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-org-slug-sso-sign-in.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-org-slug-sso-sign-in.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-org-slug-sso-sign-in.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-password-sign-in.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-password-sign-in.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/auth/workflows/use-sso-sign-in.ts",
+      "target": "apps/packages/product-client/src/hooks/auth/workflows/use-sso-sign-in.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/automations/cache/use-local-automation-executor-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/automations/cache/use-local-automation-executor-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/automations/derived/use-automation-target-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/automations/derived/use-automation-target-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/automations/lifecycle/use-local-automation-claim-poller.ts",
+      "target": "apps/packages/product-client/src/hooks/automations/lifecycle/use-local-automation-claim-poller.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/automations/lifecycle/use-local-automation-executor.ts",
+      "target": "apps/packages/product-client/src/hooks/automations/lifecycle/use-local-automation-executor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/automations/workflows/use-automation-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/automations/workflows/use-automation-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/automations/workflows/use-automation-run-open-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/automations/workflows/use-automation-run-open-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/capabilities/derived/use-app-capabilities.ts",
+      "target": "apps/packages/product-client/src/hooks/capabilities/derived/use-app-capabilities.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/capabilities/derived/use-web-app-target.ts",
+      "target": "apps/packages/product-client/src/hooks/capabilities/derived/use-web-app-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/cache/use-turn-current-file-diffs.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/cache/use-turn-current-file-diffs.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-active-chat-session-selectors.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-active-chat-session-selectors.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-active-pending-session-interactions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-active-pending-session-interactions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-active-session-config-state.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-active-session-config-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-active-session-identity.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-active-session-identity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-active-session-transcript-state.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-active-session-transcript-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-active-todo-tracker.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-active-todo-tracker.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-chat-availability-state.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-chat-launch-catalog.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-chat-loading-substep.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-chat-loading-substep.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-chat-prompt-recoveries.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-chat-prompt-recoveries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-chat-surface-state.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-chat-surface-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-configured-launch-readiness.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-configured-launch-readiness.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-configured-launch-readiness.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-configured-launch-readiness.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/derived/use-transcript-row-model.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/derived/use-transcript-row-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/facade/subagents/use-subagent-composer-strip.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/facade/subagents/use-subagent-composer-strip.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/facade/use-chat-model-selector-state.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/facade/use-chat-model-selector-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/facade/use-chat-session-controls.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/facade/use-chat-session-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/facade/use-delegated-work-composer.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/facade/use-delegated-work-composer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/lifecycle/use-cloud-workspace-polling.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/chat-transcript-selection-dom.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-dom.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/chat-transcript-selection-handlers.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-handlers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/chat-transcript-selection-listeners.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-listeners.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-composer-keyboard.test.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-keyboard.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-composer-keyboard.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-keyboard.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-dock-inset.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-draft-state.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-draft-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-prompt-attachments.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-prompt-attachments.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-root-focus.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-root-focus.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-root-focus.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-root-focus.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-slash-command-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-slash-command-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-transcript-selection.test.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-chat-transcript-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-dock-card-presence.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-dock-card-presence.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-dock-card-presence.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-dock-card-presence.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-dock-slots.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-dock-slots.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-dock-slots.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-submit-gate.test.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-submit-gate.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-submit-gate.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-submit-gate.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-textarea-autosize.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-textarea-autosize.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-textarea-autosize.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-composer-ultra-emphasis.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-composer-ultra-emphasis.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-pending-prompt-queue.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-pending-prompt-queue.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-pending-prompt-queue.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-pending-prompt-queue.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-prompt-attachments.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-prompt-attachments.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-queued-prompt-edit.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-queued-prompt-edit.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-queued-prompt-edit.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-queued-prompt-edit.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-runnable-slash-commands.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-runnable-slash-commands.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-slash-command-highlight.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-slash-command-highlight.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/ui/use-vertical-reorder.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/ui/use-vertical-reorder.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/subagents/use-linked-session-mounting.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/subagents/use-linked-session-mounting.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-launch-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-launch-control-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-launch-intent-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-intent-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-mcp-elicitation-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-mcp-elicitation-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-permission-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-permission-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-prompt-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-recovery-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-chat-user-input-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-chat-user-input-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/chat/workflows/use-prompt-outbox-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/chat/workflows/use-prompt-outbox-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/derived/use-cloud-availability-state.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/derived/use-cloud-availability-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/derived/use-cloud-repo-setup-suggestions.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-setup-suggestions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/derived/use-composer-integrations-state.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/cloud/derived/use-composer-integrations-state.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/derived/use-composer-integrations-state.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/derived/use-composer-integrations-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/facade/use-cloud-billing.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/facade/use-cloud-billing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/facade/use-cloud-integrations.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/facade/use-cloud-integrations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/workflows/use-cloud-workspace-status-screen-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/workflows/use-cloud-workspace-status-screen-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cloud/workflows/use-create-cloud-workspace.ts",
+      "target": "apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/compute/derived/use-compute-target-options.ts",
+      "target": "apps/packages/product-client/src/hooks/compute/derived/use-compute-target-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/compute/workflows/use-compute-target-appearance-preferences.ts",
+      "target": "apps/packages/product-client/src/hooks/compute/workflows/use-compute-target-appearance-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/lifecycle/use-cowork-artifact-refresh.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/lifecycle/use-cowork-artifact-refresh.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/ui/use-cowork-artifact-viewer.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/ui/use-cowork-artifact-viewer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/ui/use-cowork-session-native-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/ui/use-cowork-session-native-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/ui/use-cowork-session-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/ui/use-cowork-session-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/workflows/cowork-thread-session-record.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/workflows/cowork-thread-session-record.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/workflows/use-cowork-enable.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/workflows/use-cowork-enable.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/workflows/use-cowork-session-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/workflows/use-cowork-session-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/workflows/use-cowork-thread-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/workflows/use-cowork-thread-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/workflows/use-open-cowork-artifact.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/workflows/use-open-cowork-artifact.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/cowork/workflows/use-open-cowork-coding-session.ts",
+      "target": "apps/packages/product-client/src/hooks/cowork/workflows/use-open-cowork-coding-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/editor/ui/use-file-tree-native-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/editor/ui/use-file-tree-native-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/editor/ui/use-file-tree-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/editor/ui/use-file-tree-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/editor/workflows/use-open-in-default-editor.ts",
+      "target": "apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-launch-controls.ts",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-mode-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-mode-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-model-selection.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-model-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-repository-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-repository-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-state.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/derived/use-home-next-state.ts",
+      "target": "apps/packages/product-client/src/hooks/home/derived/use-home-next-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/facade/use-home-screen.ts",
+      "target": "apps/packages/product-client/src/hooks/home/facade/use-home-screen.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts",
+      "target": "apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/ui/use-home-next-composer-state.ts",
+      "target": "apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/ui/use-home-next-target-selection-state.ts",
+      "target": "apps/packages/product-client/src/hooks/home/ui/use-home-next-target-selection-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/workflows/home-next-launch-intent.ts",
+      "target": "apps/packages/product-client/src/hooks/home/workflows/home-next-launch-intent.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/workflows/home-next-projected-session.ts",
+      "target": "apps/packages/product-client/src/hooks/home/workflows/home-next-projected-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/workflows/use-home-cloud-repo-settings-navigation.ts",
+      "target": "apps/packages/product-client/src/hooks/home/workflows/use-home-cloud-repo-settings-navigation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/workflows/use-home-next-launch-prompt-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch-prompt-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/workflows/use-home-next-launch.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/home/workflows/use-home-next-launch.ts",
+      "target": "apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/main/facade/use-main-screen-state.ts",
+      "target": "apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/main/lifecycle/use-main-screen-shortcuts.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/main/lifecycle/use-main-screen-shortcuts.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/main/lifecycle/use-main-screen-shortcuts.ts",
+      "target": "apps/packages/product-client/src/hooks/main/lifecycle/use-main-screen-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/main/workflows/use-main-screen-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/main/workflows/use-main-screen-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/main/workflows/use-main-screen-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/main/workflows/use-main-screen-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/facade/use-active-organization.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/facade/use-active-organization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/lifecycle/use-organization-join-auth-launch.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/organizations/lifecycle/use-organization-join-auth-launch.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/lifecycle/use-organization-join-auth-launch.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/lifecycle/use-organization-join-auth-launch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/lifecycle/use-organization-selection-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/lifecycle/use-organization-selection-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/workflows/use-joined-organization-activation.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/workflows/use-joined-organization-activation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/organizations/workflows/use-organization-join-invitation-flow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/workflows/use-organization-join-invitation-flow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/workflows/use-organization-selection-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/workflows/use-organization-selection-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/organizations/workflows/use-organization-switch-action.ts",
+      "target": "apps/packages/product-client/src/hooks/organizations/workflows/use-organization-switch-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/persistence/facade/use-product-storage-context.ts",
+      "target": "apps/packages/product-client/src/hooks/persistence/facade/use-product-storage-context.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/persistence/lifecycle/use-product-storage-persistence-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/persistence/lifecycle/use-product-storage-persistence-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/persistence/lifecycle/use-product-storage-persistence-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/persistence/lifecycle/use-product-storage-persistence-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/cache/use-proposed-plan-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/cache/use-proposed-plan-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/facade/use-plan-draft-attachments.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/facade/use-plan-draft-attachments.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/ui/use-plan-handoff-dialog-state.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/ui/use-plan-handoff-dialog-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/ui/use-plan-picker.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/ui/use-plan-picker.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/workflows/use-add-plan-draft-attachment.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/workflows/use-add-plan-draft-attachment.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/workflows/use-plan-handoff-workflow.test.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/workflows/use-plan-handoff-workflow.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/workflows/use-plan-handoff-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/workflows/use-plan-handoff-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.test.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/workflows/use-proposed-plan-actions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/plans/workflows/use-proposed-plan-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/plans/workflows/use-proposed-plan-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/playground/lifecycle/use-replay-session.ts",
+      "target": "apps/packages/product-client/src/hooks/playground/lifecycle/use-replay-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/derived/use-pending-worktree-auto-delete-adoption.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/derived/use-pending-worktree-auto-delete-adoption.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-appearance-preference-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-desktop-zoom-preference-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-desktop-zoom-preference-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-desktop-zoom-preference-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-desktop-zoom-preference-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-repo-preferences-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-repo-preferences-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-repo-preferences-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-repo-preferences-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-user-preferences-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-user-preferences-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-user-preferences-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-user-preferences-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-workspace-ui-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-workspace-ui-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/lifecycle/use-workspace-ui-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/lifecycle/use-workspace-ui-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/preferences/workflows/use-worktree-auto-delete-adoption.ts",
+      "target": "apps/packages/product-client/src/hooks/preferences/workflows/use-worktree-auto-delete-adoption.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/cache/use-session-stream-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/cache/use-session-stream-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/facade/use-session-selection-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/facade/use-session-selection-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-intent-interaction-dispatch.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-interaction-dispatch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-prompt-dispatch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-runtime-helpers.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-runtime-helpers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-runtime-pending-config.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-runtime-pending-config.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-open.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-open.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-prepare.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-prepare.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-reconnect.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-reconnect.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-refresh.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-refresh.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-connection-types.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-controller.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-controller.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-types.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-handle.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-handle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-side-effects.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-side-effects.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-side-effects.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-side-effects.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/session-stream-slot-connection.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-slot-connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-activity-reconciler.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-activity-reconciler.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-error-acknowledgement.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-error-acknowledgement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-history-hydration.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-selection-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-selection-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-selection-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-selection-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-stream-connection-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-stream-connection-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-stream-flush.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-stream-flush.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-session-stream-flush.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-stream-flush.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/lifecycle/use-turn-end-sound.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/lifecycle/use-turn-end-sound.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-activation-guard.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-activation-guard.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-control-contract.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-control-contract.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-created-runtime-cleanup.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-created-runtime-cleanup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-empty-options.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-empty-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-failure-cleanup.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-failure-cleanup.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-failure-cleanup.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-failure-cleanup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-failure.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-failure.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-in-flight.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-in-flight.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-local-state.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-cleanup.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-cleanup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-materialization-interruption.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-interruption.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-materialization.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-request-options.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-request-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-runtime.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-runtime.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-runtime.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-runtime.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-supersession.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-supersession.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-supersession.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-supersession.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-creation-types.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-creation-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-interaction-debug.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-interaction-debug.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-materialization-deps.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-materialization-deps.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-mode-preferences.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-mode-preferences.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-mode-preferences.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-mode-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-relationship-hints.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-relationship-hints.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-relationship-hints.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-relationship-hints.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-replacement-dismissals.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-dismissals.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-replacement-dismissals.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-dismissals.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-replacement-shell-preferences.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-replacement-tombstones.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-selection-measurement.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-selection-measurement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-selection-options.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-selection-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-selection-relationship.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-selection-relationship.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-selection-runtime.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-selection-runtime.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-selection-runtime.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/session-shell-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/session-shell-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-delete-pending-prompt.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-delete-pending-prompt.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-dismissed-session-cleanup.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-dismissed-session-cleanup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-edit-pending-prompt.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-edit-pending-prompt.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-reorder-pending-prompts.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-reorder-pending-prompts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-cancel-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-cancel-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-config-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-config-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-dismiss-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-find-or-create-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-find-or-create-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-fork-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-fork-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-intent-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-intent-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-interaction-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-interaction-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-interaction-resolution-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-interaction-resolution-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-model-fallback-action.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-model-fallback-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-prompt-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-prompt-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-prompt-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-prompt-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-restore-actions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-restore-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-restore-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-runtime-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-runtime-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-selection-actions.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-selection-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-summary-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-summary-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-session-title-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-session-title-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-steer-pending-prompt.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-steer-pending-prompt.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.test.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-workspace-session-loader.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/sessions/workflows/use-workspace-session-loader.ts",
+      "target": "apps/packages/product-client/src/hooks/sessions/workflows/use-workspace-session-loader.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/derived/use-settings-repositories.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/derived/use-settings-repositories.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/ui/use-settings-section-shortcuts.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/ui/use-settings-section-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/workflows/use-cloud-repo-environment-editor.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/workflows/use-cloud-repo-environment-editor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/workflows/use-github-app-installation.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/workflows/use-github-app-installation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/workflows/use-github-app-user-authorization.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/workflows/use-github-app-user-authorization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/workflows/use-repository-settings.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/workflows/use-repository-settings.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/settings/workflows/use-settings-navigation.ts",
+      "target": "apps/packages/product-client/src/hooks/settings/workflows/use-settings-navigation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher.ts",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.ts",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-dispatcher.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-handler.ts",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-handler.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.ts",
+      "target": "apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-reveal-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/derived/use-sidebar-support-context.ts",
+      "target": "apps/packages/product-client/src/hooks/support/derived/use-sidebar-support-context.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/derived/use-support-menu-action.ts",
+      "target": "apps/packages/product-client/src/hooks/support/derived/use-support-menu-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/derived/use-support-report-snapshot.ts",
+      "target": "apps/packages/product-client/src/hooks/support/derived/use-support-report-snapshot.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/facade/use-support-availability.test.ts",
+      "target": "apps/packages/product-client/src/hooks/support/facade/use-support-availability.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/facade/use-support-availability.ts",
+      "target": "apps/packages/product-client/src/hooks/support/facade/use-support-availability.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/facade/use-support-modal-state.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/facade/use-support-modal-state.ts",
+      "target": "apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/facade/use-support-outreach-email.ts",
+      "target": "apps/packages/product-client/src/hooks/support/facade/use-support-outreach-email.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/support-report-upload-payload.test.ts",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/support-report-upload-payload.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/support-report-upload-payload.ts",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/support-report-upload-payload.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/support-report-upload-persistence.test.ts",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/support-report-upload-persistence.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/support-report-upload-persistence.ts",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/support-report-upload-persistence.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/use-session-debug-replay-capability.ts",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/use-session-debug-replay-capability.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/use-support-report-upload-queue.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/lifecycle/use-support-report-upload-queue.ts",
+      "target": "apps/packages/product-client/src/hooks/support/lifecycle/use-support-report-upload-queue.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/workflows/use-open-support-report-window.ts",
+      "target": "apps/packages/product-client/src/hooks/support/workflows/use-open-support-report-window.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/workflows/use-session-debug-actions.test.ts",
+      "target": "apps/packages/product-client/src/hooks/support/workflows/use-session-debug-actions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/support/workflows/use-session-debug-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/support/workflows/use-session-debug-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/facade/use-product-telemetry.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/facade/use-product-telemetry.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/telemetry-lifecycle.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/telemetry-lifecycle.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-agent-seed.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-agent-seed.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-auth-identity.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-auth-identity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-bootstrap.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-latency-flows.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-latency-flows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-organization-identity.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-organization-identity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-route-views.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-route-views.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-runtime-state.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-runtime-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/telemetry/lifecycle/use-telemetry-workspace-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/telemetry/lifecycle/use-telemetry-workspace-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/lifecycle/use-terminal-stream-controller.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-stream-controller.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/lifecycle/use-terminal-stream-controller.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-stream-controller.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/lifecycle/use-terminal-viewport.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/lifecycle/use-xterm-surface.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/ui/use-terminal-tab-native-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/ui/use-terminal-tab-native-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/ui/use-terminal-tab-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/ui/use-terminal-tab-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/workflows/use-terminal-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/workflows/use-terminal-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/terminals/workflows/use-terminal-workspace-connection.ts",
+      "target": "apps/packages/product-client/src/hooks/terminals/workflows/use-terminal-workspace-connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/theme/derived/use-resolved-mode.ts",
+      "target": "apps/packages/product-client/src/hooks/theme/derived/use-resolved-mode.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/theme/derived/use-transparent-chrome.ts",
+      "target": "apps/packages/product-client/src/hooks/theme/derived/use-transparent-chrome.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/theme/workflows/use-theme-preferences.ts",
+      "target": "apps/packages/product-client/src/hooks/theme/workflows/use-theme-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/debug/use-debug-render-count.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/debug/use-debug-render-count.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/debug/use-debug-value-change.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/debug/use-debug-value-change.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/diff/use-gap-expansion.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/diff/use-gap-expansion.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/diff/use-lazy-diff-file-lines.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/diff/use-lazy-diff-file-lines.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/document/use-document-focus-visibility.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/document/use-document-focus-visibility.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/highlighting/use-diff-highlight-measurement.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/ui/highlighting/use-diff-highlight-measurement.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/highlighting/use-diff-highlight.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/highlighting/use-diff-highlight.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/highlighting/use-highlighted-code.test.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/highlighting/use-highlighted-code.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/highlighting/use-highlighted-lines.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/highlighting/use-highlighted-lines.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/highlighting/use-highlighted-tokens.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/highlighting/use-highlighted-tokens.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/layout/use-resize-observer-width.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/layout/use-resize-observer-width.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/layout/use-resize.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/layout/use-resize.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/layout/use-tree-panel-resize.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/layout/use-tree-panel-resize.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/native/use-chat-diff-line-wrap-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/native/use-chat-diff-line-wrap-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/native/use-native-context-menu.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/native/use-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/ui/native/use-native-overlay-presence.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/ui/native/use-native-overlay-presence.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/updates/cache/use-release-notice-model.ts",
+      "target": "apps/packages/product-client/src/hooks/updates/cache/use-release-notice-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/updates/facade/use-release-notice.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/updates/facade/use-release-notice.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/updates/facade/use-release-notice.ts",
+      "target": "apps/packages/product-client/src/hooks/updates/facade/use-release-notice.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/updates/lifecycle/use-installed-release-title-cache-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/updates/lifecycle/use-installed-release-title-cache-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/updates/workflows/use-release-notice-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/updates/workflows/use-release-notice-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/cloud-workspace-materialization-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/query-keys.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/query-keys.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/query-keys.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/query-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/tabs/use-workspace-header-subagent-hierarchy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-pr-status-refresh.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-pr-status-refresh.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-pr-status-refresh.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-repo-pr-statuses.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-repo-pr-statuses.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-repo-pr-statuses.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-repo-pr-statuses.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-resolve-workspace-connection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-resolve-workspace-connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspace-collections-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-collections-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspace-collections-invalidation.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-collections-invalidation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspace-selection-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-selection-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspaces.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspaces.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-workspaces.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/cache/use-worktree-settings-target-cache.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/cache/use-worktree-settings-target-cache.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/files/use-git-changed-paths.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/files/use-git-changed-paths.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/files/use-workspace-file-context.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/files/use-workspace-file-context.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/files/use-workspace-file-context.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/files/use-workspace-file-context.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-composer-workspace-activity-model.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-composer-workspace-activity-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-git-panel-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-git-panel-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-hot-paint-gate.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-hot-paint-gate.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-logical-workspaces.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-logical-workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-right-panel-header-entries.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-right-panel-header-entries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-selected-logical-workspace.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-selected-logical-workspace.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-sidebar-shortcut-targets.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-sidebar-shortcut-targets.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-standard-repo-projection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-standard-repo-projection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-arrival-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-arrival-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-command-palette-open-files.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-command-palette-open-files.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-git-statuses.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-git-statuses.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-git-statuses.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-git-statuses.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-runtime-block.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-runtime-block.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-activities.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-activities.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-status-panel-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-status-panel-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/derived/use-workspace-surface-lookup.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-surface-lookup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/files/use-workspace-file-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/files/use-workspace-file-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/tabs/use-stable-string-array.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/tabs/use-stable-string-array.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-preferences.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-view-model.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-view-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-visibility.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-visibility.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-workspace-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/tabs/use-workspace-header-tabs-workspace-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-local-worktree-settings-target.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-local-worktree-settings-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-right-panel-controller.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-right-panel-controller.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-runtime-pressure-control-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-runtime-pressure-control-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-selected-cloud-runtime-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-selected-cloud-runtime-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-sidebar-repo-group-state.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-sidebar-repo-group-state.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-sidebar-repo-group-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-sidebar-repo-group-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-workspace-command-palette.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-workspace-command-palette.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-worktree-cleanup-policy.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-worktree-cleanup-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/use-worktree-settings-targets.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/use-worktree-settings-targets.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/workspace-command-palette-entries.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/workspace-command-palette-entries.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/facade/workspace-command-palette-entries.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/facade/workspace-command-palette-entries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/cloud-display-name-backfill-suppression.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/cloud-display-name-backfill-suppression.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/cloud-display-name-backfill-suppression.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/cloud-display-name-backfill-suppression.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/files/use-deferred-workspace-file-tree-prefetch.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/files/use-deferred-workspace-file-tree-prefetch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/right-panel/use-right-panel-lifecycle.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/right-panel/use-right-panel-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/scratch-codemirror-extensions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/scratch-codemirror-live-preview.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-active-session-activity-acknowledgement.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-active-session-activity-acknowledgement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-persisted-logical-workspace-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-persisted-logical-workspace-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-scratch-codemirror-editor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-git-status-persistence.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-git-status-persistence.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-git-status-persistence.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-git-status-persistence.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-header-tabs-debug-logging.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-header-tabs-debug-logging.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-header-tabs-preference-effects.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-header-tabs-preference-effects.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-metadata-sync.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/use-worktree-cleanup-policy-sync.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/use-worktree-cleanup-policy-sync.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/lifecycle/workspace-bootstrap-memory.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/lifecycle/workspace-bootstrap-memory.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/files/use-diff-review-measurement.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/files/use-diff-review-measurement.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/files/use-diff-review-measurement.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/files/use-diff-review-measurement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/files/use-workspace-file-search.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/files/use-workspace-file-search.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/files/use-workspace-file-search.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/files/use-workspace-file-search.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-batched-header-hierarchy-session-ids.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-batched-header-hierarchy-session-ids.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-header-tabs-group-editor.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-header-tabs-group-editor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-header-tabs-layout.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-header-tabs-layout.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-header-tabs-multi-select.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-header-tabs-multi-select.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-tab-drag.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-tab-drag.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-workspace-shell-tabs-state.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-workspace-shell-tabs-state.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-workspace-shell-tabs-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-workspace-shell-tabs-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/tabs/use-workspace-tab-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-workspace-tab-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-header-tabs-urgent-highlight.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-header-tabs-urgent-highlight.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-repo-group-native-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-repo-group-native-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-repo-group-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-repo-group-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-right-panel-header-drag.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-right-panel-header-drag.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-right-panel-new-tab-menu-request.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-right-panel-new-tab-menu-request.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-right-panel-root-focus.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-right-panel-root-focus.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-right-panel-shortcut-requests.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-right-panel-shortcut-requests.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-right-panel-state-updater.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-right-panel-state-updater.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-workspace-file-buffer-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-workspace-file-buffer-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-workspace-file-initialization-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-workspace-file-initialization-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-workspace-file-initialization-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-workspace-file-initialization-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/files/use-workspace-file-target-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-workspace-file-target-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/pending-workspace-projected-session.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-projected-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/pending-workspace-session-shell.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-session-shell.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-remote-access-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/remote-access/use-workspace-remote-access-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/remote-access/use-workspace-remote-access-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/remote-access/use-workspace-remote-access-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/runtime-ready.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/runtime-ready.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/clear-runtime-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/clear-runtime-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/cloud-readiness.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/cloud-readiness.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/cloud-selection-connection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/cloud-selection-connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/connection.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/connection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/connection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/guards.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/guards.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/initial-session.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/initial-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/types.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/selection/use-workspace-selection.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/selection/use-workspace-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/chat-tab-activation-runner.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/chat-tab-activation-runner.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-chat-tab-activation.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-activation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-close-active-workspace-tab.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-close-active-workspace-tab.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-header-tabs-close-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-header-tabs-close-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-manual-chat-group-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-manual-chat-group-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-shell-tab-order-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-shell-tab-order-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-tab-group-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-tab-group-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/use-workspace-tab-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-tab-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/workspace-shell-activation-measurement.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/workspace-shell-activation-measurement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/workspace-shell-activation-types.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/workspace-shell-activation-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/tabs/workspace-shell-state-key.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/tabs/workspace-shell-state-key.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-add-repo.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-add-repo.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-git-prompt-snapshot-effects.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-git-prompt-snapshot-effects.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-run-workspace-command.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-run-workspace-command.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-selected-cloud-runtime-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-selected-cloud-runtime-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-activation-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-activation-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-arrival-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-arrival-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-arrival-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-arrival-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-command-palette-tabs.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-command-palette-tabs.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-copy-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-copy-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-display-name-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-display-name-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-flow.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-flow.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-flow.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-flow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-entry-selection-deps.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-selection-deps.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-name-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-name-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-publish-workflow.test.tsx",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-publish-workflow.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-publish-workflow.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-publish-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-retire-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-retire-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-bootstrap-session-state.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-session-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-entry-action-helpers.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-action-helpers.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-entry-action-helpers.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-action-helpers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-entry-finalization.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-finalization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-entry-lightweight.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-lightweight.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-entry-types.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-name-eligibility.test.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-name-eligibility.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/hooks/workspaces/workflows/workspace-name-eligibility.ts",
+      "target": "apps/packages/product-client/src/hooks/workspaces/workflows/workspace-name-eligibility.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/index.css",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/agent-auth.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/agent-auth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/agent-gateway-catalog.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/agent-gateway-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/agents.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/agents.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/automation-client.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/automation-client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/cowork.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/cowork.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/debug-client.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/debug-client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/direct-session-create-guard.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/direct-session-create-guard.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/direct-session-create-guard.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/direct-session-create-guard.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/plans.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/plans.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/pull-requests.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/pull-requests.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/replay.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/replay.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/resolve-workspace-connection.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/resolve-workspace-connection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/reviews.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/reviews.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/runtime-bootstrap.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/runtime-bootstrap.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/runtime-bootstrap.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/runtime-bootstrap.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/runtime-health.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/runtime-health.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/runtime-target.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/runtime-target.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/runtime-target.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/runtime-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/session-launch-defaults-client.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/session-launch-defaults-client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/session-runtime.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/session-runtime.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/session-stream-handles.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/session-stream-handles.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/sessions.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/sessions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/terminals.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/terminals.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/workspace-file-transport.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/workspace-file-transport.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/workspace-file-transport.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/workspace-file-transport.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/workspaces.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/anyharness/worktrees.ts",
+      "target": "apps/packages/product-client/src/lib/access/anyharness/worktrees.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/organization-selection-cookie.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/organization-selection-cookie.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/product-storage.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/product-storage.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/prompt-attachment-blocks.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/prompt-attachment-blocks.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/browser/support-report-job-events.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/billing-return.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/billing-return.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/client.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/cloud-sandbox-gateway.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/cloud-sandbox-gateway.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/cloud-sandbox-gateway.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/cloud-sandbox-gateway.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/dev-desktop-handoff.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/dev-desktop-handoff.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/health.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/health.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/health.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/health.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/owner-context-headers.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/owner-context-headers.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/owner-context-headers.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/owner-context-headers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/server-capabilities.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/server-capabilities.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/timing.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/timing.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/timing.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/timing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/cloud/workspace-connection-retry.ts",
+      "target": "apps/packages/product-client/src/lib/access/cloud/workspace-connection-retry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/downloads/desktop-release-manifest.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/downloads/desktop-release-manifest.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/downloads/desktop-release-manifest.ts",
+      "target": "apps/packages/product-client/src/lib/access/downloads/desktop-release-manifest.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/persistence/organization-join-target.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/persistence/organization-join-target.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/persistence/organization-join-target.ts",
+      "target": "apps/packages/product-client/src/lib/access/persistence/organization-join-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/persistence/session-replacement-tombstones-storage.test.ts",
+      "target": "apps/packages/product-client/src/lib/access/persistence/session-replacement-tombstones-storage.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/access/persistence/session-replacement-tombstones-storage.ts",
+      "target": "apps/packages/product-client/src/lib/access/persistence/session-replacement-tombstones-storage.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/anonymous-telemetry.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/auth.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/auth.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/cloud-worker.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/config.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/connect-server.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/context-menu.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/credentials.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/deep-link.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/deep-link.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/desktop-bridge.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/desktop-install-id.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/diagnostics.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/dock.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/dock.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/menu.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/process.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/runtime.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/shell.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/ssh-target-profile.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/ssh-tunnel.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/store.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/support.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/updater-config.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/updater.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/updater.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/window.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/lib/access/tauri/workspace-scratch.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/auth-onboarding.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/auth-onboarding.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/auth-onboarding.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/auth-onboarding.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/bundled-agent-catalog.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/bundled-agent-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/cloud-launch-catalog-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/cloud-launch-catalog.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/cloud-launch-catalog.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/cloud-launch-controls.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/cloud-launch-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/configuration-issues-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/configuration-issues-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/gateway-catalog-mirror.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/gateway-catalog-mirror.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/gateway-catalog-mirror.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/gateway-catalog-mirror.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/group-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/group-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/groups.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/groups.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/groups.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/local-auth-state.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/local-auth-state.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/local-auth-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/local-auth-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/model-availability.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/model-availability.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/model-availability.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/model-availability.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/model-options.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/model-options.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/model-options.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/model-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/provider-display.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/provider-display.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/readiness-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/readiness-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/saved-model-intent.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/saved-model-intent.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/saved-model-intent.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/saved-model-intent.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/setup-workflow-reducer.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/setup-workflow-reducer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/status-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/status-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/status-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/status-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/status.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/status.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/target-ready-launch-agents.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/target-ready-launch-agents.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/agents/target-ready-launch-agents.ts",
+      "target": "apps/packages/product-client/src/lib/domain/agents/target-ready-launch-agents.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/account-profile-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/account-profile-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/account-profile-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/account-profile-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/anyharness-cache-scope.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/anyharness-cache-scope.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/anyharness-cache-scope.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/anyharness-cache-scope.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/auth-mode.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/auth-mode.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/auth-mode.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/auth-mode.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/auth-state-mapping.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/auth-state-mapping.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/auth-state-mapping.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/auth-state-mapping.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/auth-user.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/auth-user.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/connect-server.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/connect-server.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/connect-server.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/connect-server.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/current-auth-session.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/current-auth-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/desktop-navigation-codec.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/desktop-navigation-codec.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/desktop-navigation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/desktop-navigation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/desktop-navigation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/desktop-navigation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/github-signin-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/github-signin-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/login-redirect.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/login-redirect.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/session-mapping.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/session-mapping.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/session-mapping.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/session-mapping.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/auth/stored-auth-session.ts",
+      "target": "apps/packages/product-client/src/lib/domain/auth/stored-auth-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/editor/run-config.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/editor/run-config.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/local-executor/plan.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/local-executor/plan.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/local-executor/plan.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/local-executor/plan.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/local-executor/records.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/local-executor/records.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/model/presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/model/presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/run/records.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/run/records.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/run/types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/run/types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/run/ui-records.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/run/ui-records.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/schedule/presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/schedule/presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/schedule/schedule.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/schedule/schedule.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/schedule/schedule.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/schedule/schedule.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/records.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/records.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/selection-drafts.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/selection-drafts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/selection-identity.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/selection-identity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/selection-rows.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/selection-rows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/selection-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/selection-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/selection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/automations/target/selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/automations/target/selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/app-capabilities.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/app-capabilities.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/cloud-compute.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/cloud-compute.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/derive-app-capabilities.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/derive-app-capabilities.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/server-capability-contract.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/server-capability-contract.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/server-capability-contract.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/server-capability-contract.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/version-compat.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/version-compat.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/capabilities/version-compat.ts",
+      "target": "apps/packages/product-client/src/lib/domain/capabilities/version-compat.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/activity-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/activity-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/delegation-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/delegation-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/git-diff-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/git-diff-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/goal-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/goal-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/outbound-slot-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/outbound-slot-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/panel-cloud-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/panel-cloud-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/panel-interaction-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/panel-interaction-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/panel-todo-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/panel-todo-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/plan-transcript-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/plan-transcript-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/subagent-creation-transcript-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/subagent-creation-transcript-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/subagent-parent-send-transcript-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/subagent-parent-send-transcript-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/subagent-tool-transcript-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/subagent-tool-transcript-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/subagent-wake-transcript-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/subagent-wake-transcript-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/tool-artifact-transcript-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/tool-artifact-transcript-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/chat-input-helpers.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/chat-input-helpers.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/chat-input-helpers.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/chat-input-helpers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/chat-input.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/chat-input.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/chat-input.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/composer-keyboard.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/composer-keyboard.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/composer-keyboard.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/composer-keyboard.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/composer-textarea-sizing.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/composer-textarea-sizing.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/composer-textarea-sizing.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/composer-textarea-sizing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/file-mention-draft-edits.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-edits.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/file-mention-draft-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/file-mention-draft-position.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-position.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/file-mention-draft.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/file-mention-links.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/file-mention-links.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/preference-resolvers.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/preference-resolvers.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/preference-resolvers.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/preference-resolvers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/prompt-attachment-drag.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/prompt-attachment-drag.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/prompt-attachment-drag.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/prompt-attachment-drag.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/prompt-id.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/prompt-id.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/prompt-input.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/prompt-input.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/prompt-input.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/prompt-input.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/session-slash-command-policy.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/session-slash-command-policy.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/session-slash-command-policy.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/session-slash-command-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/slash-command-draft-edits.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/slash-command-draft-edits.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/slash-command-draft-edits.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/slash-command-draft-edits.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/slash-command-recognition.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/slash-command-recognition.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/composer/slash-command-recognition.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/composer/slash-command-recognition.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/launch/launch-intent.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/launch/launch-intent.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/launch/launch-intent.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/launch/launch-intent.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/launch/session-config.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/launch/session-config.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/launch-control-descriptors.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/launch-control-descriptors.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/launch-selection-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/launch-selection-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/launch-visible-agents.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/launch-visible-agents.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-display-name-parts.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-display-name-parts.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-display-name-parts.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-display-name-parts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-display.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-display.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-display.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-display.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selection-availability.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selection-availability.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selection-ids.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selection-ids.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selector-current.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selector-current.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selector-current.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selector-current.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selector-options-claude.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selector-options-claude.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selector-options-dynamic.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selector-options-dynamic.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selector-options.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selector-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-selector-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-selector-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-visibility.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-visibility.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/model-visibility.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/model-visibility.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/order-model-groups.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/order-model-groups.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/models/order-model-groups.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/models/order-model-groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/composer-config-submenu-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/composer-config-submenu-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/composer-control-groups.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/composer-control-groups.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/composer-control-groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-controls.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-controls.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-controls.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-mode-control.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-mode-control.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-mode-control.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-mode-control.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-reasoning-effort-control.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/session-controls/session-toggle-control.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/session-controls/session-toggle-control.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/submit/workspace-setup-activity.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/submit/workspace-setup-activity.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/submit/workspace-setup-activity.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/submit/workspace-setup-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/surface/chat-loading-substep.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/surface/chat-loading-substep.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/surface/chat-loading-substep.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/surface/chat-loading-substep.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/surface/chat-surface.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/chat/surface/chat-surface.ts",
+      "target": "apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/billing.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/billing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/composer-integrations.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/composer-integrations.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/composer-integrations.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/composer-integrations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/credentials.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/credentials.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/integration-reauth.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/integration-reauth.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/integration-reauth.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/integration-reauth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/integrations.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/integrations.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cloud/integrations.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cloud/integrations.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/command-palette/entries.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/command-palette/entries.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/command-palette/entries.ts",
+      "target": "apps/packages/product-client/src/lib/domain/command-palette/entries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-appearance.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-appearance.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-appearance.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-appearance.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-options.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-readiness.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-readiness.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-readiness.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-readiness.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-workspace-id.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-workspace-id.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/compute/target-workspace-id.ts",
+      "target": "apps/packages/product-client/src/lib/domain/compute/target-workspace-id.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/content-search/content-search.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/content-search/content-search.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/content-search/content-search.ts",
+      "target": "apps/packages/product-client/src/lib/domain/content-search/content-search.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cowork/artifacts.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cowork/artifacts.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cowork/artifacts.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cowork/artifacts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cowork/session-mode-defaults.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cowork/session-mode-defaults.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cowork/session-mode-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cowork/session-mode-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/cowork/threads.ts",
+      "target": "apps/packages/product-client/src/lib/domain/cowork/threads.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/delegated-work/identity.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/delegated-work/identity.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/delegated-work/identity.ts",
+      "target": "apps/packages/product-client/src/lib/domain/delegated-work/identity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/delegated-work/model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/delegated-work/model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/delegated-work/ordering.ts",
+      "target": "apps/packages/product-client/src/lib/domain/delegated-work/ordering.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/delegated-work/presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/delegated-work/presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/delegated-work/presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/delegated-work/presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/diff-parser.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/diff-parser.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/diff-parser.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/diff-parser.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/diff-view-rows.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/diff-view-rows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/document-preview.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/document-preview.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/document-preview.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/document-preview.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/file-search-tree.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/file-search-tree.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/file-search-tree.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/file-search-tree.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/file-tree-icon-colors.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/file-tree-icon-colors.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/file-visuals.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/file-visuals.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/file-visuals.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/file-visuals.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/hunk-patch.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/hunk-patch.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/hunk-patch.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/hunk-patch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/path-detection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/path-detection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/path-detection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/path-detection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/path-references.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/path-references.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/files/path-references.ts",
+      "target": "apps/packages/product-client/src/lib/domain/files/path-references.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/focus-zone.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/focus-zone.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/focus-zone.ts",
+      "target": "apps/packages/product-client/src/lib/domain/focus-zone.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-composer-controls.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-composer-controls.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-composer-controls.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-composer-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-next-launch.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-next-launch.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-next-launch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-screen.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-screen.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-screen.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-screen.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/home/home-target-picker.ts",
+      "target": "apps/packages/product-client/src/lib/domain/home/home-target-picker.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/open-targets/model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/open-targets/model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/join-auth.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/join-auth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/logo-image.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/logo-image.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/logo-image.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/logo-image.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/member-list-rows.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/member-list-rows.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/member-list-rows.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/member-list-rows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/organization-records.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/organization-records.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/organizations/organization-records.ts",
+      "target": "apps/packages/product-client/src/lib/domain/organizations/organization-records.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/handoff-mode.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/handoff-mode.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/handoff-mode.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/handoff-mode.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/handoff-prompt.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/handoff-prompt.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/handoff-prompt.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/handoff-prompt.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/implementation-mode.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/implementation-mode.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/implementation-mode.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/implementation-mode.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/implementation-prompt.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/implementation-prompt.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/implementation-prompt.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/implementation-prompt.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/implementation-target.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/implementation-target.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/implementation-target.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/implementation-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/plan-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/plan-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/proposed-plan-transcript.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/proposed-plan-transcript.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/plans/proposed-plan-transcript.ts",
+      "target": "apps/packages/product-client/src/lib/domain/plans/proposed-plan-transcript.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/playground/subagents-ux/navigation-close-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/playground/subagents-ux/navigation-close-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/appearance-css-drift.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/appearance-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/appearance-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/appearance.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/appearance.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/appearance.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/appearance.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/persisted-metadata.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/persisted-metadata.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/repo-preferences.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/repo-preferences.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/repo-preferences.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/repo-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/review-preferences.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/review-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/migration.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/migration.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/migration.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/migration.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/persisted-keys.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/persisted-keys.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/persisted-keys.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/persisted-keys.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/release-notice-preferences.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/release-notice-preferences.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/session-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/session-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/user/worktree-auto-delete.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/user/worktree-auto-delete.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-chrome.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-chrome.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/migration.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/migration.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/migration.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/migration.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persisted-chat-sessions.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-chat-sessions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persisted-git-status.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-git-status.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persisted-git-status.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-git-status.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persisted-right-panel.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-right-panel.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persisted-shell-tabs.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-shell-tabs.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persistence.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persistence.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/persistence.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persistence.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/preferences/workspace-ui/sidebar.ts",
+      "target": "apps/packages/product-client/src/lib/domain/preferences/workspace-ui/sidebar.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-config.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-config.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-config.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-config.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-feedback-summary.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-feedback-summary.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-launch.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-launch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-personas.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-personas.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-runs.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-runs.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/review-runs.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/review-runs.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/reviews/session-relationship-hints.ts",
+      "target": "apps/packages/product-client/src/lib/domain/reviews/session-relationship-hints.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/activity-fold.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/activity-fold.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/activity-fold.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/activity-fold.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/activity-mirror.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/activity-mirror.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/activity-mirror.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/activity-mirror.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/compatible-session.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/compatible-session.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/compatible-session.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/compatible-session.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/create-session-error.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/create-session-error.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/create-session-error.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/create-session-error.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/launch-controls.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/launch-controls.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/launch-controls.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/launch-controls.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/mode.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/mode.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/mode.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/mode.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/creation/retry-options.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/creation/retry-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/desktop-origin.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/desktop-origin.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-activity.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-activity.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-activity.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-entry.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-entry.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-entry.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-entry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-indexes.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-indexes.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-reducer.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-reducer.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/directory-reducer.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/directory-reducer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/directory/relationship.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/directory/relationship.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/goal-mirror.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/goal-mirror.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/history/history-event-merge.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/history/history-event-merge.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/history/history-event-merge.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/history/history-event-merge.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/hot-paint-gate.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/hot-paint-gate.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/hot-paint-gate.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/hot-paint-gate.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/hot-session-policy.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/hot-session-policy.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/model-fallback.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/model-fallback.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/model-fallback.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/model-fallback.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/prompt-readiness.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/prompt-readiness.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/prompt-readiness.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/prompt-readiness.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/running-local-sessions.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/running-local-sessions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/running-local-sessions.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/running-local-sessions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/selection/trusted-session-selection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/selection/trusted-session-selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/selection/trusted-session-selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/selection/trusted-session-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/session-emptiness.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/session-emptiness.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/session-emptiness.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/session-emptiness.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream/latest-timestamp-throttle.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream/latest-timestamp-throttle.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream/latest-timestamp-throttle.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream/latest-timestamp-throttle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream/stream-side-effect-plan.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream/stream-side-effect-plan.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream/stream-state.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream/stream-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream-patch.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream-patch.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/stream-patch.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/stream-patch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/summary.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/summary.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/summary.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/summary.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/sessions/title.ts",
+      "target": "apps/packages/product-client/src/lib/domain/sessions/title.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/admin-roles.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/admin-roles.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/agent-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/agent-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/branch-selection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/branch-selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/branch-selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/branch-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/chat-defaults.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/chat-defaults.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/chat-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/chat-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/environment-draft.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/environment-draft.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/environment-draft.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/environment-draft.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/harness-auth-sources.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/harness-auth-sources.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/harness-catalog.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/harness-catalog.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/harness-catalog.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/integrations-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/integrations-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/integrations-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/integrations-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/model-registries.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/model-registries.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/model-registries.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/model-registries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/navigation-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/navigation-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/navigation-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/navigation-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/navigation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/navigation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/navigation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/navigation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/org-integrations-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/org-integrations-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/org-integrations-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/org-integrations-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/organization-limits-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/organization-limits-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/repo-scope-selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/repo-scope-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/repositories.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/repositories.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/repositories.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/repositories.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/setup-hints.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/setup-hints.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/setup-hints.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/setup-hints.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/shortcut-targets.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/shortcut-targets.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/settings/slack-session-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/domain/settings/slack-session-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/dispatch-policy.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/dispatch-policy.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/dispatch-policy.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/dispatch-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/keyboard-resolution.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/keyboard-resolution.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/keyboard-resolution.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/keyboard-resolution.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/matching.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/matching.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/matching.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/matching.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/native-accelerators.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/native-accelerators.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/native-accelerators.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/native-accelerators.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/range.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/range.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/range.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/range.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/registry.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/registry.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/registry.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/registry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/shortcut-sections.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/shortcut-sections.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/shortcuts/shortcut-sections.ts",
+      "target": "apps/packages/product-client/src/lib/domain/shortcuts/shortcut-sections.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/formatting.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/formatting.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/formatting.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/formatting.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/report-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/report-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/report-upload-failure.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/report-upload-failure.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/report-upload-failure.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/report-upload-failure.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/report-upload-sanitizer.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/report-upload-sanitizer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug/action-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug/action-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug/export-models.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug/export-models.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug/file-name.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug/file-name.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug/locator.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug/locator.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug/sanitizer.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug/sanitizer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug/session-summary.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug/session-summary.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/session-debug.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/session-debug.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/support-menu-action.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/support-menu-action.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/support-menu-action.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/support-menu-action.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/support/types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/support/types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/anonymous-events.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/anonymous-events.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/anonymous-events.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/anonymous-events.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/debug-measurement-catalog.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/debug-measurement-catalog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/errors.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/errors.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/events.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/events.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/failures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/failures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/latency-flow-completion.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/latency-flow-completion.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/latency-flow-completion.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/latency-flow-completion.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/mode.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/mode.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/mode.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/mode.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/routes.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/routes.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/routes.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/routes.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/workspace-kind.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/workspace-kind.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/telemetry/workspace-kind.ts",
+      "target": "apps/packages/product-client/src/lib/domain/telemetry/workspace-kind.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/terminals/run-terminal.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/terminals/run-terminal.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/terminals/run-terminal.ts",
+      "target": "apps/packages/product-client/src/lib/domain/terminals/run-terminal.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/terminals/terminal-grid.ts",
+      "target": "apps/packages/product-client/src/lib/domain/terminals/terminal-grid.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/updates/release-notice.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/updates/release-notice.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/updates/release-notice.ts",
+      "target": "apps/packages/product-client/src/lib/domain/updates/release-notice.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/activity/composer-workspace-activity.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/activity/composer-workspace-activity.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/activity/composer-workspace-activity.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/activity/composer-workspace-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/changed-file-tree.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/changed-file-tree.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/changed-file-tree.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/changed-file-tree.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/diff-display-policy.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/diff-display-policy.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/diff-display-policy.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/diff-display-policy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/git-file-status-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/git-file-status-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/git-panel-diff.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-diff.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/git-panel-diff.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-diff.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/git-panel-review-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-review-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/git-panel-workspace-context.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-workspace-context.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/changes/git-review-entries.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/changes/git-review-entries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-display-name-sync.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-display-name-sync.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-display-name-sync.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-display-name-sync.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-ids.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-ids.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-runtime-kind.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-runtime-kind.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-runtime-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-runtime-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-settings.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-settings.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-settings.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-settings.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/collections.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/collections.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/collections.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/collections.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspace-id.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspace-lookup.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-lookup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspace-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspace-slot.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-slot.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspace-source.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-source.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces-duplicates.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/selected-repo-target.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/selected-repo-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/standard-projection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/standard-projection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/cloud/standard-projection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/cloud/standard-projection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/add-repo-workflow.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/add-repo-workflow.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/add-repo-workflow.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/add-repo-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/arrival.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/arrival.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/arrival.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/arrival.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/branch-naming.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/branch-naming.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/new-workspace-command.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/new-workspace-command.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/new-workspace-command.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/pending-entry.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/pending-entry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-dialog-state.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-dialog-state.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-dialog-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-dialog-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-draft.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-draft.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-file-groups.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-file-groups.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-file-groups.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-file-groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-workflow-labels.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-workflow-labels.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-workflow-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-workflow-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-workflow-steps.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-workflow-steps.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-workflow.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-workflow.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/publish-workflow.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/publish-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/workspace-creation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/workspace-creation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/workspace-creation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/workspace-creation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/creation/workspace-slug.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/creation/workspace-slug.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/display/usability.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/display/usability.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/display/usability.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/display/usability.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/display/workspace-display.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/display/workspace-display.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/display/workspace-display.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/display/workspace-display.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/git-status/pr-status-presentation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/git-status/pr-status-presentation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/git-status/pr-status-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/git-status/pr-status-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/git-status/workspace-git-status-model.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/git-status/workspace-git-status-model.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/git-status/workspace-git-status-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/git-status/workspace-git-status-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/git-status/workspace-git-status-snapshots.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/git-status/workspace-git-status-snapshots.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/scratch/scratch-list-formatting.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/scratch/scratch-list-formatting.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/hot-reopen.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/hot-reopen.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/optimistic-session-shell.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/optimistic-session-shell.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/persisted-logical-workspace-selection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/persisted-logical-workspace-selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/persisted-logical-workspace-selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/persisted-logical-workspace-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/selection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/selection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-bootstrap-selection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-bootstrap-selection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-keyed-preferences.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-keyed-preferences.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-keyed-preferences.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-keyed-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-provider-scope.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-provider-scope.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-provider-scope.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-provider-scope.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-ui-key.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-ui-key.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/selection/workspace-ui-key.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/selection/workspace-ui-key.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-header-entry.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-header-entry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-migration.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-migration.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-shortcuts.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-shortcuts.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-shortcuts.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-shortcuts.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-state-normalization.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-state-normalization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel-view.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-view.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/right-panel.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/shell-surface.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/shell-surface.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/shell/shell-surface.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/shell/shell-surface.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/cloud-workspace.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/cloud-workspace.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/recency.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/recency.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/recency.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/recency.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/repo-context-menu.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/repo-context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/repo-context-menu.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/repo-context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-detail-indicators.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-detail-indicators.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-entries.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-entries.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-group-key.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-group-key.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-group-key.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-group-key.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-groups.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-local-slots.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-local-slots.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-model.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-review.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-review.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-shortcut-targets.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-test-fixtures.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-visible-items.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-visible-items.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar-workspace-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/workspace-activity-indicator.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/worktree-settings-actions.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/worktree-settings-actions.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/sidebar/worktree-settings-actions.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/sidebar/worktree-settings-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/active-shell-tab.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/active-shell-tab.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/active-shell-tab.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/active-shell-tab.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/chrome-layout.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/chrome-layout.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/chrome-layout.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/chrome-layout.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/context-menu.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/context-menu.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/context-menu.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/context-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/drag-controller.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/drag-controller.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/drag-controller.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/drag-controller.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/drag.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/drag.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/drag.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/drag.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/group-rows.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/group-rows.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/group-rows.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/group-rows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/grouping.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/grouping.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/manual-groups.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/manual-groups.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/manual-groups.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/manual-groups.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/session-replacement.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/session-replacement.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/session-replacement.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/session-replacement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-activation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-activation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-activation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-activation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-file-seed.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-file-seed.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-file-seed.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-file-seed.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-rows.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-rows.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-rows.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-rows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-tab-state.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tab-state.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-tab-state.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tab-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-tabs.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tabs.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/shell-tabs.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tabs.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/visibility.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/visibility.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/visibility.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/visibility.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-cowork-hierarchy.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-cowork-hierarchy.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-cowork-hierarchy.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-cowork-hierarchy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-live-slots-selector.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-live-slots-selector.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-subagent-hierarchy.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-subagent-hierarchy.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-derivation.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-derivation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-derivation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-derivation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-session-query-target.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-session-query-target.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/tabs/workspace-session-query-target.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/tabs/workspace-session-query-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/viewer/file-diff-options.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/viewer/file-diff-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/viewer/file-language.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/viewer/file-language.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/viewer/viewer-target.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/viewer/viewer-target.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/workspace-copy-metadata.test.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/workspace-copy-metadata.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/workspace-copy-metadata.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/workspace-copy-metadata.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/worktrees/worktree-inventory-presentation.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/worktrees/worktree-inventory-presentation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/domain/workspaces/worktrees/worktree-settings-target.ts",
+      "target": "apps/packages/product-client/src/lib/domain/workspaces/worktrees/worktree-settings-target.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/abort/session-history-timeout.ts",
+      "target": "apps/packages/product-client/src/lib/infra/abort/session-history-timeout.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/debug/dev-session-runtime-log.ts",
+      "target": "apps/packages/product-client/src/lib/infra/debug/dev-session-runtime-log.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/debug/dev-sse-envelope-sanitizer.ts",
+      "target": "apps/packages/product-client/src/lib/infra/debug/dev-sse-envelope-sanitizer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/debug/dev-sse-event-log.ts",
+      "target": "apps/packages/product-client/src/lib/infra/debug/dev-sse-event-log.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/debug/dev-sse-event-record.ts",
+      "target": "apps/packages/product-client/src/lib/infra/debug/dev-sse-event-record.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/debug/dev-transcript-phase-log.ts",
+      "target": "apps/packages/product-client/src/lib/infra/debug/dev-transcript-phase-log.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/dom/dom-select-all.ts",
+      "target": "apps/packages/product-client/src/lib/infra/dom/dom-select-all.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/dom/scroll-chain.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/dom/scroll-chain.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/editor/highlighting.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/editor/highlighting.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/editor/highlighting.ts",
+      "target": "apps/packages/product-client/src/lib/infra/editor/highlighting.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/editor/monaco-theme.ts",
+      "target": "apps/packages/product-client/src/lib/infra/editor/monaco-theme.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/encoding/base64url.ts",
+      "target": "apps/packages/product-client/src/lib/infra/encoding/base64url.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/events/turn-end-events.ts",
+      "target": "apps/packages/product-client/src/lib/infra/events/turn-end-events.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/hf-logo.svg",
+      "target": "apps/packages/product-client/src/lib/infra/hf-logo.svg",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/interaction/typing-activity-store.ts",
+      "target": "apps/packages/product-client/src/lib/infra/interaction/typing-activity-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics-fetch.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics-fetch.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics-format.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics-format.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics-layout.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics-layout.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics-overlay.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics-overlay.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics-performance.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics-performance.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics-types.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/boot-stall-diagnostics.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/boot-stall-diagnostics.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-jank-activity.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-jank-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-latency.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-latency.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-layout-shift.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-layout-shift.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-main-thread.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-main-thread.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-main-thread.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-main-thread.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-aggregate.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-aggregate.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-catalog-types.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-catalog-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-dump.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-dump.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-env.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-env.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-events.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-events.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-install.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-install.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-metric-routing.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-metric-routing.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-metric-types.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-metric-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-observer.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-observer.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-operation-lifecycle.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-operation-lifecycle.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-registry-types.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-registry-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-report-types.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-report-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-request-options.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-request-options.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-request-options.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-request-options.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-snapshots.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-snapshots.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-state.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-summary.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-summary.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement-utils.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement-utils.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-measurement.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-measurement.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-session-activity.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-session-activity.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/debug-startup.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/debug-startup.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/latency-flow.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/latency-flow.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/latency-flow.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/latency-flow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/operation-ids.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/operation-ids.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/operation-ids.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/operation-ids.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/measurement/typing-latency-probe.ts",
+      "target": "apps/packages/product-client/src/lib/infra/measurement/typing-latency-probe.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/persistence/preferences-persistence.ts",
+      "target": "apps/packages/product-client/src/lib/infra/persistence/preferences-persistence.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/persistence/product-storage.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/persistence/product-storage.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/persistence/product-storage.ts",
+      "target": "apps/packages/product-client/src/lib/infra/persistence/product-storage.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/proliferate-api.ts",
+      "target": "apps/packages/product-client/src/lib/infra/proliferate-api.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/proliferate-web.ts",
+      "target": "apps/packages/product-client/src/lib/infra/proliferate-web.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/query/query-client.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/query/query-client.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/query/query-client.ts",
+      "target": "apps/packages/product-client/src/lib/infra/query/query-client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/query/react-query-meta.ts",
+      "target": "apps/packages/product-client/src/lib/infra/query/react-query-meta.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/right-panel-new-tab-menu.ts",
+      "target": "apps/packages/product-client/src/lib/infra/right-panel-new-tab-menu.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/scheduling/react-batching.ts",
+      "target": "apps/packages/product-client/src/lib/infra/scheduling/react-batching.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/scheduling/schedule-after-next-paint.ts",
+      "target": "apps/packages/product-client/src/lib/infra/scheduling/schedule-after-next-paint.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/terminals/terminal-close-intent.ts",
+      "target": "apps/packages/product-client/src/lib/infra/terminals/terminal-close-intent.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/terminals/terminal-grid-probe.ts",
+      "target": "apps/packages/product-client/src/lib/infra/terminals/terminal-grid-probe.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/terminals/terminal-stream-key.ts",
+      "target": "apps/packages/product-client/src/lib/infra/terminals/terminal-stream-key.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/terminals/terminal-stream-registry.test.ts",
+      "target": "apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/infra/terminals/terminal-stream-registry.ts",
+      "target": "apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/desktop-worker-revocation.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/desktop-worker-revocation.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/orchestration-bootstrap.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/orchestration-bootstrap.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/orchestration-callback.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/orchestration-callback.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/orchestration-callback.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/orchestration-callback.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/orchestration-effects.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/orchestration-effects.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/orchestration-password-flow.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/orchestration-password-flow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/orchestration-provider-flow.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/orchestration-provider-flow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/proliferate-auth-password.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/proliferate-auth-password.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/proliferate-auth-redirect.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/proliferate-auth-redirect.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/proliferate-auth-transport.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/proliferate-auth-transport.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/proliferate-auth-transport.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/proliferate-auth-transport.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/proliferate-auth.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/proliferate-auth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/auth/proliferate-sso-auth.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/auth/proliferate-sso-auth.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/anonymous-storage.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/anonymous-storage.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/anonymous.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/anonymous.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/anonymous.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/anonymous.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/client.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/client.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/client.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/config.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/config.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/config.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/config.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/native-diagnostics.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/native-diagnostics.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/native-diagnostics.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/native-diagnostics.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/posthog.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/posthog.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/release-version-invariant.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/release-version-invariant.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/scrub.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/scrub.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/sentry.test.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/sentry.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/integrations/telemetry/sentry.ts",
+      "target": "apps/packages/product-client/src/lib/integrations/telemetry/sentry.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/auth/apply-auth-state.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/auth/apply-auth-state.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/auth/apply-auth-state.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/auth/apply-auth-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/automations/local-automation-executor.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/automations/local-automation-executor.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/automations/local-automation-executor.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/automations/local-automation-executor.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/chat/complete-chat-prompt-submit-side-effects.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/chat/complete-chat-prompt-submit-side-effects.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/chat/complete-chat-prompt-submit-side-effects.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/chat/complete-chat-prompt-submit-side-effects.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/cloud/ensure-desktop-worker.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/cloud/ensure-desktop-worker.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/cloud/ensure-desktop-worker.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/cowork/create-cowork-thread.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/cowork/create-cowork-thread.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/preferences/compute-target-appearance-preferences.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/preferences/compute-target-appearance-preferences.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/preferences/compute-target-appearance-preferences.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/preferences/compute-target-appearance-preferences.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/preferences/repo-preferences-persistence.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/preferences/repo-preferences-persistence.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/preferences/user-preferences-persistence.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/preferences/user-preferences-persistence.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/reviews/review-parent-materialization.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/reviews/review-parent-materialization.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/reviews/review-parent-materialization.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/reviews/review-parent-materialization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/hot-session-ingest-manager.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/hot-session-ingest-manager.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/hot-session-ingest-manager.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/hot-session-ingest-manager.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-launch-defaults.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-launch-defaults.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-launch-defaults.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-launch-defaults.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-materialization.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-materialization.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-materialization.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-materialization.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-reconnect-state.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-reconnect-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-runtime.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-runtime.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/sessions/session-runtime.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/sessions/session-runtime.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/support/session-debug-export-workflows.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/support/session-debug-export-workflows.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/support/session-debug-export-workflows.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/support/session-debug-export-workflows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/support/support-report-upload-workflows.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/support/support-report-upload-workflows.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/support/support-report-upload-workflows.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/support/support-report-upload-workflows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/terminals/terminal-record-workflows.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/terminals/terminal-record-workflows.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/terminals/terminal-record-workflows.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/terminals/terminal-record-workflows.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/workspaces/right-panel-shortcut-requests.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/workspaces/right-panel-shortcut-requests.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/workspaces/right-panel-shortcut-requests.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/workspaces/right-panel-shortcut-requests.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/workspaces/run-workspace-publish-workflow.test.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/workspaces/run-workspace-publish-workflow.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/lib/workflows/workspaces/run-workspace-publish-workflow.ts",
+      "target": "apps/packages/product-client/src/lib/workflows/workspaces/run-workspace-publish-workflow.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/main.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/AgentsPlaygroundPage.tsx",
+      "target": "apps/packages/product-client/src/pages/AgentsPlaygroundPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/AuthPlaygroundPage.tsx",
+      "target": "apps/packages/product-client/src/pages/AuthPlaygroundPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/AuthenticatedAppHost.test.tsx",
+      "target": "apps/packages/product-client/src/pages/AuthenticatedAppHost.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/AuthenticatedAppHost.tsx",
+      "target": "apps/packages/product-client/src/pages/AuthenticatedAppHost.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/ChatPlaygroundPage.tsx",
+      "target": "apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/DesktopWorkspaceDeepLinkPage.tsx",
+      "target": "apps/packages/product-client/src/pages/DesktopWorkspaceDeepLinkPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/LoginPage.tsx",
+      "target": "apps/packages/product-client/src/pages/LoginPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/MainPage.tsx",
+      "target": "apps/packages/product-client/src/pages/MainPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/SettingsCloudRedirect.tsx",
+      "target": "apps/packages/product-client/src/pages/SettingsCloudRedirect.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/SettingsPage.tsx",
+      "target": "apps/packages/product-client/src/pages/SettingsPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/SubagentsUxPlaygroundPage.tsx",
+      "target": "apps/packages/product-client/src/pages/SubagentsUxPlaygroundPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/UpdatePlaygroundPage.tsx",
+      "target": "apps/packages/product-client/src/pages/UpdatePlaygroundPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/WorkflowsPage.test.tsx",
+      "target": "apps/packages/product-client/src/pages/WorkflowsPage.test.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/WorkflowsPage.tsx",
+      "target": "apps/packages/product-client/src/pages/WorkflowsPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/WorkspaceStatusPlaygroundPage.tsx",
+      "target": "apps/packages/product-client/src/pages/WorkspaceStatusPlaygroundPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/pages/WorkspacesPage.tsx",
+      "target": "apps/packages/product-client/src/pages/WorkspacesPage.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/providers/AppCommandActionsProvider.tsx",
+      "target": "apps/packages/product-client/src/providers/AppCommandActionsProvider.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/DesktopHostProviders.test.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/DesktopHostProviders.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/DesktopProductHostProvider.test.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/DesktopProductHostProvider.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/DesktopProductLifecycleRoot.test.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/DesktopProductLifecycleRoot.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "split",
+      "source": "apps/desktop/src/providers/ProductLifecycleRoot.test.tsx",
+      "target": "apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx",
+      "reason": "Root composition splits into a host shell plus shared ProductClient route/provider ownership."
+    },
+    {
+      "action": "split",
+      "source": "apps/desktop/src/providers/ProductLifecycleRoot.tsx",
+      "target": "apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx",
+      "reason": "Root composition splits into a host shell plus shared ProductClient route/provider ownership."
+    },
+    {
+      "action": "split",
+      "source": "apps/desktop/src/providers/ProductProviderRoot.tsx",
+      "target": "apps/packages/product-client/src/providers/ProductProviderRoot.tsx",
+      "reason": "Root composition splits into a host shell plus shared ProductClient route/provider ownership."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/providers/ShortcutRevealProvider.tsx",
+      "target": "apps/packages/product-client/src/providers/ShortcutRevealProvider.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/providers/TelemetryProvider.tsx",
+      "target": "apps/packages/product-client/src/providers/TelemetryProvider.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/providers/WorkspacePathProvider.tsx",
+      "target": "apps/packages/product-client/src/providers/WorkspacePathProvider.tsx",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/providers/app-query-client.ts",
+      "target": "apps/packages/product-client/src/providers/app-query-client.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/desktop-product-host.test.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/providers/desktop-product-host.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/activity/goal-bar-store.ts",
+      "target": "apps/packages/product-client/src/stores/activity/goal-bar-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/agents/agent-credentials-store.ts",
+      "target": "apps/packages/product-client/src/stores/agents/agent-credentials-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/auth/auth-store.ts",
+      "target": "apps/packages/product-client/src/stores/auth/auth-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-diff-preferences-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-diff-preferences-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-diff-preferences-store.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-diff-preferences-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-input-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-input-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-input-store.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-input-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-launch-intent-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-launch-intent-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-launch-intent-store.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-launch-intent-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-plan-attachment-store.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-plan-attachment-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-prompt-recovery-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-prompt-recovery-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/chat/chat-prompt-recovery-store.ts",
+      "target": "apps/packages/product-client/src/stores/chat/chat-prompt-recovery-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/cowork/cowork-ui-store.ts",
+      "target": "apps/packages/product-client/src/stores/cowork/cowork-ui-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/file-tree-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/editor/file-tree-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/file-tree-store.ts",
+      "target": "apps/packages/product-client/src/stores/editor/file-tree-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/git-panel-ui-store.ts",
+      "target": "apps/packages/product-client/src/stores/editor/git-panel-ui-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/workspace-editor-state.ts",
+      "target": "apps/packages/product-client/src/stores/editor/workspace-editor-state.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/workspace-file-buffers-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/editor/workspace-file-buffers-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/workspace-file-buffers-store.ts",
+      "target": "apps/packages/product-client/src/stores/editor/workspace-file-buffers-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/workspace-viewer-tabs-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/editor/workspace-viewer-tabs-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/editor/workspace-viewer-tabs-store.ts",
+      "target": "apps/packages/product-client/src/stores/editor/workspace-viewer-tabs-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/home/deferred-home-launch-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/home/deferred-home-launch-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/home/deferred-home-launch-store.ts",
+      "target": "apps/packages/product-client/src/stores/home/deferred-home-launch-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/home/home-draft-handoff-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/home/home-draft-handoff-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/home/home-draft-handoff-store.ts",
+      "target": "apps/packages/product-client/src/stores/home/home-draft-handoff-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/infra/connectivity-store.ts",
+      "target": "apps/packages/product-client/src/stores/infra/connectivity-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/organizations/organization-store.ts",
+      "target": "apps/packages/product-client/src/stores/organizations/organization-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/repo-preferences-store.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/repo-preferences-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/user-model-visibility-reset.test.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/user-model-visibility-reset.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/user-preferences-appearance-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/user-preferences-appearance-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/user-preferences-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/user-preferences-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/user-preferences-store.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/user-preferences-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-activity-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-activity-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-chat-tab-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-chat-tab-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-dismissal-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-dismissal-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-git-status-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-git-status-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-right-panel-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-shell-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-shell-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-sidebar-actions.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-sidebar-actions.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-state-value.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-state-value.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-store-types.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/preferences/workspace-ui-store.ts",
+      "target": "apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/search/content-search-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/search/content-search-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/search/content-search-store.ts",
+      "target": "apps/packages/product-client/src/stores/search/content-search-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/harness-connection-store.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/harness-connection-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-directory-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-directory-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-directory-store.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-directory-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-ingest-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-ingest-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-ingest-store.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-ingest-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-intent-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-intent-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-intent-store.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-intent-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-records.test.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-records.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-records.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-records.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-selection-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-selection-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-selection-store.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-selection-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-store-isolation.test.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-store-isolation.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-transcript-store.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-transcript-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/sessions/session-types.ts",
+      "target": "apps/packages/product-client/src/stores/sessions/session-types.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/shortcuts/keyboard-shortcuts-dialog-store.ts",
+      "target": "apps/packages/product-client/src/stores/shortcuts/keyboard-shortcuts-dialog-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/shortcuts/shortcut-reveal-store.ts",
+      "target": "apps/packages/product-client/src/stores/shortcuts/shortcut-reveal-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/support/support-modal-store.ts",
+      "target": "apps/packages/product-client/src/stores/support/support-modal-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/terminal/terminal-store.ts",
+      "target": "apps/packages/product-client/src/stores/terminal/terminal-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/toast/toast-store.ts",
+      "target": "apps/packages/product-client/src/stores/toast/toast-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/ui/add-repo-flow-store.ts",
+      "target": "apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/ui/agent-surface-store.ts",
+      "target": "apps/packages/product-client/src/stores/ui/agent-surface-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/ui/repo-setup-modal-store.ts",
+      "target": "apps/packages/product-client/src/stores/ui/repo-setup-modal-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/updater/updater-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/updater/updater-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/updater/updater-store.ts",
+      "target": "apps/packages/product-client/src/stores/updater/updater-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/workspaces/new-workspace-command-scope-store.ts",
+      "target": "apps/packages/product-client/src/stores/workspaces/new-workspace-command-scope-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/workspaces/workspace-sidebar-show-more-store.test.ts",
+      "target": "apps/packages/product-client/src/stores/workspaces/workspace-sidebar-show-more-store.test.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "move",
+      "source": "apps/desktop/src/stores/workspaces/workspace-sidebar-show-more-store.ts",
+      "target": "apps/packages/product-client/src/stores/workspaces/workspace-sidebar-show-more-store.ts",
+      "reason": "Desktop product source moves mechanically into ProductClient."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/test/product-host-fixtures.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/test/product-host-test-utils.tsx",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    },
+    {
+      "action": "retain",
+      "source": "apps/desktop/src/test/product-storage-test-utils.ts",
+      "reason": "Desktop host, native bridge, browser storage adapter, or test harness remains in the thin Desktop app."
+    }
+  ]
+}

--- a/specs/codebase/features/web-desktop-product-client-web-baseline.json
+++ b/specs/codebase/features/web-desktop-product-client-web-baseline.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "collectedAt": "2026-07-14T21:20:22.504Z",
+  "dist": "/Users/pablohansen/.codex/worktrees/wdu-codex-owned/product-client-extraction-mechanics/apps/web/dist",
+  "metric": "gzip_bytes",
+  "note": "Provisional legacy Web baseline. The Web replacement PR reruns this on its exact base for the binding budget.",
+  "totals": {
+    "css": 17319,
+    "js": 471379
+  },
+  "entries": [
+    {
+      "file": "assets/index-ARz6PF3D.css",
+      "name": "index-ARz6PF3D.css",
+      "kind": "css",
+      "bytes": 106276,
+      "gzipBytes": 17319
+    },
+    {
+      "file": "assets/index-ychkcnvs.js",
+      "name": "index-ychkcnvs.js",
+      "kind": "js",
+      "bytes": 1564701,
+      "gzipBytes": 471379
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the ProductClient extraction mechanics without moving Desktop product source.

- adds a qualification-only ProductClient canary export with a public shell and lazy authenticated chunk
- builds that compiled canary from both a Desktop qualification host and a minimal browser host (`desktop: null`)
- verifies emitted build URLs, including CSS, fonts, image, audio, and SVG assets
- records the deterministic Desktop move ledger and codemod proof script
- adds the provisional legacy Web bundle collector/baseline
- keeps generated qualification `dist` outputs ignored

This PR is stacked on #1194 and targets `codex/wdu-persistence-telemetry-followup` so its diff stays isolated under the founder merge hold.

## Non-goals

- no Desktop product source moves
- no legacy Web replacement
- no product route/auth/cache/runtime behavior changes
- no `product-surfaces` absorption

## Validation

- `pnpm --filter @proliferate/product-client test`
- `pnpm --filter @proliferate/product-client typecheck && pnpm --filter @proliferate/product-client build`
- `pnpm --filter @proliferate/product-client exec tsc -p qualification/browser-host/tsconfig.json`
- `pnpm --filter @proliferate/product-client exec vite build --config qualification/browser-host/vite.config.ts`
- `node scripts/verify-product-client-qualification-assets.mjs apps/packages/product-client/qualification/browser-host/dist`
- `pnpm --filter proliferate exec tsc -p qualification/product-client/tsconfig.json`
- `pnpm --filter proliferate exec vite build --config qualification/product-client/vite.config.ts`
- `node scripts/verify-product-client-qualification-assets.mjs apps/desktop/dist-product-client-qualification`
- `pnpm web:build`
- `node scripts/collect-web-bundle-baseline.mjs --dist apps/web/dist --out specs/codebase/features/web-desktop-product-client-web-baseline.json`
- `node scripts/migrate-desktop-product-client.mjs check-ledger`
- `node scripts/migrate-desktop-product-client.mjs prove-codemod`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict`
- `git diff --check`
- `pnpm --filter proliferate build`

Notes:
- `pnpm web:build` still emits the existing large-chunk warning for legacy Web.
- `pnpm --filter proliferate build` still emits existing Vite dynamic/static import chunking warnings for Tauri and highlighting assets.

