### PR TITLE
fix: clear repo-shape debt hidden behind the max-lines failure

### DIFF
--- a/apps/desktop/src/components/playground/GitReviewV2Playground.tsx
+++ b/apps/desktop/src/components/playground/GitReviewV2Playground.tsx
@@ -14,6 +14,7 @@ import {
   FolderTree,
   MoreHorizontal,
 } from "@proliferate/ui/icons";
+import { PaneIconButton } from "@proliferate/ui/layout/PaneIconButton";
 import { DiffViewer } from "@/components/content/ui/DiffViewer";
 import { FileChangeStats } from "@/components/content/ui/FileChangeStats";
 import { FileTreeEntryIcon } from "@/components/workspace/files/file-icons";
@@ -254,9 +255,9 @@ function ReviewHeader({
             align="end"
             className={`w-72 ${POPOVER_SURFACE_CLASS}`}
             trigger={
-              <HeaderIconButton label="Jump to file">
+              <PaneIconButton label="Jump to file">
                 <FolderTree className="size-3.5" />
-              </HeaderIconButton>
+              </PaneIconButton>
             }
           >
             {(close) => (
@@ -292,7 +293,7 @@ function ReviewHeader({
               </div>
             )}
           </PopoverButton>
-          <HeaderIconButton
+          <PaneIconButton
             label={allCollapsed ? "Expand all diffs" : "Collapse all diffs"}
             onClick={onToggleAll}
           >
@@ -301,41 +302,13 @@ function ReviewHeader({
             ) : (
               <CollapseAll className="size-3.5" />
             )}
-          </HeaderIconButton>
-          <HeaderIconButton label="Review options">
+          </PaneIconButton>
+          <PaneIconButton label="Review options">
             <MoreHorizontal className="size-3.5" />
-          </HeaderIconButton>
+          </PaneIconButton>
         </div>
       </div>
     </div>
-  );
-}
-
-function HeaderIconButton({
-  label,
-  onClick,
-  children,
-  ref,
-}: {
-  label: string;
-  onClick?: () => void;
-  children: React.ReactNode;
-  // Forwarded so PopoverButton triggers can anchor to the underlying element.
-  ref?: React.Ref<HTMLButtonElement>;
-}) {
-  return (
-    <Button
-      ref={ref}
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label={label}
-      title={label}
-      onClick={onClick}
-      className="size-6 rounded-md text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
-    >
-      {children}
-    </Button>
   );
 }
 

--- a/apps/desktop/src/hooks/workspaces/workflows/use-workspace-publish-workflow.ts
+++ b/apps/desktop/src/hooks/workspaces/workflows/use-workspace-publish-workflow.ts
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CreatePullRequestResponse } from "@anyharness/sdk";
 import {
-  getAnyHarnessClient,
-  resolveWorkspaceConnectionFromContext,
   useAnyHarnessWorkspaceContext,
   useCommitGitMutation,
   useCreatePullRequestMutation,
@@ -26,6 +24,7 @@ import type {
   PublishPullRequestDraft,
 } from "@/lib/domain/workspaces/creation/publish-workflow-model";
 import { persistedSnapshotFromPullRequestSummary } from "@/lib/domain/workspaces/git-status/workspace-git-status-snapshots";
+import { fetchGitDiffPatches } from "@/lib/access/anyharness/git-diff-patches";
 import { runWorkspacePublishWorkflow } from "@/lib/workflows/workspaces/run-workspace-publish-workflow";
 import { useRefreshPrStatuses } from "@/hooks/workspaces/cache/use-pr-status-refresh";
 import { useLogicalWorkspaces } from "@/hooks/workspaces/derived/use-logical-workspaces";
@@ -174,23 +173,15 @@ export function useWorkspacePublishWorkflow({
       const needsGeneratedMessage = !commitDraft.summary.trim()
         && workflowSteps.some((step) => step.kind === "commit");
       if (needsGeneratedMessage && workspaceId) {
-        const resolved = await resolveWorkspaceConnectionFromContext(
-          anyHarnessWorkspace,
-          workspaceId,
-        );
-        const client = getAnyHarnessClient(resolved.connection);
         const targets = commitDiffTargets({
           fileGroups: viewState.fileGroups,
           includeUnstaged: commitDraft.includeUnstaged,
         });
-        const patches = await Promise.all(targets.map(async (target) => {
-          const diff = await client.git.getDiff(
-            resolved.connection.anyharnessWorkspaceId,
-            target.path,
-            { scope: target.scope },
-          );
-          return { path: target.path, patch: diff.patch ?? null, binary: diff.binary };
-        }));
+        const patches = await fetchGitDiffPatches(
+          anyHarnessWorkspace,
+          workspaceId,
+          targets,
+        );
         const diffText = assembleCommitDiffText(patches);
         if (!diffText) {
           throw new Error("Nothing to describe: the pending diff is empty.");

--- a/apps/desktop/src/lib/access/anyharness/git-diff-patches.ts
+++ b/apps/desktop/src/lib/access/anyharness/git-diff-patches.ts
@@ -1,0 +1,36 @@
+import {
+  getAnyHarnessClient,
+  resolveWorkspaceConnectionFromContext,
+} from "@anyharness/sdk-react";
+import type { CommitDiffTarget } from "@/lib/domain/workspaces/creation/commit-message-generation";
+
+export interface GitDiffPatch {
+  path: string;
+  patch: string | null;
+  binary: boolean;
+}
+
+/**
+ * Fetches the raw per-file patches for a set of commit diff targets, resolving
+ * the workspace connection from the AnyHarness context. Used by the publish
+ * workflow's leave-blank-to-generate commit-message path.
+ */
+export async function fetchGitDiffPatches(
+  anyHarnessWorkspace: Parameters<typeof resolveWorkspaceConnectionFromContext>[0],
+  workspaceId: string,
+  targets: readonly CommitDiffTarget[],
+): Promise<GitDiffPatch[]> {
+  const resolved = await resolveWorkspaceConnectionFromContext(
+    anyHarnessWorkspace,
+    workspaceId,
+  );
+  const client = getAnyHarnessClient(resolved.connection);
+  return Promise.all(targets.map(async (target) => {
+    const diff = await client.git.getDiff(
+      resolved.connection.anyharnessWorkspaceId,
+      target.path,
+      { scope: target.scope },
+    );
+    return { path: target.path, patch: diff.patch ?? null, binary: diff.binary };
+  }));
+}

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -18,8 +18,6 @@
 # max-lines entries.
 
 apps/desktop/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
-apps/desktop/src/components/workspace/git/GitPanel.tsx 429 git panel pending staged/unstaged section split
-apps/desktop/src/components/workspace/git/GitReviewFileRow.tsx 404 git review file row pending action-cluster split
 apps/desktop/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 414 workspace sidebar item pending indicator/menu split
 apps/desktop/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-domain/src/chats/transcript/transcript-row-model.ts 946 transcript row model pending row-kind module split
@@ -29,3 +27,7 @@ apps/desktop/src/hooks/sessions/workflows/use-session-creation-actions.ts 406 pr
 apps/desktop/src/components/playground/WorkspaceStatusPlayground.tsx 450 status-card playground fixtures pending scenario-module split (#1202 debt repair)
 apps/desktop/src/lib/domain/preferences/appearance.ts 437 appearance preset model pending preset-catalog split (#1202 growth recorded in debt repair)
 apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx 416 virtualized transcript list pending row-window split (recorded in debt repair)
+apps/desktop/src/components/content/ui/diff/SplitDiffViewer.tsx 465 split diff viewer pending cell-renderer split (gap flattening already extracted)
+apps/desktop/src/components/playground/GitReviewV2Playground.tsx 445 git review playground fixtures pending scenario-module split
+apps/desktop/src/components/workspace/chat/input/ChatInput.tsx 401 composer input growth from workspace-status card wiring (#1210 debt repair)
+apps/desktop/src/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl.tsx 463 workspace-status composer control pending section split (#1210 debt repair)

--- a/server/proliferate/server/ai_magic/api.py
+++ b/server/proliferate/server/ai_magic/api.py
@@ -4,10 +4,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
-from proliferate.constants.cloud import GitProvider
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
-from proliferate.db.store.repositories import get_repo_config_for_user
 from proliferate.server.ai_magic.models import (
     GenerateCommitMessageRequest,
     GenerateCommitMessageResponse,
@@ -20,6 +18,7 @@ from proliferate.server.ai_magic.service import (
     generate_commit_message,
     generate_session_title,
     generate_workspace_name,
+    resolve_commit_instructions,
 )
 
 router = APIRouter(prefix="/ai_magic", tags=["ai_magic"])
@@ -49,17 +48,12 @@ async def generate_commit_message_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
 ) -> GenerateCommitMessageResponse:
-    instructions: str | None = None
-    if body.git_owner and body.git_repo_name:
-        repo_config = await get_repo_config_for_user(
-            db,
-            user_id=user.id,
-            git_provider=GitProvider.github.value,
-            git_owner=body.git_owner,
-            git_repo_name=body.git_repo_name,
-        )
-        if repo_config is not None:
-            instructions = repo_config.commit_instructions
+    instructions = await resolve_commit_instructions(
+        db,
+        user_id=user.id,
+        git_owner=body.git_owner,
+        git_repo_name=body.git_repo_name,
+    )
 
     message = await generate_commit_message(
         user.id,

--- a/server/proliferate/server/ai_magic/service.py
+++ b/server/proliferate/server/ai_magic/service.py
@@ -6,7 +6,11 @@ from threading import Lock
 from time import monotonic
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from proliferate.config import settings
+from proliferate.constants.cloud import GitProvider
+from proliferate.db.store.repositories import get_repo_config_for_user
 from proliferate.constants.ai_magic import (
     COMMIT_MESSAGE_MAX_DIFF_CHARS,
     COMMIT_MESSAGE_MAX_MESSAGE_CHARS,
@@ -246,3 +250,25 @@ async def generate_commit_message(
             message="Generated commit message was empty.",
         )
     return message
+
+
+async def resolve_commit_instructions(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_owner: str | None,
+    git_repo_name: str | None,
+) -> str | None:
+    """Per-repo commit instructions for the user's repo config, if any."""
+    if not git_owner or not git_repo_name:
+        return None
+    repo_config = await get_repo_config_for_user(
+        db,
+        user_id=user_id,
+        git_provider=GitProvider.github.value,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+    )
+    if repo_config is None:
+        return None
+    return repo_config.commit_instructions


### PR DESCRIPTION
## Summary

Main's repo-shape job fails steps in order, so while max-lines was red (fixed in #1217) the boundary/structure/docs steps never ran. They were also red. This clears the remainder:

- **Frontend boundary**: the publish workflow's leave-blank-to-generate path called `getAnyHarnessClient` directly from `use-workspace-publish-workflow.ts` (came in with #1210). The diff fetch now lives in `lib/access/anyharness/git-diff-patches.ts` behind the access boundary; the hook calls `fetchGitDiffPatches`. Behavior unchanged.
- **Server boundary**: `ai_magic/api.py` imported `db.store.repositories` for the repo-config commit-instructions lookup (also #1210). Moved into `service.resolve_commit_instructions`; the endpoint passes the session through. Behavior unchanged.
- **Frontend structure drift**: the git review playground defined a local `HeaderIconButton` primitive — swapped for the shared `PaneIconButton`; removed stale large-file allowlist entries for `GitPanel` (344 ≤ 400) and `GitReviewFileRow` (387 ≤ 400); recorded current debt for `SplitDiffViewer` (465), the git review playground (445), `ChatInput` (401), and `WorkspaceStatusComposerControl` (463).

## Verification
- All nine repo-shape steps pass locally, including the previously skipped frontend-structure, server-boundary, anyharness-boundary, and docs-integrity steps.
- Desktop typecheck clean; git-pane + workspace-hook vitest suites run (only pre-existing main failures remain: `workspace-bootstrap-empty-session`, playground scenarios).
- `proliferate.server.ai_magic.{api,service}` import cleanly with the new function in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)