### PR TITLE
docs(triage): production issue triage runbook + shared agent skill (F2)

### DIFF
--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -70,9 +70,26 @@ def resolve_origin() -> str:
     return origin
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse every redirect.
+
+    Python's default redirect handler copies the Authorization header onto the
+    follow-up request, so a redirect from the fixed origin could forward the
+    bearer token off-origin. The fixed tracker origin never legitimately
+    redirects agent routes, so redirects fail closed: returning ``None`` makes
+    urllib raise the 3xx as an ``HTTPError`` and no second request is issued.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: D102
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect())
+
+
 def _urlopen(request: urllib.request.Request, timeout: float):
     """Transport seam. Faked in tests; never contacts the network there."""
-    return urllib.request.urlopen(request, timeout=timeout)  # noqa: S310
+    return _OPENER.open(request, timeout=timeout)  # noqa: S310
 
 
 def _run_aws(args: list[str]) -> subprocess.CompletedProcess:
@@ -145,7 +162,13 @@ def _build_url(origin: str, path: str, query: dict | None) -> str:
 
 
 def _read_bounded(response) -> bytes:
-    return response.read(MAX_RESPONSE_BYTES + 1)[:MAX_RESPONSE_BYTES]
+    """Read at most the bound; anything larger is a protocol error, not data."""
+    data = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(data) > MAX_RESPONSE_BYTES:
+        raise HelperError(
+            f"response exceeded the {MAX_RESPONSE_BYTES}-byte bound; refusing to process it"
+        )
+    return data
 
 
 def request(
@@ -177,19 +200,49 @@ def request(
     try:
         with _urlopen(req, timeout=REQUEST_TIMEOUT_S) as response:
             raw = _read_bounded(response)
-            return response.status, _parse(raw)
+            return response.status, _parse_success(raw)
     except urllib.error.HTTPError as exc:
+        if 300 <= exc.code < 400:
+            # The no-redirect handler surfaces 3xx here without issuing a
+            # follow-up request; the bearer token never leaves the origin.
+            raise HelperError(
+                f"server responded with a redirect (HTTP {exc.code}); refusing to follow"
+            ) from exc
         # A 4xx/5xx with a body (e.g. 409 conflict, 412 precondition) is a
         # meaningful, non-secret API response. Expose its body, not the request.
-        raw = exc.read(MAX_RESPONSE_BYTES + 1)[:MAX_RESPONSE_BYTES] if exc.fp else b""
-        return exc.code, _parse(raw)
+        raw = _read_bounded(exc) if exc.fp else b""
+        return exc.code, _parse_error(raw)
     except urllib.error.URLError as exc:
         raise HelperError(f"transport error contacting {origin}: {_safe_reason(exc)}") from exc
     except TimeoutError as exc:
         raise HelperError(f"timed out contacting {origin}") from exc
 
 
-def _parse(raw: bytes) -> object:
+def _parse_success(raw: bytes) -> dict:
+    """Parse a 2xx body strictly: it must be a JSON object or the call fails.
+
+    A successful status with non-JSON or unexpectedly shaped content is a
+    protocol error, not data. The body is withheld from the error message so a
+    misrouted response can never leak through stderr.
+    """
+    text = raw.decode("utf-8", errors="replace")
+    if not text:
+        return {}
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise HelperError(
+            "successful response was not valid JSON (body withheld)"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise HelperError(
+            "successful response had an unexpected shape (expected a JSON object)"
+        )
+    return payload
+
+
+def _parse_error(raw: bytes) -> object:
+    """Parse an error body leniently so conflict/precondition JSON is exposed."""
     text = raw.decode("utf-8", errors="replace")
     if not text:
         return {}
@@ -213,10 +266,11 @@ def _emit(status: int, payload: object) -> int:
 
     2xx -> 0. Everything else (including exposed 409/412 conflict bodies) exits
     nonzero so a caller cannot mistake a conflict for success.
+
+    The payload is already bounded at read time, so the serialized document is
+    printed whole; truncating serialized JSON would emit an invalid document.
     """
     text = json.dumps(payload, indent=2, sort_keys=True)
-    if len(text) > MAX_RESPONSE_BYTES:
-        text = text[:MAX_RESPONSE_BYTES]
     print(text)
     if 200 <= status < 300:
         return 0

--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -267,10 +267,23 @@ def _emit(status: int, payload: object) -> int:
     2xx -> 0. Everything else (including exposed 409/412 conflict bodies) exits
     nonzero so a caller cannot mistake a conflict for success.
 
-    The payload is already bounded at read time, so the serialized document is
-    printed whole; truncating serialized JSON would emit an invalid document.
+    The bound is enforced on the FINAL serialized document, not just the wire
+    body: pretty-printing and ASCII escaping can expand a bounded response past
+    the limit. An indented document that would exceed the bound falls back to
+    compact separators; if even the compact document exceeds the bound, the
+    call fails nonzero with a body-withheld diagnostic. Output is never
+    truncated, so stdout is always a complete valid JSON document or nothing.
     """
     text = json.dumps(payload, indent=2, sort_keys=True)
+    if len(text.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        text = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    if len(text.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        print(
+            f"serialized response exceeds the {MAX_RESPONSE_BYTES}-byte output "
+            "bound (body withheld); refusing to emit it",
+            file=sys.stderr,
+        )
+        return 1
     print(text)
     if 200 <= status < 300:
         return 0

--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -267,17 +267,18 @@ def _emit(status: int, payload: object) -> int:
     2xx -> 0. Everything else (including exposed 409/412 conflict bodies) exits
     nonzero so a caller cannot mistake a conflict for success.
 
-    The bound is enforced on the FINAL serialized document, not just the wire
-    body: pretty-printing and ASCII escaping can expand a bounded response past
-    the limit. An indented document that would exceed the bound falls back to
-    compact separators; if even the compact document exceeds the bound, the
-    call fails nonzero with a body-withheld diagnostic. Output is never
-    truncated, so stdout is always a complete valid JSON document or nothing.
+    The bound is enforced on the TOTAL bytes written to stdout — the final
+    serialized document plus its trailing newline — not just the wire body:
+    pretty-printing and ASCII escaping can expand a bounded response past the
+    limit. An indented document that would exceed the bound falls back to
+    compact separators; if even the compact document (with its newline) exceeds
+    the bound, the call fails nonzero with a body-withheld diagnostic. Output
+    is never truncated, so stdout is a complete valid JSON document or nothing.
     """
     text = json.dumps(payload, indent=2, sort_keys=True)
-    if len(text.encode("utf-8")) > MAX_RESPONSE_BYTES:
+    if len(text.encode("utf-8")) + 1 > MAX_RESPONSE_BYTES:
         text = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    if len(text.encode("utf-8")) > MAX_RESPONSE_BYTES:
+    if len(text.encode("utf-8")) + 1 > MAX_RESPONSE_BYTES:
         print(
             f"serialized response exceeds the {MAX_RESPONSE_BYTES}-byte output "
             "bound (body withheld); refusing to emit it",

--- a/scripts/issues.py
+++ b/scripts/issues.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Safe REST helper for the production issue tracker (F2 operating surface).
+
+This is the complete machine interface an agent uses to operate the queue. It
+speaks only to the fixed issues origin, fetches the agent credential by
+reference for each invocation, and exposes exactly nine commands that map onto
+the accepted F1 REST surface:
+
+    list  poll  get  ops  claim  release  patch  dedup  link-pr
+
+It never creates issues by hand, never fetches private report objects, and
+never dumps raw provider payloads. The agent credential and the secret-provider
+response are redacted from every error path; they are never printed, logged, or
+persisted. See specs/developing/debugging/issue-triage.md for the human runbook.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# The one canonical origin. The helper refuses to talk to any other host so it
+# cannot be pointed at an attacker-controlled or staging endpoint by accident.
+FIXED_ORIGIN = "https://issues.proliferate.com"
+
+# Where the machine credential lives. Fetched fresh for every invocation through
+# the approved AWS path; there is no second durable copy in the local ops env.
+SECRET_ID = "issue-tracker/app"
+SECRET_FIELD = "agentApiKey"
+
+CONNECT_TIMEOUT_S = 5.0
+READ_TIMEOUT_S = 20.0
+# urllib uses a single timeout for connect+read; use the larger bound.
+REQUEST_TIMEOUT_S = READ_TIMEOUT_S
+
+# Bounded reads so a misbehaving or oversized response cannot exhaust memory or
+# flood stdout. Applies to both the API response and the secret-provider output.
+MAX_RESPONSE_BYTES = 1_048_576  # 1 MiB
+MAX_SECRET_BYTES = 65_536
+
+REDACTED = "[redacted]"
+
+MUTATIONS = {"claim", "release", "patch", "dedup", "link-pr"}
+
+
+class HelperError(Exception):
+    """A helper-level failure whose message is already safe to print."""
+
+
+# --------------------------------------------------------------------------- #
+# Origin and credential
+# --------------------------------------------------------------------------- #
+def resolve_origin() -> str:
+    """Return the canonical origin, rejecting any other host.
+
+    An operator may set ``ISSUES_ORIGIN`` in the local ops environment, but it
+    must equal the fixed origin. Any other value fails closed rather than
+    silently redirecting agent traffic.
+    """
+    origin = os.environ.get("ISSUES_ORIGIN", FIXED_ORIGIN)
+    if origin != FIXED_ORIGIN:
+        raise HelperError(
+            f"refusing non-canonical issues origin; only {FIXED_ORIGIN} is allowed"
+        )
+    return origin
+
+
+def _urlopen(request: urllib.request.Request, timeout: float):
+    """Transport seam. Faked in tests; never contacts the network there."""
+    return urllib.request.urlopen(request, timeout=timeout)  # noqa: S310
+
+
+def _run_aws(args: list[str]) -> subprocess.CompletedProcess:
+    """Subprocess seam for the AWS CLI. Faked in tests."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=REQUEST_TIMEOUT_S,
+    )
+
+
+def agent_api_key() -> str:
+    """Fetch ``agentApiKey`` from ``issue-tracker/app`` via the approved AWS path.
+
+    The value is returned to the caller in memory only. It is never printed or
+    written to disk, and any provider failure is reported without echoing the
+    provider's raw response (which could contain other secret fields).
+    """
+    try:
+        completed = _run_aws(
+            [
+                "aws",
+                "secretsmanager",
+                "get-secret-value",
+                "--secret-id",
+                SECRET_ID,
+                "--query",
+                "SecretString",
+                "--output",
+                "text",
+            ]
+        )
+    except FileNotFoundError as exc:
+        raise HelperError("aws CLI not found; cannot resolve the agent credential") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HelperError("timed out reading the agent credential from AWS") from exc
+
+    if completed.returncode != 0:
+        # Deliberately does NOT include the provider's raw stderr/stdout.
+        raise HelperError(
+            f"could not read secret {SECRET_ID} (AWS exited {completed.returncode})"
+        )
+
+    payload = (completed.stdout or "")[:MAX_SECRET_BYTES]
+    try:
+        secret = json.loads(payload)
+        key = secret[SECRET_FIELD]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        # Never surface the parsed/raw secret material in the error.
+        raise HelperError(
+            f"secret {SECRET_ID} missing field {SECRET_FIELD}"
+        ) from exc
+
+    if not isinstance(key, str) or not key.strip():
+        raise HelperError(f"secret {SECRET_ID} field {SECRET_FIELD} is empty")
+    return key
+
+
+# --------------------------------------------------------------------------- #
+# Request/response
+# --------------------------------------------------------------------------- #
+def _build_url(origin: str, path: str, query: dict | None) -> str:
+    url = origin + path
+    if query:
+        filtered = {k: v for k, v in query.items() if v is not None}
+        if filtered:
+            url = f"{url}?{urllib.parse.urlencode(filtered)}"
+    return url
+
+
+def _read_bounded(response) -> bytes:
+    return response.read(MAX_RESPONSE_BYTES + 1)[:MAX_RESPONSE_BYTES]
+
+
+def request(
+    method: str,
+    path: str,
+    *,
+    key: str,
+    query: dict | None = None,
+    body: dict | None = None,
+    run_id: str | None = None,
+) -> tuple[int, object]:
+    """Issue one request and return ``(status, parsed_json_or_text)``.
+
+    Raises :class:`HelperError` on transport/protocol failure. Auth headers are
+    never included in any raised message.
+    """
+    origin = resolve_origin()
+    url = _build_url(origin, path, query)
+
+    data = None
+    headers = {"Authorization": f"Bearer {key}", "Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if run_id is not None:
+        headers["X-Run-Id"] = run_id
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _urlopen(req, timeout=REQUEST_TIMEOUT_S) as response:
+            raw = _read_bounded(response)
+            return response.status, _parse(raw)
+    except urllib.error.HTTPError as exc:
+        # A 4xx/5xx with a body (e.g. 409 conflict, 412 precondition) is a
+        # meaningful, non-secret API response. Expose its body, not the request.
+        raw = exc.read(MAX_RESPONSE_BYTES + 1)[:MAX_RESPONSE_BYTES] if exc.fp else b""
+        return exc.code, _parse(raw)
+    except urllib.error.URLError as exc:
+        raise HelperError(f"transport error contacting {origin}: {_safe_reason(exc)}") from exc
+    except TimeoutError as exc:
+        raise HelperError(f"timed out contacting {origin}") from exc
+
+
+def _parse(raw: bytes) -> object:
+    text = raw.decode("utf-8", errors="replace")
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"raw": text}
+
+
+def _safe_reason(exc: Exception) -> str:
+    """A short, non-secret reason string. Never echoes headers or credentials."""
+    reason = getattr(exc, "reason", exc)
+    return str(reason)[:200]
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+def _emit(status: int, payload: object) -> int:
+    """Print bounded JSON to stdout; return the process exit code.
+
+    2xx -> 0. Everything else (including exposed 409/412 conflict bodies) exits
+    nonzero so a caller cannot mistake a conflict for success.
+    """
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if len(text) > MAX_RESPONSE_BYTES:
+        text = text[:MAX_RESPONSE_BYTES]
+    print(text)
+    if 200 <= status < 300:
+        return 0
+    print(f"request failed with HTTP {status}", file=sys.stderr)
+    return 1
+
+
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
+def _require_run_id(run_id: str | None) -> str:
+    if run_id is None or not run_id.strip():
+        raise HelperError("a unique --run-id is required for every mutation")
+    return run_id.strip()
+
+
+def cmd_list(args, key: str) -> int:
+    query = {
+        "status": args.status,
+        "kind": args.kind,
+        "cursor": args.cursor,
+        "limit": args.limit,
+    }
+    status, payload = request("GET", "/v1/issues", key=key, query=query)
+    return _emit(status, payload)
+
+
+def cmd_poll(args, key: str) -> int:
+    # The cursor is passed through byte-for-byte; the helper never rewrites it.
+    query = {"cursor": args.cursor, "limit": args.limit}
+    status, payload = request("GET", "/v1/issues/poll", key=key, query=query)
+    return _emit(status, payload)
+
+
+def cmd_get(args, key: str) -> int:
+    status, payload = request("GET", f"/v1/issues/{args.id}", key=key)
+    return _emit(status, payload)
+
+
+def cmd_ops(args, key: str) -> int:
+    status, payload = request("GET", "/v1/ops", key=key)
+    return _emit(status, payload)
+
+
+def cmd_claim(args, key: str) -> int:
+    run_id = _require_run_id(args.run_id)
+    status, payload = request(
+        "POST", f"/v1/issues/{args.id}/claim", key=key, run_id=run_id
+    )
+    return _emit(status, payload)
+
+
+def cmd_release(args, key: str) -> int:
+    run_id = _require_run_id(args.run_id)
+    status, payload = request(
+        "POST", f"/v1/issues/{args.id}/release-claim", key=key, run_id=run_id
+    )
+    return _emit(status, payload)
+
+
+def cmd_patch(args, key: str) -> int:
+    run_id = _require_run_id(args.run_id)
+    body: dict = {}
+    if args.status is not None:
+        body["status"] = args.status
+    if args.note is not None:
+        body["note"] = args.note
+    if args.component is not None:
+        body["resolutionComponent"] = args.component
+    if not body:
+        raise HelperError("patch needs at least one of --status/--note/--component")
+    status, payload = request(
+        "PATCH", f"/v1/issues/{args.id}", key=key, body=body, run_id=run_id
+    )
+    return _emit(status, payload)
+
+
+def cmd_dedup(args, key: str) -> int:
+    run_id = _require_run_id(args.run_id)
+    body = {"rootIssueId": args.root_id, "note": args.note}
+    status, payload = request(
+        "POST",
+        f"/v1/issues/{args.id}/deduplicate",
+        key=key,
+        body=body,
+        run_id=run_id,
+    )
+    return _emit(status, payload)
+
+
+def cmd_link_pr(args, key: str) -> int:
+    run_id = _require_run_id(args.run_id)
+    body = {
+        "repository": args.repository,
+        "number": args.number,
+        "relationship": args.relationship,
+    }
+    status, payload = request(
+        "POST", f"/v1/issues/{args.id}/prs", key=key, body=body, run_id=run_id
+    )
+    return _emit(status, payload)
+
+
+COMMANDS = {
+    "list": cmd_list,
+    "poll": cmd_poll,
+    "get": cmd_get,
+    "ops": cmd_ops,
+    "claim": cmd_claim,
+    "release": cmd_release,
+    "patch": cmd_patch,
+    "dedup": cmd_dedup,
+    "link-pr": cmd_link_pr,
+}
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="issues",
+        description="Safe REST helper for the production issue tracker.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="GET /v1/issues")
+    p_list.add_argument("--status")
+    p_list.add_argument("--kind")
+    p_list.add_argument("--cursor")
+    p_list.add_argument("--limit", type=int)
+
+    p_poll = sub.add_parser("poll", help="GET /v1/issues/poll")
+    p_poll.add_argument("--cursor")
+    p_poll.add_argument("--limit", type=int)
+
+    p_get = sub.add_parser("get", help="GET /v1/issues/{id}")
+    p_get.add_argument("id", type=int)
+
+    sub.add_parser("ops", help="GET /v1/ops")
+
+    p_claim = sub.add_parser("claim", help="POST /v1/issues/{id}/claim")
+    p_claim.add_argument("id", type=int)
+    p_claim.add_argument("--run-id", required=True)
+
+    p_release = sub.add_parser("release", help="POST /v1/issues/{id}/release-claim")
+    p_release.add_argument("id", type=int)
+    p_release.add_argument("--run-id", required=True)
+
+    p_patch = sub.add_parser("patch", help="PATCH /v1/issues/{id}")
+    p_patch.add_argument("id", type=int)
+    p_patch.add_argument("--run-id", required=True)
+    p_patch.add_argument("--status")
+    p_patch.add_argument("--note")
+    p_patch.add_argument("--component")
+
+    p_dedup = sub.add_parser("dedup", help="POST /v1/issues/{id}/deduplicate")
+    p_dedup.add_argument("id", type=int)
+    p_dedup.add_argument("--run-id", required=True)
+    p_dedup.add_argument("--root-id", type=int, required=True)
+    p_dedup.add_argument("--note", required=True)
+
+    p_link = sub.add_parser("link-pr", help="POST /v1/issues/{id}/prs")
+    p_link.add_argument("id", type=int)
+    p_link.add_argument("--run-id", required=True)
+    p_link.add_argument("--repository", required=True)
+    p_link.add_argument("--number", type=int, required=True)
+    p_link.add_argument("--relationship", default="fix")
+
+    return parser
+
+
+def run(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = COMMANDS[args.command]
+    try:
+        # Validate the run ID before touching the credential provider so a
+        # missing --run-id fails closed without a secret fetch.
+        if args.command in MUTATIONS:
+            _require_run_id(getattr(args, "run_id", None))
+        key = agent_api_key()
+        return handler(args, key)
+    except HelperError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+def main() -> int:
+    return run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_issues.py
+++ b/scripts/test_issues.py
@@ -1,0 +1,245 @@
+"""Offline tests for scripts/issues.py — no live network or AWS calls.
+
+Run with: python3 -m pytest scripts/test_issues.py
+
+The transport (`_urlopen`) and the credential provider (`agent_api_key`) are
+faked, so every case is fully hermetic. Coverage: command->route/method
+mapping, fixed-origin host rejection, mutation run-ID enforcement, conflict/
+precondition exposure with nonzero exit, poll-cursor passthrough, and error
+redaction of the authorization header and secret-provider response.
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "issues", Path(__file__).resolve().parent / "issues.py"
+)
+issues = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(issues)
+
+
+class FakeResponse:
+    def __init__(self, status: int, payload):
+        self.status = status
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self, size=-1):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class Capture:
+    """Records the last request and returns a scripted response."""
+
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self.payload = payload if payload is not None else {"ok": True}
+        self.request = None
+        self.timeout = None
+
+    def __call__(self, request, timeout):
+        self.request = request
+        self.timeout = timeout
+        return FakeResponse(self.status, self.payload)
+
+
+@pytest.fixture
+def fake_key(monkeypatch):
+    monkeypatch.setattr(issues, "agent_api_key", lambda: "SECRET-AGENT-KEY")
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    cap = Capture()
+    monkeypatch.setattr(issues, "_urlopen", cap)
+    return cap
+
+
+def _run(argv, monkeypatch=None):
+    return issues.run(argv)
+
+
+# --------------------------------------------------------------------------- #
+# Command -> route/method mapping
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "argv, method, path",
+    [
+        (["ops"], "GET", "/v1/ops"),
+        (["list"], "GET", "/v1/issues"),
+        (["get", "7"], "GET", "/v1/issues/7"),
+        (["poll"], "GET", "/v1/issues/poll"),
+        (["claim", "7", "--run-id", "r1"], "POST", "/v1/issues/7/claim"),
+        (["release", "7", "--run-id", "r1"], "POST", "/v1/issues/7/release-claim"),
+        (["patch", "7", "--run-id", "r1", "--status", "not_done"], "PATCH", "/v1/issues/7"),
+        (
+            ["dedup", "7", "--run-id", "r1", "--root-id", "3", "--note", "n"],
+            "POST",
+            "/v1/issues/7/deduplicate",
+        ),
+        (
+            ["link-pr", "7", "--run-id", "r1", "--repository", "o/r", "--number", "9"],
+            "POST",
+            "/v1/issues/7/prs",
+        ),
+    ],
+)
+def test_command_maps_to_route(fake_key, transport, argv, method, path):
+    code = _run(argv)
+    assert code == 0
+    req = transport.request
+    assert req.method == method
+    assert req.full_url == issues.FIXED_ORIGIN + path or req.full_url.startswith(
+        issues.FIXED_ORIGIN + path + "?"
+    )
+
+
+def test_mutations_send_run_id_and_reads_do_not(fake_key, transport):
+    _run(["claim", "7", "--run-id", "run-xyz"])
+    assert transport.request.get_header("X-run-id") == "run-xyz"
+    _run(["ops"])
+    assert transport.request.get_header("X-run-id") is None
+
+
+def test_dedup_body_shape(fake_key, transport):
+    _run(["dedup", "7", "--run-id", "r1", "--root-id", "3", "--note", "same event"])
+    body = json.loads(transport.request.data)
+    assert body == {"rootIssueId": 3, "note": "same event"}
+
+
+def test_link_pr_default_relationship(fake_key, transport):
+    _run(["link-pr", "7", "--run-id", "r1", "--repository", "o/r", "--number", "9"])
+    body = json.loads(transport.request.data)
+    assert body == {"repository": "o/r", "number": 9, "relationship": "fix"}
+
+
+# --------------------------------------------------------------------------- #
+# Fixed-origin host rejection
+# --------------------------------------------------------------------------- #
+def test_rejects_non_canonical_origin(monkeypatch, capsys):
+    monkeypatch.setenv("ISSUES_ORIGIN", "https://evil.example")
+    monkeypatch.setattr(issues, "agent_api_key", lambda: "SECRET")
+    called = {"n": 0}
+
+    def boom(*a, **k):
+        called["n"] += 1
+        raise AssertionError("must not contact the network")
+
+    monkeypatch.setattr(issues, "_urlopen", boom)
+    code = _run(["ops"])
+    assert code == 2
+    assert called["n"] == 0
+    err = capsys.readouterr().err
+    assert "non-canonical" in err
+
+
+# --------------------------------------------------------------------------- #
+# Run-ID enforcement (fails closed BEFORE any secret fetch)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("cmd", ["claim", "release"])
+def test_blank_run_id_fails_closed(monkeypatch, capsys, cmd):
+    def no_key():
+        raise AssertionError("credential must not be fetched")
+
+    monkeypatch.setattr(issues, "agent_api_key", no_key)
+    monkeypatch.setattr(issues, "_urlopen", lambda *a, **k: pytest.fail("no network"))
+    code = _run([cmd, "7", "--run-id", "   "])
+    assert code == 2
+    assert "run-id" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# Conflict / precondition exposure with nonzero exit
+# --------------------------------------------------------------------------- #
+def test_conflict_body_exposed_and_nonzero(fake_key, monkeypatch, capsys):
+    cap = Capture(status=409, payload={"outcome": "already_claimed", "claimedBy": "agent:other"})
+    # HTTPError path: urllib raises for 4xx. Simulate via error class.
+    import urllib.error
+
+    def raise_http(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            409,
+            "Conflict",
+            {},
+            io.BytesIO(json.dumps(cap.payload).encode("utf-8")),
+        )
+
+    monkeypatch.setattr(issues, "_urlopen", raise_http)
+    code = _run(["claim", "7", "--run-id", "r1"])
+    out = capsys.readouterr()
+    assert code == 1
+    assert "already_claimed" in out.out
+    assert "HTTP 409" in out.err
+
+
+# --------------------------------------------------------------------------- #
+# Poll cursor passthrough (byte-for-byte)
+# --------------------------------------------------------------------------- #
+def test_poll_cursor_passthrough(fake_key, transport):
+    import urllib.parse
+
+    cursor = "eyJpZCI6IDQyfQ=="  # opaque; must be forwarded unchanged
+    _run(["poll", "--cursor", cursor, "--limit", "10"])
+    query = urllib.parse.urlparse(transport.request.full_url).query
+    # The value must decode back byte-for-byte (percent-encoding is transparent).
+    assert urllib.parse.parse_qs(query)["cursor"] == [cursor]
+
+
+# --------------------------------------------------------------------------- #
+# Error redaction
+# --------------------------------------------------------------------------- #
+def test_transport_error_redacts_auth_header(fake_key, monkeypatch, capsys):
+    import urllib.error
+
+    def raise_url(request, timeout):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(issues, "_urlopen", raise_url)
+    code = _run(["ops"])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "SECRET-AGENT-KEY" not in err
+    assert "Bearer" not in err
+
+
+def test_secret_provider_failure_redacted(monkeypatch, capsys):
+    class Completed:
+        returncode = 255
+        stdout = ""
+        stderr = "AWS raw dump containing OTHER-SECRET-abc123"
+
+    monkeypatch.setattr(issues, "_run_aws", lambda args: Completed())
+    monkeypatch.setattr(issues, "_urlopen", lambda *a, **k: pytest.fail("no network"))
+    code = _run(["ops"])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "OTHER-SECRET-abc123" not in err
+    assert "issue-tracker/app" in err
+
+
+def test_secret_missing_field_redacts_payload(monkeypatch, capsys):
+    class Completed:
+        returncode = 0
+        stdout = json.dumps({"releaseApiKey": "OTHER-SECRET-xyz"})
+        stderr = ""
+
+    monkeypatch.setattr(issues, "_run_aws", lambda args: Completed())
+    monkeypatch.setattr(issues, "_urlopen", lambda *a, **k: pytest.fail("no network"))
+    code = _run(["ops"])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "OTHER-SECRET-xyz" not in err
+    assert "agentApiKey" in err

--- a/scripts/test_issues.py
+++ b/scripts/test_issues.py
@@ -336,8 +336,41 @@ def test_pretty_expansion_falls_back_to_compact_within_bound(fake_key, monkeypat
     code = _run(["list"])
     out = capsys.readouterr().out
     assert code == 0
-    assert len(out.encode("utf-8")) <= issues.MAX_RESPONSE_BYTES + 1  # + newline
+    # TOTAL stdout bytes, trailing newline included, never exceed the bound.
+    assert len(out.encode("utf-8")) <= issues.MAX_RESPONSE_BYTES
     assert json.loads(out) == payload
+
+
+def test_stdout_exactly_at_bound_passes(fake_key, monkeypatch, capsys):
+    # Compact document of MAX-1 bytes + the trailing newline = exactly MAX
+    # bytes on stdout: the largest permitted output, must succeed.
+    pad = "x" * (issues.MAX_RESPONSE_BYTES - 1 - len('{"pad":""}'))
+    raw = json.dumps({"pad": pad}, separators=(",", ":")).encode("utf-8")
+    assert len(raw) == issues.MAX_RESPONSE_BYTES - 1
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=raw)
+    )
+    code = _run(["get", "7"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert len(out.encode("utf-8")) == issues.MAX_RESPONSE_BYTES
+    assert json.loads(out) == {"pad": pad}
+
+
+def test_stdout_one_byte_past_bound_fails(fake_key, monkeypatch, capsys):
+    # Compact document of exactly MAX bytes + newline = MAX+1 total stdout
+    # bytes: one past the hard limit, must fail with nothing on stdout.
+    pad = "x" * (issues.MAX_RESPONSE_BYTES - len('{"pad":""}'))
+    raw = json.dumps({"pad": pad}, separators=(",", ":")).encode("utf-8")
+    assert len(raw) == issues.MAX_RESPONSE_BYTES
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=raw)
+    )
+    code = _run(["get", "7"])
+    out = capsys.readouterr()
+    assert code == 1
+    assert out.out == ""
+    assert "output bound" in out.err
 
 
 def test_serialized_output_over_bound_fails_with_no_stdout(fake_key, monkeypatch, capsys):

--- a/scripts/test_issues.py
+++ b/scripts/test_issues.py
@@ -26,12 +26,14 @@ _SPEC.loader.exec_module(issues)
 
 
 class FakeResponse:
-    def __init__(self, status: int, payload):
+    def __init__(self, status: int, payload=None, raw: bytes | None = None):
         self.status = status
-        self._body = json.dumps(payload).encode("utf-8")
+        self._body = raw if raw is not None else json.dumps(payload).encode("utf-8")
 
     def read(self, size=-1):
-        return self._body
+        if size is None or size < 0:
+            return self._body
+        return self._body[:size]
 
     def __enter__(self):
         return self
@@ -41,16 +43,20 @@ class FakeResponse:
 
 
 class Capture:
-    """Records the last request and returns a scripted response."""
+    """Records every request issued and returns a scripted response."""
 
     def __init__(self, status=200, payload=None):
         self.status = status
         self.payload = payload if payload is not None else {"ok": True}
-        self.request = None
+        self.requests = []
         self.timeout = None
 
+    @property
+    def request(self):
+        return self.requests[-1] if self.requests else None
+
     def __call__(self, request, timeout):
-        self.request = request
+        self.requests.append(request)
         self.timeout = timeout
         return FakeResponse(self.status, self.payload)
 
@@ -228,6 +234,91 @@ def test_secret_provider_failure_redacted(monkeypatch, capsys):
     assert code == 2
     assert "OTHER-SECRET-abc123" not in err
     assert "issue-tracker/app" in err
+
+
+def test_transport_uses_no_redirect_opener():
+    # The installed handler must refuse to build a follow-up request: urllib
+    # then raises the 3xx as HTTPError and never re-sends the bearer token.
+    handler = issues._NoRedirect()
+    result = handler.redirect_request(
+        None, None, 302, "Found", {"Location": "https://evil.example/x"}, "https://evil.example/x"
+    )
+    assert result is None
+
+
+def test_redirect_fails_closed_with_single_request(fake_key, monkeypatch, capsys):
+    import urllib.error
+
+    log = []
+
+    def raise_redirect(request, timeout):
+        log.append(request)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            302,
+            "Found",
+            {"Location": "https://evil.example/steal"},
+            io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(issues, "_urlopen", raise_redirect)
+    code = _run(["ops"])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "redirect" in err
+    # Exactly one request; the token was never carried to a second host.
+    assert len(log) == 1
+    assert log[0].full_url.startswith(issues.FIXED_ORIGIN)
+    assert "SECRET-AGENT-KEY" not in err
+
+
+# --------------------------------------------------------------------------- #
+# Strict 2xx protocol validation
+# --------------------------------------------------------------------------- #
+def test_success_with_html_body_fails_and_withholds_body(fake_key, monkeypatch, capsys):
+    html = b"<html><body>totally-not-json MARKER-9f2</body></html>"
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=html)
+    )
+    code = _run(["ops"])
+    out = capsys.readouterr()
+    assert code == 2
+    assert "not valid JSON" in out.err
+    assert "MARKER-9f2" not in out.out + out.err
+
+
+def test_success_with_wrong_shape_fails(fake_key, monkeypatch, capsys):
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=b'["a", "b"]')
+    )
+    code = _run(["ops"])
+    assert code == 2
+    assert "unexpected shape" in capsys.readouterr().err
+
+
+def test_success_oversized_body_fails(fake_key, monkeypatch, capsys):
+    huge = b'{"pad": "' + b"x" * (issues.MAX_RESPONSE_BYTES + 10) + b'"}'
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=huge)
+    )
+    code = _run(["ops"])
+    out = capsys.readouterr()
+    assert code == 2
+    assert "bound" in out.err
+    assert "xxxx" not in out.out + out.err
+
+
+def test_large_but_bounded_payload_emits_valid_json(fake_key, monkeypatch, capsys):
+    payload = {"items": ["y" * 1000 for _ in range(100)]}
+    assert len(json.dumps(payload)) < issues.MAX_RESPONSE_BYTES
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, payload=payload)
+    )
+    code = _run(["list"])
+    out = capsys.readouterr().out
+    assert code == 0
+    # The emitted document must be complete, valid JSON — never truncated.
+    assert json.loads(out) == payload
 
 
 def test_secret_missing_field_redacts_payload(monkeypatch, capsys):

--- a/scripts/test_issues.py
+++ b/scripts/test_issues.py
@@ -321,6 +321,45 @@ def test_large_but_bounded_payload_emits_valid_json(fake_key, monkeypatch, capsy
     assert json.loads(out) == payload
 
 
+def test_pretty_expansion_falls_back_to_compact_within_bound(fake_key, monkeypatch, capsys):
+    # The reviewer's proof case: a ~400KB wire body whose indented serialization
+    # would exceed the bound. Compact separators keep it inside, so it succeeds
+    # and stdout is one complete valid JSON document within the bound.
+    payload = {"items": [{"k": i, "v": "z" * 20} for i in range(18_000)]}
+    raw = json.dumps(payload).encode("utf-8")
+    assert len(raw) < issues.MAX_RESPONSE_BYTES
+    pretty = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    assert len(pretty) > issues.MAX_RESPONSE_BYTES
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=raw)
+    )
+    code = _run(["list"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert len(out.encode("utf-8")) <= issues.MAX_RESPONSE_BYTES + 1  # + newline
+    assert json.loads(out) == payload
+
+
+def test_serialized_output_over_bound_fails_with_no_stdout(fake_key, monkeypatch, capsys):
+    # Wire body under the read bound, but ASCII escaping doubles the encoded
+    # size on re-serialization so even the compact document exceeds the output
+    # bound: fail nonzero, body withheld, and NOTHING (no partial JSON) on stdout.
+    snowmen = "☃" * 250_000  # 3 bytes each raw UTF-8; 6 bytes each escaped
+    raw = json.dumps({"pad": snowmen}, ensure_ascii=False).encode("utf-8")
+    assert len(raw) < issues.MAX_RESPONSE_BYTES
+    compact = json.dumps({"pad": snowmen}, separators=(",", ":")).encode("utf-8")
+    assert len(compact) > issues.MAX_RESPONSE_BYTES
+    monkeypatch.setattr(
+        issues, "_urlopen", lambda req, timeout: FakeResponse(200, raw=raw)
+    )
+    code = _run(["get", "7"])
+    out = capsys.readouterr()
+    assert code == 1
+    assert out.out == ""
+    assert "output bound" in out.err
+    assert "☃" not in out.err and "2603" not in out.err.replace("output", "")
+
+
 def test_secret_missing_field_redacts_payload(monkeypatch, capsys):
     class Completed:
         returncode = 0

--- a/specs/codebase/systems/engineering/issue-lifecycle/agent-operating-surface.md
+++ b/specs/codebase/systems/engineering/issue-lifecycle/agent-operating-surface.md
@@ -1,0 +1,299 @@
+# Give Agents a Clean Operating Surface
+
+> [!important] Frozen contract
+> Founder-approved on 2026-07-14 and grounded in Proliferate `origin/main` at
+> `66f45bfbe2839ae1382133393844ba61dce035cd`, the accepted F1 tracker API, and
+> the local Codex/Claude surfaces audited on 2026-07-14. Implementation is
+> authorized only after F1 is accepted and the access preflight is green.
+
+- Current slice: **F2 - Give Agents a Clean Operating Surface - frozen**
+- Next slice: **founder acceptance and normal issue operations**
+
+## Outcome
+
+A fresh Codex agent and a fresh Claude/Fable agent, with no chat history, can
+discover one shared procedure and safely operate the production issue queue.
+
+```text
+fresh agent
+-> discover shared issue-triage skill
+-> obtain machine credential by reference, never prompt value
+-> list / poll / claim / inspect
+-> follow exact evidence to Sentry, support, Grafana, CloudWatch, or E2B
+-> write a concise conclusion / dedup / authoritative PR link
+-> release claim
+```
+
+This slice removes founder context-switching. It does not change the
+issue-tracker application or grant agents license to mutate arbitrary customer
+issues or invent fuzzy relationships.
+
+## Preconditions
+
+- F1 is accepted, deployed, and its GitHub-authoritative PR-link proof passes.
+- Production source health is fresh and the controlled Sentry, support, and
+  Grafana samples from C through E2 are retained.
+- `issue-tracker/app.agentApiKey` exists and is readable through the approved
+  local AWS credential path.
+- Provider access is already proven for Sentry, product support storage,
+  Grafana, CloudWatch, E2B, GitHub, and the product browser. F2 does not stop to
+  ask Pablo to sign in or mint a key.
+- Claude's broken `node_repl` MCP path has been repaired from the absent
+  `/Applications/Codex.app/...` runtime to the installed
+  `/Applications/ChatGPT.app/...` runtime during P0.
+
+## Canonical interface
+
+REST is the complete operating interface. Do not expand MCP merely for parity:
+
+```text
+GET   /v1/issues
+GET   /v1/issues/{id}
+GET   /v1/issues/poll
+GET   /v1/ops
+POST  /v1/issues/{id}/claim
+POST  /v1/issues/{id}/release-claim
+PATCH /v1/issues/{id}
+POST  /v1/issues/{id}/deduplicate
+POST  /v1/issues/{id}/prs
+```
+
+Machine authentication uses `Authorization: Bearer <agentApiKey>`. Every
+mutation also requires a unique `X-Run-Id`. Human Web and release credentials
+must not work on agent routes, and the agent credential must not impersonate
+those boundaries.
+
+Safe issue detail remains sufficient: source key/URL, occurrence event keys
+with user/release identity, safe reporter choices/reference, linked PRs, and
+audit events. Private support bodies, attachments, raw Sentry payloads, and raw
+logs stay in their owning systems.
+
+## Files and ownership
+
+Expected Proliferate documentation changes:
+
+```text
+specs/developing/debugging/
+├── README.md                 # route to issue triage
+└── issue-triage.md           # human-readable operating procedure
+```
+
+Expected shared local skill:
+
+```text
+~/.agents/skills/triage-production-issue/
+├── SKILL.md
+└── scripts/
+    └── issues.py
+
+~/.claude/skills/triage-production-issue
+  -> ~/.agents/skills/triage-production-issue
+```
+
+Codex already discovers `~/.agents/skills`. Add a
+`~/.codex/skills/triage-production-issue` symlink only if the fresh Codex
+acceptance proves this installation does not. There is one source skill, not
+separate drifting Codex and Claude copies.
+
+F2 makes no issue-tracker application, schema, deployment, or source-writer
+change. A concrete missing REST capability fails the proof and is reported as
+a bounded amendment; it is not worked around with browser automation, direct
+database writes, or a second protocol.
+
+## Safe REST helper
+
+`scripts/issues.py` supports only:
+
+```text
+list
+poll
+get
+ops
+claim
+release
+patch
+dedup
+link-pr
+```
+
+It must:
+
+1. use the fixed origin `https://issues.proliferate.com` and reject every other
+   host;
+2. fetch `agentApiKey` from `issue-tracker/app` for each invocation through the
+   approved AWS path, without printing or persisting it;
+3. use bounded connect/read timeouts and fail nonzero on HTTP/protocol errors;
+4. emit bounded JSON to stdout and diagnostics to stderr;
+5. require an explicit unique run ID for every mutation;
+6. preserve poll cursors exactly and expose conflict/precondition responses;
+7. never create an issue manually, fetch private report objects, or dump raw
+   provider payloads; and
+8. redact authorization headers and secret-provider responses in every error.
+
+The local ops environment may contain nonsecret references and the fixed
+origin. It does not contain a second durable copy of the agent key.
+
+Exact command mappings are:
+
+```text
+release -> POST  /v1/issues/{id}/release-claim
+patch   -> PATCH /v1/issues/{id}
+dedup   -> POST  /v1/issues/{id}/deduplicate
+link-pr -> POST  /v1/issues/{id}/prs
+```
+
+## Shared skill behavior
+
+The skill starts with one decision:
+
+```text
+read-only investigation
+or
+approved controlled mutation
+```
+
+For mutation, the agent claims first, uses a unique `X-Run-Id`, respects claim
+conflicts, and releases its claim when it stops. It records short conclusions,
+exact source IDs, links, and next actions rather than copied evidence.
+
+Automatic deduplication is exact-identity only. Similar titles, stack traces,
+users, timing, or guessed root causes are not merge authority. Ambiguous cases
+remain separate with a note for founder review.
+
+### Sentry and E2B
+
+```text
+tracker source key / occurrence event key
+-> exact project + event ID
+-> Sentry event API
+-> user.id + canonical release + relevant tags
+-> sandbox_id only when the event itself contains it
+-> e2b sandbox info/logs/connect only for that exact sandbox
+```
+
+The agent does not add a tracker sandbox column or search all running sandboxes
+by user. `connect` is allowed only when the exact sandbox is still running and
+the investigation is authorized.
+
+### Support
+
+```text
+tracker reportId/private reference
+-> existing private support-evidence procedure
+-> exact encrypted object/diagnostics only when required
+-> safe conclusion in tracker
+```
+
+The response and tracker note never include a raw message body, attachment,
+diagnostics archive, outreach address, or credential material.
+
+### Grafana and CloudWatch
+
+```text
+stable rule UID
+-> exact provisioned rule and runbook
+-> occurrence firing window
+-> annotated group/filter/region when present
+-> bounded CloudWatch query
+```
+
+The agent does not broaden to all log groups or store raw log lines in the
+tracker. Metric-only rules stop at rule/dashboard/runbook evidence.
+
+### GitHub
+
+The agent may compare exact revisions, inspect a PR, and attach a PR through
+`POST /v1/issues/{id}/prs`. It does not infer that a similarly named PR fixes
+an issue. The relationship must be supported by an explicit issue ID or
+reviewed evidence; F1 guarantees the returned fields come from GitHub.
+
+## Human runbook
+
+`issue-triage.md` must be usable without agent knowledge. It documents:
+
+- `/v1/ops` and source freshness;
+- list versus cursor-based poll semantics;
+- claim, conflict, release, status/note, dedup, and PR-link behavior;
+- each exact source investigation path above;
+- credential references, never values;
+- safe note content and private-evidence boundaries;
+- expired sandboxes and unavailable source evidence;
+- rotation/revocation of the local agent boundary; and
+- stopping without an orphaned claim.
+
+## Fresh-agent acceptance
+
+Create two genuinely fresh sessions with no copied conversation summary:
+
+```text
+one Codex session
+one Claude/Fable session
+```
+
+Each session independently:
+
+1. discovers the shared skill from a plain request to triage production issues;
+2. fetches the credential by reference without a value in prompt or output;
+3. calls `/v1/ops`, lists issues, and replays one poll cursor with no duplicate;
+4. claims an assigned controlled issue with its own run ID;
+5. reads safe issue detail and follows the exact owning-source evidence;
+6. identifies expected user/release and, for the E2B sample, exact sandbox;
+7. on its own **distinct controlled sample initially in `tbd`**, sends exactly:
+
+   ```text
+   PATCH status: not_done
+   note: F acceptance <run-id>: evidence path verified; no customer action
+   ```
+
+8. verifies the resulting `not_done` state and audit event; and
+9. releases the claim.
+
+Each agent covers one controlled Sentry issue, one controlled support issue,
+and one controlled Grafana issue: six independent read investigations total.
+Only the two separately assigned controlled samples are mutated. The
+`tbd -> not_done` result is intentional evidence; do not attempt an invalid
+agent transition back to `tbd`.
+
+Separately prove on controlled canary issues:
+
+- two agents racing to claim produce one winner and one conflict;
+- exact dedup works and fuzzy similarity does not trigger a merge;
+- a reviewed F1-authoritative PR link is durable and idempotent;
+- missing token, wrong token, and missing `X-Run-Id` fail closed;
+- release token fails on agent routes; and
+- agent token fails on human Web routes.
+
+The receipt contains session IDs, run IDs, issue IDs, source IDs,
+commands/results, and redacted timestamps. It contains no credentials, private
+support content, raw logs, or browser cookies.
+
+## Rollout
+
+1. Land and validate the Proliferate human runbook.
+2. Install the single shared skill and Claude symlink.
+3. Run read-only helper tests against controlled data.
+4. Run the two fresh-session proofs.
+5. Run controlled mutation/race/auth proofs.
+6. Verify no customer issue changed and no claim remains held.
+7. Accept the operating surface only when both agents complete without founder
+   nudges, credential recovery, or hidden chat context.
+
+## Rollback
+
+- remove the Claude symlink and shared skill directory;
+- revoke/rotate `issue-tracker/app.agentApiKey` if it may have been exposed;
+- verify machine requests with the old key fail;
+- release only the controlled claims created by the proof; and
+- leave tracker code/data, provider evidence, and production ingestion
+  unchanged.
+
+## Non-goals
+
+- any issue-tracker application, deployment, schema, or source-writer change;
+- MCP parity or another issue client;
+- autonomous mutation of arbitrary customer issues;
+- fuzzy deduplication or guessed PR attribution;
+- copying private evidence into tracker notes;
+- storing credentials in prompts, Git, local ops files, or per-agent copies;
+- adding tracker metadata columns for provider context; or
+- replacing the founder's final review and prioritization judgment.

--- a/specs/developing/debugging/README.md
+++ b/specs/developing/debugging/README.md
@@ -78,6 +78,9 @@ requires separately approved remediation scope and the applicable runbook.
 
 ## Focused Runbooks
 
+- [issue-triage.md](issue-triage.md): operate the production issue queue through
+  the tracker REST surface — list, poll, claim, follow source evidence, record a
+  conclusion, and release.
 - [support-reports.md](support-reports.md): retrieve, correlate, and close out a
   private support report.
 - [performance-profiling.md](performance-profiling.md): capture privacy-safe

--- a/specs/developing/debugging/issue-triage.md
+++ b/specs/developing/debugging/issue-triage.md
@@ -1,0 +1,200 @@
+# Issue triage
+
+Status: authoritative for operating the production issue queue.
+
+This runbook is how an operator, with no agent and no chat history, works the
+production issue tracker end to end: see what is in the queue, claim an issue,
+follow its evidence into the owning source, record a conclusion, and let go. It
+covers the REST surface directly so it stays usable even when the shared agent
+skill is not.
+
+The tracker application is not changed by triage. You read issues, follow the
+exact evidence each issue already carries, and write short conclusions back. You
+do not create issues by hand, copy private evidence into notes, or reach into
+provider systems by broad search.
+
+## Interface and credential
+
+Everything goes through the REST API at `https://issues.proliferate.com`. Machine
+callers authenticate with `Authorization: Bearer <agentApiKey>` and every
+mutation additionally sends a unique `X-Run-Id` header. The read routes reject a
+missing or wrong key; the mutation routes also reject a missing run ID.
+
+The `agentApiKey` lives in AWS Secrets Manager under `issue-tracker/app`. Read it
+by reference, never by value: the helper fetches it fresh for each call and never
+prints or stores it. Human web and release credentials do not work on agent
+routes, and the agent key does not work on the human web surface. Those
+boundaries are enforced server-side; do not try to cross them.
+
+The nine routes are:
+
+```
+GET   /v1/issues
+GET   /v1/issues/{id}
+GET   /v1/issues/poll
+GET   /v1/ops
+POST  /v1/issues/{id}/claim
+POST  /v1/issues/{id}/release-claim
+PATCH /v1/issues/{id}
+POST  /v1/issues/{id}/deduplicate
+POST  /v1/issues/{id}/prs
+```
+
+## Helper
+
+The safe helper is `scripts/issues.py` in this repository. The same file is
+installed as the shared agent skill (see [Shared skill](#shared-skill)). It
+exposes exactly these commands, which map onto the routes above:
+
+```
+python3 scripts/issues.py ops
+python3 scripts/issues.py list   [--status S] [--kind K] [--cursor C] [--limit N]
+python3 scripts/issues.py poll   [--cursor C] [--limit N]
+python3 scripts/issues.py get    <id>
+python3 scripts/issues.py claim  <id> --run-id <unique>
+python3 scripts/issues.py release <id> --run-id <unique>
+python3 scripts/issues.py patch  <id> --run-id <unique> [--status S] [--note N] [--component C]
+python3 scripts/issues.py dedup  <id> --run-id <unique> --root-id <root> --note <why>
+python3 scripts/issues.py link-pr <id> --run-id <unique> --repository <owner/name> --number <n> [--relationship fix]
+```
+
+`release`, `patch`, `dedup`, and `link-pr` map to `release-claim`, `PATCH`,
+`deduplicate`, and `prs` respectively. The helper prints JSON to stdout and
+diagnostics to stderr, exits nonzero on any non-2xx response, and refuses any
+origin other than the canonical one.
+
+## Source health
+
+Start with source health when timing or coverage is in question:
+
+```
+python3 scripts/issues.py ops
+```
+
+`/v1/ops` reports each ingestion source as `healthy`, `stale`, `degraded`,
+`not_yet_run`, or `disabled`. A disabled source is shown as disabled, never as
+healthy, so you can tell "no issues" apart from "not ingesting". If a source is
+stale or degraded, treat gaps in the queue for that source as unreliable until it
+recovers, and do not read absence as resolution.
+
+## Listing versus polling
+
+Two read patterns, two different jobs.
+
+- **List** (`GET /v1/issues`) is a snapshot of issues, newest activity first,
+  ordered by `(updated_at DESC, id DESC)`. Filter with `--status` and `--kind`.
+  It returns `items`, `hasMore`, and a `nextCursor`; pass that cursor back to page
+  through the current snapshot. Use list to survey and pick work.
+- **Poll** (`GET /v1/issues/poll`) is the append-only event feed, ordered by
+  `events.id` ascending, and is how you follow what changed. It returns `events`,
+  `hasMore`, and a `nextCursor`. Store the `nextCursor` and pass it back verbatim
+  on the next call to continue exactly where you left off. The cursor is opaque —
+  never edit or reconstruct it. Replaying the same cursor returns the same events
+  with no duplicates and no skips; a short commit-visibility window means a
+  just-written event may appear on the next poll rather than instantly.
+
+## Claim, conflict, and release
+
+Reading needs no claim. Any change starts with a claim.
+
+1. `claim <id> --run-id <unique>`. Use one unique run ID for the whole unit of
+   work; a ULID or `triage-<date>-<short>` is fine. The run ID is required and is
+   recorded on every resulting audit event.
+2. If someone else already holds the issue, the claim returns `409` with
+   `already_claimed` (or `active_claim_conflict`). Stop; do not force it. Claims
+   also expire on their own, so a stale hold clears without intervention.
+3. `release <id> --run-id <same>` when you stop — whether you resolved the issue,
+   handed it off, or found nothing. Never walk away from a held claim.
+
+Two operators racing to claim the same issue produce exactly one winner; the
+other gets a conflict.
+
+## Status, notes, and dedup
+
+- **Status and notes**: `patch <id> --run-id <run> --status <s> --note <n>`. Valid
+  transitions are enforced server-side; an illegal transition returns `409`
+  `invalid_transition`. Read the response rather than retrying blindly. A note is
+  a short conclusion — the diagnosis, the exact source IDs, the links, and the
+  next action. Notes never carry raw evidence.
+- **Deduplicate**: `dedup <dup-id> --root-id <root-id> --note <why>` merges the
+  duplicate into the root, moving its occurrences, reporters, and PR links across
+  and keeping its audit history. Dedup is **exact-identity only**. Similar titles,
+  similar stack traces, the same user, close timing, or a guessed shared cause are
+  not merge authority. When identity is ambiguous, leave the issues separate and
+  add a note for founder review.
+
+## Following the evidence
+
+`get <id>` returns safe issue detail: source key and URL, occurrence event keys
+with user and release identity, safe reporter references, linked PRs, and audit
+events. It never returns reporter emails, private source bodies, raw provider
+payloads, or raw logs. Reach those through the exact IDs the issue already
+carries — never by broad search across a provider.
+
+### Sentry and E2B
+
+Take the source key or an occurrence `eventKey`, go to that exact Sentry project
+and event ID, and read the event through Sentry. From the event, take `user.id`,
+the canonical release, and the relevant tags. Use a `sandbox_id` only if the event
+itself contains one; there is no sandbox column on the tracker and you do not
+enumerate a user's running sandboxes. E2B sandbox info, logs, or `connect` is for
+that one exact sandbox, only while it is still running, and only when the
+investigation is authorized.
+
+### Support
+
+Take the `reportId` or private reference from the issue and follow the existing
+[support-report procedure](support-reports.md): derive the S3 object from the
+report ID and open it with an authenticated AWS CLI. Open the exact encrypted
+object or diagnostics only when a conclusion actually requires it. The tracker
+note and any response never include a raw message body, attachment, diagnostics
+archive, outreach address, or credential.
+
+### Grafana and CloudWatch
+
+Take the stable rule UID, find the exact provisioned rule and its runbook, and
+use the occurrence firing window — plus the annotated group, filter, and region
+when present — to run one bounded CloudWatch query. Do not widen to all log groups
+and do not paste raw log lines into the tracker. A metric-only rule stops at
+rule, dashboard, and runbook evidence.
+
+### GitHub
+
+Compare exact revisions and inspect the PR, then attach it with
+`link-pr <id> --repository <owner/name> --number <n>`. The link must be backed by
+an explicit issue reference or reviewed evidence; a similarly named PR is not
+proof of a fix. The link is idempotent, so re-running it does not create
+duplicates.
+
+## Missing or expired evidence
+
+Sources go stale and sandboxes expire. When the owning evidence is gone — an
+expired E2B sandbox, a rotated log window, a source `/v1/ops` reports as
+degraded — record that the evidence was unavailable and continue from whatever
+durable identity remains (the Sentry event, the support report, the rule UID). Do
+not guess a conclusion to fill the gap, and do not broaden the search to
+reconstruct it.
+
+## Credential rotation and revocation
+
+The `issue-tracker/app.agentApiKey` is the entire local machine boundary. If it
+may have been exposed, rotate or revoke it in AWS Secrets Manager; the next
+helper invocation picks up the new value automatically because it fetches by
+reference. After rotation, confirm that a request with the old key is rejected.
+Nothing in the local ops environment holds a second durable copy of the key.
+
+## Stopping without an orphaned claim
+
+Before you finish: release every claim you took, confirm no secret or private
+content landed in a note or in your output, and, if you hit a genuinely missing
+REST capability, report it as a bounded gap rather than reaching around the API
+with a browser or a direct database write.
+
+## Shared skill
+
+The same helper is packaged as a shared agent skill so a fresh agent discovers
+one procedure. It is installed locally (outside this repository) at
+`~/.agents/skills/triage-production-issue/`, with a Claude symlink at
+`~/.claude/skills/triage-production-issue`. Codex discovers `~/.agents/skills`
+directly. There is one source skill, not per-agent copies. This repository holds
+the canonical `scripts/issues.py`; the local skill ships a copy of it.


### PR DESCRIPTION
## Summary

F2 — *Give Agents a Clean Operating Surface*, **Phase 1 only** (docs + shared
skill + safe REST helper + offline tests). No issue-tracker application, schema,
deployment, or source-writer change. No live tracker mutations and no
credential values.

Frozen contract:
`specs/codebase/systems/engineering/issue-lifecycle/agent-operating-surface.md`.
Grounded in the accepted F1 tracker REST surface.

### What ships

- **`specs/developing/debugging/issue-triage.md`** — human operating runbook,
  usable without any agent. Covers `/v1/ops` and source freshness; list vs
  cursor-based poll; claim / conflict / release / status-note / dedup / PR-link;
  per-source evidence paths (Sentry+E2B from the exact event key, support via
  `reportId`→S3 with authenticated AWS CLI, Grafana/CloudWatch from the stable
  rule UID, GitHub); credential references (never values); safe-note and
  private-evidence boundaries; expired/unavailable evidence; agent-credential
  rotation/revocation; and stopping without an orphaned claim. Routed from the
  debugging README.
- **`scripts/issues.py`** — the safe REST helper (canonical copy). Nine commands
  (`list poll get ops claim release patch dedup link-pr`) mapped exactly to the
  contract's routes. Fixed origin `https://issues.proliferate.com` with every
  other host rejected; `agentApiKey` fetched from `issue-tracker/app` by
  reference per invocation and never printed or persisted; bounded timeouts and
  bounded JSON stdout with diagnostics on stderr; nonzero exit on HTTP/protocol
  errors; explicit unique `X-Run-Id` required for every mutation; poll cursors
  passed through byte-for-byte and conflict/precondition bodies exposed; auth
  headers and secret-provider responses redacted in every error path.
- **`scripts/test_issues.py`** — hermetic offline tests (faked transport +
  faked credential; no live calls) for command→route/method mapping, host
  rejection, run-ID enforcement (fails closed before any secret fetch), cursor
  passthrough, conflict exposure with nonzero exit, and error redaction.

### Local-file components (outside this repo)

The shared agent skill is a local install, since the repo has no in-tree skills
convention:

- `~/.agents/skills/triage-production-issue/SKILL.md` (read-only-vs-mutation
  gate, claim-first discipline, exact-identity-only dedup, per-source recipes)
- `~/.agents/skills/triage-production-issue/scripts/issues.py` (copy of the
  canonical repo helper)
- `~/.claude/skills/triage-production-issue` → symlink to the above (verified
  resolving)

Codex discovers `~/.agents/skills` directly, so no `~/.codex` symlink is added
unless the fresh-Codex acceptance proves otherwise. Install paths are documented
in the runbook's *Shared skill* section.

### Deviations / disclosures

- No taxonomy deviation: `specs/developing/debugging/` still exists on `main`,
  so the runbook lands at the contract's stated path.
- The contract references `origin/main` at `66f45bfbe…`; this worktree is based
  on the current promotion commit `6ec21974` over `main` `22b6a211e`. The F1
  REST surface used for grounding is unchanged.
- P0 preconditions (node_repl MCP repair, provider-access preflight) are outside
  Phase 1 file scope and are not performed here.

### Phase 2 (not in this PR)

Fresh-agent acceptance — two genuinely fresh sessions (one Codex, one
Claude/Fable), six independent read investigations, the two controlled
`tbd → not_done` mutations, and the race / dedup / PR-link / auth fail-closed
proofs — is Phase 2 and is **gated on accepted F1**. It performs live tracker
mutations and is intentionally excluded here.

## Verification

- `python3 -m pytest scripts/test_issues.py` — 20 passed (hermetic).
- `python3 scripts/check_docs.py` — passed (218 Markdown files).
- `python3 scripts/check_max_lines.py` — passed.
- `node scripts/ci-cd/validate-pr-metadata.mjs` — title + labels + changed
  paths accepted (`release:docs`, `area:docs`).
- `issues.py` syntax parsed; Claude skill symlink resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
