### PR TITLE
chore(desktop): bump version to 0.3.29 for the status-card release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proliferate",
   "private": true,
-  "version": "0.3.28",
+  "version": "0.3.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proliferate"
-version = "0.3.28"
+version = "0.3.29"
 edition.workspace = true
 
 [build-dependencies]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Proliferate",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "identifier": "com.proliferate.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Unblocks the desktop production release for #1210.

`desktop-v0.3.28` already shipped from an earlier commit, so the release guard refuses to republish v0.3.28 from #1210's SHA. This bumps all four version pins (`package.json`, `tauri.conf.json`, `Cargo.toml`, root `Cargo.lock`) to 0.3.29 so the desktop updater assets can publish with the workspace-status-card + AI-commit-message changes.

After merge: run **Release Desktop** (or Promote Production with `only_surfaces=desktop`) for the merge SHA — a desktop-only build (~10 min), no full re-promote needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)