### PR TITLE
fix(desktop): clear max-lines debt from git review v2 merge

### DIFF
--- a/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -33,14 +33,12 @@ import {
   getChatLineType,
   getDiffLineIndex,
   getDiffLineNumberColumnWidth,
-  type ChatDiffRow,
 } from "@/lib/domain/files/diff-view-rows";
+import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
 import {
-  clampGapReveal,
-  resolveGapLineCount,
-  useGapExpansion,
-  type GapExpansionState,
-} from "@/hooks/ui/diff/use-gap-expansion";
+  flattenWithGapExpansion,
+  type ChatRenderRow,
+} from "@/hooks/ui/diff/diff-gap-flatten";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
 import { useContentSearchStore } from "@/stores/search/content-search-store";
 import { useChatTranscriptRow } from "@proliferate/product-ui/chat/transcript/ChatContentSearchContext";
@@ -326,87 +324,6 @@ function ChatContentColumn({
       })}
     </div>
   );
-}
-
-/** Flattened render row: either a data row from the diff or an expanded gap line */
-type ChatRenderRow =
-  | ChatDiffRow
-  | { kind: "expanded-gap-line"; key: string; line: DiffLine };
-
-function makeGapContextLine(
-  fileLines: string[],
-  gap: InterHunkGap,
-  offset: number,
-): DiffLine {
-  const newLine = gap.newStartLine + offset;
-  return {
-    type: "context",
-    marker: " ",
-    content: fileLines[newLine - 1] ?? "",
-    oldLineNum: gap.oldStartLine + offset,
-    newLineNum: newLine,
-    lineNum: newLine,
-    tokenIndex: -1,
-  };
-}
-
-function flattenWithGapExpansion(
-  rows: ChatDiffRow[],
-  gapStates: Map<number, GapExpansionState>,
-  fileLines: string[] | undefined,
-): ChatRenderRow[] {
-  const result: ChatRenderRow[] = [];
-  for (const row of rows) {
-    if (row.kind !== "gap") {
-      result.push(row);
-      continue;
-    }
-
-    // Resolve unknown trailing gap count against fetched file length
-    const gap = resolveGapLineCount(row.gap, fileLines);
-    if (!gap) continue;
-    const resolvedRow: ChatDiffRow = gap === row.gap ? row : { ...row, gap };
-
-    const state = gapStates.get(row.gapIndex);
-    if (!fileLines || !state || gap.lineCount <= 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    const totalGapLines = gap.lineCount;
-    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
-    if (top === 0 && bottom === 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    for (let i = 0; i < top; i++) {
-      result.push({
-        kind: "expanded-gap-line",
-        key: `${row.key}-top-${i}`,
-        line: makeGapContextLine(fileLines, gap, i),
-      });
-    }
-
-    if (!fullyExpanded) {
-      const residualGap: InterHunkGap = {
-        kind: "gap",
-        oldStartLine: gap.oldStartLine + top,
-        newStartLine: gap.newStartLine + top,
-        lineCount: totalGapLines - top - bottom,
-      };
-      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
-    }
-
-    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
-      result.push({
-        kind: "expanded-gap-line",
-        key: `${row.key}-bottom-${i}`,
-        line: makeGapContextLine(fileLines, gap, i),
-      });
-    }
-  }
-  return result;
 }
 
 export function ChatDiffViewer({

--- a/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
+++ b/apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx
@@ -26,91 +26,14 @@ import {
   getSplitEmptyLineType,
   getSplitLineNumber,
   getSplitLineType,
-  type SplitDiffRow,
   type SplitSide,
 } from "@/lib/domain/files/diff-view-rows";
+import { useGapExpansion } from "@/hooks/ui/diff/use-gap-expansion";
 import {
-  clampGapReveal,
-  resolveGapLineCount,
-  useGapExpansion,
-  type GapExpansionState,
-} from "@/hooks/ui/diff/use-gap-expansion";
+  flattenSplitWithGapExpansion,
+  type SplitRenderRow,
+} from "@/hooks/ui/diff/diff-gap-flatten";
 import type { HighlightedToken } from "@/lib/infra/editor/highlighting";
-
-/** Flattened render row for split view */
-type SplitRenderRow =
-  | SplitDiffRow
-  | { kind: "expanded-gap-line"; key: string; oldLine: DiffLine; newLine: DiffLine };
-
-function makeSplitGapContextLine(
-  fileLines: string[],
-  gap: InterHunkGap,
-  offset: number,
-): DiffLine {
-  const newLine = gap.newStartLine + offset;
-  return {
-    type: "context",
-    marker: " ",
-    content: fileLines[newLine - 1] ?? "",
-    oldLineNum: gap.oldStartLine + offset,
-    newLineNum: newLine,
-    lineNum: newLine,
-    tokenIndex: -1,
-  };
-}
-
-function flattenSplitWithGapExpansion(
-  rows: SplitDiffRow[],
-  gapStates: Map<number, GapExpansionState>,
-  fileLines: string[] | undefined,
-): SplitRenderRow[] {
-  const result: SplitRenderRow[] = [];
-  for (const row of rows) {
-    if (row.kind !== "gap") {
-      result.push(row);
-      continue;
-    }
-
-    // Resolve unknown trailing gap count against fetched file length
-    const gap = resolveGapLineCount(row.gap, fileLines);
-    if (!gap) continue;
-    const resolvedRow: SplitDiffRow = gap === row.gap ? row : { ...row, gap };
-
-    const state = gapStates.get(row.gapIndex);
-    if (!fileLines || !state || gap.lineCount <= 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    const totalGapLines = gap.lineCount;
-    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
-    if (top === 0 && bottom === 0) {
-      result.push(resolvedRow);
-      continue;
-    }
-
-    for (let i = 0; i < top; i++) {
-      const line = makeSplitGapContextLine(fileLines, gap, i);
-      result.push({ kind: "expanded-gap-line", key: `${row.key}-top-${i}`, oldLine: line, newLine: line });
-    }
-
-    if (!fullyExpanded) {
-      const residualGap: InterHunkGap = {
-        kind: "gap",
-        oldStartLine: gap.oldStartLine + top,
-        newStartLine: gap.newStartLine + top,
-        lineCount: totalGapLines - top - bottom,
-      };
-      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
-    }
-
-    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
-      const line = makeSplitGapContextLine(fileLines, gap, i);
-      result.push({ kind: "expanded-gap-line", key: `${row.key}-bottom-${i}`, oldLine: line, newLine: line });
-    }
-  }
-  return result;
-}
 
 const SPLIT_DIFF_PRE_STYLE = {
   color: "var(--diffs-fg)",

--- a/apps/desktop/src/components/playground/GitReviewV2Playground.tsx
+++ b/apps/desktop/src/components/playground/GitReviewV2Playground.tsx
@@ -12,14 +12,12 @@ import {
   CollapseAll,
   ExpandAll,
   FolderTree,
-  GitCommit,
   MoreHorizontal,
 } from "@proliferate/ui/icons";
 import { DiffViewer } from "@/components/content/ui/DiffViewer";
 import { FileChangeStats } from "@/components/content/ui/FileChangeStats";
 import { FileTreeEntryIcon } from "@/components/workspace/files/file-icons";
 import {
-  GIT_REVIEW_V2_BRANCH,
   GIT_REVIEW_V2_FILES,
   GIT_REVIEW_V2_TARGETS,
   type GitReviewV2File,
@@ -309,14 +307,6 @@ function ReviewHeader({
           </HeaderIconButton>
         </div>
       </div>
-      <div className="flex min-w-0 items-center gap-1.5">
-        <span className="flex min-w-0 items-center gap-1 truncate text-[length:var(--text-ui)] text-sidebar-muted-foreground">
-          <span className="truncate">{GIT_REVIEW_V2_BRANCH.local}</span>
-          <span aria-hidden="true" className="shrink-0">→</span>
-          <span className="truncate">{GIT_REVIEW_V2_BRANCH.remote}</span>
-        </span>
-        <CommitSplitButton />
-      </div>
     </div>
   );
 }
@@ -346,31 +336,6 @@ function HeaderIconButton({
     >
       {children}
     </Button>
-  );
-}
-
-function CommitSplitButton() {
-  return (
-    <div className="ms-auto flex shrink-0 items-center">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-6 gap-1 rounded-md rounded-e-none border border-e-0 border-sidebar-border bg-sidebar-background px-2 text-[length:var(--text-ui)] text-sidebar-foreground hover:bg-sidebar-accent"
-      >
-        <GitCommit className="size-3.5" />
-        Commit or push
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label="More git actions"
-        className="h-6 w-5 rounded-md rounded-s-none border border-sidebar-border bg-sidebar-background px-0 text-sidebar-muted-foreground hover:bg-sidebar-accent"
-      >
-        <ChevronDown className="size-3" />
-      </Button>
-    </div>
   );
 }
 

--- a/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, type CSSProperties, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, type CSSProperties } from "react";
 import {
   type AnyHarnessQueryTimingOptions,
   useGitDiffQuery,
@@ -6,23 +6,15 @@ import {
   useStagePatchMutation,
   useUnstagePatchMutation,
 } from "@anyharness/sdk-react";
-import { Button } from "@proliferate/ui/primitives/Button";
 import { DiffViewer } from "@/components/content/ui/DiffViewer";
 import type { UnifiedDiffHunkActions } from "@/components/content/ui/diff/UnifiedDiffViewer";
-import { FileChangeStats } from "@/components/content/ui/FileChangeStats";
-import {
-  ArrowUpRight,
-  ChevronDown,
-  CircleAlert,
-  FileIcon,
-  RefreshCw,
-} from "@proliferate/ui/icons";
+import { CircleAlert, FileIcon, RefreshCw } from "@proliferate/ui/icons";
 import {
   DiffDisplayPolicyPlaceholder,
   formatEmptyDiffState,
   GitReviewInlineEmptyState,
 } from "@/components/workspace/git/GitReviewInlineState";
-import { FileTreeEntryIcon } from "@/components/workspace/files/file-icons";
+import { GitReviewFileSectionShell } from "@/components/workspace/git/GitReviewFileSectionShell";
 import { useLazyDiffFileLines } from "@/hooks/ui/diff/use-lazy-diff-file-lines";
 import type { MeasurementOperationId } from "@/lib/domain/telemetry/debug-measurement-catalog";
 import { extractHunkPatch, isHunkActionEligible } from "@/lib/domain/files/hunk-patch";
@@ -44,9 +36,6 @@ type OpenFile = (path: string) => Promise<void>;
 const SIDEBAR_DIFF_SURFACE_STYLE = {
   "--codex-diffs-surface-override": "var(--color-background)",
 } as CSSProperties;
-
-const REVIEW_HEADER_ACTION_CLASS =
-  "size-6 shrink-0 rounded-md border-0 bg-transparent p-0 text-sidebar-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring";
 
 // Header row (min-h-9 + py) height estimate for content-visibility sizing.
 const REVIEW_CARD_HEADER_ESTIMATE_PX = 38;
@@ -378,163 +367,6 @@ export function GitReviewFileRow({
       </GitReviewFileSectionShell>
     </div>
   );
-}
-
-/**
- * Flat review-document section: sticky Codex-style header (file icon,
- * front-truncated path with dimmed directory, status chip, always-on +N/−N)
- * over the diff body. Replaces the FileDiffCard card look for the git pane.
- */
-function GitReviewFileSectionShell({
-  file,
-  additions,
-  deletions,
-  binary,
-  showStagedChip,
-  collapsed,
-  onToggleCollapsed,
-  onOpenFile,
-  children,
-}: {
-  file: GitPanelReviewFile;
-  additions: number;
-  deletions: number;
-  binary: boolean;
-  showStagedChip: boolean;
-  collapsed: boolean;
-  onToggleCollapsed: () => void;
-  onOpenFile: () => void;
-  children: ReactNode;
-}) {
-  const name = basenameOf(file.path);
-  const dir = file.path.slice(0, file.path.length - name.length);
-  const status = file.currentDiff?.status ?? null;
-  const statusChip = status === "deleted" || status === "renamed" || status === "copied"
-    ? status
-    : null;
-  const hoverTitle = file.oldPath ? `${file.oldPath} → ${file.path}` : file.path;
-
-  return (
-    <section
-      data-review-file-section=""
-      className="bg-[var(--color-background)]"
-    >
-      <div
-        role="button"
-        tabIndex={0}
-        aria-expanded={!collapsed}
-        onClick={onToggleCollapsed}
-        onKeyDown={(event) => {
-          if (
-            event.target === event.currentTarget
-            && (event.key === "Enter" || event.key === " ")
-          ) {
-            event.preventDefault();
-            onToggleCollapsed();
-          }
-        }}
-        // Near-opaque color-mix, never backdrop-blur: blur resampling across
-        // many sticky headers starves the WKWebView compositor.
-        className="sticky top-0 z-10 cursor-pointer select-none bg-[color-mix(in_srgb,var(--color-diff-sidebar-file-header-surface)_97%,transparent)]"
-      >
-        <div className="group/diff-header @container/diff-header flex min-h-8 items-center gap-2 px-3 py-1 text-chat leading-[var(--text-chat--line-height)] text-sidebar-foreground hover:bg-[var(--color-diff-sidebar-file-header-hover-surface)]">
-          {/* The growing flex item is this container; the name span inside is
-              content-sized so every row's name is left-anchored beside the
-              icon. [direction:rtl] front-truncates overflow so the basename
-              (the tail) always stays visible. */}
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <FileTreeEntryIcon
-              name={name}
-              path={file.path}
-              kind="file"
-              className="size-4 shrink-0"
-            />
-            <span className="min-w-0 truncate [direction:rtl]" title={hoverTitle}>
-              <span className="min-w-0 truncate [direction:ltr] [unicode-bidi:plaintext] @xs/diff-header:hidden">
-                {name}
-              </span>
-              <span className="hidden min-w-0 truncate [direction:ltr] [unicode-bidi:plaintext] @xs/diff-header:inline">
-                <span className="text-sidebar-muted-foreground">{dir}</span>
-                <span className="text-sidebar-foreground">{name}</span>
-              </span>
-            </span>
-            {/* Stats trail the title directly (Codex changes-pane layout),
-                not right-aligned; only hover actions pin to the edge. */}
-            <span className="flex shrink-0 items-center gap-1.5">
-              {showStagedChip && <GitReviewHeaderChip label="staged" />}
-              {statusChip && <GitReviewHeaderChip label={statusChip} />}
-              {binary && additions === 0 && deletions === 0 ? (
-                <span className="text-[length:var(--text-ui-sm)] text-sidebar-muted-foreground">
-                  binary
-                </span>
-              ) : (
-                <FileChangeStats
-                  additions={additions}
-                  deletions={deletions}
-                  className="leading-none"
-                />
-              )}
-            </span>
-          </div>
-          <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-200 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`Open ${file.path}`}
-                title="Open file"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onOpenFile();
-                }}
-                className={REVIEW_HEADER_ACTION_CLASS}
-              >
-                <ArrowUpRight className="size-3.5" />
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Toggle file diff"
-                aria-expanded={!collapsed}
-                data-app-action-review-file-expanded={collapsed ? "false" : "true"}
-                data-app-action-review-file-toggle=""
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onToggleCollapsed();
-                }}
-                className={REVIEW_HEADER_ACTION_CLASS}
-              >
-                <ChevronDown
-                  className={`size-3.5 transition-transform duration-200 ${
-                    collapsed ? "rotate-0" : "rotate-180"
-                  }`}
-                />
-              </Button>
-          </span>
-        </div>
-      </div>
-      {!collapsed && (
-        <div className="relative overflow-hidden">
-          {children}
-        </div>
-      )}
-    </section>
-  );
-}
-
-/** Quiet status word (staged / deleted / renamed…) — plain muted text, no pill. */
-function GitReviewHeaderChip({ label }: { label: string }) {
-  return (
-    <span className="text-[length:var(--text-ui-sm)] leading-[var(--text-ui-sm--line-height)] text-sidebar-muted-foreground">
-      {label}
-    </span>
-  );
-}
-
-function basenameOf(path: string): string {
-  const segments = path.split("/").filter(Boolean);
-  return segments[segments.length - 1] ?? path;
 }
 
 function formatDiffErrorMessage(error: unknown): string {

--- a/apps/desktop/src/components/workspace/git/GitReviewFileSectionShell.tsx
+++ b/apps/desktop/src/components/workspace/git/GitReviewFileSectionShell.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ArrowUpRight, ChevronDown } from "@proliferate/ui/icons";
+import { FileChangeStats } from "@/components/content/ui/FileChangeStats";
+import { FileTreeEntryIcon } from "@/components/workspace/files/file-icons";
+import type { GitPanelReviewFile } from "@/lib/domain/workspaces/changes/git-panel-diff";
+
+const REVIEW_HEADER_ACTION_CLASS =
+  "size-6 shrink-0 rounded-md border-0 bg-transparent p-0 text-sidebar-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring";
+
+/**
+ * Flat review-document section: sticky Codex-style header (file icon,
+ * front-truncated path with dimmed directory, status chip, always-on +N/−N)
+ * over the diff body. Replaces the FileDiffCard card look for the git pane.
+ */
+export function GitReviewFileSectionShell({
+  file,
+  additions,
+  deletions,
+  binary,
+  showStagedChip,
+  collapsed,
+  onToggleCollapsed,
+  onOpenFile,
+  children,
+}: {
+  file: GitPanelReviewFile;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  showStagedChip: boolean;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  onOpenFile: () => void;
+  children: ReactNode;
+}) {
+  const name = basenameOf(file.path);
+  const dir = file.path.slice(0, file.path.length - name.length);
+  const status = file.currentDiff?.status ?? null;
+  const statusChip = status === "deleted" || status === "renamed" || status === "copied"
+    ? status
+    : null;
+  const hoverTitle = file.oldPath ? `${file.oldPath} → ${file.path}` : file.path;
+
+  return (
+    <section
+      data-review-file-section=""
+      className="bg-[var(--color-background)]"
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={!collapsed}
+        onClick={onToggleCollapsed}
+        onKeyDown={(event) => {
+          if (
+            event.target === event.currentTarget
+            && (event.key === "Enter" || event.key === " ")
+          ) {
+            event.preventDefault();
+            onToggleCollapsed();
+          }
+        }}
+        // Near-opaque color-mix, never backdrop-blur: blur resampling across
+        // many sticky headers starves the WKWebView compositor.
+        className="sticky top-0 z-10 cursor-pointer select-none bg-[color-mix(in_srgb,var(--color-diff-sidebar-file-header-surface)_97%,transparent)]"
+      >
+        <div className="group/diff-header @container/diff-header flex min-h-8 items-center gap-2 px-3 py-1 text-chat leading-[var(--text-chat--line-height)] text-sidebar-foreground hover:bg-[var(--color-diff-sidebar-file-header-hover-surface)]">
+          {/* The growing flex item is this container; the name span inside is
+              content-sized so every row's name is left-anchored beside the
+              icon. [direction:rtl] front-truncates overflow so the basename
+              (the tail) always stays visible. */}
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <FileTreeEntryIcon
+              name={name}
+              path={file.path}
+              kind="file"
+              className="size-4 shrink-0"
+            />
+            <span className="min-w-0 truncate [direction:rtl]" title={hoverTitle}>
+              <span className="min-w-0 truncate [direction:ltr] [unicode-bidi:plaintext] @xs/diff-header:hidden">
+                {name}
+              </span>
+              <span className="hidden min-w-0 truncate [direction:ltr] [unicode-bidi:plaintext] @xs/diff-header:inline">
+                <span className="text-sidebar-muted-foreground">{dir}</span>
+                <span className="text-sidebar-foreground">{name}</span>
+              </span>
+            </span>
+            {/* Stats trail the title directly (Codex changes-pane layout),
+                not right-aligned; only hover actions pin to the edge. */}
+            <span className="flex shrink-0 items-center gap-1.5">
+              {showStagedChip && <GitReviewHeaderChip label="staged" />}
+              {statusChip && <GitReviewHeaderChip label={statusChip} />}
+              {binary && additions === 0 && deletions === 0 ? (
+                <span className="text-[length:var(--text-ui-sm)] text-sidebar-muted-foreground">
+                  binary
+                </span>
+              ) : (
+                <FileChangeStats
+                  additions={additions}
+                  deletions={deletions}
+                  className="leading-none"
+                />
+              )}
+            </span>
+          </div>
+          <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-200 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Open ${file.path}`}
+                title="Open file"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onOpenFile();
+                }}
+                className={REVIEW_HEADER_ACTION_CLASS}
+              >
+                <ArrowUpRight className="size-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Toggle file diff"
+                aria-expanded={!collapsed}
+                data-app-action-review-file-expanded={collapsed ? "false" : "true"}
+                data-app-action-review-file-toggle=""
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggleCollapsed();
+                }}
+                className={REVIEW_HEADER_ACTION_CLASS}
+              >
+                <ChevronDown
+                  className={`size-3.5 transition-transform duration-200 ${
+                    collapsed ? "rotate-0" : "rotate-180"
+                  }`}
+                />
+              </Button>
+          </span>
+        </div>
+      </div>
+      {!collapsed && (
+        <div className="relative overflow-hidden">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** Quiet status word (staged / deleted / renamed…) — plain muted text, no pill. */
+function GitReviewHeaderChip({ label }: { label: string }) {
+  return (
+    <span className="text-[length:var(--text-ui-sm)] leading-[var(--text-ui-sm--line-height)] text-sidebar-muted-foreground">
+      {label}
+    </span>
+  );
+}
+
+function basenameOf(path: string): string {
+  const segments = path.split("/").filter(Boolean);
+  return segments[segments.length - 1] ?? path;
+}
+

--- a/apps/desktop/src/hooks/ui/diff/diff-gap-flatten.ts
+++ b/apps/desktop/src/hooks/ui/diff/diff-gap-flatten.ts
@@ -1,0 +1,146 @@
+import type { DiffLine, InterHunkGap } from "@/lib/domain/files/diff-parser";
+import type { ChatDiffRow, SplitDiffRow } from "@/lib/domain/files/diff-view-rows";
+import {
+  clampGapReveal,
+  resolveGapLineCount,
+  type GapExpansionState,
+} from "@/hooks/ui/diff/use-gap-expansion";
+
+/** Flattened render row: either a data row from the diff or an expanded gap line */
+export type ChatRenderRow =
+  | ChatDiffRow
+  | { kind: "expanded-gap-line"; key: string; line: DiffLine };
+
+/** Flattened render row for split view */
+export type SplitRenderRow =
+  | SplitDiffRow
+  | { kind: "expanded-gap-line"; key: string; oldLine: DiffLine; newLine: DiffLine };
+
+function makeGapContextLine(
+  fileLines: string[],
+  gap: InterHunkGap,
+  offset: number,
+): DiffLine {
+  const newLine = gap.newStartLine + offset;
+  return {
+    type: "context",
+    marker: " ",
+    content: fileLines[newLine - 1] ?? "",
+    oldLineNum: gap.oldStartLine + offset,
+    newLineNum: newLine,
+    lineNum: newLine,
+    tokenIndex: -1,
+  };
+}
+
+export function flattenWithGapExpansion(
+  rows: ChatDiffRow[],
+  gapStates: Map<number, GapExpansionState>,
+  fileLines: string[] | undefined,
+): ChatRenderRow[] {
+  const result: ChatRenderRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== "gap") {
+      result.push(row);
+      continue;
+    }
+
+    // Resolve unknown trailing gap count against fetched file length
+    const gap = resolveGapLineCount(row.gap, fileLines);
+    if (!gap) continue;
+    const resolvedRow: ChatDiffRow = gap === row.gap ? row : { ...row, gap };
+
+    const state = gapStates.get(row.gapIndex);
+    if (!fileLines || !state || gap.lineCount <= 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    const totalGapLines = gap.lineCount;
+    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+    if (top === 0 && bottom === 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    for (let i = 0; i < top; i++) {
+      result.push({
+        kind: "expanded-gap-line",
+        key: `${row.key}-top-${i}`,
+        line: makeGapContextLine(fileLines, gap, i),
+      });
+    }
+
+    if (!fullyExpanded) {
+      const residualGap: InterHunkGap = {
+        kind: "gap",
+        oldStartLine: gap.oldStartLine + top,
+        newStartLine: gap.newStartLine + top,
+        lineCount: totalGapLines - top - bottom,
+      };
+      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
+    }
+
+    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
+      result.push({
+        kind: "expanded-gap-line",
+        key: `${row.key}-bottom-${i}`,
+        line: makeGapContextLine(fileLines, gap, i),
+      });
+    }
+  }
+  return result;
+}
+
+export function flattenSplitWithGapExpansion(
+  rows: SplitDiffRow[],
+  gapStates: Map<number, GapExpansionState>,
+  fileLines: string[] | undefined,
+): SplitRenderRow[] {
+  const result: SplitRenderRow[] = [];
+  for (const row of rows) {
+    if (row.kind !== "gap") {
+      result.push(row);
+      continue;
+    }
+
+    // Resolve unknown trailing gap count against fetched file length
+    const gap = resolveGapLineCount(row.gap, fileLines);
+    if (!gap) continue;
+    const resolvedRow: SplitDiffRow = gap === row.gap ? row : { ...row, gap };
+
+    const state = gapStates.get(row.gapIndex);
+    if (!fileLines || !state || gap.lineCount <= 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    const totalGapLines = gap.lineCount;
+    const { top, bottom, fullyExpanded } = clampGapReveal(state, totalGapLines);
+    if (top === 0 && bottom === 0) {
+      result.push(resolvedRow);
+      continue;
+    }
+
+    for (let i = 0; i < top; i++) {
+      const line = makeGapContextLine(fileLines, gap, i);
+      result.push({ kind: "expanded-gap-line", key: `${row.key}-top-${i}`, oldLine: line, newLine: line });
+    }
+
+    if (!fullyExpanded) {
+      const residualGap: InterHunkGap = {
+        kind: "gap",
+        oldStartLine: gap.oldStartLine + top,
+        newStartLine: gap.newStartLine + top,
+        lineCount: totalGapLines - top - bottom,
+      };
+      result.push({ kind: "gap", key: `${row.key}-residual`, gap: residualGap, gapIndex: row.gapIndex });
+    }
+
+    for (let i = totalGapLines - bottom; i < totalGapLines; i++) {
+      const line = makeGapContextLine(fileLines, gap, i);
+      result.push({ kind: "expanded-gap-line", key: `${row.key}-bottom-${i}`, oldLine: line, newLine: line });
+    }
+  }
+  return result;
+}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -28,12 +28,11 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1103 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
-cloud/sdk/src/types/generated.ts 773 existing generated cloud SDK type surface (+billing budget-limit/usage types)
+cloud/sdk/src/types/generated.ts 776 existing generated cloud SDK type surface (+git numstat line-count fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
-apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 631 existing desktop diff viewer component (+unified-search highlight rows, growth recorded in debt repair)
-apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 540 existing desktop split diff viewer component
+apps/desktop/src/components/content/ui/diff/ChatDiffViewer.tsx 550 existing desktop diff viewer component (gap-expansion flattening extracted to diff-gap-flatten)
 apps/desktop/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 908 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock + ProductHost test-host wiring
 apps/desktop/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/desktop/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file


### PR DESCRIPTION
## Summary

PR #1214 left main's repo-shape check red on the max-lines ratchet. This clears it structurally rather than by bumping allowlists:

- Extract the (identical-modulo-row-shape) gap-expansion flattening helpers out of `ChatDiffViewer`/`SplitDiffViewer` into `hooks/ui/diff/diff-gap-flatten.ts`. ChatDiffViewer 633→550 (allowlist ratcheted 631→550), SplitDiffViewer 542→466 (entry removed).
- Extract `GitReviewFileSectionShell` from `GitReviewFileRow` (555→387).
- Remove the stale commit split button from the git review playground mock (507→472) — the shipped pane dropped it.
- Allowlist the generated cloud SDK types at 776 (grew with the numstat line-count fields; generated file).

## Verification
- `check_max_lines.py` + the other three repo-shape scripts green locally.
- Desktop typecheck clean; git-pane + diff-viewer + playground vitest suites run (only the 3 pre-existing `playground.test.ts` failures from main remain, untouched by this diff).
- Pure code motion — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)