### PR TITLE
fix(anyharness): restore Sentry error-event emission in runtime daemon (B2 amendment)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
  "file-rotate",
  "sentry",
  "sentry-anyhow",
- "sentry-tracing 0.47.0",
+ "sentry-tracing",
  "serde_json",
  "tokio",
  "tower",
@@ -1447,7 +1447,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1678,7 +1678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3345,7 +3345,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4283,7 +4283,7 @@ dependencies = [
  "rfd 0.15.4",
  "rusqlite",
  "sentry",
- "sentry-tracing 0.47.0",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sha2",
@@ -4327,7 +4327,7 @@ dependencies = [
  "clap",
  "sentry",
  "sentry-anyhow",
- "sentry-tracing 0.47.0",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sha2",
@@ -4350,7 +4350,7 @@ dependencies = [
  "rusqlite",
  "sentry",
  "sentry-anyhow",
- "sentry-tracing 0.47.0",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sha2",
@@ -4438,7 +4438,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4870,7 +4870,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4929,7 +4929,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5134,106 +5134,82 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
+checksum = "d631477761f57c76148456e55e80e9a479ff3fa4c65b2b4a0c3acf1167fd4638"
 dependencies = [
  "cfg_aliases 0.2.1",
  "httpdate",
  "reqwest 0.13.2",
  "rustls",
  "sentry-actix",
- "sentry-backtrace 0.48.2",
+ "sentry-backtrace",
  "sentry-contexts",
- "sentry-core 0.48.2",
+ "sentry-core",
  "sentry-debug-images",
  "sentry-panic",
- "sentry-tracing 0.48.2",
+ "sentry-tracing",
  "tokio",
  "ureq",
 ]
 
 [[package]]
 name = "sentry-actix"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffb8fd78b8f4527146013ab52293e03242770a31dcd97eee4b82b7f770ffab3"
+checksum = "119ede4e37790ec04e8a14073c8414f0a4b2648402856c0563495a9a5cf54d57"
 dependencies = [
  "actix-http",
  "actix-web",
  "bytes",
  "futures-util",
- "sentry-core 0.48.2",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.47.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15257eeba11d42eb0d6893fed26033504b031abaef3b3809343e4967f476502"
+checksum = "d8f73466a403f4da78c7e576049d6044b31d2b16dfcc26b51705f318ed74b804"
 dependencies = [
  "anyhow",
- "sentry-backtrace 0.47.0",
- "sentry-core 0.47.0",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.47.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+checksum = "448b0981fbde6cdc9eb087ba3dc01035a253fef9a0d9e79aaf198fc26acb2e64"
 dependencies = [
  "backtrace",
  "regex",
- "sentry-core 0.47.0",
-]
-
-[[package]]
-name = "sentry-backtrace"
-version = "0.48.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
-dependencies = [
- "backtrace",
- "regex",
- "sentry-core 0.48.2",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
+checksum = "9e5e909d02170ba6d1dc5ebd05bef7999280f5d960e3eaee5d1a18d88d41b334"
 dependencies = [
  "hostname",
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core 0.48.2",
+ "sentry-core",
  "uname",
 ]
 
 [[package]]
 name = "sentry-core"
-version = "0.47.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
 dependencies = [
  "rand 0.9.4",
- "sentry-types 0.47.0",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.48.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
-dependencies = [
- "rand 0.9.4",
- "sentry-types 0.48.2",
+ "sentry-types",
  "serde",
  "serde_json",
  "url",
@@ -5241,71 +5217,42 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660e9def38a573a869a182f7e90f58aaaa460f38b92b31fd1755ec537193bb48"
+checksum = "f81d7749c57fc78ed52134889e8121da874065bc40da788d5798cce0f8c19f15"
 dependencies = [
  "findshlibs",
- "sentry-core 0.48.2",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
+checksum = "0b7d93d6ecb55d2251c5fc084c55c03a2bc68904918d76117e602c999e92f00f"
 dependencies = [
- "sentry-backtrace 0.48.2",
- "sentry-core 0.48.2",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-tracing"
-version = "0.47.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+checksum = "58d26379236c4ef97eaf081bca3c7bf0ef6f06b3aa881eca2ee8e8dbc923e5b8"
 dependencies = [
  "bitflags 2.11.0",
- "sentry-core 0.47.0",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sentry-tracing"
-version = "0.48.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
-dependencies = [
- "bitflags 2.11.0",
- "sentry-backtrace 0.48.2",
- "sentry-core 0.48.2",
+ "sentry-backtrace",
+ "sentry-core",
  "tracing-core",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "sentry-types"
-version = "0.47.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.48.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
+checksum = "2239099d47e76857b0825a182ecdb90159add7aa1097b60247c6e7ca6bf49c6a"
 dependencies = [
  "debugid",
  "hex",
@@ -6427,7 +6374,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7596,7 +7543,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2.4"
 file-rotate = "0.8.0"
 sentry = { version = "0.48.2", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "release-health", "reqwest", "rustls"] }
-sentry-anyhow = "0.47.0"
-sentry-tracing = { version = "0.47.0", features = ["logs"] }
+# sentry-anyhow / sentry-tracing MUST stay on the same minor as `sentry`:
+# a version split links two `sentry-core` instances, the tracing layer then
+# captures into a clientless Hub, and every runtime ERROR event is silently
+# dropped (production incident 2026-06-14 -> 2026-07-15, B2 amendment). The
+# `tracing_error_reaches_the_sentry_client` tests fail on any new divergence.
+sentry-anyhow = "0.48.2"
+sentry-tracing = { version = "0.48.2", features = ["logs"] }
 
 # Error handling
 thiserror = "2"

--- a/anyharness/crates/anyharness/Cargo.toml
+++ b/anyharness/crates/anyharness/Cargo.toml
@@ -25,3 +25,6 @@ tower-http.workspace = true
 sentry.workspace = true
 sentry-anyhow.workspace = true
 sentry-tracing.workspace = true
+
+[dev-dependencies]
+sentry = { workspace = true, features = ["test"] }

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -208,6 +208,26 @@ mod tests {
     };
 
     #[test]
+    fn tracing_error_reaches_the_sentry_client() {
+        // Regression (B2 amendment): PR #684 bumped `sentry` to 0.48 while
+        // `sentry-tracing` stayed at 0.47, linking two `sentry-core` instances.
+        // The tracing layer then captured events into the 0.47 Hub — which has
+        // no client — so every runtime ERROR event was silently dropped in
+        // production from 2026-06-14. This test binds a test client to the same
+        // `sentry-core` the layer uses; it fails (0 events) whenever the two
+        // crates diverge again.
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry().with(sentry_tracing::layer());
+        let events = sentry::test::with_captured_events(|| {
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::error!("sentry emission regression probe");
+            });
+        });
+        assert_eq!(events.len(), 1, "tracing ERROR must reach the Sentry client");
+        assert_eq!(events[0].level, sentry::Level::Error);
+    }
+
+    #[test]
     fn sentry_scope_tags_include_runtime_surface_and_mode() {
         let tags = sentry_scope_tags();
         assert!(tags.iter().any(|(k, v)| *k == "surface" && v == "anyharness_runtime"));

--- a/anyharness/crates/proliferate-supervisor/Cargo.toml
+++ b/anyharness/crates/proliferate-supervisor/Cargo.toml
@@ -23,3 +23,6 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+sentry = { workspace = true, features = ["test"] }

--- a/anyharness/crates/proliferate-supervisor/src/logging.rs
+++ b/anyharness/crates/proliferate-supervisor/src/logging.rs
@@ -487,6 +487,23 @@ mod tests {
     }
 
     #[test]
+    fn tracing_error_reaches_the_sentry_client() {
+        // Regression (B2 amendment): a `sentry` / `sentry-tracing` version split
+        // links two `sentry-core` instances, so the tracing layer captures into
+        // a clientless Hub and every ERROR event is silently dropped (observed
+        // live in production from 2026-06-14). Fails with 0 events on any
+        // future divergence.
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry().with(sentry_tracing::layer());
+        let events = sentry::test::with_captured_events(|| {
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::error!("sentry emission regression probe");
+            });
+        });
+        assert_eq!(events.len(), 1, "tracing ERROR must reach the Sentry client");
+    }
+
+    #[test]
     fn runtime_env_tag_survives_while_other_env_tags_are_redacted() {
         let mut event = Event::new();
         event.tags.insert("runtime_env".to_string(), "e2b".to_string());

--- a/anyharness/crates/proliferate-worker/Cargo.toml
+++ b/anyharness/crates/proliferate-worker/Cargo.toml
@@ -27,3 +27,6 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+sentry = { workspace = true, features = ["test"] }

--- a/anyharness/crates/proliferate-worker/src/logging.rs
+++ b/anyharness/crates/proliferate-worker/src/logging.rs
@@ -486,6 +486,23 @@ mod tests {
     }
 
     #[test]
+    fn tracing_error_reaches_the_sentry_client() {
+        // Regression (B2 amendment): a `sentry` / `sentry-tracing` version split
+        // links two `sentry-core` instances, so the tracing layer captures into
+        // a clientless Hub and every ERROR event is silently dropped (observed
+        // live in production from 2026-06-14). Fails with 0 events on any
+        // future divergence.
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry().with(sentry_tracing::layer());
+        let events = sentry::test::with_captured_events(|| {
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::error!("sentry emission regression probe");
+            });
+        });
+        assert_eq!(events.len(), 1, "tracing ERROR must reach the Sentry client");
+    }
+
+    #[test]
     fn runtime_env_tag_survives_while_other_env_tags_are_redacted() {
         let mut event = Event::new();
         event.tags.insert("runtime_env".to_string(), "e2b".to_string());

--- a/specs/codebase/systems/engineering/observability/sentry.md
+++ b/specs/codebase/systems/engineering/observability/sentry.md
@@ -142,6 +142,15 @@ following up with reporters. Observability does not own tracker state.
   success condition.
 - Local file or structured logs remain the primary fallback when Sentry is
   absent or unavailable.
+- The Rust workspace's `sentry`, `sentry-anyhow`, and `sentry-tracing`
+  dependencies must resolve to a single `sentry-core` instance. A version
+  split links two `sentry-core` crates, the tracing layer then captures into a
+  clientless Hub, and every runtime ERROR event is silently dropped while
+  local logs still show the error (production incident 2026-06-14 to
+  2026-07-15: a `sentry`-only bump left `sentry-tracing` behind; discovered by
+  slice C's canary against the B2-deployed runtime and repaired as a B2
+  amendment). The `tracing_error_reaches_the_sentry_client` tests in
+  AnyHarness, Worker, and Supervisor fail on any new divergence.
 
 Use the [Sentry operating procedure](../../../../developing/operating/analytics/sentry.md)
 to discover current provider state and verify delivery without exposing


### PR DESCRIPTION
## B2 amendment — runtime Sentry error events silently dropped since 2026-06-14

**Trigger:** slice C's canary against the B2-deployed production runtime (`sha-22b6a211e28c`): a real gateway spawn error traversed `processes.rs::run_command` → `ApiError::internal`, appeared in the daemon log, but produced **no Sentry event** — with a valid DSN, reachable ingest (curl 200), correct identity env, and a manual envelope to the same DSN landing. Sentry group `7545173933` lastSeen `2026-06-14`. Evidence: C's `c-sentry-activation.json` receipt + ledger row.

**Root cause (dependency split, exact date match):** PR #684 (merged 2026-06-14) bumped `sentry` 0.47.0 → 0.48.2 but left `sentry-anyhow`/`sentry-tracing` at 0.47.0. Cargo linked **two `sentry-core` instances**: `sentry::init` bound the client to the 0.48 Hub, while the 0.47 `sentry_tracing::layer()` captured ERROR events into the clientless 0.47 Hub — dropped without a trace. Panic/manual paths (0.48) kept working, which masked the outage. All four Rust emitters affected (anyharness, worker, supervisor, desktop-native).

**Fix (minimal):**
- Root `Cargo.toml`: `sentry-anyhow`/`sentry-tracing` aligned with `sentry`. All resolve to 0.48.5 — `sentry 0.48.2` does not compile against `sentry-types 0.48.5` (upstream changed `Envelope::filter` in a patch release), so the whole family is updated together; `Cargo.lock` now carries exactly **one** `sentry-core`.
- Regression tests `tracing_error_reaches_the_sentry_client` in AnyHarness/Worker/Supervisor: binds a `sentry::test` client on the same `sentry-core` the layer uses and asserts the ERROR event arrives. **Verified failing (0 events) on unfixed main** — that failing run is the reproduction — and green after the alignment.
- Invariant recorded in `specs/codebase/systems/engineering/observability/sentry.md` (the frozen B2/B1 contracts were retired from the tree by #1207 per precedent, so the system doc is the durable home).

**Verification:** `cargo test -p anyharness` 18 passed · `-p proliferate-worker` 12 passed · `-p proliferate-supervisor` 52 passed · `cargo check --workspace` clean · `check_docs` (209 files) + `check_max_lines` pass.

**Deploy plan (blocked on review):** after approval — template rebuild → smoke (`--expected-version`/`--expected-sha`) → staging → production via the proven B2 lane, then hand the fixed runtime to C for canary steps 7–9. No deploy until reviews clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
