### PR TITLE
feat(telemetry): bounded runtime identity + exact E2B build stamping (B2)

### DIFF
--- a/.github/workflows/_deploy-e2b.yml
+++ b/.github/workflows/_deploy-e2b.yml
@@ -93,6 +93,11 @@ jobs:
           set -euo pipefail
           short_sha="${GIT_SHA:0:12}"
           echo "sha_tag=sha-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          # The canonical runtime version the build stamps and the smoke asserts.
+          runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
+          : "${runtime_version:?Failed to read anyharness/sdk/package.json version.}"
+          echo "runtime_version=${runtime_version}" >> "$GITHUB_OUTPUT"
         env:
           GIT_SHA: ${{ inputs.git_sha }}
 
@@ -113,6 +118,8 @@ jobs:
         run: >
           node scripts/smoke-cloud-template.mjs
           --template "$E2B_PUBLIC_TEMPLATE_FAMILY:${{ steps.tag.outputs.sha_tag }}"
+          --expected-version "${{ steps.tag.outputs.runtime_version }}"
+          --expected-sha "${{ steps.tag.outputs.short_sha }}"
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
 

--- a/.github/workflows/_deploy-server.yml
+++ b/.github/workflows/_deploy-server.yml
@@ -141,22 +141,28 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
       # Version pins stamped into the image and reported by /health and /meta.
-      # serverVersion comes from the root VERSION file; desktop/runtime/worker
-      # pins from their tracked package manifests at this commit.
+      # The canonical hosted release version is the root VERSION file, which must
+      # agree with anyharness/sdk/package.json. Server, runtime, and worker pins
+      # all use that canonical value: the worker/supervisor Cargo package version
+      # is a stale `0.1.0` and must never become a hosted `/meta` pin. Desktop
+      # keeps its own tracked package version.
       - name: Resolve version pins
         id: pins
         run: |
           set -euo pipefail
           server_version="$(cat VERSION)"
-          desktop_version="$(jq -r '.version' apps/desktop/package.json)"
           runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
-          worker_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' anyharness/crates/proliferate-worker/Cargo.toml | head -n 1)"
-          : "${worker_version:?Failed to read the proliferate-worker crate version.}"
+          if [ "$server_version" != "$runtime_version" ]; then
+            echo "Canonical version mismatch: VERSION=${server_version} but anyharness/sdk/package.json=${runtime_version}. They must agree for hosted release pins." >&2
+            exit 1
+          fi
+          canonical_version="$server_version"
+          desktop_version="$(jq -r '.version' apps/desktop/package.json)"
           {
-            echo "server_version=${server_version}"
+            echo "server_version=${canonical_version}"
             echo "desktop_version=${desktop_version}"
-            echo "runtime_version=${runtime_version}"
-            echo "worker_version=${worker_version}"
+            echo "runtime_version=${canonical_version}"
+            echo "worker_version=${canonical_version}"
             echo "min_desktop_version=${desktop_version}"
           } >> "$GITHUB_OUTPUT"
 
@@ -269,14 +275,12 @@ jobs:
               {"name":"SANDBOX_PROVIDER","value":"e2b"},
               {"name":"E2B_TEMPLATE_NAME","value":$e2b},
               {"name":"SERVER_GIT_SHA","value":$git},
-              {"name":"ANYHARNESS_GIT_SHA","value":$git},
               {"name":"PROLIFERATE_TELEMETRY_MODE","value":"hosted_product"},
+              {"name":"PROLIFERATE_REQUIRE_RELEASE_IDENTITY","value":"1"},
               {"name":"SENTRY_ENVIRONMENT","value":$environment},
               {"name":"SENTRY_RELEASE","value":$release},
               {"name":"CLOUD_RUNTIME_SENTRY_ENVIRONMENT","value":$environment},
-              {"name":"CLOUD_RUNTIME_SENTRY_RELEASE","value":$release},
               {"name":"CLOUD_TARGET_SENTRY_ENVIRONMENT","value":$environment},
-              {"name":"CLOUD_TARGET_SENTRY_RELEASE","value":$release},
               {"name":"SUPPORT_REPORT_S3_BUCKET","value":$support_report_bucket},
               {"name":"SUPPORT_REPORT_S3_PREFIX","value":$support_report_prefix},
               {"name":"SUPPORT_REPORT_S3_REGION","value":$support_report_region},
