### PR TITLE
docs(specs): fix relocated unification doc links

### DIFF
--- a/specs/codebase/systems/product/clients/web-desktop-unification/README.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/README.md
@@ -667,11 +667,11 @@ checks the complete 2220-file `move`/`split`/`retain`/`delete` ledger, proves a
 deterministic idempotent import codemod on a disposable copy, and lands the
 deterministic legacy-Web bundle collector with a provisional baseline. The
 reserved real files are not created. The complete living contract is
-[`web-desktop-client-unification-d1g.md`](web-desktop-client-unification-d1g.md);
+[`web-desktop-client-unification-d1g.md`](migration/d1g.md);
 the recorded entry contract is
-[`web-desktop-product-client-entry-contract.md`](web-desktop-product-client-entry-contract.md)
+[`web-desktop-product-client-entry-contract.md`](entry-contract.md)
 and the move ledger is
-[`web-desktop-product-client-move-ledger.md`](web-desktop-product-client-move-ledger.md).
+[`web-desktop-product-client-move-ledger.md`](move-ledger.md).
 
 Related authoritative docs:
 

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/d1g.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/d1g.md
@@ -7,13 +7,13 @@ Status: **current implementation scope**.
 - Prior completed implementation: PR #1182 (D1f), merge
   `f93afce8190bba943277d588c9bfb0d051c615c9`
 - Parent architecture:
-  [`web-desktop-client-unification.md`](web-desktop-client-unification.md)
+  [`web-desktop-client-unification.md`](../README.md)
 - Application-entry contract:
-  [`web-desktop-product-client-entry-contract.md`](web-desktop-product-client-entry-contract.md)
+  [`web-desktop-product-client-entry-contract.md`](../entry-contract.md)
 - Move ledger:
-  [`web-desktop-product-client-move-ledger.md`](web-desktop-product-client-move-ledger.md)
+  [`web-desktop-product-client-move-ledger.md`](../move-ledger.md)
 - Pipeline ledger:
-  [`../../developing/deploying/web-desktop-unification-rollout.md`](../../developing/deploying/web-desktop-unification-rollout.md)
+  [`../../developing/deploying/web-desktop-unification-rollout.md`](../../../../../../developing/deploying/web-desktop-unification-rollout.md)
 - Approved contract:
   `03 - Prove ProductClient Extraction Mechanics.md` (founder-approved r3;
   decisions 8–9 approved 2026-07-14)
@@ -50,7 +50,7 @@ At this slice's head, on base `f93afce81`:
 ## Entry contract (recorded, not implemented)
 
 The full contract is in
-[`web-desktop-product-client-entry-contract.md`](web-desktop-product-client-entry-contract.md).
+[`web-desktop-product-client-entry-contract.md`](../entry-contract.md).
 Summary of what this slice locks:
 
 - **Public entry:** `ProductClient({ RoutesComponent }): ReactElement`, exported
@@ -160,7 +160,7 @@ cutover baseline.
 ## Move ledger summary counts
 
 Full ledger:
-[`web-desktop-product-client-move-ledger.md`](web-desktop-product-client-move-ledger.md).
+[`web-desktop-product-client-move-ledger.md`](../move-ledger.md).
 Source root `apps/desktop/src` = **2220 files at base**. Checked by
 `scripts/check-product-client-move-ledger.py` (every disk path has exactly one
 classification, no target collisions, no unclassified product file):


### PR DESCRIPTION
## Summary

Fixes the doc-integrity failure on `main` after #1195 merged across the docs reorg: the relocated unification docs' relative Markdown targets still pointed at the pre-reorg filenames. Links in `web-desktop-unification/README.md` and `migration/d1g.md` now point at `migration/d1g.md`, `entry-contract.md`, `move-ledger.md`, and `../README.md`.

`python3 scripts/check_docs.py` passes locally.

## Impact

Docs-only; unblocks the red repo-shape check on `main`.