### PR TITLE
feat(desktop): Cmd+F searches actual chat content, unified search overlay

### DIFF
--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 import { useContentSearchStore } from "@/stores/search/content-search-store";
+import { useChatTranscriptRow } from "@proliferate/product-ui/chat/transcript/ChatContentSearchContext";
 
 const CHAT_DIFF_PRE_STYLE = {
   color: "var(--diffs-fg)",
@@ -476,6 +477,13 @@ export function ChatDiffViewer({
     () => contentSearchUnitIdProp ?? `diff:${fallbackContentSearchUnitId}:${filePath ?? "inline"}`,
     [contentSearchUnitIdProp, fallbackContentSearchUnitId, filePath],
   );
+  // Interleave inline diff matches with the surrounding transcript-row prose
+  // matches: a diff sits just after its row's prose (rowIndex * 2 + 1). Outside
+  // a transcript row (no context) the unit stays unkeyed and sorts last.
+  const transcriptRow = useChatTranscriptRow();
+  const contentSearchRowOrderKey = transcriptRow
+    ? transcriptRow.rowIndex * 2 + 1
+    : undefined;
   const contentSearchMatchIds = useMemo(
     () => {
       const normalizedQuery = normalizeContentSearchQuery(contentSearchQuery);
@@ -542,15 +550,16 @@ export function ChatDiffViewer({
     registerContentSearchUnit({
       unitId: contentSearchUnitId,
       surface: "chat",
-      scope: "diffs",
       query: contentSearchQuery,
       matchIds: contentSearchMatchIds,
+      orderKey: contentSearchRowOrderKey,
     });
 
     return () => unregisterContentSearchUnit(contentSearchUnitId);
   }, [
     contentSearchMatchIds,
     contentSearchQuery,
+    contentSearchRowOrderKey,
     contentSearchUnitId,
     registerContentSearchUnit,
     unregisterContentSearchUnit,

--- a/apps/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/apps/desktop/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -14,6 +14,8 @@ import {
 } from "@proliferate/product-domain/chats/composer/prompt-display-parts";
 import type { PromptDraftAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
 import { tokenizeSerializedFileLinks } from "@/lib/domain/chat/composer/file-mention-links";
+import { useChatContentSearchPaint } from "@proliferate/product-ui/chat/transcript/ChatContentSearchContext";
+import { markSearchChildren } from "@proliferate/product-ui/chat/transcript/MarkdownContentSearchMarks";
 
 type PromptContentRendererVariant = "transcript" | "compact";
 type PromptContentRendererLayout = "stack" | "wrap" | "auto";
@@ -127,12 +129,23 @@ function PromptDisplayPartView({
 
 function FileLinkedText({ text }: { text: string }) {
   const tokens = tokenizeSerializedFileLinks(text);
+  // Chat content-search paint for user-message prose. Only applies inside a
+  // committed transcript turn row (not the composer or in-flight prompt rows,
+  // which the search index doesn't cover).
+  const paint = useChatContentSearchPaint();
+  const searchPaint = paint?.rowUnitId.startsWith("chatrow:turn:") ? paint : null;
 
   return (
     <div className="whitespace-pre-wrap break-words text-[length:var(--prose-text-size,var(--text-chat))] leading-[var(--prose-text-line-height,var(--text-chat--line-height))]">
       {tokens.map((token, index) => {
         if (token.type === "text") {
-          return <Fragment key={`text-${index}`}>{token.text}</Fragment>;
+          return (
+            <Fragment key={`text-${index}`}>
+              {searchPaint
+                ? markSearchChildren(token.text, searchPaint.query, searchPaint.rowUnitId)
+                : token.text}
+            </Fragment>
+          );
         }
         return (
           <FilePathLink key={`${token.path}-${index}`} rawPath={token.path}>

--- a/apps/desktop/src/components/workspace/chat/surface/SessionContentSearchOverlay.test.tsx
+++ b/apps/desktop/src/components/workspace/chat/surface/SessionContentSearchOverlay.test.tsx
@@ -10,7 +10,6 @@ function resetContentSearchStore() {
     open: false,
     query: "",
     surface: "chat",
-    scope: "diffs",
     activeMatchIndex: 0,
     activeMatchId: null,
     unitsById: {},
@@ -36,7 +35,6 @@ describe("SessionContentSearchOverlay", () => {
     useContentSearchStore.setState({
       open: true,
       surface: "file",
-      scope: "diffs",
     });
 
     render(

--- a/apps/desktop/src/components/workspace/chat/surface/SessionContentSearchOverlay.tsx
+++ b/apps/desktop/src/components/workspace/chat/surface/SessionContentSearchOverlay.tsx
@@ -81,13 +81,13 @@ export function SessionContentSearchOverlay({
     return null;
   }
 
-  const placeholder = surface === "file"
-    ? "Search file…"
-    : "Search diff…";
+  const placeholder = surface === "file" ? "Search file…" : "Search chat…";
   const inputLabel = surface === "file" ? "Find in file" : "Find in chat";
+  // The only surface difference is vertical placement: the file overlay sits
+  // below the viewer toolbar; the chat overlay hugs the top. Styling is
+  // otherwise the shared chat pill.
   const offsetClassName = surface === "file" ? "top-12" : "top-2";
   const resultRowColumnClass = "col-[1/3]";
-  const isFileSurface = surface === "file";
   const resultLabel = hasMatches
     ? `${activeMatchIndex + 1} of ${matchCount}`
     : "No results";
@@ -115,15 +115,15 @@ export function SessionContentSearchOverlay({
       data-content-search-overlay
       data-content-search-surface={surface}
     >
-      <div className={`pointer-events-auto grid max-w-[70vw] grid-cols-[minmax(0,1fr)_auto] overflow-hidden border-[0.5px] border-border bg-sidebar-background shadow-[0px_8px_16px_-4px_rgba(0,0,0,0.12)] ${isFileSurface ? "w-[300px] rounded-lg" : "w-[340px] rounded-[20px]"}`}>
-        <div className={`col-[1/2] row-[1] flex min-w-0 items-center gap-2 ${isFileSurface ? "h-7 pl-2.5" : "h-[44px] pl-4"}`}>
-          <Search className={`shrink-0 ${isFileSurface ? "size-4 text-muted-foreground" : "size-4 text-foreground"}`} />
+      <div className="pointer-events-auto grid max-w-[70vw] w-[340px] grid-cols-[minmax(0,1fr)_auto] overflow-hidden rounded-[20px] border-[0.5px] border-border bg-sidebar-background shadow-[0px_8px_16px_-4px_rgba(0,0,0,0.12)]">
+        <div className="col-[1/2] row-[1] flex h-[44px] min-w-0 items-center gap-2 pl-4">
+          <Search className="size-4 shrink-0 text-foreground" />
           <Input
             ref={inputRef}
             id="content-search-input"
             aria-label={inputLabel}
             placeholder={placeholder}
-            className={`min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 ${isFileSurface ? "h-5 text-[13px] leading-5" : "h-6 text-base leading-6"}`}
+            className="h-6 min-w-0 flex-1 rounded-none border-0 bg-transparent px-0 text-base leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0"
             type="text"
             value={query}
             onChange={(event: ChangeEvent<HTMLInputElement>) =>
@@ -134,7 +134,7 @@ export function SessionContentSearchOverlay({
         </div>
         {hasQuery && (
           <>
-            <div className={`${resultRowColumnClass} row-[2] flex min-w-0 items-center border-t border-border transition-[border-width,max-height,opacity,padding,translate] duration-200 ease-out max-h-9 translate-y-0 opacity-100 ${isFileSurface ? "px-2.5 py-1 text-[13px] leading-5" : "px-4 py-2 text-base leading-6"}`}>
+            <div className={`${resultRowColumnClass} row-[2] flex min-w-0 items-center border-t border-border px-4 py-2 text-base leading-6 transition-[border-width,max-height,opacity,padding,translate] duration-200 ease-out max-h-9 translate-y-0 opacity-100`}>
               <div className="flex items-center gap-3">
                 <SearchNavigationButton
                   label="Previous result"
@@ -149,13 +149,13 @@ export function SessionContentSearchOverlay({
                 />
               </div>
             </div>
-            <span className={`pointer-events-none ${resultRowColumnClass} row-[2] min-w-0 text-right text-muted-foreground transition-[max-height,opacity,padding,translate] duration-200 ease-out max-h-9 translate-y-0 opacity-100 ${isFileSurface ? "px-2.5 py-1 text-[13px] leading-5" : "px-4 py-2 text-base leading-6"}`}>
+            <span className={`pointer-events-none ${resultRowColumnClass} row-[2] min-w-0 px-4 py-2 text-right text-base leading-6 text-muted-foreground transition-[max-height,opacity,padding,translate] duration-200 ease-out max-h-9 translate-y-0 opacity-100`}>
               {resultLabel}
             </span>
           </>
         )}
-        <div className={`col-[2/3] row-[1] flex items-center ${isFileSurface ? "h-7 pr-2" : "h-[44px] pr-4"}`}>
-          <div className={`h-4 w-px bg-border ${isFileSurface ? "mx-1.5" : "mr-2 ml-2"}`} />
+        <div className="col-[2/3] row-[1] flex h-[44px] items-center pr-4">
+          <div className="mr-2 ml-2 h-4 w-px bg-border" />
           <Button
             type="button"
             variant="unstyled"

--- a/apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx
@@ -199,6 +199,13 @@ export function MessageList({
       chatRowKeyFromUnitId(target.rowUnitId),
     );
 
+    // First attempt synchronously — the target row is usually already mounted
+    // (marks exist), so the active highlight lands in the same tick. The rAF
+    // retries only cover the virtualized case where the row mounts after the
+    // scroll above.
+    if (scrollActiveChatRowMatchIntoView(target)) {
+      return;
+    }
     let frame = 0;
     let rafId = 0;
     const tick = () => {

--- a/apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/desktop/src/components/workspace/chat/transcript/MessageList.tsx
@@ -34,9 +34,17 @@ import {
   type ChatTranscriptGoalEventRenderInput,
   type ChatTranscriptPendingPromptRenderInput,
   type ChatTranscriptPendingStatusInput,
+  type ChatTranscriptScrollHandle,
   type ChatTranscriptTurnRowRenderInput,
   type ChatTranscriptTurnStatusInput,
 } from "@proliferate/product-ui/chat/transcript/ChatTranscriptView";
+import { useContentSearchStore } from "@/stores/search/content-search-store";
+import { useChatTranscriptContentSearch } from "@/hooks/chat/search/use-chat-transcript-content-search";
+import {
+  chatRowKeyFromUnitId,
+  parseChatRowMatchId,
+  scrollActiveChatRowMatchIntoView,
+} from "@/lib/domain/content-search/chat-row-match-jump";
 import type { ChatTranscriptState } from "@proliferate/product-domain/chats/transcript/chat-transcript-state";
 import { collectToolCallIdsWithProposedPlan } from "@proliferate/product-domain/chats/transcript/transcript-rendering";
 import {
@@ -151,6 +159,60 @@ export function MessageList({
   const effectiveTranscriptViewState = typingActive
     ? deferredTranscriptViewState
     : transcriptViewState;
+
+  // Chat content search (Cmd+F). The index hook owns match counts/navigation;
+  // the paint prop + scroll handle drive highlighting and jump-to-match. All of
+  // it is inert unless search is open on the chat surface.
+  const contentSearchOpen = useContentSearchStore((state) => state.open);
+  const contentSearchSurface = useContentSearchStore((state) => state.surface);
+  const contentSearchQuery = useContentSearchStore((state) => state.query);
+  const contentSearchActiveMatchId = useContentSearchStore((state) => state.activeMatchId);
+  const chatSearchActive = contentSearchOpen && contentSearchSurface === "chat";
+  const deferredContentSearchQuery = useDeferredValue(contentSearchQuery);
+  const transcriptScrollHandleRef = useRef<ChatTranscriptScrollHandle | null>(null);
+
+  useChatTranscriptContentSearch({
+    transcript,
+    activeSessionId,
+    optimisticPrompt,
+    outboxEntries,
+    goalEvents,
+  });
+
+  const contentSearchPaint = useMemo(
+    () =>
+      chatSearchActive && deferredContentSearchQuery.trim().length > 0
+        ? { query: deferredContentSearchQuery }
+        : null,
+    [chatSearchActive, deferredContentSearchQuery],
+  );
+
+  useEffect(() => {
+    if (!chatSearchActive) {
+      return;
+    }
+    const target = parseChatRowMatchId(contentSearchActiveMatchId);
+    if (!target) {
+      return;
+    }
+    transcriptScrollHandleRef.current?.scrollToRowKey(
+      chatRowKeyFromUnitId(target.rowUnitId),
+    );
+
+    let frame = 0;
+    let rafId = 0;
+    const tick = () => {
+      if (scrollActiveChatRowMatchIntoView(target)) {
+        return;
+      }
+      frame += 1;
+      if (frame <= 10) {
+        rafId = window.requestAnimationFrame(tick);
+      }
+    };
+    rafId = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(rafId);
+  }, [chatSearchActive, contentSearchActiveMatchId]);
 
   // Transcript-wide ExitPlanMode suppression index (the plan-doubling fix):
   // a proposed_plan item can land in a different turn than the ExitPlanMode
@@ -294,6 +356,8 @@ export function MessageList({
                   renderGoalEventRow={renderGoalEventRow}
                   renderPendingPromptTrailingStatus={renderPendingPromptTrailingStatusRow}
                   renderTurnTrailingStatus={renderTurnTrailingStatusRow}
+                  contentSearch={contentSearchPaint}
+                  scrollHandleRef={transcriptScrollHandleRef}
                 />
               </DebugProfiler>
             </ProposedPlanToolCallIdsProvider>

--- a/apps/desktop/src/components/workspace/files/FileEditorView.test.tsx
+++ b/apps/desktop/src/components/workspace/files/FileEditorView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { createElement } from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fileViewerTarget,
@@ -478,5 +478,38 @@ describe("FileEditorView", () => {
 
     expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("source");
     expect(useContentSearchStore.getState().surface).toBe("file");
+  });
+
+  it("leaves the rich preview when file search opens via the shortcut path", () => {
+    const target = fileViewerTarget("README.md");
+    const targetKey = viewerTargetKey(target);
+    useWorkspaceViewerTabsStore.setState({
+      materializedWorkspaceId: "workspace-1",
+    });
+    useWorkspaceViewerTabsStore.getState().openTarget(target);
+    readWorkspaceFileQuery.mockReturnValue({
+      data: {
+        content: "# Hello\n",
+        isText: true,
+        path: "README.md",
+        sizeBytes: 8,
+        tooLarge: false,
+        versionToken: "v1",
+      },
+      error: null,
+      isLoading: false,
+    });
+    render(createElement(FileEditorView, {
+      filePath: "README.md",
+      targetKey,
+    }));
+
+    // Markdown defaults to the rendered view; Cmd+F opens search through the
+    // store without going through the toolbar handler.
+    act(() => {
+      useContentSearchStore.getState().openSearch("file");
+    });
+
+    expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("source");
   });
 });

--- a/apps/desktop/src/components/workspace/files/FileEditorView.test.tsx
+++ b/apps/desktop/src/components/workspace/files/FileEditorView.test.tsx
@@ -160,7 +160,6 @@ describe("FileEditorView", () => {
       open: false,
       query: "",
       surface: "chat",
-      scope: "diffs",
       activeMatchIndex: 0,
       activeMatchId: null,
       unitsById: {},
@@ -406,7 +405,6 @@ describe("FileEditorView", () => {
     expect(screen.queryByLabelText("Search files")).toBeNull();
     fireEvent.click(screen.getByLabelText("Find in file"));
     expect(useContentSearchStore.getState().open).toBe(true);
-    expect(useContentSearchStore.getState().scope).toBe("diffs");
     expect(useContentSearchStore.getState().surface).toBe("file");
     expect(container.querySelector('[data-content-search-surface="file"]')).toBeTruthy();
     expect(screen.getByPlaceholderText("Search file…")).toBeTruthy();

--- a/apps/desktop/src/components/workspace/files/FileEditorView.tsx
+++ b/apps/desktop/src/components/workspace/files/FileEditorView.tsx
@@ -1,4 +1,6 @@
 import {
+  useEffect,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -103,6 +105,25 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
     void openFile(path);
   };
   const canFindInFile = !activeDiffTarget && Boolean(read?.isText && !read.tooLarge);
+
+  // Marks only paint in source view, so entering file search must leave the
+  // rich preview — from every entry point (toolbar icon, Cmd+F shortcut).
+  // Only on the open transition: toggling rich preview back on mid-search is
+  // an explicit user choice we don't fight.
+  const searchOpen = useContentSearchStore((s) => s.open);
+  const searchSurface = useContentSearchStore((s) => s.surface);
+  const fileSearchActive = searchOpen && searchSurface === "file";
+  const prevFileSearchActiveRef = useRef(fileSearchActive);
+  useEffect(() => {
+    const activated = fileSearchActive && !prevFileSearchActiveRef.current;
+    prevFileSearchActiveRef.current = fileSearchActive;
+    if (!activated || !canFindInFile) {
+      return;
+    }
+    if (normalizedEffectiveMode === "rendered") {
+      setTargetMode(targetKey, "source");
+    }
+  }, [fileSearchActive, canFindInFile, normalizedEffectiveMode, setTargetMode, targetKey]);
 
   const renderPaneContent = (content: ReactNode) => (
     <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">

--- a/apps/desktop/src/components/workspace/files/FileEditorView.tsx
+++ b/apps/desktop/src/components/workspace/files/FileEditorView.tsx
@@ -82,7 +82,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
       setTargetMode(targetKey, "source");
     }
 
-    openContentSearch("diffs", "file");
+    openContentSearch("file");
   };
   const toggleRichPreview = () => {
     setTargetMode(

--- a/apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
+++ b/apps/desktop/src/components/workspace/files/viewer/FileSourceView.tsx
@@ -153,7 +153,6 @@ export function FileSourceView({
     registerContentSearchUnit({
       unitId: contentSearchUnitId,
       surface: "file",
-      scope: "diffs",
       query: contentSearchQuery,
       matchIds: contentSearchMatchIds,
     });

--- a/apps/desktop/src/hooks/chat/search/use-chat-transcript-content-search.test.ts
+++ b/apps/desktop/src/hooks/chat/search/use-chat-transcript-content-search.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import { createTranscriptState, type TranscriptState } from "@anyharness/sdk";
+import {
+  selectVisibleContentSearchMatchIds,
+  useContentSearchStore,
+} from "@/stores/search/content-search-store";
+import { useChatTranscriptContentSearch } from "./use-chat-transcript-content-search";
+
+function resetStore() {
+  useContentSearchStore.setState({
+    open: false,
+    query: "",
+    surface: "chat",
+    activeMatchIndex: 0,
+    activeMatchId: null,
+    unitsById: {},
+    nextUnitOrder: 0,
+  });
+}
+
+function transcriptWithAssistantProse(text: string): TranscriptState {
+  const transcript = createTranscriptState("session-1");
+  transcript.turnOrder.push("turn-0");
+  transcript.turnsById["turn-0"] = {
+    turnId: "turn-0",
+    itemOrder: ["item-0"],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:00:01.000Z",
+    stopReason: "stop",
+    fileBadges: [],
+  };
+  transcript.itemsById["item-0"] = {
+    kind: "assistant_prose",
+    itemId: "item-0",
+    turnId: "turn-0",
+    status: "completed",
+    sourceAgentKind: "claude",
+    messageId: null,
+    title: null,
+    nativeToolName: null,
+    parentToolCallId: null,
+    contentParts: [],
+    timestamp: "2026-01-01T00:00:00.000Z",
+    startedSeq: 1,
+    lastUpdatedSeq: 1,
+    completedSeq: 1,
+    completedAt: "2026-01-01T00:00:00.000Z",
+    text,
+    isStreaming: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  return transcript;
+}
+
+function renderIndex(transcript: TranscriptState) {
+  return renderHook(() =>
+    useChatTranscriptContentSearch({
+      transcript,
+      activeSessionId: "session-1",
+      optimisticPrompt: null,
+      outboxEntries: [],
+      goalEvents: [],
+    }),
+  );
+}
+
+describe("useChatTranscriptContentSearch", () => {
+  beforeEach(resetStore);
+  afterEach(() => {
+    cleanup();
+    resetStore();
+  });
+
+  it("registers a per-row unit with one match id per occurrence", () => {
+    useContentSearchStore.setState({ open: true, surface: "chat", query: "foo" });
+    const transcript = transcriptWithAssistantProse("foo bar **foo** baz foo");
+    renderIndex(transcript);
+
+    expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([
+      "chatrow:turn:turn-0:block:content:0",
+      "chatrow:turn:turn-0:block:content:1",
+      "chatrow:turn:turn-0:block:content:2",
+    ]);
+  });
+
+  it("stays inert while search is closed", () => {
+    const transcript = transcriptWithAssistantProse("foo foo");
+    renderIndex(transcript);
+    expect(useContentSearchStore.getState().unitsById).toEqual({});
+  });
+
+  it("stays inert on the file surface", () => {
+    useContentSearchStore.setState({ open: true, surface: "file", query: "foo" });
+    const transcript = transcriptWithAssistantProse("foo foo");
+    renderIndex(transcript);
+    expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([]);
+  });
+
+  it("unregisters units on unmount", () => {
+    useContentSearchStore.setState({ open: true, surface: "chat", query: "foo" });
+    const transcript = transcriptWithAssistantProse("foo");
+    const { unmount } = renderIndex(transcript);
+    expect(Object.keys(useContentSearchStore.getState().unitsById)).toHaveLength(1);
+    unmount();
+    expect(useContentSearchStore.getState().unitsById).toEqual({});
+  });
+});

--- a/apps/desktop/src/hooks/chat/search/use-chat-transcript-content-search.ts
+++ b/apps/desktop/src/hooks/chat/search/use-chat-transcript-content-search.ts
@@ -1,0 +1,156 @@
+import { useDeferredValue, useEffect, useMemo, useRef } from "react";
+import type {
+  PendingPromptEntry,
+  TranscriptState,
+} from "@anyharness/sdk";
+import type { PromptOutboxEntry } from "@proliferate/product-domain/sessions/intents/session-intent-model";
+import type { GoalTranscriptEvent } from "@proliferate/product-domain/activity/goal-transcript-events";
+import {
+  buildTranscriptRowModel,
+  createTranscriptRowModelCache,
+  type TranscriptRowModelCache,
+} from "@proliferate/product-domain/chats/transcript/transcript-row-model";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import { turnHasAssistantRenderableTranscriptContent } from "@proliferate/product-domain/chats/pending-prompts/pending-prompts";
+import {
+  findContentSearchMatches,
+  normalizeContentSearchQuery,
+} from "@/lib/domain/content-search/content-search";
+import { extractTranscriptRowProseSegments } from "@/lib/domain/content-search/transcript-search-text";
+import { useContentSearchStore } from "@/stores/search/content-search-store";
+
+interface ChatTranscriptContentSearchInput {
+  transcript: TranscriptState;
+  activeSessionId: string;
+  optimisticPrompt: PendingPromptEntry | null;
+  outboxEntries: readonly PromptOutboxEntry[];
+  goalEvents: readonly GoalTranscriptEvent[];
+}
+
+interface IndexedUnit {
+  unitId: string;
+  matchIds: string[];
+  orderKey: number;
+}
+
+const EMPTY_ROWS: readonly TranscriptVirtualRow[] = [];
+const EMPTY_UNITS: readonly IndexedUnit[] = [];
+
+// Row object -> its extracted prose segments. Rows from the row-model cache are
+// referentially stable while their content is unchanged, so a streaming update
+// only recomputes the rows that actually changed.
+const rowSegmentCache = new WeakMap<TranscriptVirtualRow, string[]>();
+
+/**
+ * Data-level content-search index for the chat surface: the authoritative
+ * source of match counts and navigation order (the DOM paint layer is
+ * best-effort). Registers one store unit per transcript row that contains
+ * matches, keyed `chatrow:<rowKey>` so the jump-to-match layer can recover the
+ * row from an active match id. Entirely inert unless chat search is open with a
+ * non-empty query. See specs/codebase/features/content-search.md.
+ */
+export function useChatTranscriptContentSearch({
+  transcript,
+  activeSessionId,
+  optimisticPrompt,
+  outboxEntries,
+  goalEvents,
+}: ChatTranscriptContentSearchInput): void {
+  const open = useContentSearchStore((state) => state.open);
+  const surface = useContentSearchStore((state) => state.surface);
+  const rawQuery = useContentSearchStore((state) => state.query);
+  const registerUnit = useContentSearchStore((state) => state.registerUnit);
+  const unregisterUnit = useContentSearchStore((state) => state.unregisterUnit);
+
+  const deferredQuery = useDeferredValue(rawQuery);
+  const query = normalizeContentSearchQuery(deferredQuery);
+  const shouldIndex = open && surface === "chat" && query.length > 0;
+
+  const rowCacheRef = useRef<TranscriptRowModelCache>(createTranscriptRowModelCache());
+
+  const rows = useMemo<readonly TranscriptVirtualRow[]>(() => {
+    if (!shouldIndex) {
+      return EMPTY_ROWS;
+    }
+    const latestTurnId = transcript.turnOrder[transcript.turnOrder.length - 1] ?? null;
+    const latestTurn = latestTurnId ? transcript.turnsById[latestTurnId] ?? null : null;
+    return buildTranscriptRowModel(
+      {
+        activeSessionId,
+        transcript,
+        visibleOptimisticPrompt: optimisticPrompt,
+        visibleOutboxEntries: outboxEntries,
+        latestTurnId,
+        latestTurnHasAssistantRenderableContent:
+          turnHasAssistantRenderableTranscriptContent(latestTurn, transcript),
+        goalEvents,
+      },
+      rowCacheRef.current,
+    );
+  }, [shouldIndex, transcript, activeSessionId, optimisticPrompt, outboxEntries, goalEvents]);
+
+  const units = useMemo<readonly IndexedUnit[]>(() => {
+    if (!shouldIndex) {
+      return EMPTY_UNITS;
+    }
+    const result: IndexedUnit[] = [];
+    rows.forEach((row, rowIndex) => {
+      const segments = getRowSegments(row, transcript);
+      let count = 0;
+      for (const segment of segments) {
+        count += findContentSearchMatches(segment, query).length;
+      }
+      if (count === 0) {
+        return;
+      }
+      const unitId = `chatrow:${row.key}`;
+      result.push({
+        unitId,
+        matchIds: Array.from({ length: count }, (_, index) => `${unitId}:${index}`),
+        orderKey: rowIndex * 2,
+      });
+    });
+    return result;
+  }, [shouldIndex, rows, transcript, query]);
+
+  const registeredRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const nextIds = new Set(units.map((unit) => unit.unitId));
+    for (const unitId of registeredRef.current) {
+      if (!nextIds.has(unitId)) {
+        unregisterUnit(unitId);
+      }
+    }
+    for (const unit of units) {
+      registerUnit({
+        unitId: unit.unitId,
+        surface: "chat",
+        query,
+        matchIds: unit.matchIds,
+        orderKey: unit.orderKey,
+      });
+    }
+    registeredRef.current = nextIds;
+  }, [units, query, registerUnit, unregisterUnit]);
+
+  useEffect(
+    () => () => {
+      for (const unitId of registeredRef.current) {
+        unregisterUnit(unitId);
+      }
+      registeredRef.current = new Set();
+    },
+    [unregisterUnit],
+  );
+}
+
+function getRowSegments(row: TranscriptVirtualRow, transcript: TranscriptState): string[] {
+  const cached = rowSegmentCache.get(row);
+  if (cached) {
+    return cached;
+  }
+  const segments = extractTranscriptRowProseSegments(row, transcript);
+  rowSegmentCache.set(row, segments);
+  return segments;
+}

--- a/apps/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx
+++ b/apps/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.test.tsx
@@ -54,7 +54,6 @@ describe("useWorkspaceContentShortcuts", () => {
       open: false,
       query: "",
       surface: "chat",
-      scope: "diffs",
       activeMatchIndex: 0,
       activeMatchId: null,
       unitsById: {},
@@ -220,7 +219,6 @@ describe("useWorkspaceContentShortcuts", () => {
     expect(runShortcutHandler("workspace.find-content", { source: "keyboard" })).toBe(true);
     expect(useContentSearchStore.getState().open).toBe(true);
     expect(useContentSearchStore.getState().surface).toBe("chat");
-    expect(useContentSearchStore.getState().scope).toBe("diffs");
   });
 
   it("routes content search to the file viewer when file viewer owns focus", () => {
@@ -241,7 +239,6 @@ describe("useWorkspaceContentShortcuts", () => {
     expect(runShortcutHandler("workspace.find-content", { source: "keyboard" })).toBe(true);
     expect(useContentSearchStore.getState().open).toBe(true);
     expect(useContentSearchStore.getState().surface).toBe("file");
-    expect(useContentSearchStore.getState().scope).toBe("diffs");
   });
 
   it("declines content search when the terminal owns focus", () => {

--- a/apps/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts
+++ b/apps/desktop/src/hooks/workspaces/ui/use-workspace-content-shortcuts.ts
@@ -93,7 +93,7 @@ export function useWorkspaceContentShortcuts(
       return false;
     }
 
-    openContentSearch("diffs", surface);
+    openContentSearch(surface);
     return true;
   }, { enabled });
 }

--- a/apps/desktop/src/lib/domain/content-search/chat-row-match-jump.test.ts
+++ b/apps/desktop/src/lib/domain/content-search/chat-row-match-jump.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  chatRowKeyFromUnitId,
+  parseChatRowMatchId,
+  scrollActiveChatRowMatchIntoView,
+} from "./chat-row-match-jump";
+
+describe("parseChatRowMatchId", () => {
+  it("splits the trailing ordinal off a colon-heavy row key", () => {
+    expect(parseChatRowMatchId("chatrow:turn:abc:block:content:2")).toEqual({
+      rowUnitId: "chatrow:turn:abc:block:content",
+      ordinal: 2,
+    });
+  });
+
+  it("returns null for non-chat-row ids and malformed input", () => {
+    expect(parseChatRowMatchId(null)).toBeNull();
+    expect(parseChatRowMatchId("diff:foo:line:0:1")).toBeNull();
+    expect(parseChatRowMatchId("chatrow:turn:abc:block:content:x")).toBeNull();
+  });
+});
+
+describe("chatRowKeyFromUnitId", () => {
+  it("strips the chatrow prefix", () => {
+    expect(chatRowKeyFromUnitId("chatrow:turn:abc:block:content")).toBe(
+      "turn:abc:block:content",
+    );
+  });
+});
+
+describe("scrollActiveChatRowMatchIntoView", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function seedMarks(rowUnitId: string, count: number) {
+    const container = document.createElement("div");
+    for (let index = 0; index < count; index += 1) {
+      const mark = document.createElement("mark");
+      mark.className = "codex-thread-find-match";
+      mark.setAttribute("data-content-search-row", rowUnitId);
+      mark.scrollIntoView = () => {};
+      container.append(mark);
+    }
+    document.body.append(container);
+    return container;
+  }
+
+  it("activates the mark at the given ordinal and clears the previous active", () => {
+    const rowUnitId = "chatrow:turn:abc:block:content";
+    const container = seedMarks(rowUnitId, 3);
+    const marks = container.querySelectorAll("mark");
+    marks[0].classList.add("codex-thread-find-active");
+
+    expect(scrollActiveChatRowMatchIntoView({ rowUnitId, ordinal: 2 })).toBe(true);
+
+    expect(marks[0].classList.contains("codex-thread-find-active")).toBe(false);
+    expect(marks[2].classList.contains("codex-thread-find-active")).toBe(true);
+  });
+
+  it("clamps to the last painted mark when fewer are painted than counted", () => {
+    const rowUnitId = "chatrow:turn:abc:block:content";
+    const container = seedMarks(rowUnitId, 2);
+    const marks = container.querySelectorAll("mark");
+
+    expect(scrollActiveChatRowMatchIntoView({ rowUnitId, ordinal: 5 })).toBe(true);
+    expect(marks[1].classList.contains("codex-thread-find-active")).toBe(true);
+  });
+
+  it("returns false when the row has no painted marks yet", () => {
+    expect(
+      scrollActiveChatRowMatchIntoView({
+        rowUnitId: "chatrow:turn:missing:block:content",
+        ordinal: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/domain/content-search/chat-row-match-jump.ts
+++ b/apps/desktop/src/lib/domain/content-search/chat-row-match-jump.ts
@@ -1,0 +1,68 @@
+const CHAT_ROW_ID_PREFIX = "chatrow:";
+
+export interface ChatRowMatchTarget {
+  rowUnitId: string;
+  ordinal: number;
+}
+
+/**
+ * Parses a chat-row content-search match id (`chatrow:<rowKey>:<ordinal>`)
+ * into its row unit id and match ordinal. Row keys themselves contain colons
+ * (`turn:<id>:block:<key>`), so only the trailing numeric segment is the
+ * ordinal. Returns null for ids from other surfaces (diff/file marks).
+ */
+export function parseChatRowMatchId(matchId: string | null): ChatRowMatchTarget | null {
+  if (!matchId || !matchId.startsWith(CHAT_ROW_ID_PREFIX)) {
+    return null;
+  }
+  const lastColon = matchId.lastIndexOf(":");
+  if (lastColon <= CHAT_ROW_ID_PREFIX.length - 1) {
+    return null;
+  }
+  const ordinal = Number(matchId.slice(lastColon + 1));
+  if (!Number.isInteger(ordinal) || ordinal < 0) {
+    return null;
+  }
+  return { rowUnitId: matchId.slice(0, lastColon), ordinal };
+}
+
+export function chatRowKeyFromUnitId(rowUnitId: string): string {
+  return rowUnitId.startsWith(CHAT_ROW_ID_PREFIX)
+    ? rowUnitId.slice(CHAT_ROW_ID_PREFIX.length)
+    : rowUnitId;
+}
+
+/**
+ * Marks the active chat-row match in the DOM and scrolls it into view. The
+ * painted marks (document order guaranteed by querySelectorAll) are selected by
+ * ordinal, clamped to the last painted mark when fewer are painted than the
+ * data index counted (a benign extraction/render mismatch). Only chat-row marks
+ * are touched — diff/file marks manage their active class through React.
+ * Returns true once a mark was activated.
+ */
+export function scrollActiveChatRowMatchIntoView(target: ChatRowMatchTarget): boolean {
+  const selector = `mark[data-content-search-row="${cssEscape(target.rowUnitId)}"]`;
+  const marks = document.querySelectorAll<HTMLElement>(selector);
+  if (marks.length === 0) {
+    return false;
+  }
+
+  for (const active of document.querySelectorAll<HTMLElement>(
+    "mark[data-content-search-row].codex-thread-find-active",
+  )) {
+    active.classList.remove("codex-thread-find-active");
+  }
+
+  const index = Math.min(target.ordinal, marks.length - 1);
+  const mark = marks[index];
+  mark.classList.add("codex-thread-find-active");
+  mark.scrollIntoView({ block: "center", inline: "nearest" });
+  return true;
+}
+
+function cssEscape(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replace(/["\\]/g, "\\$&");
+}

--- a/apps/desktop/src/lib/domain/content-search/transcript-search-text.test.ts
+++ b/apps/desktop/src/lib/domain/content-search/transcript-search-text.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdownToSearchText } from "./transcript-search-text";
+
+describe("stripMarkdownToSearchText", () => {
+  it("returns empty for empty input", () => {
+    expect(stripMarkdownToSearchText("")).toBe("");
+  });
+
+  it("drops emphasis and strong markers but keeps the text", () => {
+    expect(stripMarkdownToSearchText("This is **bold** and *italic* text")).toBe(
+      "This is bold and italic text",
+    );
+    expect(stripMarkdownToSearchText("__strong__ and _em_")).toBe("strong and em");
+  });
+
+  it("keeps inline code content without backticks", () => {
+    expect(stripMarkdownToSearchText("run `npm test` now")).toBe("run npm test now");
+  });
+
+  it("keeps link and image labels and drops the target", () => {
+    expect(stripMarkdownToSearchText("see [the docs](https://example.com)")).toBe(
+      "see the docs",
+    );
+    expect(stripMarkdownToSearchText("![alt text](img.png)")).toBe("alt text");
+  });
+
+  it("strips heading, blockquote, and list markers", () => {
+    expect(stripMarkdownToSearchText("# Heading")).toBe("Heading");
+    expect(stripMarkdownToSearchText("> quoted line")).toBe("quoted line");
+    expect(stripMarkdownToSearchText("- bullet item")).toBe("bullet item");
+    expect(stripMarkdownToSearchText("1. first item")).toBe("first item");
+  });
+
+  it("keeps fenced code body but drops the fence markers", () => {
+    const input = ["intro", "```ts", "const x = 1;", "```", "outro"].join("\n");
+    expect(stripMarkdownToSearchText(input)).toBe(
+      ["intro", "const x = 1;", "outro"].join("\n"),
+    );
+  });
+
+  it("does not treat emphasis markers inside fenced code as markdown", () => {
+    const input = ["```", "a = b * c * d", "```"].join("\n");
+    expect(stripMarkdownToSearchText(input)).toBe("a = b * c * d");
+  });
+
+  it("is deterministic across repeated calls", () => {
+    const input = "**a** [b](c) `d`";
+    expect(stripMarkdownToSearchText(input)).toBe(stripMarkdownToSearchText(input));
+  });
+});

--- a/apps/desktop/src/lib/domain/content-search/transcript-search-text.ts
+++ b/apps/desktop/src/lib/domain/content-search/transcript-search-text.ts
@@ -1,0 +1,103 @@
+import type { TranscriptState } from "@anyharness/sdk";
+import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+
+// Deterministic, cheap markdown-to-plain-text reduction used to COUNT content
+// search matches in transcript prose. It approximates the text a reader sees
+// once markdown is rendered: syntax markers are dropped, link/image labels are
+// kept (URLs dropped), and fenced/inline code content is preserved. It does
+// not need to match the painted DOM exactly — the paint layer highlights
+// best-effort and the active-match jump clamps to whatever marks exist (see
+// specs/codebase/features/content-search.md).
+
+const FENCE_LINE = /^\s*(`{3,}|~{3,}).*$/;
+
+export function stripMarkdownToSearchText(markdown: string): string {
+  if (!markdown) {
+    return "";
+  }
+
+  const lines = markdown.split("\n");
+  const out: string[] = [];
+  let inFence = false;
+
+  for (const line of lines) {
+    if (FENCE_LINE.test(line)) {
+      // Drop the fence marker line itself; keep the code body between fences.
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    out.push(stripInlineMarkdown(stripBlockPrefix(line)));
+  }
+
+  return out.join("\n");
+}
+
+// Removes leading block markers (heading #, blockquote >, list bullets and
+// ordered markers) so their punctuation isn't matched as content.
+function stripBlockPrefix(line: string): string {
+  return line
+    .replace(/^\s*#{1,6}\s+/, "")
+    .replace(/^\s*>\s?/, "")
+    .replace(/^\s*[-*+]\s+/, "")
+    .replace(/^\s*\d+[.)]\s+/, "");
+}
+
+/**
+ * Extracts the searchable prose segments of a transcript row: user-message
+ * text (plain) and assistant prose (markdown-stripped). Tool-call rows, their
+ * (collapsed) output bodies, reasoning, and plan cards are intentionally out of
+ * scope — they are not part of the conversation prose the paint layer
+ * highlights. Returns one string per prose item so match counting mirrors the
+ * per-message paint. See specs/codebase/features/content-search.md.
+ */
+export function extractTranscriptRowProseSegments(
+  row: TranscriptVirtualRow,
+  transcript: TranscriptState,
+): string[] {
+  if (row.kind !== "turn") {
+    return [];
+  }
+
+  const segments: string[] = [];
+  for (const block of row.renderPresentation.displayBlocks) {
+    if (block.kind !== "item") {
+      // Tool blocks (collapsed_actions / inline_tools / inline_tool /
+      // subagent_creations) are out of scope.
+      continue;
+    }
+    const item = transcript.itemsById[block.itemId];
+    if (!item) {
+      continue;
+    }
+    if (item.kind === "user_message") {
+      const text = item.text.trim();
+      if (text) {
+        segments.push(text);
+      }
+    } else if (item.kind === "assistant_prose") {
+      const text = stripMarkdownToSearchText(item.text).trim();
+      if (text) {
+        segments.push(text);
+      }
+    }
+  }
+  return segments;
+}
+
+function stripInlineMarkdown(text: string): string {
+  return text
+    // Images and links: keep the label, drop the target.
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    // Inline code: keep the content, drop the backticks.
+    .replace(/`([^`]*)`/g, "$1")
+    // Emphasis / strong markers.
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    // Strikethrough.
+    .replace(/~~(.*?)~~/g, "$1");
+}

--- a/apps/desktop/src/stores/search/content-search-store.test.ts
+++ b/apps/desktop/src/stores/search/content-search-store.test.ts
@@ -9,7 +9,6 @@ function resetStore() {
     open: false,
     query: "",
     surface: "chat",
-    scope: "diffs",
     activeMatchIndex: 0,
     activeMatchId: null,
     unitsById: {},
@@ -20,32 +19,72 @@ function resetStore() {
 describe("content search store", () => {
   afterEach(resetStore);
 
-  it("filters visible matches by normalized query and active scope", () => {
+  it("filters visible matches by normalized query and active surface", () => {
     resetStore();
     useContentSearchStore.getState().setQuery("  foo  ");
     useContentSearchStore.getState().registerUnit({
-      unitId: "diff-a",
+      unitId: "chat-diff",
       surface: "chat",
-      scope: "diffs",
       query: "foo",
-      matchIds: ["diff-a:0", "diff-a:1"],
+      matchIds: ["chat-diff:0", "chat-diff:1"],
     });
     useContentSearchStore.getState().registerUnit({
-      unitId: "chat-a",
-      surface: "chat",
-      scope: "chat",
+      unitId: "file-source",
+      surface: "file",
       query: "foo",
-      matchIds: ["chat-a:0"],
+      matchIds: ["file-source:0"],
     });
 
     expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([
-      "diff-a:0",
-      "diff-a:1",
+      "chat-diff:0",
+      "chat-diff:1",
     ]);
 
-    useContentSearchStore.getState().setScope("chat");
+    useContentSearchStore.getState().openSearch("file");
+    expect(useContentSearchStore.getState().surface).toBe("file");
     expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([
-      "chat-a:0",
+      "file-source:0",
+    ]);
+  });
+
+  it("orders keyed units by orderKey ascending and unkeyed units last", () => {
+    resetStore();
+    useContentSearchStore.getState().setQuery("foo");
+    // Register out of visual order to prove sorting is by orderKey, not
+    // registration order.
+    useContentSearchStore.getState().registerUnit({
+      unitId: "unkeyed-diff",
+      surface: "chat",
+      query: "foo",
+      matchIds: ["unkeyed-diff:0"],
+    });
+    useContentSearchStore.getState().registerUnit({
+      unitId: "row-2",
+      surface: "chat",
+      query: "foo",
+      matchIds: ["row-2:0"],
+      orderKey: 4,
+    });
+    useContentSearchStore.getState().registerUnit({
+      unitId: "row-0",
+      surface: "chat",
+      query: "foo",
+      matchIds: ["row-0:0"],
+      orderKey: 0,
+    });
+    useContentSearchStore.getState().registerUnit({
+      unitId: "row-0-diff",
+      surface: "chat",
+      query: "foo",
+      matchIds: ["row-0-diff:0"],
+      orderKey: 1,
+    });
+
+    expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([
+      "row-0:0",
+      "row-0-diff:0",
+      "row-2:0",
+      "unkeyed-diff:0",
     ]);
   });
 
@@ -53,48 +92,47 @@ describe("content search store", () => {
     resetStore();
     useContentSearchStore.getState().setQuery("foo");
     useContentSearchStore.getState().registerUnit({
-      unitId: "diff-a",
+      unitId: "chat-a",
       surface: "chat",
-      scope: "diffs",
       query: "foo",
-      matchIds: ["diff-a:0", "diff-a:1"],
+      matchIds: ["chat-a:0", "chat-a:1"],
+      orderKey: 0,
     });
 
-    expect(useContentSearchStore.getState().activeMatchId).toBe("diff-a:0");
+    expect(useContentSearchStore.getState().activeMatchId).toBe("chat-a:0");
 
     useContentSearchStore.getState().goToNextMatch();
-    expect(useContentSearchStore.getState().activeMatchId).toBe("diff-a:1");
+    expect(useContentSearchStore.getState().activeMatchId).toBe("chat-a:1");
 
     useContentSearchStore.getState().goToNextMatch();
-    expect(useContentSearchStore.getState().activeMatchId).toBe("diff-a:0");
+    expect(useContentSearchStore.getState().activeMatchId).toBe("chat-a:0");
 
     useContentSearchStore.getState().goToPreviousMatch();
-    expect(useContentSearchStore.getState().activeMatchId).toBe("diff-a:1");
+    expect(useContentSearchStore.getState().activeMatchId).toBe("chat-a:1");
   });
 
   it("keeps chat and file search surfaces isolated", () => {
     resetStore();
     useContentSearchStore.getState().setQuery("foo");
     useContentSearchStore.getState().registerUnit({
-      unitId: "chat-diff",
+      unitId: "chat-row",
       surface: "chat",
-      scope: "diffs",
       query: "foo",
-      matchIds: ["chat-diff:0"],
+      matchIds: ["chat-row:0"],
+      orderKey: 0,
     });
     useContentSearchStore.getState().registerUnit({
       unitId: "file-source",
       surface: "file",
-      scope: "diffs",
       query: "foo",
       matchIds: ["file-source:0"],
     });
 
     expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([
-      "chat-diff:0",
+      "chat-row:0",
     ]);
 
-    useContentSearchStore.getState().openSearch("diffs", "file");
+    useContentSearchStore.getState().openSearch("file");
     expect(useContentSearchStore.getState().surface).toBe("file");
     expect(selectVisibleContentSearchMatchIds(useContentSearchStore.getState())).toEqual([
       "file-source:0",

--- a/apps/desktop/src/stores/search/content-search-store.ts
+++ b/apps/desktop/src/stores/search/content-search-store.ts
@@ -1,39 +1,36 @@
 import { create } from "zustand";
 import { normalizeContentSearchQuery } from "@/lib/domain/content-search/content-search";
 
-export type ContentSearchScope = "chat" | "diffs";
 export type ContentSearchSurface = "chat" | "file";
 
 export interface ContentSearchUnitRegistration {
   unitId: string;
   surface?: ContentSearchSurface;
-  scope: ContentSearchScope;
   query: string;
   matchIds: readonly string[];
+  orderKey?: number;
 }
 
 interface ContentSearchUnit {
   unitId: string;
   surface: ContentSearchSurface;
-  scope: ContentSearchScope;
   query: string;
   matchIds: string[];
   order: number;
+  orderKey: number | null;
 }
 
 interface ContentSearchState {
   open: boolean;
   query: string;
   surface: ContentSearchSurface;
-  scope: ContentSearchScope;
   activeMatchIndex: number;
   activeMatchId: string | null;
   unitsById: Record<string, ContentSearchUnit>;
   nextUnitOrder: number;
-  openSearch: (scope?: ContentSearchScope, surface?: ContentSearchSurface) => void;
+  openSearch: (surface?: ContentSearchSurface) => void;
   closeSearch: () => void;
   setQuery: (query: string) => void;
-  setScope: (scope: ContentSearchScope) => void;
   goToNextMatch: () => void;
   goToPreviousMatch: () => void;
   registerUnit: (registration: ContentSearchUnitRegistration) => void;
@@ -44,18 +41,16 @@ export const useContentSearchStore = create<ContentSearchState>((set) => ({
   open: false,
   query: "",
   surface: "chat",
-  scope: "diffs",
   activeMatchIndex: 0,
   activeMatchId: null,
   unitsById: {},
   nextUnitOrder: 0,
 
-  openSearch: (scope, surface = "chat") => {
+  openSearch: (surface = "chat") => {
     set((state) => resolveActiveMatch({
       ...state,
       open: true,
       surface,
-      scope: scope ?? state.scope,
     }, 0));
   },
 
@@ -67,13 +62,6 @@ export const useContentSearchStore = create<ContentSearchState>((set) => ({
     set((state) => resolveActiveMatch({
       ...state,
       query,
-    }, 0));
-  },
-
-  setScope: (scope) => {
-    set((state) => resolveActiveMatch({
-      ...state,
-      scope,
     }, 0));
   },
 
@@ -91,12 +79,13 @@ export const useContentSearchStore = create<ContentSearchState>((set) => ({
       const matchIds = [...registration.matchIds];
       const previous = state.unitsById[registration.unitId];
       const surface = registration.surface ?? "chat";
+      const orderKey = registration.orderKey ?? null;
 
       if (
         previous
         && previous.surface === surface
-        && previous.scope === registration.scope
         && previous.query === query
+        && previous.orderKey === orderKey
         && stringArraysEqual(previous.matchIds, matchIds)
       ) {
         return state;
@@ -110,10 +99,10 @@ export const useContentSearchStore = create<ContentSearchState>((set) => ({
           [registration.unitId]: {
             unitId: registration.unitId,
             surface,
-            scope: registration.scope,
             query,
             matchIds,
             order: previous?.order ?? state.nextUnitOrder,
+            orderKey,
           },
         },
       };
@@ -139,7 +128,7 @@ export const useContentSearchStore = create<ContentSearchState>((set) => ({
 
 export function selectVisibleContentSearchMatchIds(state: Pick<
   ContentSearchState,
-  "query" | "surface" | "scope" | "unitsById"
+  "query" | "surface" | "unitsById"
 >): string[] {
   const query = normalizeContentSearchQuery(state.query);
   if (!query) {
@@ -147,16 +136,30 @@ export function selectVisibleContentSearchMatchIds(state: Pick<
   }
 
   return Object.values(state.unitsById)
-    .filter((unit) =>
-      unit.surface === state.surface && unit.scope === state.scope && unit.query === query
-    )
-    .sort((left, right) => left.order - right.order)
+    .filter((unit) => unit.surface === state.surface && unit.query === query)
+    .sort(compareContentSearchUnits)
     .flatMap((unit) => unit.matchIds);
+}
+
+// Units with an explicit orderKey sort first, ascending. Units without one
+// (e.g. inline diffs that can't cheaply learn their row index) fall after all
+// keyed units, in registration order among themselves.
+function compareContentSearchUnits(left: ContentSearchUnit, right: ContentSearchUnit): number {
+  if (left.orderKey !== null && right.orderKey !== null) {
+    return left.orderKey - right.orderKey || left.order - right.order;
+  }
+  if (left.orderKey !== null) {
+    return -1;
+  }
+  if (right.orderKey !== null) {
+    return 1;
+  }
+  return left.order - right.order;
 }
 
 function resolveActiveMatch<State extends Pick<
   ContentSearchState,
-  "query" | "surface" | "scope" | "unitsById"
+  "query" | "surface" | "unitsById"
 >>(
   state: State,
   requestedIndex: number,

--- a/apps/packages/product-ui/package.json
+++ b/apps/packages/product-ui/package.json
@@ -203,6 +203,14 @@
       "types": "./dist/chat/transcript/AssistantMessage.d.ts",
       "import": "./dist/chat/transcript/AssistantMessage.js"
     },
+    "./chat/transcript/ChatContentSearchContext": {
+      "types": "./dist/chat/transcript/ChatContentSearchContext.d.ts",
+      "import": "./dist/chat/transcript/ChatContentSearchContext.js"
+    },
+    "./chat/transcript/MarkdownContentSearchMarks": {
+      "types": "./dist/chat/transcript/MarkdownContentSearchMarks.d.ts",
+      "import": "./dist/chat/transcript/MarkdownContentSearchMarks.js"
+    },
     "./chat/transcript/CloudChatTranscriptRowItems": {
       "types": "./dist/chat/transcript/CloudChatTranscriptRowItems.d.ts",
       "import": "./dist/chat/transcript/CloudChatTranscriptRowItems.js"

--- a/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
@@ -112,6 +112,7 @@ function AssistantMessageContent({
           renderLink={renderLink}
           renderInlineCode={renderInlineCode}
           renderCodeBlock={renderCodeBlock}
+          enableContentSearch
         />
       )}
       {splitContent.liveContent && (
@@ -124,6 +125,7 @@ function AssistantMessageContent({
             renderCodeBlock={renderCodeBlock}
             revealText={isStreaming}
             revealedUpTo={revealedUpTo}
+            enableContentSearch
           />
         </div>
       )}

--- a/apps/packages/product-ui/src/chat/transcript/ChatContentSearchContext.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ChatContentSearchContext.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Content-search paint layer (Cmd+F in chat). Two contexts feed the prose
+ * highlighter in MarkdownBody:
+ *
+ *  - the active normalized query (null when search is closed / not the chat
+ *    surface — the disabled fast path), provided once at the transcript root;
+ *  - the enclosing transcript row's stable unit id + index, provided per row.
+ *
+ * Highlighting is deliberately best-effort: match COUNTS and navigation come
+ * from a separate data-level index (see the desktop
+ * use-chat-transcript-content-search hook), so painting only decorates what it
+ * can reach. Everything here is inert (context null → zero work) when search is
+ * closed. See specs/codebase/features/content-search.md.
+ */
+
+export const ChatContentSearchQueryContext = createContext<string | null>(null);
+
+export interface ChatTranscriptRowContextValue {
+  rowUnitId: string;
+  rowIndex: number;
+}
+
+export const ChatTranscriptRowContext = createContext<ChatTranscriptRowContextValue | null>(
+  null,
+);
+
+export function useChatTranscriptRow(): ChatTranscriptRowContextValue | null {
+  return useContext(ChatTranscriptRowContext);
+}
+
+export interface ChatContentSearchPaint {
+  query: string;
+  rowUnitId: string;
+}
+
+/** Resolves the paint target for the current row, or null when inert. */
+export function useChatContentSearchPaint(): ChatContentSearchPaint | null {
+  const query = useContext(ChatContentSearchQueryContext);
+  const row = useContext(ChatTranscriptRowContext);
+  if (!query || !row) {
+    return null;
+  }
+  return { query, rowUnitId: row.rowUnitId };
+}
+
+export function ChatTranscriptRowProvider({
+  value,
+  children,
+}: {
+  value: ChatTranscriptRowContextValue;
+  children: ReactNode;
+}) {
+  return (
+    <ChatTranscriptRowContext.Provider value={value}>
+      {children}
+    </ChatTranscriptRowContext.Provider>
+  );
+}

--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptView.tsx
@@ -4,15 +4,18 @@ import type {
   ChatTranscriptViewProps,
 } from "./ChatTranscriptViewTypes";
 import { ChatTranscriptRows } from "./ChatTranscriptRows";
+import { ChatContentSearchQueryContext } from "./ChatContentSearchContext";
 import { useChatTranscriptCopySelection } from "./useChatTranscriptCopySelection";
 import { useChatTranscriptRowRenderer } from "./useChatTranscriptRowRenderer";
 import { useChatTranscriptViewModel } from "./useChatTranscriptViewModel";
 
 export type {
+  ChatTranscriptContentSearch,
   ChatTranscriptGoalEventRenderInput,
   ChatTranscriptOutboxActions,
   ChatTranscriptPendingPromptRenderInput,
   ChatTranscriptPendingStatusInput,
+  ChatTranscriptScrollHandle,
   ChatTranscriptTurnRowRenderInput,
   ChatTranscriptTurnStatusInput,
   ChatTranscriptViewProps,
@@ -33,8 +36,11 @@ export function ChatTranscriptView({
   renderPendingPromptTrailingStatus,
   renderTurnTrailingStatus,
   renderGoalEventRow,
+  contentSearch,
+  scrollHandleRef,
 }: ChatTranscriptViewProps) {
   const selectionRootRef = useRef<HTMLDivElement>(null);
+  const searchQuery = contentSearch?.query.trim() ? contentSearch.query.trim() : null;
   const model = useChatTranscriptViewModel({
     state,
     renderPendingPromptTrailingStatus,
@@ -67,26 +73,29 @@ export function ChatTranscriptView({
   });
 
   return (
-    <ChatTranscriptRows
-      rowListKey={`${model.selectedWorkspaceId ?? "workspace"}:${model.activeSessionId}`}
-      rows={model.virtualRows}
-      selectionRootRef={selectionRootRef}
-      hasOlderHistory={model.hasOlderHistory}
-      isLoadingOlderHistory={model.isLoadingOlderHistory}
-      olderHistoryCursor={model.olderHistoryCursor}
-      bottomInsetPx={model.bottomInsetPx}
-      nonDisplacingBottomInsetPx={model.nonDisplacingBottomInsetPx}
-      selectedWorkspaceId={model.selectedWorkspaceId}
-      activeSessionId={model.activeSessionId}
-      isSessionBusy={
-        model.sessionViewState === "working" || model.sessionViewState === "needs_input"
-      }
-      pendingPromptText={model.visibleOptimisticPrompt?.text ?? null}
-      onLoadOlderHistory={model.onLoadOlderHistory}
-      onScrollSample={onScrollSample}
-      renderRow={renderVirtualRow}
-      columnClassName={model.columnClassName}
-      gutterClassName={model.gutterClassName}
-    />
+    <ChatContentSearchQueryContext.Provider value={searchQuery}>
+      <ChatTranscriptRows
+        rowListKey={`${model.selectedWorkspaceId ?? "workspace"}:${model.activeSessionId}`}
+        rows={model.virtualRows}
+        selectionRootRef={selectionRootRef}
+        hasOlderHistory={model.hasOlderHistory}
+        isLoadingOlderHistory={model.isLoadingOlderHistory}
+        olderHistoryCursor={model.olderHistoryCursor}
+        bottomInsetPx={model.bottomInsetPx}
+        nonDisplacingBottomInsetPx={model.nonDisplacingBottomInsetPx}
+        selectedWorkspaceId={model.selectedWorkspaceId}
+        activeSessionId={model.activeSessionId}
+        isSessionBusy={
+          model.sessionViewState === "working" || model.sessionViewState === "needs_input"
+        }
+        pendingPromptText={model.visibleOptimisticPrompt?.text ?? null}
+        onLoadOlderHistory={model.onLoadOlderHistory}
+        onScrollSample={onScrollSample}
+        renderRow={renderVirtualRow}
+        columnClassName={model.columnClassName}
+        gutterClassName={model.gutterClassName}
+        scrollHandleRef={scrollHandleRef}
+      />
+    </ChatContentSearchQueryContext.Provider>
   );
 }

--- a/apps/packages/product-ui/src/chat/transcript/ChatTranscriptViewTypes.ts
+++ b/apps/packages/product-ui/src/chat/transcript/ChatTranscriptViewTypes.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 import type {
   ChatTranscriptState,
   PendingPromptEntry,
@@ -57,6 +57,20 @@ export interface ChatTranscriptGoalEventRenderInput {
   event: GoalTranscriptEvent;
 }
 
+/** Active chat content-search state driving the prose paint layer. */
+export interface ChatTranscriptContentSearch {
+  query: string;
+}
+
+/**
+ * Imperative handle exposed by ChatTranscriptView so the content-search
+ * jump-to-match can bring an off-screen (virtualized) row into view before the
+ * mark it targets can be found in the DOM.
+ */
+export interface ChatTranscriptScrollHandle {
+  scrollToRowKey: (rowKey: string) => void;
+}
+
 export interface ChatTranscriptViewProps {
   state: ChatTranscriptState;
   outboxActions?: ChatTranscriptOutboxActions;
@@ -67,4 +81,12 @@ export interface ChatTranscriptViewProps {
   renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
   /** Omitted surfaces (e.g. the cloud preview transcript) render no goal rows. */
   renderGoalEventRow?: (input: ChatTranscriptGoalEventRenderInput) => ReactNode;
+  /**
+   * Chat content search. When set (search open on the chat surface), the
+   * transcript prose is highlighted for `query`. Null/undefined disables the
+   * paint layer entirely (zero cost).
+   */
+  contentSearch?: ChatTranscriptContentSearch | null;
+  /** Ref to the imperative scroll handle for content-search jump-to-match. */
+  scrollHandleRef?: RefObject<ChatTranscriptScrollHandle | null>;
 }

--- a/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/FullTranscriptRowList.tsx
@@ -1,11 +1,14 @@
 import {
   useCallback,
   useEffect,
+  useImperativeHandle,
   useLayoutEffect,
   memo,
+  useMemo,
   useRef,
   type ReactNode,
 } from "react";
+import { ChatTranscriptRowProvider } from "./ChatContentSearchContext";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
 import type { TranscriptVirtualizationMode } from "@proliferate/product-domain/chats/transcript/transcript-virtualization-config";
 import {
@@ -54,6 +57,7 @@ export function FullTranscriptRowList({
   gutterClassName = DEFAULT_CHAT_SURFACE_GUTTER_CLASSNAME,
   fallbackReason,
   virtualizationMode,
+  scrollHandleRef,
 }: FullTranscriptRowListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -78,6 +82,15 @@ export function FullTranscriptRowList({
     onScrollSample,
     autoFollowBottomInsetPx: effectiveNonDisplacingBottomInsetPx,
   });
+
+  // Content-search jump-to-match. The full list mounts every row, so the
+  // overlay can scroll the target mark into view directly; we only release the
+  // stick-to-bottom pin so that scroll isn't immediately fought back.
+  useImperativeHandle(scrollHandleRef, () => ({
+    scrollToRowKey: () => {
+      setPinned(false);
+    },
+  }), [setPinned]);
 
   const logPrefetchDecision = useCallback((
     trigger: HistoryPrefetchTrigger,
@@ -305,13 +318,19 @@ const MemoizedFullTranscriptRow = memo(function MemoizedFullTranscriptRow({
   rowIndex: number;
   renderRow: TranscriptRowRenderer;
 }) {
+  const rowContext = useMemo(
+    () => ({ rowUnitId: `chatrow:${row.key}`, rowIndex }),
+    [row.key, rowIndex],
+  );
   return (
     <div
       data-transcript-virtual-row="true"
       data-index={rowIndex}
       className="w-full"
     >
-      {renderRow(row, rowIndex)}
+      <ChatTranscriptRowProvider value={rowContext}>
+        {renderRow(row, rowIndex)}
+      </ChatTranscriptRowProvider>
     </div>
   );
 }, (prev, next) =>

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -21,6 +21,12 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ProviderLinkMention } from "./ProviderLinkMention";
 import { MarkdownCodeBlockShell } from "./MarkdownCodeBlock";
+import {
+  ChatContentSearchQueryContext,
+  useChatContentSearchPaint,
+  type ChatContentSearchPaint,
+} from "./ChatContentSearchContext";
+import { markSearchChildren } from "./MarkdownContentSearchMarks";
 
 interface MarkdownBodyProps {
   content: string;
@@ -32,6 +38,13 @@ interface MarkdownBodyProps {
   revealText?: boolean;
   /** Character offset into the source string: text before this was already rendered. */
   revealedUpTo?: number;
+  /**
+   * Opt this body into the chat content-search paint layer. Only the
+   * conversation prose (user/assistant messages) sets this; secondary chrome
+   * (tool detail bodies, plan cards) leaves it false so its text isn't
+   * highlighted and never appears in the search index.
+   */
+  enableContentSearch?: boolean;
 }
 
 /**
@@ -114,11 +127,14 @@ const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
 // component via useContext — the component identity stays stable, and the
 // context value flows from MarkdownBody's provider without rebuilding the map.
 
-// Factory: creates a stable component that reads reveal context and delegates.
+// Factory: creates a stable component that reads reveal + search context and
+// delegates. Both are read via useContext so the component identity stays
+// stable across renders (see the identity comment above).
 function mdComponent(tag: MdTag, className: string) {
   return (props: MdElementProps) => {
     const ctx = useContext(MarkdownRevealContext);
-    return mdHtmlElement(tag, className, props, ctx);
+    const searchPaint = useChatContentSearchPaint();
+    return mdHtmlElement(tag, className, props, ctx, searchPaint);
   };
 }
 
@@ -301,6 +317,7 @@ export const MarkdownBody = memo(function MarkdownBody({
   taskListItems = "inline",
   revealText = false,
   revealedUpTo = 0,
+  enableContentSearch = false,
 }: MarkdownBodyProps) {
   const markdownClassName = [
     `${PROSE_TEXT} text-foreground break-words`,
@@ -337,7 +354,7 @@ export const MarkdownBody = memo(function MarkdownBody({
     [revealText, revealedUpTo],
   );
 
-  return (
+  const body = (
     <MarkdownRevealContext.Provider value={revealState}>
       <div className={markdownClassName}>
         <ReactMarkdown
@@ -350,6 +367,19 @@ export const MarkdownBody = memo(function MarkdownBody({
       </div>
     </MarkdownRevealContext.Provider>
   );
+
+  // Secondary chrome (tool detail bodies, plan cards) reuses MarkdownBody but
+  // must stay out of chat content-search. Shadow the query context to null so
+  // the highlighter is inert regardless of the ambient transcript query.
+  if (!enableContentSearch) {
+    return (
+      <ChatContentSearchQueryContext.Provider value={null}>
+        {body}
+      </ChatContentSearchQueryContext.Provider>
+    );
+  }
+
+  return body;
 });
 
 function MarkdownCode({
@@ -413,6 +443,7 @@ function mdHtmlElement(
   baseClassName: string,
   props: MdElementProps,
   ctx: MarkdownRevealState | null = null,
+  searchPaint: ChatContentSearchPaint | null = null,
 ) {
   const {
     children,
@@ -430,8 +461,13 @@ function mdHtmlElement(
       dangerouslySetInnerHTML,
     });
   }
-  const finalChildren = ctx?.enabled
-    ? revealChildren(children, node as HastNode | undefined, ctx)
-    : children;
+  // Content-search highlighting takes precedence over the streaming reveal:
+  // search runs on settled content, so the reveal fade is irrelevant while a
+  // query is active.
+  const finalChildren = searchPaint
+    ? markSearchChildren(children, searchPaint.query, searchPaint.rowUnitId)
+    : ctx?.enabled
+      ? revealChildren(children, node as HastNode | undefined, ctx)
+      : children;
   return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
 }

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownContentSearchMarks.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownContentSearchMarks.tsx
@@ -1,0 +1,88 @@
+import { Fragment, type ReactNode } from "react";
+
+/**
+ * Wraps content-search query matches inside a markdown text node with
+ * `<mark class="codex-thread-find-match">` (the same class the diff/file
+ * highlighters use, so styling is shared). Marks carry only the row unit id —
+ * no per-match id — because the active match is resolved by DOM ordinal at
+ * jump time, not encoded at render (see the desktop jump-to-match effect).
+ *
+ * Only direct string children are decorated. Matches that span nested inline
+ * formatting (bold/italic/inline-code/links) are left unpainted — an accepted
+ * v1 edge; the data-level index still counts them.
+ */
+export function markSearchChildren(
+  children: ReactNode,
+  query: string,
+  rowUnitId: string,
+): ReactNode {
+  if (typeof children === "string") {
+    return markString(children, query, rowUnitId);
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, index) =>
+      typeof child === "string" ? (
+        <Fragment key={index}>{markString(child, query, rowUnitId)}</Fragment>
+      ) : (
+        child
+      )
+    );
+  }
+  return children;
+}
+
+function markString(text: string, query: string, rowUnitId: string): ReactNode {
+  const ranges = findMatchRanges(text, query);
+  if (ranges.length === 0) {
+    return text;
+  }
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  ranges.forEach((range, index) => {
+    if (range.start > cursor) {
+      nodes.push(
+        <Fragment key={`t-${index}`}>{text.slice(cursor, range.start)}</Fragment>,
+      );
+    }
+    nodes.push(
+      <mark
+        key={`m-${index}`}
+        className="codex-thread-find-match"
+        data-content-search-row={rowUnitId}
+      >
+        {text.slice(range.start, range.end)}
+      </mark>,
+    );
+    cursor = range.end;
+  });
+  if (cursor < text.length) {
+    nodes.push(<Fragment key="t-tail">{text.slice(cursor)}</Fragment>);
+  }
+  return nodes;
+}
+
+interface MatchRange {
+  start: number;
+  end: number;
+}
+
+function findMatchRanges(text: string, query: string): MatchRange[] {
+  const needle = query.toLocaleLowerCase();
+  if (!needle) {
+    return [];
+  }
+  const haystack = text.toLocaleLowerCase();
+  const ranges: MatchRange[] = [];
+  let from = 0;
+  while (from <= haystack.length) {
+    const start = haystack.indexOf(needle, from);
+    if (start === -1) {
+      break;
+    }
+    const end = start + needle.length;
+    ranges.push({ start, end });
+    from = end;
+  }
+  return ranges;
+}

--- a/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/TranscriptRowListShared.tsx
@@ -2,6 +2,7 @@ import type { ReactNode, RefObject } from "react";
 import { ChevronDown, Spinner } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
 import type { TranscriptVirtualRow } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import type { ChatTranscriptScrollHandle } from "./ChatTranscriptViewTypes";
 
 export const TRANSCRIPT_TOP_PADDING_PX = 16;
 // Stick-to-bottom engine tuning (see useTranscriptStickToBottom).
@@ -55,6 +56,7 @@ export interface TranscriptRowListBaseProps {
   renderRow: (row: TranscriptVirtualRow, rowIndex: number) => ReactNode;
   columnClassName?: string;
   gutterClassName?: string;
+  scrollHandleRef?: RefObject<ChatTranscriptScrollHandle | null>;
 }
 
 export function resolveTranscriptBottomInsets(

--- a/apps/packages/product-ui/src/chat/transcript/VirtualTranscriptRow.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualTranscriptRow.tsx
@@ -1,5 +1,6 @@
-import { memo, type ReactNode } from "react";
+import { memo, useMemo, type ReactNode } from "react";
 import type { TranscriptVirtualRow as TranscriptVirtualRowModel } from "@proliferate/product-domain/chats/transcript/transcript-virtual-rows";
+import { ChatTranscriptRowProvider } from "./ChatContentSearchContext";
 
 export type TranscriptVirtualRowRenderer = (
   row: TranscriptVirtualRowModel,
@@ -19,6 +20,10 @@ export const MemoizedVirtualTranscriptRow = memo(function MemoizedVirtualTranscr
   renderRow: TranscriptVirtualRowRenderer;
   measureElement: (element: Element | null) => void;
 }) {
+  const rowContext = useMemo(
+    () => ({ rowUnitId: `chatrow:${row.key}`, rowIndex }),
+    [row.key, rowIndex],
+  );
   return (
     <div
       ref={measureElement}
@@ -26,7 +31,9 @@ export const MemoizedVirtualTranscriptRow = memo(function MemoizedVirtualTranscr
       data-index={virtualIndex}
       className="w-full"
     >
-      {renderRow(row, rowIndex)}
+      <ChatTranscriptRowProvider value={rowContext}>
+        {renderRow(row, rowIndex)}
+      </ChatTranscriptRowProvider>
     </div>
   );
 }, (prev, next) =>

--- a/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TranscriptVirtualizationMode } from "@proliferate/product-domain/chats/transcript/transcript-virtualization-config";
 import {
@@ -59,6 +59,7 @@ export function VirtualizedTranscriptRowList({
   gutterClassName,
   onFallback,
   virtualizationMode,
+  scrollHandleRef,
 }: VirtualizedTranscriptRowListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -105,6 +106,23 @@ export function VirtualizedTranscriptRowList({
     initialOffset: () => estimatedInitialBottomOffset,
     useAnimationFrameWithResizeObserver: true,
   });
+  // Content-search jump-to-match: bring an off-screen row into view so its
+  // painted marks mount before the overlay queries the DOM for the active one.
+  useImperativeHandle(scrollHandleRef, () => ({
+    scrollToRowKey: (rowKey: string) => {
+      const index = renderableRows.findIndex(
+        (row) => row.kind === "transcript" && row.key === rowKey,
+      );
+      if (index < 0) {
+        return;
+      }
+      setPinned(false);
+      notifyProgrammaticScroll(() => {
+        virtualizer.scrollToIndex(index, { align: "center" });
+      });
+    },
+  }), [notifyProgrammaticScroll, renderableRows, setPinned, virtualizer]);
+
   const virtualItems = virtualizer.getVirtualItems();
   const totalContentHeight = virtualizer.getTotalSize();
   const firstVirtualItem = virtualItems[0] ?? null;

--- a/specs/codebase/features/content-search.md
+++ b/specs/codebase/features/content-search.md
@@ -1,0 +1,107 @@
+# Content Search (Cmd+F)
+
+Read this doc when a change touches in-app find (Cmd+F) on the chat transcript
+or the file viewer: match counting, highlighting, jump-to-match, the shared
+overlay, or the content-search store.
+
+## Surfaces
+
+One store (`apps/desktop/src/stores/search/content-search-store.ts`) and one
+overlay (`SessionContentSearchOverlay`) drive two surfaces:
+
+- **chat** — the transcript. Searches conversation prose (user + assistant
+  messages) plus inline diffs rendered in tool calls.
+- **file** — the file viewer. Searches the open file's source / diff.
+
+`surface` alone gates which units are visible; there is no separate "scope".
+The shortcut (`workspace.find-content`) resolves the surface from the focused
+zone and calls `openSearch(surface)`. Placeholder/aria: "Search chat…" /
+"Find in chat" and "Search file…" / "Find in file". The overlay pill is shared;
+the only per-surface difference is vertical offset (file sits below the viewer
+toolbar).
+
+## Store model
+
+`registerUnit({ unitId, surface, query, matchIds, orderKey? })` records a unit
+(a diff instance, a file source view, or one transcript row). Visible matches =
+the flattened `matchIds` of units whose `surface` and normalized `query` match
+the active search, ordered by `orderKey` ascending. Units without an `orderKey`
+(e.g. inline diffs that can't cheaply learn their transcript row index) sort
+after all keyed units, in registration order. `activeMatchId` walks that
+flattened list.
+
+## Chat: index / paint split
+
+The chat surface separates **counting** from **highlighting** because most
+transcript rows are unmounted (virtualized), so the DOM cannot be the source of
+truth.
+
+- **Index (data — authoritative).**
+  `apps/desktop/src/hooks/chat/search/use-chat-transcript-content-search.ts`
+  rebuilds the transcript row model and, per row, extracts searchable prose via
+  `apps/desktop/src/lib/domain/content-search/transcript-search-text.ts`
+  (`extractTranscriptRowProseSegments` → markdown-stripped assistant prose +
+  plain user text). It registers one store unit per matching row:
+  `unitId = "chatrow:" + rowKey`, `matchIds = [unitId + ":" + i]`,
+  `orderKey = rowIndex * 2`. This yields exact counts regardless of
+  virtualization and is entirely inert unless chat search is open with a
+  non-empty query. Per-row extraction is memoized on row identity (a `WeakMap`),
+  and the query is behind `useDeferredValue`, so streaming updates only recompute
+  changed rows.
+
+- **Paint (React, context-gated).** `ChatTranscriptView` receives a
+  `contentSearch={{ query }}` prop and publishes it through
+  `ChatContentSearchQueryContext`; each transcript row publishes its unit id +
+  index through `ChatTranscriptRowContext` (see
+  `apps/packages/product-ui/src/chat/transcript/ChatContentSearchContext.tsx`).
+  `MarkdownBody` (assistant prose, opted in via `enableContentSearch`) and the
+  desktop `FileLinkedText` (user prose) wrap query matches in
+  `<mark class="codex-thread-find-match" data-content-search-row={rowUnitId}>` —
+  no per-match id at render time. Everything is inert when the query context is
+  null; secondary chrome (tool detail bodies, plan cards) reuses `MarkdownBody`
+  without `enableContentSearch` and shadows the query context to null so its
+  text is never highlighted and never indexed.
+
+- **Jump-to-match.** When `activeMatchId` is a `chatrow:` id, `MessageList`
+  parses the row key + ordinal
+  (`apps/desktop/src/lib/domain/content-search/chat-row-match-jump.ts`), calls
+  the `ChatTranscriptView` imperative `scrollToRowKey` handle to bring an
+  off-screen row into view, then runs a bounded rAF retry loop that selects the
+  ordinal-th `mark[data-content-search-row=...]` in document order, marks it
+  active, and scrolls it into view. If fewer marks are painted than the index
+  counted, the ordinal clamps to the last painted mark (a benign
+  extraction/render mismatch); the row is still scrolled into view.
+
+Inline diffs inside a transcript row register through `ChatDiffViewer` with
+`orderKey = rowIndex * 2 + 1` (read from the row context) so a row's diff
+matches interleave just after its prose. Diff/file marks keep their existing
+React-rendered `data-content-search-match-id` marks and active class — the
+overlay's own scroll effect still handles them.
+
+## Virtualization handling
+
+- The imperative `scrollToRowKey` handle lives on both list implementations
+  (`VirtualizedTranscriptRowList` → `virtualizer.scrollToIndex`;
+  `FullTranscriptRowList` → all rows mounted, so it only releases the
+  stick-to-bottom pin and lets the mark scroll happen). Both release the
+  bottom pin so the jump isn't fought by auto-follow.
+
+## Out of scope / known v1 edges
+
+- **Tool-call titles and collapsed tool output are not searched.** Collapsed
+  bodies aren't rendered, so they aren't painted; tool-call titles are a
+  deliberate deferral (they fan out across many renderers). They are in neither
+  the index nor the paint layer, keeping counts and highlights consistent.
+- **Matches spanning inline formatting** (e.g. a query straddling a bold run, an
+  inline-code span, or a link) may go unpainted — matching is per text segment.
+  The index still counts them; the jump clamps.
+- **User-message prose** is painted only inside committed transcript turn rows,
+  not the composer or in-flight prompt rows (which the index doesn't cover).
+
+## Performance
+
+The chat paint/index layers must stay inert when search is closed or the
+surface isn't chat (context value null, hook returns early, zero work). This is
+load-bearing: transcript re-renders racing keystrokes have historically caused
+multi-second stalls (see the INPUT-PRIORITY note in `MessageList.tsx`). The
+paint query is deferred, and per-row extraction is memoized on row identity.

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -4,6 +4,9 @@ Read this doc when a change touches session streams, transcript replay,
 transcript row models, pending/outbox prompt rows, long-history loading, or
 chat transcript rendering performance.
 
+In-app find (Cmd+F) over transcript prose is documented separately in
+[`../../../features/content-search.md`](../../../features/content-search.md).
+
 ## Stream And Transcript Rules
 
 - SSE events should be batched into at most one Zustand store write per


### PR DESCRIPTION
## What

Cmd+F in the chat view now searches the conversation itself — user messages, assistant prose, and inline diffs — instead of only diff blocks. One search architecture across chat and file surfaces, one overlay visual (the chat pill).

### How it works (see specs/codebase/features/content-search.md)

- **Index layer (data, not DOM):** a chat-view hook extracts prose per transcript row (markdown-stripped) and registers per-row match units in the content-search store — exact counts regardless of virtualization (only ~viewport+8 rows are mounted on long transcripts).
- **Paint layer (React, context-gated):** `MarkdownBody` and user-prompt text wrap query matches in the existing `codex-thread-find-match` marks via context (MarkdownRevealContext pattern — no memo busting, zero work while search is closed).
- **Jump-to-match:** active match id parses to row + ordinal → transcript virtualizer `scrollToIndex` → bounded rAF retry activates the mark by DOM ordinal.
- **Store cleanup:** the never-populated `scope` concept is deleted; units get an explicit `orderKey` so prose and inline-diff matches interleave in document order.
- **Overlay:** file surface adopts the chat pill styling; chat placeholder is now "Search chat…".
- **File viewer:** opening file search from any entry point (incl. Cmd+F) now leaves the rich preview for source view, where marks paint.

### Deliberate v1 scope

- Tool-call **title** text is not searched: titles are derived renderer-locally across 10+ components; indexing them without painting each renderer yields counts that don't match highlights.
- Collapsed tool-call output is not searched (not rendered → not part of visible conversation).
- Matches spanning inline formatting boundaries are counted and scrolled to but may not paint — jump clamps to the nearest painted mark.

## Verification

- Desktop tsc clean; 48 desktop vitest (store/overlay/shortcuts/extraction/jump/index hook/FileEditorView), 60 product-ui transcript tests, docs integrity check — all green.
- Manual verification in the running dev profile (chat search + file rich-preview flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)