### PR TITLE
fix(sidebar): unify row geometry and timestamp font size

### DIFF
--- a/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
@@ -213,7 +213,7 @@ export function ProductSidebarWorkspaceRow({
                 />
               </Tooltip>
             ) : trailingLabel ? (
-              <div className={`col-start-1 row-start-1 flex items-center justify-end overflow-visible truncate whitespace-nowrap text-right tabular-nums text-faint transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
+              <div className={`col-start-1 row-start-1 flex items-center justify-end overflow-visible truncate whitespace-nowrap text-right text-ui tabular-nums text-faint transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
                   ? "opacity-0"
                   : "group-hover:opacity-0 group-focus-within:opacity-0"
                 }`}>

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
@@ -37,7 +37,7 @@ export function ProductSidebarRepoGroupHeader({
     <SidebarRowSurface
       onPress={onToggleCollapsed}
       aria-expanded={!collapsed}
-      className={`group/folder-row h-[30px] justify-between overflow-x-hidden py-1 text-sidebar-nav focus-visible:outline-offset-[-2px] ${className}`}
+      className={`group/folder-row h-[28px] justify-between overflow-x-hidden py-1 text-sidebar-nav focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       <div className="flex min-w-0 flex-1 items-center gap-1 pl-1">
@@ -140,7 +140,7 @@ export function ProductSidebarWorkspaceRow({
     <SidebarRowSurface
       active={active}
       onPress={onSelect}
-      className={`${hasSubtitle ? "h-[42px]" : "h-[30px]"} px-2 py-1 text-sidebar-row focus-visible:outline-offset-[-2px] ${className}`}
+      className={`${hasSubtitle ? "h-[40px]" : "h-[28px]"} px-2 py-1 text-sidebar-row focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       {hoverAction ? (
@@ -213,7 +213,7 @@ export function ProductSidebarWorkspaceRow({
                 />
               </Tooltip>
             ) : trailingLabel ? (
-              <div className={`col-start-1 row-start-1 flex items-center justify-end overflow-visible truncate whitespace-nowrap text-right text-ui-sm tabular-nums text-faint transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
+              <div className={`col-start-1 row-start-1 flex items-center justify-end overflow-visible truncate whitespace-nowrap text-right tabular-nums text-faint transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
                   ? "opacity-0"
                   : "group-hover:opacity-0 group-focus-within:opacity-0"
                 }`}>

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
@@ -33,7 +33,7 @@ export function ProductSidebarThreadRow({
     <SidebarRowSurface
       active={active}
       onPress={onSelect}
-      className={`${hasSubtitle ? "h-[40px]" : "h-[28px]"} pl-2 pr-1 py-1 focus-visible:outline-offset-[-2px] ${className}`}
+      className={`${hasSubtitle ? "h-[40px]" : "h-[28px]"} pl-2 pr-1 py-1 text-sidebar-row focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       {hoverAction ? (
@@ -41,13 +41,13 @@ export function ProductSidebarThreadRow({
           {hoverAction}
         </div>
       ) : null}
-      <div className="flex w-full items-center gap-1.5 text-sm leading-4">
+      <div className="flex w-full items-center gap-1.5">
         <div className="flex w-4 shrink-0 items-center justify-center">
           {status}
         </div>
 
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <div className={`flex min-w-0 flex-1 ${hasSubtitle ? "flex-col items-start justify-center gap-0.5" : "items-center gap-2"} truncate text-ui leading-5 text-sidebar-foreground`}>
+          <div className={`flex min-w-0 flex-1 ${hasSubtitle ? "flex-col items-start justify-center gap-0.5" : "items-center gap-2"} truncate text-sidebar-foreground`}>
             <span className="max-w-full truncate">
               {label}
             </span>
@@ -66,7 +66,7 @@ export function ProductSidebarThreadRow({
 
         <div className="flex shrink-0 items-center gap-1">
           {trailingLabel && !active && !expandControl ? (
-            <div className="truncate text-right text-sm leading-4 tabular-nums text-sidebar-muted-foreground group-focus-within:opacity-0 group-hover:opacity-0">
+            <div className="truncate text-right text-ui tabular-nums text-sidebar-muted-foreground group-focus-within:opacity-0 group-hover:opacity-0">
               {trailingLabel}
             </div>
           ) : null}

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
@@ -33,7 +33,7 @@ export function ProductSidebarThreadRow({
     <SidebarRowSurface
       active={active}
       onPress={onSelect}
-      className={`${hasSubtitle ? "h-[42px]" : "h-[30px]"} pl-2 pr-1 py-1 focus-visible:outline-offset-[-2px] ${className}`}
+      className={`${hasSubtitle ? "h-[40px]" : "h-[28px]"} pl-2 pr-1 py-1 focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       {hoverAction ? (

--- a/apps/packages/ui/src/layout/SidebarNavRow.tsx
+++ b/apps/packages/ui/src/layout/SidebarNavRow.tsx
@@ -32,7 +32,7 @@ export function SidebarNavRow({
       active={active}
       disabled={disabled}
       onPress={onPress}
-      className={`min-h-[calc(1lh+0.5rem)] gap-2 px-2 py-1 text-ui leading-5 focus-visible:outline-offset-[-2px] ${className}`}
+      className={`h-[28px] gap-2 px-2 py-1 text-ui leading-5 focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
       {/* Codex parity: the icon carries the row ink, not a dimmer tier, and

--- a/apps/packages/ui/test/SidebarNavRow.test.tsx
+++ b/apps/packages/ui/test/SidebarNavRow.test.tsx
@@ -19,7 +19,7 @@ describe("SidebarNavRow", () => {
     );
 
     const row = screen.getByRole("button", { name: "G General" });
-    expect(row.className).toContain("min-h-[calc(1lh+0.5rem)]");
+    expect(row.className).toContain("h-[28px]");
     expect(row.className).toContain("gap-2");
     expect(row.className).toContain("px-2");
     expect(row.className).toContain("!text-sidebar-foreground");


### PR DESCRIPTION
Follow-up to #1202.

- Nav rows (New chat / Workspaces / Workflows / Support) now use the same fixed row height as workspace and thread rows — previously they were ~25px (content-derived `min-h`) vs 30px, so the two row families had different vertical rhythm.
- All sidebar rows tightened by 2px (30 → 28px; two-line subtitle rows 42 → 40px).
- Relative timestamps on workspace/thread rows now inherit the row's font size (12px `text-sidebar-row`) instead of the smaller `text-ui-sm`.

Verified live via the workspace-status playground DOM probe: every row type measures 28.0px / 12px font / 4px vertical padding; timestamps 12px.

Tests: desktop sidebar + settings suites (22 files / 126 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)