@@ -344,10 +348,17 @@ jobs:
             (.environment // []) as $current
             | ($updates[0] | map(.name)) as $updated_names
             | ["SUPPORT_GITHUB_APP_PRIVATE_KEY", "SUPPORT_LINEAR_API_KEY", "SUPPORT_FEED_BEARER_TOKEN"] as $secret_names
+            # Stale runtime-identity overrides the server never re-authors. The
+            # task definition is merged from the previous revision, so dropping
+            # our own assignments is not enough: any inherited copy must be
+            # stripped here or it survives forever. Kept in lockstep with the
+            # ASSERT_JQ forbidden-name check below.
+            | ["SERVER_VERSION", "ANYHARNESS_VERSION", "ANYHARNESS_GIT_SHA", "E2B_TEMPLATE_VERSION", "CLOUD_RUNTIME_SENTRY_RELEASE", "CLOUD_TARGET_SENTRY_RELEASE", "E2B_RUNTIME_SENTRY_RELEASE"] as $forbidden_names
             | ($current | map(select(
                 .name as $name
                 | ($updated_names | index($name) | not)
                 and ($secret_names | index($name) | not)
+                and ($forbidden_names | index($name) | not)
               ))) + $updates[0];
 
           def merge_secrets($updates):
@@ -378,6 +389,9 @@ jobs:
           cat > assert-task.jq <<'ASSERT_JQ'
           def feed_secrets($c): [ $c.secrets[]? | select(.name == "SUPPORT_FEED_BEARER_TOKEN") ];
           def feed_plain($c): [ $c.environment[]? | select(.name == "SUPPORT_FEED_BEARER_TOKEN") ];
+          def forbidden_names: ["SERVER_VERSION", "ANYHARNESS_VERSION", "ANYHARNESS_GIT_SHA", "E2B_TEMPLATE_VERSION", "CLOUD_RUNTIME_SENTRY_RELEASE", "CLOUD_TARGET_SENTRY_RELEASE", "E2B_RUNTIME_SENTRY_RELEASE"];
+          def stale_vars($c): [ $c.environment[]? | select(.name as $n | forbidden_names | index($n)) ];
+          def strict_identity($c): [ $c.environment[]? | select(.name == "PROLIFERATE_REQUIRE_RELEASE_IDENTITY" and .value == "1") ];
           ([ .containerDefinitions[] | select(.name == $container) ]) as $matches
           | if ($matches | length) != 1 then
               error("expected exactly one \($container) container, found \($matches | length)")
@@ -385,6 +399,8 @@ jobs:
           | $matches[0] as $c
           | (feed_secrets($c)) as $secrets
           | (feed_plain($c)) as $plain
+          | (stale_vars($c)) as $stale
+          | (strict_identity($c)) as $strict
           | if ($secrets | length) != 1 then
               error("expected exactly one SUPPORT_FEED_BEARER_TOKEN ECS secret, found \($secrets | length)")
             elif ($plain | length) != 0 then
@@ -393,6 +409,10 @@ jobs:
               error("SUPPORT_FEED_BEARER_TOKEN must reference a Secrets Manager secret ARN")
             elif (($secrets[0].valueFrom // "") | endswith(":supportFeedToken::") | not) then
               error("SUPPORT_FEED_BEARER_TOKEN must project the supportFeedToken field")
+            elif ($stale | length) != 0 then
+              error("stale runtime-identity variables must not remain: \($stale | map(.name) | join(", "))")
+            elif ($strict | length) != 1 then
+              error("PROLIFERATE_REQUIRE_RELEASE_IDENTITY=1 must be set for strict hosted release identity")
             else empty end
           ASSERT_JQ
 

--- a/anyharness/crates/proliferate-supervisor/src/logging.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging.rs
@@ -11,6 +11,9 @@ const TARGET_SENTRY_ENVIRONMENT_ENV: &str = "PROLIFERATE_TARGET_SENTRY_ENVIRONME
 // own `<component>@<version>+<sha>` from its compile-time build stamp.
 const SUPERVISOR_SENTRY_RELEASE_ENV: &str = "PROLIFERATE_SUPERVISOR_SENTRY_RELEASE";
 const TARGET_SENTRY_TRACES_SAMPLE_RATE_ENV: &str = "PROLIFERATE_TARGET_SENTRY_TRACES_SAMPLE_RATE";
+/// The single env-like Sentry tag preserved as bounded deployment identity.
+/// Its allowed live value is `e2b`; every other env-like tag stays redacted.
+const RUNTIME_ENV_TAG: &str = "runtime_env";
 
 pub struct TelemetryGuards {
     _sentry: Option<sentry::ClientInitGuard>,
@@ -313,7 +316,12 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
         scrub_value(value, Some(key));
     }
     for (key, value) in &mut event.tags {
-        if sensitive_key(key) {
+        if key == RUNTIME_ENV_TAG {
+            // Bounded deployment identity: the runtime-environment tag survives
+            // (allowed live value `e2b`). Every other env-like tag key still
+            // matches `sensitive_key` and stays redacted.
+            *value = scrub_text(value);
+        } else if sensitive_key(key) {
             *value = "[redacted]".to_string();
         } else {
             *value = scrub_text(value);
@@ -369,7 +377,7 @@ pub fn init() -> TelemetryGuards {
 
             let runtime_env = std::env::var("PROLIFERATE_RUNTIME_ENV")
                 .unwrap_or_else(|_| "local".to_string());
-            scope.set_tag("runtime_env", &runtime_env);
+            scope.set_tag(RUNTIME_ENV_TAG, &runtime_env);
 
             if let Ok(org_id) = std::env::var("PROLIFERATE_ORG_ID") {
                 if !org_id.trim().is_empty() {
@@ -476,5 +484,28 @@ mod tests {
             .frames[0];
         assert_eq!(frame.abs_path.as_deref(), Some("[redacted-path]"));
         assert!(frame.context_line.is_none());
+    }
+
+    #[test]
+    fn runtime_env_tag_survives_while_other_env_tags_are_redacted() {
+        let mut event = Event::new();
+        event.tags.insert("runtime_env".to_string(), "e2b".to_string());
+        event.tags.insert("deploy_env".to_string(), "prod".to_string());
+        event
+            .tags
+            .insert("environment_name".to_string(), "prod".to_string());
+
+        let scrubbed = scrub_event(event).expect("event should remain");
+
+        // Bounded deployment identity is preserved; other env-like tags are not.
+        assert_eq!(scrubbed.tags.get("runtime_env").map(String::as_str), Some("e2b"));
+        assert_eq!(
+            scrubbed.tags.get("deploy_env").map(String::as_str),
+            Some("[redacted]")
+        );
+        assert_eq!(
+            scrubbed.tags.get("environment_name").map(String::as_str),
+            Some("[redacted]")
+        );
     }
 }

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -11,6 +11,9 @@ const TARGET_SENTRY_ENVIRONMENT_ENV: &str = "PROLIFERATE_TARGET_SENTRY_ENVIRONME
 // own `<component>@<version>+<sha>` from its compile-time build stamp.
 const WORKER_SENTRY_RELEASE_ENV: &str = "PROLIFERATE_WORKER_SENTRY_RELEASE";
 const TARGET_SENTRY_TRACES_SAMPLE_RATE_ENV: &str = "PROLIFERATE_TARGET_SENTRY_TRACES_SAMPLE_RATE";
+/// The single env-like Sentry tag preserved as bounded deployment identity.
+/// Its allowed live value is `e2b`; every other env-like tag stays redacted.
+const RUNTIME_ENV_TAG: &str = "runtime_env";
 
 pub struct TelemetryGuards {
     _sentry: Option<sentry::ClientInitGuard>,
@@ -311,7 +314,12 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
         scrub_value(value, Some(key));
     }
     for (key, value) in &mut event.tags {
-        if sensitive_key(key) {
+        if key == RUNTIME_ENV_TAG {
+            // Bounded deployment identity: the runtime-environment tag survives
+            // (allowed live value `e2b`). Every other env-like tag key still
+            // matches `sensitive_key` and stays redacted.
+            *value = scrub_text(value);
+        } else if sensitive_key(key) {
             *value = "[redacted]".to_string();
         } else {
             *value = scrub_text(value);
@@ -365,7 +373,7 @@ pub fn init() -> TelemetryGuards {
 
             let runtime_env = std::env::var("PROLIFERATE_RUNTIME_ENV")
                 .unwrap_or_else(|_| "local".to_string());
-            scope.set_tag("runtime_env", &runtime_env);
+            scope.set_tag(RUNTIME_ENV_TAG, &runtime_env);
 
             if let Ok(org_id) = std::env::var("PROLIFERATE_ORG_ID") {
                 if !org_id.trim().is_empty() {
@@ -475,5 +483,28 @@ mod tests {
             .frames[0];
         assert_eq!(frame.abs_path.as_deref(), Some("[redacted-path]"));
         assert!(frame.context_line.is_none());
+    }
+
+    #[test]
+    fn runtime_env_tag_survives_while_other_env_tags_are_redacted() {
+        let mut event = Event::new();
+        event.tags.insert("runtime_env".to_string(), "e2b".to_string());
+        event.tags.insert("deploy_env".to_string(), "prod".to_string());
+        event
+            .tags
+            .insert("environment_name".to_string(), "prod".to_string());
+
+        let scrubbed = scrub_event(event).expect("event should remain");
+
+        // Bounded deployment identity is preserved; other env-like tags are not.
+        assert_eq!(scrubbed.tags.get("runtime_env").map(String::as_str), Some("e2b"));
+        assert_eq!(
+            scrubbed.tags.get("deploy_env").map(String::as_str),
+            Some("[redacted]")
+        );
+        assert_eq!(
+            scrubbed.tags.get("environment_name").map(String::as_str),
+            Some("[redacted]")
+        );
     }
 }

--- a/apps/desktop/src/lib/integrations/telemetry/scrub.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/scrub.ts
@@ -2,6 +2,7 @@ import type * as Sentry from "@sentry/react";
 import type { Breadcrumb, ErrorEvent } from "@sentry/react";
 import {
   scrubTelemetryData as scrubSharedTelemetryData,
+  scrubTelemetryEvent as scrubSharedTelemetryEvent,
   scrubTelemetryText,
 } from "@proliferate/product-domain/telemetry/scrub";
 import type { CaptureResult } from "posthog-js/lib/src/types";
@@ -99,7 +100,7 @@ type SentryEventPayload = {
 };
 
 function scrubSentryEventPayload(event: SentryEventPayload): SentryEventPayload {
-  const scrubbed = scrubTelemetryData(event);
+  const scrubbed = scrubSharedTelemetryEvent(event);
   scrubbed.transaction = scrubbed.transaction
     ? scrubTelemetryText(scrubbed.transaction)
     : scrubbed.transaction;

--- a/apps/desktop/src/lib/integrations/telemetry/sentry.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/sentry.test.ts
@@ -81,4 +81,34 @@ describe("desktop sentry transport", () => {
       }),
     );
   });
+
+  it("preserves the top-level deployment environment through beforeSend scrubbing", async () => {
+    const sentry = await loadSentryModule();
+
+    sentry.initializeDesktopSentry({
+      environment: "production",
+      release: "proliferate-desktop@test",
+      sentry: {
+        enabled: true,
+        dsn: "https://sentry.example/123",
+        tracesSampleRate: 1,
+        enableLogs: true,
+        replaysOnErrorSampleRate: 1,
+      },
+      apiBaseUrl: "https://app.proliferate.com/api",
+      telemetryMode: "hosted_product",
+    });
+
+    const initArgs = mocks.initMock.mock.calls[0][0] as {
+      beforeSend: (event: Record<string, unknown>) => Record<string, unknown>;
+    };
+    const scrubbed = initArgs.beforeSend({
+      environment: "production",
+      tags: { environment: "prod" },
+    });
+
+    // Deployment identity survives; a nested `environment` value stays redacted.
+    expect(scrubbed.environment).toBe("production");
+    expect((scrubbed.tags as Record<string, unknown>).environment).toBe("[redacted]");
+  });
 });

--- a/apps/mobile/src/lib/integrations/telemetry/sentry.ts
+++ b/apps/mobile/src/lib/integrations/telemetry/sentry.ts
@@ -7,6 +7,7 @@ import type {
 } from "@sentry/react-native";
 import {
   scrubTelemetryData,
+  scrubTelemetryEvent,
   scrubTelemetryText,
 } from "@proliferate/product-domain/telemetry/scrub";
 
@@ -86,7 +87,7 @@ function scrubSentrySpan<T extends SentrySpanPayload>(span: T): T {
 }
 
 function scrubSentryEventPayload(event: MutableSentryEvent): MutableSentryEvent {
-  const scrubbed = scrubTelemetryData(event);
+  const scrubbed = scrubTelemetryEvent(event);
   scrubbed.transaction = scrubbed.transaction
     ? scrubTelemetryText(scrubbed.transaction)
     : scrubbed.transaction;

--- a/apps/packages/product-domain/src/telemetry/scrub.test.ts
+++ b/apps/packages/product-domain/src/telemetry/scrub.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { scrubTelemetryData, scrubTelemetryText, scrubTelemetryUrl } from "./scrub";
+import {
+  scrubTelemetryData,
+  scrubTelemetryEvent,
+  scrubTelemetryText,
+  scrubTelemetryUrl,
+} from "./scrub";
 
 describe("scrubTelemetryData", () => {
   it("redacts sensitive keys recursively", () => {
@@ -56,6 +61,28 @@ describe("scrubTelemetryData", () => {
         "ios /private/var/mobile/Containers/Data/app/file android /data/user/0/app/file win C:/Users/pablo/app/file",
       ),
     ).toBe("ios [redacted-path] android [redacted-path] win [redacted-path]");
+  });
+
+  it("preserves the top-level deployment environment while redacting nested env data", () => {
+    expect(
+      scrubTelemetryEvent({
+        environment: "production",
+        tags: { environment: "prod", runtime_env: "e2b" },
+        contexts: { app: { env: { SECRET: "x" } } },
+      }),
+    ).toEqual({
+      environment: "production",
+      // Nested `environment`/`env`/`runtime_env` keys all match the sensitive
+      // key pattern and stay redacted; only the top-level string survives.
+      tags: { environment: "[redacted]", runtime_env: "[redacted]" },
+      contexts: { app: { env: "[redacted]" } },
+    });
+  });
+
+  it("scrubs the preserved top-level environment string as text", () => {
+    expect(
+      scrubTelemetryEvent({ environment: "Bearer secret /Users/pablo/app" }).environment,
+    ).toBe("[redacted-token] [redacted-path]");
   });
 
   it("can preserve PostHog internal envelope keys while scrubbing user data", () => {

--- a/apps/packages/product-domain/src/telemetry/scrub.ts
+++ b/apps/packages/product-domain/src/telemetry/scrub.ts
@@ -10,8 +10,11 @@ const RELATIVE_URL_WITH_QUERY_PATTERN =
   /(^|[\s("'=])((?:\/|\.\/|\.\.\/)[^\s<>"')?#]+)\?([^\s<>"')#]+)(#[^\s<>"')]*)?/g;
 const QUERY_SECRET_PATTERN =
   /([?&](?:code|state|access_token|refresh_token|id_token|token|auth|key|secret|password)=)[^&#\s]+/gi;
+// The path group must start with `/` so it cannot overlap with the authority
+// group's character class; an ambiguous split is polynomial-backtracking bait
+// (CodeQL js/polynomial-redos) on adversarial `scheme://"""...` inputs.
 const ABSOLUTE_URL_PARTS_PATTERN =
-  /^([a-z][a-z0-9+.-]*:\/\/[^/?#]+)([^?#]*)(?:[?#].*)?$/i;
+  /^([a-z][a-z0-9+.-]*:\/\/[^/?#]+)(\/[^?#]*)?(?:[?#].*)?$/i;
 
 export type Scrubbable =
   | string
@@ -99,4 +102,24 @@ function scrubValue(
 
 export function scrubTelemetryData<T>(value: T, options: ScrubTelemetryOptions = {}): T {
   return scrubValue(value as Scrubbable, undefined, options) as T;
+}
+
+/**
+ * Recursively scrub a Sentry event while preserving its top-level
+ * `environment` field as bounded deployment identity.
+ *
+ * The generic recursive scrubber redacts any `environment`/`env` key, which
+ * would drop the deployment environment name (e.g. `production`) that support
+ * investigation depends on. This wrapper snapshots only the top-level
+ * `environment` string, runs the recursive scrubber, then restores the snapshot
+ * scrubbed as text. Nested `env`/`environment` fields, raw process-environment
+ * maps, and every other sensitive key stay redacted.
+ */
+export function scrubTelemetryEvent<T>(value: T, options: ScrubTelemetryOptions = {}): T {
+  const originalEnvironment = (value as { environment?: unknown } | null | undefined)?.environment;
+  const scrubbed = scrubTelemetryData(value, options);
+  if (typeof originalEnvironment === "string") {
+    (scrubbed as { environment?: unknown }).environment = scrubTelemetryText(originalEnvironment);
+  }
+  return scrubbed;
 }

--- a/apps/web/src/lib/integrations/telemetry/sentry.ts
+++ b/apps/web/src/lib/integrations/telemetry/sentry.ts
@@ -14,6 +14,7 @@ import type {
 } from "@sentry/react";
 import {
   scrubTelemetryData,
+  scrubTelemetryEvent,
   scrubTelemetryText,
 } from "@proliferate/product-domain/telemetry/scrub";
 
@@ -115,7 +116,7 @@ function scrubSentrySpan<T extends SentrySpanPayload>(span: T): T {
 }
 
 function scrubSentryEventPayload(event: MutableSentryEvent): MutableSentryEvent {
-  const scrubbed = scrubTelemetryData(event);
+  const scrubbed = scrubTelemetryEvent(event);
   scrubbed.transaction = scrubbed.transaction
     ? scrubTelemetryText(scrubbed.transaction)
     : scrubbed.transaction;

--- a/scripts/build-template.mjs
+++ b/scripts/build-template.mjs
@@ -7,6 +7,13 @@ import os from "node:os";
 import path from "node:path";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
+const RUNTIME_SDK_PACKAGE_JSON = path.join(REPO_ROOT, "anyharness", "sdk", "package.json");
+// A release version segment: semver, optionally with a pre-release suffix.
+const RUNTIME_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+// Versions that indicate an unstamped/degraded build; a production runtime
+// bundle must never carry any of these.
+const PLACEHOLDER_VERSIONS = new Set(["0.0.0", "0.0.0-dev", "0.1.0"]);
+const FULL_GIT_SHA_RE = /^[0-9a-f]{40}$/;
 const DEFAULT_BUILD_TARGET = "x86_64-unknown-linux-musl";
 const DEV_TEMPLATE_CPU_COUNT = 4;
 const DEV_TEMPLATE_MEMORY_MB = 8192;
@@ -225,8 +232,64 @@ function resolveBinaryPath({ explicitBinaryPath, binaryName, displayName, envNam
   );
 }
 
+/**
+ * The canonical runtime version, read from `anyharness/sdk/package.json`. This
+ * is the single source the immutable-template build stamps into all three
+ * binaries; a missing or placeholder version is rejected so a production build
+ * can never fall back to a crate's stale `0.1.0`.
+ */
+function readCanonicalRuntimeVersion() {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(RUNTIME_SDK_PACKAGE_JSON, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Failed to read runtime version from ${RUNTIME_SDK_PACKAGE_JSON}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+  const version = typeof parsed.version === "string" ? parsed.version.trim() : "";
+  if (!RUNTIME_VERSION_RE.test(version) || PLACEHOLDER_VERSIONS.has(version)) {
+    throw new Error(
+      `anyharness/sdk/package.json version is missing or non-release: ${JSON.stringify(parsed.version)}`
+    );
+  }
+  return version;
+}
+
+/**
+ * The full 40-character SHA of the exact checked-out revision. Prefers an
+ * explicit `PROLIFERATE_BUILD_SHA`/`GIT_SHA` (set by the deploy workflow), else
+ * resolves `git rev-parse HEAD`. A missing or malformed SHA is rejected so the
+ * stamped Sentry release always carries a deterministic commit.
+ */
+function resolveBuildSha() {
+  const explicit = (process.env.PROLIFERATE_BUILD_SHA || process.env.GIT_SHA || "")
+    .trim()
+    .toLowerCase();
+  let resolved = explicit;
+  if (!resolved) {
+    const gitResult = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+    resolved = (gitResult.stdout || "").trim().toLowerCase();
+  }
+  if (!FULL_GIT_SHA_RE.test(resolved)) {
+    throw new Error(
+      `Could not resolve a full 40-character git SHA for the runtime build (got ${JSON.stringify(resolved)}).`
+    );
+  }
+  return resolved;
+}
+
 function rebuildRuntimeBundle() {
-  console.log("Rebuilding Linux runtime bundle artifacts...");
+  const buildVersion = readCanonicalRuntimeVersion();
+  const buildSha = resolveBuildSha();
+  console.log(
+    `Rebuilding Linux runtime bundle artifacts (version ${buildVersion}, sha ${buildSha.slice(0, 12)})...`
+  );
   const result = spawnSync(
     "cargo",
     [
@@ -244,7 +307,13 @@ function rebuildRuntimeBundle() {
     {
       cwd: REPO_ROOT,
       stdio: "inherit",
-      env: process.env,
+      // Stamp the exact version + SHA into all three binaries in this single
+      // build (build.rs reads these and fails closed on a malformed SHA).
+      env: {
+        ...process.env,
+        PROLIFERATE_BUILD_VERSION: buildVersion,
+        PROLIFERATE_BUILD_SHA: buildSha,
+      },
     }
   );
 

--- a/scripts/smoke-cloud-template.mjs
+++ b/scripts/smoke-cloud-template.mjs
@@ -6,17 +6,26 @@ function printUsage() {
   console.log(`Smoke-test a built E2B cloud template.
 
 Usage:
-  node scripts/smoke-cloud-template.mjs --template <template-ref>
+  node scripts/smoke-cloud-template.mjs --template <template-ref> [--expected-version <version>] [--expected-sha <sha>]
 
 Options:
-  --template <template-ref>  Exact template ref to create from, usually
-                             <family>:<tag>.
-  --help                     Show this help text.
+  --template <template-ref>    Exact template ref to create from, usually
+                               <family>:<tag>.
+  --expected-version <version> Canonical runtime version all three binaries must
+                               report. When set, a mismatch fails the smoke test
+                               before any rolling reference is moved.
+  --expected-sha <sha>         Source SHA (12+ hex chars; truncated to 12) whose
+                               build stamp must be embedded in all three
+                               binaries. When set, an unstamped or differently
+                               stamped binary fails the smoke test.
+  --help                       Show this help text.
 `);
 }
 
 function parseArgs(argv) {
   let templateRef = "";
+  let expectedVersion = "";
+  let expectedSha = "";
   let help = false;
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -24,6 +33,14 @@ function parseArgs(argv) {
     switch (arg) {
       case "--template":
         templateRef = argv[i + 1] || "";
+        i += 1;
+        break;
+      case "--expected-version":
+        expectedVersion = argv[i + 1] || "";
+        i += 1;
+        break;
+      case "--expected-sha":
+        expectedSha = argv[i + 1] || "";
         i += 1;
         break;
       case "--help":
@@ -38,8 +55,24 @@ function parseArgs(argv) {
   if (!help && !templateRef) {
     throw new Error("--template is required.");
   }
+  if (expectedSha) {
+    const normalized = expectedSha.trim().toLowerCase();
+    if (normalized.length < 12 || !/^[0-9a-f]+$/.test(normalized)) {
+      throw new Error("--expected-sha must be at least 12 lowercase hex characters.");
+    }
+    expectedSha = normalized.slice(0, 12);
+  }
 
-  return { templateRef, help };
+  return { templateRef, expectedVersion, expectedSha, help };
+}
+
+// Match the worker self-update gate: split `--version` output on whitespace and
+// accept an exact token (optionally `v`-prefixed). Substrings never match, so
+// `0.3.0` does not satisfy an expected `0.3.0-rc1`.
+function versionOutputMatches(output, expected) {
+  return output
+    .split(/\s+/)
+    .some((token) => token === expected || token.replace(/^v/, "") === expected);
 }
 
 function assertSuccessful(result, message) {
@@ -97,6 +130,71 @@ async function main() {
     );
     assertSuccessful(binaryCheck, "Runtime bundle binaries were not executable in the template");
     console.log(`Runtime bundle:\n${binaryCheck.stdout.trim()}`);
+
+    // Prove all three binaries report the expected canonical version before any
+    // rolling reference is moved. A stale-stamp bundle (e.g. Cargo `0.1.0`)
+    // fails here, so `_deploy-e2b.yml` never promotes an unidentified build.
+    if (parsed.expectedVersion) {
+      const versionCheck = await sandbox.commands.run(
+        [
+          'echo "anyharness=$(/home/user/anyharness --version)"',
+          'echo "proliferate-worker=$(/home/user/.proliferate/bin/proliferate-worker --version)"',
+          'echo "proliferate-supervisor=$(/home/user/.proliferate/bin/proliferate-supervisor --version)"',
+        ].join("\n"),
+        { timeoutMs: 30_000 }
+      );
+      assertSuccessful(versionCheck, "Runtime binaries did not report --version");
+      const reported = new Map(
+        versionCheck.stdout
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .map((line) => {
+            const separator = line.indexOf("=");
+            return [line.slice(0, separator), line.slice(separator + 1)];
+          })
+      );
+      for (const binary of ["anyharness", "proliferate-worker", "proliferate-supervisor"]) {
+        const output = reported.get(binary) || "";
+        if (!versionOutputMatches(output, parsed.expectedVersion)) {
+          throw new Error(
+            `${binary} reported version ${JSON.stringify(output)}, expected ${JSON.stringify(
+              parsed.expectedVersion
+            )}`
+          );
+        }
+      }
+      console.log(`All three binaries report expected version ${parsed.expectedVersion}.`);
+    }
+
+    // Prove the expected source SHA was stamped into all three binaries.
+    // `--version` deliberately reports only the version token (the worker
+    // self-update/anyharness-update preflights exact-match it against pins),
+    // and the contract adds no build-info endpoint, so the stamped
+    // PROLIFERATE_STAMPED_GIT_SHA literal — compiled into each binary and the
+    // source of its `<component>@<version>+<sha>` Sentry release — is asserted
+    // directly in the binary image. The immutable `sha-<12>` template tag
+    // remains the canonical source-revision binding.
+    if (parsed.expectedSha) {
+      const shaCheck = await sandbox.commands.run(
+        [
+          "set -eu",
+          `sha="${parsed.expectedSha}"`,
+          'for bin in /home/user/anyharness /home/user/.proliferate/bin/proliferate-worker /home/user/.proliferate/bin/proliferate-supervisor; do',
+          '  if ! grep -a -q "$sha" "$bin"; then',
+          '    echo "missing stamped sha in $bin" >&2',
+          "    exit 1",
+          "  fi",
+          "done",
+        ].join("\n"),
+        { timeoutMs: 60_000 }
+      );
+      assertSuccessful(
+        shaCheck,
+        `Runtime binaries do not carry the expected stamped source SHA ${parsed.expectedSha}`
+      );
+      console.log(`All three binaries carry the stamped source SHA ${parsed.expectedSha}.`);
+    }
 
     const installCheck = await sandbox.commands.run(
       "/home/user/anyharness install-agents --agent claude --agent codex",

--- a/server/proliferate/integrations/sentry.py
+++ b/server/proliferate/integrations/sentry.py
@@ -37,7 +37,17 @@ def _scrub_breadcrumb(
 
 
 def _scrub_event(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any] | None:
+    # The top-level `environment` field is deployment identity (e.g. the Sentry
+    # environment name), not a raw process-environment map. The generic scrubber
+    # would redact it because the key matches `env`, so snapshot it first, run
+    # the recursive scrub, then restore the snapshot scrubbed only as text. This
+    # is bounded: nested `env`/`environment` keys stay redacted.
+    original_environment = event.get("environment")
+
     scrubbed = scrub_mapping(event) or {}
+
+    if isinstance(original_environment, str):
+        scrubbed["environment"] = scrub_text(original_environment)
 
     message = scrubbed.get("message")
     if isinstance(message, str):

--- a/server/tests/integration/test_support_feed_deploy_render.py
+++ b/server/tests/integration/test_support_feed_deploy_render.py
@@ -76,7 +76,16 @@ def _merge(
     merge_program, _ = _render_jq_programs()
     env_file = tmp_path / "env-updates.json"
     sec_file = tmp_path / "secret-updates.json"
-    env_file.write_text(json.dumps([{"name": "API_URL", "value": "https://new"}]))
+    # Mirror the real render: strict release identity is one of the env updates,
+    # so a merged task satisfies the strengthened fail-closed assertion.
+    env_file.write_text(
+        json.dumps(
+            [
+                {"name": "API_URL", "value": "https://new"},
+                {"name": "PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "value": "1"},
+            ]
+        )
+    )
     sec_file.write_text(json.dumps(secret_updates))
     prog_file = tmp_path / "merge.jq"
     raw_file = tmp_path / "raw.json"
@@ -139,6 +148,14 @@ def test_render_projects_single_feed_secret_and_strips_inherited_plaintext(tmp_p
                 "environment": [
                     {"name": "API_URL", "value": "old"},
                     {"name": "SUPPORT_FEED_BEARER_TOKEN", "value": "LEAKED-PLAINTEXT"},
+                    # Stale runtime-identity overrides inherited from the prior
+                    # task revision; the merge must strip them.
+                    {"name": "ANYHARNESS_GIT_SHA", "value": "deadbeefcafe"},
+                    {
+                        "name": "CLOUD_RUNTIME_SENTRY_RELEASE",
+                        "value": "proliferate-server@0.1.0+abc",
+                    },
+                    {"name": "E2B_RUNTIME_SENTRY_RELEASE", "value": "stale"},
                 ],
                 "secrets": [
                     {
@@ -167,6 +184,17 @@ def test_render_projects_single_feed_secret_and_strips_inherited_plaintext(tmp_p
     assert [e for e in container["environment"] if e["name"] == "SUPPORT_FEED_BEARER_TOKEN"] == []
     # A non-feed inherited secret survives.
     assert any(s["name"] == "OTHER" for s in container["secrets"])
+    # Every inherited stale runtime-identity override is stripped.
+    env_names = {e["name"] for e in container["environment"]}
+    for forbidden in (
+        "ANYHARNESS_GIT_SHA",
+        "CLOUD_RUNTIME_SENTRY_RELEASE",
+        "E2B_RUNTIME_SENTRY_RELEASE",
+    ):
+        assert forbidden not in env_names
+    # Strict release identity flows in from the env updates.
+    strict = {"name": "PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "value": "1"}
+    assert strict in container["environment"]
     # Mutable metadata is stripped before registration.
     for stripped in ("taskDefinitionArn", "revision", "status", "requiresAttributes"):
         assert stripped not in final
@@ -180,7 +208,10 @@ def test_render_assert_passes_on_well_formed_task(tmp_path: Path) -> None:
         "containerDefinitions": [
             {
                 "name": _CONTAINER,
-                "environment": [{"name": "API_URL", "value": "x"}],
+                "environment": [
+                    {"name": "API_URL", "value": "x"},
+                    {"name": "PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "value": "1"},
+                ],
                 "secrets": [{"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM}],
             }
         ]
@@ -245,6 +276,27 @@ def test_render_assert_passes_on_well_formed_task(tmp_path: Path) -> None:
             },
             "must reference a Secrets Manager secret ARN",
             id="not-secrets-manager-arn",
+        ),
+        pytest.param(
+            {
+                "name": _CONTAINER,
+                "environment": [
+                    {"name": "PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "value": "1"},
+                    {"name": "ANYHARNESS_GIT_SHA", "value": "deadbeefcafe"},
+                ],
+                "secrets": [{"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM}],
+            },
+            "stale runtime-identity variables must not remain",
+            id="stale-runtime-identity-remains",
+        ),
+        pytest.param(
+            {
+                "name": _CONTAINER,
+                "environment": [{"name": "API_URL", "value": "x"}],
+                "secrets": [{"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM}],
+            },
+            "PROLIFERATE_REQUIRE_RELEASE_IDENTITY=1 must be set",
+            id="strict-identity-absent",
         ),
     ],
 )

--- a/server/tests/unit/test_sentry_integration.py
+++ b/server/tests/unit/test_sentry_integration.py
@@ -194,6 +194,35 @@ def _init_and_capture_release(monkeypatch: pytest.MonkeyPatch) -> str:
     return release
 
 
+def test_scrub_event_preserves_top_level_deployment_environment() -> None:
+    # Top-level `environment` is deployment identity and must survive, while a
+    # nested `environment` value and a raw env map stay redacted.
+    scrubbed = sentry_integration._scrub_event(
+        {
+            "environment": "production",
+            "tags": {"environment": "prod"},
+            "extra": {"env": {"SECRET_TOKEN": "value"}},
+        },
+        {},
+    )
+
+    assert scrubbed is not None
+    assert scrubbed["environment"] == "production"
+    assert scrubbed["tags"]["environment"] == "[redacted]"
+    assert scrubbed["extra"]["env"] == "[redacted]"
+
+
+def test_scrub_event_scrubs_preserved_environment_as_text() -> None:
+    # An abusive environment string is still scrubbed as text before it survives.
+    scrubbed = sentry_integration._scrub_event(
+        {"environment": "Bearer secret-token /Users/pablo/proliferate"},
+        {},
+    )
+
+    assert scrubbed is not None
+    assert scrubbed["environment"] == "[redacted-token] [redacted-path]"
+
+
 def test_init_prefers_configured_canonical_server_release(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -100,10 +100,10 @@ gate.
 | Workflow | Trigger and posture | Role |
 | --- | --- | --- |
 | `_deploy-desktop.yml` | Reusable only | Validate/build Desktop for staging or call the Desktop publisher for production. |
-| `_deploy-e2b.yml` | Reusable only | Build and/or promote one immutable E2B template into a rolling environment tag. |
+| `_deploy-e2b.yml` | Reusable only | Build and/or promote one immutable E2B template into a rolling environment tag; the smoke proves the three runtime binaries report the canonical version and carry the stamped source SHA before the rolling tag moves. |
 | `_deploy-litellm.yml` | Reusable only | Build and roll the LiteLLM ECS service when its environment switch is enabled. |
 | `_deploy-mobile.yml` | Reusable only | Run the selected EAS build and optional submit lane when enabled. |
-| `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, roll ECS, and verify health. |
+| `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, roll ECS, and verify health. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, and preserves the support-feed secret, all asserted before registration. |
 | `_deploy-web.yml` | Reusable only | Deploy and verify the selected Vercel web surface. |
 | `_deploy-workers.yml` | Reusable only | Report the disabled Worker lane, or fail if enabled before a canonical deploy exists. |
 

--- a/specs/codebase/systems/engineering/issue-lifecycle/README.md
+++ b/specs/codebase/systems/engineering/issue-lifecycle/README.md
@@ -4,6 +4,9 @@
   issue resolution, attribution, releases, and changelog communication.
 - [Private Support Feed](private-support-feed.md) — active deployment contract
   for the authenticated completed-report feed consumed by the tracker.
+- [Production Runtime Evidence](production-runtime-evidence.md) — frozen B2
+  contract for bounded runtime/Sentry identity, exact E2B build stamping, and
+  the fresh-sandbox proof.
 - [Observability](../observability/README.md) owns Sentry and structured-log
   event production, scrubbing, and correlation before evidence enters this
   system.

--- a/specs/codebase/systems/engineering/issue-lifecycle/production-runtime-evidence.md
+++ b/specs/codebase/systems/engineering/issue-lifecycle/production-runtime-evidence.md
@@ -1,0 +1,395 @@
+# Make Production Runtime Evidence Usable
+
+> [!important] Frozen contract
+> Founder-approved on 2026-07-14 and grounded in Proliferate `origin/main` at
+> `66f45bfbe2839ae1382133393844ba61dce035cd` and a read-only production
+> audit on 2026-07-14. Implementation is authorized only after the centralized
+> access preflight is green and this contract is promoted.
+
+- Current slice: **B2 — Make production runtime evidence usable — frozen**
+- Implementation base: the exact accepted B1 revision
+- Parallel tracker slice: **A — Put the target tracker live, dark — frozen**
+- Dependent slice: **C — Activate Sentry and prove sandbox investigation — frozen**
+
+## Outcome
+
+Make the product's runtime and Sentry evidence identify the exact deployed
+code, environment, user, and E2B sandbox without reworking the support feed.
+
+```text
+exact reviewed source revision
+-> build one immutable E2B template with exact version + SHA
+-> prove AnyHarness, worker, and supervisor identify that build
+-> move the environment's E2B rolling reference
+-> deploy the same server revision with stale identity overrides removed
+-> create one fresh internal sandbox
+-> prove the exact runtime/template/owner/provider identity and health
+-> leave tracker ingestion disabled
+```
+
+B2 is complete only when staging and production run the same tested source and
+runtime build, the live task no longer carries the known stale identity
+overrides, and one fresh production E2B sandbox runs all three expected
+binaries with the bounded identity inputs C will observe.
+
+## Current production baseline
+
+Observed on 2026-07-14:
+
+- production uses ECS task `proliferate-prod-server:113` and image
+  `proliferate-server:66f45bfbe283`;
+- `/api/meta` reports server `0.1.0`, runtime `0.3.28`, and worker `0.1.0`;
+- the live task carries stale `SERVER_VERSION`, `ANYHARNESS_VERSION`,
+  `ANYHARNESS_GIT_SHA`, `E2B_TEMPLATE_VERSION`,
+  `CLOUD_RUNTIME_SENTRY_RELEASE`, `CLOUD_TARGET_SENTRY_RELEASE`, and
+  `E2B_RUNTIME_SENTRY_RELEASE` values;
+- generic telemetry scrubbing changes Sentry's top-level `environment` to
+  `[redacted]` in server and product-client events;
+- worker and supervisor scrub their bounded `runtime_env` tag;
+- E2B rebuild does not pass `PROLIFERATE_BUILD_VERSION` or
+  `PROLIFERATE_BUILD_SHA`, so Rust package fallback can report `0.1.0` and no
+  source SHA; and
+- the current `:production` rolling template predates the merged runtime
+  identity work.
+
+The identity producer path already exists:
+
+```text
+connect.py resolves owner user + exact provider sandbox ID
+-> bootstrap.py emits PROLIFERATE_USER_ID, PROLIFERATE_SANDBOX_ID,
+   and PROLIFERATE_RUNTIME_ENV=e2b
+-> AnyHarness, worker, and supervisor attach bounded Sentry identity
+-> values are scoped to the runtime processes rather than the user shell
+```
+
+B2 deploys and proves this path. It does not redesign it.
+
+## Dependencies and green access gate
+
+B2 does not start until:
+
+- the complete centralized access preflight is green;
+- B1 is accepted and its receipt proves the private feed secret remains
+  correctly injected through the same server deployment workflow;
+- GitHub Actions OIDC can deploy the selected staging/production surfaces;
+- `E2B_API_KEY` and `E2B_ACCESS_TOKEN` exist for Actions;
+- `E2B_TEAM_ID`, `E2B_PUBLIC_TEMPLATE_FAMILY`, and each environment's
+  `E2B_TEMPLATE_REF` identify the expected template family;
+- the authenticated local E2B client can create, exec, inspect, log, and kill
+  a dedicated sandbox;
+- current ECS Sentry DSN configuration entries exist and are nonempty for
+  server/runtime/target; these are non-secret ingest endpoints, not secret
+  references; and
+- one authenticated internal product user can initiate and clean up a
+  founder-owned cloud-sandbox record, while the direct E2B client has the
+  separately proved provider lifecycle authority. P0 may record that the
+  pre-B2 staging materializer did not reach readiness; B2 already owns making
+  the fresh product-created sandbox healthy in staging and production.
+
+No slice may stop halfway for a key, sign-in, provider scope, secret location,
+or permission decision. B2 consumes the P0-proven paths and the accepted B1
+deployment contract.
+
+## Scope
+
+B2 owns:
+
+- preserving only bounded Sentry deployment/runtime identity through the
+  existing privacy scrubbers;
+- removing inherited server-authored runtime release overrides;
+- stamping the exact version and source SHA into AnyHarness, worker, and
+  supervisor in one E2B build;
+- failing immutable-template smoke on identity mismatch;
+- deploying the exact E2B template before the server revision that launches
+  it; and
+- proving one fresh internal runtime in staging and production.
+
+B2 must preserve B1's support-feed secret injection unchanged. It does not
+re-open feed auth, privacy, schema, or deployment design.
+
+## Repository changes
+
+Expected bounded file tree:
+
+```text
+proliferate/
+├── .github/workflows/
+│   ├── _deploy-server.yml
+│   └── _deploy-e2b.yml
+├── scripts/
+│   ├── build-template.mjs
+│   └── smoke-cloud-template.mjs
+├── server/
+│   ├── proliferate/integrations/sentry.py
+│   └── tests/unit/test_sentry_integration.py
+├── apps/
+│   ├── packages/product-domain/src/telemetry/
+│   │   ├── scrub.ts
+│   │   └── scrub.test.ts
+│   ├── desktop/src/lib/integrations/telemetry/
+│   │   ├── scrub.ts
+│   │   └── sentry.test.ts
+│   ├── web/src/lib/integrations/telemetry/sentry.ts
+│   └── mobile/src/lib/integrations/telemetry/sentry.ts
+├── anyharness/crates/
+│   ├── proliferate-worker/src/logging.rs
+│   └── proliferate-supervisor/src/logging.rs
+└── specs/
+    ├── developing/analytics/sentry.md
+    ├── developing/deploying/ci-cd.md
+    └── developing/reference/env-vars.yaml
+```
+
+Existing build stamp and identity producers under the three runtime crates,
+`server/proliferate/server/cloud/runtime/bootstrap.py`, and
+`server/proliferate/server/cloud/materialization/sandbox_io/connect.py` remain
+authoritative review seams. No server domain, database, migration, tracker, or
+support-feed implementation belongs in this PR.
+
+## Server deployment identity
+
+In `.github/workflows/_deploy-server.yml`:
+
+1. preserve B1's `SUPPORT_FEED_BEARER_TOKEN` ECS secret entry exactly;
+2. add `PROLIFERATE_REQUIRE_RELEASE_IDENTITY=1` for hosted tasks;
+3. stop constructing `ANYHARNESS_GIT_SHA`,
+   `CLOUD_RUNTIME_SENTRY_RELEASE`, or `CLOUD_TARGET_SENTRY_RELEASE` from the
+   server SHA/release;
+4. explicitly remove the known stale inherited variables:
+
+   ```text
+   SERVER_VERSION
+   ANYHARNESS_VERSION
+   ANYHARNESS_GIT_SHA
+   E2B_TEMPLATE_VERSION
+   CLOUD_RUNTIME_SENTRY_RELEASE
+   CLOUD_TARGET_SENTRY_RELEASE
+   E2B_RUNTIME_SENTRY_RELEASE
+   ```
+
+5. require `VERSION` and `anyharness/sdk/package.json` to agree and use that
+   canonical release version for the hosted server/runtime/worker pins rather
+   than worker/supervisor Cargo package `0.1.0`; and
+6. inspect the final rendered task before registration, failing if any
+   forbidden name remains, strict identity is absent, or B1's feed secret was
+   lost/converted to plaintext.
+
+Deleting assignments alone is insufficient because the workflow merges the
+previous task definition's environment. The guards in
+`bootstrap.py::_runtime_sentry_release`, `_target_sentry_env`, and
+`server/proliferate/server/release.py::sanitize_component_release_override`
+remain authoritative.
+
+## Exact three-binary E2B build
+
+`scripts/build-template.mjs::rebuildRuntimeBundle` must:
+
+1. read the canonical runtime version from
+   `anyharness/sdk/package.json`;
+2. resolve the full SHA of the exact checked-out revision;
+3. reject missing/malformed version or SHA input; and
+4. pass `PROLIFERATE_BUILD_VERSION` and `PROLIFERATE_BUILD_SHA` into the
+   single build of AnyHarness, worker, and supervisor.
+
+No production build may fall back to Cargo package versions or an empty source
+SHA.
+
+`scripts/smoke-cloud-template.mjs` gains an explicit expected-version input and
+runs all three binaries with `--version`. Any mismatch fails the immutable
+template before `_deploy-e2b.yml` moves `:staging` or `:production`. The exact
+checkout plus immutable `sha-<12>` template tag binds the source SHA; the
+stamped SHA remains the source for each component's canonical Sentry release.
+B2 does not add a second build-info endpoint.
+
+## Bounded Sentry envelope preservation
+
+The exact top-level Sentry field `environment` is deployment identity, not a
+raw process-environment map.
+
+For product clients, add one product-domain envelope scrubber:
+
+```text
+snapshot exact top-level event.environment
+-> run the existing recursive telemetry scrubber
+-> scrub the snapshot as text
+-> restore only that top-level string
+```
+
+Web, Desktop, and Mobile Sentry adapters use it. Server `_scrub_event` applies
+the same bounded rule locally.
+
+Worker and supervisor `scrub_event` preserve only the exact tag
+`runtime_env`, whose allowed live value here is `e2b`. Other env-like keys,
+raw process-environment maps, URLs, paths, bodies, tokens, and secrets remain
+redacted.
+
+Immediate deployment proof is required for the server, hosted Web, and E2B
+runtime. Desktop and Mobile carry the bounded code correction through their
+normal release lanes; B2 does not add a Desktop or TestFlight release.
+
+B2 deliberately manufactures no Sentry exception. Local/focused tests prove
+the scrubbers and live runtime checks prove the deployed inputs. C owns the
+harmless intentional exception and the first live assertion of
+`environment`, user, sandbox, `runtime_env`, release, and exact event identity.
+
+## Deployment and live runtime proof
+
+For each environment:
+
+```text
+exact reviewed checkout
+-> build immutable sha-<12> template once
+-> smoke all three binary versions
+-> move the environment rolling template reference
+-> deploy the exact server image from the same revision
+-> create a fresh internal sandbox
+-> verify provider/template/owner mapping + three binaries + runtime health
+```
+
+The fresh-sandbox proof compares:
+
+- product cloud-sandbox owner user ID to the designated internal user;
+- product `e2b_sandbox_id` to the E2B provider sandbox ID;
+- product `e2b_template_ref` to the moved rolling target and immutable build;
+- AnyHarness, worker, and supervisor `--version` to the canonical version;
+- runtime health and worker heartbeat to the expected AnyHarness/worker pins;
+  and
+- only the named daemon identity inputs
+  `PROLIFERATE_USER_ID`, `PROLIFERATE_SANDBOX_ID`, and
+  `PROLIFERATE_RUNTIME_ENV=e2b` through a bounded process inspection that
+  returns comparison results rather than a full environment dump.
+
+No customer workspace is used. No intentional error is triggered.
+
+## Verification
+
+### Local and CI proof
+
+At minimum:
+
+```bash
+cd server
+DEBUG=true uv run pytest -q \
+  tests/unit/test_sentry_integration.py \
+  tests/unit/test_runtime_sentry_release.py
+
+cd ..
+pnpm --filter @proliferate/product-domain test
+cargo test -p proliferate-worker
+cargo test -p proliferate-supervisor
+node --check scripts/build-template.mjs
+node --check scripts/smoke-cloud-template.mjs
+python3 scripts/check_docs.py
+```
+
+Focused tests prove:
+
+- top-level Sentry `environment` survives in Python and TypeScript;
+- nested `env`/`environment` fields and representative secrets remain
+  redacted;
+- `runtime_env=e2b` survives worker/supervisor scrubbing while other env-like
+  keys do not;
+- missing/malformed build identity fails before publish;
+- all three template binaries must report the expected release version;
+- the rendered ECS task removes every forbidden variable, enables strict
+  identity, and preserves B1's secret-backed feed entry; and
+- server runtime release guards reject server-authored component overrides.
+
+### Staging proof
+
+For the exact reviewed 40-character SHA:
+
+1. record the prior staging ECS task, image, immutable template, and rolling
+   target;
+2. build immutable `sha-<12>` from that checkout with the expected version/SHA;
+3. prove all three binaries report the expected version;
+4. smoke the immutable template, then move only the staging rolling reference;
+5. deploy the exact server image;
+6. inspect the live task for exact image, strict identity, forbidden-variable
+   absence, and preserved B1 feed secret;
+7. prove `/api/health` and `/api/meta` report coherent expected versions; and
+8. create one fresh internal E2B sandbox and perform the bounded mapping,
+   binary, identity-input, and health proof above.
+
+### Production proof
+
+Promote the same staging-tested revision and immutable template. Do not rebuild
+from a mutable branch.
+
+Repeat the staging task, health, meta, and fresh-sandbox checks in production.
+Record exact task/image/template/SHA/version coordinates, owner/provider
+identity comparisons, and rollback commands in a private `0600` receipt.
+Do not create a Sentry event; hand the live sandbox coordinates to C.
+
+## Failure and rollback behavior
+
+- Missing/malformed version or SHA fails before E2B publish.
+- Any binary-version mismatch fails immutable-template smoke; rolling tags do
+  not move.
+- A failed staging proof blocks production.
+- Before mutation, record the previous ECS task definition, image, immutable
+  E2B tag, and rolling target.
+- If the server proof fails, restore the prior server task.
+- If the fresh runtime proof fails, restore the prior E2B rolling target and
+  prior server task as a pair so server/template pins remain coherent.
+- After rollback, re-prove health, `/api/meta`, B1 feed auth, and one fresh
+  sandbox from the restored target.
+- A concrete contradiction with the frozen code contract returns for a
+  bounded amendment; it does not authorize architecture re-derivation.
+
+## Acceptance criteria
+
+- [ ] The complete centralized access preflight is green.
+- [ ] B1 is accepted and its feed-secret deployment remains unchanged.
+- [ ] Exact reviewed base and deployment revision are recorded.
+- [ ] No forbidden inherited release/version variable remains live.
+- [ ] Strict hosted release identity is enabled.
+- [ ] The exact immutable E2B template passes three-binary version smoke before
+      either rolling reference moves.
+- [ ] `/api/meta` and all three runtime binaries report coherent expected
+      versions.
+- [ ] Focused Python/TypeScript/Rust tests preserve only the approved bounded
+      Sentry identity while redacting raw environment data.
+- [ ] One fresh production sandbox maps to the exact internal owner, provider
+      sandbox, template, runtime scope, version, and source revision.
+- [ ] No intentional Sentry exception occurs; C owns live-event proof.
+- [ ] Tracker ingestion remains disabled.
+- [ ] Prior server/template coordinates and tested rollback commands are in
+      the private receipt.
+
+## Non-goals
+
+- changing B1's feed auth, wire shape, secret store, or privacy contract;
+- enabling Sentry, support, Grafana, or another tracker source;
+- triggering C's exception-to-tracker investigation;
+- writing tracker adapters, schemas, migrations, or backfills;
+- reporter notification, outreach, or product UI changes;
+- Grafana or CloudWatch work;
+- general telemetry, IAM, deployment, or Terraform redesign;
+- adding metadata beyond user ID, sandbox ID, bounded runtime environment,
+  deployment environment, release version, and source revision; or
+- emergency Desktop/Mobile distribution solely to prove corrected telemetry.
+
+## Founder teach-back before freeze
+
+Pablo should be able to explain:
+
+1. why the exact E2B template is built and smoked before the server that
+   launches it is promoted;
+2. why deleting deploy assignments does not remove stale variables from an
+   inherited ECS task; and
+3. why B2 proves runtime inputs without manufacturing a Sentry exception,
+   while C proves the first live event.
+
+## Handoff
+
+```text
+Status:              Frozen
+Repository:          proliferate-ai/proliferate
+Grounded base:       66f45bfbe2839ae1382133393844ba61dce035cd
+Implementation base: exact accepted B1 revision chosen at freeze
+Authority:           this founder-approved contract until explicit promotion
+Implementation:      prohibited until founder approval + green preflight
+Tracker sources:     remain disabled throughout B2
+Receipt consumed by: C
+```

--- a/specs/codebase/systems/engineering/observability/sentry.md
+++ b/specs/codebase/systems/engineering/observability/sentry.md
@@ -74,6 +74,21 @@ authorization headers, tokens, secrets, environment values, or provider
 responses. Correlation identifiers are diagnostic metadata, not permission to
 copy user content into Sentry.
 
+Two exact, bounded fields are deliberately preserved through the scrubbers
+because they are deployment identity, not a raw process-environment map:
+
+- The top-level Sentry `environment` field (for example `production`). Server
+  `_scrub_event` and the shared product-domain `scrubTelemetryEvent` envelope
+  wrapper (used by the Web, Desktop, and Mobile adapters) snapshot only that
+  top-level string, run the recursive scrubber, then restore the snapshot
+  scrubbed as text. Nested `environment`/`env` keys and raw environment maps
+  stay redacted.
+- The `runtime_env` tag on Worker and Supervisor events, whose only allowed
+  live value is `e2b`. Every other env-like tag key stays redacted.
+
+Nothing beyond user ID, sandbox ID, bounded runtime environment, deployment
+environment, release version, and source revision is added to any event.
+
 Replay defaults are deliberately narrow:
 
 - Web and Mobile set normal and error replay rates to zero. Mobile also

--- a/specs/codebase/systems/product/clients/web-desktop-unification/README.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/README.md
@@ -667,11 +667,11 @@ checks the complete 2220-file `move`/`split`/`retain`/`delete` ledger, proves a
 deterministic idempotent import codemod on a disposable copy, and lands the
 deterministic legacy-Web bundle collector with a provisional baseline. The
 reserved real files are not created. The complete living contract is
-[`web-desktop-client-unification-d1g.md`](web-desktop-client-unification-d1g.md);
+[`web-desktop-client-unification-d1g.md`](migration/d1g.md);
 the recorded entry contract is
-[`web-desktop-product-client-entry-contract.md`](web-desktop-product-client-entry-contract.md)
+[`web-desktop-product-client-entry-contract.md`](entry-contract.md)
 and the move ledger is
-[`web-desktop-product-client-move-ledger.md`](web-desktop-product-client-move-ledger.md).
+[`web-desktop-product-client-move-ledger.md`](move-ledger.md).
 
 Related authoritative docs:
 

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/d1g.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/d1g.md
@@ -7,13 +7,13 @@ Status: **current implementation scope**.
 - Prior completed implementation: PR #1182 (D1f), merge
   `f93afce8190bba943277d588c9bfb0d051c615c9`
 - Parent architecture:
-  [`web-desktop-client-unification.md`](web-desktop-client-unification.md)
+  [`web-desktop-client-unification.md`](../README.md)
 - Application-entry contract:
-  [`web-desktop-product-client-entry-contract.md`](web-desktop-product-client-entry-contract.md)
+  [`web-desktop-product-client-entry-contract.md`](../entry-contract.md)
 - Move ledger:
-  [`web-desktop-product-client-move-ledger.md`](web-desktop-product-client-move-ledger.md)
+  [`web-desktop-product-client-move-ledger.md`](../move-ledger.md)
 - Pipeline ledger:
-  [`../../developing/deploying/web-desktop-unification-rollout.md`](../../developing/deploying/web-desktop-unification-rollout.md)
+  [`../../developing/deploying/web-desktop-unification-rollout.md`](../../../../../../developing/deploying/web-desktop-unification-rollout.md)
 - Approved contract:
   `03 - Prove ProductClient Extraction Mechanics.md` (founder-approved r3;
   decisions 8–9 approved 2026-07-14)
@@ -50,7 +50,7 @@ At this slice's head, on base `f93afce81`:
 ## Entry contract (recorded, not implemented)
 
 The full contract is in
-[`web-desktop-product-client-entry-contract.md`](web-desktop-product-client-entry-contract.md).
+[`web-desktop-product-client-entry-contract.md`](../entry-contract.md).
 Summary of what this slice locks:
 
 - **Public entry:** `ProductClient({ RoutesComponent }): ReactElement`, exported
@@ -160,7 +160,7 @@ cutover baseline.
 ## Move ledger summary counts
 
 Full ledger:
-[`web-desktop-product-client-move-ledger.md`](web-desktop-product-client-move-ledger.md).
+[`web-desktop-product-client-move-ledger.md`](../move-ledger.md).
 Source root `apps/desktop/src` = **2220 files at base**. Checked by
 `scripts/check-product-client-move-ledger.py` (every disk path has exactly one
 classification, no target collisions, no unclassified product file):

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -949,6 +949,24 @@
   description: When true, the server fails closed (raises at release-ID construction) instead of emitting a degraded `0.0.0-dev`/SHA-less release. Production task definitions set this so a build shipped without a stamped version/SHA cannot emit a non-deterministic release
   tags: [production]
 
+- name: PROLIFERATE_BUILD_VERSION
+  secret: false
+  default: ""
+  description: Canonical runtime version stamped into the AnyHarness/worker/supervisor binaries at build time (from `anyharness/sdk/package.json`). The immutable E2B template build (`scripts/build-template.mjs --rebuild-runtime`) sets it; when set, a missing/malformed `PROLIFERATE_BUILD_SHA` fails the build so the release ID carries a deterministic SHA. Unset dev/test builds fall back to the crate `Cargo.toml` version
+  tags: [ci]
+
+- name: PROLIFERATE_BUILD_SHA
+  secret: false
+  default: ""
+  description: Full 40-character source SHA of the exact checkout, stamped (truncated to 12) into the runtime binaries' release ID. Set by the immutable E2B template build; rejected if missing/malformed when `PROLIFERATE_BUILD_VERSION` is set
+  tags: [ci]
+
+- name: PROLIFERATE_RUNTIME_ENV
+  secret: false
+  default: ""
+  description: Bounded runtime environment for a cloud sandbox (`e2b`), emitted by the server bootstrap into the runtime processes. It is the single env-like Sentry tag (`runtime_env`) preserved through worker/supervisor scrubbing; every other env-like tag stays redacted
+  tags: [production]
+
 - name: SIGNUPS_SLACK_WEBHOOK_URL
   secret: true
   default: ""


### PR DESCRIPTION
## Scope (Phase 1 only)

Support-system slice **B2 — Make production runtime evidence usable**. Repository change + local/CI verification only. **No deploys, no AWS/E2B/GitHub environment mutation.** Phase 2 (template build/smoke, rolling-ref moves, server deploys, fresh-sandbox proofs, `0600` receipt) is separately authorized after independent review. Tracker ingestion stays disabled.

- **Frozen contract (in-tree after the docs-taxonomy rebase):** `specs/codebase/systems/engineering/issue-lifecycle/production-runtime-evidence.md`
- **Original implementation base (B1 accepted revision):** `92b9545ace66d177a63999811fda5c180e61cbe2`; branch now rebased onto current `main` (`9757e86d`) per review.

## What changed

**Server deployment identity (`_deploy-server.yml`)**
- Adds `PROLIFERATE_REQUIRE_RELEASE_IDENTITY=1` for hosted tasks.
- Stops authoring `ANYHARNESS_GIT_SHA`, `CLOUD_RUNTIME_SENTRY_RELEASE`, `CLOUD_TARGET_SENTRY_RELEASE` from the server SHA/release.
- Strips the seven stale inherited vars in the merge jq (`SERVER_VERSION`, `ANYHARNESS_VERSION`, `ANYHARNESS_GIT_SHA`, `E2B_TEMPLATE_VERSION`, `CLOUD_RUNTIME_SENTRY_RELEASE`, `CLOUD_TARGET_SENTRY_RELEASE`, `E2B_RUNTIME_SENTRY_RELEASE`) — the task is merged from the previous revision, so dropping assignments alone is insufficient — and the final rendered-task assert fails if any forbidden name remains or strict identity is absent.
- Requires `VERSION` and `anyharness/sdk/package.json` to agree and uses that canonical version for the server/runtime/worker pins instead of the worker/supervisor Cargo `0.1.0`.
- **B1's `SUPPORT_FEED_BEARER_TOKEN` secret entry and its ASSERT gate are preserved intact** (assert extended, never weakened).

**Exact three-binary E2B build**
- `build-template.mjs::rebuildRuntimeBundle` reads the canonical runtime version from `anyharness/sdk/package.json`, resolves the full checkout SHA, rejects missing/malformed input, and passes `PROLIFERATE_BUILD_VERSION`/`PROLIFERATE_BUILD_SHA` into the single AnyHarness/worker/supervisor build.
- `smoke-cloud-template.mjs` gains `--expected-version` **and `--expected-sha`**: it runs all three binaries with `--version` and additionally asserts the stamped 12-char source SHA literal (`PROLIFERATE_STAMPED_GIT_SHA`, the source of each binary's `<component>@<version>+<sha>` Sentry release) is embedded in each binary image. Either mismatch fails before `_deploy-e2b.yml` moves any rolling ref. `_deploy-e2b.yml` wires both from the exact `git_sha` checkout.

**Source-revision proof model (recorded per review decision B2-DECISION-001)**
- The binaries' `--version` output deliberately reports only the version token: the worker self-update and anyharness-update preflights exact-match that token against pins (`version_output_matches`), and the frozen contract states the immutable `sha-<12>` template tag binds the source SHA with no second build-info endpoint. The smoke therefore proves the stamped SHA via the embedded build-stamp literal, and the canonical source-revision binding for Phase 2's receipt remains: immutable `sha-<12>` tag + stamped Sentry release + this smoke assertion.

**Bounded Sentry envelope preservation**
- Shared `scrubTelemetryEvent` (product-domain) snapshots the top-level `environment`, runs the recursive scrubber, then restores it scrubbed as text; wired into Web/Desktop/Mobile adapters. Server `_scrub_event` applies the same bounded rule.
- Worker/supervisor `scrub_event` preserve only the exact `runtime_env` tag (allowed value `e2b`); all other env-like keys stay redacted.

**Docs (remapped to the post-restructure taxonomy)**
- Bounded-identity privacy rules → `specs/codebase/systems/engineering/observability/sentry.md` (successor of the deleted `specs/developing/analytics/sentry.md`).
- Workflow-fact one-liners → `specs/codebase/systems/engineering/delivery/README.md` (`ci-cd.md` is now a router that must not carry facts).
- `PROLIFERATE_BUILD_VERSION` / `PROLIFERATE_BUILD_SHA` / `PROLIFERATE_RUNTIME_ENV` → `specs/developing/reference/env-vars.yaml` (with `default`, no `ci_type`, YAML-safe).
- Frozen contract promoted at `systems/engineering/issue-lifecycle/production-runtime-evidence.md` beside B1's `private-support-feed.md`, indexed in the issue-lifecycle README.

## Verification (all green, post-rebase)

| Command | Result |
| --- | --- |
| `pytest test_sentry_integration.py test_runtime_sentry_release.py test_support_feed_deploy_render.py` | 23 passed |
| `pnpm --filter @proliferate/product-domain test` | 549 passed |
| desktop `vitest run .../telemetry/sentry.test.ts` | 2 passed |
| `cargo test -p proliferate-worker` | 51 passed |
| `cargo test -p proliferate-supervisor` | 11 passed |
| `node --check build-template.mjs smoke-cloud-template.mjs` | OK |
| `python3 scripts/check_max_lines.py` | passed |
| `ruby -ryaml YAML.load_file(env-vars.yaml)` | parses clean |
| `python3 scripts/check_docs.py` | no new failures (9 pre-existing web-desktop-unification link errors exist on clean origin/main; quarantined) |

## Phase 2 must know

- Hosted E2B lane step names: **Resolve immutable template tag** (outputs `sha_tag`, `short_sha`, `runtime_version`) → **Build and publish immutable template** (`--rebuild-runtime` stamps version/SHA) → **Smoke test immutable public ref** (`--expected-version` + `--expected-sha` gates) → **Promote immutable build** (moves rolling ref). Expected version comes from `anyharness/sdk/package.json`; expected SHA is `${GIT_SHA:0:12}` of the exact checkout.
- Rollback coordinates unchanged: record prior ECS task/image, immutable `sha-<12>` tag, and rolling target before mutation; restore server task and E2B rolling target as a pair.
- Receipt must record the source-revision binding chain: immutable tag ↔ stamped binaries (smoke-proven) ↔ stamped Sentry releases.

## Review-pass delta (post e031b6b7)

- Rebased onto current `main` (`9757e86d`); doc targets remapped to the new taxonomy (see reply comment for the per-finding disposition).
- `smoke-cloud-template.mjs` additionally gains `--expected-sha` (stamped-SHA-in-binary assertion; see "Source-revision proof model" above).
- Fixed CodeQL `js/polynomial-redos` on the pre-existing `ABSOLUTE_URL_PARTS_PATTERN` in `product-domain/telemetry/scrub.ts` (unambiguous path group; behavior unchanged, 549 tests green).
- Separate final commit repairs 9 dangling web-desktop-unification doc links that make `scripts/check_docs.py` (Repo shape CI) fail on clean `origin/main`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
