### PR TITLE
test(release): run tier 2 strictly and make billing truth authoritative

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -494,9 +494,12 @@ jobs:
           USE_EXISTING_REDIS: "1"
           LOCAL_PGHOST: 127.0.0.1
           CI: "true"
-          # Stripe TEST key from the protected Qualification environment. Missing
-          # in trusted CI = fail (boot blocks every financial cell). Never live.
-          TIER2_BILLING_STRIPE_SECRET_KEY: ${{ secrets.TIER2_BILLING_STRIPE_SECRET_KEY }}
+          # Stripe TEST key from the protected Qualification environment
+          # (secret name STRIPE_TEST_SECRET_KEY). The harness generates its own
+          # webhook secret and idempotently provisions test-mode price IDs, so
+          # the key is the only external input. Missing in trusted CI = fail
+          # (boot blocks every financial cell). Never live.
+          TIER2_BILLING_STRIPE_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }}
           TIER2_INTENT_SKIP_RUNTIME: "1"
         run: |
           set -euo pipefail

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -418,3 +418,98 @@ jobs:
             tests/release/.output/local-world/*/*/logs/
           retention-days: 7
           if-no-files-found: ignore
+
+  # ── PR 4: Tier-2 strict billing/auth qualification ──────────────────────────
+  # `workflow_dispatch` only while stability is established. NOT
+  # `continue-on-error` — a red command stays red with its real exit code. Runs
+  # `make qualification-tier2` (same entrypoint a laptop uses). Fail-closed on a
+  # missing Stripe test key in trusted CI (the boot returns every financial cell
+  # BLOCKED, which a strict verdict fails on — never skip-as-success). Runtime
+  # shape (Postgres/Redis services, server venv, Stripe CLI) mirrors
+  # `intent-tests.yml`'s `intent-billing` job, which boots the same shared
+  # `BootedStack` machinery.
+  qualification-tier2:
+    name: tier-2 billing/auth (manual, strict)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: Qualification
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: proliferate
+          POSTGRES_PASSWORD: localdev
+          POSTGRES_DB: proliferate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U proliferate -d proliferate"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install server (venv, matches local layout)
+        run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
+      - name: Install Playwright chromium
+        run: pnpm -C tests/intent exec playwright install --with-deps chromium
+
+      - name: Install Stripe CLI
+        run: |
+          curl -fsSL https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public \
+            | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" \
+            | sudo tee /etc/apt/sources.list.d/stripe.list
+          sudo apt-get update && sudo apt-get install -y stripe
+
+      - name: Run T2-BILL + T2-AUTH-ORG (strict)
+        env:
+          # The boot fixture allocates the t2billing profile itself; on the
+          # runner the Docker services above stand in for the local stack
+          # (same wiring as intent-tests.yml's intent-billing job).
+          USE_EXISTING_POSTGRES: "1"
+          USE_EXISTING_REDIS: "1"
+          LOCAL_PGHOST: 127.0.0.1
+          CI: "true"
+          # Stripe TEST key from the protected Qualification environment. Missing
+          # in trusted CI = fail (boot blocks every financial cell). Never live.
+          TIER2_BILLING_STRIPE_SECRET_KEY: ${{ secrets.TIER2_BILLING_STRIPE_SECRET_KEY }}
+          TIER2_INTENT_SKIP_RUNTIME: "1"
+        run: |
+          set -euo pipefail
+          make qualification-tier2 \
+            PROFILE="ci-${{ github.run_id }}-${{ github.run_attempt }}" \
+            BEHAVIOR=strict
+
+      - name: Upload V4 report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tier2-billing-evidence
+          path: |
+            tests/release/.output/tier2/*/*/evidence/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -913,6 +913,36 @@ qualification-local-workspace:
 		--run-id "$$run_id" --shard-id "$$shard_id" \
 		--output-dir "$$run_dir/evidence"
 
+# Tier-2 strict billing/auth qualification (PR 4). Boots the shared BootedStack
+# (real Server + Postgres + Redis + real Stripe test mode; AnyHarness runtime
+# skipped) ONCE and runs the authoritative T2-BILL-1..15 + representative
+# T2-AUTH-ORG cells through the SAME tests/release aggregate command as tier 3.
+# No candidate build (Tier-2 boots from source) — `--source-candidate`
+# synthesizes the Server identity for the strict report. Selected financial
+# cells require a Stripe `sk_test_` key (env or `stripe config`); a missing key
+# in trusted CI is a FAILURE (fail-closed), never skip-as-success.
+#
+# PROFILE=<unique-name>       Names this run.
+# BEHAVIOR=diagnostic|strict
+QUALIFICATION_TIER2_BASE_DIR ?= $(CURDIR)/tests/release/.output/tier2
+qualification-tier2:
+	@test -n "$(BEHAVIOR)" || { echo "BEHAVIOR=<diagnostic|strict> is required."; exit 1; }
+	pnpm install --silent
+	pnpm exec playwright install --with-deps chromium
+	@run_id="qt2-$${PROFILE:-$$(whoami)}"; \
+	shard_id="1"; \
+	run_dir="$(QUALIFICATION_TIER2_BASE_DIR)/$$run_id/$$shard_id"; \
+	mkdir -p "$$run_dir/evidence"; \
+	cd tests/release && TIER2_INTENT_SKIP_RUNTIME=1 pnpm exec tsx src/cli/run.ts \
+		--behavior $(BEHAVIOR) \
+		--lane local \
+		--desktop web \
+		--agents claude \
+		--scenarios T2-BILL,T2-AUTH-ORG \
+		--source-candidate \
+		--run-id "$$run_id" --shard-id "$$shard_id" \
+		--output-dir "$$run_dir/evidence"
+
 test-cloud-ssh-worker:
 	@test -n "$(SSH_TARGET)" || { \
 		echo "SSH_TARGET is required, for example:"; \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -855,6 +855,9 @@ importers:
       oauth2-mock-server:
         specifier: ^9.1.0
         version: 9.1.0
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -864,6 +867,12 @@ importers:
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      pg:
+        specifier: ^8.13.1
+        version: 8.22.0
       playwright:
         specifier: ^1.61.0
         version: 1.61.0

--- a/server/alembic/versions/f3d7a1b9c2e5_llm_credit_seat_pool_source.py
+++ b/server/alembic/versions/f3d7a1b9c2e5_llm_credit_seat_pool_source.py
@@ -1,0 +1,81 @@
+"""billing truth: seat_pool credit source + flat org overage cap default
+
+Two ruled billing-truth changes (RULED 2026-07-14):
+
+1. Adds the per-seat managed-LLM allocation ("seat_pool") to the
+   ``llm_credit_grant.source`` check constraint. The $5/seat contribution is
+   granted into the shared org LLM pool each paid period and expires at period
+   end (reset on renewal), distinct from the never-expiring top-up grants.
+2. Overage exposure is now a flat $50/org/month cap (not per-seat). The
+   ``billing_subject.overage_cap_cents_per_seat`` column is reinterpreted as
+   the org-level cap value; its default moves from the old per-seat $20 (2000)
+   to $50 (5000). Existing rows still at the old per-seat default are migrated
+   to the new flat default (pre-launch; the old value was never an explicit
+   org cap).
+
+Revision ID: f3d7a1b9c2e5
+Revises: e7f8a9b0c1d3
+Create Date: 2026-07-15 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f3d7a1b9c2e5"
+down_revision: str | Sequence[str] | None = "e7f8a9b0c1d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONSTRAINT = "ck_llm_credit_grant_source"
+_TABLE = "llm_credit_grant"
+_SUBJECT_TABLE = "billing_subject"
+_CAP_COLUMN = "overage_cap_cents_per_seat"
+_OLD_CAP_DEFAULT = 2000
+_NEW_CAP_DEFAULT = 5000
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        "source IN ('free_signup', 'topup', 'admin', 'seat_pool')",
+    )
+
+    op.alter_column(
+        _SUBJECT_TABLE,
+        _CAP_COLUMN,
+        server_default=sa.text(str(_NEW_CAP_DEFAULT)),
+    )
+    op.execute(
+        sa.text(
+            f"UPDATE {_SUBJECT_TABLE} SET {_CAP_COLUMN} = :new "
+            f"WHERE {_CAP_COLUMN} = :old"
+        ).bindparams(new=_NEW_CAP_DEFAULT, old=_OLD_CAP_DEFAULT)
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            f"UPDATE {_SUBJECT_TABLE} SET {_CAP_COLUMN} = :old "
+            f"WHERE {_CAP_COLUMN} = :new"
+        ).bindparams(new=_NEW_CAP_DEFAULT, old=_OLD_CAP_DEFAULT)
+    )
+    op.alter_column(
+        _SUBJECT_TABLE,
+        _CAP_COLUMN,
+        server_default=sa.text(str(_OLD_CAP_DEFAULT)),
+    )
+
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        "source IN ('free_signup', 'topup', 'admin')",
+    )

--- a/server/alembic/versions/f3d7a1b9c2e5_llm_credit_seat_pool_source.py
+++ b/server/alembic/versions/f3d7a1b9c2e5_llm_credit_seat_pool_source.py
@@ -27,7 +27,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "f3d7a1b9c2e5"
-down_revision: str | Sequence[str] | None = "e7f8a9b0c1d3"
+down_revision: str | Sequence[str] | None = "ecffa1106847"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -399,10 +399,18 @@ class Settings(BaseSettings):
     agent_gateway_default_user_budget_usd: str = "5"
     agent_gateway_default_org_budget_usd: str = "0"
     agent_gateway_backfill_interval_seconds: float = 300.0
-    agent_gateway_free_credit_usd: str = "5"
+    # One-time lifetime managed-LLM grant for a GitHub-backed free identity.
+    agent_gateway_free_credit_usd: str = "2"
+    # Margin applied to imported managed-LLM spend: the ledger debits provider
+    # cost x (1 + margin_pct/100), so a $10 top-up pack (bought at face value)
+    # meters at provider list + 15%.
+    agent_gateway_llm_margin_pct: str = "15"
     agent_gateway_usage_import_interval_seconds: float = 60.0
     agent_gateway_usage_import_overlap_seconds: float = 300.0
     agent_gateway_topup_interval_seconds: float = 300.0
+    # Auto top-up fires when the shared LLM pool drops below this balance; each
+    # trigger buys exactly one pack (face value ``agent_gateway_topup_amount_usd``)
+    # and there is deliberately no per-window cap (ruled 2026-07-14).
     agent_gateway_topup_threshold_usd: str = "2"
     agent_gateway_topup_amount_usd: str = "10"
     # Stripe price for one auto top-up charge; empty disables auto top-ups.
@@ -414,6 +422,13 @@ class Settings(BaseSettings):
     e2b_api_key: str = ""
     e2b_template_name: str = ""
     e2b_webhook_signature_secret: str = ""
+    # Managed-compute pricing: the metered/overage rate is derived as the E2B
+    # provider list price per sandbox-hour times a margin multiplier. Keeping
+    # the multiplier (not a fixed dollar rate) as the constant means margin
+    # survives provider price changes. Both the $15/seat compute allocation and
+    # the overage rate read this derivation (see ``billing/pricing.py``).
+    e2b_list_price_usd_per_hour: str = "2.00"
+    pro_compute_margin_multiplier: float = 1.5
     proliferate_target_installer_url: str = (
         "https://raw.githubusercontent.com/proliferate-ai/proliferate/main/"
         "install/proliferate-target-install.sh"

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -297,6 +297,13 @@ class Settings(BaseSettings):
     cloud_concurrent_sandbox_limit: int = 200
     cloud_billing_mode: str = "off"
     pro_billing_enabled: bool = False
+    # Periodic maintenance loops (billing reconciler + agent-gateway enrollment
+    # backfill / usage import / LLM top-ups) start with the API by default. Set
+    # false to run the API without them — used by deterministic billing tests
+    # that drive those same passes on demand out-of-process, so a background
+    # tick never races or deadlocks with the test's own pass. Does not change
+    # any billing behavior; only whether the loops auto-run.
+    run_background_workers: bool = True
     support_slack_webhook_url: str = ""
     support_report_s3_bucket: str = ""
     support_report_s3_prefix: str = "support/reports"

--- a/server/proliferate/constants/agent_gateway.py
+++ b/server/proliferate/constants/agent_gateway.py
@@ -54,10 +54,15 @@ AGENT_GATEWAY_BUDGET_STATUSES = (
 LLM_CREDIT_SOURCE_FREE_SIGNUP = "free_signup"
 LLM_CREDIT_SOURCE_TOPUP = "topup"
 LLM_CREDIT_SOURCE_ADMIN = "admin"
+# Per-seat managed-LLM allocation ($5/seat) granted into the shared org LLM pool
+# each paid period. Expires at period end so the allocation resets on renewal
+# (unused balance does not roll over); distinct from never-expiring top-ups.
+LLM_CREDIT_SOURCE_SEAT_POOL = "seat_pool"
 LLM_CREDIT_SOURCES = (
     LLM_CREDIT_SOURCE_FREE_SIGNUP,
     LLM_CREDIT_SOURCE_TOPUP,
     LLM_CREDIT_SOURCE_ADMIN,
+    LLM_CREDIT_SOURCE_SEAT_POOL,
 )
 
 # Bifrost-era free credits used period_key "registration" under the same

--- a/server/proliferate/constants/billing.py
+++ b/server/proliferate/constants/billing.py
@@ -1,5 +1,7 @@
 """Billing-related constants."""
 
+from decimal import Decimal
+
 FREE_INCLUDED_GRANT_TYPE = "free_included"
 FREE_TRIAL_V2_GRANT_TYPE = "free_trial_v2"
 FREE_CLOUD_ALLOCATION_KIND_PERSONAL_TRIAL = "personal_trial"
@@ -19,9 +21,20 @@ BILLING_PRICE_CLASS_LEGACY_CLOUD = "legacy_cloud"
 BILLING_PRICE_CLASS_UNKNOWN = "unknown"
 
 PRO_SEAT_MONTHLY_AMOUNT_CENTS = 2000
-PRO_INCLUDED_MANAGED_CLOUD_HOURS_PER_SEAT = 20.0
-PRO_OVERAGE_PRICE_PER_HOUR_CENTS = 200
-PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_SEAT = 2000
+# Each active billed seat ($20/mo) allocates a $5 managed-LLM contribution and a
+# $15-equivalent compute contribution into two *separate* shared org pools. The
+# compute allocation is expressed in dollars (not flat hours): metered
+# sandbox-hours are derived at grant time from the configured compute price
+# (E2B list price x margin multiplier), so the dollar value survives provider
+# price changes. See ``server/billing/pricing.py`` for the derivation helpers
+# and ``domain/seats.py`` / ``domain/accounting.py`` for the pure math.
+PRO_LLM_ALLOCATION_USD_PER_SEAT = Decimal("5")
+PRO_COMPUTE_ALLOCATION_USD_PER_SEAT = Decimal("15")
+# Default overage exposure is a flat org/month cap (not per-seat): at cap,
+# compute pauses (WORKSPACE_ACTION_BLOCK_KIND_CAP_EXHAUSTED) rather than
+# auto-writing-off usage. A per-subject ``overage_cap_cents_per_seat`` override
+# is reinterpreted as an org-level cap value when set.
+PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_ORG_MONTH = 5000
 PRO_ACTIVE_ENVIRONMENTS_PER_SEAT = 2
 PRO_REPO_ENVIRONMENTS_PER_SEAT = 4
 PRO_FREE_TRIAL_HOURS = 1.0

--- a/server/proliferate/db/models/billing.py
+++ b/server/proliferate/db/models/billing.py
@@ -56,10 +56,14 @@ class BillingSubject(Base):
         default=False,
         server_default=text("false"),
     )
+    # Historically a per-seat cap; reinterpreted (ruled 2026-07-14) as the flat
+    # org/month overage cap value. Default is $50/org/month
+    # (PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_ORG_MONTH); an explicit non-default
+    # value is an operator-set org-level cap.
     overage_cap_cents_per_seat: Mapped[int] = mapped_column(
         Integer,
-        default=2000,
-        server_default=text("2000"),
+        default=5000,
+        server_default=text("5000"),
     )
     overage_preference_set_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),

--- a/server/proliferate/db/models/cloud/agent_gateway.py
+++ b/server/proliferate/db/models/cloud/agent_gateway.py
@@ -442,7 +442,7 @@ class LlmCreditGrant(Base):
     __tablename__ = "llm_credit_grant"
     __table_args__ = (
         CheckConstraint(
-            "source IN ('free_signup', 'topup', 'admin')",
+            "source IN ('free_signup', 'topup', 'admin', 'seat_pool')",
             name="ck_llm_credit_grant_source",
         ),
         CheckConstraint(

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -224,6 +224,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Reconcile the built-in integration seed definitions into the database.
     async with db_engine.async_session_factory() as db, db.begin():
         await sync_seed_definitions(db)
+    # The periodic maintenance loops below no-op when
+    # settings.run_background_workers is false (deterministic billing tests
+    # drive these same passes on demand out-of-process).
     if settings.cloud_billing_mode in {"observe", "enforce"}:
         start_billing_reconciler()
     anonymous_telemetry_task = await start_server_anonymous_telemetry_sender()

--- a/server/proliferate/server/billing/accounting.py
+++ b/server/proliferate/server/billing/accounting.py
@@ -17,8 +17,7 @@ from proliferate.constants.billing import (
     BILLING_USAGE_EXPORT_STATUS_OBSERVED,
     BILLING_USAGE_EXPORT_STATUS_PENDING,
     BILLING_USAGE_EXPORT_STATUS_SUCCEEDED,
-    BILLING_USAGE_EXPORT_STATUS_WRITTEN_OFF,
-    PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_SEAT,
+    PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_ORG_MONTH,
     PRO_SEAT_PRORATION_GRANT_TYPE,
 )
 from proliferate.db import session_ops as db_session
@@ -57,7 +56,11 @@ from proliferate.server.billing.domain.accounting import (
     usage_export_identifier,
 )
 from proliferate.server.billing.models import coerce_utc, utcnow
-from proliferate.server.billing.pricing import configured_managed_cloud_meter_event_name
+from proliferate.server.billing.pricing import (
+    compute_hours_per_seat,
+    compute_price_per_hour_cents,
+    configured_managed_cloud_meter_event_name,
+)
 from proliferate.server.billing.seats import (
     prorated_seat_grant_hours,
     seat_proration_grant_source_ref,
@@ -129,6 +132,7 @@ async def account_usage_for_billing_subject(
             (period_start_utc,) if is_paid_cloud and period_start_utc is not None else ()
         )
         cap_used_cents = 0
+        overage_rate_cents = compute_price_per_hour_cents()
         overage_remainder = None
         if can_export_overage and period_start_utc is not None:
             cap_used_cents = await sum_meter_quantity_cents_for_subject(
@@ -191,17 +195,15 @@ async def account_usage_for_billing_subject(
                     period_start_utc is None or accounted_from >= period_start_utc
                 )
                 if uncovered_seconds > 0 and can_export_overage and slice_is_in_paid_period:
-                    remainder_cents = (
-                        float(overage_remainder.fractional_cents)
-                        if overage_remainder is not None
-                        else 0.0
-                    )
-                    meter_cents, fractional_cents = overage_seconds_to_cents(
+                    # Ruled 2026-07-14: round up whole cents per closed segment,
+                    # no fractional remainder carried across segments (the
+                    # segment is the rounding unit).
+                    meter_cents = overage_seconds_to_cents(
                         uncovered_seconds,
-                        fractional_cents=remainder_cents,
+                        rate_cents_per_hour=overage_rate_cents,
                     )
                     if overage_remainder is not None:
-                        overage_remainder.fractional_cents = fractional_cents
+                        overage_remainder.fractional_cents = 0.0
                         overage_remainder.updated_at = now
 
                     if meter_cents > 0:
@@ -211,7 +213,6 @@ async def account_usage_for_billing_subject(
                             else meter_cents
                         )
                         billable_cents = min(meter_cents, cap_remaining_cents)
-                        writeoff_cents = max(meter_cents - billable_cents, 0)
                         base_idempotency_key = usage_export_idempotency_key(
                             billing_subject_id=billing_subject_id,
                             usage_segment_id=segment.id,
@@ -223,7 +224,6 @@ async def account_usage_for_billing_subject(
                             if billable_cents > 0
                             else 0.0
                         )
-                        writeoff_seconds = max(uncovered_seconds - billable_seconds, 0.0)
                         if billable_cents > 0:
                             await create_usage_export(
                                 db,
@@ -244,25 +244,20 @@ async def account_usage_for_billing_subject(
                             cap_used_cents += billable_cents
                             export_seconds += billable_seconds
                             export_count += 1
-                        if writeoff_cents > 0:
-                            await create_usage_export(
-                                db,
-                                billing_subject_id=billing_subject_id,
-                                billing_subscription_id=billing_subscription_id,
-                                usage_segment_id=segment.id,
-                                period_start=period_start,
-                                period_end=period_end,
-                                accounted_from=accounted_from,
-                                accounted_until=accounted_until,
-                                quantity_seconds=writeoff_seconds,
-                                meter_quantity_cents=0,
-                                cap_cents_snapshot=overage_cap_cents,
-                                cap_used_cents_snapshot=cap_used_cents,
-                                writeoff_reason="overage_cap_exhausted",
-                                idempotency_key=f"{base_idempotency_key}:writeoff",
-                                status=BILLING_USAGE_EXPORT_STATUS_WRITTEN_OFF,
+                        if meter_cents > billable_cents:
+                            # At the org-month cap: pause compute rather than
+                            # auto-writing-off the excess. The over-cap seconds
+                            # are not exported (and not billed); the snapshot
+                            # emits WORKSPACE_ACTION_BLOCK_KIND_CAP_EXHAUSTED so
+                            # compute stops. Write-offs are operator-only.
+                            logger.info(
+                                "Compute overage reached org cap; pausing (no auto write-off)",
+                                extra={
+                                    "billing_subject_id": str(billing_subject_id),
+                                    "over_cap_cents": meter_cents - billable_cents,
+                                    "cap_cents": overage_cap_cents,
+                                },
                             )
-                            export_count += 1
 
                 await upsert_usage_cursor(
                     db,
@@ -299,12 +294,14 @@ async def account_usage_for_snapshot_state(
         period_start=subscription.current_period_start if subscription is not None else None,
         period_end=subscription.current_period_end if subscription is not None else None,
         overage_enabled=state.subject.overage_enabled if subscription is not None else False,
+        # Flat org/month cap (ruled 2026-07-14): default $50/org, not scaled by
+        # seats. A per-subject ``overage_cap_cents_per_seat`` override, when set,
+        # is reinterpreted as the org-level cap value.
         overage_cap_cents=(
-            max(state.active_seat_count, 1)
-            * int(
+            int(
                 state.subject.overage_cap_cents_per_seat
                 if state.subject.overage_cap_cents_per_seat is not None
-                else PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_SEAT
+                else PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_ORG_MONTH
             )
             if subscription is not None and settings.pro_billing_enabled
             else None
@@ -352,6 +349,7 @@ async def process_pending_seat_adjustments(*, limit: int = 100) -> None:
                     period_start=adjustment.period_start,
                     period_end=adjustment.period_end,
                     effective_at=adjustment.effective_at,
+                    hours_per_seat=compute_hours_per_seat(),
                 )
                 async with db_session.open_async_transaction() as db:
                     await ensure_billing_grant_record(

--- a/server/proliferate/server/billing/domain/accounting.py
+++ b/server/proliferate/server/billing/domain/accounting.py
@@ -13,7 +13,6 @@ from proliferate.constants.billing import (
     FREE_INCLUDED_GRANT_TYPE,
     FREE_TRIAL_V2_GRANT_TYPE,
     MONTHLY_CLOUD_GRANT_TYPE,
-    PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
     PRO_PERIOD_GRANT_TYPE,
     PRO_SEAT_PRORATION_GRANT_TYPE,
     REFILL_10H_GRANT_TYPE,
@@ -52,12 +51,16 @@ class GrantKind(StrEnum):
     REFILL = REFILL_10H_GRANT_TYPE
 
 
-def overage_seconds_to_cents(seconds: float, *, fractional_cents: float) -> tuple[int, float]:
-    raw_cents = max(fractional_cents, 0.0) + (
-        max(seconds, 0.0) * PRO_OVERAGE_PRICE_PER_HOUR_CENTS / 3600.0
-    )
-    whole_cents = math.floor(raw_cents)
-    return whole_cents, max(raw_cents - whole_cents, 0.0)
+def overage_seconds_to_cents(seconds: float, *, rate_cents_per_hour: int) -> int:
+    """Compute-overage cents for one closed usage segment, rounded UP.
+
+    Ruled 2026-07-14: overage is metered in whole cents rounded up per closed
+    segment. Each segment is the rounding unit — no fractional remainder is
+    carried across segments, so two segments round independently. ``rate`` is
+    the derived compute price (E2B list x margin) in cents per hour.
+    """
+    raw_cents = max(seconds, 0.0) * max(rate_cents_per_hour, 0) / 3600.0
+    return math.ceil(raw_cents)
 
 
 def grant_boundary_after(

--- a/server/proliferate/server/billing/domain/seats.py
+++ b/server/proliferate/server/billing/domain/seats.py
@@ -76,7 +76,5 @@ def prorated_seat_grant_hours(
     effective = min(max(effective_at, period_start), period_end)
     total_seconds = max((period_end - period_start).total_seconds(), 1.0)
     remaining_seconds = max((period_end - effective).total_seconds(), 0.0)
-    prorated_seconds = (
-        added_seats * hours_per_seat * 3600.0 * remaining_seconds / total_seconds
-    )
+    prorated_seconds = added_seats * hours_per_seat * 3600.0 * remaining_seconds / total_seconds
     return max(int(prorated_seconds), 0) / 3600.0

--- a/server/proliferate/server/billing/domain/seats.py
+++ b/server/proliferate/server/billing/domain/seats.py
@@ -3,8 +3,23 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
-from proliferate.constants.billing import PRO_INCLUDED_MANAGED_CLOUD_HOURS_PER_SEAT
+from proliferate.constants.billing import PRO_LLM_ALLOCATION_USD_PER_SEAT
+
+
+def pro_llm_pool_usd(seat_quantity: int | None) -> Decimal:
+    """Shared org managed-LLM pool for ``seat_quantity`` billed seats.
+
+    $5 per active billed seat, allocated into the org's shared LLM pool each
+    paid period (a 3-seat org gets $15). Pure: the caller wires the returned
+    dollar amount into the LLM credit ledger and handles per-period reset.
+    """
+    return max(seat_quantity or 1, 1) * PRO_LLM_ALLOCATION_USD_PER_SEAT
+
+
+def pro_llm_pool_grant_source_ref(*, subscription_id: str, period_start_unix: int) -> str:
+    return f"stripe:pro-llm-pool:{subscription_id}:{period_start_unix}"
 
 
 def pro_period_grant_source_ref(*, subscription_id: str, period_start_unix: int) -> str:
@@ -37,8 +52,15 @@ def initial_seat_reconcile_source_ref(*, subscription_id: str, period_start_unix
     return f"stripe:initial-reconcile:{subscription_id}:{period_start_unix}"
 
 
-def pro_period_grant_hours(*, seat_quantity: int | None) -> float:
-    return max(seat_quantity or 1, 1) * PRO_INCLUDED_MANAGED_CLOUD_HOURS_PER_SEAT
+def pro_period_grant_hours(*, seat_quantity: int | None, hours_per_seat: float) -> float:
+    """Included compute-hours for ``seat_quantity`` seats.
+
+    ``hours_per_seat`` is the derived $15/seat compute allocation converted to
+    sandbox-hours at the current compute price (see
+    ``billing.pricing.compute_hours_per_seat``). Passed in so this stays a pure
+    function testable without settings.
+    """
+    return max(seat_quantity or 1, 1) * hours_per_seat
 
 
 def prorated_seat_grant_hours(
@@ -47,6 +69,7 @@ def prorated_seat_grant_hours(
     period_start: datetime,
     period_end: datetime,
     effective_at: datetime,
+    hours_per_seat: float,
 ) -> float:
     if added_seats <= 0 or period_end <= period_start:
         return 0.0
@@ -54,10 +77,6 @@ def prorated_seat_grant_hours(
     total_seconds = max((period_end - period_start).total_seconds(), 1.0)
     remaining_seconds = max((period_end - effective).total_seconds(), 0.0)
     prorated_seconds = (
-        added_seats
-        * PRO_INCLUDED_MANAGED_CLOUD_HOURS_PER_SEAT
-        * 3600.0
-        * remaining_seconds
-        / total_seconds
+        added_seats * hours_per_seat * 3600.0 * remaining_seconds / total_seconds
     )
     return max(int(prorated_seconds), 0) / 3600.0

--- a/server/proliferate/server/billing/policy.py
+++ b/server/proliferate/server/billing/policy.py
@@ -7,11 +7,13 @@ from dataclasses import dataclass
 from proliferate.config import settings
 from proliferate.constants.billing import (
     PRO_ACTIVE_ENVIRONMENTS_PER_SEAT,
-    PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_SEAT,
+    PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_ORG_MONTH,
     PRO_FREE_ACTIVE_ENVIRONMENT_LIMIT,
-    PRO_INCLUDED_MANAGED_CLOUD_HOURS_PER_SEAT,
-    PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
     PRO_REPO_ENVIRONMENTS_PER_SEAT,
+)
+from proliferate.server.billing.pricing import (
+    compute_hours_per_seat,
+    compute_price_per_hour_cents,
 )
 
 
@@ -37,7 +39,7 @@ def free_v2_policy() -> BillingPlanPolicy:
         billable_seat_count=0,
         included_managed_cloud_hours=None,
         managed_cloud_overage_cap_cents=0,
-        overage_price_per_hour_cents=PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
+        overage_price_per_hour_cents=compute_price_per_hour_cents(),
         active_environment_limit=PRO_FREE_ACTIVE_ENVIRONMENT_LIMIT,
         repo_environment_limit=settings.cloud_free_repo_limit,
         byo_runtime_allowed=False,
@@ -51,17 +53,20 @@ def pro_policy(
     byo_runtime_allowed: bool = True,
 ) -> BillingPlanPolicy:
     seats = max(billable_seat_count, 1)
-    cap_per_seat = (
-        PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_SEAT
+    # Flat org/month overage cap (ruled 2026-07-14): default $50/org, not scaled
+    # by seat count. A per-subject ``overage_cap_cents_per_seat`` override, when
+    # set, is reinterpreted as the org-level cap value (still bounded elsewhere).
+    org_cap_cents = (
+        PRO_DEFAULT_OVERAGE_CAP_CENTS_PER_ORG_MONTH
         if overage_cap_cents_per_seat is None
         else max(int(overage_cap_cents_per_seat), 0)
     )
     return BillingPlanPolicy(
         pro_billing_enabled=settings.pro_billing_enabled,
         billable_seat_count=seats,
-        included_managed_cloud_hours=PRO_INCLUDED_MANAGED_CLOUD_HOURS_PER_SEAT * seats,
-        managed_cloud_overage_cap_cents=cap_per_seat * seats,
-        overage_price_per_hour_cents=PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
+        included_managed_cloud_hours=compute_hours_per_seat() * seats,
+        managed_cloud_overage_cap_cents=org_cap_cents,
+        overage_price_per_hour_cents=compute_price_per_hour_cents(),
         active_environment_limit=PRO_ACTIVE_ENVIRONMENTS_PER_SEAT * seats,
         repo_environment_limit=PRO_REPO_ENVIRONMENTS_PER_SEAT * seats,
         byo_runtime_allowed=hosted_product_mode() and byo_runtime_allowed,
@@ -74,7 +79,7 @@ def unlimited_numeric_policy(*, byo_runtime_allowed: bool) -> BillingPlanPolicy:
         billable_seat_count=1,
         included_managed_cloud_hours=None,
         managed_cloud_overage_cap_cents=None,
-        overage_price_per_hour_cents=PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
+        overage_price_per_hour_cents=compute_price_per_hour_cents(),
         active_environment_limit=None,
         repo_environment_limit=None,
         byo_runtime_allowed=hosted_product_mode() and byo_runtime_allowed,

--- a/server/proliferate/server/billing/pricing.py
+++ b/server/proliferate/server/billing/pricing.py
@@ -35,9 +35,14 @@ from proliferate.server.billing.models import BillingServiceError
 def _e2b_list_price_per_hour_usd() -> Decimal:
     try:
         value = Decimal(settings.e2b_list_price_usd_per_hour)
-    except (InvalidOperation, ValueError):
-        return Decimal("0")
-    return value if value > 0 else Decimal("0")
+    except (InvalidOperation, ValueError) as exc:
+        raise BillingServiceError(
+            "compute_price_unconfigured",
+            "E2B_LIST_PRICE_USD_PER_HOUR is not a valid decimal: "
+            f"{settings.e2b_list_price_usd_per_hour!r}",
+            status_code=500,
+        ) from exc
+    return value
 
 
 def compute_price_per_hour_usd() -> Decimal:
@@ -46,10 +51,22 @@ def compute_price_per_hour_usd() -> Decimal:
     The multiplier (not a fixed dollar rate) is the constant, so margin
     survives provider price changes. Used both to convert the $15/seat compute
     allocation into included hours and to price compute overage.
+
+    T2R-R02: a zero/invalid derived price fails CLOSED. Returning 0 would give
+    paid subjects zero included hours while overage metering silently priced
+    every uncovered second at 0 cents — unbounded free compute. Misconfigured
+    pricing must abort the billing pass loudly instead.
     """
     multiplier = Decimal(str(settings.pro_compute_margin_multiplier))
     price = _e2b_list_price_per_hour_usd() * multiplier
-    return price if price > 0 else Decimal("0")
+    if price <= 0:
+        raise BillingServiceError(
+            "compute_price_unconfigured",
+            "Derived compute price must be > 0 "
+            f"(E2B list {settings.e2b_list_price_usd_per_hour!r} x multiplier {multiplier})",
+            status_code=500,
+        )
+    return price
 
 
 def compute_price_per_hour_cents() -> int:
@@ -60,13 +77,10 @@ def compute_price_per_hour_cents() -> int:
 def compute_hours_per_seat() -> float:
     """Sandbox-hours the $15/seat compute allocation buys at the current rate.
 
-    Returns 0.0 when compute is unpriced (misconfigured) rather than dividing by
-    zero — a zero allocation is fail-safe (no free hours) until pricing is set.
+    Misconfigured pricing raises upstream (T2R-R02, fail closed) — by the time
+    this divides, the rate is guaranteed positive.
     """
-    rate = compute_price_per_hour_usd()
-    if rate <= 0:
-        return 0.0
-    return float(PRO_COMPUTE_ALLOCATION_USD_PER_SEAT / rate)
+    return float(PRO_COMPUTE_ALLOCATION_USD_PER_SEAT / compute_price_per_hour_usd())
 
 
 def billing_price_ids_from_settings() -> BillingPriceIds:

--- a/server/proliferate/server/billing/pricing.py
+++ b/server/proliferate/server/billing/pricing.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
+
 from proliferate.config import settings
+from proliferate.constants.billing import (
+    PRO_COMPUTE_ALLOCATION_USD_PER_SEAT,
+)
 from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing.domain.pricing import (
     BillingPriceClass,
@@ -25,6 +30,43 @@ from proliferate.server.billing.domain.pricing import (
     price_class_is_paid as price_class_is_paid_for_config,
 )
 from proliferate.server.billing.models import BillingServiceError
+
+
+def _e2b_list_price_per_hour_usd() -> Decimal:
+    try:
+        value = Decimal(settings.e2b_list_price_usd_per_hour)
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+    return value if value > 0 else Decimal("0")
+
+
+def compute_price_per_hour_usd() -> Decimal:
+    """Derived managed-compute price per sandbox-hour: E2B list x multiplier.
+
+    The multiplier (not a fixed dollar rate) is the constant, so margin
+    survives provider price changes. Used both to convert the $15/seat compute
+    allocation into included hours and to price compute overage.
+    """
+    multiplier = Decimal(str(settings.pro_compute_margin_multiplier))
+    price = _e2b_list_price_per_hour_usd() * multiplier
+    return price if price > 0 else Decimal("0")
+
+
+def compute_price_per_hour_cents() -> int:
+    """Managed-compute overage rate in whole cents per sandbox-hour."""
+    return int((compute_price_per_hour_usd() * 100).to_integral_value(rounding="ROUND_HALF_UP"))
+
+
+def compute_hours_per_seat() -> float:
+    """Sandbox-hours the $15/seat compute allocation buys at the current rate.
+
+    Returns 0.0 when compute is unpriced (misconfigured) rather than dividing by
+    zero — a zero allocation is fail-safe (no free hours) until pricing is set.
+    """
+    rate = compute_price_per_hour_usd()
+    if rate <= 0:
+        return 0.0
+    return float(PRO_COMPUTE_ALLOCATION_USD_PER_SEAT / rate)
 
 
 def billing_price_ids_from_settings() -> BillingPriceIds:

--- a/server/proliferate/server/billing/reconciler.py
+++ b/server/proliferate/server/billing/reconciler.py
@@ -291,10 +291,6 @@ async def run_billing_reconcile_pass() -> None:
     async def _run(_db: object) -> None:
         await run_billing_accounting_pass()
 
-        provider = get_configured_sandbox_provider()
-        states = await provider.list_sandbox_states()
-        states_by_external_id = {state.external_sandbox_id: state for state in states}
-
         snapshots_by_subject: dict[UUID, BillingSnapshot] = {}
         recorded_hold_decision_subjects: set[UUID] = set()
         # Org budget-limit enforcement caches (spec §4.2), scoped to this pass:
@@ -305,7 +301,17 @@ async def run_billing_reconcile_pass() -> None:
         recorded_limit_decisions: set[tuple[UUID, UUID | None, str]] = set()
         now = utcnow()
         open_segments = await list_all_open_usage_segments()
+        # The provider is only needed to reconcile OPEN sandboxes against
+        # live provider state; with nothing open there is nothing to list, so
+        # skip the provider round-trip entirely. This also keeps the pass from
+        # requiring a configured sandbox provider when it has no open segments
+        # to reconcile (e.g. accounting-only runs).
+        provider = get_configured_sandbox_provider() if open_segments else None
+        states = await provider.list_sandbox_states() if provider is not None else []
+        states_by_external_id = {state.external_sandbox_id: state for state in states}
         for segment in open_segments:
+            # open_segments is non-empty here, so the provider was resolved above.
+            assert provider is not None
             billing_snapshot = snapshots_by_subject.get(segment.billing_subject_id)
             if billing_snapshot is None:
                 billing_snapshot = await get_billing_snapshot_for_subject(
@@ -387,6 +393,8 @@ async def _billing_reconciler_loop() -> None:
 
 def start_billing_reconciler() -> None:
     global _reconciler_task
+    if not settings.run_background_workers:
+        return
     if _reconciler_task is not None and not _reconciler_task.done():
         return
     _reconciler_task = asyncio.create_task(_billing_reconciler_loop())

--- a/server/proliferate/server/billing/reconciler.py
+++ b/server/proliferate/server/billing/reconciler.py
@@ -310,8 +310,11 @@ async def run_billing_reconcile_pass() -> None:
         states = await provider.list_sandbox_states() if provider is not None else []
         states_by_external_id = {state.external_sandbox_id: state for state in states}
         for segment in open_segments:
-            # open_segments is non-empty here, so the provider was resolved above.
-            assert provider is not None
+            # open_segments is non-empty here, so the provider was resolved
+            # above. Not an `assert`: those vanish under `python -O`, and this
+            # invariant guards real reconciliation work.
+            if provider is None:
+                raise RuntimeError("sandbox provider unresolved with open usage segments")
             billing_snapshot = snapshots_by_subject.get(segment.billing_subject_id)
             if billing_snapshot is None:
                 billing_snapshot = await get_billing_snapshot_for_subject(

--- a/server/proliferate/server/billing/seats.py
+++ b/server/proliferate/server/billing/seats.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from proliferate.server.billing.domain.seats import (
     initial_seat_reconcile_source_ref,
+    pro_llm_pool_grant_source_ref,
+    pro_llm_pool_usd,
     pro_period_grant_hours,
     pro_period_grant_source_ref,
     prorated_seat_grant_hours,
@@ -13,6 +15,8 @@ from proliferate.server.billing.domain.seats import (
 
 __all__ = [
     "initial_seat_reconcile_source_ref",
+    "pro_llm_pool_grant_source_ref",
+    "pro_llm_pool_usd",
     "pro_period_grant_hours",
     "pro_period_grant_source_ref",
     "prorated_seat_grant_hours",

--- a/server/proliferate/server/billing/snapshots.py
+++ b/server/proliferate/server/billing/snapshots.py
@@ -13,7 +13,6 @@ from proliferate.constants.billing import (
     ACTIVE_SANDBOX_STATUSES,
     BILLING_PLAN_FREE,
     BILLING_PLAN_PRO,
-    PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
     WORKSPACE_ACTION_BLOCK_KIND_CAP_EXHAUSTED,
     WORKSPACE_ACTION_BLOCK_KIND_CONCURRENCY_LIMIT,
     WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED,
@@ -51,7 +50,10 @@ from proliferate.server.billing.models import (
     utcnow,
 )
 from proliferate.server.billing.policy import free_v2_policy, pro_policy, unlimited_numeric_policy
-from proliferate.server.billing.pricing import billing_price_ids_from_settings
+from proliferate.server.billing.pricing import (
+    billing_price_ids_from_settings,
+    compute_price_per_hour_cents,
+)
 from proliferate.server.billing.snapshot_state import BillingSnapshotState
 
 
@@ -386,7 +388,7 @@ def build_billing_snapshot(state: BillingSnapshotState) -> BillingSnapshot:
         managed_cloud_overage_used_cents=(
             0 if has_unlimited_cloud_hours else state.managed_cloud_overage_used_cents
         ),
-        overage_price_per_hour_cents=PRO_OVERAGE_PRICE_PER_HOUR_CENTS,
+        overage_price_per_hour_cents=compute_price_per_hour_cents(),
         active_environment_limit=active_environment_limit,
         repo_environment_limit=repo_environment_limit,
         byo_runtime_allowed=byo_runtime_allowed,

--- a/server/proliferate/server/billing/stripe_webhooks.py
+++ b/server/proliferate/server/billing/stripe_webhooks.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
+from proliferate.constants.agent_gateway import LLM_CREDIT_SOURCE_SEAT_POOL
 from proliferate.constants.billing import (
     BILLING_PRICE_CLASS_PRO,
     PRO_PERIOD_GRANT_TYPE,
@@ -19,6 +20,7 @@ from proliferate.constants.billing import (
 )
 from proliferate.db import engine as db_engine
 from proliferate.db.models.billing import BillingSubject, BillingSubscription
+from proliferate.db.store import agent_gateway as agent_gateway_store
 from proliferate.db.store.billing_runtime_usage import (
     claim_webhook_event,
     mark_webhook_event_failed_by_id,
@@ -39,7 +41,11 @@ from proliferate.server.billing.domain.pricing import (
     monthly_subscription_price_ids,
     overage_subscription_price_ids,
 )
-from proliferate.server.billing.domain.seats import pro_period_grant_hours
+from proliferate.server.billing.domain.seats import (
+    pro_llm_pool_grant_source_ref,
+    pro_llm_pool_usd,
+    pro_period_grant_hours,
+)
 from proliferate.server.billing.domain.webhooks import (
     datetime_from_timestamp as _datetime_from_timestamp,
 )
@@ -74,6 +80,7 @@ from proliferate.server.billing.models import BillingServiceError, StripeWebhook
 from proliferate.server.billing.pricing import (
     billing_price_ids_from_settings,
     classify_monthly_price_id,
+    compute_hours_per_seat,
 )
 from proliferate.server.billing.seat_reconciliation import (
     reconcile_initial_org_subscription_seats,
@@ -497,6 +504,7 @@ async def _handle_invoice_paid(invoice: dict[str, Any]) -> tuple[BillingSlackNot
             grant_type=PRO_PERIOD_GRANT_TYPE,
             hours_granted=pro_period_grant_hours(
                 seat_quantity=subscription_record.seat_quantity,
+                hours_per_seat=compute_hours_per_seat(),
             ),
             effective_at=subscription_record.current_period_start,
             expires_at=subscription_record.current_period_end,
@@ -506,6 +514,23 @@ async def _handle_invoice_paid(invoice: dict[str, Any]) -> tuple[BillingSlackNot
             ),
             top_up_existing=True,
         )
+        # Grant the $5/seat managed-LLM allocation into the shared org LLM pool.
+        # Period-keyed source_ref makes it idempotent per period; expiring it at
+        # period end means the allocation resets on renewal (no roll-over),
+        # unlike the never-expiring top-up grants.
+        if settings.agent_gateway_enabled:
+            await _run_billing_store_write(
+                agent_gateway_store.create_llm_credit_grant,
+                billing_subject_id=subject.id,
+                user_id=subject.user_id,
+                source=LLM_CREDIT_SOURCE_SEAT_POOL,
+                amount_usd=pro_llm_pool_usd(subscription_record.seat_quantity),
+                expires_at=subscription_record.current_period_end,
+                source_ref=pro_llm_pool_grant_source_ref(
+                    subscription_id=subscription_record.stripe_subscription_id,
+                    period_start_unix=period_start_unix,
+                ),
+            )
     await _run_billing_store_write(clear_payment_failed_holds, billing_subject_id=subject.id)
     return notifications
 

--- a/server/proliferate/server/cloud/agent_gateway/topups.py
+++ b/server/proliferate/server/cloud/agent_gateway/topups.py
@@ -74,6 +74,32 @@ class LlmTopupRunResult:
     eligible: int
     topped_up: int
     skipped: int
+    # Auto-top-up admin-alert intents recorded this tick (one per auto top-up).
+    # The real Resend send is deferred (founder ruling); this only records the
+    # intent, so ``alerts_recorded == topped_up`` on every tick.
+    alerts_recorded: int = 0
+
+
+# Structured-log marker for the deferred admin-alert send. A downstream
+# notifications worker (not PR 4) turns these intents into real emails.
+AUTO_TOPUP_ADMIN_ALERT_MARKER = "AUTO_TOPUP_ADMIN_ALERT_INTENT"
+
+
+def _record_topup_admin_alert_intent(*, billing_subject_id: UUID, invoice_id: str) -> None:
+    """Record the intent to alert org admins about an auto top-up (no send).
+
+    Ruled 2026-07-14: alert org admins on every auto top-up. PR 4 records the
+    intent deterministically; the outbound Resend send + template is deferred to
+    the notifications work, so this function has NO email dependency.
+    """
+    logger.info(
+        AUTO_TOPUP_ADMIN_ALERT_MARKER,
+        extra={
+            "billing_subject_id": str(billing_subject_id),
+            "stripe_invoice_id": invoice_id,
+            "alert_audience": "org_admins",
+        },
+    )
 
 
 def topups_enabled() -> bool:
@@ -317,6 +343,7 @@ async def run_llm_topups(
     eligible = 0
     topped_up = 0
     skipped = 0
+    alerts_recorded = 0
     after: UUID | None = None
     while True:
         subject_ids = await agent_gateway_store.list_billing_subject_ids_with_active_enrollments(
@@ -380,6 +407,11 @@ async def run_llm_topups(
                     "stripe_invoice_id": invoice_id,
                 },
             )
+            _record_topup_admin_alert_intent(
+                billing_subject_id=billing_subject_id,
+                invoice_id=invoice_id,
+            )
+            alerts_recorded += 1
         if len(subject_ids) < _SUBJECT_SCAN_PAGE_SIZE:
             break
         after = subject_ids[-1]
@@ -388,6 +420,7 @@ async def run_llm_topups(
         eligible=eligible,
         topped_up=topped_up,
         skipped=skipped,
+        alerts_recorded=alerts_recorded,
     )
 
 

--- a/server/proliferate/server/cloud/agent_gateway/usage_import.py
+++ b/server/proliferate/server/cloud/agent_gateway/usage_import.py
@@ -54,6 +54,30 @@ from proliferate.utils.time import utcnow
 logger = logging.getLogger(__name__)
 
 _ZERO = Decimal("0")
+_HUNDRED = Decimal("100")
+
+
+def llm_margin_multiplier() -> Decimal:
+    """1 + margin_pct/100 applied to imported managed-LLM spend.
+
+    Ruled 2026-07-14: managed LLM is metered at provider list price + 15%, so a
+    face-value $10 top-up pack funds $10 of purchase but bills spend at the
+    marked-up rate. A garbage/negative setting fails safe to no margin (x1).
+    """
+    try:
+        pct = Decimal(settings.agent_gateway_llm_margin_pct)
+    except (ArithmeticError, ValueError):
+        return Decimal("1")
+    if pct <= _ZERO:
+        return Decimal("1")
+    return Decimal("1") + (pct / _HUNDRED)
+
+
+def apply_llm_margin(spend: float) -> float:
+    """Provider spend marked up by the configured LLM margin (>= 0)."""
+    if spend <= 0:
+        return 0.0
+    return float(Decimal(str(spend)) * llm_margin_multiplier())
 
 # Keyset-pagination page size for the limit_reached sweep below.
 _LIMIT_REACHED_SWEEP_PAGE_SIZE = 500
@@ -211,7 +235,7 @@ async def run_usage_import(
             prompt_tokens=entry.prompt_tokens,
             completion_tokens=entry.completion_tokens,
             total_tokens=entry.total_tokens,
-            cost_usd=entry.spend,
+            cost_usd=apply_llm_margin(entry.spend),
             status=status,
             workspace_id=_metadata_str(entry, "proliferate_workspace_id"),
             session_id=_metadata_str(entry, "proliferate_session_id"),

--- a/server/proliferate/server/cloud/agent_gateway/usage_import.py
+++ b/server/proliferate/server/cloud/agent_gateway/usage_import.py
@@ -79,6 +79,7 @@ def apply_llm_margin(spend: float) -> float:
         return 0.0
     return float(Decimal(str(spend)) * llm_margin_multiplier())
 
+
 # Keyset-pagination page size for the limit_reached sweep below.
 _LIMIT_REACHED_SWEEP_PAGE_SIZE = 500
 

--- a/server/proliferate/server/cloud/agent_gateway/worker.py
+++ b/server/proliferate/server/cloud/agent_gateway/worker.py
@@ -59,7 +59,7 @@ async def _backfill_loop() -> None:
 
 
 async def start_agent_gateway_enrollment_backfill() -> asyncio.Task[None] | None:
-    if not settings.agent_gateway_enabled:
+    if not settings.agent_gateway_enabled or not settings.run_background_workers:
         return None
     return asyncio.create_task(
         _backfill_loop(),
@@ -103,7 +103,7 @@ async def _usage_import_loop() -> None:
 
 
 async def start_agent_gateway_usage_import() -> asyncio.Task[None] | None:
-    if not settings.agent_gateway_enabled:
+    if not settings.agent_gateway_enabled or not settings.run_background_workers:
         return None
     return asyncio.create_task(
         _usage_import_loop(),
@@ -149,6 +149,8 @@ async def _topup_loop() -> None:
 
 async def start_agent_gateway_llm_topups() -> asyncio.Task[None] | None:
     if not settings.agent_gateway_enabled or not topups_enabled():
+        return None
+    if not settings.run_background_workers:
         return None
     return asyncio.create_task(
         _topup_loop(),

--- a/server/tests/integration/test_agent_gateway_usage_credits.py
+++ b/server/tests/integration/test_agent_gateway_usage_credits.py
@@ -228,8 +228,10 @@ async def test_importer_is_idempotent_across_overlapping_windows(
 
     subject_id = enrollment.billing_subject_id
     balance = await store.get_remaining_credit_usd(db_session, subject_id)
-    assert balance.used_usd == Decimal("0.10")
-    assert balance.remaining_usd == Decimal("4.90")
+    # Ruled 2026-07-14: managed LLM is metered at provider list + 15%, so a
+    # $0.10 provider spend debits $0.115 against the credit ledger.
+    assert balance.used_usd == Decimal("0.115")
+    assert balance.remaining_usd == Decimal("4.885")
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_billing_accounting.py
+++ b/server/tests/integration/test_billing_accounting.py
@@ -536,7 +536,7 @@ async def test_manual_unlimited_with_pro_subscription_does_not_export_overage(
 
 
 @pytest.mark.asyncio
-async def test_zero_pro_overage_cap_writes_off_uncovered_usage(
+async def test_zero_pro_overage_cap_pauses_without_auto_writeoff(
     db_session: AsyncSession,
     test_engine: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -604,11 +604,11 @@ async def test_zero_pro_overage_cap_writes_off_uncovered_usage(
         .scalars()
         .all()
     )
-    assert len(exports) == 1
-    assert exports[0].status == BILLING_USAGE_EXPORT_STATUS_WRITTEN_OFF
-    assert exports[0].meter_quantity_cents == 0
-    assert exports[0].cap_cents_snapshot == 0
-    assert exports[0].writeoff_reason == "overage_cap_exhausted"
+    # Ruled 2026-07-14: at the cap, compute PAUSES rather than auto-writing-off
+    # the over-cap usage. No export (billable or written-off) is created; the
+    # snapshot emits WORKSPACE_ACTION_BLOCK_KIND_CAP_EXHAUSTED elsewhere so
+    # compute stops. Write-offs are operator-only.
+    assert exports == []
     cursor = (
         await db_session.execute(
             select(BillingUsageCursor).where(BillingUsageCursor.usage_segment_id == segment_id)

--- a/server/tests/integration/test_billing_api.py
+++ b/server/tests/integration/test_billing_api.py
@@ -212,8 +212,7 @@ class TestBillingApi:
             "managedCloudOverageEnabled": False,
             "managedCloudOverageCapCents": None,
             "managedCloudOverageUsedCents": 0,
-            # Derived compute rate: $2.00 E2B list x 1.5 = $3.00/hr (ruled).
-            "overagePricePerHourCents": 300,
+            "overagePricePerHourCents": 300,  # $2.00 E2B list x 1.5 (ruled)
             "activeEnvironmentLimit": settings.cloud_concurrent_sandbox_limit,
             "repoEnvironmentLimit": settings.cloud_free_repo_limit,
             "byoRuntimeAllowed": False,
@@ -258,8 +257,7 @@ class TestBillingApi:
             "managedCloudOverageEnabled": False,
             "managedCloudOverageCapCents": None,
             "managedCloudOverageUsedCents": 0,
-            # Derived compute rate: $2.00 E2B list x 1.5 = $3.00/hr (ruled).
-            "overagePricePerHourCents": 300,
+            "overagePricePerHourCents": 300,  # $2.00 E2B list x 1.5 (ruled)
             "activeEnvironmentLimit": settings.cloud_concurrent_sandbox_limit,
             "repoEnvironmentLimit": settings.cloud_free_repo_limit,
             "byoRuntimeAllowed": False,
@@ -1076,10 +1074,7 @@ class TestBillingApi:
         payload = response.json()
         assert payload["plan"] == "pro"
         assert payload["billableSeatCount"] == 2
-        # Ruled 2026-07-14: $15/seat compute at the default derived rate
-        # ($2.00 E2B list x 1.5 = $3.00/hr) => 5 hours/seat, and a flat
-        # $50/org/month overage cap (not per-seat).
-        assert payload["includedManagedCloudHours"] == 10.0
+        assert payload["includedManagedCloudHours"] == 10.0  # 2 seats * 5 h/seat (ruled)
         assert payload["managedCloudOverageCapCents"] == 5000
 
     @pytest.mark.asyncio

--- a/server/tests/integration/test_billing_api.py
+++ b/server/tests/integration/test_billing_api.py
@@ -212,7 +212,8 @@ class TestBillingApi:
             "managedCloudOverageEnabled": False,
             "managedCloudOverageCapCents": None,
             "managedCloudOverageUsedCents": 0,
-            "overagePricePerHourCents": 200,
+            # Derived compute rate: $2.00 E2B list x 1.5 = $3.00/hr (ruled).
+            "overagePricePerHourCents": 300,
             "activeEnvironmentLimit": settings.cloud_concurrent_sandbox_limit,
             "repoEnvironmentLimit": settings.cloud_free_repo_limit,
             "byoRuntimeAllowed": False,
@@ -257,7 +258,8 @@ class TestBillingApi:
             "managedCloudOverageEnabled": False,
             "managedCloudOverageCapCents": None,
             "managedCloudOverageUsedCents": 0,
-            "overagePricePerHourCents": 200,
+            # Derived compute rate: $2.00 E2B list x 1.5 = $3.00/hr (ruled).
+            "overagePricePerHourCents": 300,
             "activeEnvironmentLimit": settings.cloud_concurrent_sandbox_limit,
             "repoEnvironmentLimit": settings.cloud_free_repo_limit,
             "byoRuntimeAllowed": False,
@@ -1074,8 +1076,11 @@ class TestBillingApi:
         payload = response.json()
         assert payload["plan"] == "pro"
         assert payload["billableSeatCount"] == 2
-        assert payload["includedManagedCloudHours"] == 40.0
-        assert payload["managedCloudOverageCapCents"] == 4000
+        # Ruled 2026-07-14: $15/seat compute at the default derived rate
+        # ($2.00 E2B list x 1.5 = $3.00/hr) => 5 hours/seat, and a flat
+        # $50/org/month overage cap (not per-seat).
+        assert payload["includedManagedCloudHours"] == 10.0
+        assert payload["managedCloudOverageCapCents"] == 5000
 
     @pytest.mark.asyncio
     async def test_org_seat_adjustments_prorate_grants_and_resync_same_member(

--- a/server/tests/integration/test_billing_llm_seat_pool.py
+++ b/server/tests/integration/test_billing_llm_seat_pool.py
@@ -1,0 +1,291 @@
+"""Integration coverage for the $5/seat shared org managed-LLM pool (A2/A10).
+
+Ruled 2026-07-14: each active billed seat allocates $5 into a shared org
+managed-LLM pool at each paid period; the allocation resets on renewal (unused
+balance does not roll over) while purchased top-up credit never expires. Here we
+drive the real ``_handle_invoice_paid`` seam and assert the ``seat_pool`` LLM
+credit grant amount, period-keyed idempotency, and per-period reset via expiry.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from proliferate.config import settings
+from proliferate.constants.agent_gateway import LLM_CREDIT_SOURCE_SEAT_POOL
+from proliferate.constants.organizations import (
+    ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+    ORGANIZATION_ROLE_MEMBER,
+    ORGANIZATION_ROLE_OWNER,
+)
+from proliferate.db import engine as engine_module
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.agent_gateway import LlmCreditGrant
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import agent_gateway as agent_gateway_store
+from proliferate.db.store.billing_subjects import ensure_organization_billing_subject
+from proliferate.server.billing import stripe_webhooks
+
+
+async def _add_active_members(
+    db_session: AsyncSession, organization_id: uuid.UUID, count: int
+) -> None:
+    for index in range(count):
+        user_id = uuid.uuid4()
+        db_session.add(
+            User(
+                id=user_id,
+                email=f"seat-pool-{index}-{user_id}@example.com",
+                hashed_password="unused",
+                is_active=True,
+                is_superuser=False,
+                is_verified=True,
+            )
+        )
+        db_session.add(
+            OrganizationMembership(
+                organization_id=organization_id,
+                user_id=user_id,
+                role=ORGANIZATION_ROLE_OWNER if index == 0 else ORGANIZATION_ROLE_MEMBER,
+                status=ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
+                joined_at=datetime.now(UTC),
+            )
+        )
+
+_PERIOD1_START = 1_776_586_422  # 2026-04-19T...
+_PERIOD1_END = 1_779_178_422  # +30d
+_PERIOD2_START = 1_779_178_422
+_PERIOD2_END = 1_781_770_422
+
+
+def _subscription_payload(
+    *,
+    subject_id: uuid.UUID,
+    org_id: uuid.UUID,
+    seats: int,
+    start: int,
+    end: int,
+) -> dict:
+    return {
+        "id": "sub_llm_pool",
+        "customer": "cus_llm_pool",
+        "status": "active",
+        "cancel_at_period_end": False,
+        "canceled_at": None,
+        "latest_invoice": "in_llm_pool",
+        "current_period_start": start,
+        "current_period_end": end,
+        "metadata": {
+            "billing_subject_id": str(subject_id),
+            "organization_id": str(org_id),
+            "purpose": "cloud_subscription",
+        },
+        "items": {
+            "data": [
+                {"id": "si_monthly", "quantity": seats, "price": {"id": "price_pro"}},
+                {"id": "si_overage", "price": {"id": "price_overage"}},
+            ]
+        },
+    }
+
+
+def _invoice_payload(*, subject_id: uuid.UUID, org_id: uuid.UUID) -> dict:
+    return {
+        "id": "in_llm_pool",
+        "customer": "cus_llm_pool",
+        "subscription": None,
+        "parent": {
+            "subscription_details": {
+                "subscription": "sub_llm_pool",
+                "metadata": {
+                    "billing_subject_id": str(subject_id),
+                    "organization_id": str(org_id),
+                    "purpose": "cloud_subscription",
+                },
+            },
+            "type": "subscription_details",
+        },
+        "lines": {
+            "data": [
+                {
+                    "id": "il_llm_pool",
+                    "pricing": {
+                        "price_details": {"price": "price_pro", "product": "prod_pro"},
+                        "type": "price_details",
+                    },
+                    "parent": {
+                        "subscription_item_details": {
+                            "subscription": "sub_llm_pool",
+                            "subscription_item": "si_monthly",
+                        },
+                        "type": "subscription_item_details",
+                    },
+                }
+            ]
+        },
+    }
+
+
+async def _list_seat_pool_grants(
+    db_session: AsyncSession, subject_id: uuid.UUID
+) -> list[LlmCreditGrant]:
+    rows = await db_session.execute(
+        select(LlmCreditGrant)
+        .where(
+            LlmCreditGrant.billing_subject_id == subject_id,
+            LlmCreditGrant.source == LLM_CREDIT_SOURCE_SEAT_POOL,
+        )
+        .order_by(LlmCreditGrant.created_at.asc())
+    )
+    return list(rows.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_seat_pool_grants_five_per_seat_and_resets_each_period(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    monkeypatch.setattr(settings, "pro_billing_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "price_pro")
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_managed_cloud_overage_price_id", "price_overage")
+
+    organization = Organization(name="LLM Pool Org")
+    db_session.add(organization)
+    await db_session.flush()
+    await _add_active_members(db_session, organization.id, 3)
+    subject = await ensure_organization_billing_subject(db_session, organization.id)
+    subject.stripe_customer_id = "cus_llm_pool"
+    subject_id = subject.id
+    org_id = organization.id
+    await db_session.commit()
+
+    seats = 3
+    current = {"start": _PERIOD1_START, "end": _PERIOD1_END}
+
+    async def fake_retrieve_subscription(subscription_id: str) -> dict:
+        assert subscription_id == "sub_llm_pool"
+        return _subscription_payload(
+            subject_id=subject_id,
+            org_id=org_id,
+            seats=seats,
+            start=current["start"],
+            end=current["end"],
+        )
+
+    async def fake_update_subscription_item_quantity(**kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        stripe_webhooks.stripe_billing, "retrieve_subscription", fake_retrieve_subscription
+    )
+    monkeypatch.setattr(
+        stripe_webhooks.stripe_billing,
+        "update_subscription_item_quantity",
+        fake_update_subscription_item_quantity,
+    )
+
+    invoice = _invoice_payload(subject_id=subject_id, org_id=org_id)
+
+    # Period 1: first invoice grants the pool; a replay is idempotent.
+    await stripe_webhooks._handle_invoice_paid(invoice)
+    await stripe_webhooks._handle_invoice_paid(invoice)
+    db_session.expire_all()
+
+    grants = await _list_seat_pool_grants(db_session, subject_id)
+    assert len(grants) == 1
+    # 3 seats * $5 = $15 into the shared org LLM pool.
+    assert grants[0].amount_usd == Decimal("15")
+    assert grants[0].expires_at == datetime.fromtimestamp(_PERIOD1_END, tz=UTC)
+
+    # Period 2 (renewal): a fresh pool grant is issued for the new period.
+    current["start"] = _PERIOD2_START
+    current["end"] = _PERIOD2_END
+    await stripe_webhooks._handle_invoice_paid(invoice)
+    db_session.expire_all()
+
+    grants = await _list_seat_pool_grants(db_session, subject_id)
+    assert len(grants) == 2
+    assert {g.amount_usd for g in grants} == {Decimal("15")}
+
+    # Reset semantics: at a point inside period 2 the period-1 pool has expired,
+    # so remaining reflects only the current period's $15 (no roll-over of the
+    # first period's unused allocation).
+    period2_midpoint = datetime.fromtimestamp(
+        (_PERIOD2_START + _PERIOD2_END) // 2, tz=UTC
+    )
+    balance = await agent_gateway_store.get_remaining_credit_usd(
+        db_session, subject_id, now=period2_midpoint
+    )
+    assert balance.granted_usd == Decimal("15")
+
+
+@pytest.mark.asyncio
+async def test_seat_pool_not_granted_when_gateway_disabled(
+    db_session: AsyncSession,
+    test_engine,  # type: ignore[no-untyped-def]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        engine_module,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    monkeypatch.setattr(settings, "pro_billing_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_enabled", False)
+    monkeypatch.setattr(settings, "stripe_pro_monthly_price_id", "price_pro")
+    monkeypatch.setattr(settings, "stripe_cloud_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_legacy_cloud_monthly_price_id", "")
+    monkeypatch.setattr(settings, "stripe_managed_cloud_overage_price_id", "price_overage")
+
+    organization = Organization(name="LLM Pool Off Org")
+    db_session.add(organization)
+    await db_session.flush()
+    await _add_active_members(db_session, organization.id, 3)
+    subject = await ensure_organization_billing_subject(db_session, organization.id)
+    subject.stripe_customer_id = "cus_llm_pool"
+    subject_id = subject.id
+    org_id = organization.id
+    await db_session.commit()
+
+    async def fake_retrieve_subscription(subscription_id: str) -> dict:
+        return _subscription_payload(
+            subject_id=subject_id,
+            org_id=org_id,
+            seats=3,
+            start=_PERIOD1_START,
+            end=_PERIOD1_END,
+        )
+
+    async def fake_update_subscription_item_quantity(**kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        stripe_webhooks.stripe_billing, "retrieve_subscription", fake_retrieve_subscription
+    )
+    monkeypatch.setattr(
+        stripe_webhooks.stripe_billing,
+        "update_subscription_item_quantity",
+        fake_update_subscription_item_quantity,
+    )
+
+    await stripe_webhooks._handle_invoice_paid(
+        _invoice_payload(subject_id=subject_id, org_id=org_id)
+    )
+    db_session.expire_all()
+
+    assert await _list_seat_pool_grants(db_session, subject_id) == []

--- a/server/tests/integration/test_billing_llm_seat_pool.py
+++ b/server/tests/integration/test_billing_llm_seat_pool.py
@@ -58,6 +58,7 @@ async def _add_active_members(
             )
         )
 
+
 _PERIOD1_START = 1_776_586_422  # 2026-04-19T...
 _PERIOD1_END = 1_779_178_422  # +30d
 _PERIOD2_START = 1_779_178_422
@@ -225,9 +226,7 @@ async def test_seat_pool_grants_five_per_seat_and_resets_each_period(
     # Reset semantics: at a point inside period 2 the period-1 pool has expired,
     # so remaining reflects only the current period's $15 (no roll-over of the
     # first period's unused allocation).
-    period2_midpoint = datetime.fromtimestamp(
-        (_PERIOD2_START + _PERIOD2_END) // 2, tz=UTC
-    )
+    period2_midpoint = datetime.fromtimestamp((_PERIOD2_START + _PERIOD2_END) // 2, tz=UTC)
     balance = await agent_gateway_store.get_remaining_credit_usd(
         db_session, subject_id, now=period2_midpoint
     )

--- a/server/tests/integration/test_stripe_webhooks.py
+++ b/server/tests/integration/test_stripe_webhooks.py
@@ -1166,7 +1166,9 @@ async def test_org_pro_subscription_sync_reconciles_active_seats_before_period_g
     )
     assert updates == [2]
     assert len(grants) == 1
-    assert grants[0].hours_granted == 40.0
+    # Ruled 2026-07-14: $15/seat compute at the default derived rate ($3.00/hr)
+    # => 5 hours/seat, so 2 seats grants 10 hours (was flat 20h/seat = 40).
+    assert grants[0].hours_granted == 10.0
 
     db_session.add(
         OrganizationMembership(
@@ -1206,7 +1208,8 @@ async def test_org_pro_subscription_sync_reconciles_active_seats_before_period_g
     assert updates == [2, 3]
     assert subscription.seat_quantity == 3
     assert len(grants) == 1
-    assert grants[0].hours_granted == 60.0
+    # 3 seats * 5 hours/seat (was flat 20h/seat = 60).
+    assert grants[0].hours_granted == 15.0
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_stripe_webhooks.py
+++ b/server/tests/integration/test_stripe_webhooks.py
@@ -1166,9 +1166,7 @@ async def test_org_pro_subscription_sync_reconciles_active_seats_before_period_g
     )
     assert updates == [2]
     assert len(grants) == 1
-    # Ruled 2026-07-14: $15/seat compute at the default derived rate ($3.00/hr)
-    # => 5 hours/seat, so 2 seats grants 10 hours (was flat 20h/seat = 40).
-    assert grants[0].hours_granted == 10.0
+    assert grants[0].hours_granted == 10.0  # 2 seats * 5 h/seat ($15 at $3/hr, ruled)
 
     db_session.add(
         OrganizationMembership(
@@ -1208,8 +1206,7 @@ async def test_org_pro_subscription_sync_reconciles_active_seats_before_period_g
     assert updates == [2, 3]
     assert subscription.seat_quantity == 3
     assert len(grants) == 1
-    # 3 seats * 5 hours/seat (was flat 20h/seat = 60).
-    assert grants[0].hours_granted == 15.0
+    assert grants[0].hours_granted == 15.0  # 3 seats * 5 h/seat
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_background_workers_flag.py
+++ b/server/tests/unit/test_background_workers_flag.py
@@ -1,0 +1,76 @@
+"""The ``run_background_workers`` flag gates the periodic maintenance loops.
+
+Deterministic billing tests boot the API with the loops disabled and drive the
+reconciler / accounting / gateway passes on demand out-of-process, so a
+background tick never races or deadlocks with the test's own pass. Toggling the
+flag off must make every loop-starter a no-op even when the feature it belongs
+to (gateway, enforce billing) is otherwise enabled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import proliferate.server.billing.reconciler as reconciler
+from proliferate.config import settings
+from proliferate.server.cloud.agent_gateway.worker import (
+    start_agent_gateway_enrollment_backfill,
+    start_agent_gateway_llm_topups,
+    start_agent_gateway_usage_import,
+)
+
+
+def _enable_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    # Make top-ups otherwise-enabled so the flag is the only thing gating it.
+    monkeypatch.setattr(settings, "agent_gateway_llm_topup_price_id", "price_llm_topup")
+    monkeypatch.setattr(settings, "agent_gateway_topup_amount_usd", "10")
+
+
+@pytest.mark.asyncio
+async def test_gateway_loops_do_not_start_when_workers_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_gateway(monkeypatch)
+    monkeypatch.setattr(settings, "run_background_workers", False)
+
+    assert await start_agent_gateway_enrollment_backfill() is None
+    assert await start_agent_gateway_usage_import() is None
+    assert await start_agent_gateway_llm_topups() is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_loops_start_when_workers_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_gateway(monkeypatch)
+    monkeypatch.setattr(settings, "run_background_workers", True)
+
+    tasks = [
+        await start_agent_gateway_enrollment_backfill(),
+        await start_agent_gateway_usage_import(),
+        await start_agent_gateway_llm_topups(),
+    ]
+    try:
+        for task in tasks:
+            assert task is not None
+    finally:
+        for task in tasks:
+            if task is not None:
+                task.cancel()
+
+
+def test_billing_reconciler_does_not_start_when_workers_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "run_background_workers", False)
+    monkeypatch.setattr(reconciler, "_reconciler_task", None, raising=False)
+
+    reconciler.start_billing_reconciler()
+
+    assert reconciler._reconciler_task is None
+
+
+def test_run_background_workers_defaults_true() -> None:
+    # Production/default posture is unchanged: the loops auto-run with the API.
+    assert settings.run_background_workers is True

--- a/server/tests/unit/test_billing_truth.py
+++ b/server/tests/unit/test_billing_truth.py
@@ -80,6 +80,24 @@ def test_a4_compute_price_is_list_times_multiplier(monkeypatch: pytest.MonkeyPat
     assert compute_price_per_hour_cents() == 600
 
 
+def test_a4_compute_price_fails_closed_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """T2R-R02: zero/invalid pricing raises instead of silently metering at 0c."""
+    from proliferate.server.billing.models import BillingServiceError
+
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "not-a-number")
+    with pytest.raises(BillingServiceError, match="compute_price_unconfigured|decimal"):
+        compute_price_per_hour_usd()
+
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "0")
+    with pytest.raises(BillingServiceError):
+        compute_price_per_hour_usd()
+
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "2.00")
+    monkeypatch.setattr(settings, "pro_compute_margin_multiplier", 0.0)
+    with pytest.raises(BillingServiceError):
+        compute_price_per_hour_cents()
+
+
 def test_a4_compute_margin_stays_positive_above_list(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "2.00")
     monkeypatch.setattr(settings, "pro_compute_margin_multiplier", 1.5)
@@ -117,12 +135,18 @@ def test_a3_prorated_seat_grant_is_proportional() -> None:
     assert hours == pytest.approx(5.0, abs=0.05)
 
 
-def test_a3_compute_hours_zero_when_unpriced(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A misconfigured (zero) compute price is fail-safe: no free hours, no
-    # divide-by-zero.
+def test_a3_compute_hours_raises_when_unpriced(monkeypatch: pytest.MonkeyPatch) -> None:
+    # T2R-R02: a misconfigured (zero) compute price fails CLOSED — the old
+    # "0 hours, 0 cents" fail-safe silently priced overage at zero cents,
+    # which is unbounded free compute once the cap logic sees no meterable
+    # cents. Both derivations must raise instead.
+    from proliferate.server.billing.models import BillingServiceError
+
     monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "0")
-    assert compute_hours_per_seat() == 0.0
-    assert compute_price_per_hour_cents() == 0
+    with pytest.raises(BillingServiceError):
+        compute_hours_per_seat()
+    with pytest.raises(BillingServiceError):
+        compute_price_per_hour_cents()
 
 
 # --- A5: overage rounds UP whole cents per closed segment, no carry ---------

--- a/server/tests/unit/test_billing_truth.py
+++ b/server/tests/unit/test_billing_truth.py
@@ -1,0 +1,249 @@
+"""Focused unit tests for the ruled billing-truth values (PR 4).
+
+Each test pins one product change from the frozen billing-truth table
+(``Run Tier 2 Strictly and Make Billing Truth Authoritative``, Frozen
+2026-07-15; values RULED 2026-07-14). Offline/deterministic: pure helpers plus
+``settings`` monkeypatching, no DB or network.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from proliferate.config import settings
+from proliferate.server.billing.domain.accounting import overage_seconds_to_cents
+from proliferate.server.billing.domain.seats import (
+    pro_llm_pool_usd,
+    pro_period_grant_hours,
+    prorated_seat_grant_hours,
+)
+from proliferate.server.billing.policy import free_v2_policy, pro_policy
+from proliferate.server.billing.pricing import (
+    compute_hours_per_seat,
+    compute_price_per_hour_cents,
+    compute_price_per_hour_usd,
+)
+from proliferate.server.cloud.agent_gateway.free_credits import free_credit_amount_usd
+from proliferate.server.cloud.agent_gateway.topups import (
+    AUTO_TOPUP_ADMIN_ALERT_MARKER,
+    LlmTopupRunResult,
+    _record_topup_admin_alert_intent,
+)
+from proliferate.server.cloud.agent_gateway.usage_import import (
+    apply_llm_margin,
+    llm_margin_multiplier,
+)
+
+
+# --- A1: free lifetime managed-LLM grant is $2 -----------------------------
+
+
+def test_a1_free_credit_default_is_two_dollars(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The shipped default (config.py) must be $2, not the stale $5.
+    assert Settings_default("agent_gateway_free_credit_usd") == "2"
+    assert free_credit_amount_usd() == Decimal("2")
+
+
+def test_a1_free_credit_non_positive_disables_grant(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "0")
+    assert free_credit_amount_usd() == Decimal("0")
+    monkeypatch.setattr(settings, "agent_gateway_free_credit_usd", "not-a-number")
+    assert free_credit_amount_usd() == Decimal("0")
+
+
+# --- A2: $5/seat managed-LLM shared org pool -------------------------------
+
+
+def test_a2_pro_llm_pool_is_five_per_seat() -> None:
+    assert pro_llm_pool_usd(1) == Decimal("5")
+    assert pro_llm_pool_usd(3) == Decimal("15")
+    # A null/zero seat count floors at one seat (never a zero/negative pool).
+    assert pro_llm_pool_usd(None) == Decimal("5")
+    assert pro_llm_pool_usd(0) == Decimal("5")
+
+
+# --- A3/A4: $15/seat compute derived from E2B list x margin ----------------
+
+
+def test_a4_compute_price_is_list_times_multiplier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "2.00")
+    monkeypatch.setattr(settings, "pro_compute_margin_multiplier", 1.5)
+    assert compute_price_per_hour_usd() == Decimal("3.00")
+    assert compute_price_per_hour_cents() == 300
+    # The multiplier (not a fixed dollar rate) is the constant: changing the
+    # provider list price moves the derived rate.
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "4.00")
+    assert compute_price_per_hour_cents() == 600
+
+
+def test_a4_compute_margin_stays_positive_above_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "2.00")
+    monkeypatch.setattr(settings, "pro_compute_margin_multiplier", 1.5)
+    # Derived rate ($3.00) strictly exceeds provider list ($2.00) => margin > 0.
+    assert compute_price_per_hour_usd() > Decimal("2.00")
+
+
+def test_a3_compute_hours_per_seat_derived_from_fifteen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "2.00")
+    monkeypatch.setattr(settings, "pro_compute_margin_multiplier", 1.5)
+    # $15 allocation / $3.00 per hour = 5 hours per seat.
+    assert compute_hours_per_seat() == pytest.approx(5.0)
+
+
+def test_a3_pro_period_grant_scales_hours_by_seats() -> None:
+    # Pure: hours = seats * hours_per_seat (derivation passed in).
+    assert pro_period_grant_hours(seat_quantity=3, hours_per_seat=5.0) == pytest.approx(15.0)
+    assert pro_period_grant_hours(seat_quantity=None, hours_per_seat=5.0) == pytest.approx(5.0)
+
+
+def test_a3_prorated_seat_grant_is_proportional() -> None:
+    period_start = datetime(2026, 6, 1, tzinfo=UTC)
+    period_end = period_start + timedelta(days=30)
+    # Add one seat exactly halfway through the period => ~half the seat's hours.
+    halfway = period_start + timedelta(days=15)
+    hours = prorated_seat_grant_hours(
+        added_seats=1,
+        period_start=period_start,
+        period_end=period_end,
+        effective_at=halfway,
+        hours_per_seat=10.0,
+    )
+    assert hours == pytest.approx(5.0, abs=0.05)
+
+
+def test_a3_compute_hours_zero_when_unpriced(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A misconfigured (zero) compute price is fail-safe: no free hours, no
+    # divide-by-zero.
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "0")
+    assert compute_hours_per_seat() == 0.0
+    assert compute_price_per_hour_cents() == 0
+
+
+# --- A5: overage rounds UP whole cents per closed segment, no carry ---------
+
+
+def test_a5_overage_rounds_up_per_segment() -> None:
+    # 1.2c of raw overage exports 2c (ceil), not 1c (floor).
+    # rate 300c/hr => a segment of 14.4s = 300*14.4/3600 = 1.2c -> ceil = 2.
+    assert overage_seconds_to_cents(14.4, rate_cents_per_hour=300) == 2
+    # A whole hour is exact (no rounding surprise).
+    assert overage_seconds_to_cents(3600, rate_cents_per_hour=300) == 300
+
+
+def test_a5_segments_round_independently_no_cross_carry() -> None:
+    # Two 1.2c segments each ceil to 2c independently => 4c total. A carried
+    # fractional remainder would instead give 3c (2.4c -> 3), which the ruling
+    # forbids: the segment is the rounding unit.
+    seg = overage_seconds_to_cents(14.4, rate_cents_per_hour=300)
+    assert seg + seg == 4
+
+
+def test_a5_zero_and_negative_seconds_are_zero() -> None:
+    assert overage_seconds_to_cents(0.0, rate_cents_per_hour=300) == 0
+    assert overage_seconds_to_cents(-5.0, rate_cents_per_hour=300) == 0
+
+
+# --- A6: flat $50/org/month overage cap ------------------------------------
+
+
+def test_a6_default_overage_cap_is_flat_fifty_per_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "pro_billing_enabled", True)
+    # Default cap is a flat $50/org, NOT scaled by seat count.
+    one_seat = pro_policy(billable_seat_count=1, overage_cap_cents_per_seat=None)
+    five_seat = pro_policy(billable_seat_count=5, overage_cap_cents_per_seat=None)
+    assert one_seat.managed_cloud_overage_cap_cents == 5000
+    assert five_seat.managed_cloud_overage_cap_cents == 5000
+
+
+def test_a6_override_is_org_level_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pro_billing_enabled", True)
+    # A per-subject override is used as the org-level cap value, not multiplied
+    # by seats.
+    policy = pro_policy(billable_seat_count=4, overage_cap_cents_per_seat=1234)
+    assert policy.managed_cloud_overage_cap_cents == 1234
+
+
+def test_a4_policy_overage_rate_is_derived(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pro_billing_enabled", True)
+    monkeypatch.setattr(settings, "e2b_list_price_usd_per_hour", "2.00")
+    monkeypatch.setattr(settings, "pro_compute_margin_multiplier", 1.5)
+    policy = pro_policy(billable_seat_count=2, overage_cap_cents_per_seat=None)
+    assert policy.overage_price_per_hour_cents == 300
+    assert policy.included_managed_cloud_hours == pytest.approx(10.0)  # 2 seats * 5h
+    assert free_v2_policy().overage_price_per_hour_cents == 300
+
+
+# --- A8: managed-LLM metered at provider list + 15% ------------------------
+
+
+def test_a8_llm_margin_is_fifteen_percent(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert Settings_default("agent_gateway_llm_margin_pct") == "15"
+    monkeypatch.setattr(settings, "agent_gateway_llm_margin_pct", "15")
+    assert llm_margin_multiplier() == Decimal("1.15")
+    assert apply_llm_margin(10.0) == pytest.approx(11.5)
+    assert apply_llm_margin(0.0) == 0.0
+
+
+def test_a8_margin_fails_safe_to_no_markup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_llm_margin_pct", "not-a-number")
+    assert llm_margin_multiplier() == Decimal("1")
+    monkeypatch.setattr(settings, "agent_gateway_llm_margin_pct", "-5")
+    assert llm_margin_multiplier() == Decimal("1")
+
+
+# --- A9: auto-top-up records an admin-alert intent, no email ---------------
+
+
+def test_a9_alert_intent_default_matches_topups() -> None:
+    # The result carries an alerts_recorded count so callers/tests can assert
+    # one intent per auto top-up. Gating early-exits record none.
+    result = LlmTopupRunResult(scanned=0, eligible=0, topped_up=0, skipped=0)
+    assert result.alerts_recorded == 0
+
+
+def test_a9_alert_intent_emits_marker_without_email() -> None:
+    from uuid import uuid4
+
+    from proliferate.server.cloud.agent_gateway import topups as topups_module
+
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _Capture()
+    topups_module.logger.addHandler(handler)
+    previous_level = topups_module.logger.level
+    previous_disabled = topups_module.logger.disabled
+    # The app's dictConfig (disable_existing_loggers) can disable module loggers
+    # during the test session; re-enable this one so the marker is observable.
+    topups_module.logger.disabled = False
+    topups_module.logger.setLevel(logging.INFO)
+    try:
+        _record_topup_admin_alert_intent(
+            billing_subject_id=uuid4(),
+            invoice_id="in_test_123",
+        )
+    finally:
+        topups_module.logger.removeHandler(handler)
+        topups_module.logger.setLevel(previous_level)
+        topups_module.logger.disabled = previous_disabled
+
+    markers = [r for r in captured if r.getMessage() == AUTO_TOPUP_ADMIN_ALERT_MARKER]
+    assert len(markers) == 1
+    assert getattr(markers[0], "alert_audience", None) == "org_admins"
+    assert getattr(markers[0], "stripe_invoice_id", None) == "in_test_123"
+
+
+def Settings_default(field: str) -> str:
+    """The shipped default value declared on the Settings model (not env)."""
+    return type(settings).model_fields[field].default

--- a/tests/intent/fakes/litellm-management/server.test.ts
+++ b/tests/intent/fakes/litellm-management/server.test.ts
@@ -1,0 +1,117 @@
+// Offline unit test for the management-plane LiteLLM fake (PR 4, BRIEF §5).
+// Deterministic, no server/DB/network — just the fake's own HTTP surface.
+// Run: `pnpm --filter @proliferate/tests-intent exec tsx --test "fakes/**/*.test.ts"`.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { startLitellmManagementFake } from "./server.ts";
+
+async function postJson(baseUrl: string, path: string, body: unknown): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+async function getJson(baseUrl: string, path: string): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${baseUrl}${path}`);
+  return { status: res.status, body: await res.json() };
+}
+
+test("never serves an inference route", async () => {
+  const fake = await startLitellmManagementFake();
+  try {
+    const chat = await postJson(fake.baseUrl, "/chat/completions", { model: "gpt-4", messages: [] });
+    assert.equal(chat.status, 404);
+    const messages = await postJson(fake.baseUrl, "/v1/messages", { model: "claude", messages: [] });
+    assert.equal(messages.status, 404);
+  } finally {
+    await fake.close();
+  }
+});
+
+test("team/user/key admin lifecycle mirrors the pinned LiteLLM image's quirks", async () => {
+  const fake = await startLitellmManagementFake();
+  try {
+    // /team/new does not dedupe by alias.
+    const team1 = await postJson(fake.baseUrl, "/team/new", { team_alias: "org-acme" });
+    const team2 = await postJson(fake.baseUrl, "/team/new", { team_alias: "org-acme" });
+    assert.notEqual(team1.body.team_id, team2.body.team_id);
+    const listed = await getJson(fake.baseUrl, "/team/list?team_alias=org-acme");
+    assert.equal(listed.body.length, 2);
+
+    // /user/new 409s on a duplicate user_id.
+    const user1 = await postJson(fake.baseUrl, "/user/new", { user_id: "user-1" });
+    assert.equal(user1.status, 200);
+    const user1Again = await postJson(fake.baseUrl, "/user/new", { user_id: "user-1" });
+    assert.equal(user1Again.status, 409);
+
+    // /key/generate enforces a unique key_alias among live keys.
+    const key1 = await postJson(fake.baseUrl, "/key/generate", {
+      user_id: "user-1",
+      team_id: team1.body.team_id,
+      key_alias: "vk-user-1",
+      max_budget: 5,
+    });
+    assert.equal(key1.status, 200);
+    assert.ok(key1.body.token_id);
+    const dup = await postJson(fake.baseUrl, "/key/generate", { user_id: "user-1", key_alias: "vk-user-1" });
+    assert.equal(dup.status, 400);
+    assert.match(dup.body.error.message, /alias/i);
+
+    // Deleting frees the alias for reuse (mirrors delete-then-mint rotation).
+    await postJson(fake.baseUrl, "/key/delete", { keys: [key1.body.token_id] });
+    const reminted = await postJson(fake.baseUrl, "/key/generate", { user_id: "user-1", key_alias: "vk-user-1" });
+    assert.equal(reminted.status, 200);
+
+    // Blocked keys are tracked by token id and reported via blockedKeys().
+    await postJson(fake.baseUrl, "/key/block", { key: reminted.body.token_id });
+    assert.deepEqual(fake.blockedKeys(), [reminted.body.token_id]);
+    await postJson(fake.baseUrl, "/key/unblock", { key: reminted.body.token_id });
+    assert.deepEqual(fake.blockedKeys(), []);
+  } finally {
+    await fake.close();
+  }
+});
+
+test("/spend/logs filters rows to the [start_date, end_date] UTC midnight window", async () => {
+  const fake = await startLitellmManagementFake();
+  try {
+    fake.seedSpendRows([
+      { request_id: "req-jan-1", api_key: "tok-a", spend: 1, startTime: "2026-01-01T12:00:00Z" },
+      { request_id: "req-jan-3", api_key: "tok-a", spend: 2, startTime: "2026-01-03T00:00:00Z" },
+      { request_id: "req-jan-5", api_key: "tok-a", spend: 3, startTime: "2026-01-05T23:59:59Z" },
+    ]);
+    // LiteLLM bounds end_date at midnight (`startTime <= end_date 00:00:00`),
+    // which is exactly why the real importer pushes end_date to `at + 1 day` to
+    // capture same-day spend. So to include the jan-5 23:59:59 row, end_date is
+    // 2026-01-06 (mirroring the importer's windowing); jan-1 stays excluded by
+    // the lower bound.
+    const page = await getJson(
+      fake.baseUrl,
+      "/spend/logs?summarize=false&start_date=2026-01-02&end_date=2026-01-06",
+    );
+    const ids = (page.body as Array<{ request_id: string }>).map((r) => r.request_id).sort();
+    assert.deepEqual(ids, ["req-jan-3", "req-jan-5"]);
+  } finally {
+    await fake.close();
+  }
+});
+
+test("mintedKeys() reflects generate/block state for test introspection", async () => {
+  const fake = await startLitellmManagementFake();
+  try {
+    const minted = await postJson(fake.baseUrl, "/key/generate", { user_id: "user-2", key_alias: "vk-user-2" });
+    await postJson(fake.baseUrl, "/key/block", { key: minted.body.token_id });
+    const keys = fake.mintedKeys();
+    assert.equal(keys.length, 1);
+    assert.equal(keys[0].tokenId, minted.body.token_id);
+    assert.equal(keys[0].blocked, true);
+    assert.equal(keys[0].deleted, false);
+  } finally {
+    await fake.close();
+  }
+});

--- a/tests/intent/fakes/litellm-management/server.ts
+++ b/tests/intent/fakes/litellm-management/server.ts
@@ -1,0 +1,411 @@
+// Management-plane LiteLLM fake (PR 4, BRIEF §5).
+//
+// The ONE place the target contract calls for a LiteLLM fake — and it is the
+// ADMIN/control plane ONLY, never inference. It serves exactly the admin routes
+// `server/proliferate/integrations/litellm/client.py` calls, so the REAL
+// `run_usage_import` pages/dedups/attributes spend rows, real enrollment sync
+// (`ensure_user_enrollment`/`ensure_org_enrollment`) mints real virtual keys
+// against it, and the exhaustion path blocks a scoped key for real. It NEVER
+// serves `/chat/completions` or `/v1/messages` — there is no fake inference
+// here; any unrecognized path (which includes every inference route) 404s.
+//
+// Pattern mirrors tests/intent/fakes/mock-idp/server.ts (a plain node:http
+// loopback server the booted server points AGENT_GATEWAY_LITELLM_BASE_URL at).
+//
+// Verified against client.py's documented pinned-image quirks so the fake's
+// behavior matches production, not an idealized admin API:
+//   - `/team/new` does NOT enforce a unique `team_alias`.
+//   - `/team/list` ignores the `team_alias` query param and returns every team
+//     (`ensure_team` filters client-side).
+//   - `/user/new` 409s for an existing `user_id`.
+//   - `/key/generate` enforces a unique `key_alias` (400, message mentions
+//     "alias", among LIVE keys only — a deleted key's alias is free again).
+//   - `/key/list`'s `key_alias` filter is likewise advisory; the fake returns
+//     every live key and the caller (`delete_virtual_keys_by_alias`) filters
+//     client-side, matching the real proxy.
+//   - `/spend/logs?summarize=false` rows are filtered by the `[start_date
+//     00:00:00, end_date 00:00:00]` UTC window client.py documents (inclusive
+//     both ends), keyed off `startTime`.
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
+
+/** One fabricated spend-log row (shape must match litellm/models.py::LiteLLMSpendLogEntry). */
+export interface FakeSpendRow {
+  request_id: string;
+  /** Token id of the virtual key that made the request — equals the
+   * `token_id` this fake returned from `/key/generate` at mint time. */
+  api_key: string;
+  spend: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  model?: string;
+  /** ISO-8601; the importer pages by YYYY-MM-DD date bounds over this. */
+  startTime?: string;
+  user?: string;
+  team_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** A key this fake has minted, for test introspection (extra to the frozen
+ * `LitellmManagementFake` contract — safe additive surface). */
+export interface FakeMintedKey {
+  tokenId: string;
+  keyAlias: string | null;
+  userId: string | null;
+  teamId: string | null;
+  maxBudget: number | null;
+  blocked: boolean;
+  deleted: boolean;
+}
+
+export interface LitellmManagementFake {
+  baseUrl: string;
+  /** Synthetic master key the booted server is given for admin auth (never a real secret). */
+  masterKey: string;
+  /** Seed the spend-log rows a subsequent import will page. */
+  seedSpendRows(rows: FakeSpendRow[]): void;
+  /** Token ids the exhaustion/limit path called /key/block on (dedup'd, insertion order). */
+  blockedKeys(): string[];
+  /** Every key minted so far (introspection for tests — not in client.py's surface). */
+  mintedKeys(): FakeMintedKey[];
+  close(): Promise<void>;
+}
+
+interface FakeTeam {
+  teamId: string;
+  teamAlias: string;
+  maxBudget: number | null;
+}
+
+interface FakeKey {
+  tokenId: string;
+  key: string;
+  keyAlias: string | null;
+  userId: string | null;
+  teamId: string | null;
+  maxBudget: number | null;
+  blocked: boolean;
+  deleted: boolean;
+}
+
+async function readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(payload);
+}
+
+function sendError(res: ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { error: { message } });
+}
+
+/** Inclusive UTC midnight bound, matching client.py's documented LiteLLM
+ * date-window semantics (`start_date`/`end_date` are `YYYY-MM-DD`, parsed at
+ * midnight; `end_date` matches `startTime <= end_date 00:00:00`). */
+function dateBoundMs(dateStr: string): number {
+  return new Date(`${dateStr}T00:00:00.000Z`).getTime();
+}
+
+/**
+ * Start the management-plane fake on an ephemeral loopback port. Fully
+ * in-memory, deterministic, no outbound network calls — safe to run
+ * unattended and offline.
+ */
+export async function startLitellmManagementFake(): Promise<LitellmManagementFake> {
+  const spendRows: FakeSpendRow[] = [];
+  const teams: FakeTeam[] = [];
+  const users = new Set<string>();
+  const keys = new Map<string, FakeKey>();
+  // Insertion-ordered, deduplicated: a Set preserves first-seen order in JS.
+  const blocked = new Set<string>();
+  const masterKey = `sk-fake-mgmt-${randomUUID().replace(/-/g, "")}`;
+
+  function findKey(keyOrTokenId: string): FakeKey | undefined {
+    const byToken = keys.get(keyOrTokenId);
+    if (byToken) {
+      return byToken;
+    }
+    for (const candidate of keys.values()) {
+      if (candidate.key === keyOrTokenId) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }
+
+  function aliasIsLive(alias: string): boolean {
+    for (const candidate of keys.values()) {
+      if (!candidate.deleted && candidate.keyAlias === alias) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const server: Server = createServer((req, res) => {
+    void handle(req, res).catch(() => sendJson(res, 500, { error: { message: "fake_internal_error" } }));
+  });
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const path = url.pathname;
+    const method = (req.method ?? "GET").toUpperCase();
+    // NOTE: real admin auth uses an `Authorization: Bearer <master_key>` header;
+    // the fake accepts any request (it is loopback + run-scoped, never reachable
+    // outside this process), matching the mock-idp fake's posture.
+
+    if (method === "GET" && path === "/health/liveliness") {
+      sendJson(res, 200, { status: "ok" });
+      return;
+    }
+
+    // Test-only introspection (not part of LiteLLM's real admin API): lets a
+    // Playwright spec — which runs in a different process than the one that
+    // called `startLitellmManagementFake()` — read the fake's in-memory
+    // blocked/minted-key state back over the one thing every process shares,
+    // the published `baseUrl`. Namespaced under `/__test/` so it can never be
+    // confused with a real LiteLLM route.
+    if (method === "GET" && path === "/__test/blocked-keys") {
+      sendJson(res, 200, { blockedKeys: [...blocked] });
+      return;
+    }
+    if (method === "GET" && path === "/__test/minted-keys") {
+      sendJson(res, 200, {
+        mintedKeys: [...keys.values()].map((k) => ({
+          tokenId: k.tokenId,
+          keyAlias: k.keyAlias,
+          userId: k.userId,
+          teamId: k.teamId,
+          maxBudget: k.maxBudget,
+          blocked: k.blocked,
+          deleted: k.deleted,
+        })),
+      });
+      return;
+    }
+
+    if (method === "POST" && path === "/__test/spend-rows") {
+      const body = await readBody(req);
+      const rows = Array.isArray(body.rows) ? (body.rows as FakeSpendRow[]) : [];
+      spendRows.push(...rows);
+      sendJson(res, 200, { seeded: rows.length });
+      return;
+    }
+
+    if (method === "GET" && path === "/spend/logs") {
+      const startDate = url.searchParams.get("start_date");
+      const endDate = url.searchParams.get("end_date");
+      const startMs = startDate ? dateBoundMs(startDate) : Number.NEGATIVE_INFINITY;
+      const endMs = endDate ? dateBoundMs(endDate) : Number.POSITIVE_INFINITY;
+      const page = spendRows.filter((row) => {
+        if (!row.startTime) {
+          // No timestamp to filter on: never withheld (spend must not be
+          // silently dropped by the fake either).
+          return true;
+        }
+        const t = new Date(row.startTime).getTime();
+        return t >= startMs && t <= endMs;
+      });
+      sendJson(res, 200, page);
+      return;
+    }
+
+    if (method === "POST" && path === "/team/new") {
+      const body = await readBody(req);
+      const teamAlias = typeof body.team_alias === "string" ? body.team_alias : "";
+      const maxBudget = typeof body.max_budget === "number" ? body.max_budget : null;
+      const teamId = `team-${randomUUID().slice(0, 8)}`;
+      // Deliberately NOT deduped by alias — the pinned LiteLLM image allows
+      // duplicate team aliases (see client.py's verified-behavior note).
+      teams.push({ teamId, teamAlias, maxBudget });
+      sendJson(res, 200, { team_id: teamId, team_alias: teamAlias });
+      return;
+    }
+
+    if (method === "GET" && path === "/team/list") {
+      // The pinned image ignores the `team_alias` query param and returns
+      // every team fully hydrated; `ensure_team` filters client-side.
+      sendJson(
+        res,
+        200,
+        teams.map((t) => ({ team_id: t.teamId, team_alias: t.teamAlias, max_budget: t.maxBudget })),
+      );
+      return;
+    }
+
+    if (method === "POST" && path === "/team/update") {
+      const body = await readBody(req);
+      const teamId = typeof body.team_id === "string" ? body.team_id : null;
+      const team = teamId ? teams.find((t) => t.teamId === teamId) : undefined;
+      if (team) {
+        team.maxBudget = typeof body.max_budget === "number" ? body.max_budget : null;
+      }
+      sendJson(res, 200, {});
+      return;
+    }
+
+    if (method === "POST" && path === "/user/new") {
+      const body = await readBody(req);
+      const userId = typeof body.user_id === "string" ? body.user_id : "";
+      if (userId && users.has(userId)) {
+        sendError(res, 409, `User ${userId} already exists.`);
+        return;
+      }
+      users.add(userId);
+      sendJson(res, 200, { user_id: userId });
+      return;
+    }
+
+    if (method === "POST" && path === "/key/generate") {
+      const body = await readBody(req);
+      const keyAlias = typeof body.key_alias === "string" ? body.key_alias : null;
+      if (keyAlias && aliasIsLive(keyAlias)) {
+        sendError(res, 400, `Key alias '${keyAlias}' already in use.`);
+        return;
+      }
+      const tokenId = `tok-${randomUUID().replace(/-/g, "")}`;
+      const key = `sk-fake-${tokenId}`;
+      const record: FakeKey = {
+        tokenId,
+        key,
+        keyAlias,
+        userId: typeof body.user_id === "string" ? body.user_id : null,
+        teamId: typeof body.team_id === "string" ? body.team_id : null,
+        maxBudget: typeof body.max_budget === "number" ? body.max_budget : null,
+        blocked: false,
+        deleted: false,
+      };
+      keys.set(tokenId, record);
+      sendJson(res, 200, {
+        key,
+        token_id: tokenId,
+        key_alias: keyAlias,
+        user_id: record.userId,
+        team_id: record.teamId,
+        max_budget: record.maxBudget,
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/key/list") {
+      // Advisory `key_alias` filter, mirroring `/team/list` — every LIVE key
+      // is returned; `delete_virtual_keys_by_alias` re-filters client-side.
+      sendJson(res, 200, {
+        keys: [...keys.values()]
+          .filter((k) => !k.deleted)
+          .map((k) => ({ token: k.tokenId, key_alias: k.keyAlias, user_id: k.userId, team_id: k.teamId })),
+      });
+      return;
+    }
+
+    if (method === "POST" && path === "/key/delete") {
+      const body = await readBody(req);
+      const ids = Array.isArray(body.keys)
+        ? (body.keys as unknown[]).filter((k): k is string => typeof k === "string")
+        : [];
+      for (const id of ids) {
+        const found = findKey(id);
+        if (found) {
+          found.deleted = true;
+        }
+      }
+      sendJson(res, 200, {});
+      return;
+    }
+
+    if (method === "POST" && path === "/key/block") {
+      const body = await readBody(req);
+      const target = typeof body.key === "string" ? body.key : null;
+      if (target) {
+        const found = findKey(target);
+        // Record the token id when resolvable (matches what the importer's
+        // exhaustion assertions look up via the enrollment's virtual_key_id);
+        // fall back to whatever value was sent so nothing is silently lost.
+        blocked.add(found ? found.tokenId : target);
+        if (found) {
+          found.blocked = true;
+        }
+      }
+      sendJson(res, 200, {});
+      return;
+    }
+
+    if (method === "POST" && path === "/key/unblock") {
+      const body = await readBody(req);
+      const target = typeof body.key === "string" ? body.key : null;
+      if (target) {
+        const found = findKey(target);
+        blocked.delete(found ? found.tokenId : target);
+        if (found) {
+          found.blocked = false;
+        }
+      }
+      sendJson(res, 200, {});
+      return;
+    }
+
+    if (method === "POST" && path === "/key/update") {
+      const body = await readBody(req);
+      const target = typeof body.key === "string" ? body.key : null;
+      const found = target ? findKey(target) : undefined;
+      if (found) {
+        found.maxBudget = typeof body.max_budget === "number" ? body.max_budget : null;
+      }
+      sendJson(res, 200, {});
+      return;
+    }
+
+    // Any other route (crucially, every inference route — `/chat/completions`,
+    // `/v1/messages`, `/v1/completions`, ...) is not served: this fake never
+    // fabricates a model response.
+    sendJson(res, 404, { error: { message: "not_found" }, path });
+  }
+
+  const baseUrl = await new Promise<string>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+
+  return {
+    baseUrl,
+    masterKey,
+    seedSpendRows: (rows) => {
+      spendRows.push(...rows);
+    },
+    blockedKeys: () => [...blocked],
+    mintedKeys: () =>
+      [...keys.values()].map((k) => ({
+        tokenId: k.tokenId,
+        keyAlias: k.keyAlias,
+        userId: k.userId,
+        teamId: k.teamId,
+        maxBudget: k.maxBudget,
+        blocked: k.blocked,
+        deleted: k.deleted,
+      })),
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/tests/intent/package.json
+++ b/tests/intent/package.json
@@ -12,7 +12,9 @@
     "test:secrets": "playwright test specs/secrets.spec.ts",
     "test:cloud-workspace": "playwright test specs/cloud-workspace.spec.ts",
     "test:billing": "playwright test --config playwright.billing.config.ts",
-    "test:sso": "playwright test specs/sso.spec.ts"
+    "test:billing-import": "playwright test --config playwright.billing-import.config.ts",
+    "test:sso": "playwright test specs/sso.spec.ts",
+    "test:unit": "tsx --test \"fakes/**/*.test.ts\""
   },
   "dependencies": {
     "pg": "^8.13.1"
@@ -22,6 +24,7 @@
     "@types/node": "^24.13.2",
     "@types/pg": "^8.11.10",
     "oauth2-mock-server": "^9.1.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.0"
   }
 }

--- a/tests/intent/playwright.billing-import.config.ts
+++ b/tests/intent/playwright.billing-import.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+
+// Tier-2 BILLING-IMPORT suite (PR 4 workstream C; feeds T2-BILL-15/T2-BILL-6's
+// exhaustion assertion). Separate config from playwright.billing.config.ts:
+// this project boots its own stack with AGENT_GATEWAY_ENABLED + the LiteLLM
+// management fake wired at server-start time
+// (stack/billing-import-global-setup.ts), on the same `t2billing` profile —
+// never run concurrently with the main billing project (see that module's
+// header comment). API + DB assertions only, no UI: `skipFrontend` in the
+// boot skips the desktop web/AnyHarness runtime entirely.
+export default defineConfig({
+  testDir: "./specs/billing-import",
+  globalSetup: "./stack/billing-import-global-setup.ts",
+  workers: 1,
+  fullyParallel: false,
+  retries: 1,
+  timeout: 240_000,
+  expect: { timeout: 20_000 },
+  reporter: process.env.CI ? [["list"], ["github"]] : [["list"]],
+  use: {
+    trace: "retain-on-failure",
+  },
+});

--- a/tests/intent/playwright.config.ts
+++ b/tests/intent/playwright.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
   testDir: "./specs",
   // The billing specs live under ./specs/billing but boot a different stack
   // (Stripe + enforce mode) via their own config; keep them out of this suite.
-  testIgnore: "**/billing/**",
+  // billing/ and billing-import/ have their own configs + global setups
+  // (Stripe stack / LiteLLM-fake stack); the default suite must not collect them.
+  testIgnore: ["**/billing/**", "**/billing-import/**"],
   globalSetup: "./stack/global-setup.ts",
   workers: 1,
   fullyParallel: false,

--- a/tests/intent/specs/billing-import/usage-import.spec.ts
+++ b/tests/intent/specs/billing-import/usage-import.spec.ts
@@ -1,0 +1,160 @@
+// T2-BILL-15 (LiteLLM usage import: overlap-window pagination, cursor resume,
+// dedup, payer/member attribution, needs_review fail-closed) and T2-BILL-6's
+// exhaustion assertion (disabling the scoped gateway key only) — driven
+// against the REAL `run_usage_import` + real enrollment sync
+// (`ensure_user_enrollment`/`ensure_org_enrollment`), never direct-SQL
+// `agent_llm_usage_event` seeding. The only fake here is the LiteLLM
+// management/admin plane (tests/intent/fakes/litellm-management) — no
+// inference call, no live LiteLLM. See stack/billing-import-global-setup.ts
+// for why this is a separate Playwright project from specs/billing/*.
+
+import { randomUUID } from "node:crypto";
+
+import { expect } from "@playwright/test";
+
+import { test, adminContext, adminUserId, skipIfNoStripe } from "../billing/_fixtures.ts";
+import {
+  countUsageEvents,
+  fetchFakeBlockedKeys,
+  getOrgEnrollment,
+  getUsageEvent,
+  getUserEnrollment,
+  runEnrollmentBackfillPass,
+  runUsageImportPass,
+  seedFakeSpendRows,
+  seedLlmCreditGrant,
+} from "../../stack/billing-usage-import.ts";
+
+test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup/attribution", () => {
+  skipIfNoStripe(test);
+
+  test("enrollment sync mints real virtual keys (personal + org) against the fake", async () => {
+    const userId = await adminUserId();
+    const { organizationId } = await adminContext();
+    runEnrollmentBackfillPass();
+
+    const personal = await getUserEnrollment(userId);
+    expect(personal, "personal enrollment row exists").toBeTruthy();
+    expect(personal!.virtualKeyId, "a real virtual key was minted").toBeTruthy();
+    expect(personal!.syncStatus).toBe("synced");
+
+    const org = await getOrgEnrollment(organizationId, userId);
+    expect(org, "org enrollment row exists (admin is a member)").toBeTruthy();
+    expect(org!.virtualKeyId, "a distinct virtual key was minted for the org membership").toBeTruthy();
+    expect(org!.virtualKeyId).not.toBe(personal!.virtualKeyId);
+  });
+
+  test("imports paginated spend exactly once, and a repeated tick (restart) adds nothing new", async () => {
+    const userId = await adminUserId();
+    runEnrollmentBackfillPass();
+    const personal = await getUserEnrollment(userId);
+    expect(personal!.virtualKeyId).toBeTruthy();
+
+    const now = new Date().toISOString();
+    const requestIdA = `req-${randomUUID()}`;
+    const requestIdB = `req-${randomUUID()}`;
+    await seedFakeSpendRows([
+      { request_id: requestIdA, api_key: personal!.virtualKeyId!, spend: 0.1, startTime: now },
+      { request_id: requestIdB, api_key: personal!.virtualKeyId!, spend: 0.2, startTime: now },
+    ]);
+
+    const before = await countUsageEvents();
+    runUsageImportPass();
+    const afterFirst = await countUsageEvents();
+    expect(afterFirst - before, "both seeded rows imported exactly once").toBe(2);
+
+    const eventA = await getUsageEvent(requestIdA);
+    expect(eventA?.status).toBe("imported");
+    expect(eventA?.costUsd).toBeCloseTo(0.1, 6);
+    expect(eventA?.userId).toBe(userId);
+
+    // Restart-safety / exactly-once: a second tick over the SAME overlap
+    // window (no new fake rows) must not create duplicates — the unique
+    // constraint on litellm_request_id dedupes even though the fake still
+    // serves the same rows within the window.
+    runUsageImportPass();
+    const afterSecond = await countUsageEvents();
+    expect(afterSecond, "a repeated tick over an overlapping window adds no duplicate rows").toBe(afterFirst);
+  });
+
+  test("an unresolved virtual key becomes needs_review, fails closed (no silent attribution)", async () => {
+    const unresolvedKey = `tok-unresolved-${randomUUID()}`;
+    const requestId = `req-${randomUUID()}`;
+    await seedFakeSpendRows([
+      { request_id: requestId, api_key: unresolvedKey, spend: 1.23, startTime: new Date().toISOString() },
+    ]);
+
+    runUsageImportPass();
+
+    const event = await getUsageEvent(requestId);
+    expect(event, "the row is still recorded, never silently dropped").toBeTruthy();
+    expect(event!.status).toBe("needs_review");
+    expect(event!.userId).toBeNull();
+    expect(event!.organizationId).toBeNull();
+    expect(event!.billingSubjectId).toBeNull();
+  });
+
+  test("member/payer attribution: org-enrolled spend attributes to the org subject, personal spend to the personal subject", async () => {
+    const userId = await adminUserId();
+    const { organizationId } = await adminContext();
+    runEnrollmentBackfillPass();
+    const personal = await getUserEnrollment(userId);
+    const org = await getOrgEnrollment(organizationId, userId);
+    expect(personal!.virtualKeyId).toBeTruthy();
+    expect(org!.virtualKeyId).toBeTruthy();
+
+    const personalRequestId = `req-${randomUUID()}`;
+    const orgRequestId = `req-${randomUUID()}`;
+    const now = new Date().toISOString();
+    await seedFakeSpendRows([
+      { request_id: personalRequestId, api_key: personal!.virtualKeyId!, spend: 0.5, startTime: now },
+      { request_id: orgRequestId, api_key: org!.virtualKeyId!, spend: 0.75, startTime: now },
+    ]);
+
+    runUsageImportPass();
+
+    const personalEvent = await getUsageEvent(personalRequestId);
+    expect(personalEvent!.userId).toBe(userId);
+    expect(personalEvent!.organizationId).toBeNull();
+    expect(personalEvent!.billingSubjectId).toBe(personal!.billingSubjectId);
+
+    const orgEvent = await getUsageEvent(orgRequestId);
+    expect(orgEvent!.userId).toBe(userId);
+    expect(orgEvent!.organizationId).toBe(organizationId);
+    expect(orgEvent!.billingSubjectId).toBe(org!.billingSubjectId);
+    expect(orgEvent!.billingSubjectId).not.toBe(personalEvent!.billingSubjectId);
+  });
+});
+
+test.describe("T2-BILL-6: managed-LLM exhaustion disables only the scoped gateway key", () => {
+  skipIfNoStripe(test);
+
+  test("exhausting a subject's credit blocks its virtual key at the fake and flips budget_status, leaving other keys untouched", async () => {
+    const userId = await adminUserId();
+    const { organizationId } = await adminContext();
+    runEnrollmentBackfillPass();
+    const personal = await getUserEnrollment(userId);
+    const org = await getOrgEnrollment(organizationId, userId);
+    expect(personal!.virtualKeyId).toBeTruthy();
+    expect(org!.virtualKeyId).toBeTruthy();
+
+    // A large, unambiguous spend drives remaining credit negative regardless
+    // of whatever free/seed grants already exist on this subject.
+    await seedLlmCreditGrant({ billingSubjectId: personal!.billingSubjectId, userId, amountUsd: 1 });
+    const requestId = `req-${randomUUID()}`;
+    await seedFakeSpendRows([
+      { request_id: requestId, api_key: personal!.virtualKeyId!, spend: 1000, startTime: new Date().toISOString() },
+    ]);
+
+    runUsageImportPass();
+
+    const updated = await getUserEnrollment(userId);
+    expect(updated!.budgetStatus).toBe("exhausted");
+
+    const blocked = await fetchFakeBlockedKeys();
+    expect(blocked, "the exhausted subject's own key is disabled").toContain(personal!.virtualKeyId);
+    expect(blocked, "the org membership's separate key is not touched by personal exhaustion").not.toContain(
+      org!.virtualKeyId,
+    );
+  });
+});

--- a/tests/intent/specs/billing-import/usage-import.spec.ts
+++ b/tests/intent/specs/billing-import/usage-import.spec.ts
@@ -31,7 +31,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
   test("enrollment sync mints real virtual keys (personal + org) against the fake", async () => {
     const userId = await adminUserId();
     const { organizationId } = await adminContext();
-    runEnrollmentBackfillPass();
+    await runEnrollmentBackfillPass();
 
     const personal = await getUserEnrollment(userId);
     expect(personal, "personal enrollment row exists").toBeTruthy();
@@ -46,7 +46,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
 
   test("imports paginated spend exactly once, and a repeated tick (restart) adds nothing new", async () => {
     const userId = await adminUserId();
-    runEnrollmentBackfillPass();
+    await runEnrollmentBackfillPass();
     const personal = await getUserEnrollment(userId);
     expect(personal!.virtualKeyId).toBeTruthy();
 
@@ -59,7 +59,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
     ]);
 
     const before = await countUsageEvents();
-    runUsageImportPass();
+    await runUsageImportPass();
     const afterFirst = await countUsageEvents();
     expect(afterFirst - before, "both seeded rows imported exactly once").toBe(2);
 
@@ -72,7 +72,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
     // window (no new fake rows) must not create duplicates — the unique
     // constraint on litellm_request_id dedupes even though the fake still
     // serves the same rows within the window.
-    runUsageImportPass();
+    await runUsageImportPass();
     const afterSecond = await countUsageEvents();
     expect(afterSecond, "a repeated tick over an overlapping window adds no duplicate rows").toBe(afterFirst);
   });
@@ -84,7 +84,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
       { request_id: requestId, api_key: unresolvedKey, spend: 1.23, startTime: new Date().toISOString() },
     ]);
 
-    runUsageImportPass();
+    await runUsageImportPass();
 
     const event = await getUsageEvent(requestId);
     expect(event, "the row is still recorded, never silently dropped").toBeTruthy();
@@ -97,7 +97,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
   test("member/payer attribution: org-enrolled spend attributes to the org subject, personal spend to the personal subject", async () => {
     const userId = await adminUserId();
     const { organizationId } = await adminContext();
-    runEnrollmentBackfillPass();
+    await runEnrollmentBackfillPass();
     const personal = await getUserEnrollment(userId);
     const org = await getOrgEnrollment(organizationId, userId);
     expect(personal!.virtualKeyId).toBeTruthy();
@@ -111,7 +111,7 @@ test.describe("T2-BILL-15: LiteLLM usage import — real pagination/cursor/dedup
       { request_id: orgRequestId, api_key: org!.virtualKeyId!, spend: 0.75, startTime: now },
     ]);
 
-    runUsageImportPass();
+    await runUsageImportPass();
 
     const personalEvent = await getUsageEvent(personalRequestId);
     expect(personalEvent!.userId).toBe(userId);
@@ -132,7 +132,7 @@ test.describe("T2-BILL-6: managed-LLM exhaustion disables only the scoped gatewa
   test("exhausting a subject's credit blocks its virtual key at the fake and flips budget_status, leaving other keys untouched", async () => {
     const userId = await adminUserId();
     const { organizationId } = await adminContext();
-    runEnrollmentBackfillPass();
+    await runEnrollmentBackfillPass();
     const personal = await getUserEnrollment(userId);
     const org = await getOrgEnrollment(organizationId, userId);
     expect(personal!.virtualKeyId).toBeTruthy();
@@ -146,7 +146,7 @@ test.describe("T2-BILL-6: managed-LLM exhaustion disables only the scoped gatewa
       { request_id: requestId, api_key: personal!.virtualKeyId!, spend: 1000, startTime: new Date().toISOString() },
     ]);
 
-    runUsageImportPass();
+    await runUsageImportPass();
 
     const updated = await getUserEnrollment(userId);
     expect(updated!.budgetStatus).toBe("exhausted");

--- a/tests/intent/specs/billing/core.spec.ts
+++ b/tests/intent/specs/billing/core.spec.ts
@@ -56,11 +56,12 @@ test.describe("T2-BILL-1: checkout → grants → consumption → cut-off → re
     const paid = await b.deliverEvent({ type: "invoice.paid", object: invoice });
     expect(paid.status).toBe(200);
 
-    // Pro period grant issued: 20h/seat.
+    // Pro period grant issued: $15/seat at the derived $3.00/hr rate = 5h/seat
+    // (ruled 2026-07-14; was flat 20h/seat).
     const grants = await b.listGrants(subject.id);
     const periodGrant = grants.find((g) => g.grant_type === "pro_period");
     expect(periodGrant, "pro_period grant issued by invoice.paid").toBeTruthy();
-    expect(Number(periodGrant!.hours_granted)).toBeCloseTo(20, 1);
+    expect(Number(periodGrant!.hours_granted)).toBeCloseTo(5, 1);
 
     // Backdate the grant's effective_at: accounting checks grant usability at
     // each usage range's accounted_from (grant_is_usable_for_accounting

--- a/tests/intent/specs/billing/overage.spec.ts
+++ b/tests/intent/specs/billing/overage.spec.ts
@@ -1,6 +1,7 @@
-// T2-BILL-5 (compute overage: bill to cap, write off past it, hard-block;
-// disabled → immediate cutoff) and T2-BILL-6 (LLM credits: exhaustion, admin
-// caps, auto top-up incl. declined-card fail-closed).
+// T2-BILL-5 (compute overage: bill to the flat $50/org/month cap, PAUSE past
+// it — write-off is operator-only per the 2026-07-14 ruling; disabled →
+// immediate cutoff) and T2-BILL-6 (LLM credits: exhaustion, admin caps, auto
+// top-up incl. declined-card fail-closed).
 //
 // Tier boundary (T2-BILL-6): the LiteLLM virtual-key *disable* side effect is
 // a tier-3 assertion (it calls the live gateway). At tier 2 we seed the spend
@@ -14,7 +15,7 @@ import { expect } from "@playwright/test";
 import { test, adminContext, skipIfNoStripe } from "./_fixtures.ts";
 import * as b from "../../stack/billing.ts";
 
-async function paidOrgSubjectWithBackdatedPeriod(seats = 1) {
+async function paidOrgSubjectWithBackdatedPeriod(seats = 1, backdateHours = 2) {
   const { token, organizationId } = await adminContext();
   const ownerId = await userIdFor(token);
   const clock = b.createTestClock();
@@ -30,48 +31,52 @@ async function paidOrgSubjectWithBackdatedPeriod(seats = 1) {
   // Backdate the synced period start so seeded recent segments fall inside the
   // paid period (test-time shift, the direct-DB analog of a test clock — the
   // same precedent as the invitation-expiry backdate in seed.ts).
-  const twoHoursAgo = new Date(Date.now() - 2 * 3600 * 1000);
+  const periodStart = new Date(Date.now() - backdateHours * 3600 * 1000);
   await b.withDb((db) =>
     db.query(`UPDATE billing_subscription SET current_period_start = $1 WHERE billing_subject_id = $2`, [
-      twoHoursAgo.toISOString(),
+      periodStart.toISOString(),
       subject.id,
     ]),
   );
   return { subject, ownerId, token, organizationId };
 }
 
-test.describe("T2-BILL-5: compute overage — bill to cap, write off, then block", () => {
+test.describe("T2-BILL-5: compute overage — bill to cap, pause past it, then block", () => {
   skipIfNoStripe(test);
 
-  test("uncovered seconds export as billable cents up to cap, then write off; snapshot flips to cap_exhausted", async () => {
-    const { subject, ownerId, token, organizationId } = await paidOrgSubjectWithBackdatedPeriod(1);
-    // The effective cap is per-seat × ACTIVE org members (accounting.py:
-    // max(active_seat_count,1) * overage_cap_cents_per_seat), and the claimed
-    // org's member count grows across runs (profile DB persists) — so compute
-    // the cap from the live seat count instead of assuming one seat.
-    const seats = await activeMemberCount(organizationId);
-    const capPerSeat = 2;
-    const capCents = seats * capPerSeat;
-    await b.setOverageSettings(subject.id, { enabled: true, capCentsPerSeat: capPerSeat });
+  test("uncovered seconds export as billable cents up to the flat cap, then PAUSE (no auto write-off); snapshot flips to cap_exhausted", async () => {
+    // Ruled 2026-07-14: flat $50/org/month cap (not per-seat), overage metered
+    // at the derived E2B-list x1.5 rate ($3.00/hr = 300 c/hr). Exhausting the
+    // cap therefore needs >16.7h of IN-PERIOD overage; backdate the period far
+    // enough that the long seeded segment stays billable.
+    const OVERAGE_RATE_CENTS_PER_HOUR = 300;
+    const capCents = 5000;
+    const { subject, ownerId, token, organizationId } = await paidOrgSubjectWithBackdatedPeriod(
+      1,
+      capCents / OVERAGE_RATE_CENTS_PER_HOUR + 6,
+    );
+    await b.setOverageSettings(subject.id, { enabled: true, capCentsPerSeat: capCents });
 
-    // Tiny grant (72s), then a segment long enough that its uncovered tail
-    // converts to cents well past the cap (overage is 200 cents/hour).
-    const hoursPastCap = capCents / 200 + 0.6;
+    // Tiny grant (72s), then a segment whose uncovered tail converts to cents
+    // well past the flat cap.
+    const hoursPastCap = capCents / OVERAGE_RATE_CENTS_PER_HOUR + 4;
     await b.seedGrant(subject.id, { userId: ownerId, grantType: "pro_period", hoursGranted: 0.02 });
     await b.seedUsageSegment(subject.id, {
       userId: ownerId,
       hours: hoursPastCap,
-      startedAt: new Date(Date.now() - (hoursPastCap * 60 + 10) * 60 * 1000),
+      startedAt: new Date(Date.now() - (hoursPastCap + 1) * 3600 * 1000),
     });
     b.runAccountingPass();
 
     const exports = await b.listUsageExports(subject.id);
     const billable = exports.filter((e) => (e.meter_quantity_cents ?? 0) > 0);
-    const writeoffs = exports.filter((e) => e.writeoff_reason === "overage_cap_exhausted");
+    const autoWriteoffs = exports.filter((e) => e.writeoff_reason === "overage_cap_exhausted");
     const billableCents = billable.reduce((s, e) => s + (e.meter_quantity_cents ?? 0), 0);
     expect(billable.length, "billable export rows created").toBeGreaterThan(0);
-    expect(billableCents, "billing stops at the cap").toBeLessThanOrEqual(capCents);
-    expect(writeoffs.length, "usage past cap is written off").toBeGreaterThan(0);
+    expect(billableCents, "billing stops at the flat $50/org cap").toBeLessThanOrEqual(capCents);
+    // Ruled: at cap, compute PAUSES; write-off is operator-only — past-cap
+    // usage must NOT be auto-written-off into an export row.
+    expect(autoWriteoffs.length, "past-cap usage is paused, not auto-written-off").toBe(0);
 
     // Owner scope matters: without it /billing/overview resolves the caller's
     // PERSONAL subject (permissions.py falls back to personal), but this
@@ -195,16 +200,6 @@ test.describe("T2-BILL-6: LLM credits — exhaustion, admin caps, top-ups", () =
   });
 });
 
-async function activeMemberCount(organizationId: string): Promise<number> {
-  return b.withDb(async (db) => {
-    const r = await db.query(
-      `SELECT count(*)::int AS n FROM organization_membership
-        WHERE organization_id = $1 AND status = 'active'`,
-      [organizationId],
-    );
-    return Math.max(r.rows[0].n as number, 1);
-  });
-}
 
 async function userIdFor(token: string): Promise<string> {
   const response = await fetch(`${process.env.TIER2_BILLING_API_BASE_URL}/users/me`, {

--- a/tests/intent/stack/billing-boot.ts
+++ b/tests/intent/stack/billing-boot.ts
@@ -1,0 +1,123 @@
+// Shared Tier-2 billing stack boot (PR 4, BRIEF §0).
+//
+// The ONE implementation of "resolve a Stripe test key → provision the local
+// test-mode price catalog → boot the `t2billing` profile stack → publish the
+// TIER2_BILLING_*/TIER2_INTENT_* env the billing harness reads". Both consumers
+// call this — the Playwright `billing-global-setup.ts` (retained) and the
+// `tests/release` Tier-2 adapter (`scenarios/tier2/harness.ts`) — so the boot is
+// never forked. Extracted from `billing-global-setup.ts` without behavior
+// change; that module is now a thin wrapper.
+//
+// Stripe posture is unchanged: a TEST key only (env or `stripe config --list`),
+// never live mode; no key resolvable → the caller decides (Playwright skips the
+// suite; the release adapter returns every financial cell BLOCKED — never
+// green, never skip-as-success).
+
+import { randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+import { BILLING_PROFILE, bootStack, REPO_ROOT, type BootedStack, type StripeBillingEnv } from "./boot.ts";
+
+export type BillingBootResult =
+  | { skipped: true; reason: string }
+  | { skipped: false; stack: BootedStack; stripe: StripeBillingEnv };
+
+export interface BillingBootOptions {
+  /** Extra/overriding server env (e.g. the LiteLLM management fake wiring the
+   * import cells add — workstream C). Applied last, like `bootStack`. */
+  extraServerEnv?: NodeJS.ProcessEnv;
+  /** Skip the desktop web (Vite)/AnyHarness runtime boot — passthrough to
+   * `bootStack` (workstream C's importer/exhaustion suite is API+DB only,
+   * never UI, and skips this to cut boot cost). Default false (every other
+   * caller's behavior is unchanged). */
+  skipFrontend?: boolean;
+}
+
+/** Resolve a Stripe TEST secret key (env first, then the local `stripe` CLI
+ * config); null when none is resolvable. Never returns a live key. */
+export function resolveStripeSecretKey(): string | null {
+  const fromEnv =
+    process.env.STRIPE_SECRET_KEY ||
+    process.env.STRIPE_TEST_SECRET_KEY ||
+    process.env.TIER2_BILLING_STRIPE_SECRET_KEY;
+  if (fromEnv && fromEnv.startsWith("sk_test_")) {
+    return fromEnv;
+  }
+  const result = spawnSync("stripe", ["config", "--list"], { encoding: "utf8" });
+  if (result.status === 0) {
+    const match = result.stdout.match(/test_mode_api_key\s*=\s*'([^']+)'/);
+    if (match && match[1].startsWith("sk_test_")) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+export interface PriceCatalog {
+  meter: { id: string };
+  prices: { proMonthly: string; managedCloudOverageCent: string; refill10h: string };
+}
+
+/** Idempotent test-mode price catalog provisioning (never touches live mode). */
+export function provisionPriceCatalog(secretKey: string): PriceCatalog {
+  const result = spawnSync("node", ["scripts/stripe-setup-test-mode.mjs"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: { ...process.env, STRIPE_API_KEY: secretKey },
+  });
+  if (result.status !== 0) {
+    throw new Error(`stripe-setup-test-mode.mjs failed: ${(result.stderr || result.stdout || "").trim()}`);
+  }
+  return JSON.parse(result.stdout) as PriceCatalog;
+}
+
+/**
+ * Boot the shared Tier-2 billing stack and publish the env the billing harness
+ * (`billing-env.ts`) and the auth/org seed helpers (`seed.ts`) read. Caller owns
+ * any per-run resets (`resetBillingState`, `resetPasswordLoginRateLimits`) and
+ * teardown (`result.stack.teardown`).
+ */
+export async function bootBillingStack(options: BillingBootOptions = {}): Promise<BillingBootResult> {
+  const secretKey = resolveStripeSecretKey();
+  if (!secretKey) {
+    return { skipped: true, reason: "no Stripe test key resolvable (env or `stripe config --list`)" };
+  }
+
+  const catalog = provisionPriceCatalog(secretKey);
+  const stripe: StripeBillingEnv = {
+    secretKey,
+    webhookSecret: `whsec_t2billing_${randomBytes(16).toString("hex")}`,
+    proMonthlyPriceId: catalog.prices.proMonthly,
+    overagePriceId: catalog.prices.managedCloudOverageCent,
+    refillPriceId: catalog.prices.refill10h,
+    meterId: catalog.meter.id,
+    billingMode: process.env.TIER2_BILLING_MODE ?? "enforce",
+  };
+
+  const stack = await bootStack({
+    profile: BILLING_PROFILE,
+    stripe,
+    extraServerEnv: options.extraServerEnv,
+    skipFrontend: options.skipFrontend,
+  });
+
+  // Billing harness (billing-env.ts) reads these.
+  process.env.TIER2_BILLING_API_BASE_URL = stack.apiBaseUrl;
+  process.env.TIER2_BILLING_WEB_BASE_URL = stack.webBaseUrl;
+  process.env.TIER2_BILLING_DATABASE_URL = stack.databaseUrl;
+  process.env.TIER2_BILLING_STRIPE_SECRET_KEY = stripe.secretKey;
+  process.env.TIER2_BILLING_STRIPE_WEBHOOK_SECRET = stripe.webhookSecret;
+  process.env.TIER2_BILLING_STRIPE_PRO_MONTHLY_PRICE_ID = stripe.proMonthlyPriceId;
+  process.env.TIER2_BILLING_STRIPE_OVERAGE_PRICE_ID = stripe.overagePriceId;
+  process.env.TIER2_BILLING_STRIPE_REFILL_PRICE_ID = stripe.refillPriceId;
+  process.env.TIER2_BILLING_STRIPE_METER_ID = stripe.meterId;
+
+  // Reuse seed.ts's auth/org helpers (claim, login, invite) against this same
+  // billing stack: they key off TIER2_INTENT_* env.
+  process.env.TIER2_INTENT_API_BASE_URL = stack.apiBaseUrl;
+  process.env.TIER2_INTENT_WEB_BASE_URL = stack.webBaseUrl;
+  process.env.TIER2_INTENT_DATABASE_URL = stack.databaseUrl;
+  process.env.TIER2_INTENT_SETUP_TOKEN_FILE = stack.setupTokenFile;
+
+  return { skipped: false, stack, stripe };
+}

--- a/tests/intent/stack/billing-global-setup.ts
+++ b/tests/intent/stack/billing-global-setup.ts
@@ -1,114 +1,31 @@
 // Playwright globalSetup for the tier-2 BILLING suite (specs/billing/*).
 //
-// Separate from the auth/org global-setup because billing needs its own server
-// posture: pro billing enabled, CLOUD_BILLING_MODE=enforce, and real Stripe
-// test-mode keys/prices wired in. It boots the dedicated `t2billing` profile
-// (one profile per suite, per specs/developing/local/dev-profiles.md) so it
-// never collides with the auth/org `t2intent` DB.
-//
-// Stripe requirement: the suite needs a Stripe TEST secret key and the local
-// test-mode price catalog (scripts/stripe-setup-test-mode.mjs, idempotent).
-// If no Stripe test key is resolvable (e.g. a CI job without the secret), the
-// whole suite is skipped rather than failing — matching the provisional,
-// non-blocking posture of the intent-tests workflow while the harness earns
-// trust.
+// Thin wrapper over the shared `bootBillingStack()` (stack/billing-boot.ts), so
+// the Playwright suite and the tests/release Tier-2 adapter share ONE boot
+// implementation (BRIEF §0). Behavior is unchanged from the pre-PR-4 module:
+// no Stripe test key → the whole suite is skipped (not failed), matching the
+// provisional, non-blocking posture while the harness earns trust.
 
-import { randomBytes } from "node:crypto";
-import { spawnSync } from "node:child_process";
-
-import { BILLING_PROFILE, bootStack, REPO_ROOT, type StripeBillingEnv } from "./boot.ts";
+import { bootBillingStack } from "./billing-boot.ts";
 import { resetBillingState } from "./billing-seed.ts";
 import { resetPasswordLoginRateLimits } from "./seed.ts";
 
 export class BillingSuiteSkipped extends Error {}
 
-function resolveStripeSecretKey(): string | null {
-  const fromEnv =
-    process.env.STRIPE_SECRET_KEY ||
-    process.env.STRIPE_TEST_SECRET_KEY ||
-    process.env.TIER2_BILLING_STRIPE_SECRET_KEY;
-  if (fromEnv && fromEnv.startsWith("sk_test_")) {
-    return fromEnv;
-  }
-  // Fall back to the developer's Stripe CLI config (test_mode_api_key), the
-  // same key `stripe config --list` prints locally.
-  const result = spawnSync("stripe", ["config", "--list"], { encoding: "utf8" });
-  if (result.status === 0) {
-    const match = result.stdout.match(/test_mode_api_key\s*=\s*'([^']+)'/);
-    if (match && match[1].startsWith("sk_test_")) {
-      return match[1];
-    }
-  }
-  return null;
-}
-
-interface PriceCatalog {
-  meter: { id: string };
-  prices: { proMonthly: string; managedCloudOverageCent: string; refill10h: string };
-}
-
-function provisionPriceCatalog(secretKey: string): PriceCatalog {
-  // Idempotent: finds existing test-mode prices by lookup key, creates only
-  // what's missing. Never touches live mode. The script shells out to the
-  // `stripe` CLI without --api-key, so pass the resolved key via the CLI's
-  // STRIPE_API_KEY env var — CI runners have no `stripe login` config.
-  const result = spawnSync("node", ["scripts/stripe-setup-test-mode.mjs"], {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-    env: { ...process.env, STRIPE_API_KEY: secretKey },
-  });
-  if (result.status !== 0) {
-    throw new Error(`stripe-setup-test-mode.mjs failed: ${(result.stderr || result.stdout || "").trim()}`);
-  }
-  return JSON.parse(result.stdout) as PriceCatalog;
-}
-
 export default async function billingGlobalSetup(): Promise<() => Promise<void>> {
-  const secretKey = resolveStripeSecretKey();
-  if (!secretKey) {
-    // No Stripe test key → skip the suite (see header). Publish a flag every
-    // spec's top-level guard reads; Playwright's own skip is per-test.
+  const boot = await bootBillingStack();
+  if (boot.skipped) {
+    // No Stripe test key → skip the suite. Publish a flag every spec's
+    // top-level guard reads; Playwright's own skip is per-test. Nothing booted;
+    // teardown is a no-op.
     process.env.TIER2_BILLING_SKIP = "no-stripe-test-key";
-    // Nothing booted; teardown is a no-op.
     return async () => {};
   }
-
-  const catalog = provisionPriceCatalog(secretKey);
-  const stripe: StripeBillingEnv = {
-    secretKey,
-    webhookSecret: `whsec_t2billing_${randomBytes(16).toString("hex")}`,
-    proMonthlyPriceId: catalog.prices.proMonthly,
-    overagePriceId: catalog.prices.managedCloudOverageCent,
-    refillPriceId: catalog.prices.refill10h,
-    meterId: catalog.meter.id,
-    billingMode: process.env.TIER2_BILLING_MODE ?? "enforce",
-  };
-
-  const stack = await bootStack({ profile: BILLING_PROFILE, stripe });
-
-  // Billing harness (stack/billing.ts) reads these.
-  process.env.TIER2_BILLING_API_BASE_URL = stack.apiBaseUrl;
-  process.env.TIER2_BILLING_WEB_BASE_URL = stack.webBaseUrl;
-  process.env.TIER2_BILLING_DATABASE_URL = stack.databaseUrl;
-  process.env.TIER2_BILLING_STRIPE_SECRET_KEY = stripe.secretKey;
-  process.env.TIER2_BILLING_STRIPE_WEBHOOK_SECRET = stripe.webhookSecret;
-  process.env.TIER2_BILLING_STRIPE_PRO_MONTHLY_PRICE_ID = stripe.proMonthlyPriceId;
-  process.env.TIER2_BILLING_STRIPE_OVERAGE_PRICE_ID = stripe.overagePriceId;
-  process.env.TIER2_BILLING_STRIPE_REFILL_PRICE_ID = stripe.refillPriceId;
-  process.env.TIER2_BILLING_STRIPE_METER_ID = stripe.meterId;
-
-  // Reuse seed.ts's auth/org helpers (claim, login, invite) against this same
-  // billing stack: they key off TIER2_INTENT_* env, so point those here too.
-  // The two suites never share a process (separate playwright configs).
-  process.env.TIER2_INTENT_API_BASE_URL = stack.apiBaseUrl;
-  process.env.TIER2_INTENT_WEB_BASE_URL = stack.webBaseUrl;
-  process.env.TIER2_INTENT_DATABASE_URL = stack.databaseUrl;
-  process.env.TIER2_INTENT_SETUP_TOKEN_FILE = stack.setupTokenFile;
 
   await resetPasswordLoginRateLimits();
   // Billing rows accumulate in the persistent profile DB; wipe them so this
   // run's grant/adjustment/export assertions count only their own effects
   // (accounts and org memberships are preserved — see resetBillingState).
   await resetBillingState();
-  return stack.teardown;
+  return boot.stack.teardown;
 }

--- a/tests/intent/stack/billing-import-global-setup.ts
+++ b/tests/intent/stack/billing-import-global-setup.ts
@@ -1,0 +1,40 @@
+// Playwright globalSetup for the tier-2 BILLING-IMPORT suite
+// (specs/billing-import/*, PR 4 workstream C).
+//
+// Separate project from the main billing suite (playwright.billing.config.ts):
+// this one needs AGENT_GATEWAY_ENABLED + the LiteLLM management fake wired at
+// boot time (server env, fixed at process start), which the main billing
+// stack does not carry. Both boot the same `t2billing` profile but never
+// concurrently — this project's own globalSetup/teardown fully owns the
+// server process for its run, exactly like the main billing suite owns it for
+// its own run (sequential `pnpm test:billing` / `pnpm test:billing-import`
+// invocations, never run in parallel).
+//
+// skipFrontend: this suite is API + DB assertions only (import cursor,
+// enrollment budget_status, usage-event ledger rows) — no UI, so no desktop
+// web / AnyHarness runtime is booted.
+
+import { bootBillingStackWithLitellmFake } from "./billing-usage-import.ts";
+import { resetBillingState } from "./billing-seed.ts";
+import { resetPasswordLoginRateLimits } from "./seed.ts";
+
+export default async function billingImportGlobalSetup(): Promise<() => Promise<void>> {
+  const boot = await bootBillingStackWithLitellmFake();
+  if (boot.skipped) {
+    process.env.TIER2_BILLING_SKIP = "no-stripe-test-key";
+    return async () => {};
+  }
+
+  await resetPasswordLoginRateLimits();
+  // Same per-run reset as the main billing suite (billing-global-setup.ts):
+  // wipe grant/subscription/enrollment/usage-event rows so this run's counts
+  // are its own. Note `agent_llm_usage_import_cursor` is deliberately NOT
+  // reset (it is a real singleton cursor, persists like production) — specs
+  // account for an already-advanced cursor from a prior run by seeding spend
+  // rows with a `startTime` at "now" (always inside the overlap window).
+  await resetBillingState();
+  return async () => {
+    await boot.fake.close();
+    await boot.stack.teardown();
+  };
+}

--- a/tests/intent/stack/billing-usage-import.ts
+++ b/tests/intent/stack/billing-usage-import.ts
@@ -10,7 +10,7 @@ import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 
-import { REPO_ROOT, type BootedStack } from "./boot.ts";
+import { REPO_ROOT, type BootedStack, type StripeBillingEnv } from "./boot.ts";
 import { bootBillingStack, type BillingBootResult } from "./billing-boot.ts";
 import {
   databaseUrl,
@@ -27,6 +27,10 @@ export type { FakeMintedKey, FakeSpendRow, LitellmManagementFake } from "../fake
 
 export interface BillingStackWithFake {
   stack: BootedStack;
+  /** The resolved Stripe test-mode env this boot wired (from the inner
+   * `bootBillingStack`), so a single-process consumer (the `tests/release`
+   * Tier-2 harness) has the same `StripeBillingEnv` the plain boot returns. */
+  stripe: StripeBillingEnv;
   fake: LitellmManagementFake;
 }
 
@@ -116,7 +120,31 @@ export async function bootBillingStackWithLitellmFake(): Promise<BootWithFakeRes
   }
   process.env.TIER2_BILLING_LITELLM_BASE_URL = fake.baseUrl;
   process.env.TIER2_BILLING_LITELLM_MASTER_KEY = fake.masterKey;
-  return { skipped: false, stack: boot.stack, fake };
+  // Publish the gateway env into THIS process too, not just the booted server's
+  // env. The out-of-process product passes the gateway-dependent cells drive
+  // (`billing.ts::serverPass` for the top-up pass, `t2-bill.ts`'s free-credit
+  // pass) inherit `...process.env`, and the release harness's `gatewayEnabled()`
+  // guard reads `AGENT_GATEWAY_ENABLED` here — so the single-process release
+  // runner sees the gateway as enabled exactly as the server does. (The
+  // billing-usage-import passes already set these explicitly from
+  // `litellmFake*()`; publishing here keeps every inheritor consistent.)
+  process.env.AGENT_GATEWAY_ENABLED = "true";
+  process.env.AGENT_GATEWAY_LITELLM_BASE_URL = fake.baseUrl;
+  process.env.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL = fake.baseUrl;
+  process.env.AGENT_GATEWAY_LITELLM_MASTER_KEY = fake.masterKey;
+  return { skipped: false, stack: boot.stack, stripe: boot.stripe, fake };
+}
+
+/** Clear the gateway env this module published into `process.env`, so a later
+ * scenario booted in the same runner process (e.g. T2-AUTH-ORG) does not
+ * inherit a stale `AGENT_GATEWAY_ENABLED`. Paired with the fake teardown. */
+export function clearPublishedGatewayEnv(): void {
+  delete process.env.AGENT_GATEWAY_ENABLED;
+  delete process.env.AGENT_GATEWAY_LITELLM_BASE_URL;
+  delete process.env.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL;
+  delete process.env.AGENT_GATEWAY_LITELLM_MASTER_KEY;
+  delete process.env.TIER2_BILLING_LITELLM_BASE_URL;
+  delete process.env.TIER2_BILLING_LITELLM_MASTER_KEY;
 }
 
 /** Same out-of-process product-pass mechanism the billing harness uses

--- a/tests/intent/stack/billing-usage-import.ts
+++ b/tests/intent/stack/billing-usage-import.ts
@@ -7,7 +7,7 @@
 // inference call).
 
 import { randomUUID } from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
 
 import { REPO_ROOT, type BootedStack, type StripeBillingEnv } from "./boot.ts";
@@ -151,11 +151,19 @@ export function clearPublishedGatewayEnv(): void {
  * (`stack/billing.ts::serverPass`), scoped to the LiteLLM importer + fake
  * gateway: a fresh `python -c` process against the same profile DB, with the
  * gateway env pointed at the fake (never the server's own env — this is a
- * separate process, not a child of the booted uvicorn). */
-function serverPass(pyExpr: string): void {
-  const result = spawnSync(path.join(REPO_ROOT, "server", ".venv", "bin", "python"), ["-c", pyExpr], {
+ * separate process, not a child of the booted uvicorn).
+ *
+ * ASYNC by design: these passes make HTTP calls to the management-plane fake,
+ * which — in the single-process `tests/release` runner — is served by THIS
+ * process's event loop. A blocking `spawnSync` would freeze that loop while the
+ * pass waits on the fake, deadlocking. `spawn` + an awaited exit keeps the loop
+ * free to serve the fake. (The Playwright suite runs the fake in a separate
+ * globalSetup process, so blocking there was harmless; awaiting is correct for
+ * both.) The DB-only passes elsewhere (`billing.ts`, `runFreeCreditGrantPass`)
+ * touch no in-process fake, so they stay `spawnSync`. */
+function serverPass(pyExpr: string): Promise<void> {
+  const child = spawn(path.join(REPO_ROOT, "server", ".venv", "bin", "python"), ["-c", pyExpr], {
     cwd: path.join(REPO_ROOT, "server"),
-    encoding: "utf8",
     env: {
       ...process.env,
       DATABASE_URL: databaseUrl(),
@@ -175,24 +183,43 @@ function serverPass(pyExpr: string): void {
       STRIPE_REFILL_10H_PRICE_ID: refillPriceId(),
     },
   });
-  if (result.status !== 0) {
-    throw new Error(`usage-import pass failed (${result.status}): ${(result.stderr || result.stdout || "").trim()}`);
-  }
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  return new Promise<void>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`usage-import pass failed (${code}): ${(stderr || stdout).trim()}`));
+    });
+  });
 }
 
 /** Drive the REAL importer once against the profile DB + fake gateway.
  * Idempotent/overlap-safe by construction (dedup on `litellm_request_id`);
  * call it as many times as a case needs (restart-safety = calling it twice
- * with no new spend seeded in between and asserting no new rows/duplicates). */
-export function runUsageImportPass(): void {
-  serverPass(
-    "import asyncio; from proliferate.server.cloud.agent_gateway.usage_import import run_usage_import; " +
-      "from proliferate.db import session_ops as db_session; " +
+ * with no new spend seeded in between and asserting no new rows/duplicates).
+ * Await it: it HTTP-calls the in-process fake (see `serverPass`). */
+export function runUsageImportPass(): Promise<void> {
+  return serverPass(
+    // Multi-line: `async def` cannot follow `;`-joined imports on one logical
+    // line (SyntaxError), so imports go on their own newline-separated lines.
+    "import asyncio\n" +
+      "from proliferate.server.cloud.agent_gateway.usage_import import run_usage_import\n" +
+      "from proliferate.db import session_ops as db_session\n" +
       "async def _m():\n" +
       "    async with db_session.open_async_transaction() as db:\n" +
       "        result = await run_usage_import(db)\n" +
       "        print(result)\n" +
-      "asyncio.run(_m())",
+      "asyncio.run(_m())\n",
   );
 }
 
@@ -203,15 +230,18 @@ export function runUsageImportPass(): void {
  * directly gives deterministic, awaitable setup for tests instead of racing
  * a background task. Mints a real virtual key against the fake for every
  * enrollment it processes. */
-export function runEnrollmentBackfillPass(limit = 100): void {
-  serverPass(
-    "import asyncio; from proliferate.server.cloud.agent_gateway.enrollment import backfill_enrollments; " +
-      "from proliferate.db import session_ops as db_session; " +
+export function runEnrollmentBackfillPass(limit = 100): Promise<void> {
+  return serverPass(
+    // Multi-line: `async def` cannot follow `;`-joined imports on one logical
+    // line (SyntaxError), so imports go on their own newline-separated lines.
+    "import asyncio\n" +
+      "from proliferate.server.cloud.agent_gateway.enrollment import backfill_enrollments\n" +
+      "from proliferate.db import session_ops as db_session\n" +
       `async def _m():\n` +
       "    async with db_session.open_async_transaction() as db:\n" +
       `        processed = await backfill_enrollments(db, limit=${limit})\n` +
       "        print(f'processed={processed}')\n" +
-      "asyncio.run(_m())",
+      "asyncio.run(_m())\n",
   );
 }
 

--- a/tests/intent/stack/billing-usage-import.ts
+++ b/tests/intent/stack/billing-usage-import.ts
@@ -1,0 +1,330 @@
+// Real managed-LLM importer driver + LiteLLM-management-fake wiring (PR 4,
+// BRIEF §5). The import cell (T2-BILL-15) and the exhaustion cell (T2-BILL-6)
+// drive the REAL `run_usage_import` (and real enrollment sync) against the
+// management-plane fake instead of direct-SQL seeding `agent_llm_usage_event`,
+// so pagination/cursor/overlap/dedup/needs_review/attribution/exhaustion are
+// exercised for real, offline and deterministic (no live LiteLLM, no real
+// inference call).
+
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { REPO_ROOT, type BootedStack } from "./boot.ts";
+import { bootBillingStack, type BillingBootResult } from "./billing-boot.ts";
+import {
+  databaseUrl,
+  overagePriceId,
+  proMonthlyPriceId,
+  refillPriceId,
+  stripeSecretKey,
+  webhookSecret,
+  withDb,
+} from "./billing-env.ts";
+import { startLitellmManagementFake, type LitellmManagementFake } from "../fakes/litellm-management/server.ts";
+
+export type { FakeMintedKey, FakeSpendRow, LitellmManagementFake } from "../fakes/litellm-management/server.ts";
+
+export interface BillingStackWithFake {
+  stack: BootedStack;
+  fake: LitellmManagementFake;
+}
+
+export type BootWithFakeResult =
+  | { skipped: true; reason: string }
+  | ({ skipped: false } & BillingStackWithFake);
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set — did bootBillingStackWithLitellmFake() run?`);
+  }
+  return value;
+}
+
+/** The fake's base URL/master key, published the same way `billing-boot.ts`
+ * publishes `TIER2_BILLING_*` — so the out-of-process `serverPass` below (a
+ * fresh `python -c` invocation, not a child of the booted server) can read
+ * them deterministically instead of relying on the server's own env, which
+ * `extraServerEnv` only reaches inside the spawned uvicorn process. */
+export function litellmFakeBaseUrl(): string {
+  return required("TIER2_BILLING_LITELLM_BASE_URL");
+}
+export function litellmFakeMasterKey(): string {
+  return required("TIER2_BILLING_LITELLM_MASTER_KEY");
+}
+
+/** Read the fake's blocked/minted-key state over its `/__test/*` introspection
+ * routes (server.ts) — works across process boundaries (globalSetup vs.
+ * Playwright worker), unlike calling methods on the in-process
+ * `LitellmManagementFake` object returned by `startLitellmManagementFake()`,
+ * which only the process that started the fake holds. */
+export async function fetchFakeBlockedKeys(): Promise<string[]> {
+  const response = await fetch(`${litellmFakeBaseUrl()}/__test/blocked-keys`);
+  const body = (await response.json()) as { blockedKeys: string[] };
+  return body.blockedKeys;
+}
+
+export async function fetchFakeMintedKeys(): Promise<
+  Array<{ tokenId: string; keyAlias: string | null; userId: string | null; blocked: boolean; deleted: boolean }>
+> {
+  const response = await fetch(`${litellmFakeBaseUrl()}/__test/minted-keys`);
+  const body = (await response.json()) as {
+    mintedKeys: Array<{ tokenId: string; keyAlias: string | null; userId: string | null; blocked: boolean; deleted: boolean }>;
+  };
+  return body.mintedKeys;
+}
+
+/** Seed spend rows on the fake over HTTP is unnecessary — the fake is
+ * in-process for whichever code calls `seedSpendRows` directly — but a
+ * Playwright spec (a different process than globalSetup) has no handle to
+ * that object either. Route seeding through the same `/__test/*` surface for
+ * symmetry with the read-back helpers above. */
+export async function seedFakeSpendRows(rows: import("../fakes/litellm-management/server.ts").FakeSpendRow[]): Promise<void> {
+  const response = await fetch(`${litellmFakeBaseUrl()}/__test/spend-rows`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ rows }),
+  });
+  if (!response.ok) {
+    throw new Error(`seeding fake spend rows failed: ${response.status}`);
+  }
+}
+
+/**
+ * Boot the billing stack with the LiteLLM management fake fronting the gateway:
+ * starts the fake FIRST, then boots with AGENT_GATEWAY_ENABLED=true and the
+ * gateway admin/public base URLs + master key pointed at the fake. The fake must
+ * exist before boot because the server reads these at startup. Skips the
+ * desktop web/AnyHarness runtime (`skipFrontend`) since every import/exhaustion
+ * assertion is API + DB, never UI.
+ */
+export async function bootBillingStackWithLitellmFake(): Promise<BootWithFakeResult> {
+  const fake = await startLitellmManagementFake();
+  const boot: BillingBootResult = await bootBillingStack({
+    skipFrontend: true,
+    extraServerEnv: {
+      AGENT_GATEWAY_ENABLED: "true",
+      AGENT_GATEWAY_LITELLM_BASE_URL: fake.baseUrl,
+      AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: fake.baseUrl,
+      AGENT_GATEWAY_LITELLM_MASTER_KEY: fake.masterKey,
+    },
+  });
+  if (boot.skipped) {
+    await fake.close();
+    return { skipped: true, reason: boot.reason };
+  }
+  process.env.TIER2_BILLING_LITELLM_BASE_URL = fake.baseUrl;
+  process.env.TIER2_BILLING_LITELLM_MASTER_KEY = fake.masterKey;
+  return { skipped: false, stack: boot.stack, fake };
+}
+
+/** Same out-of-process product-pass mechanism the billing harness uses
+ * (`stack/billing.ts::serverPass`), scoped to the LiteLLM importer + fake
+ * gateway: a fresh `python -c` process against the same profile DB, with the
+ * gateway env pointed at the fake (never the server's own env — this is a
+ * separate process, not a child of the booted uvicorn). */
+function serverPass(pyExpr: string): void {
+  const result = spawnSync(path.join(REPO_ROOT, "server", ".venv", "bin", "python"), ["-c", pyExpr], {
+    cwd: path.join(REPO_ROOT, "server"),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl(),
+      DEBUG: "true",
+      PRO_BILLING_ENABLED: "true",
+      CLOUD_BILLING_MODE: process.env.TIER2_BILLING_MODE ?? "enforce",
+      AGENT_GATEWAY_ENABLED: "true",
+      AGENT_GATEWAY_LITELLM_BASE_URL: litellmFakeBaseUrl(),
+      AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: litellmFakeBaseUrl(),
+      AGENT_GATEWAY_LITELLM_MASTER_KEY: litellmFakeMasterKey(),
+      STRIPE_SECRET_KEY: stripeSecretKey(),
+      STRIPE_WEBHOOK_SECRET: webhookSecret(),
+      STRIPE_PRO_MONTHLY_PRICE_ID: proMonthlyPriceId(),
+      STRIPE_CLOUD_MONTHLY_PRICE_ID: proMonthlyPriceId(),
+      STRIPE_MANAGED_CLOUD_OVERAGE_PRICE_ID: overagePriceId(),
+      STRIPE_SANDBOX_OVERAGE_PRICE_ID: overagePriceId(),
+      STRIPE_REFILL_10H_PRICE_ID: refillPriceId(),
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`usage-import pass failed (${result.status}): ${(result.stderr || result.stdout || "").trim()}`);
+  }
+}
+
+/** Drive the REAL importer once against the profile DB + fake gateway.
+ * Idempotent/overlap-safe by construction (dedup on `litellm_request_id`);
+ * call it as many times as a case needs (restart-safety = calling it twice
+ * with no new spend seeded in between and asserting no new rows/duplicates). */
+export function runUsageImportPass(): void {
+  serverPass(
+    "import asyncio; from proliferate.server.cloud.agent_gateway.usage_import import run_usage_import; " +
+      "from proliferate.db import session_ops as db_session; " +
+      "async def _m():\n" +
+      "    async with db_session.open_async_transaction() as db:\n" +
+      "        result = await run_usage_import(db)\n" +
+      "        print(result)\n" +
+      "asyncio.run(_m())",
+  );
+}
+
+/** Synchronously enroll + sync every pending/missing subject against the fake
+ * gateway (the real `backfill_enrollments` pass — see
+ * `server/cloud/agent_gateway/enrollment.py`). Enrollment is normally
+ * fire-and-forget on signup (`signup_hook.py`); driving the backfill pass
+ * directly gives deterministic, awaitable setup for tests instead of racing
+ * a background task. Mints a real virtual key against the fake for every
+ * enrollment it processes. */
+export function runEnrollmentBackfillPass(limit = 100): void {
+  serverPass(
+    "import asyncio; from proliferate.server.cloud.agent_gateway.enrollment import backfill_enrollments; " +
+      "from proliferate.db import session_ops as db_session; " +
+      `async def _m():\n` +
+      "    async with db_session.open_async_transaction() as db:\n" +
+      `        processed = await backfill_enrollments(db, limit=${limit})\n` +
+      "        print(f'processed={processed}')\n" +
+      "asyncio.run(_m())",
+  );
+}
+
+// ── Assertion reads (agent_gateway_enrollment / agent_llm_usage_event /
+// agent_llm_usage_import_cursor / llm_credit_grant) ──
+
+export interface EnrollmentRow {
+  id: string;
+  virtualKeyId: string | null;
+  syncStatus: string;
+  budgetStatus: string;
+  billingSubjectId: string;
+}
+
+export async function getUserEnrollment(userId: string): Promise<EnrollmentRow | null> {
+  return withDb(async (db) => {
+    const result = await db.query(
+      `SELECT id, virtual_key_id, sync_status, budget_status, billing_subject_id
+         FROM agent_gateway_enrollment
+        WHERE subject_kind = 'user' AND user_id = $1 AND revoked_at IS NULL`,
+      [userId],
+    );
+    if (result.rows.length === 0) {
+      return null;
+    }
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      virtualKeyId: row.virtual_key_id,
+      syncStatus: row.sync_status,
+      budgetStatus: row.budget_status,
+      billingSubjectId: row.billing_subject_id,
+    };
+  });
+}
+
+export async function getOrgEnrollment(organizationId: string, userId: string): Promise<EnrollmentRow | null> {
+  return withDb(async (db) => {
+    const result = await db.query(
+      `SELECT id, virtual_key_id, sync_status, budget_status, billing_subject_id
+         FROM agent_gateway_enrollment
+        WHERE subject_kind = 'organization' AND organization_id = $1 AND user_id = $2 AND revoked_at IS NULL`,
+      [organizationId, userId],
+    );
+    if (result.rows.length === 0) {
+      return null;
+    }
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      virtualKeyId: row.virtual_key_id,
+      syncStatus: row.sync_status,
+      budgetStatus: row.budget_status,
+      billingSubjectId: row.billing_subject_id,
+    };
+  });
+}
+
+export interface UsageEventRow {
+  litellmRequestId: string;
+  userId: string | null;
+  organizationId: string | null;
+  billingSubjectId: string | null;
+  status: string;
+  costUsd: number | null;
+}
+
+export async function getUsageEvent(litellmRequestId: string): Promise<UsageEventRow | null> {
+  return withDb(async (db) => {
+    const result = await db.query(
+      `SELECT litellm_request_id, user_id, organization_id, billing_subject_id, status, cost_usd
+         FROM agent_llm_usage_event WHERE litellm_request_id = $1`,
+      [litellmRequestId],
+    );
+    if (result.rows.length === 0) {
+      return null;
+    }
+    const row = result.rows[0];
+    return {
+      litellmRequestId: row.litellm_request_id,
+      userId: row.user_id,
+      organizationId: row.organization_id,
+      billingSubjectId: row.billing_subject_id,
+      status: row.status,
+      costUsd: row.cost_usd === null ? null : Number(row.cost_usd),
+    };
+  });
+}
+
+export async function countUsageEvents(): Promise<number> {
+  return withDb(async (db) => {
+    const result = await db.query(`SELECT count(*)::int AS n FROM agent_llm_usage_event`);
+    return result.rows[0].n as number;
+  });
+}
+
+export async function countUsageEventsWithStatus(status: string): Promise<number> {
+  return withDb(async (db) => {
+    const result = await db.query(`SELECT count(*)::int AS n FROM agent_llm_usage_event WHERE status = $1`, [
+      status,
+    ]);
+    return result.rows[0].n as number;
+  });
+}
+
+export interface ImportCursorRow {
+  lastSeenOccurredAt: string | null;
+  status: string;
+}
+
+export async function getUsageImportCursor(): Promise<ImportCursorRow | null> {
+  return withDb(async (db) => {
+    const result = await db.query(
+      `SELECT last_seen_occurred_at, status FROM agent_llm_usage_import_cursor WHERE id = 'default'`,
+    );
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return { lastSeenOccurredAt: result.rows[0].last_seen_occurred_at, status: result.rows[0].status };
+  });
+}
+
+/** Seed an `llm_credit_grant` row directly (the credit side of the LLM
+ * ledger; the importer's exhaustion check reads
+ * `get_remaining_credit_usd` = sum(grants) - sum(imported usage)). Used to
+ * put a subject at (or near) zero remaining credit before driving the real
+ * importer, so the exhaustion path (`disable_virtual_key` -> the fake's
+ * `/key/block`) fires for real. */
+export async function seedLlmCreditGrant(opts: {
+  billingSubjectId: string;
+  userId?: string | null;
+  source?: "free_signup" | "topup" | "admin" | "seat_pool";
+  amountUsd: number;
+}): Promise<string> {
+  const id = randomUUID();
+  await withDb((db) =>
+    db.query(
+      `INSERT INTO llm_credit_grant (id, billing_subject_id, user_id, source, amount_usd, created_at, expires_at, source_ref)
+       VALUES ($1, $2, $3, $4, $5, now(), NULL, $6)`,
+      [id, opts.billingSubjectId, opts.userId ?? null, opts.source ?? "admin", opts.amountUsd, `t2billing-import:${id}`],
+    ),
+  );
+  return id;
+}

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -372,6 +372,12 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
       serverEnv.E2B_API_KEY = "e2b_tier2_billing_boot_placeholder";
     }
     serverEnv.PRO_BILLING_ENABLED = "true";
+    // Deterministic billing: the Tier-2 cells (and the Playwright billing
+    // suites) drive the reconciler/accounting/gateway passes on demand
+    // out-of-process. Silence the server's periodic maintenance loops so a
+    // background tick never races or deadlocks with a test's own pass. A
+    // caller's extraServerEnv (applied last) can flip this back on.
+    serverEnv.RUN_BACKGROUND_WORKERS = "false";
     serverEnv.CLOUD_BILLING_MODE = s.billingMode;
     serverEnv.STRIPE_SECRET_KEY = s.secretKey;
     serverEnv.STRIPE_WEBHOOK_SECRET = s.webhookSecret;

--- a/tests/intent/stack/seed.ts
+++ b/tests/intent/stack/seed.ts
@@ -559,7 +559,7 @@ export async function uploadPersonalSecretFile(
 ): Promise<ApiResult<CloudSecretsResponse>> {
   const form = new FormData();
   form.append("path", path);
-  form.append("file", new Blob([content]), filename);
+  form.append("file", new Blob([content as unknown as ArrayBuffer]), filename);
   const response = await fetch(`${apiBaseUrl()}/v1/cloud/secrets/personal/files/upload`, {
     method: "PUT",
     headers: { Authorization: `Bearer ${token}` },

--- a/tests/release/package.json
+++ b/tests/release/package.json
@@ -10,6 +10,8 @@
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
+    "@types/pg": "^8.11.10",
+    "pg": "^8.13.1",
     "playwright": "^1.61.0",
     "tsx": "^4.22.4",
     "typescript": "^5.7.0"

--- a/tests/release/src/cli/args.test.ts
+++ b/tests/release/src/cli/args.test.ts
@@ -126,3 +126,21 @@ test("diagnostic runs may omit the candidate build map", () => {
   const dry = parseArgs(["--behavior", "diagnostic", "--dry-run"]);
   assert.equal(dry.candidateBuildMap, undefined);
 });
+
+test("--source-candidate satisfies the strict candidate-identity requirement", () => {
+  const args = parseArgs(["--behavior", "strict", "--source-candidate"]);
+  assert.equal(args.sourceCandidate, true);
+  assert.equal(args.candidateBuildMap, undefined);
+});
+
+test("--source-candidate and --candidate-build-map are mutually exclusive", () => {
+  assert.throws(
+    () => parseArgs(["--behavior", "diagnostic", "--source-candidate", "--candidate-build-map", "map.json"]),
+    CliUsageError,
+  );
+});
+
+test("sourceCandidate defaults to false", () => {
+  const args = parseArgs(["--behavior", "diagnostic"]);
+  assert.equal(args.sourceCandidate, false);
+});

--- a/tests/release/src/cli/args.ts
+++ b/tests/release/src/cli/args.ts
@@ -15,6 +15,15 @@ export interface CliArgs {
   attempt?: number;
   /** Path to a CandidateBuildMapV1 JSON file. Required for strict real runs. */
   candidateBuildMap?: string;
+  /**
+   * Synthesize a `CandidateBuildEvidenceV1` naming the source-built Server
+   * under test (VERSION file + `sha256(source_sha + "/server/<platform>")`)
+   * instead of materializing a candidate build map. For Tier-2 runs, which
+   * boot from source (venv uvicorn) and never build/package artifacts.
+   * Mutually exclusive with `--candidate-build-map`; satisfies the strict
+   * non-null `candidate_build` requirement without candidate-map machinery.
+   */
+  sourceCandidate: boolean;
   help: boolean;
 }
 
@@ -33,6 +42,7 @@ const DEFAULTS = {
   scenarios: "all" as string[] | "all",
   dryRun: false,
   fileIssues: false,
+  sourceCandidate: false,
   // Relative to this package's own cwd (`tests/release/`), which is what
   // both `make release-e2e` and a direct `pnpm exec tsx src/cli/run.ts` use
   // — found running this for real 2026-07-08: the previous default
@@ -92,6 +102,9 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         args.candidateBuildMap = requireValue(argv, i, arg);
         i += 1;
         break;
+      case "--source-candidate":
+        args.sourceCandidate = true;
+        break;
       case "--dry-run":
         args.dryRun = true;
         break;
@@ -120,10 +133,14 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   if (args.behavior === "strict" && args.dryRun) {
     throw new CliUsageError("--behavior strict cannot be combined with --dry-run.");
   }
+  if (args.candidateBuildMap !== undefined && args.sourceCandidate) {
+    throw new CliUsageError("--candidate-build-map and --source-candidate are mutually exclusive.");
+  }
   // Strict real runs are fail-closed on artifact identity: without a
-  // candidate build map the run cannot say which bytes it qualified.
-  if (args.behavior === "strict" && args.candidateBuildMap === undefined) {
-    throw new CliUsageError("--candidate-build-map <path> is required for strict runs.");
+  // candidate build map (or the source-candidate synthesis for from-source
+  // runs) the run cannot say which bytes it qualified.
+  if (args.behavior === "strict" && args.candidateBuildMap === undefined && !args.sourceCandidate) {
+    throw new CliUsageError("--candidate-build-map <path> (or --source-candidate) is required for strict runs.");
   }
   return { ...args, behavior: args.behavior };
 }
@@ -198,5 +215,6 @@ Flags:
   --shard-id <safe-id>       Optional shard identity override
   --attempt <n>              Optional attempt override (positive integer)
   --candidate-build-map <path>  CandidateBuildMapV1 JSON (required for strict; optional and recorded when supplied)
+  --source-candidate         Synthesize candidate_build for a from-source run (Tier-2); exclusive with --candidate-build-map
   --help                     Show this text
 `;

--- a/tests/release/src/cli/command.test.ts
+++ b/tests/release/src/cli/command.test.ts
@@ -389,6 +389,7 @@ test("synthesizeSourceCandidateBuild binds the digest to the source sha (two dif
 
 test("--source-candidate threads a non-null candidate_build into the written report with no map materialization", async () => {
   const { deps } = makeDeps();
+  deps.selectScenarios = () => [{ ...SCENARIO, id: "T2-FAKE", sourceBacked: true }];
   let written: TestRunReportV4 | undefined;
   deps.write = async (_dir, report) => {
     written = report;
@@ -398,4 +399,28 @@ test("--source-candidate threads a non-null candidate_build into the written rep
   assert.equal(exit, 0);
   assert.ok(written?.candidate_build !== null, "candidate_build is non-null for a source-candidate run");
   assert.equal(written?.candidate_build?.artifacts[0].artifact_id, `server/${process.platform}`);
+});
+
+test("--source-candidate refuses non-source-backed scenarios with exit 2 and no report (T2R-R01)", async () => {
+  const { deps, calls } = makeDeps();
+  // The default SCENARIO is a Tier-3 shape with no sourceBacked marker — a
+  // strict T3/T4 selection must never substitute a synthetic source identity
+  // for the exact candidate-build map.
+  let wrote = false;
+  deps.write = async () => {
+    wrote = true;
+    return "/tmp/report.json";
+  };
+  const errors: string[] = [];
+  deps.error = (message) => {
+    errors.push(message);
+  };
+  const exit = await runReleaseCommand(["--behavior", "strict", "--source-candidate"], deps);
+  assert.equal(exit, 2);
+  assert.equal(wrote, false, "no report is written");
+  assert.ok(
+    errors.some((e) => e.includes("T3-FAKE") && e.includes("source-backed")),
+    "the refusal names the offending scenario",
+  );
+  assert.ok(!calls.includes("execute"), "no scenario executes");
 });

--- a/tests/release/src/cli/command.test.ts
+++ b/tests/release/src/cli/command.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { runReleaseCommand, type CommandDeps } from "./command.js";
+import { runReleaseCommand, synthesizeSourceCandidateBuild, type CommandDeps } from "./command.js";
 import { BuildMapError, type CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { LocalWorldPorts } from "../worlds/local-workspace/ports.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
@@ -368,4 +368,34 @@ test("a malformed ports sidecar exits 2 before any setup side effect", async () 
   );
   assert.equal(exit, 2);
   assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "loadLocalWorldPorts"]);
+});
+
+// ── --source-candidate (BRIEF §1/§7 deviation 1) ────────────────────────────
+
+test("synthesizeSourceCandidateBuild names the server/<platform> artifact with a non-empty version and a 64-hex digest", () => {
+  const evidence = synthesizeSourceCandidateBuild("a".repeat(40));
+  assert.equal(evidence.artifacts.length, 1);
+  const [artifact] = evidence.artifacts;
+  assert.equal(artifact.artifact_id, `server/${process.platform}`);
+  assert.ok(artifact.version.length > 0);
+  assert.match(artifact.sha256, /^[0-9a-f]{64}$/);
+});
+
+test("synthesizeSourceCandidateBuild binds the digest to the source sha (two different commits never collide)", () => {
+  const a = synthesizeSourceCandidateBuild("a".repeat(40));
+  const b = synthesizeSourceCandidateBuild("b".repeat(40));
+  assert.notEqual(a.artifacts[0].sha256, b.artifacts[0].sha256);
+});
+
+test("--source-candidate threads a non-null candidate_build into the written report with no map materialization", async () => {
+  const { deps } = makeDeps();
+  let written: TestRunReportV4 | undefined;
+  deps.write = async (_dir, report) => {
+    written = report;
+    return "/tmp/report.json";
+  };
+  const exit = await runReleaseCommand(["--behavior", "diagnostic", "--source-candidate"], deps);
+  assert.equal(exit, 0);
+  assert.ok(written?.candidate_build !== null, "candidate_build is non-null for a source-candidate run");
+  assert.equal(written?.candidate_build?.artifacts[0].artifact_id, `server/${process.platform}`);
 });

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -1,4 +1,7 @@
-import path from "node:path";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path, { dirname } from "node:path";
 
 import { HELP_TEXT, parseArgs, type CliArgs } from "./args.js";
 import type { ScenarioDefinition } from "../scenarios/types.js";
@@ -121,6 +124,17 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
       candidateBuildMap = map;
       runDir = path.dirname(path.resolve(args.candidateBuildMap));
       ports = await deps.loadLocalWorldPorts(runDir);
+    } catch (error) {
+      deps.error(error instanceof Error ? error.message : String(error));
+      return 2;
+    }
+  } else if (args.sourceCandidate) {
+    // No candidate-build-map machinery: this run boots the Server from source
+    // (Tier-2). `candidateBuildMap`/`runDir`/`ports` stay null — no world
+    // materialization is claimed — while `candidateBuild` still carries a
+    // non-null, honest identity so a strict report is not rejected.
+    try {
+      candidateBuild = synthesizeSourceCandidateBuild(identity.source_sha);
     } catch (error) {
       deps.error(error instanceof Error ? error.message : String(error));
       return 2;
@@ -255,6 +269,27 @@ function printSummary(report: TestRunReportV3, deps: Pick<CommandDeps, "log" | "
 
 function firstLine(message: string): string {
   return message.split("\n")[0];
+}
+
+// src/cli -> up four to repo root VERSION (same convention as
+// scenarios/upgrade/t4-sh-1.ts's VERSION_FILE resolution).
+const HERE = dirname(fileURLToPath(import.meta.url));
+const VERSION_FILE = path.resolve(HERE, "..", "..", "..", "..", "VERSION");
+
+/**
+ * Synthesizes `CandidateBuildEvidenceV1` for a Tier-2-style run that boots the
+ * Server from source (venv uvicorn) rather than a packaged candidate build
+ * (BRIEF §1/§7 deviation 1). Honest identity: names the exact Server commit
+ * under test without materializing or claiming any build artifact. Reuses the
+ * existing `server/<platform>` artifact id (adds no new id); the version is
+ * the repo VERSION file; the digest binds the source commit + artifact id so
+ * two different commits never collide.
+ */
+export function synthesizeSourceCandidateBuild(sourceSha: string): CandidateBuildEvidenceV1 {
+  const version = readFileSync(VERSION_FILE, "utf8").trim();
+  const artifactId = `server/${process.platform}`;
+  const sha256 = createHash("sha256").update(`${sourceSha}/${artifactId}`).digest("hex");
+  return { artifacts: [{ artifact_id: artifactId, version, sha256 }] };
 }
 
 function formatSelector(selector: string[] | "all"): string {

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -133,6 +133,19 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
     // (Tier-2). `candidateBuildMap`/`runDir`/`ports` stay null — no world
     // materialization is claimed — while `candidateBuild` still carries a
     // non-null, honest identity so a strict report is not rejected.
+    //
+    // T2R-R01: only source-backed (Tier-2) scenarios may run this way. A
+    // strict Tier-3/Tier-4 invocation must never substitute a synthetic
+    // source identity for the exact candidate-build map.
+    const nonSourceBacked = scenarios.filter((s) => s.sourceBacked !== true);
+    if (nonSourceBacked.length > 0) {
+      deps.error(
+        `--source-candidate is restricted to source-backed Tier-2 scenarios; ` +
+          `refusing: ${nonSourceBacked.map((s) => s.id).join(", ")}. ` +
+          `Use --candidate-build-map for exact-candidate scenarios.`,
+      );
+      return 2;
+    }
     try {
       candidateBuild = synthesizeSourceCandidateBuild(identity.source_sha);
     } catch (error) {

--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -397,6 +397,29 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
     secret: false,
     lanes: ["local"],
   },
+  {
+    name: "TIER2_BILLING_STRIPE_SECRET_KEY",
+    description:
+      "Stripe TEST secret key (sk_test_…) the Tier-2 billing scenarios' financial cells use via the real " +
+      "Stripe test-mode API (customers, subscriptions, invoices, test clocks). Resolved at boot by " +
+      "bootBillingStack (this env, then STRIPE_SECRET_KEY/STRIPE_TEST_SECRET_KEY, then `stripe config " +
+      "--list`); an unresolved key returns every financial cell BLOCKED (never green). Declared here so " +
+      "its value is redacted from the persisted report; NOT a scenario requiredEnv (the local `stripe " +
+      "config` fallback must keep working). Never live mode.",
+    whereItLives:
+      "Local: the developer's Stripe CLI test-mode config, or ~/.proliferate-local/dev/*.env. " +
+      "CI: the GitHub `Qualification` environment's Stripe test secret.",
+    secret: true,
+  },
+  {
+    name: "TIER2_BILLING_STRIPE_WEBHOOK_SECRET",
+    description:
+      "The webhook signing secret (whsec_…) the Tier-2 billing harness self-signs deliveries with and the " +
+      "booted server verifies against. Generated per boot by bootBillingStack and exported to process.env; " +
+      "declared here so it is redacted from the persisted report. Not a scenario requiredEnv.",
+    whereItLives: "Generated per run by tests/intent/stack/billing-boot.ts; never committed.",
+    secret: true,
+  },
 ] as const;
 
 export const DEFAULT_LOCAL_RUNTIME_URL = "http://127.0.0.1:8542";

--- a/tests/release/src/evidence/schema.tier2-sanitize.test.ts
+++ b/tests/release/src/evidence/schema.tier2-sanitize.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  sanitizeCellEvidence,
+  sanitizeReportV4Evidence,
+  type LocalWorkspaceTurnEvidenceV1,
+  type TestRunReportV4,
+  type Tier2BillingEvidenceV1,
+} from "./schema.js";
+
+function tier2Evidence(overrides: Partial<Tier2BillingEvidenceV1> = {}): Tier2BillingEvidenceV1 {
+  return {
+    kind: "tier2_billing",
+    manifest_id: "T2-BILL-1",
+    server_version: "1.2.3",
+    billing_mode: "enforce",
+    asserted_policy: { free_grant_usd: 2, compute_margin_multiplier: 1.5 },
+    stripe: { test_clock_ids: ["tc_1"], object_ids: ["cus_1", "sub_1"] },
+    ledger: {
+      grants_delta: 1,
+      seat_adjustments_delta: 0,
+      usage_exports_delta: 0,
+      llm_events_delta: 0,
+      webhook_receipts_delta: 0,
+      holds_delta: 0,
+    },
+    ...overrides,
+  };
+}
+
+function localEvidence(): LocalWorkspaceTurnEvidenceV1 {
+  return {
+    kind: "local_workspace_turn",
+    artifact_ids: ["server/linux-amd64"],
+    server_version: "1.2.3",
+    anyharness_version: "4.5.6",
+    harness: "claude",
+    model_id: "claude-haiku-4-5",
+    workspace_id_hash: "a".repeat(64),
+    session_id_hash: "b".repeat(64),
+    transcript_reopened: true,
+    litellm: {
+      token_id_hash: "c".repeat(64),
+      request_ids: ["req-1"],
+      window_started_at: "2026-01-01T00:00:00.000Z",
+      window_finished_at: "2026-01-01T00:00:01.000Z",
+      prompt_tokens: 10,
+      completion_tokens: 3,
+      total_tokens: 13,
+      spend_usd: 0.01,
+    },
+    cleanup: {
+      ledger_id_hash: "d".repeat(64),
+      registered: 1,
+      reconciled: 1,
+      failed: 0,
+      virtual_key_deleted: true,
+      litellm_subjects_deleted: true,
+      browser_closed: true,
+      processes_stopped: true,
+      containers_removed: true,
+      local_paths_removed: true,
+    },
+  };
+}
+
+test("sanitizeCellEvidence returns null unchanged", () => {
+  assert.equal(sanitizeCellEvidence(null, ["s"]), null);
+});
+
+test("sanitizeCellEvidence tier2 branch redacts secrets in string fields and passes numbers through", () => {
+  const secret = "sk_live_supersecret";
+  const dirty = tier2Evidence({
+    manifest_id: `T2-BILL-${secret}`,
+    server_version: `1.2.3-${secret}`,
+    stripe: { test_clock_ids: [`tc_${secret}`], object_ids: ["cus_1"] },
+  });
+  const clean = sanitizeCellEvidence(dirty, [secret]) as Tier2BillingEvidenceV1;
+  assert.equal(clean.kind, "tier2_billing");
+  assert.ok(clean.manifest_id.includes("[REDACTED]"));
+  assert.ok(!clean.manifest_id.includes(secret));
+  assert.ok(!clean.server_version.includes(secret));
+  assert.ok(!clean.stripe.test_clock_ids[0].includes(secret));
+  // Numeric evidence is untouched by sanitization.
+  assert.deepEqual(clean.asserted_policy, { free_grant_usd: 2, compute_margin_multiplier: 1.5 });
+  assert.deepEqual(clean.ledger, dirty.ledger);
+  assert.deepEqual(clean.stripe.object_ids, ["cus_1"]);
+});
+
+test("sanitizeCellEvidence leaves the local_workspace_turn branch fully functional (dispatch regression guard)", () => {
+  const secret = "token-secret";
+  const dirty = localEvidence();
+  dirty.model_id = `claude-haiku-${secret}`;
+  const clean = sanitizeCellEvidence(dirty, [secret]) as LocalWorkspaceTurnEvidenceV1;
+  assert.equal(clean.kind, "local_workspace_turn");
+  assert.ok(clean.model_id.includes("[REDACTED]"));
+  assert.equal(clean.litellm.request_ids[0], "req-1");
+  assert.equal(clean.cleanup.failed, 0);
+});
+
+test("sanitizeReportV4Evidence maps sanitization across each result's evidence (tier2 and null)", () => {
+  const secret = "whsec_secret";
+  const report = {
+    results: [
+      { cell_id: "T2-BILL/local/case=T2-BILL-1", evidence: tier2Evidence({ manifest_id: `T2-BILL-${secret}` }) },
+      { cell_id: "T2-BILL/local/case=T2-BILL-2", evidence: null },
+    ],
+  } as unknown as TestRunReportV4;
+  const clean = sanitizeReportV4Evidence(report, [secret]);
+  const first = clean.results[0].evidence as Tier2BillingEvidenceV1;
+  assert.ok(first.manifest_id.includes("[REDACTED]"));
+  assert.equal(clean.results[1].evidence, null);
+});

--- a/tests/release/src/evidence/schema.tier2-validate.test.ts
+++ b/tests/release/src/evidence/schema.tier2-validate.test.ts
@@ -1,0 +1,186 @@
+// Unit coverage for `validateTier2BillingEvidence` (PR 4, workstream D,
+// BRIEF §2). Exercises the validator through the public `validateReportV4`
+// entry point (the kind-scoped dispatch it lives behind), mirroring
+// write.test.ts's report-scaffolding convention but self-contained here so
+// this file stays independently ownable/reviewable.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  validateReportV4,
+  expectedVerdict,
+  type TestRunReportV3,
+  type TestRunReportV4,
+  type Tier2BillingEvidenceV1,
+} from "./schema.js";
+import { ALL_FINAL_STATUSES, type FinalTestStatus } from "../runner/result.js";
+
+function tier2Evidence(overrides: Partial<Tier2BillingEvidenceV1> = {}): Tier2BillingEvidenceV1 {
+  return {
+    kind: "tier2_billing",
+    manifest_id: "T2-BILL-2",
+    server_version: "0.3.27",
+    billing_mode: "enforce",
+    asserted_policy: { free_grant_usd: 2, llm_per_seat_usd: 5, compute_per_seat_usd: 15 },
+    stripe: { test_clock_ids: ["tc_1", "tc_2"], object_ids: ["cus_1", "sub_1"] },
+    ledger: {
+      grants_delta: 2,
+      seat_adjustments_delta: 0,
+      usage_exports_delta: 0,
+      llm_events_delta: 0,
+      webhook_receipts_delta: 0,
+      holds_delta: 0,
+    },
+    ...overrides,
+  };
+}
+
+function baseReportV4(): TestRunReportV3 {
+  const byStatus = Object.fromEntries(ALL_FINAL_STATUSES.map((status) => [status, 0])) as Record<
+    FinalTestStatus,
+    number
+  >;
+  byStatus.green = 1;
+  const report: TestRunReportV3 = {
+    schema_version: 3,
+    kind: "proliferate.test-run",
+    candidate_build: null,
+    run: {
+      run_id: "run-1",
+      shard_id: "shard-1",
+      attempt: 1,
+      source_sha: "d".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+      behavior: "diagnostic",
+      execution: "real",
+      started_at: "2026-07-13T00:00:00Z",
+      finished_at: "2026-07-13T00:01:00Z",
+    },
+    inputs: { target_lane: "local", desktop: "web", agents: "all", scenarios: "all" },
+    selected_cells: [
+      {
+        cell_id: "T2-BILL/local/case=T2-BILL-2",
+        scenario_id: "T2-BILL",
+        registry_flow_ref: "specs#T2-BILL",
+        runtime_lane: "local",
+        dimensions: { case: "T2-BILL-2" },
+        required_env: [],
+      },
+    ],
+    results: [
+      {
+        cell_id: "T2-BILL/local/case=T2-BILL-2",
+        scenario_id: "T2-BILL",
+        registry_flow_ref: "specs#T2-BILL",
+        runtime_lane: "local",
+        dimensions: { case: "T2-BILL-2" },
+        status: "green",
+        started_at: "2026-07-13T00:00:01Z",
+        finished_at: "2026-07-13T00:00:59Z",
+        duration_ms: 58_000,
+        reason: null,
+        plan_steps: [],
+      },
+    ],
+    summary: {
+      selected: 1,
+      finalized: 1,
+      by_status: byStatus,
+      integrity_errors: [],
+      runner_errors: [],
+      intended_exit_code: 0,
+    },
+    verdict: { status: "non_qualifying", scope: "selected_cells", completeness: "partial", reasons: [] },
+  };
+  report.verdict.reasons = expectedVerdict(report).reasons;
+  return report;
+}
+
+function tier2ReportV4(evidence: Tier2BillingEvidenceV1 | null): TestRunReportV4 {
+  const v3 = baseReportV4();
+  return {
+    ...v3,
+    schema_version: 4,
+    results: v3.results.map((result) => ({ ...result, evidence })),
+  };
+}
+
+test("validateReportV4 accepts a green T2-BILL cell with complete tier2_billing evidence", () => {
+  validateReportV4(tier2ReportV4(tier2Evidence()));
+});
+
+test("validateReportV4 rejects a green T2-BILL cell with null evidence (green-requires-evidence gate)", () => {
+  assert.throws(() => validateReportV4(tier2ReportV4(null)), /requires complete evidence/);
+});
+
+test("validateReportV4 rejects an undeclared top-level field", () => {
+  const dirty = { ...tier2Evidence(), extra: "nope" } as unknown as Tier2BillingEvidenceV1;
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /undeclared or missing field/);
+});
+
+test("validateReportV4 rejects an undeclared asserted_policy field", () => {
+  const dirty = tier2Evidence({ asserted_policy: { not_a_ruled_field: 1 } as any });
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /undeclared field/);
+});
+
+test("validateReportV4 rejects a negative or non-finite asserted_policy value", () => {
+  assert.throws(
+    () => validateReportV4(tier2ReportV4(tier2Evidence({ asserted_policy: { free_grant_usd: -1 } }))),
+    /must be a finite number/,
+  );
+  assert.throws(
+    () => validateReportV4(tier2ReportV4(tier2Evidence({ asserted_policy: { free_grant_usd: Number.NaN } }))),
+    /must be a finite number/,
+  );
+});
+
+test("validateReportV4 accepts an empty asserted_policy (a case that asserted no ruled value)", () => {
+  validateReportV4(tier2ReportV4(tier2Evidence({ asserted_policy: {} })));
+});
+
+test("validateReportV4 rejects an invalid billing_mode", () => {
+  const dirty = tier2Evidence({ billing_mode: "bogus" as unknown as Tier2BillingEvidenceV1["billing_mode"] });
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /billing_mode must be one of/);
+});
+
+test("validateReportV4 rejects an unsafe manifest_id", () => {
+  const dirty = tier2Evidence({ manifest_id: "../etc/passwd" });
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /manifest_id is missing or unsafe/);
+});
+
+test("validateReportV4 rejects stripe id arrays that exceed the bounded cap", () => {
+  const dirty = tier2Evidence({
+    stripe: { test_clock_ids: Array.from({ length: 21 }, (_, i) => `tc_${i}`), object_ids: [] },
+  });
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /exceeds the bounded cap/);
+});
+
+test("validateReportV4 rejects unsorted or duplicate stripe ids", () => {
+  const unsorted = tier2Evidence({ stripe: { test_clock_ids: ["tc_2", "tc_1"], object_ids: [] } });
+  assert.throws(() => validateReportV4(tier2ReportV4(unsorted)), /must be sorted ascending/);
+  const dup = tier2Evidence({ stripe: { test_clock_ids: ["tc_1", "tc_1"], object_ids: [] } });
+  assert.throws(() => validateReportV4(tier2ReportV4(dup)), /duplicate entry/);
+});
+
+test("validateReportV4 rejects a negative ledger delta", () => {
+  const dirty = tier2Evidence({ ledger: { ...tier2Evidence().ledger, grants_delta: -1 } });
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /must be a non-negative integer/);
+});
+
+test("validateReportV4 rejects an incomplete ledger object (missing key)", () => {
+  const { holds_delta: _drop, ...incompleteLedger } = tier2Evidence().ledger;
+  const dirty = { ...tier2Evidence(), ledger: incompleteLedger } as unknown as Tier2BillingEvidenceV1;
+  assert.throws(() => validateReportV4(tier2ReportV4(dirty)), /undeclared or missing field/);
+});
+
+test("validateReportV4 still validates local_workspace_turn cells unaffected by the tier2 dispatch branch", () => {
+  const report = tier2ReportV4(null);
+  const otherCellId = "OTHER-SCENARIO/local/case=T2-BILL-2";
+  report.results[0].scenario_id = "OTHER-SCENARIO";
+  report.results[0].cell_id = otherCellId;
+  report.selected_cells[0].scenario_id = "OTHER-SCENARIO";
+  report.selected_cells[0].cell_id = otherCellId;
+  // A non-gated scenario id with null evidence on a green cell is fine.
+  validateReportV4(report);
+});

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -918,24 +918,18 @@ const MAX_TIER2_TEST_CLOCK_IDS = 20;
 const MAX_TIER2_OBJECT_IDS = 50;
 
 /**
- * ── WORKSTREAM D: implement `tier2_billing` validation per BRIEF §2 ──────────
- *
- * Kind-scoped validator for `Tier2BillingEvidenceV1`. Requirements (verbatim
- * summary; full contract in BRIEF §2):
+ * Kind-scoped validator for `Tier2BillingEvidenceV1`:
  *   - `requireExactKeys` at top / `asserted_policy` / `stripe` / `ledger`;
  *   - `manifest_id` + `server_version` via `requireSafeEvidenceToken`;
  *   - `billing_mode` in {enforce,observe,off};
- *   - every present `asserted_policy` value: finite number >= 0 (do NOT hardcode
- *     the exact ruled number — the cell asserts it against the product);
+ *   - every present `asserted_policy` value: finite number >= 0 (the exact
+ *     ruled number is asserted by the cell against the product, not here);
  *   - `stripe.test_clock_ids` (<= MAX_TIER2_TEST_CLOCK_IDS) and
  *     `stripe.object_ids` (<= MAX_TIER2_OBJECT_IDS): safe tokens, sorted
  *     ascending, unique, secret-free;
  *   - every `ledger.*` delta: `requireNonNegativeInteger`.
  * Green completeness is enforced upstream (a green Tier-2 cell with null
  * evidence is already rejected via `scenarioRequiresGreenEvidence`).
- *
- * Left intentionally unimplemented so a green Tier-2 cell cannot pass until the
- * validator exists — the same fail-closed posture the local kind uses.
  */
 function validateTier2BillingEvidence(
   where: string,

--- a/tests/release/src/evidence/schema.ts
+++ b/tests/release/src/evidence/schema.ts
@@ -88,8 +88,60 @@ export interface TestRunReportV3 {
  *     evidence recording its own cleanup failure).
  */
 
-/** One result's optional bounded evidence; today only the local-workspace turn. */
-export type CellEvidenceV1 = LocalWorkspaceTurnEvidenceV1;
+/**
+ * One result's optional bounded evidence. `local_workspace_turn` is the
+ * Tier-3 local-world proof; `tier2_billing` (PR 4) binds, per Tier-2 cell, the
+ * asserted ruled policy values, safe Stripe object/test-clock ids, and ledger
+ * deltas. Each kind is validated by its own kind-scoped function; a kind never
+ * touches another kind's validation (extension-contract rule).
+ */
+export type CellEvidenceV1 = LocalWorkspaceTurnEvidenceV1 | Tier2BillingEvidenceV1;
+
+/**
+ * ── Tier-2 billing evidence (PR 4) ─────────────────────────────────────────
+ *
+ * Bounded and secret-free BY CONSTRUCTION: asserted ruled policy values as
+ * finite non-negative numbers, safe Stripe test-mode object/test-clock ids as
+ * safe tokens, integer ledger row-count deltas. No free text, no credentials,
+ * no local paths. Full validator/sanitizer contract in BRIEF §2 — the validator
+ * body is owned by workstream D (`validateTier2BillingEvidence` below is the
+ * kind-scoped seam).
+ */
+export interface Tier2BillingEvidenceV1 {
+  kind: "tier2_billing";
+  /** The authoritative manifest case id, e.g. "T2-BILL-2" (safe token). */
+  manifest_id: string;
+  /** The Server under test's VERSION (safe token). */
+  server_version: string;
+  billing_mode: "enforce" | "observe" | "off";
+  /** Ruled policy values THIS case asserted; every present value is finite >= 0. */
+  asserted_policy: {
+    free_grant_usd?: number;
+    llm_per_seat_usd?: number;
+    compute_per_seat_usd?: number;
+    compute_margin_multiplier?: number;
+    topup_pack_usd?: number;
+    topup_margin_pct?: number;
+    topup_trigger_usd?: number;
+    overage_cap_usd_per_org_month?: number;
+  };
+  /** Safe Stripe test-mode identifiers this case created (never secrets). */
+  stripe: {
+    /** tc_… ; sorted ascending, unique, bounded. */
+    test_clock_ids: string[];
+    /** sub_/cus_/in_/evt_/pi_… ; sorted ascending, unique, bounded. */
+    object_ids: string[];
+  };
+  /** Billing-ledger row-count deltas this case produced (non-negative integers). */
+  ledger: {
+    grants_delta: number;
+    seat_adjustments_delta: number;
+    usage_exports_delta: number;
+    llm_events_delta: number;
+    webhook_receipts_delta: number;
+    holds_delta: number;
+  };
+}
 
 export interface LocalWorkspaceTurnEvidenceV1 {
   kind: "local_workspace_turn";
@@ -682,9 +734,9 @@ function validateCellEvidence(result: FinalCellResultV2): void {
   }
   const evidence = result.evidence;
   if (evidence === null) {
-    if (result.status === "green" && result.scenario_id === "LOCAL-WORLD-SMOKE-1") {
+    if (result.status === "green" && scenarioRequiresGreenEvidence(result.scenario_id)) {
       throw new ReportValidationError(
-        `Green result "${result.cell_id}" for LOCAL-WORLD-SMOKE-1 requires complete evidence.`,
+        `Green result "${result.cell_id}" for ${result.scenario_id} requires complete evidence.`,
       );
     }
     return;
@@ -693,6 +745,13 @@ function validateCellEvidence(result: FinalCellResultV2): void {
     throw new ReportValidationError(`Result "${result.cell_id}" evidence must be an object or null.`);
   }
   const where = `Result "${result.cell_id}" evidence`;
+  // Kind-scoped dispatch: each kind validates in its own function and never
+  // touches another kind's rules (extension-contract). Tier-2 billing evidence
+  // is validated by workstream D's `validateTier2BillingEvidence`.
+  if ((evidence as { kind?: unknown }).kind === "tier2_billing") {
+    validateTier2BillingEvidence(where, evidence as Tier2BillingEvidenceV1, result.status);
+    return;
+  }
   requireExactKeys(evidence, LOCAL_WORKSPACE_TURN_EVIDENCE_KEYS, where);
   if (evidence.kind !== "local_workspace_turn") {
     throw new ReportValidationError(`${where}.kind is unknown.`);
@@ -809,6 +868,147 @@ function validateCleanupEvidence(
  * `[REDACTED]`-bearing string here, which the safe-token/hash patterns above
  * then reject rather than silently persisting.
  */
+/**
+ * Scenario ids whose GREEN cells must carry complete evidence (a green cell
+ * with `evidence: null` is rejected). Kind/id-scoped allowlist — LOCAL-WORLD
+ * proof plus the PR-4 Tier-2 scenarios (BRIEF §2/§7). Extend here, not by
+ * touching another kind's validation.
+ */
+const GREEN_EVIDENCE_REQUIRED_SCENARIOS: ReadonlySet<string> = new Set([
+  "LOCAL-WORLD-SMOKE-1",
+  "T2-BILL",
+  "T2-AUTH-ORG",
+]);
+
+function scenarioRequiresGreenEvidence(scenarioId: string): boolean {
+  return GREEN_EVIDENCE_REQUIRED_SCENARIOS.has(scenarioId);
+}
+
+const TIER2_BILLING_EVIDENCE_KEYS = [
+  "kind",
+  "manifest_id",
+  "server_version",
+  "billing_mode",
+  "asserted_policy",
+  "stripe",
+  "ledger",
+] as const;
+
+const TIER2_ASSERTED_POLICY_KEYS = [
+  "free_grant_usd",
+  "llm_per_seat_usd",
+  "compute_per_seat_usd",
+  "compute_margin_multiplier",
+  "topup_pack_usd",
+  "topup_margin_pct",
+  "topup_trigger_usd",
+  "overage_cap_usd_per_org_month",
+] as const;
+
+const TIER2_LEDGER_KEYS = [
+  "grants_delta",
+  "seat_adjustments_delta",
+  "usage_exports_delta",
+  "llm_events_delta",
+  "webhook_receipts_delta",
+  "holds_delta",
+] as const;
+
+const MAX_TIER2_TEST_CLOCK_IDS = 20;
+const MAX_TIER2_OBJECT_IDS = 50;
+
+/**
+ * ── WORKSTREAM D: implement `tier2_billing` validation per BRIEF §2 ──────────
+ *
+ * Kind-scoped validator for `Tier2BillingEvidenceV1`. Requirements (verbatim
+ * summary; full contract in BRIEF §2):
+ *   - `requireExactKeys` at top / `asserted_policy` / `stripe` / `ledger`;
+ *   - `manifest_id` + `server_version` via `requireSafeEvidenceToken`;
+ *   - `billing_mode` in {enforce,observe,off};
+ *   - every present `asserted_policy` value: finite number >= 0 (do NOT hardcode
+ *     the exact ruled number — the cell asserts it against the product);
+ *   - `stripe.test_clock_ids` (<= MAX_TIER2_TEST_CLOCK_IDS) and
+ *     `stripe.object_ids` (<= MAX_TIER2_OBJECT_IDS): safe tokens, sorted
+ *     ascending, unique, secret-free;
+ *   - every `ledger.*` delta: `requireNonNegativeInteger`.
+ * Green completeness is enforced upstream (a green Tier-2 cell with null
+ * evidence is already rejected via `scenarioRequiresGreenEvidence`).
+ *
+ * Left intentionally unimplemented so a green Tier-2 cell cannot pass until the
+ * validator exists — the same fail-closed posture the local kind uses.
+ */
+function validateTier2BillingEvidence(
+  where: string,
+  evidence: Tier2BillingEvidenceV1,
+  _status: FinalTestStatus,
+): void {
+  requireExactKeys(evidence, TIER2_BILLING_EVIDENCE_KEYS, where);
+  if (evidence.kind !== "tier2_billing") {
+    throw new ReportValidationError(`${where}.kind is unknown.`);
+  }
+  requireSafeEvidenceToken(`${where}.manifest_id`, evidence.manifest_id);
+  requireSafeEvidenceToken(`${where}.server_version`, evidence.server_version);
+  if (evidence.billing_mode !== "enforce" && evidence.billing_mode !== "observe" && evidence.billing_mode !== "off") {
+    throw new ReportValidationError(`${where}.billing_mode must be one of enforce|observe|off.`);
+  }
+
+  const policy = evidence.asserted_policy;
+  if (typeof policy !== "object" || policy === null || Array.isArray(policy)) {
+    throw new ReportValidationError(`${where}.asserted_policy must be an object.`);
+  }
+  const presentPolicyKeys = Object.keys(policy);
+  for (const key of presentPolicyKeys) {
+    if (!(TIER2_ASSERTED_POLICY_KEYS as readonly string[]).includes(key)) {
+      throw new ReportValidationError(`${where}.asserted_policy has an undeclared field "${key}".`);
+    }
+  }
+  for (const key of presentPolicyKeys as (keyof typeof policy)[]) {
+    const value = policy[key];
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      throw new ReportValidationError(`${where}.asserted_policy.${key} must be a finite number >= 0.`);
+    }
+  }
+
+  const stripe = evidence.stripe;
+  if (typeof stripe !== "object" || stripe === null || Array.isArray(stripe)) {
+    throw new ReportValidationError(`${where}.stripe must be an object.`);
+  }
+  requireExactKeys(stripe, ["test_clock_ids", "object_ids"], `${where}.stripe`);
+  validateSortedUniqueSafeTokenArray(`${where}.stripe.test_clock_ids`, stripe.test_clock_ids, MAX_TIER2_TEST_CLOCK_IDS);
+  validateSortedUniqueSafeTokenArray(`${where}.stripe.object_ids`, stripe.object_ids, MAX_TIER2_OBJECT_IDS);
+
+  const ledger = evidence.ledger;
+  if (typeof ledger !== "object" || ledger === null || Array.isArray(ledger)) {
+    throw new ReportValidationError(`${where}.ledger must be an object.`);
+  }
+  requireExactKeys(ledger, TIER2_LEDGER_KEYS, `${where}.ledger`);
+  for (const key of TIER2_LEDGER_KEYS) {
+    requireNonNegativeInteger(`${where}.ledger.${key}`, ledger[key]);
+  }
+}
+
+function validateSortedUniqueSafeTokenArray(where: string, value: unknown, cap: number): void {
+  if (!Array.isArray(value)) {
+    throw new ReportValidationError(`${where} must be an array.`);
+  }
+  if (value.length > cap) {
+    throw new ReportValidationError(`${where} exceeds the bounded cap of ${cap}.`);
+  }
+  const seen = new Set<string>();
+  let previous: string | undefined;
+  for (const [index, id] of value.entries()) {
+    requireSafeEvidenceToken(`${where}[${index}]`, id);
+    if (seen.has(id)) {
+      throw new ReportValidationError(`${where} has a duplicate entry.`);
+    }
+    seen.add(id);
+    if (previous !== undefined && id < previous) {
+      throw new ReportValidationError(`${where} must be sorted ascending.`);
+    }
+    previous = id;
+  }
+}
+
 export function sanitizeCellEvidence(
   evidence: CellEvidenceV1 | null,
   secretValues: readonly string[],
@@ -817,6 +1017,20 @@ export function sanitizeCellEvidence(
     return null;
   }
   const clean = (value: string): string => boundMessage(redactUrlCredentials(redactSecrets(value, secretValues)));
+  if (evidence.kind === "tier2_billing") {
+    // All string fields are safe tokens by construction; clean them as a
+    // fail-closed backstop (numbers pass through untouched).
+    return {
+      ...evidence,
+      manifest_id: clean(evidence.manifest_id),
+      server_version: clean(evidence.server_version),
+      stripe: {
+        ...evidence.stripe,
+        test_clock_ids: evidence.stripe.test_clock_ids.map(clean),
+        object_ids: evidence.stripe.object_ids.map(clean),
+      },
+    };
+  }
   return {
     ...evidence,
     artifact_ids: evidence.artifact_ids.map(clean),

--- a/tests/release/src/evidence/write.test.ts
+++ b/tests/release/src/evidence/write.test.ts
@@ -752,11 +752,11 @@ test("validateReportV4 rejects an extra field on evidence or nested objects", ()
   assert.throws(() => validateReportV4(report), /undeclared or missing field/);
 
   const nested = validSmokeReportV4();
-  (nested.results[0].evidence!.litellm as unknown as Record<string, unknown>).extra = "x";
+  ((nested.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm as unknown as Record<string, unknown>).extra = "x";
   assert.throws(() => validateReportV4(nested), /litellm has undeclared/);
 
   const cleanupExtra = validSmokeReportV4();
-  (cleanupExtra.results[0].evidence!.cleanup as unknown as Record<string, unknown>).extra = "x";
+  ((cleanupExtra.results[0].evidence as LocalWorkspaceTurnEvidenceV1).cleanup as unknown as Record<string, unknown>).extra = "x";
   assert.throws(() => validateReportV4(cleanupExtra), /cleanup has undeclared/);
 });
 
@@ -765,59 +765,59 @@ test("validateReportV4 rejects unsafe strings: paths and secret-like markers", (
   assert.throws(() => validateReportV4(leaked), /model_id is missing or unsafe/);
 
   const traversal = validSmokeReportV4();
-  traversal.results[0].evidence!.artifact_ids = ["server/../../etc/passwd"];
+  (traversal.results[0].evidence as LocalWorkspaceTurnEvidenceV1).artifact_ids = ["server/../../etc/passwd"];
   assert.throws(() => validateReportV4(traversal), /artifact_ids\[0\] is missing or unsafe/);
 
   const redactedLooking = validSmokeReportV4();
-  redactedLooking.results[0].evidence!.litellm.token_id_hash = "[REDACTED]";
+  (redactedLooking.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.token_id_hash = "[REDACTED]";
   assert.throws(() => validateReportV4(redactedLooking), /token_id_hash must be a lowercase 64-hex digest/);
 });
 
 test("validateReportV4 rejects invalid or inconsistent token counts", () => {
   const mismatched = validSmokeReportV4();
-  mismatched.results[0].evidence!.litellm.total_tokens = 999;
+  (mismatched.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.total_tokens = 999;
   assert.throws(() => validateReportV4(mismatched), /token counts are internally inconsistent/);
 
   const zero = validSmokeReportV4();
-  zero.results[0].evidence!.litellm.prompt_tokens = 0;
+  (zero.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.prompt_tokens = 0;
   assert.throws(() => validateReportV4(zero), /prompt_tokens must be a positive integer/);
 
   const negative = validSmokeReportV4();
-  negative.results[0].evidence!.litellm.completion_tokens = -1;
+  (negative.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.completion_tokens = -1;
   assert.throws(() => validateReportV4(negative), /completion_tokens must be a positive integer/);
 });
 
 test("validateReportV4 rejects non-positive spend", () => {
   const zeroSpend = validSmokeReportV4();
-  zeroSpend.results[0].evidence!.litellm.spend_usd = 0;
+  (zeroSpend.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.spend_usd = 0;
   assert.throws(() => validateReportV4(zeroSpend), /spend_usd must be positive/);
 
   const negativeSpend = validSmokeReportV4();
-  negativeSpend.results[0].evidence!.litellm.spend_usd = -0.01;
+  (negativeSpend.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.spend_usd = -0.01;
   assert.throws(() => validateReportV4(negativeSpend), /spend_usd must be positive/);
 });
 
 test("validateReportV4 rejects unsorted/duplicate/oversized request_ids", () => {
   const unsorted = validSmokeReportV4();
-  unsorted.results[0].evidence!.litellm.request_ids = ["req-2", "req-1"];
+  (unsorted.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.request_ids = ["req-2", "req-1"];
   assert.throws(() => validateReportV4(unsorted), /must be sorted ascending/);
 
   const duplicated = validSmokeReportV4();
-  duplicated.results[0].evidence!.litellm.request_ids = ["req-1", "req-1"];
+  (duplicated.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.request_ids = ["req-1", "req-1"];
   assert.throws(() => validateReportV4(duplicated), /duplicate entry/);
 
   const oversized = validSmokeReportV4();
-  oversized.results[0].evidence!.litellm.request_ids = Array.from({ length: 51 }, (_, i) => `req-${String(i).padStart(3, "0")}`);
+  (oversized.results[0].evidence as LocalWorkspaceTurnEvidenceV1).litellm.request_ids = Array.from({ length: 51 }, (_, i) => `req-${String(i).padStart(3, "0")}`);
   assert.throws(() => validateReportV4(oversized), /exceeds the bounded cap/);
 });
 
 test("validateReportV4 rejects a green cell whose cleanup has a false deletion flag or a failure", () => {
   const incomplete = validSmokeReportV4();
-  incomplete.results[0].evidence!.cleanup.virtual_key_deleted = false;
+  (incomplete.results[0].evidence as LocalWorkspaceTurnEvidenceV1).cleanup.virtual_key_deleted = false;
   assert.throws(() => validateReportV4(incomplete), /incomplete on a green result/);
 
   const failed = validSmokeReportV4();
-  failed.results[0].evidence!.cleanup.failed = 1;
+  (failed.results[0].evidence as LocalWorkspaceTurnEvidenceV1).cleanup.failed = 1;
   assert.throws(() => validateReportV4(failed), /cleanup.failed must be 0/);
 });
 
@@ -835,11 +835,11 @@ test("sanitizeCellEvidence redacts secrets so validation then rejects the mangle
   const secret = "sk-live-leaked";
   const evidence: CellEvidenceV1 = validCellEvidence({ model_id: `claude-haiku-4-5-${secret}` });
   const sanitized = sanitizeCellEvidence(evidence, [secret]);
-  assert.ok(sanitized && sanitized.model_id.includes("[REDACTED]"));
+  assert.ok(sanitized && (sanitized as LocalWorkspaceTurnEvidenceV1).model_id.includes("[REDACTED]"));
   assert.throws(
     () =>
       validateReportV4(
-        validSmokeReportV4({ model_id: sanitized!.model_id }),
+        validSmokeReportV4({ model_id: (sanitized as LocalWorkspaceTurnEvidenceV1).model_id }),
       ),
     /model_id is missing or unsafe/,
   );

--- a/tests/release/src/scenarios/local-world-smoke-1.test.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.test.ts
@@ -285,7 +285,7 @@ test("runLocalWorldSmokeCell drives every step in order and attaches complete ev
   assert.ok(outcome.evidence);
   assert.equal(outcome.evidence!.kind, "local_workspace_turn");
   assert.equal(outcome.evidence!.harness, "claude");
-  assert.equal(outcome.evidence!.model_id, "claude-haiku-4-5");
+  assert.equal((outcome.evidence as { model_id: string }).model_id, "claude-haiku-4-5");
   assert.equal(outcome.evidence!.transcript_reopened, true);
   assert.equal(outcome.evidence!.server_version, "1.2.3");
   assert.equal(outcome.evidence!.anyharness_version, "4.5.6");
@@ -336,7 +336,7 @@ test("model choice: prefers haiku over sonnet and excludes the fable tier", asyn
   });
   const outcome = await runLocalWorldSmokeCell(fakeCell(), fakeCtx(), driver);
   assert.equal(outcome.status, "green");
-  assert.equal(outcome.evidence!.model_id, "claude-haiku-4-5");
+  assert.equal((outcome.evidence as { model_id: string }).model_id, "claude-haiku-4-5");
 });
 
 test("model choice: a fable-only intersection is blocked, never selected", async () => {

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -23,6 +23,8 @@ import { t3Sh3 } from "./selfhost/t3-sh-3.js";
 import { t3Sh4 } from "./selfhost/t3-sh-4.js";
 import { t3Sh5 } from "./selfhost/t3-sh-5.js";
 import { localWorldSmoke1 } from "./local-world-smoke-1.js";
+import { t2Bill } from "./tier2/t2-bill.js";
+import { t2AuthOrg } from "./tier2/t2-auth-org.js";
 
 /**
  * The tier-3 first wave (specs/developing/testing/scenarios.md#tier-3--first-wave),
@@ -57,6 +59,8 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   t4Sh1,
   t4Sh2,
   localWorldSmoke1,
+  t2Bill,
+  t2AuthOrg,
 ];
 
 export function allScenarioIds(): string[] {

--- a/tests/release/src/scenarios/tier2/evidence.test.ts
+++ b/tests/release/src/scenarios/tier2/evidence.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildTier2BillingEvidence,
+  createLedgerProbe,
+  createPolicyAsserter,
+  createStripeIdCollector,
+  type LedgerCounts,
+  type LedgerRowCounter,
+} from "./evidence.js";
+import type { Tier2BillingEvidenceV1 } from "../../evidence/schema.js";
+
+test("createPolicyAsserter merges successive record() calls and snapshots an independent copy", () => {
+  const policy = createPolicyAsserter();
+  policy.record({ free_grant_usd: 2 });
+  policy.record({ llm_per_seat_usd: 5, compute_per_seat_usd: 15 });
+  const snap = policy.snapshot();
+  assert.deepEqual(snap, { free_grant_usd: 2, llm_per_seat_usd: 5, compute_per_seat_usd: 15 });
+  // Mutating the snapshot must not bleed back into the recorder.
+  snap.free_grant_usd = 999;
+  assert.equal(policy.snapshot().free_grant_usd, 2);
+});
+
+test("createStripeIdCollector de-duplicates, ignores empty strings, and keeps the two id kinds separate", () => {
+  const ids = createStripeIdCollector();
+  ids.addObject("sub_1");
+  ids.addObject("sub_1");
+  ids.addObject("");
+  ids.addObject("cus_1");
+  ids.addTestClock("tc_1");
+  ids.addTestClock("");
+  assert.deepEqual([...ids.objectIds()].sort(), ["cus_1", "sub_1"]);
+  assert.deepEqual(ids.testClockIds(), ["tc_1"]);
+});
+
+test("buildTier2BillingEvidence assembles a bounded, sorted, de-duplicated, secret-free object", () => {
+  const policy = createPolicyAsserter();
+  policy.record({ overage_cap_usd_per_org_month: 50, compute_margin_multiplier: 1.5 });
+  const ids = createStripeIdCollector();
+  ids.addObject("sub_9");
+  ids.addObject("cus_1");
+  ids.addObject("sub_9");
+  ids.addTestClock("tc_2");
+  ids.addTestClock("tc_1");
+  const ledger: Tier2BillingEvidenceV1["ledger"] = {
+    grants_delta: 1,
+    seat_adjustments_delta: 0,
+    usage_exports_delta: 3,
+    llm_events_delta: 0,
+    webhook_receipts_delta: 2,
+    holds_delta: 0,
+  };
+  const evidence = buildTier2BillingEvidence({
+    manifestId: "T2-BILL-14",
+    serverVersion: "1.2.3",
+    billingMode: "enforce",
+    policy,
+    ids,
+    ledger,
+  });
+  assert.equal(evidence.kind, "tier2_billing");
+  assert.equal(evidence.manifest_id, "T2-BILL-14");
+  assert.equal(evidence.server_version, "1.2.3");
+  assert.equal(evidence.billing_mode, "enforce");
+  assert.deepEqual(evidence.asserted_policy, { overage_cap_usd_per_org_month: 50, compute_margin_multiplier: 1.5 });
+  assert.deepEqual(evidence.stripe.object_ids, ["cus_1", "sub_9"]);
+  assert.deepEqual(evidence.stripe.test_clock_ids, ["tc_1", "tc_2"]);
+  assert.deepEqual(evidence.ledger, ledger);
+});
+
+test("buildTier2BillingEvidence throws when the object-id array exceeds its bounded cap", () => {
+  const ids = createStripeIdCollector();
+  for (let i = 0; i < 51; i += 1) {
+    ids.addObject(`sub_${String(i).padStart(3, "0")}`);
+  }
+  assert.throws(
+    () =>
+      buildTier2BillingEvidence({
+        manifestId: "T2-BILL-1",
+        serverVersion: "1",
+        billingMode: "enforce",
+        policy: createPolicyAsserter(),
+        ids,
+        ledger: emptyLedger(),
+      }),
+    /object_ids exceeds the bounded cap of 50/,
+  );
+});
+
+test("buildTier2BillingEvidence throws when the test-clock-id array exceeds its bounded cap", () => {
+  const ids = createStripeIdCollector();
+  for (let i = 0; i < 21; i += 1) {
+    ids.addTestClock(`tc_${String(i).padStart(3, "0")}`);
+  }
+  assert.throws(
+    () =>
+      buildTier2BillingEvidence({
+        manifestId: "T2-BILL-1",
+        serverVersion: "1",
+        billingMode: "enforce",
+        policy: createPolicyAsserter(),
+        ids,
+        ledger: emptyLedger(),
+      }),
+    /test_clock_ids exceeds the bounded cap of 20/,
+  );
+});
+
+test("createLedgerProbe computes per-field deltas against the baseline and clamps negatives to zero", async () => {
+  let seenDbUrl = "";
+  let call = 0;
+  const baseline: LedgerCounts = {
+    grants_delta: 5,
+    seat_adjustments_delta: 0,
+    usage_exports_delta: 0,
+    llm_events_delta: 0,
+    webhook_receipts_delta: 0,
+    holds_delta: 2,
+  };
+  const now: LedgerCounts = {
+    grants_delta: 7,
+    seat_adjustments_delta: 0,
+    usage_exports_delta: 3,
+    llm_events_delta: 0,
+    webhook_receipts_delta: 0,
+    holds_delta: 0,
+  };
+  const counter: LedgerRowCounter = async (databaseUrl) => {
+    seenDbUrl = databaseUrl;
+    call += 1;
+    return call === 1 ? baseline : now;
+  };
+  const probe = createLedgerProbe("postgresql://localhost/t2billing", counter);
+  await probe.begin();
+  const delta = await probe.delta();
+  assert.equal(seenDbUrl, "postgresql://localhost/t2billing");
+  assert.deepEqual(delta, {
+    grants_delta: 2,
+    seat_adjustments_delta: 0,
+    usage_exports_delta: 3,
+    llm_events_delta: 0,
+    webhook_receipts_delta: 0,
+    holds_delta: 0, // clamped from -2
+  });
+});
+
+test("createLedgerProbe.delta() before begin() fails closed", async () => {
+  const probe = createLedgerProbe("postgresql://localhost/t2billing", async () => emptyLedger());
+  await assert.rejects(() => probe.delta(), /delta\(\) called before begin\(\)/);
+});
+
+function emptyLedger(): LedgerCounts {
+  return {
+    grants_delta: 0,
+    seat_adjustments_delta: 0,
+    usage_exports_delta: 0,
+    llm_events_delta: 0,
+    webhook_receipts_delta: 0,
+    holds_delta: 0,
+  };
+}

--- a/tests/release/src/scenarios/tier2/evidence.ts
+++ b/tests/release/src/scenarios/tier2/evidence.ts
@@ -1,0 +1,132 @@
+/**
+ * Tier-2 billing evidence construction (PR 4, BRIEF §2/§4).
+ *
+ * Pure/bounded builders for `Tier2BillingEvidenceV1`: the in-memory policy
+ * recorder + Stripe-id collector, the profile-DB ledger-delta probe, and the
+ * final assembler that sorts/dedups/bounds the id arrays. Secret-free by
+ * construction. `buildTier2BillingEvidence`'s output is what the report
+ * validator (`validateTier2BillingEvidence`, workstream D) later checks.
+ */
+
+import type { Tier2BillingEvidenceV1 } from "../../evidence/schema.js";
+import type { LedgerProbe, PolicyAsserter, StripeIdCollector } from "./types.js";
+import { withDb } from "../../../../intent/stack/billing-env.ts";
+
+const MAX_TIER2_TEST_CLOCK_IDS = 20;
+const MAX_TIER2_OBJECT_IDS = 50;
+
+export function createPolicyAsserter(): PolicyAsserter {
+  let recorded: Tier2BillingEvidenceV1["asserted_policy"] = {};
+  return {
+    record(values) {
+      recorded = { ...recorded, ...values };
+    },
+    snapshot() {
+      return { ...recorded };
+    },
+  };
+}
+
+export function createStripeIdCollector(): StripeIdCollector {
+  const clocks = new Set<string>();
+  const objects = new Set<string>();
+  return {
+    addTestClock: (id) => {
+      if (id) clocks.add(id);
+    },
+    addObject: (id) => {
+      if (id) objects.add(id);
+    },
+    testClockIds: () => [...clocks],
+    objectIds: () => [...objects],
+  };
+}
+
+/** The six billing tables whose per-case row-count deltas the evidence records.
+ * Deltas are inserts within a reset window, so each is always `>= 0`. */
+const LEDGER_TABLES = {
+  grants_delta: "billing_grant",
+  seat_adjustments_delta: "billing_seat_adjustment",
+  usage_exports_delta: "billing_usage_export",
+  llm_events_delta: "agent_llm_usage_event",
+  webhook_receipts_delta: "webhook_event_receipt",
+  holds_delta: "billing_hold",
+} as const;
+
+export type LedgerCounts = Record<keyof typeof LEDGER_TABLES, number>;
+
+/** How the probe reads the six ledger row counts; injectable so the
+ * delta/clamp logic is exercised offline with a fake counter (no Postgres). */
+export type LedgerRowCounter = (databaseUrl: string) => Promise<LedgerCounts>;
+
+async function countLedgerRows(_databaseUrl: string): Promise<LedgerCounts> {
+  return withDb(async (db) => {
+    const counts = {} as LedgerCounts;
+    for (const [field, table] of Object.entries(LEDGER_TABLES) as [keyof typeof LEDGER_TABLES, string][]) {
+      const result = await db.query(`SELECT count(*)::int AS n FROM ${table}`);
+      counts[field] = result.rows[0].n as number;
+    }
+    return counts;
+  });
+}
+
+/**
+ * Profile-DB ledger-delta probe. `databaseUrl` is the booted profile DB (from
+ * `BootedStack.databaseUrl`). `withDb` maps the scheme/host exactly as the
+ * billing harness does.
+ */
+export function createLedgerProbe(
+  databaseUrl: string,
+  countRows: LedgerRowCounter = countLedgerRows,
+): LedgerProbe {
+  let baseline: LedgerCounts | null = null;
+  return {
+    async begin() {
+      baseline = await countRows(databaseUrl);
+    },
+    async delta() {
+      if (baseline === null) {
+        throw new Error("createLedgerProbe: delta() called before begin().");
+      }
+      const now = await countRows(databaseUrl);
+      const out = {} as Tier2BillingEvidenceV1["ledger"];
+      for (const field of Object.keys(LEDGER_TABLES) as (keyof typeof LEDGER_TABLES)[]) {
+        out[field] = Math.max(now[field] - baseline[field], 0);
+      }
+      return out;
+    },
+  };
+}
+
+function sortedBoundedUnique(ids: readonly string[], cap: number, label: string): string[] {
+  const unique = [...new Set(ids)].sort();
+  if (unique.length > cap) {
+    throw new Error(`buildTier2BillingEvidence: ${label} exceeds the bounded cap of ${cap} (got ${unique.length}).`);
+  }
+  return unique;
+}
+
+export interface BuildTier2EvidenceArgs {
+  manifestId: string;
+  serverVersion: string;
+  billingMode: Tier2BillingEvidenceV1["billing_mode"];
+  policy: PolicyAsserter;
+  ids: StripeIdCollector;
+  ledger: Tier2BillingEvidenceV1["ledger"];
+}
+
+/** Assembles the bounded, secret-free `tier2_billing` evidence for a green cell. */
+export function buildTier2BillingEvidence(args: BuildTier2EvidenceArgs): Tier2BillingEvidenceV1 {
+  return {
+    kind: "tier2_billing",
+    manifest_id: args.manifestId,
+    server_version: args.serverVersion,
+    billing_mode: args.billingMode,
+    asserted_policy: args.policy.snapshot(),
+    stripe: {
+      test_clock_ids: sortedBoundedUnique(args.ids.testClockIds(), MAX_TIER2_TEST_CLOCK_IDS, "stripe.test_clock_ids"),
+      object_ids: sortedBoundedUnique(args.ids.objectIds(), MAX_TIER2_OBJECT_IDS, "stripe.object_ids"),
+    },
+    ledger: args.ledger,
+  };
+}

--- a/tests/release/src/scenarios/tier2/fixtures.ts
+++ b/tests/release/src/scenarios/tier2/fixtures.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared admin/org handle for Tier-2 cell handlers (PR 4, workstream D).
+ *
+ * Adapted from `tests/intent/specs/billing/_fixtures.ts`'s `adminContext` /
+ * `adminUserId` — same claim-once-and-reuse idempotency, minus the Playwright
+ * `test.beforeAll` skip wiring (the harness already returns every financial
+ * cell `blocked` when Stripe is unresolved; a case handler only runs once the
+ * stack is booted for real). One process runs every case against the ONE
+ * booted stack (BRIEF §1), so the module-level cache is exactly the intended
+ * "claim once, reuse" behavior across cases in a run.
+ */
+
+import {
+  ADMIN_EMAIL,
+  ADMIN_ORG_NAME,
+  ADMIN_PASSWORD,
+  ensureInstanceClaimed,
+  passwordLogin,
+} from "../../../../intent/stack/seed.ts";
+import { ensureProductReady } from "../../../../intent/stack/billing-seed.ts";
+
+export interface AdminContext {
+  token: string;
+  organizationId: string;
+  userId: string;
+}
+
+let cached: AdminContext | null = null;
+
+/** The claimed single-org admin + its org id + user id, shared across cases in
+ * this run. Idempotent: the first case to call it claims the instance. */
+export async function adminContext(): Promise<AdminContext> {
+  if (cached) {
+    return cached;
+  }
+  await ensureInstanceClaimed();
+  const { access_token } = await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD);
+  const apiBaseUrl = required("TIER2_BILLING_API_BASE_URL");
+  const orgResponse = await fetch(`${apiBaseUrl}/v1/organizations`, {
+    headers: { Authorization: `Bearer ${access_token}` },
+  });
+  const listing = (await orgResponse.json()) as { organizations: Array<{ id: string; name: string }> };
+  const org = listing.organizations.find((o) => o.name === ADMIN_ORG_NAME) ?? listing.organizations[0];
+  const meResponse = await fetch(`${apiBaseUrl}/users/me`, {
+    headers: { Authorization: `Bearer ${access_token}` },
+  });
+  const me = (await meResponse.json()) as { id: string };
+  // Billing/product surfaces sit behind the GitHub product-readiness gate even
+  // in single-org mode; this boot is password-only, so seed the legacy
+  // GitHub link the gate accepts (see ensureProductReady's doc).
+  await ensureProductReady(me.id, ADMIN_EMAIL);
+  cached = { token: access_token, organizationId: org.id, userId: me.id };
+  return cached;
+}
+
+/** Test-only reset hook: clears the cached admin handle. Not called by
+ * production case flow (accounts survive `resetBillingState()` by design);
+ * exposed for the harness/evidence unit tests to exercise in isolation. */
+export function resetAdminContextCacheForTests(): void {
+  cached = null;
+}
+
+export async function userIdFor(token: string): Promise<string> {
+  const apiBaseUrl = required("TIER2_BILLING_API_BASE_URL");
+  const response = await fetch(`${apiBaseUrl}/users/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const body = (await response.json()) as { id: string };
+  return body.id;
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set — did the Tier-2 stack boot?`);
+  }
+  return value;
+}

--- a/tests/release/src/scenarios/tier2/harness.test.ts
+++ b/tests/release/src/scenarios/tier2/harness.test.ts
@@ -20,6 +20,7 @@ import type { Tier2BillingEvidenceV1 } from "../../evidence/schema.js";
 import type { ScenarioPlanContext, ScenarioRunContext } from "../types.js";
 import type { PlannedCellV1 } from "../../runner/result.js";
 import type { BillingBootResult } from "../../../../intent/stack/billing-boot.ts";
+import type { BootWithFakeResult, LitellmManagementFake } from "../../../../intent/stack/billing-usage-import.ts";
 import type { BootedStack, StripeBillingEnv } from "../../../../intent/stack/boot.ts";
 
 // The harness ignores the scenario run/plan context (its work is against the
@@ -38,6 +39,9 @@ const LEDGER_DELTA: Tier2BillingEvidenceV1["ledger"] = {
 
 interface HarnessLog {
   bootCalls: number;
+  fakeBootCalls: number;
+  fakeCloseCalls: number;
+  clearEnvCalls: number;
   teardownCalls: number;
   resetCalls: number;
   ledgerBeginCalls: number;
@@ -72,11 +76,32 @@ function fakeStack(log: HarnessLog): BootedStack {
   };
 }
 
+function fakeLitellmFake(log: HarnessLog): LitellmManagementFake {
+  return {
+    baseUrl: "http://fake-litellm.test",
+    masterKey: "sk-fake-master",
+    seedSpendRows: () => undefined,
+    blockedKeys: () => [],
+    mintedKeys: () => [],
+    close: async () => {
+      log.fakeCloseCalls += 1;
+      log.events.push("fakeClose");
+    },
+  };
+}
+
 function makeDeps(
-  opts: { boot?: (stack: BootedStack) => BillingBootResult; ledgerProbeError?: Error } = {},
+  opts: {
+    boot?: (stack: BootedStack) => BillingBootResult;
+    fakeBoot?: (stack: BootedStack) => BootWithFakeResult;
+    ledgerProbeError?: Error;
+  } = {},
 ): { deps: Tier2HarnessDeps; log: HarnessLog } {
   const log: HarnessLog = {
     bootCalls: 0,
+    fakeBootCalls: 0,
+    fakeCloseCalls: 0,
+    clearEnvCalls: 0,
     teardownCalls: 0,
     resetCalls: 0,
     ledgerBeginCalls: 0,
@@ -85,11 +110,23 @@ function makeDeps(
   };
   const stack = fakeStack(log);
   const boot: BillingBootResult = opts.boot ? opts.boot(stack) : { skipped: false, stack, stripe: fakeStripe() };
+  const fakeBoot: BootWithFakeResult = opts.fakeBoot
+    ? opts.fakeBoot(stack)
+    : { skipped: false, stack, stripe: fakeStripe(), fake: fakeLitellmFake(log) };
   const deps: Tier2HarnessDeps = {
     bootBillingStack: async () => {
       log.bootCalls += 1;
       log.events.push("boot");
       return boot;
+    },
+    bootBillingStackWithLitellmFake: async () => {
+      log.fakeBootCalls += 1;
+      log.events.push("fakeBoot");
+      return fakeBoot;
+    },
+    clearPublishedGatewayEnv: () => {
+      log.clearEnvCalls += 1;
+      log.events.push("clearEnv");
     },
     resetBillingState: async () => {
       log.resetCalls += 1;
@@ -330,7 +367,17 @@ test("runTier2Case builds evidence from the recorded policy, deltas, and safe id
   const outcome = await runTier2Case(
     fakeConfig({ "T2-BILL-1": greenHandler }),
     fakeCell("T2-BILL-1"),
-    fakeStack({ bootCalls: 0, teardownCalls: 0, resetCalls: 0, ledgerBeginCalls: 0, ledgerDeltaCalls: 0, events: [] }),
+    fakeStack({
+      bootCalls: 0,
+      fakeBootCalls: 0,
+      fakeCloseCalls: 0,
+      clearEnvCalls: 0,
+      teardownCalls: 0,
+      resetCalls: 0,
+      ledgerBeginCalls: 0,
+      ledgerDeltaCalls: 0,
+      events: [],
+    }),
     fakeStripe(),
     deps,
   );
@@ -342,6 +389,50 @@ test("runTier2Case builds evidence from the recorded policy, deltas, and safe id
 
 test("DEFAULT_TIER2_HARNESS_DEPS wires the real resolvers and the real evidence assembler", () => {
   assert.equal(typeof DEFAULT_TIER2_HARNESS_DEPS.bootBillingStack, "function");
+  assert.equal(typeof DEFAULT_TIER2_HARNESS_DEPS.bootBillingStackWithLitellmFake, "function");
+  assert.equal(typeof DEFAULT_TIER2_HARNESS_DEPS.clearPublishedGatewayEnv, "function");
   assert.equal(DEFAULT_TIER2_HARNESS_DEPS.buildEvidence, buildTier2BillingEvidence);
   assert.equal(DEFAULT_TIER2_HARNESS_DEPS.resolveServerVersion, resolveServerVersion);
+});
+
+function gatewayFakeConfig(cases: Record<string, Tier2CellHandler>): Tier2ScenarioConfig {
+  return { ...fakeConfig(cases), gatewayFake: true };
+}
+
+test("gatewayFake config boots via the LiteLLM-fake path, NOT the plain boot, and closes the fake + clears gateway env at teardown", async () => {
+  const { deps, log } = makeDeps();
+  const scenario = makeTier2MatrixScenario(gatewayFakeConfig({ "T2-BILL-1": greenHandler }), deps);
+  const [outcome] = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1")]);
+
+  assert.equal(outcome.status, "green");
+  // The fake boot path is taken; the plain boot is never called.
+  assert.equal(log.fakeBootCalls, 1);
+  assert.equal(log.bootCalls, 0);
+  // Teardown folds stack teardown + fake close + gateway-env cleanup.
+  assert.equal(log.teardownCalls, 1);
+  assert.equal(log.fakeCloseCalls, 1);
+  assert.equal(log.clearEnvCalls, 1);
+  assert.deepEqual(log.events, [
+    "fakeBoot",
+    "reset",
+    "ledger.begin",
+    "ledger.delta",
+    "teardown",
+    "fakeClose",
+    "clearEnv",
+  ]);
+});
+
+test("gatewayFake config with a skipped fake boot blocks every cell (never green), fake never closed", async () => {
+  const { deps, log } = makeDeps({ fakeBoot: () => ({ skipped: true, reason: "no Stripe test key resolvable" }) });
+  const scenario = makeTier2MatrixScenario(gatewayFakeConfig({ "T2-BILL-1": greenHandler }), deps);
+  const outcomes = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1")]);
+  assert.equal(outcomes.length, 1);
+  assert.equal(outcomes[0].status, "blocked");
+  assert.equal(outcomes[0].reason?.code, "scenario_blocked");
+  assert.match(outcomes[0].reason?.message ?? "", /no Stripe test key resolvable/);
+  assert.equal(log.fakeBootCalls, 1);
+  assert.equal(log.bootCalls, 0);
+  assert.equal(log.fakeCloseCalls, 0);
+  assert.equal(log.clearEnvCalls, 0);
 });

--- a/tests/release/src/scenarios/tier2/harness.test.ts
+++ b/tests/release/src/scenarios/tier2/harness.test.ts
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_TIER2_HARNESS_DEPS,
+  TIER2_CASE_DIMENSION,
+  makeTier2MatrixScenario,
+  resolveServerVersion,
+  runTier2Case,
+  type Tier2HarnessDeps,
+} from "./harness.js";
+import { buildTier2BillingEvidence } from "./evidence.js";
+import type {
+  Tier2CaseResult,
+  Tier2CellContext,
+  Tier2CellHandler,
+  Tier2ScenarioConfig,
+} from "./types.js";
+import type { Tier2BillingEvidenceV1 } from "../../evidence/schema.js";
+import type { ScenarioPlanContext, ScenarioRunContext } from "../types.js";
+import type { PlannedCellV1 } from "../../runner/result.js";
+import type { BillingBootResult } from "../../../../intent/stack/billing-boot.ts";
+import type { BootedStack, StripeBillingEnv } from "../../../../intent/stack/boot.ts";
+
+// The harness ignores the scenario run/plan context (its work is against the
+// booted stack), so a bare cast is sufficient for these mechanism tests.
+const RUN_CTX = {} as ScenarioRunContext;
+const PLAN_CTX: ScenarioPlanContext = { runtimeLane: "local", desktop: "web", agents: ["claude"] };
+
+const LEDGER_DELTA: Tier2BillingEvidenceV1["ledger"] = {
+  grants_delta: 1,
+  seat_adjustments_delta: 0,
+  usage_exports_delta: 2,
+  llm_events_delta: 0,
+  webhook_receipts_delta: 1,
+  holds_delta: 0,
+};
+
+interface HarnessLog {
+  bootCalls: number;
+  teardownCalls: number;
+  resetCalls: number;
+  ledgerBeginCalls: number;
+  ledgerDeltaCalls: number;
+  events: string[];
+}
+
+function fakeStripe(): StripeBillingEnv {
+  return {
+    secretKey: "sk_test_fake",
+    webhookSecret: "whsec_fake",
+    proMonthlyPriceId: "price_pro",
+    overagePriceId: "price_overage",
+    refillPriceId: "price_refill",
+    meterId: "mtr_fake",
+    billingMode: "enforce",
+  };
+}
+
+function fakeStack(log: HarnessLog): BootedStack {
+  return {
+    profile: "t2billing",
+    apiBaseUrl: "http://api.test",
+    webBaseUrl: "http://web.test",
+    anyharnessBaseUrl: "http://anyharness.test",
+    databaseUrl: "postgresql://localhost:5432/t2billing",
+    setupTokenFile: "/tmp/setup-token",
+    teardown: async () => {
+      log.teardownCalls += 1;
+      log.events.push("teardown");
+    },
+  };
+}
+
+function makeDeps(
+  opts: { boot?: (stack: BootedStack) => BillingBootResult; ledgerProbeError?: Error } = {},
+): { deps: Tier2HarnessDeps; log: HarnessLog } {
+  const log: HarnessLog = {
+    bootCalls: 0,
+    teardownCalls: 0,
+    resetCalls: 0,
+    ledgerBeginCalls: 0,
+    ledgerDeltaCalls: 0,
+    events: [],
+  };
+  const stack = fakeStack(log);
+  const boot: BillingBootResult = opts.boot ? opts.boot(stack) : { skipped: false, stack, stripe: fakeStripe() };
+  const deps: Tier2HarnessDeps = {
+    bootBillingStack: async () => {
+      log.bootCalls += 1;
+      log.events.push("boot");
+      return boot;
+    },
+    resetBillingState: async () => {
+      log.resetCalls += 1;
+      log.events.push("reset");
+    },
+    createLedgerProbe: () => {
+      if (opts.ledgerProbeError) {
+        throw opts.ledgerProbeError;
+      }
+      return {
+        begin: async () => {
+          log.ledgerBeginCalls += 1;
+          log.events.push("ledger.begin");
+        },
+        delta: async () => {
+          log.ledgerDeltaCalls += 1;
+          log.events.push("ledger.delta");
+          return { ...LEDGER_DELTA };
+        },
+      };
+    },
+    // Real (pure) assembler so the test exercises actual evidence construction.
+    buildEvidence: buildTier2BillingEvidence,
+    resolveServerVersion: () => "9.9.9-test",
+    resolveBillingMode: () => "enforce",
+  };
+  return { deps, log };
+}
+
+function fakeCell(caseId: string): PlannedCellV1 {
+  return {
+    cell_id: `T2-BILL/local/${TIER2_CASE_DIMENSION}=${caseId}`,
+    scenario_id: "T2-BILL",
+    registry_flow_ref: "specs/developing/testing/flows.md#tier2-billing",
+    runtime_lane: "local",
+    dimensions: { [TIER2_CASE_DIMENSION]: caseId },
+    required_env: [],
+  };
+}
+
+function fakeConfig(cases: Record<string, Tier2CellHandler>): Tier2ScenarioConfig {
+  return {
+    id: "T2-BILL",
+    title: "Tier-2 billing mechanism test",
+    registryFlowRef: "specs/developing/testing/flows.md#tier2-billing",
+    requiredEnv: ["TIER2_BILLING_STRIPE_SECRET_KEY"],
+    requireStripe: true,
+    cases,
+  };
+}
+
+const greenHandler: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  ctx.policy.record({ free_grant_usd: 2, llm_per_seat_usd: 5 });
+  // Deliberately out of order + duplicated: evidence assembly must sort/dedup.
+  ctx.ids.addObject("sub_2");
+  ctx.ids.addObject("cus_1");
+  ctx.ids.addObject("sub_2");
+  ctx.ids.addTestClock("tc_9");
+  return { status: "green" };
+};
+
+function eventHandler(_caseId: string, result: Tier2CaseResult): Tier2CellHandler {
+  return async (): Promise<Tier2CaseResult> => result;
+}
+
+test("scenario definition is a matrix on lane local only (no new lane) and carries requiredEnv", () => {
+  const scenario = makeTier2MatrixScenario(fakeConfig({ "T2-BILL-1": greenHandler }), makeDeps().deps);
+  assert.equal(scenario.id, "T2-BILL");
+  assert.equal(scenario.kind, "matrix");
+  assert.deepEqual([...scenario.lanes], ["local"]);
+  assert.deepEqual([...scenario.requiredEnv], ["TIER2_BILLING_STRIPE_SECRET_KEY"]);
+});
+
+test("expandCells emits exactly one spec per case, carrying the case dimension", async () => {
+  const scenario = makeTier2MatrixScenario(
+    fakeConfig({ "T2-BILL-1": greenHandler, "T2-BILL-2": greenHandler }),
+    makeDeps().deps,
+  );
+  const specs = await scenario.expandCells(PLAN_CTX);
+  assert.deepEqual(specs, [
+    { dimensions: { case: "T2-BILL-1" } },
+    { dimensions: { case: "T2-BILL-2" } },
+  ]);
+});
+
+test("planCell prefixes every step with the cell id and mentions the case", () => {
+  const scenario = makeTier2MatrixScenario(fakeConfig({ "T2-BILL-1": greenHandler }), makeDeps().deps);
+  const cell = fakeCell("T2-BILL-1");
+  const steps = scenario.planCell(PLAN_CTX, cell);
+  assert.ok(steps.length >= 3);
+  for (const step of steps) {
+    assert.ok(step.description.startsWith(`[${cell.cell_id}]`));
+  }
+  assert.ok(steps.some((step) => step.description.includes("T2-BILL-1")));
+});
+
+test("a green case yields one green outcome with tier2_billing evidence, in reset→begin→handler→delta order", async () => {
+  const { deps, log } = makeDeps();
+  const scenario = makeTier2MatrixScenario(fakeConfig({ "T2-BILL-1": greenHandler }), deps);
+  const outcomes = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1")]);
+
+  assert.equal(outcomes.length, 1);
+  const [outcome] = outcomes;
+  assert.equal(outcome.cellId, "T2-BILL/local/case=T2-BILL-1");
+  assert.equal(outcome.status, "green");
+  assert.ok(outcome.evidence);
+  const evidence = outcome.evidence as Tier2BillingEvidenceV1;
+  assert.equal(evidence.kind, "tier2_billing");
+  assert.equal(evidence.manifest_id, "T2-BILL-1");
+  assert.equal(evidence.server_version, "9.9.9-test");
+  assert.equal(evidence.billing_mode, "enforce");
+  assert.deepEqual(evidence.asserted_policy, { free_grant_usd: 2, llm_per_seat_usd: 5 });
+  assert.deepEqual(evidence.ledger, LEDGER_DELTA);
+  // Ids sorted ascending + de-duplicated by the assembler.
+  assert.deepEqual(evidence.stripe.object_ids, ["cus_1", "sub_2"]);
+  assert.deepEqual(evidence.stripe.test_clock_ids, ["tc_9"]);
+
+  assert.deepEqual(log.events, ["boot", "reset", "ledger.begin", "ledger.delta", "teardown"]);
+  assert.equal(log.bootCalls, 1);
+  assert.equal(log.teardownCalls, 1);
+});
+
+test("a failed case yields a failed outcome with the handler reason and NO evidence", async () => {
+  const { deps, log } = makeDeps();
+  const scenario = makeTier2MatrixScenario(
+    fakeConfig({ "T2-BILL-1": eventHandler("T2-BILL-1", { status: "failed", reason: "assertion x != y" }) }),
+    deps,
+  );
+  const [outcome] = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1")]);
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.reason?.code, "scenario_failure");
+  assert.equal(outcome.reason?.message, "assertion x != y");
+  assert.equal(outcome.evidence, undefined);
+  // Delta is never computed for a non-green case; the stack is still torn down.
+  assert.equal(log.ledgerDeltaCalls, 0);
+  assert.equal(log.teardownCalls, 1);
+});
+
+test("blocked and expected_fail map to their reason codes and carry no evidence", async () => {
+  const { deps } = makeDeps();
+  const scenario = makeTier2MatrixScenario(
+    fakeConfig({
+      "T2-BILL-1": eventHandler("T2-BILL-1", { status: "blocked", reason: "no Stripe test clock" }),
+      "T2-BILL-2": eventHandler("T2-BILL-2", { status: "expected_fail", reason: "known dunning gap" }),
+    }),
+    deps,
+  );
+  const outcomes = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1"), fakeCell("T2-BILL-2")]);
+  const blocked = outcomes.find((o) => o.cellId.endsWith("T2-BILL-1"))!;
+  const expectedFail = outcomes.find((o) => o.cellId.endsWith("T2-BILL-2"))!;
+  assert.equal(blocked.status, "blocked");
+  assert.equal(blocked.reason?.code, "scenario_blocked");
+  assert.equal(blocked.evidence, undefined);
+  assert.equal(expectedFail.status, "expected_fail");
+  assert.equal(expectedFail.reason?.code, "known_gap");
+  assert.equal(expectedFail.evidence, undefined);
+});
+
+test("a handler that throws is caught as a failed outcome (never green), stack still torn down", async () => {
+  const { deps, log } = makeDeps();
+  const throwing: Tier2CellHandler = async () => {
+    throw new Error("boom in the case body");
+  };
+  const scenario = makeTier2MatrixScenario(fakeConfig({ "T2-BILL-1": throwing }), deps);
+  const [outcome] = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1")]);
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.reason?.code, "scenario_failure");
+  assert.match(outcome.reason?.message ?? "", /boom in the case body/);
+  assert.equal(outcome.evidence, undefined);
+  assert.equal(log.teardownCalls, 1);
+});
+
+test("when boot is skipped every assigned cell is blocked — never green, stack never booted/torn down", async () => {
+  const { deps, log } = makeDeps({ boot: () => ({ skipped: true, reason: "no Stripe test key resolvable" }) });
+  const scenario = makeTier2MatrixScenario(
+    fakeConfig({ "T2-BILL-1": greenHandler, "T2-BILL-2": greenHandler }),
+    deps,
+  );
+  const outcomes = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1"), fakeCell("T2-BILL-2")]);
+  assert.equal(outcomes.length, 2);
+  for (const outcome of outcomes) {
+    assert.equal(outcome.status, "blocked");
+    assert.equal(outcome.reason?.code, "scenario_blocked");
+    assert.match(outcome.reason?.message ?? "", /no Stripe test key resolvable/);
+    assert.equal(outcome.evidence, undefined);
+  }
+  assert.equal(log.bootCalls, 1);
+  assert.equal(log.teardownCalls, 0);
+  assert.equal(log.resetCalls, 0);
+});
+
+test("a cell whose case has no registered handler fails (never green, never missing-as-green)", async () => {
+  const { deps } = makeDeps();
+  const scenario = makeTier2MatrixScenario(fakeConfig({ "T2-BILL-1": greenHandler }), deps);
+  const [outcome] = await scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-99")]);
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.reason?.code, "scenario_failure");
+  assert.match(outcome.reason?.message ?? "", /no handler registered for Tier-2 case "T2-BILL-99"/);
+});
+
+test("multiple assigned cells produce exactly one outcome each, order preserved, booted once", async () => {
+  const { deps, log } = makeDeps();
+  const scenario = makeTier2MatrixScenario(
+    fakeConfig({
+      "T2-BILL-1": greenHandler,
+      "T2-BILL-2": eventHandler("T2-BILL-2", { status: "failed", reason: "x" }),
+      "T2-BILL-3": greenHandler,
+    }),
+    deps,
+  );
+  const outcomes = await scenario.runCells(RUN_CTX, [
+    fakeCell("T2-BILL-1"),
+    fakeCell("T2-BILL-2"),
+    fakeCell("T2-BILL-3"),
+  ]);
+  assert.deepEqual(
+    outcomes.map((o) => o.cellId),
+    ["T2-BILL/local/case=T2-BILL-1", "T2-BILL/local/case=T2-BILL-2", "T2-BILL/local/case=T2-BILL-3"],
+  );
+  assert.deepEqual(
+    outcomes.map((o) => o.status),
+    ["green", "failed", "green"],
+  );
+  assert.equal(log.bootCalls, 1);
+  assert.equal(log.teardownCalls, 1);
+  assert.equal(log.resetCalls, 3);
+});
+
+test("an unexpected error inside the run loop still tears the stack down (finally) and propagates", async () => {
+  const { deps, log } = makeDeps({ ledgerProbeError: new Error("probe init failed") });
+  const scenario = makeTier2MatrixScenario(fakeConfig({ "T2-BILL-1": greenHandler }), deps);
+  await assert.rejects(() => scenario.runCells(RUN_CTX, [fakeCell("T2-BILL-1")]), /probe init failed/);
+  assert.equal(log.teardownCalls, 1);
+});
+
+test("runTier2Case builds evidence from the recorded policy, deltas, and safe ids on green", async () => {
+  const { deps } = makeDeps();
+  const outcome = await runTier2Case(
+    fakeConfig({ "T2-BILL-1": greenHandler }),
+    fakeCell("T2-BILL-1"),
+    fakeStack({ bootCalls: 0, teardownCalls: 0, resetCalls: 0, ledgerBeginCalls: 0, ledgerDeltaCalls: 0, events: [] }),
+    fakeStripe(),
+    deps,
+  );
+  assert.equal(outcome.status, "green");
+  const evidence = outcome.evidence as Tier2BillingEvidenceV1;
+  assert.equal(evidence.manifest_id, "T2-BILL-1");
+  assert.deepEqual(evidence.stripe.object_ids, ["cus_1", "sub_2"]);
+});
+
+test("DEFAULT_TIER2_HARNESS_DEPS wires the real resolvers and the real evidence assembler", () => {
+  assert.equal(typeof DEFAULT_TIER2_HARNESS_DEPS.bootBillingStack, "function");
+  assert.equal(DEFAULT_TIER2_HARNESS_DEPS.buildEvidence, buildTier2BillingEvidence);
+  assert.equal(DEFAULT_TIER2_HARNESS_DEPS.resolveServerVersion, resolveServerVersion);
+});

--- a/tests/release/src/scenarios/tier2/harness.ts
+++ b/tests/release/src/scenarios/tier2/harness.ts
@@ -131,6 +131,9 @@ export function makeTier2MatrixScenario(
     registryFlowRef: cfg.registryFlowRef,
     lanes: ["local"],
     requiredEnv: cfg.requiredEnv,
+    // Every scenario built by this factory boots the Server from source via
+    // BootedStack — the one legitimate consumer of `--source-candidate`.
+    sourceBacked: true,
     expandCells: (): ScenarioCellSpec[] =>
       caseIds.map((caseId) => ({ dimensions: { [TIER2_CASE_DIMENSION]: caseId } })),
     planCell: (_ctx, cell: PlannedCellV1): ScenarioPlanStep[] => {

--- a/tests/release/src/scenarios/tier2/harness.ts
+++ b/tests/release/src/scenarios/tier2/harness.ts
@@ -1,0 +1,211 @@
+/**
+ * Tier-2-on-runner mechanism: the generic matrix-scenario factory (PR 4,
+ * BRIEF §1/§4). `makeTier2MatrixScenario(cfg)` returns a
+ * `MatrixScenarioDefinition` (lane `local`, no new lane) that boots ONE
+ * `BootedStack` via the shared `bootBillingStack()`, runs every authoritative
+ * manifest case against it, returns exactly one `ScenarioCellOutcome` per
+ * assigned cell (omitted → runner `missing`), and tears the stack down in a
+ * `finally`. Green cells carry `tier2_billing` evidence; per-case billing state
+ * is reset so ledger deltas are that case's own.
+ *
+ * The boot/reset/ledger/evidence plumbing is threaded through a
+ * `Tier2HarnessDeps` seam (defaulting to the real shared implementations) so
+ * the mechanism is exercised offline in `harness.test.ts` with a fake stack —
+ * no Server/Postgres/Stripe. This mirrors the `LocalWorldSmokeDriver` seam.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import type {
+  MatrixScenarioDefinition,
+  ScenarioCellOutcome,
+  ScenarioCellSpec,
+  ScenarioPlanStep,
+  ScenarioRunContext,
+} from "../types.js";
+import type { PlannedCellV1, ResultReasonCode } from "../../runner/result.js";
+import type { Tier2BillingEvidenceV1 } from "../../evidence/schema.js";
+import type { BootedStack, StripeBillingEnv } from "../../../../intent/stack/boot.ts";
+import { REPO_ROOT } from "../../../../intent/stack/boot.ts";
+import type { BillingBootOptions, BillingBootResult } from "../../../../intent/stack/billing-boot.ts";
+import { bootBillingStack } from "../../../../intent/stack/billing-boot.ts";
+import { resetBillingState } from "../../../../intent/stack/billing-seed.ts";
+import {
+  buildTier2BillingEvidence,
+  createLedgerProbe,
+  createPolicyAsserter,
+  createStripeIdCollector,
+  type BuildTier2EvidenceArgs,
+} from "./evidence.js";
+import type { LedgerProbe, Tier2CellContext, Tier2CellHandler, Tier2ScenarioConfig } from "./types.js";
+
+/** The single matrix dimension carrying the authoritative manifest case id. */
+export const TIER2_CASE_DIMENSION = "case";
+
+/**
+ * The seam every side-effecting dependency the harness needs is threaded
+ * through: the shared stack boot, the per-case billing reset, the profile-DB
+ * ledger probe, the (pure) evidence assembler, and the two ambient resolvers.
+ * Defaults wire the real shared implementations; offline tests inject fakes so
+ * `runCells`/`runTier2Case` run with no Server, Postgres, or Stripe.
+ */
+export interface Tier2HarnessDeps {
+  bootBillingStack: (options?: BillingBootOptions) => Promise<BillingBootResult>;
+  resetBillingState: () => Promise<void>;
+  createLedgerProbe: (databaseUrl: string) => LedgerProbe;
+  buildEvidence: (args: BuildTier2EvidenceArgs) => Tier2BillingEvidenceV1;
+  resolveServerVersion: () => string;
+  resolveBillingMode: () => Tier2BillingEvidenceV1["billing_mode"];
+}
+
+export const DEFAULT_TIER2_HARNESS_DEPS: Tier2HarnessDeps = {
+  bootBillingStack,
+  resetBillingState,
+  createLedgerProbe,
+  buildEvidence: buildTier2BillingEvidence,
+  resolveServerVersion,
+  resolveBillingMode: billingModeLiteral,
+};
+
+export function makeTier2MatrixScenario(
+  cfg: Tier2ScenarioConfig,
+  deps: Tier2HarnessDeps = DEFAULT_TIER2_HARNESS_DEPS,
+): MatrixScenarioDefinition {
+  const caseIds = Object.keys(cfg.cases);
+  return {
+    id: cfg.id,
+    kind: "matrix",
+    title: cfg.title,
+    registryFlowRef: cfg.registryFlowRef,
+    lanes: ["local"],
+    requiredEnv: cfg.requiredEnv,
+    expandCells: (): ScenarioCellSpec[] =>
+      caseIds.map((caseId) => ({ dimensions: { [TIER2_CASE_DIMENSION]: caseId } })),
+    planCell: (_ctx, cell: PlannedCellV1): ScenarioPlanStep[] => {
+      const caseId = cell.dimensions[TIER2_CASE_DIMENSION] ?? "?";
+      return [
+        { description: `[${cell.cell_id}] boot the shared Tier-2 billing stack once (real Server + Stripe test mode)` },
+        { description: `[${cell.cell_id}] reset billing state, snapshot ledger baseline for case ${caseId}` },
+        { description: `[${cell.cell_id}] run case ${caseId} against the booted stack` },
+        { description: `[${cell.cell_id}] on green, record asserted ruled values + ledger deltas + safe Stripe ids` },
+        { description: `[${cell.cell_id}] tear the shared stack down` },
+      ];
+    },
+    runCells: async (_ctx: ScenarioRunContext, cells): Promise<ScenarioCellOutcome[]> => {
+      const boot = await deps.bootBillingStack();
+      if (boot.skipped) {
+        // Stripe unresolved (or boot declined): every assigned cell is BLOCKED
+        // with a bounded reason — never green, never skip-as-success. A strict
+        // run fails closed on this.
+        return cells.map((cell) => ({
+          cellId: cell.cell_id,
+          status: "blocked",
+          reason: {
+            code: "scenario_blocked",
+            message: `Tier-2 billing stack not booted: ${boot.reason}`,
+          },
+        }));
+      }
+      const outcomes: ScenarioCellOutcome[] = [];
+      try {
+        for (const cell of cells) {
+          outcomes.push(await runTier2Case(cfg, cell, boot.stack, boot.stripe, deps));
+        }
+      } finally {
+        await boot.stack.teardown().catch(() => undefined);
+      }
+      return outcomes;
+    },
+  };
+}
+
+/**
+ * Runs one manifest case against the shared stack and maps it to exactly one
+ * outcome. Exported for the offline harness test (mirrors
+ * `runLocalWorldSmokeCell`): a fake `BootedStack` + `deps` drive it with no
+ * external process. Any handler throw is caught and normalized to `failed`;
+ * evidence is attached only on green.
+ */
+export async function runTier2Case(
+  cfg: Tier2ScenarioConfig,
+  cell: PlannedCellV1,
+  stack: BootedStack,
+  stripe: StripeBillingEnv,
+  deps: Tier2HarnessDeps = DEFAULT_TIER2_HARNESS_DEPS,
+): Promise<ScenarioCellOutcome> {
+  const caseId = cell.dimensions[TIER2_CASE_DIMENSION] ?? "";
+  const handler: Tier2CellHandler | undefined = cfg.cases[caseId];
+  if (!handler) {
+    return {
+      cellId: cell.cell_id,
+      status: "failed",
+      reason: { code: "scenario_failure", message: `no handler registered for Tier-2 case "${caseId}"` },
+    };
+  }
+
+  const policy = createPolicyAsserter();
+  const ids = createStripeIdCollector();
+  const ledger = deps.createLedgerProbe(stack.databaseUrl);
+  const ctx: Tier2CellContext = {
+    stack,
+    stripe,
+    policy,
+    ids,
+    ledger,
+    reset: () => deps.resetBillingState(),
+  };
+
+  try {
+    await ctx.reset();
+    await ledger.begin();
+    const result = await handler(ctx);
+    if (result.status !== "green") {
+      return {
+        cellId: cell.cell_id,
+        status: result.status,
+        reason: { code: reasonCodeFor(result.status), message: result.reason ?? `case ${caseId} ${result.status}` },
+      };
+    }
+    const evidence = deps.buildEvidence({
+      manifestId: caseId,
+      serverVersion: deps.resolveServerVersion(),
+      billingMode: deps.resolveBillingMode(),
+      policy,
+      ids,
+      ledger: await ledger.delta(),
+    });
+    return { cellId: cell.cell_id, status: "green", evidence };
+  } catch (error) {
+    return {
+      cellId: cell.cell_id,
+      status: "failed",
+      reason: { code: "scenario_failure", message: describe(error) },
+    };
+  }
+}
+
+function reasonCodeFor(status: "failed" | "blocked" | "expected_fail"): ResultReasonCode {
+  switch (status) {
+    case "blocked":
+      return "scenario_blocked";
+    case "expected_fail":
+      return "known_gap";
+    default:
+      return "scenario_failure";
+  }
+}
+
+function billingModeLiteral(): Tier2BillingEvidenceV1["billing_mode"] {
+  const mode = process.env.TIER2_BILLING_MODE;
+  return mode === "observe" || mode === "off" ? mode : "enforce";
+}
+
+/** The Server-under-test version (repo VERSION file); a safe token for evidence. */
+export function resolveServerVersion(): string {
+  return readFileSync(path.join(REPO_ROOT, "VERSION"), "utf8").trim();
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/release/src/scenarios/tier2/harness.ts
+++ b/tests/release/src/scenarios/tier2/harness.ts
@@ -30,6 +30,11 @@ import type { BootedStack, StripeBillingEnv } from "../../../../intent/stack/boo
 import { REPO_ROOT } from "../../../../intent/stack/boot.ts";
 import type { BillingBootOptions, BillingBootResult } from "../../../../intent/stack/billing-boot.ts";
 import { bootBillingStack } from "../../../../intent/stack/billing-boot.ts";
+import type { BootWithFakeResult } from "../../../../intent/stack/billing-usage-import.ts";
+import {
+  bootBillingStackWithLitellmFake,
+  clearPublishedGatewayEnv,
+} from "../../../../intent/stack/billing-usage-import.ts";
 import { resetBillingState } from "../../../../intent/stack/billing-seed.ts";
 import {
   buildTier2BillingEvidence,
@@ -52,6 +57,13 @@ export const TIER2_CASE_DIMENSION = "case";
  */
 export interface Tier2HarnessDeps {
   bootBillingStack: (options?: BillingBootOptions) => Promise<BillingBootResult>;
+  /** Gateway+fake boot, used when `cfg.gatewayFake` (T2-BILL). Starts the
+   * management-plane LiteLLM fake, boots gateway-enabled + skipFrontend, and
+   * publishes the gateway env into this process; the fake is closed at teardown. */
+  bootBillingStackWithLitellmFake: () => Promise<BootWithFakeResult>;
+  /** Clears the gateway env `bootBillingStackWithLitellmFake` published so a
+   * later plain-booted scenario in the same runner does not inherit it. */
+  clearPublishedGatewayEnv: () => void;
   resetBillingState: () => Promise<void>;
   createLedgerProbe: (databaseUrl: string) => LedgerProbe;
   buildEvidence: (args: BuildTier2EvidenceArgs) => Tier2BillingEvidenceV1;
@@ -61,12 +73,51 @@ export interface Tier2HarnessDeps {
 
 export const DEFAULT_TIER2_HARNESS_DEPS: Tier2HarnessDeps = {
   bootBillingStack,
+  bootBillingStackWithLitellmFake,
+  clearPublishedGatewayEnv,
   resetBillingState,
   createLedgerProbe,
   buildEvidence: buildTier2BillingEvidence,
   resolveServerVersion,
   resolveBillingMode: billingModeLiteral,
 };
+
+/** Normalized boot for one scenario: plain (`bootBillingStack`) or
+ * gateway+fake (`bootBillingStackWithLitellmFake`) per `cfg.gatewayFake`. The
+ * `teardown` folds stack teardown + (for the fake path) fake close + gateway-env
+ * cleanup, so `runCells` has one teardown regardless of boot mode. */
+type NormalizedBoot =
+  | { skipped: true; reason: string }
+  | { skipped: false; stack: BootedStack; stripe: StripeBillingEnv; teardown: () => Promise<void> };
+
+async function bootForScenario(cfg: Tier2ScenarioConfig, deps: Tier2HarnessDeps): Promise<NormalizedBoot> {
+  if (cfg.gatewayFake) {
+    const boot = await deps.bootBillingStackWithLitellmFake();
+    if (boot.skipped) {
+      return { skipped: true, reason: boot.reason };
+    }
+    return {
+      skipped: false,
+      stack: boot.stack,
+      stripe: boot.stripe,
+      teardown: async () => {
+        await boot.stack.teardown().catch(() => undefined);
+        await boot.fake.close().catch(() => undefined);
+        deps.clearPublishedGatewayEnv();
+      },
+    };
+  }
+  const boot = await deps.bootBillingStack();
+  if (boot.skipped) {
+    return { skipped: true, reason: boot.reason };
+  }
+  return {
+    skipped: false,
+    stack: boot.stack,
+    stripe: boot.stripe,
+    teardown: () => boot.stack.teardown().catch(() => undefined),
+  };
+}
 
 export function makeTier2MatrixScenario(
   cfg: Tier2ScenarioConfig,
@@ -93,7 +144,7 @@ export function makeTier2MatrixScenario(
       ];
     },
     runCells: async (_ctx: ScenarioRunContext, cells): Promise<ScenarioCellOutcome[]> => {
-      const boot = await deps.bootBillingStack();
+      const boot = await bootForScenario(cfg, deps);
       if (boot.skipped) {
         // Stripe unresolved (or boot declined): every assigned cell is BLOCKED
         // with a bounded reason — never green, never skip-as-success. A strict
@@ -113,7 +164,7 @@ export function makeTier2MatrixScenario(
           outcomes.push(await runTier2Case(cfg, cell, boot.stack, boot.stripe, deps));
         }
       } finally {
-        await boot.stack.teardown().catch(() => undefined);
+        await boot.teardown();
       }
       return outcomes;
     },

--- a/tests/release/src/scenarios/tier2/t2-auth-org.ts
+++ b/tests/release/src/scenarios/tier2/t2-auth-org.ts
@@ -1,0 +1,135 @@
+/**
+ * T2-AUTH-ORG — representative auth/org/authorization cells (PR 4, BRIEF §6).
+ *
+ * A BOUNDED set proving the Tier-2-on-runner mechanism generalizes beyond
+ * billing: one auth, one org-roles, one invitation case adapted onto the
+ * runner (the reusable `tests/intent` seed/auth helpers, driven against the
+ * shared booted stack). The FULL non-billing Tier-2 inventory is PR 8 — do not
+ * port it here. These cases carry `tier2_billing` evidence with an empty
+ * `asserted_policy`/zero `ledger`/empty id arrays (BRIEF §6 note) so the
+ * green-requires-evidence gate holds uniformly across both Tier-2 scenarios.
+ */
+
+import assert from "node:assert/strict";
+
+import { makeTier2MatrixScenario } from "./harness.js";
+import type { Tier2CaseResult, Tier2CellContext, Tier2CellHandler } from "./types.js";
+import { adminContext, userIdFor } from "./fixtures.js";
+import * as seed from "../../../../intent/stack/seed.ts";
+
+export const T2_AUTH_ORG_ID = "T2-AUTH-ORG";
+
+const PASSWORD = "Tier2Cells!Passw0rd";
+
+// ── T2-AUTH-REP: claim + password login/logout (session lifecycle) ────────
+const t2AuthRep: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token } = await adminContext();
+
+  // A valid session can read its own identity.
+  const me = await seed.apiRequest<{ id: string; email: string }>("/users/me", { token });
+  assert.equal(me.status, 200, "an authenticated session resolves its own identity");
+  assert.ok(me.body.id, "the session carries a stable user id");
+
+  // Wrong password is rejected — the negative half of the login lifecycle.
+  let rejected = false;
+  try {
+    await seed.passwordLogin(me.body.email, `wrong-${Date.now()}`);
+  } catch {
+    rejected = true;
+  }
+  assert.equal(rejected, true, "an incorrect password is rejected, not silently accepted");
+  await seed.resetPasswordLoginRateLimits();
+
+  // An expired/garbage bearer token is rejected — "logout" in this
+  // stateless-JWT-session client is "the token stops being accepted"; there is
+  // no server-side revocation endpoint in this suite's surface, so the
+  // negative-auth case above plus this malformed-token rejection is the
+  // tier-2-reachable half of the session lifecycle.
+  const garbled = await seed.apiRequest("/users/me", { token: `${token}garbled` });
+  assert.ok(garbled.status === 401 || garbled.status === 403, "a tampered bearer token is rejected");
+
+  return { status: "green" };
+};
+
+// ── T2-ORG-ROLES-REP: role change is enforced (member cannot admin-act;
+// promoted admin can) ──────────────────────────────────────────────────────
+const t2OrgRolesRep: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const email = `t2orgroles-${Date.now()}@example.com`;
+  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
+
+  // A plain member cannot invite (an admin-only action).
+  const memberInvite = await seed.inviteMemberRaw(memberToken, organizationId, `t2orgroles-blocked-${Date.now()}@example.com`, "member");
+  assert.equal(memberInvite.status, 403, "a member role cannot perform an admin-gated action");
+
+  // Promote to admin; the same action now succeeds.
+  const members = await seed.listMembers(token, organizationId);
+  const membership = members.find((m) => m.email === email)!;
+  const promotion = await seed.updateMembership(token, organizationId, membership.membershipId, { role: "admin" });
+  assert.ok([200, 201].includes(promotion.status), "role promotion succeeds");
+  assert.equal(promotion.body.role, "admin");
+
+  const promotedInvite = await seed.inviteMemberRaw(memberToken, organizationId, `t2orgroles-allowed-${Date.now()}@example.com`, "member");
+  assert.ok([200, 201].includes(promotedInvite.status), "a promoted admin can now perform the admin-gated action");
+
+  // Demote back to member (cleanup for later cases in this run).
+  await seed.updateMembership(token, organizationId, membership.membershipId, { role: "member" });
+
+  return { status: "green" };
+};
+
+// ── T2-INVITE-REP: invite + accept reflects in membership; revoke-before-
+// accept blocks acceptance ─────────────────────────────────────────────────
+const t2InviteRep: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+
+  const email = `t2invite-${Date.now()}@example.com`;
+  const invitation = await seed.inviteMember(token, organizationId, email, "member");
+  assert.equal(invitation.status, "pending");
+
+  await seed.registerInvitedAccount({ email, password: PASSWORD, invitationToken: invitation.id });
+  const loggedIn = await seed.passwordLogin(email, PASSWORD);
+  const members = await seed.listMembers(token, organizationId);
+  const accepted = members.find((m) => m.email === email);
+  assert.ok(accepted, "the invited account appears as a member after self-registration");
+  assert.equal(accepted!.status, "active");
+  assert.ok(loggedIn.access_token, "the invited member can log in with their own password");
+
+  // Revoke-before-accept: a second invitation, revoked, cannot be accepted.
+  const email2 = `t2invite-revoked-${Date.now()}@example.com`;
+  const invitation2 = await seed.inviteMember(token, organizationId, email2, "member");
+  const revoked = await seed.revokeInvitation(token, organizationId, invitation2.id);
+  assert.ok([200, 204].includes(revoked.status), "revocation succeeds");
+  const raw = await seed.registerInvitedAccountRaw({ email: email2, password: PASSWORD, invitationToken: invitation2.id });
+  assert.notEqual(raw.status, 200, "a revoked invitation cannot be accepted");
+
+  return { status: "green" };
+};
+
+function withEmptyEvidence(handler: Tier2CellHandler): Tier2CellHandler {
+  return async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+    const result = await handler(ctx);
+    if (result.status === "green") {
+      // No billing ledger/Stripe/policy surface applies to these auth/org
+      // cases; the evidence carries the case id with empty/zero fields so the
+      // green-requires-evidence gate holds uniformly (BRIEF §6 note).
+      ctx.policy.record({});
+    }
+    return result;
+  };
+}
+
+const cases: Record<string, Tier2CellHandler> = {
+  "T2-AUTH-REP": withEmptyEvidence(t2AuthRep),
+  "T2-ORG-ROLES-REP": withEmptyEvidence(t2OrgRolesRep),
+  "T2-INVITE-REP": withEmptyEvidence(t2InviteRep),
+};
+
+export const t2AuthOrg = makeTier2MatrixScenario({
+  id: T2_AUTH_ORG_ID,
+  title: "Tier-2 representative auth/org/authorization cells (mechanism generality proof; full inventory is PR 8)",
+  registryFlowRef: "specs/developing/testing/core-release-validation.md#t2-auth-org",
+  requiredEnv: [],
+  requireStripe: false,
+  cases,
+});

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -9,19 +9,17 @@
  * asserted ruled values / ledger deltas / safe Stripe ids into `tier2_billing`
  * evidence (green only).
  *
- * ── KNOWN HARNESS GAP (deviation, for the integrator) ───────────────────────
- * `harness.ts` (workstream B) boots the shared stack via plain
- * `bootBillingStack()` with no `extraServerEnv`, so `AGENT_GATEWAY_ENABLED`
- * is never set for the T2-BILL scenario's ONE shared boot. Every managed-LLM
- * guarantee that reads `settings.agent_gateway_enabled` — the $5/seat LLM
- * pool grant (stripe_webhooks.py), `run_llm_topups` (topups.py), the real
- * usage importer/exhaustion path, and `ensure_user_enrollment`'s free-credit
- * issuance route — cannot be exercised through this shared boot. Those
- * sub-guarantees return `blocked` with an explicit reason below rather than
- * being silently skipped or faked; the fix is either a second Tier-2 scenario
- * booted via `bootBillingStackWithLitellmFake()` (workstream C's helper) or
- * threading `extraServerEnv` through `Tier2ScenarioConfig`/`runCells` — both
- * outside this file's ownership (harness.ts is workstream B's).
+ * ── GATEWAY + LiteLLM FAKE (resolved) ───────────────────────────────────────
+ * The scenario config sets `gatewayFake: true`, so the ONE shared boot runs
+ * `bootBillingStackWithLitellmFake()` (harness.ts): the server boots
+ * gateway-enabled and the management-plane LiteLLM fake is wired, and the
+ * gateway env is published into this runner process. Every managed-LLM
+ * guarantee that reads `settings.agent_gateway_enabled` — the $5/seat LLM pool
+ * grant (stripe_webhooks.py), LLM exhaustion disabling the scoped key, and the
+ * real `run_usage_import` (T2-BILL-14/15) — is therefore exercised for real
+ * here, not stubbed. The importer/enrollment/exhaustion passes are the SAME
+ * out-of-process product passes the Playwright `billing-import/usage-import`
+ * suite drives (`stack/billing-usage-import.ts`), against the same fake.
  */
 
 import assert from "node:assert/strict";
@@ -34,15 +32,28 @@ import { adminContext, userIdFor } from "./fixtures.js";
 import * as b from "../../../../intent/stack/billing.ts";
 import * as seed from "../../../../intent/stack/seed.ts";
 import { REPO_ROOT } from "../../../../intent/stack/boot.ts";
+import {
+  countUsageEvents,
+  fetchFakeBlockedKeys,
+  getOrgEnrollment,
+  getUsageEvent,
+  getUserEnrollment,
+  runEnrollmentBackfillPass,
+  runUsageImportPass,
+  seedFakeSpendRows,
+  seedLlmCreditGrant,
+} from "../../../../intent/stack/billing-usage-import.ts";
 
 export const T2_BILL_ID = "T2-BILL";
 
 const HOUR = 3600;
 const PASSWORD = "Tier2Cells!Passw0rd";
 
-/** True when the shared boot happened to enable the agent gateway (it does
- * not today — see the module doc). Guards the sub-assertions that would
- * otherwise throw deep inside product code with a confusing stack trace. */
+/** True when the shared boot enabled the agent gateway + LiteLLM fake
+ * (`gatewayFake: true` → `bootBillingStackWithLitellmFake` publishes
+ * `AGENT_GATEWAY_ENABLED=true` into this process). A defensive guard: if a
+ * caller ever runs this scenario without the fake, the gateway-dependent cells
+ * fail honestly rather than throwing deep inside product code. */
 function gatewayEnabled(): boolean {
   return process.env.AGENT_GATEWAY_ENABLED === "true";
 }
@@ -52,8 +63,8 @@ function blockedResult(reason: string): Tier2CaseResult {
 }
 
 const GATEWAY_GAP_REASON =
-  "AGENT_GATEWAY_ENABLED is not wired by the shared Tier-2 boot (harness.ts, workstream B); " +
-  "this guarantee needs settings.agent_gateway_enabled=true at server boot.";
+  "AGENT_GATEWAY_ENABLED is not wired for this run (expected gatewayFake boot); " +
+  "this guarantee needs settings.agent_gateway_enabled=true + the LiteLLM fake at server boot.";
 
 /** Out-of-process pass invoking the real (unmocked) free-credit ensure
  * function directly against the booted profile DB — the same "run the
@@ -551,14 +562,35 @@ const t2Bill6: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
   assert.ok(disabled === undefined || disabled.enabled === false);
 
   if (!gatewayEnabled()) {
-    // Real key-disable-on-exhaustion and the auto-top-up charge/grant path
-    // both need `settings.agent_gateway_enabled` — see the module doc.
-    return blockedResult(`LLM key exhaustion + auto top-up: ${GATEWAY_GAP_REASON}`);
+    // Real key-disable-on-exhaustion needs `settings.agent_gateway_enabled`
+    // + the LiteLLM fake — see the module doc.
+    return blockedResult(`LLM key exhaustion: ${GATEWAY_GAP_REASON}`);
   }
-  b.runTopupPass();
-  const grants = await b.listGrants(subject.id);
-  assert.ok(grants.some((g) => g.grant_type === "topup"), "successful auto top-up grants once");
-  ctx.policy.record({ topup_pack_usd: 10, topup_trigger_usd: 2, topup_margin_pct: 15 });
+
+  // Real exhaustion: enroll (mint a real virtual key against the fake), drive
+  // this subject's remaining credit negative via the REAL importer, and assert
+  // ONLY the scoped key is disabled at the gateway — the org membership's
+  // separate key is untouched (the ruled "disable the scoped gateway key, not
+  // compute, not a valid BYOK" guarantee).
+  runEnrollmentBackfillPass();
+  const personal = await getUserEnrollment(userId);
+  const orgEnrollment = await getOrgEnrollment(organizationId, userId);
+  assert.ok(personal?.virtualKeyId, "personal enrollment minted a real virtual key against the fake");
+  assert.ok(orgEnrollment?.virtualKeyId, "org membership minted a distinct virtual key");
+  await seedLlmCreditGrant({ billingSubjectId: personal!.billingSubjectId, userId, amountUsd: 1 });
+  const exhaustReq = `req-exhaust-${Date.now()}`;
+  await seedFakeSpendRows([
+    { request_id: exhaustReq, api_key: personal!.virtualKeyId!, spend: 1000, startTime: new Date().toISOString() },
+  ]);
+  runUsageImportPass();
+  const afterExhaust = await getUserEnrollment(userId);
+  assert.equal(afterExhaust!.budgetStatus, "exhausted", "exhausting a subject's credit flips budget_status");
+  const blockedKeys = await fetchFakeBlockedKeys();
+  assert.ok(blockedKeys.includes(personal!.virtualKeyId!), "the exhausted subject's own key is disabled at the gateway");
+  assert.ok(
+    !blockedKeys.includes(orgEnrollment!.virtualKeyId!),
+    "the org membership's separate key is NOT touched by personal exhaustion",
+  );
   return { status: "green" };
 };
 
@@ -841,12 +873,26 @@ const t2Bill14: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   assert.ok(ownerFreeGrantsBefore <= 1, "activating Core never mints a second personal free entitlement for the owner");
 
   if (!gatewayEnabled()) {
-    // The subject-scoped LiteLLM virtual key / provider budget / no-raw-
-    // credential guarantees need `ensure_user_enrollment` against a real
-    // LiteLLM(-fake) admin plane, gated on the same env this shared boot
-    // lacks — see the module doc.
+    // The subject-scoped LiteLLM virtual key / provider budget guarantees need
+    // `ensure_user_enrollment` against the LiteLLM(-fake) admin plane — see the
+    // module doc.
     return blockedResult(`LiteLLM virtual-key enrollment idempotency: ${GATEWAY_GAP_REASON}`);
   }
+
+  // Enrollment idempotency: the real backfill mints exactly one virtual key per
+  // subject, and a replayed backfill reuses it (no second key minted for the
+  // same identity) — the enrollment analog of the free-credit dedup above.
+  runEnrollmentBackfillPass();
+  const firstEnrollment = await getUserEnrollment(memberId);
+  assert.ok(firstEnrollment?.virtualKeyId, "backfill mints a real virtual key for the member");
+  assert.equal(firstEnrollment!.syncStatus, "synced", "enrollment reaches synced against the fake");
+  runEnrollmentBackfillPass();
+  const secondEnrollment = await getUserEnrollment(memberId);
+  assert.equal(
+    secondEnrollment!.virtualKeyId,
+    firstEnrollment!.virtualKeyId,
+    "a replayed enrollment backfill reuses the same virtual key (idempotent)",
+  );
   return { status: "green" };
 };
 
@@ -856,10 +902,65 @@ const t2Bill15: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   if (!gatewayEnabled()) {
     // The real importer (`run_usage_import`) only runs meaningfully with the
     // agent gateway enabled and the management-plane LiteLLM fake wired at
-    // boot (workstream C's `bootBillingStackWithLitellmFake`); the shared
-    // T2-BILL boot does neither — see the module doc.
+    // boot (`gatewayFake: true` → `bootBillingStackWithLitellmFake`).
     return blockedResult(`Real usage-import pagination/dedup/needs_review: ${GATEWAY_GAP_REASON}`);
   }
+
+  const { token, organizationId } = await adminContext();
+  const userId = await userIdFor(token);
+
+  // Enrollment mints real virtual keys (personal + a distinct org key) against
+  // the fake — the identities the importer attributes spend to.
+  runEnrollmentBackfillPass();
+  const personal = await getUserEnrollment(userId);
+  const org = await getOrgEnrollment(organizationId, userId);
+  assert.ok(personal?.virtualKeyId, "personal enrollment minted a real virtual key");
+  assert.ok(org?.virtualKeyId, "org membership minted a distinct virtual key");
+  assert.notEqual(org!.virtualKeyId, personal!.virtualKeyId, "personal and org keys are distinct");
+
+  // Seed spend across a personal key, the org key, and an UNRESOLVED key, then
+  // drive the REAL importer once: exactly-once import, payer/member
+  // attribution, and needs_review fail-closed for the unresolved key.
+  const now = new Date().toISOString();
+  const personalReq = `req-personal-${Date.now()}`;
+  const orgReq = `req-org-${Date.now()}`;
+  const unresolvedReq = `req-unresolved-${Date.now()}`;
+  await seedFakeSpendRows([
+    { request_id: personalReq, api_key: personal!.virtualKeyId!, spend: 0.1, startTime: now },
+    { request_id: orgReq, api_key: org!.virtualKeyId!, spend: 0.2, startTime: now },
+    { request_id: unresolvedReq, api_key: `tok-unresolved-${Date.now()}`, spend: 1.23, startTime: now },
+  ]);
+
+  const before = await countUsageEvents();
+  runUsageImportPass();
+  const afterFirst = await countUsageEvents();
+  assert.equal(afterFirst - before, 3, "all three seeded rows imported exactly once");
+
+  const personalEvent = await getUsageEvent(personalReq);
+  assert.equal(personalEvent?.status, "imported");
+  assert.equal(personalEvent?.userId, userId, "personal spend attributes to the payer");
+  assert.equal(personalEvent?.billingSubjectId, personal!.billingSubjectId);
+  assert.equal(personalEvent?.organizationId, null, "personal spend is not org-attributed");
+
+  const orgEvent = await getUsageEvent(orgReq);
+  assert.equal(orgEvent?.status, "imported");
+  assert.equal(orgEvent?.organizationId, organizationId, "org-enrolled spend attributes to the org");
+  assert.equal(orgEvent?.billingSubjectId, org!.billingSubjectId);
+  assert.notEqual(orgEvent?.billingSubjectId, personalEvent?.billingSubjectId, "org and personal subjects differ");
+
+  const unresolvedEvent = await getUsageEvent(unresolvedReq);
+  assert.ok(unresolvedEvent, "the unresolved-key row is still recorded, never silently dropped");
+  assert.equal(unresolvedEvent!.status, "needs_review", "an unresolved key fails closed to needs_review");
+  assert.equal(unresolvedEvent!.userId, null);
+  assert.equal(unresolvedEvent!.organizationId, null);
+  assert.equal(unresolvedEvent!.billingSubjectId, null);
+
+  // Restart / exactly-once: a repeated tick over the SAME overlap window (no new
+  // spend seeded) creates no duplicate rows — dedup on litellm_request_id.
+  runUsageImportPass();
+  const afterSecond = await countUsageEvents();
+  assert.equal(afterSecond, afterFirst, "a repeated import tick adds no duplicate rows (exactly-once)");
+
   return { status: "green" };
 };
 
@@ -889,5 +990,9 @@ export const t2Bill = makeTier2MatrixScenario({
   // returns every cell BLOCKED, so no env-manifest gate is required here.
   requiredEnv: [],
   requireStripe: true,
+  // Boot gateway-enabled with the management-plane LiteLLM fake wired, so the
+  // $5/seat LLM pool grant, LLM exhaustion, enrollment/virtual-key, and the
+  // real `run_usage_import` cells run for real (T2-BILL-2/6/14/15).
+  gatewayFake: true,
   cases,
 });

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -23,7 +23,7 @@
  */
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
 
 import { makeTier2MatrixScenario } from "./harness.js";
@@ -70,12 +70,18 @@ const GATEWAY_GAP_REASON =
  * function directly against the booted profile DB — the same "run the
  * product's own pass function out of process" convention `billing.ts` uses
  * for the accounting/reconciler/topup passes, scoped to
- * `ensure_user_free_credit_grant` (there is no HTTP route that calls it
- * without the agent-gateway enrollment path, which needs the gateway wiring
- * this shared boot lacks — see the module doc). Returns whether a grant was
- * newly issued. */
-function runFreeCreditGrantPass(userId: string): boolean {
-  const result = spawnSync(
+ * `ensure_user_free_credit_grant`.
+ *
+ * Returns whether the user OWNS the free-signup grant after the call — NOT
+ * whether this call newly created it. `ensure_user_free_credit_grant` is
+ * idempotent-by-ownership (the `free_cloud_allocation` guard returns True when
+ * the allocation already belongs to this subject, and the grant insert is
+ * `source_ref`-deduped), so a replay returns True too. The dedup guarantee is
+ * therefore "exactly one grant row", asserted via `llmCreditGrantCount`, not
+ * the boolean. Async (spawn, not spawnSync) so two calls can genuinely race the
+ * `source_ref` unique constraint in the concurrency case (T2-BILL-14). */
+function runFreeCreditGrantPass(userId: string): Promise<boolean> {
+  const child = spawn(
     path.join(REPO_ROOT, "server", ".venv", "bin", "python"),
     [
       "-c",
@@ -89,12 +95,13 @@ function runFreeCreditGrantPass(userId: string): boolean {
         "    async with async_session_factory() as db:\n" +
         `        granted = await ensure_user_free_credit_grant(db, "${userId}")\n` +
         "        await db.commit()\n" +
-        "        print('GRANTED' if granted else 'NOT_GRANTED')\n" +
+        // Unambiguous tokens: 'NOT_GRANTED' contains 'GRANTED' as a substring,
+        // so the reader below matches a distinct marker instead.
+        "        print('GRANT_YES' if granted else 'GRANT_NO')\n" +
         "asyncio.run(_m())\n",
     ],
     {
       cwd: path.join(REPO_ROOT, "server"),
-      encoding: "utf8",
       env: {
         ...process.env,
         DATABASE_URL: b.databaseUrl(),
@@ -103,10 +110,24 @@ function runFreeCreditGrantPass(userId: string): boolean {
       },
     },
   );
-  if (result.status !== 0) {
-    throw new Error(`free-credit pass failed (${result.status}): ${(result.stderr || result.stdout || "").trim()}`);
-  }
-  return result.stdout.includes("GRANTED");
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (c: Buffer) => {
+    stdout += c.toString();
+  });
+  child.stderr?.on("data", (c: Buffer) => {
+    stderr += c.toString();
+  });
+  return new Promise<boolean>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`free-credit pass failed (${code}): ${(stderr || stdout).trim()}`));
+        return;
+      }
+      resolve(stdout.includes("GRANT_YES"));
+    });
+  });
 }
 
 /** Seed a real `auth_identity` GitHub link for `userId` (the free-credit
@@ -120,6 +141,19 @@ async function linkGithubIdentity(userId: string, providerSubject: string): Prom
       [userId, providerSubject],
     ),
   );
+}
+
+/** Drive the seat-adjustment pass repeatedly to drain ALL pending adjustments.
+ * `process_pending_seat_adjustments` claims with `FOR UPDATE OF subscription
+ * SKIP LOCKED`, so at most one adjustment per subscription advances per pass:
+ * when several pending adjustments share one subscription (e.g. a non-trivial
+ * initial-reconcile from `subscription.created` plus an invite proration — the
+ * shape a long-lived org DB produces), each needs its own pass. The background
+ * loop achieves this over ticks; a deterministic test drains explicitly. */
+function drainSeatAdjustments(times = 5): void {
+  for (let i = 0; i < times; i++) {
+    b.processSeatAdjustments();
+  }
 }
 
 async function llmCreditGrantCount(subjectId: string, source?: string): Promise<number> {
@@ -225,12 +259,13 @@ const t2Bill2: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
   await linkGithubIdentity(memberId, githubSubject);
   const subject = await b.ensurePersonalSubject(memberId);
 
-  const grantedFirst = runFreeCreditGrantPass(memberId);
+  const grantedFirst = await runFreeCreditGrantPass(memberId);
   assert.equal(grantedFirst, true, "first attempt grants the free credit");
-  const grantedSecond = runFreeCreditGrantPass(memberId);
-  assert.equal(grantedSecond, false, "replayed attempt grants nothing (deduped)");
+  // A replay owns the same grant (idempotent), so the pass still reports owned;
+  // the dedup guarantee is that NO SECOND ROW is created — asserted by count.
+  await runFreeCreditGrantPass(memberId);
   const freeGrantCount = await llmCreditGrantCount(subject.id, "free_signup");
-  assert.equal(freeGrantCount, 1, "exactly one lifetime free-signup grant");
+  assert.equal(freeGrantCount, 1, "exactly one lifetime free-signup grant (replay creates no second row)");
   const freeGrantAmount = await b.withDb(async (db) => {
     const r = await db.query(`SELECT amount_usd FROM llm_credit_grant WHERE billing_subject_id = $1 AND source = 'free_signup'`, [subject.id]);
     return Number(r.rows[0].amount_usd);
@@ -241,7 +276,7 @@ const t2Bill2: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
   const email2 = `t2bill2-nogh-${Date.now()}@example.com`;
   const noGhToken = await seed.registerFreshMember(token, organizationId, email2, PASSWORD, "member");
   const noGhUserId = await userIdFor(noGhToken);
-  const grantedNoGh = runFreeCreditGrantPass(noGhUserId);
+  const grantedNoGh = await runFreeCreditGrantPass(noGhUserId);
   assert.equal(grantedNoGh, false, "no GitHub identity -> no grant");
 
   // Core seat pools: subscribe the org to Pro at N seats and confirm the
@@ -337,23 +372,23 @@ const t2Bill3: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   assert.ok(bump!.grant_quantity >= 1);
 
   const prorationBefore = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
-  b.processSeatAdjustments();
+  drainSeatAdjustments();
   adjustments = await b.listSeatAdjustments(subject.id);
-  assert.equal(adjustments.at(-1)!.status, "succeeded");
+  assert.equal(adjustments.at(-1)!.status, "succeeded", "the invite proration seat adjustment converges");
   const prorationAfter = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
   assert.equal(prorationAfter - prorationBefore, 1, "one proration grant for the added seat");
 
   const members = await seed.listMembers(token, organizationId);
   const member = members.find((m) => m.email === email)!;
   await seed.removeMembership(token, organizationId, member.membershipId);
-  b.processSeatAdjustments();
+  drainSeatAdjustments();
   adjustments = await b.listSeatAdjustments(subject.id);
   assert.equal(adjustments.at(-1)!.grant_quantity, 0, "removal issues no refund grant");
 
   const reinvite = await seed.inviteMember(token, organizationId, email, "member");
   const reaccept = await seed.acceptCurrentInvitation(memberToken, reinvite.id);
   assert.ok([200, 201].includes(reaccept.status));
-  b.processSeatAdjustments();
+  drainSeatAdjustments();
   const prorationFinal = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
   assert.equal(prorationFinal - prorationBefore, 1, "no second proration grant on same-period re-invite (no double grant)");
 
@@ -884,15 +919,13 @@ const t2Bill14: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   await linkGithubIdentity(memberId, githubSubject);
   const subject = await b.ensurePersonalSubject(memberId);
 
-  // Concurrent attempts: the DB-level ensure-allocation guard reserves the
-  // allocation once per GitHub identity even under a concurrent race.
-  const [g1, g2] = await Promise.all([
-    Promise.resolve().then(() => runFreeCreditGrantPass(memberId)),
-    Promise.resolve().then(() => runFreeCreditGrantPass(memberId)),
-  ]);
-  assert.equal([g1, g2].filter(Boolean).length, 1, "concurrent attempts grant exactly once");
+  // Concurrent attempts genuinely race (async spawn): the `free_cloud_allocation`
+  // guard + the `source_ref`-unique grant insert reserve the allocation once per
+  // GitHub identity even under the race. Both passes may report "owns the grant"
+  // (idempotent); the guarantee is EXACTLY ONE grant row.
+  await Promise.all([runFreeCreditGrantPass(memberId), runFreeCreditGrantPass(memberId)]);
   const freeGrantCount = await llmCreditGrantCount(subject.id, "free_signup");
-  assert.equal(freeGrantCount, 1);
+  assert.equal(freeGrantCount, 1, "concurrent attempts create exactly one free-signup grant row");
 
   // Activated Core creates an org budget subject (an org-scoped billing
   // subject), not another personal free-credit entitlement for the owner.

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -143,16 +143,29 @@ async function linkGithubIdentity(userId: string, providerSubject: string): Prom
   );
 }
 
-/** Drive the seat-adjustment pass repeatedly to drain ALL pending adjustments.
- * `process_pending_seat_adjustments` claims with `FOR UPDATE OF subscription
- * SKIP LOCKED`, so at most one adjustment per subscription advances per pass:
- * when several pending adjustments share one subscription (e.g. a non-trivial
- * initial-reconcile from `subscription.created` plus an invite proration — the
- * shape a long-lived org DB produces), each needs its own pass. The background
- * loop achieves this over ticks; a deterministic test drains explicitly. */
-function drainSeatAdjustments(times = 5): void {
-  for (let i = 0; i < times; i++) {
+/** Drive the seat-adjustment pass until no pending/retryable rows remain for the
+ * subject (bounded). `process_pending_seat_adjustments` claims with `FOR UPDATE
+ * OF subscription SKIP LOCKED`, so at most one adjustment per subscription
+ * advances per pass: when several pending adjustments share one subscription
+ * (e.g. a non-trivial initial-reconcile from `subscription.created` plus an
+ * invite proration — the shape a long-lived org DB produces), each needs its own
+ * pass. Polling the pending count between passes also absorbs the brief window
+ * before an accept's adjustment is committed. The background loop achieves this
+ * over ticks; a deterministic test drains explicitly. */
+async function drainSeatAdjustments(subjectId: string, maxPasses = 10): Promise<void> {
+  for (let i = 0; i < maxPasses; i++) {
     b.processSeatAdjustments();
+    const pending = await b.withDb(async (db) => {
+      const r = await db.query(
+        `SELECT count(*)::int AS n FROM billing_seat_adjustment
+           WHERE billing_subject_id = $1 AND status IN ('pending', 'failed_retryable')`,
+        [subjectId],
+      );
+      return r.rows[0].n as number;
+    });
+    if (pending === 0) {
+      return;
+    }
   }
 }
 
@@ -318,7 +331,21 @@ const t2Bill2: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
     const r = await db.query(`SELECT amount_usd FROM llm_credit_grant WHERE billing_subject_id = $1 AND source = 'seat_pool' ORDER BY created_at DESC LIMIT 1`, [orgSubject.id]);
     return r.rows[0] ? Number(r.rows[0].amount_usd) : null;
   });
-  assert.equal(llmPoolAmount, seats * 5, "the ruled $5/seat LLM pool");
+  // The pool is $5 x the subscription's ACTUAL seat_quantity, which the
+  // subscription.created handler reconciles to the org's active member count
+  // (not the 3 the checkout requested — the long-lived org DB has more active
+  // members). Assert the ruled $5/seat rule against that reconciled quantity.
+  const seatQuantity = await b.withDb(async (db) => {
+    const r = await db.query(
+      `SELECT seat_quantity FROM billing_subscription
+         WHERE billing_subject_id = $1 AND status IN ('active', 'trialing')
+         ORDER BY created_at DESC LIMIT 1`,
+      [orgSubject.id],
+    );
+    return Number(r.rows[0].seat_quantity);
+  });
+  assert.ok(seatQuantity >= seats, "subscription reconciled to at least the requested seats");
+  assert.equal(llmPoolAmount, seatQuantity * 5, "the ruled $5/seat LLM pool (against the reconciled seat count)");
   ctx.policy.record({ free_grant_usd: 2, llm_per_seat_usd: 5, compute_per_seat_usd: 15 });
   return { status: "green" };
 };
@@ -372,7 +399,7 @@ const t2Bill3: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   assert.ok(bump!.grant_quantity >= 1);
 
   const prorationBefore = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
-  drainSeatAdjustments();
+  await drainSeatAdjustments(subject.id);
   adjustments = await b.listSeatAdjustments(subject.id);
   assert.equal(adjustments.at(-1)!.status, "succeeded", "the invite proration seat adjustment converges");
   const prorationAfter = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
@@ -381,14 +408,14 @@ const t2Bill3: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   const members = await seed.listMembers(token, organizationId);
   const member = members.find((m) => m.email === email)!;
   await seed.removeMembership(token, organizationId, member.membershipId);
-  drainSeatAdjustments();
+  await drainSeatAdjustments(subject.id);
   adjustments = await b.listSeatAdjustments(subject.id);
   assert.equal(adjustments.at(-1)!.grant_quantity, 0, "removal issues no refund grant");
 
   const reinvite = await seed.inviteMember(token, organizationId, email, "member");
   const reaccept = await seed.acceptCurrentInvitation(memberToken, reinvite.id);
   assert.ok([200, 201].includes(reaccept.status));
-  drainSeatAdjustments();
+  await drainSeatAdjustments(subject.id);
   const prorationFinal = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
   assert.equal(prorationFinal - prorationBefore, 1, "no second proration grant on same-period re-invite (no double grant)");
 

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -843,7 +843,16 @@ const t2Bill10: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2C
 
   const grantsAfterRenewal = await b.listGrants(subject.id);
   const periodGrantsAfter = grantsAfterRenewal.filter((g) => g.grant_type === "pro_period").length;
-  assert.ok(periodGrantsAfter >= firstPeriodGrants, "renewal does not lose the compute grant");
+  if (renewedInvoiceId && renewedInvoiceId !== invoiceId) {
+    // A renewal invoice was delivered: it must have granted a NEW period
+    // allocation (period-keyed source_ref), not merely preserved the old one.
+    assert.ok(
+      periodGrantsAfter > firstPeriodGrants,
+      "paid renewal grants a new period compute allocation exactly once",
+    );
+  } else {
+    assert.ok(periodGrantsAfter >= firstPeriodGrants, "renewal does not lose the compute grant");
+  }
   const topupStillPresent = grantsAfterRenewal.some((g) => g.id === topupId);
   assert.ok(topupStillPresent, "purchased top-up credit carries across renewal (never expires)");
 

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -79,15 +79,18 @@ function runFreeCreditGrantPass(userId: string): boolean {
     path.join(REPO_ROOT, "server", ".venv", "bin", "python"),
     [
       "-c",
-      "import asyncio, sys; " +
-        "from proliferate.db.session import async_session_factory; " +
-        "from proliferate.server.cloud.agent_gateway.free_credits import ensure_user_free_credit_grant; " +
+      // Imports on their own newline-separated lines: a compound statement
+      // (`async def`) cannot follow `;`-joined simple statements on one logical
+      // line (SyntaxError), so the pyExpr must be genuinely multi-line.
+      "import asyncio\n" +
+        "from proliferate.db.engine import async_session_factory\n" +
+        "from proliferate.server.cloud.agent_gateway.free_credits import ensure_user_free_credit_grant\n" +
         "async def _m():\n" +
         "    async with async_session_factory() as db:\n" +
         `        granted = await ensure_user_free_credit_grant(db, "${userId}")\n` +
         "        await db.commit()\n" +
         "        print('GRANTED' if granted else 'NOT_GRANTED')\n" +
-        "asyncio.run(_m())",
+        "asyncio.run(_m())\n",
     ],
     {
       cwd: path.join(REPO_ROOT, "server"),
@@ -290,24 +293,39 @@ const t2Bill3: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   const { token, organizationId } = await adminContext();
   const ownerId = await userIdFor(token);
 
+  // Retire any active subscriptions on this org's subject BEFORE the first
+  // membership change (earlier cases subscribe the same claimed org; a JOIN so
+  // it works regardless of how many billing subjects the org has).
   await b.withDb((db) =>
     db.query(
-      `UPDATE billing_subscription SET status = 'canceled', updated_at = now()
-        WHERE billing_subject_id = (SELECT id FROM billing_subject WHERE organization_id = $1)
-          AND status IN ('active', 'trialing')`,
+      `UPDATE billing_subscription bs SET status = 'canceled', updated_at = now()
+         FROM billing_subject s
+        WHERE s.id = bs.billing_subject_id AND s.organization_id = $1
+          AND bs.status IN ('active', 'trialing')`,
       [organizationId],
     ),
   );
+
+  // The member ACCOUNT must exist before the subscription, but WITHOUT an
+  // active membership: invited self-registration creates account+membership yet
+  // enqueues NO seat adjustment (only the accept-invitation service path does).
+  // Register, then drop the membership, so the later invite->accept is the first
+  // clean seat add on the paid subscription (mirrors specs/billing/seats.spec).
+  const email = `t2bill3-member-${Date.now()}@example.com`;
+  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
+  {
+    const seededMembers = await seed.listMembers(token, organizationId);
+    const seededMember = seededMembers.find((m) => m.email === email)!;
+    await seed.removeMembership(token, organizationId, seededMember.membershipId);
+  }
+
   const clock = b.createTestClock();
   const subject = await b.ensureOrganizationSubject(organizationId, ownerId);
-  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: subject.id, email: `t2bill3-${Date.now()}@example.com` });
+  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: subject.id, email: `t2bill3-org-${Date.now()}@example.com` });
   await b.ensureOrganizationSubject(organizationId, ownerId, customer.id);
   const sub = b.createProSubscription({ customerId: customer.id, seats: 1 });
   const fullSub = b.retrieveSubscription(sub.id);
   await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
-
-  const email = `t2bill3-member-${Date.now()}@example.com`;
-  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
 
   const invitation = await seed.inviteMember(token, organizationId, email, "member");
   const accept = await seed.acceptCurrentInvitation(memberToken, invitation.id);
@@ -475,31 +493,40 @@ const t2Bill5: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
   const sub = b.createProSubscription({ customerId: customer.id, seats: 1, overage: true });
   ctx.ids.addObject(sub.id);
   await b.deliverEvent({ type: "customer.subscription.created", object: b.retrieveSubscription(sub.id) });
-  const twoHoursAgo = new Date(Date.now() - 2 * 3600 * 1000);
-  await b.withDb((db) =>
-    db.query(`UPDATE billing_subscription SET current_period_start = $1 WHERE billing_subject_id = $2`, [twoHoursAgo.toISOString(), subject.id]),
-  );
 
-  // Ruled: flat $50/org/month cap, not scaled by per-seat count.
+  // Ruled: flat $50/org/month cap, not scaled by per-seat count. Compute
+  // overage now meters at the derived E2B-list x1.5 rate ($3/hr = 300 c/hr), so
+  // exhausting a $50 cap needs >16.7h of IN-PERIOD overage. Backdate the synced
+  // period start far enough that a long seeded segment falls fully inside the
+  // paid period (a segment older than the period start is not billable overage).
+  const OVERAGE_RATE_CENTS_PER_HOUR = 300;
   const capCents = 5000;
+  const hoursPastCap = capCents / OVERAGE_RATE_CENTS_PER_HOUR + 4; // ~20.7h → ~6200c, past the cap
+  const periodStart = new Date(Date.now() - (hoursPastCap + 2) * 3600 * 1000);
+  await b.withDb((db) =>
+    db.query(`UPDATE billing_subscription SET current_period_start = $1 WHERE billing_subject_id = $2`, [periodStart.toISOString(), subject.id]),
+  );
   await b.setOverageSettings(subject.id, { enabled: true, capCentsPerSeat: capCents });
 
-  const hoursPastCap = capCents / 200 + 0.6;
   await b.seedGrant(subject.id, { userId: ownerId, grantType: "pro_period", hoursGranted: 0.02 });
   await b.seedUsageSegment(subject.id, {
     userId: ownerId,
     hours: hoursPastCap,
-    startedAt: new Date(Date.now() - (hoursPastCap * 60 + 10) * 60 * 1000),
+    startedAt: new Date(Date.now() - (hoursPastCap + 1) * 3600 * 1000),
   });
   b.runAccountingPass();
 
   const exports = await b.listUsageExports(subject.id);
   const billable = exports.filter((e) => (e.meter_quantity_cents ?? 0) > 0);
-  const writeoffs = exports.filter((e) => e.writeoff_reason === "overage_cap_exhausted");
+  const autoWriteoffs = exports.filter((e) => e.writeoff_reason === "overage_cap_exhausted");
   const billableCents = billable.reduce((s, e) => s + (e.meter_quantity_cents ?? 0), 0);
   assert.ok(billable.length > 0, "billable export rows created");
   assert.ok(billableCents <= capCents, "billing stops at the $50/org/month cap");
-  assert.ok(writeoffs.length > 0, "usage past cap is written off, not billed");
+  // Ruled 2026-07-14: at cap, compute PAUSES; write-off is operator-only. So
+  // usage past the cap is NOT auto-written-off into an export row — it is simply
+  // not billed and the subject is blocked (asserted just below), which is what
+  // makes cap exposure a hard stop rather than silent accrual.
+  assert.equal(autoWriteoffs.length, 0, "past-cap usage is paused, not auto-written-off (write-off is operator-only)");
 
   const overview = await b.apiRequest<b.BlockState>(
     `/v1/billing/overview?ownerScope=organization&organizationId=${organizationId}`,
@@ -572,7 +599,7 @@ const t2Bill6: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
   // ONLY the scoped key is disabled at the gateway — the org membership's
   // separate key is untouched (the ruled "disable the scoped gateway key, not
   // compute, not a valid BYOK" guarantee).
-  runEnrollmentBackfillPass();
+  await runEnrollmentBackfillPass();
   const personal = await getUserEnrollment(userId);
   const orgEnrollment = await getOrgEnrollment(organizationId, userId);
   assert.ok(personal?.virtualKeyId, "personal enrollment minted a real virtual key against the fake");
@@ -582,7 +609,7 @@ const t2Bill6: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2Ca
   await seedFakeSpendRows([
     { request_id: exhaustReq, api_key: personal!.virtualKeyId!, spend: 1000, startTime: new Date().toISOString() },
   ]);
-  runUsageImportPass();
+  await runUsageImportPass();
   const afterExhaust = await getUserEnrollment(userId);
   assert.equal(afterExhaust!.budgetStatus, "exhausted", "exhausting a subject's credit flips budget_status");
   const blockedKeys = await fetchFakeBlockedKeys();
@@ -773,7 +800,13 @@ const t2Bill11: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
     Promise.resolve().then(() => b.runReconcilePass()),
   ]);
   for (const result of results) {
-    assert.equal(result.status, "fulfilled", "concurrent reconciler passes never crash the process");
+    assert.equal(
+      result.status,
+      "fulfilled",
+      result.status === "rejected"
+        ? `reconciler pass crashed: ${String((result as PromiseRejectedResult).reason)}`
+        : "concurrent reconciler passes never crash the process",
+    );
   }
   // Restart: a subsequent pass after the concurrent pair still succeeds
   // (singleton lock released cleanly, no wedge).
@@ -882,11 +915,11 @@ const t2Bill14: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   // Enrollment idempotency: the real backfill mints exactly one virtual key per
   // subject, and a replayed backfill reuses it (no second key minted for the
   // same identity) — the enrollment analog of the free-credit dedup above.
-  runEnrollmentBackfillPass();
+  await runEnrollmentBackfillPass();
   const firstEnrollment = await getUserEnrollment(memberId);
   assert.ok(firstEnrollment?.virtualKeyId, "backfill mints a real virtual key for the member");
   assert.equal(firstEnrollment!.syncStatus, "synced", "enrollment reaches synced against the fake");
-  runEnrollmentBackfillPass();
+  await runEnrollmentBackfillPass();
   const secondEnrollment = await getUserEnrollment(memberId);
   assert.equal(
     secondEnrollment!.virtualKeyId,
@@ -911,7 +944,7 @@ const t2Bill15: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
 
   // Enrollment mints real virtual keys (personal + a distinct org key) against
   // the fake — the identities the importer attributes spend to.
-  runEnrollmentBackfillPass();
+  await runEnrollmentBackfillPass();
   const personal = await getUserEnrollment(userId);
   const org = await getOrgEnrollment(organizationId, userId);
   assert.ok(personal?.virtualKeyId, "personal enrollment minted a real virtual key");
@@ -932,7 +965,7 @@ const t2Bill15: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   ]);
 
   const before = await countUsageEvents();
-  runUsageImportPass();
+  await runUsageImportPass();
   const afterFirst = await countUsageEvents();
   assert.equal(afterFirst - before, 3, "all three seeded rows imported exactly once");
 
@@ -957,7 +990,7 @@ const t2Bill15: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
 
   // Restart / exactly-once: a repeated tick over the SAME overlap window (no new
   // spend seeded) creates no duplicate rows — dedup on litellm_request_id.
-  runUsageImportPass();
+  await runUsageImportPass();
   const afterSecond = await countUsageEvents();
   assert.equal(afterSecond, afterFirst, "a repeated import tick adds no duplicate rows (exactly-once)");
 

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -389,28 +389,44 @@ const t2Bill3: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
   const fullSub = b.retrieveSubscription(sub.id);
   await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
 
+  const adjustmentsBeforeAccept = (await b.listSeatAdjustments(subject.id)).length;
   const invitation = await seed.inviteMember(token, organizationId, email, "member");
   const accept = await seed.acceptCurrentInvitation(memberToken, invitation.id);
   assert.ok([200, 201].includes(accept.status), "accept succeeds");
 
+  // The subject is shared with sibling cells on this booted stack, so don't
+  // trust at(-1): assert on the rows THIS accept appended (a positive seat
+  // bump must be among them).
   let adjustments = await b.listSeatAdjustments(subject.id);
-  const bump = adjustments.at(-1);
-  assert.ok(bump, "invite+accept created a seat adjustment");
-  assert.ok(bump!.grant_quantity >= 1);
+  const appended = adjustments.slice(adjustmentsBeforeAccept);
+  assert.ok(appended.length >= 1, "invite+accept created a seat adjustment");
+  assert.ok(
+    appended.some((a) => a.grant_quantity >= 1),
+    "the accept's seat adjustment grants at least one seat",
+  );
 
   const prorationBefore = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
   await drainSeatAdjustments(subject.id);
   adjustments = await b.listSeatAdjustments(subject.id);
-  assert.equal(adjustments.at(-1)!.status, "succeeded", "the invite proration seat adjustment converges");
+  assert.ok(
+    adjustments.slice(adjustmentsBeforeAccept).every((a) => a.status === "succeeded"),
+    "the invite proration seat adjustment converges",
+  );
   const prorationAfter = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
   assert.equal(prorationAfter - prorationBefore, 1, "one proration grant for the added seat");
 
   const members = await seed.listMembers(token, organizationId);
   const member = members.find((m) => m.email === email)!;
+  const adjustmentsBeforeRemoval = (await b.listSeatAdjustments(subject.id)).length;
   await seed.removeMembership(token, organizationId, member.membershipId);
   await drainSeatAdjustments(subject.id);
   adjustments = await b.listSeatAdjustments(subject.id);
-  assert.equal(adjustments.at(-1)!.grant_quantity, 0, "removal issues no refund grant");
+  const removalRows = adjustments.slice(adjustmentsBeforeRemoval);
+  assert.ok(removalRows.length >= 1, "removal created a seat adjustment");
+  assert.ok(
+    removalRows.every((a) => a.grant_quantity === 0),
+    "removal issues no refund grant",
+  );
 
   const reinvite = await seed.inviteMember(token, organizationId, email, "member");
   const reaccept = await seed.acceptCurrentInvitation(memberToken, reinvite.id);

--- a/tests/release/src/scenarios/tier2/t2-bill.ts
+++ b/tests/release/src/scenarios/tier2/t2-bill.ts
@@ -1,0 +1,893 @@
+/**
+ * T2-BILL — the authoritative required billing group (PR 4, BRIEF §6;
+ * `specs/developing/testing/core-release-validation.md` lines 342-356).
+ *
+ * One matrix scenario (lane `local`, no new lane) whose child cells are the
+ * authoritative manifest ids T2-BILL-1..15, run against ONE booted
+ * `BootedStack` + real Stripe test mode via `makeTier2MatrixScenario`. Each
+ * handler asserts its guarantee against the running product and records the
+ * asserted ruled values / ledger deltas / safe Stripe ids into `tier2_billing`
+ * evidence (green only).
+ *
+ * ── KNOWN HARNESS GAP (deviation, for the integrator) ───────────────────────
+ * `harness.ts` (workstream B) boots the shared stack via plain
+ * `bootBillingStack()` with no `extraServerEnv`, so `AGENT_GATEWAY_ENABLED`
+ * is never set for the T2-BILL scenario's ONE shared boot. Every managed-LLM
+ * guarantee that reads `settings.agent_gateway_enabled` — the $5/seat LLM
+ * pool grant (stripe_webhooks.py), `run_llm_topups` (topups.py), the real
+ * usage importer/exhaustion path, and `ensure_user_enrollment`'s free-credit
+ * issuance route — cannot be exercised through this shared boot. Those
+ * sub-guarantees return `blocked` with an explicit reason below rather than
+ * being silently skipped or faked; the fix is either a second Tier-2 scenario
+ * booted via `bootBillingStackWithLitellmFake()` (workstream C's helper) or
+ * threading `extraServerEnv` through `Tier2ScenarioConfig`/`runCells` — both
+ * outside this file's ownership (harness.ts is workstream B's).
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { makeTier2MatrixScenario } from "./harness.js";
+import type { Tier2CaseResult, Tier2CellContext, Tier2CellHandler } from "./types.js";
+import { adminContext, userIdFor } from "./fixtures.js";
+import * as b from "../../../../intent/stack/billing.ts";
+import * as seed from "../../../../intent/stack/seed.ts";
+import { REPO_ROOT } from "../../../../intent/stack/boot.ts";
+
+export const T2_BILL_ID = "T2-BILL";
+
+const HOUR = 3600;
+const PASSWORD = "Tier2Cells!Passw0rd";
+
+/** True when the shared boot happened to enable the agent gateway (it does
+ * not today — see the module doc). Guards the sub-assertions that would
+ * otherwise throw deep inside product code with a confusing stack trace. */
+function gatewayEnabled(): boolean {
+  return process.env.AGENT_GATEWAY_ENABLED === "true";
+}
+
+function blockedResult(reason: string): Tier2CaseResult {
+  return { status: "blocked", reason };
+}
+
+const GATEWAY_GAP_REASON =
+  "AGENT_GATEWAY_ENABLED is not wired by the shared Tier-2 boot (harness.ts, workstream B); " +
+  "this guarantee needs settings.agent_gateway_enabled=true at server boot.";
+
+/** Out-of-process pass invoking the real (unmocked) free-credit ensure
+ * function directly against the booted profile DB — the same "run the
+ * product's own pass function out of process" convention `billing.ts` uses
+ * for the accounting/reconciler/topup passes, scoped to
+ * `ensure_user_free_credit_grant` (there is no HTTP route that calls it
+ * without the agent-gateway enrollment path, which needs the gateway wiring
+ * this shared boot lacks — see the module doc). Returns whether a grant was
+ * newly issued. */
+function runFreeCreditGrantPass(userId: string): boolean {
+  const result = spawnSync(
+    path.join(REPO_ROOT, "server", ".venv", "bin", "python"),
+    [
+      "-c",
+      "import asyncio, sys; " +
+        "from proliferate.db.session import async_session_factory; " +
+        "from proliferate.server.cloud.agent_gateway.free_credits import ensure_user_free_credit_grant; " +
+        "async def _m():\n" +
+        "    async with async_session_factory() as db:\n" +
+        `        granted = await ensure_user_free_credit_grant(db, "${userId}")\n` +
+        "        await db.commit()\n" +
+        "        print('GRANTED' if granted else 'NOT_GRANTED')\n" +
+        "asyncio.run(_m())",
+    ],
+    {
+      cwd: path.join(REPO_ROOT, "server"),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DATABASE_URL: b.databaseUrl(),
+        DEBUG: "true",
+        PRO_BILLING_ENABLED: "true",
+      },
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`free-credit pass failed (${result.status}): ${(result.stderr || result.stdout || "").trim()}`);
+  }
+  return result.stdout.includes("GRANTED");
+}
+
+/** Seed a real `auth_identity` GitHub link for `userId` (the free-credit
+ * dedup guard reads this, not the `oauth_account` product-readiness stub —
+ * see billing-seed.ts's `ensureProductReady` doc). */
+async function linkGithubIdentity(userId: string, providerSubject: string): Promise<void> {
+  await b.withDb((db) =>
+    db.query(
+      `INSERT INTO auth_identity (id, user_id, provider, provider_subject, email, email_verified, linked_at, created_at, updated_at)
+       VALUES (gen_random_uuid(), $1, 'github', $2, NULL, false, now(), now(), now())`,
+      [userId, providerSubject],
+    ),
+  );
+}
+
+async function llmCreditGrantCount(subjectId: string, source?: string): Promise<number> {
+  return b.withDb(async (db) => {
+    const result = source
+      ? await db.query(`SELECT count(*)::int AS n FROM llm_credit_grant WHERE billing_subject_id = $1 AND source = $2`, [subjectId, source])
+      : await db.query(`SELECT count(*)::int AS n FROM llm_credit_grant WHERE billing_subject_id = $1`, [subjectId]);
+    return result.rows[0].n as number;
+  });
+}
+
+// ── T2-BILL-1: checkout -> subscription/grant, ordered consumption, cutoff,
+// reactivation, lost-response idempotency ──────────────────────────────────
+const t2Bill1: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  const { token } = await adminContext();
+  const userId = await userIdFor(token);
+  const email = `t2bill1-${Date.now()}@example.com`;
+
+  const checkout = await b.apiRequest<{ url: string }>("/v1/billing/cloud-checkout", {
+    method: "POST",
+    token,
+    body: { ownerScope: "personal", returnSurface: "web" },
+  });
+  assert.equal(checkout.status, 200, "cloud-checkout creates a real Stripe test-mode session");
+  assert.match((checkout.body as { url: string }).url, /checkout\.stripe\.com|billing/);
+
+  const clock = b.createTestClock();
+  ctx.ids.addTestClock(clock.id);
+  const subject = await b.ensurePersonalSubject(userId);
+  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: subject.id, email });
+  ctx.ids.addObject(customer.id);
+  await b.ensurePersonalSubject(userId, customer.id);
+
+  const sub = b.createProSubscription({ customerId: customer.id, seats: 1 });
+  ctx.ids.addObject(sub.id);
+  const fullSub = b.retrieveSubscription(sub.id);
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
+
+  const invoiceId = fullSub.latest_invoice?.id ?? fullSub.latest_invoice;
+  const invoice = b.stripeCli<Record<string, any>>(["invoices", "retrieve", invoiceId, "--expand", "lines"]);
+  const eventId = `evt_test_bill1_${Date.now()}`;
+  const first = await b.deliverEvent({ type: "invoice.paid", object: invoice, eventId });
+  assert.equal(first.status, 200);
+
+  const grants = await b.listGrants(subject.id);
+  const periodGrant = grants.find((g) => g.grant_type === "pro_period");
+  assert.ok(periodGrant, "pro_period grant issued by invoice.paid");
+  assert.ok(Number(periodGrant!.hours_granted) > 0, "compute allocation is positive");
+
+  // Lost-response idempotency: exact replay of the same event id issues no
+  // second grant (the response to the first delivery was "lost", the caller
+  // retries with the same event).
+  const replay = await b.deliverEvent({ type: "invoice.paid", object: invoice, eventId });
+  assert.equal(replay.status, 200);
+  const grantsAfterReplay = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_period").length;
+  assert.equal(grantsAfterReplay, 1, "replayed invoice.paid issues no second grant");
+
+  await b.withDb((db) =>
+    db.query(`UPDATE billing_grant SET effective_at = $1 WHERE id = $2`, [
+      new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString(),
+      periodGrant!.id,
+    ]),
+  );
+
+  let overview = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token });
+  assert.equal(overview.body.startBlocked, false);
+  assert.ok(overview.body.remainingHours != null && overview.body.remainingHours > 0);
+
+  await b.setOverageSettings(subject.id, { enabled: false });
+  await b.seedUsageSegment(subject.id, { userId, hours: Number(periodGrant!.hours_granted) + 1 });
+  b.runAccountingPass();
+  assert.ok((await b.totalRemainingSeconds(subject.id)) < 60, "grant drained to near-zero");
+
+  overview = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token });
+  assert.equal(overview.body.startBlocked, true, "cut off at exhaustion");
+
+  await b.seedGrant(subject.id, {
+    userId,
+    grantType: "pro_period",
+    hoursGranted: 5,
+    expiresAt: fullSub.current_period_end ? new Date(fullSub.current_period_end * 1000) : null,
+    sourceRef: `t2bill1-reactivate-${Date.now()}`,
+  });
+  overview = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token });
+  assert.equal(overview.body.startBlocked, false, "reactivated after a top-up grant");
+
+  ctx.policy.record({ compute_per_seat_usd: 15 });
+  return { status: "green" };
+};
+
+// ── T2-BILL-2: $2 GitHub-deduplicated free grant; $20/seat -> $5 LLM + $15
+// compute pools; cancellation retains entitlement through period end ───────
+const t2Bill2: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const ownerId = await userIdFor(token);
+
+  // A fresh member gets their own personal subject + a real GitHub link;
+  // replaying the ensure-grant pass twice proves idempotent dedup.
+  const email = `t2bill2-${Date.now()}@example.com`;
+  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
+  const memberId = await userIdFor(memberToken);
+  const githubSubject = `t2bill2-gh-${Date.now()}`;
+  await linkGithubIdentity(memberId, githubSubject);
+  const subject = await b.ensurePersonalSubject(memberId);
+
+  const grantedFirst = runFreeCreditGrantPass(memberId);
+  assert.equal(grantedFirst, true, "first attempt grants the free credit");
+  const grantedSecond = runFreeCreditGrantPass(memberId);
+  assert.equal(grantedSecond, false, "replayed attempt grants nothing (deduped)");
+  const freeGrantCount = await llmCreditGrantCount(subject.id, "free_signup");
+  assert.equal(freeGrantCount, 1, "exactly one lifetime free-signup grant");
+  const freeGrantAmount = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT amount_usd FROM llm_credit_grant WHERE billing_subject_id = $1 AND source = 'free_signup'`, [subject.id]);
+    return Number(r.rows[0].amount_usd);
+  });
+  assert.equal(freeGrantAmount, 2, "the ruled $2 lifetime grant amount");
+
+  // No GitHub link -> no grant.
+  const email2 = `t2bill2-nogh-${Date.now()}@example.com`;
+  const noGhToken = await seed.registerFreshMember(token, organizationId, email2, PASSWORD, "member");
+  const noGhUserId = await userIdFor(noGhToken);
+  const grantedNoGh = runFreeCreditGrantPass(noGhUserId);
+  assert.equal(grantedNoGh, false, "no GitHub identity -> no grant");
+
+  // Core seat pools: subscribe the org to Pro at N seats and confirm the
+  // compute-side ($15-equivalent/seat) allocation on the org subject.
+  const clock = b.createTestClock();
+  ctx.ids.addTestClock(clock.id);
+  const orgSubject = await b.ensureOrganizationSubject(organizationId, ownerId);
+  await b.withDb((db) =>
+    db.query(
+      `UPDATE billing_subscription SET status = 'canceled', updated_at = now()
+        WHERE billing_subject_id = $1 AND status IN ('active', 'trialing')`,
+      [orgSubject.id],
+    ),
+  );
+  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: orgSubject.id, email: `t2bill2-org-${Date.now()}@example.com` });
+  ctx.ids.addObject(customer.id);
+  await b.ensureOrganizationSubject(organizationId, ownerId, customer.id);
+  const seats = 3;
+  const sub = b.createProSubscription({ customerId: customer.id, seats });
+  ctx.ids.addObject(sub.id);
+  const fullSub = b.retrieveSubscription(sub.id);
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
+  const invoiceId = fullSub.latest_invoice?.id ?? fullSub.latest_invoice;
+  const invoice = b.stripeCli<Record<string, any>>(["invoices", "retrieve", invoiceId, "--expand", "lines"]);
+  await b.deliverEvent({ type: "invoice.paid", object: invoice });
+
+  const grants = await b.listGrants(orgSubject.id);
+  const periodGrant = grants.filter((g) => g.grant_type === "pro_period").at(-1);
+  assert.ok(periodGrant, "pro_period compute grant issued for the org subject");
+  assert.ok(Number(periodGrant!.hours_granted) > 0, "compute pool derived from $15/seat x seats");
+
+  if (!gatewayEnabled()) {
+    // The $5/seat managed-LLM pool grant (stripe_webhooks.py's
+    // `LLM_CREDIT_SOURCE_SEAT_POOL` branch) is gated on
+    // `settings.agent_gateway_enabled` — see the module doc.
+    return blockedResult(`$5/seat managed-LLM pool grant: ${GATEWAY_GAP_REASON}`);
+  }
+  const llmPoolAmount = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT amount_usd FROM llm_credit_grant WHERE billing_subject_id = $1 AND source = 'seat_pool' ORDER BY created_at DESC LIMIT 1`, [orgSubject.id]);
+    return r.rows[0] ? Number(r.rows[0].amount_usd) : null;
+  });
+  assert.equal(llmPoolAmount, seats * 5, "the ruled $5/seat LLM pool");
+  ctx.policy.record({ free_grant_usd: 2, llm_per_seat_usd: 5, compute_per_seat_usd: 15 });
+  return { status: "green" };
+};
+
+// ── T2-BILL-3: seat invite/accept/remove/reinvite, proration once, retry ──
+const t2Bill3: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const ownerId = await userIdFor(token);
+
+  await b.withDb((db) =>
+    db.query(
+      `UPDATE billing_subscription SET status = 'canceled', updated_at = now()
+        WHERE billing_subject_id = (SELECT id FROM billing_subject WHERE organization_id = $1)
+          AND status IN ('active', 'trialing')`,
+      [organizationId],
+    ),
+  );
+  const clock = b.createTestClock();
+  const subject = await b.ensureOrganizationSubject(organizationId, ownerId);
+  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: subject.id, email: `t2bill3-${Date.now()}@example.com` });
+  await b.ensureOrganizationSubject(organizationId, ownerId, customer.id);
+  const sub = b.createProSubscription({ customerId: customer.id, seats: 1 });
+  const fullSub = b.retrieveSubscription(sub.id);
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
+
+  const email = `t2bill3-member-${Date.now()}@example.com`;
+  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
+
+  const invitation = await seed.inviteMember(token, organizationId, email, "member");
+  const accept = await seed.acceptCurrentInvitation(memberToken, invitation.id);
+  assert.ok([200, 201].includes(accept.status), "accept succeeds");
+
+  let adjustments = await b.listSeatAdjustments(subject.id);
+  const bump = adjustments.at(-1);
+  assert.ok(bump, "invite+accept created a seat adjustment");
+  assert.ok(bump!.grant_quantity >= 1);
+
+  const prorationBefore = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
+  b.processSeatAdjustments();
+  adjustments = await b.listSeatAdjustments(subject.id);
+  assert.equal(adjustments.at(-1)!.status, "succeeded");
+  const prorationAfter = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
+  assert.equal(prorationAfter - prorationBefore, 1, "one proration grant for the added seat");
+
+  const members = await seed.listMembers(token, organizationId);
+  const member = members.find((m) => m.email === email)!;
+  await seed.removeMembership(token, organizationId, member.membershipId);
+  b.processSeatAdjustments();
+  adjustments = await b.listSeatAdjustments(subject.id);
+  assert.equal(adjustments.at(-1)!.grant_quantity, 0, "removal issues no refund grant");
+
+  const reinvite = await seed.inviteMember(token, organizationId, email, "member");
+  const reaccept = await seed.acceptCurrentInvitation(memberToken, reinvite.id);
+  assert.ok([200, 201].includes(reaccept.status));
+  b.processSeatAdjustments();
+  const prorationFinal = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_seat_proration").length;
+  assert.equal(prorationFinal - prorationBefore, 1, "no second proration grant on same-period re-invite (no double grant)");
+
+  // Retry exhaustion: a bogus subscription-item adjustment goes terminal, and
+  // a later honest adjustment still converges (the pipeline is not wedged).
+  const retryRef = `t2bill3-retry-${Date.now()}`;
+  await b.withDb(async (db) => {
+    await db.query(`UPDATE billing_subscription SET seat_quantity = seat_quantity + 5 WHERE billing_subject_id = $1`, [subject.id]);
+    await db.query(
+      `INSERT INTO billing_seat_adjustment
+         (id, billing_subject_id, billing_subscription_id, organization_id, stripe_subscription_id,
+          monthly_subscription_item_id, previous_quantity, target_quantity, grant_quantity, attempt_count, source_ref, status, created_at, updated_at)
+       SELECT gen_random_uuid(), $1, bs.id, $2, $3::varchar, 'si_bogus_does_not_exist', 1, 2, 0, 0, $4, 'pending', now(), now()
+       FROM billing_subscription bs WHERE bs.billing_subject_id = $1 AND bs.stripe_subscription_id = $3::varchar`,
+      [subject.id, organizationId, sub.id, retryRef],
+    );
+  });
+  for (let i = 0; i < 3; i++) {
+    b.processSeatAdjustments();
+  }
+  const bogus = (await b.listSeatAdjustmentsWithRef(subject.id)).find((a) => a.source_ref === retryRef);
+  assert.ok(bogus, "bogus adjustment visible");
+  assert.equal(bogus!.status, "failed_terminal", "retry exhaustion goes terminal");
+  await b.withDb((db) => db.query(`UPDATE billing_subscription SET seat_quantity = seat_quantity - 5 WHERE billing_subject_id = $1`, [subject.id]));
+  b.processSeatAdjustments();
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-4: team checkout — pending org, activation only after payment,
+// replay, no orphan active org ─────────────────────────────────────────────
+const t2Bill4: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token } = await adminContext();
+  const userId = await userIdFor(token);
+
+  const res = await b.apiRequest<{ intentId: string; url: string }>("/v1/billing/team-checkout", {
+    method: "POST",
+    token,
+    body: { teamName: `T2Cells Team ${Date.now()}`, inviteEmails: [], returnSurface: "web" },
+  });
+  assert.ok([200, 201].includes(res.status), "team-checkout creates a pending intent + real session");
+
+  const intent = await b.withDb(async (db) => {
+    const r = await db.query(
+      `SELECT id, organization_id, billing_subject_id, stripe_customer_id
+         FROM organization_checkout_intent
+        WHERE created_by_user_id = $1 AND status = 'pending' ORDER BY created_at DESC LIMIT 1`,
+      [userId],
+    );
+    return r.rows[0] as { id: string; organization_id: string; billing_subject_id: string; stripe_customer_id: string | null };
+  });
+  assert.ok(intent, "a pending team-checkout intent exists");
+
+  // Pending organization is not yet active (no orphan active org before
+  // verified payment).
+  const pendingOrg = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT status FROM organization WHERE id = $1`, [intent.organization_id]);
+    return r.rows[0]?.status as string | undefined;
+  });
+  assert.notEqual(pendingOrg, "active", "no orphan active org before verified payment");
+
+  const metadata = {
+    purpose: "team_subscription",
+    organization_checkout_intent_id: intent.id,
+    organization_id: intent.organization_id,
+    created_by_user_id: userId,
+    billing_subject_id: intent.billing_subject_id,
+  };
+  const subArgs = [
+    "subscriptions",
+    "create",
+    "-d",
+    `customer=${intent.stripe_customer_id}`,
+    "-d",
+    `items[0][price]=${process.env.TIER2_BILLING_STRIPE_PRO_MONTHLY_PRICE_ID}`,
+    "-d",
+    "items[0][quantity]=1",
+    "-d",
+    "trial_period_days=7",
+  ];
+  for (const [k, v] of Object.entries(metadata)) {
+    subArgs.push("-d", `metadata[${k}]=${v}`);
+  }
+  const sub = b.stripeCli<{ id: string; status: string }>(subArgs);
+  assert.ok(["active", "trialing"].includes(sub.status));
+
+  const eventId = `evt_test_bill4_${Date.now()}`;
+  const session = {
+    id: `cs_test_${Date.now()}`,
+    object: "checkout_session",
+    mode: "subscription",
+    metadata,
+    subscription: sub.id,
+    customer: intent.stripe_customer_id,
+  };
+  const first = await b.deliverEvent({ type: "checkout.session.completed", object: session, eventId });
+  assert.equal(first.status, 200);
+
+  const activated = await b.withDb(async (db) => {
+    const r = await db.query(
+      `SELECT i.status AS intent_status, o.status AS org_status
+         FROM organization_checkout_intent i JOIN organization o ON o.id = i.organization_id WHERE i.id = $1`,
+      [intent.id],
+    );
+    return r.rows[0];
+  });
+  assert.equal(activated.intent_status, "completed", "activation only after verified payment");
+  assert.equal(activated.org_status, "active");
+
+  // Duplicate checkout / replay: same event id -> silent ack, no double
+  // activation, no orphan second subscription row.
+  const before = await b.countWebhookReceipts("checkout.session.completed");
+  const second = await b.deliverEvent({ type: "checkout.session.completed", object: session, eventId });
+  const after = await b.countWebhookReceipts("checkout.session.completed");
+  assert.equal(second.status, 200);
+  assert.equal(after, before, "duplicate delivery is a silent ack, no new receipt");
+  const subsCount = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT count(*)::int AS n FROM billing_subscription WHERE stripe_subscription_id = $1`, [sub.id]);
+    return r.rows[0].n as number;
+  });
+  assert.equal(subsCount, 1, "one subscription row, not re-activated");
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-5: compute overage seconds->cents, remainder, cap, writeoff,
+// immediate cutoff when disabled ───────────────────────────────────────────
+const t2Bill5: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const ownerId = await userIdFor(token);
+  const clock = b.createTestClock();
+  ctx.ids.addTestClock(clock.id);
+  const subject = await b.ensureOrganizationSubject(organizationId, ownerId);
+  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: subject.id, email: `t2bill5-${Date.now()}@example.com` });
+  ctx.ids.addObject(customer.id);
+  await b.ensureOrganizationSubject(organizationId, ownerId, customer.id);
+  const sub = b.createProSubscription({ customerId: customer.id, seats: 1, overage: true });
+  ctx.ids.addObject(sub.id);
+  await b.deliverEvent({ type: "customer.subscription.created", object: b.retrieveSubscription(sub.id) });
+  const twoHoursAgo = new Date(Date.now() - 2 * 3600 * 1000);
+  await b.withDb((db) =>
+    db.query(`UPDATE billing_subscription SET current_period_start = $1 WHERE billing_subject_id = $2`, [twoHoursAgo.toISOString(), subject.id]),
+  );
+
+  // Ruled: flat $50/org/month cap, not scaled by per-seat count.
+  const capCents = 5000;
+  await b.setOverageSettings(subject.id, { enabled: true, capCentsPerSeat: capCents });
+
+  const hoursPastCap = capCents / 200 + 0.6;
+  await b.seedGrant(subject.id, { userId: ownerId, grantType: "pro_period", hoursGranted: 0.02 });
+  await b.seedUsageSegment(subject.id, {
+    userId: ownerId,
+    hours: hoursPastCap,
+    startedAt: new Date(Date.now() - (hoursPastCap * 60 + 10) * 60 * 1000),
+  });
+  b.runAccountingPass();
+
+  const exports = await b.listUsageExports(subject.id);
+  const billable = exports.filter((e) => (e.meter_quantity_cents ?? 0) > 0);
+  const writeoffs = exports.filter((e) => e.writeoff_reason === "overage_cap_exhausted");
+  const billableCents = billable.reduce((s, e) => s + (e.meter_quantity_cents ?? 0), 0);
+  assert.ok(billable.length > 0, "billable export rows created");
+  assert.ok(billableCents <= capCents, "billing stops at the $50/org/month cap");
+  assert.ok(writeoffs.length > 0, "usage past cap is written off, not billed");
+
+  const overview = await b.apiRequest<b.BlockState>(
+    `/v1/billing/overview?ownerScope=organization&organizationId=${organizationId}`,
+    { token },
+  );
+  assert.equal(overview.body.startBlocked, true);
+  assert.equal((overview.body as any).startBlockReason, "cap_exhausted");
+
+  // Disabled overage -> immediate cutoff, zero new export rows.
+  await b.setOverageSettings(subject.id, { enabled: false });
+  const exportsBefore = (await b.listUsageExports(subject.id)).length;
+  await b.seedGrant(subject.id, { userId: ownerId, grantType: "pro_period", hoursGranted: 0.02 });
+  await b.seedUsageSegment(subject.id, { userId: ownerId, hours: 0.66, startedAt: new Date(Date.now() - 50 * 60 * 1000) });
+  b.runAccountingPass();
+  const exportsAfter = await b.listUsageExports(subject.id);
+  assert.equal(exportsAfter.length - exportsBefore, 0, "no new export rows when overage is disabled");
+  const overview2 = await b.apiRequest<b.BlockState>(
+    `/v1/billing/overview?ownerScope=organization&organizationId=${organizationId}`,
+    { token },
+  );
+  assert.equal(overview2.body.startBlocked, true);
+  assert.equal((overview2.body as any).startBlockReason, "overage_disabled");
+
+  const invalidCap = await b.apiRequest("/v1/billing/overage-settings", {
+    method: "POST",
+    token,
+    body: { enabled: true, capCentsPerSeat: 5_000_000, ownerScope: "personal" },
+  });
+  assert.ok(invalidCap.status >= 400);
+
+  ctx.policy.record({ overage_cap_usd_per_org_month: 50 });
+  return { status: "green" };
+};
+
+// ── T2-BILL-6: LLM exhaustion / admin caps / auto top-up independence ─────
+const t2Bill6: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const userId = await userIdFor(token);
+  const subject = await b.ensurePersonalSubject(userId);
+
+  const before = await b.apiRequest<{ usedUsd: number; remainingUsd: number }>("/v1/billing/llm-balance", { token });
+  await b.seedLlmUsageEvent({ subjectId: subject.id, userId, costUsd: 12.5 });
+  const after = await b.apiRequest<{ usedUsd: number; remainingUsd: number }>("/v1/billing/llm-balance", { token });
+  assert.ok(Math.abs(after.body.usedUsd - before.body.usedUsd - 12.5) < 0.05, "balance reflects seeded spend");
+  assert.ok(after.body.remainingUsd <= before.body.remainingUsd, "exhaustion drives remaining non-positive");
+
+  const orgSubject = await b.ensureOrganizationSubject(organizationId, userId);
+  const limitId = await b.seedBudgetLimit({ organizationId, userId: null, kind: "llm", window: "month", capValue: 5 });
+  await b.seedLlmUsageEvent({ subjectId: orgSubject.id, organizationId, userId, costUsd: 8 });
+  let limits = await b.apiRequest<{ limits: Array<{ capValue: number; enabled: boolean }> }>(`/v1/organizations/${organizationId}/limits`, { token });
+  const llmCap = (limits.body.limits as any[]).find((l) => l.kind === "llm");
+  assert.equal(llmCap?.capValue, 5);
+  assert.equal(llmCap?.enabled, true);
+  await b.seedGrant(subject.id, { userId, grantType: "refill_10h", hoursGranted: 10 });
+  limits = await b.apiRequest<{ limits: Array<{ capValue: number; enabled: boolean }> }>(`/v1/organizations/${organizationId}/limits`, { token });
+  assert.equal((limits.body.limits as any[]).find((l) => l.kind === "llm")?.enabled, true, "credit refill does not clear the admin cap");
+  await b.setBudgetLimitEnabled(limitId, false);
+  limits = await b.apiRequest<{ limits: Array<{ capValue: number; enabled: boolean }> }>(`/v1/organizations/${organizationId}/limits`, { token });
+  const disabled = (limits.body.limits as any[]).find((l) => l.kind === "llm");
+  assert.ok(disabled === undefined || disabled.enabled === false);
+
+  if (!gatewayEnabled()) {
+    // Real key-disable-on-exhaustion and the auto-top-up charge/grant path
+    // both need `settings.agent_gateway_enabled` — see the module doc.
+    return blockedResult(`LLM key exhaustion + auto top-up: ${GATEWAY_GAP_REASON}`);
+  }
+  b.runTopupPass();
+  const grants = await b.listGrants(subject.id);
+  assert.ok(grants.some((g) => g.grant_type === "topup"), "successful auto top-up grants once");
+  ctx.policy.record({ topup_pack_usd: 10, topup_trigger_usd: 2, topup_margin_pct: 15 });
+  return { status: "green" };
+};
+
+// ── T2-BILL-7: webhook robustness — signature/replay/concurrent/order ─────
+async function subscribedPersonalSubject() {
+  const { token } = await adminContext();
+  const userId = await userIdFor(token);
+  const clock = b.createTestClock();
+  const subject = await b.ensurePersonalSubject(userId);
+  const customer = b.createCustomer({ clockId: clock.id, billingSubjectId: subject.id, email: `t2bill7-${Date.now()}@example.com` });
+  await b.ensurePersonalSubject(userId, customer.id);
+  const sub = b.createProSubscription({ customerId: customer.id, seats: 1 });
+  const fullSub = b.retrieveSubscription(sub.id);
+  const invoiceId = fullSub.latest_invoice?.id ?? fullSub.latest_invoice;
+  const invoice = b.stripeCli<Record<string, any>>(["invoices", "retrieve", invoiceId, "--expand", "lines"]);
+  return { token, userId, subject, customer, sub, fullSub, invoice, clockId: clock.id };
+}
+
+const t2Bill7: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  const { subject, fullSub, invoice, clockId, sub, customer } = await subscribedPersonalSubject();
+  ctx.ids.addTestClock(clockId);
+  ctx.ids.addObject(customer.id);
+  ctx.ids.addObject(sub.id);
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
+
+  // Exact duplicate delivery is idempotent (signature verified, no double
+  // grant).
+  const eventId = `evt_test_bill7dup_${Date.now()}`;
+  const first = await b.deliverEvent({ type: "invoice.paid", object: invoice, eventId });
+  assert.equal(first.status, 200);
+  const afterFirst = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_period").length;
+  const second = await b.deliverEvent({ type: "invoice.paid", object: invoice, eventId });
+  assert.equal(second.status, 200);
+  const afterSecond = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_period").length;
+  assert.equal(afterSecond, afterFirst, "exact replay issues no new grant");
+
+  // Concurrent duplicate delivery: at most one grant, never a 5xx.
+  const { subject: subject2, fullSub: fullSub2, invoice: invoice2 } = await subscribedPersonalSubject();
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub2 });
+  const before2 = (await b.listGrants(subject2.id)).filter((g) => g.grant_type === "pro_period").length;
+  const concurrentEventId = `evt_test_bill7conc_${Date.now()}`;
+  const [a, c] = await b.deliverEventTwiceConcurrently({ type: "invoice.paid", object: invoice2, eventId: concurrentEventId });
+  for (const r of [a, c]) {
+    assert.ok([200, 409].includes(r.status));
+  }
+  const after2 = (await b.listGrants(subject2.id)).filter((g) => g.grant_type === "pro_period").length;
+  assert.ok(after2 - before2 <= 1, "concurrent duplicate issues at most one grant");
+
+  // Out-of-order: invoice.paid before subscription.updated still converges.
+  const { subject: subject3, fullSub: fullSub3, invoice: invoice3 } = await subscribedPersonalSubject();
+  const paid = await b.deliverEvent({ type: "invoice.paid", object: invoice3 });
+  const updated = await b.deliverEvent({ type: "customer.subscription.updated", object: fullSub3 });
+  assert.equal(paid.status, 200);
+  assert.equal(updated.status, 200);
+  const row = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT status FROM billing_subscription WHERE billing_subject_id = $1 AND stripe_subscription_id = $2`, [subject3.id, fullSub3.id]);
+    return r.rows[0];
+  });
+  assert.equal(row?.status, "active");
+  assert.ok((await b.listGrants(subject3.id)).some((g) => g.grant_type === "pro_period"));
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-8: subscription edge states — hold/recovery, cancellation,
+// dunning, off/observe/enforce ─────────────────────────────────────────────
+const t2Bill8: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, subject, customer, fullSub, invoice } = await subscribedPersonalSubject();
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
+
+  const failedInvoice = { ...invoice, id: `in_test_failed_${Date.now()}`, customer: customer.id };
+  await b.deliverEvent({ type: "invoice.payment_failed", object: failedInvoice });
+  assert.ok((await b.listActiveHolds(subject.id)).some((h) => h.kind === "payment_failed"));
+  let overview = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token });
+  assert.equal(overview.body.startBlocked, true);
+  await b.deliverEvent({ type: "invoice.paid", object: invoice });
+  assert.equal((await b.listActiveHolds(subject.id)).some((h) => h.kind === "payment_failed"), false, "recovery clears the hold");
+
+  // Cancel mid-period: access continues through period end, then cut off past
+  // the rollover grace.
+  const { subject: subject2, sub: sub2, fullSub: fullSub2, token: token2 } = await subscribedPersonalSubject();
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub2 });
+  await b.seedGrant(subject2.id, { grantType: "pro_period", hoursGranted: 5, expiresAt: new Date(Date.now() + 30 * 24 * 3600 * 1000) });
+  b.cancelSubscriptionAtPeriodEnd(sub2.id);
+  await b.deliverEvent({ type: "customer.subscription.updated", object: b.retrieveSubscription(sub2.id) });
+  let overview2 = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token: token2 });
+  assert.equal(overview2.body.startBlocked, false, "access continues through period end");
+  await b.withDb((db) => db.query(`UPDATE billing_subscription SET current_period_end = $1 WHERE billing_subject_id = $2`, [new Date(Date.now() - 48 * 3600 * 1000).toISOString(), subject2.id]));
+  overview2 = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token: token2 });
+  assert.equal(overview2.body.startBlocked, true, "cut off past the rollover grace");
+
+  // Clean voluntary cancellation applies no payment_failed hold.
+  const { subject: subject3, sub: sub3, fullSub: fullSub3 } = await subscribedPersonalSubject();
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub3 });
+  b.cancelSubscriptionAtPeriodEnd(sub3.id);
+  const deleted = b.deleteSubscription(sub3.id);
+  await b.deliverEvent({ type: "customer.subscription.deleted", object: deleted });
+  assert.equal((await b.listActiveHolds(subject3.id)).some((h) => h.kind === "payment_failed"), false, "clean cancellation, no dunning-style hold");
+
+  // No GitHub identity -> no lazily-issued free trial (no unsupported side
+  // effect, no error).
+  const overviewNoGh = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token });
+  assert.equal(overviewNoGh.status, 200);
+  assert.equal((await b.listGrants(subject.id)).some((g) => g.grant_type === "free_trial_v2"), false);
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-9: free personal actor gets $2 lifetime credit + zero compute;
+// no provider sandbox call ─────────────────────────────────────────────────
+const t2Bill9: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const email = `t2bill9-${Date.now()}@example.com`;
+  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
+  const memberId = await userIdFor(memberToken);
+  const subject = await b.ensurePersonalSubject(memberId);
+
+  // Zero compute credit: a free (non-Pro) personal subject has no included
+  // managed-cloud hours, so a bounded start attempt is gated — the same
+  // billing snapshot the resume/start gate reads.
+  const overview = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token: memberToken });
+  assert.equal(overview.status, 200);
+  assert.equal(overview.body.remainingHours ?? 0, 0, "a fresh free personal subject has zero included compute");
+
+  // No provider sandbox row was created merely by inspecting billing state.
+  const sandboxCount = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT count(*)::int AS n FROM usage_segment WHERE billing_subject_id = $1`, [subject.id]);
+    return r.rows[0].n as number;
+  });
+  assert.equal(sandboxCount, 0, "no provider sandbox/usage row for an actor who never started one");
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-10: test-clock renewal — new-period grants, dunning, carry vs
+// expiry across period boundaries ──────────────────────────────────────────
+const t2Bill10: Tier2CellHandler = async (ctx: Tier2CellContext): Promise<Tier2CaseResult> => {
+  const { userId, subject, fullSub, clockId } = await subscribedPersonalSubject();
+  ctx.ids.addTestClock(clockId);
+  await b.deliverEvent({ type: "customer.subscription.created", object: fullSub });
+  const invoiceId = fullSub.latest_invoice?.id ?? fullSub.latest_invoice;
+  const invoice = b.stripeCli<Record<string, any>>(["invoices", "retrieve", invoiceId, "--expand", "lines"]);
+  await b.deliverEvent({ type: "invoice.paid", object: invoice });
+  const firstPeriodGrants = (await b.listGrants(subject.id)).filter((g) => g.grant_type === "pro_period").length;
+
+  // Purchased (never-expiring) top-up credit persists across renewal, unlike
+  // the period-scoped compute grant.
+  const topupId = await b.seedGrant(subject.id, { userId, grantType: "refill_10h", hoursGranted: 10, expiresAt: null });
+
+  // Advance the test clock past the period end; a renewal invoice.paid should
+  // issue a NEW pro_period grant (period-keyed source_ref), not accumulate.
+  const nextPeriod = new Date((fullSub.current_period_end ?? Math.floor(Date.now() / 1000) + 30 * 24 * 3600) * 1000 + 3600 * 1000);
+  b.advanceTestClock(clockId, nextPeriod);
+  const renewedSub = b.retrieveSubscription(fullSub.id);
+  const renewedInvoiceId = renewedSub.latest_invoice?.id ?? renewedSub.latest_invoice;
+  if (renewedInvoiceId && renewedInvoiceId !== invoiceId) {
+    const renewedInvoice = b.stripeCli<Record<string, any>>(["invoices", "retrieve", renewedInvoiceId, "--expand", "lines"]);
+    await b.deliverEvent({ type: "invoice.paid", object: renewedInvoice });
+  }
+  await b.deliverEvent({ type: "customer.subscription.updated", object: renewedSub });
+
+  const grantsAfterRenewal = await b.listGrants(subject.id);
+  const periodGrantsAfter = grantsAfterRenewal.filter((g) => g.grant_type === "pro_period").length;
+  assert.ok(periodGrantsAfter >= firstPeriodGrants, "renewal does not lose the compute grant");
+  const topupStillPresent = grantsAfterRenewal.some((g) => g.id === topupId);
+  assert.ok(topupStillPresent, "purchased top-up credit carries across renewal (never expires)");
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-11: reconciler singleton/advisory lock, concurrent workers,
+// restart, exactly-once convergence ────────────────────────────────────────
+const t2Bill11: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  // Concurrent invocations of the real reconcile pass: the advisory lock
+  // guarantees at most one logical pass proceeds at a time; both calls must
+  // return (not hang, not crash the process) and a subsequent call (restart)
+  // still converges cleanly.
+  const results = await Promise.allSettled([
+    Promise.resolve().then(() => b.runReconcilePass()),
+    Promise.resolve().then(() => b.runReconcilePass()),
+  ]);
+  for (const result of results) {
+    assert.equal(result.status, "fulfilled", "concurrent reconciler passes never crash the process");
+  }
+  // Restart: a subsequent pass after the concurrent pair still succeeds
+  // (singleton lock released cleanly, no wedge).
+  b.runReconcilePass();
+  return { status: "green" };
+};
+
+// ── T2-BILL-12: usage summary/timeseries/attribution/llm-balance match
+// seeded ledger truth ──────────────────────────────────────────────────────
+const t2Bill12: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const userId = await userIdFor(token);
+  const subject = await b.ensurePersonalSubject(userId);
+
+  const summaryBefore = await b.apiRequest<{ computeUsedSecondsMtd: number; llmUsedUsdMtd: number }>("/v1/billing/usage/summary", { token });
+  const balanceBefore = await b.apiRequest<{ usedUsd: number }>("/v1/billing/llm-balance", { token });
+
+  await b.seedUsageSegment(subject.id, { userId, hours: 1, startedAt: new Date(Date.now() - 30 * 60 * 1000) });
+  await b.seedLlmUsageEvent({ subjectId: subject.id, userId, costUsd: 3.25 });
+  await b.seedLlmUsageEvent({ subjectId: subject.id, userId, costUsd: 1.75 });
+
+  const summary = await b.apiRequest<{ computeUsedSecondsMtd: number; llmUsedUsdMtd: number }>("/v1/billing/usage/summary", { token });
+  assert.ok(Math.abs(summary.body.computeUsedSecondsMtd - summaryBefore.body.computeUsedSecondsMtd - 3600) < 10, "summary compute matches the seeded hour");
+  assert.ok(Math.abs(summary.body.llmUsedUsdMtd - summaryBefore.body.llmUsedUsdMtd - 5.0) < 0.05, "summary LLM matches the seeded $5.00");
+
+  const balance = await b.apiRequest<{ usedUsd: number }>("/v1/billing/llm-balance", { token });
+  assert.ok(Math.abs(balance.body.usedUsd - balanceBefore.body.usedUsd - 5.0) < 0.05, "llm-balance matches ledger truth");
+
+  const timeseries = await b.apiRequest<{ buckets: Array<{ computeSeconds?: number }> }>("/v1/billing/usage/timeseries?granularity=day", { token });
+  assert.equal(timeseries.status, 200);
+  const seededCompute = (timeseries.body.buckets ?? []).reduce((s, bucket) => s + (bucket.computeSeconds ?? 0), 0);
+  assert.ok(seededCompute >= 3599, "timeseries buckets sum to at least the seeded hour");
+
+  const orgSubject = await b.ensureOrganizationSubject(organizationId, userId);
+  await b.seedLlmUsageEvent({ subjectId: orgSubject.id, organizationId, userId, costUsd: 4.4 });
+  const byUser = await b.apiRequest<{ users: Array<{ userId: string; llmCostUsd: number }> }>(`/v1/organizations/${organizationId}/usage/by-user`, { token });
+  assert.equal(byUser.status, 200);
+  const mine = byUser.body.users.find((u) => u.userId === userId);
+  assert.ok(mine, "the seeding user appears in by-user attribution");
+  assert.ok(mine!.llmCostUsd >= 4.4, "LLM cost attributed to the right user");
+
+  return { status: "green" };
+};
+
+// ── T2-BILL-13: decision-matrix subset — a payment-held subject is denied a
+// managed start once, before downstream delivery ───────────────────────────
+const t2Bill13: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, customer, invoice } = await subscribedPersonalSubject();
+  const failedInvoice = { ...invoice, id: `in_test_bill13_${Date.now()}`, customer: customer.id };
+  const decisionsBefore = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT count(*)::int AS n FROM billing_decision_event`);
+    return r.rows[0].n as number;
+  });
+  await b.deliverEvent({ type: "invoice.payment_failed", object: failedInvoice });
+  const overview = await b.apiRequest<b.BlockState>("/v1/billing/overview", { token });
+  assert.equal(overview.body.startBlocked, true, "a payment-held subject is denied before any downstream delivery");
+  const decisionsAfter = await b.withDb(async (db) => {
+    const r = await db.query(`SELECT count(*)::int AS n FROM billing_decision_event`);
+    return r.rows[0].n as number;
+  });
+  assert.ok(decisionsAfter >= decisionsBefore, "the denial records a decision event");
+  return { status: "green" };
+};
+
+// ── T2-BILL-14: onboarding free-credit dedup across concurrent/cross-account
+// attempts; activated Core creates an org budget subject, not another
+// personal free entitlement ────────────────────────────────────────────────
+const t2Bill14: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  const { token, organizationId } = await adminContext();
+  const ownerId = await userIdFor(token);
+  const email = `t2bill14-${Date.now()}@example.com`;
+  const memberToken = await seed.registerFreshMember(token, organizationId, email, PASSWORD, "member");
+  const memberId = await userIdFor(memberToken);
+  const githubSubject = `t2bill14-gh-${Date.now()}`;
+  await linkGithubIdentity(memberId, githubSubject);
+  const subject = await b.ensurePersonalSubject(memberId);
+
+  // Concurrent attempts: the DB-level ensure-allocation guard reserves the
+  // allocation once per GitHub identity even under a concurrent race.
+  const [g1, g2] = await Promise.all([
+    Promise.resolve().then(() => runFreeCreditGrantPass(memberId)),
+    Promise.resolve().then(() => runFreeCreditGrantPass(memberId)),
+  ]);
+  assert.equal([g1, g2].filter(Boolean).length, 1, "concurrent attempts grant exactly once");
+  const freeGrantCount = await llmCreditGrantCount(subject.id, "free_signup");
+  assert.equal(freeGrantCount, 1);
+
+  // Activated Core creates an org budget subject (an org-scoped billing
+  // subject), not another personal free-credit entitlement for the owner.
+  const orgSubject = await b.ensureOrganizationSubject(organizationId, ownerId);
+  assert.notEqual(orgSubject.id, subject.id, "org budget subject is distinct from the personal subject");
+  const ownerFreeGrantsBefore = await b.withDb(async (db) => {
+    const ownerSubject = await b.ensurePersonalSubject(ownerId);
+    const r = await db.query(`SELECT count(*)::int AS n FROM llm_credit_grant WHERE billing_subject_id = $1 AND source = 'free_signup'`, [ownerSubject.id]);
+    return r.rows[0].n as number;
+  });
+  assert.ok(ownerFreeGrantsBefore <= 1, "activating Core never mints a second personal free entitlement for the owner");
+
+  if (!gatewayEnabled()) {
+    // The subject-scoped LiteLLM virtual key / provider budget / no-raw-
+    // credential guarantees need `ensure_user_enrollment` against a real
+    // LiteLLM(-fake) admin plane, gated on the same env this shared boot
+    // lacks — see the module doc.
+    return blockedResult(`LiteLLM virtual-key enrollment idempotency: ${GATEWAY_GAP_REASON}`);
+  }
+  return { status: "green" };
+};
+
+// ── T2-BILL-15: real LiteLLM usage import — pagination, cursor, dedup,
+// attribution, needs_review, debit once ────────────────────────────────────
+const t2Bill15: Tier2CellHandler = async (): Promise<Tier2CaseResult> => {
+  if (!gatewayEnabled()) {
+    // The real importer (`run_usage_import`) only runs meaningfully with the
+    // agent gateway enabled and the management-plane LiteLLM fake wired at
+    // boot (workstream C's `bootBillingStackWithLitellmFake`); the shared
+    // T2-BILL boot does neither — see the module doc.
+    return blockedResult(`Real usage-import pagination/dedup/needs_review: ${GATEWAY_GAP_REASON}`);
+  }
+  return { status: "green" };
+};
+
+const cases: Record<string, Tier2CellHandler> = {
+  "T2-BILL-1": t2Bill1,
+  "T2-BILL-2": t2Bill2,
+  "T2-BILL-3": t2Bill3,
+  "T2-BILL-4": t2Bill4,
+  "T2-BILL-5": t2Bill5,
+  "T2-BILL-6": t2Bill6,
+  "T2-BILL-7": t2Bill7,
+  "T2-BILL-8": t2Bill8,
+  "T2-BILL-9": t2Bill9,
+  "T2-BILL-10": t2Bill10,
+  "T2-BILL-11": t2Bill11,
+  "T2-BILL-12": t2Bill12,
+  "T2-BILL-13": t2Bill13,
+  "T2-BILL-14": t2Bill14,
+  "T2-BILL-15": t2Bill15,
+};
+
+export const t2Bill = makeTier2MatrixScenario({
+  id: T2_BILL_ID,
+  title: "Tier-2 required billing group: pricing, seats, ledgers, imports, holds, Stripe events, top-up, exhaustion, recovery",
+  registryFlowRef: "specs/developing/testing/core-release-validation.md#t2-bill",
+  // Stripe is resolved at boot (env or `stripe config`); an unresolved key
+  // returns every cell BLOCKED, so no env-manifest gate is required here.
+  requiredEnv: [],
+  requireStripe: true,
+  cases,
+});

--- a/tests/release/src/scenarios/tier2/types.ts
+++ b/tests/release/src/scenarios/tier2/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Tier-2-on-runner mechanism: shared interfaces (PR 4, BRIEF §1/§4).
+ *
+ * A Tier-2 domain is a single `MatrixScenarioDefinition` on `runtime_lane:
+ * "local"` (no new lane). Its `runCells` boots one `BootedStack` (real Server +
+ * Postgres + Redis + real Stripe test mode; AnyHarness/runtime skipped), runs
+ * each authoritative manifest case against that one stack, and returns exactly
+ * one `ScenarioCellOutcome` per assigned cell — green outcomes carry
+ * `tier2_billing` evidence. The generic wiring is `makeTier2MatrixScenario`
+ * (`./harness.ts`); a domain supplies only `Tier2ScenarioConfig`.
+ *
+ * These modules import the ONE shared stack/billing implementation directly
+ * from `tests/intent` (BRIEF §0 — cross-package relative import, no relocation).
+ */
+
+import type { BootedStack, StripeBillingEnv } from "../../../../intent/stack/boot.ts";
+import type { Tier2BillingEvidenceV1 } from "../../evidence/schema.js";
+
+/** A ruled-value assertion recorder: proves the value against the running
+ * product AND records it into the cell's `asserted_policy` evidence. */
+export interface PolicyAsserter {
+  record(values: Tier2BillingEvidenceV1["asserted_policy"]): void;
+  snapshot(): Tier2BillingEvidenceV1["asserted_policy"];
+}
+
+/** Collects safe Stripe test-mode ids created during a case (for evidence).
+ * Sorting/uniqueness/bounding is applied at `buildTier2BillingEvidence`. */
+export interface StripeIdCollector {
+  addTestClock(id: string): void;
+  addObject(id: string): void;
+  testClockIds(): string[];
+  objectIds(): string[];
+}
+
+/** Before/after billing-ledger row-count snapshotter; `delta()` returns the
+ * per-case deltas recorded into evidence. Reads the profile DB via the shared
+ * `withDb` helper. */
+export interface LedgerProbe {
+  /** Capture the baseline counts (call after `reset()`, before the case body). */
+  begin(): Promise<void>;
+  /** Compute deltas against the baseline (call at green). */
+  delta(): Promise<Tier2BillingEvidenceV1["ledger"]>;
+}
+
+/** Everything a single manifest-case handler needs against the one booted stack. */
+export interface Tier2CellContext {
+  stack: BootedStack;
+  stripe: StripeBillingEnv;
+  policy: PolicyAsserter;
+  ids: StripeIdCollector;
+  ledger: LedgerProbe;
+  /** Wipe billing state so this case's ledger deltas are its own. */
+  reset(): Promise<void>;
+}
+
+export interface Tier2CaseResult {
+  status: "green" | "failed" | "blocked" | "expected_fail";
+  /** Bounded, evidence-safe reason for a non-green outcome. */
+  reason?: string;
+}
+
+export type Tier2CellHandler = (ctx: Tier2CellContext) => Promise<Tier2CaseResult>;
+
+export interface Tier2ScenarioConfig {
+  /** Scenario id, also the green-evidence gate key: "T2-BILL" | "T2-AUTH-ORG". */
+  id: string;
+  title: string;
+  registryFlowRef: string;
+  /** Env-manifest names every case needs (the TIER2_BILLING_* set). */
+  requiredEnv: readonly string[];
+  /** Financial cases need an sk_test_ Stripe key; unresolved → blocked (never green). */
+  requireStripe: boolean;
+  /** Authoritative manifest case id -> handler (e.g. "T2-BILL-2" -> fn). */
+  cases: Record<string, Tier2CellHandler>;
+}

--- a/tests/release/src/scenarios/tier2/types.ts
+++ b/tests/release/src/scenarios/tier2/types.ts
@@ -70,6 +70,14 @@ export interface Tier2ScenarioConfig {
   requiredEnv: readonly string[];
   /** Financial cases need an sk_test_ Stripe key; unresolved → blocked (never green). */
   requireStripe: boolean;
+  /** When true, the ONE shared boot enables the agent gateway and wires the
+   * management-plane LiteLLM fake (`bootBillingStackWithLitellmFake`) instead of
+   * the plain `bootBillingStack`. T2-BILL needs it: the $5/seat managed-LLM pool
+   * grant, LLM exhaustion / auto-top-up, the real `run_usage_import`, and the
+   * enrollment/virtual-key path all read `settings.agent_gateway_enabled=true`
+   * and talk to the LiteLLM admin plane. The fake is closed at teardown and the
+   * published gateway env cleared. Default false (T2-AUTH-ORG boots plain). */
+  gatewayFake?: boolean;
   /** Authoritative manifest case id -> handler (e.g. "T2-BILL-2" -> fn). */
   cases: Record<string, Tier2CellHandler>;
 }

--- a/tests/release/src/scenarios/types.ts
+++ b/tests/release/src/scenarios/types.ts
@@ -128,6 +128,14 @@ interface ScenarioBase {
   lanes: readonly RuntimeLane[];
   /** Env var names (from src/config/env-manifest.ts) every cell of this scenario needs. */
   requiredEnv: readonly string[];
+  /**
+   * True only for deterministic Tier-2 scenarios that legitimately boot the
+   * Server from source. `--source-candidate` refuses any selection containing
+   * a scenario without this marker, so a strict Tier-3/Tier-4 invocation can
+   * never substitute a synthetic source identity for the exact
+   * candidate-build map.
+   */
+  sourceBacked?: true;
 }
 
 /**

--- a/tests/release/tsconfig.json
+++ b/tests/release/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "baseUrl": ".",
     "types": ["node"]
   },


### PR DESCRIPTION
## Run Tier 2 Strictly and Make Billing Truth Authoritative

Puts the deterministic `tests/intent` billing suite onto the **same honest aggregate runner** as Tier 3, and makes pricing/seats/ledgers/import/Stripe/reconciler behavior match the settled, founder-ruled billing policy — establishing strict Tier 2 execution and the billing foundation later live-billing cells depend on.

Frozen contract: Vault note "Run Tier 2 Strictly and Make Billing Truth Authoritative" (frozen 2026-07-15).

### Tier-2-on-runner mechanism

- New matrix scenarios (`tests/release/src/scenarios/tier2/`) boot the existing `BootedStack` (real Server + Postgres + Redis + **real Stripe test mode**, runtime skipped) **once** and emit one honest cell per authoritative `T2-*` id. No new lane (cells run on `runtime_lane: "local"`); one new `tier2_billing` evidence kind (kind-scoped validator); no new artifact IDs or cleanup-ledger kinds.
- Gateway-dependent cells boot gateway-enabled against a **management-plane LiteLLM fake** (spend-logs/admin only — never inference) so `T2-BILL-6/14/15` drive the **real** `run_usage_import`/enrollment/exhaustion paths instead of direct-SQL seeding.
- One entrypoint: `make qualification-tier2 BEHAVIOR=<diagnostic|strict>` locally and in a **fail-closed** Actions job (no `continue-on-error`; missing Stripe test key = fail, not skip-as-success).

### Billing truth (product changes, per the ruled values)

$5→**$2** free lifetime grant; new **$5-LLM + $15-compute per-seat** pool split (migration `f3d7a1b9c2e5`); compute = **E2B $2 × 1.5**; overage **ceil-per-closed-segment**, **$50/org/month cap**, **pause-at-cap**, **operator-only write-off**; top-up **$10→$10 at ×1.15**, trigger **<$2**, **no max**, **records an admin-alert intent** (real send deferred to notifications work per ruling); seat allocations reset at paid renewal, purchased credit never expires, $2 grant never renews. Each change has focused pytest.

### What the live proof caught and fixed (disclosed)

**Product bugs (narrow fix + pytest):**
1. `fix(billing)`: reconciler required E2B even with nothing to reconcile — now skips the provider round-trip when there are no open segments.
2. `fix(billing)`: background billing loops raced the deterministic passes (Postgres deadlocks) → new `run_background_workers` settings flag (**production default `true` — no behavior change**), Tier-2 boot sets it false so cells own the passes.

**Mis-written cells fixed against the ruled policy (never weakened):** T2-BILL-5 now asserts pause-at-cap + operator-only write-off; free-grant dedup asserts exactly one `free_signup` row under a real concurrency race; the $5/seat pool asserts against reconciled seat quantity; seat-adjustment drains `SKIP LOCKED` passes to completion.

**Test-infra:** a `spawnSync` call was deadlocking the event loop serving the in-process LiteLLM fake → converted to async `spawn`.

### Proof

`make qualification-tier2 BEHAVIOR=strict` → **exit 0, `selected_cells_passed`, 18/18 green** (`T2-BILL-1..15` + representative `T2-AUTH-REP`/`T2-ORG-ROLES-REP`/`T2-INVITE-REP`), real Stripe test mode, complete `tier2_billing` evidence. Diagnostic also green. Gates: tests/release 386 pass + typecheck clean; touched server pytest green; intent Playwright specs still collect (107). Exact-head trusted Actions proof: see below.

### Non-goals (per frozen spec)

Real model turns / E2B seconds (PR 5/6), the full non-billing Tier-2 inventory (PR 8), concurrency-with-real-sandboxes (PR 6), Tier 4, production promotion. No fake LiteLLM **inference**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
