### PR TITLE
fix(desktop): composer per-model control gating, arrow-key nav, and chat input polish

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ApprovalCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ApprovalCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { ComposerAttachedPanel } from "#product/components/workspace/chat/input/ComposerAttachedPanel";
 import {
   ComposerOptionRow,
+  useComposerOptionArrowKeys,
   useComposerOptionNumberKeys,
 } from "#product/components/workspace/chat/input/ComposerOptionRow";
 import { useActivePendingApproval } from "#product/hooks/chat/derived/use-active-pending-session-interactions";
@@ -67,6 +68,12 @@ export function ApprovalCard({
   useComposerOptionNumberKeys(options.length, (index) => {
     options[index]?.onSelect();
   });
+  const { highlightedIndex, highlight } = useComposerOptionArrowKeys(
+    options.length,
+    (index) => {
+      options[index]?.onSelect();
+    },
+  );
 
   return (
     <ComposerAttachedPanel title="Permission request">
@@ -81,6 +88,8 @@ export function ApprovalCard({
               index={index}
               label={option.label}
               destructive={option.destructive}
+              highlighted={highlightedIndex === index}
+              onHover={() => highlight(index)}
               onSelect={option.onSelect}
             />
           ))}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFastModeToggle.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFastModeToggle.tsx
@@ -22,34 +22,46 @@ export function ComposerFastModeToggle({ control }: ComposerFastModeToggleProps)
     selectedOption?.description,
   );
 
-  return (
-    <Tooltip content={tooltip}>
-      <ComposerControlButton
-        iconOnly
-        disabled={!control.settable || !nextValue}
-        active={!!control.isEnabled}
-        className={control.isEnabled ? "bg-[var(--color-composer-control-hover)]" : ""}
-        icon={
-          <Zap
-            className={`size-3.5 transition-[color,fill,opacity] ${
-              control.isEnabled
-                ? "fill-current stroke-none opacity-100"
-                : "fill-none stroke-current stroke-[1.5] text-[color:var(--color-composer-control-muted-foreground)] opacity-100"
-            }`}
-          />
+  // The pending indicator renders as a sibling, never inside the fixed-width
+  // icon-only button: a trailing node in that box fights `justify-center` and
+  // visibly shoves the zap glyph sideways while a change is queued (the
+  // reasoning bars already follow this sibling pattern).
+  const toggle = (
+    <ComposerControlButton
+      iconOnly
+      disabled={!control.settable || !nextValue}
+      active={!!control.isEnabled}
+      className={control.isEnabled ? "bg-[var(--color-composer-control-hover)]" : ""}
+      icon={
+        <Zap
+          className={`size-3.5 transition-[color,fill,opacity] ${
+            control.isEnabled
+              ? "fill-current stroke-none opacity-100"
+              : "fill-none stroke-current stroke-[1.5] text-[color:var(--color-composer-control-muted-foreground)] opacity-100"
+          }`}
+        />
+      }
+      label="Fast"
+      aria-label={tooltip}
+      title={tooltip}
+      onClick={() => {
+        if (nextValue) {
+          control.onSelect(nextValue);
         }
-        label="Fast"
-        trailing={control.pendingState
-          ? <PendingConfigIndicator pendingState={control.pendingState} />
-          : null}
-        aria-label={tooltip}
-        title={tooltip}
-        onClick={() => {
-          if (nextValue) {
-            control.onSelect(nextValue);
-          }
-        }}
-      />
-    </Tooltip>
+      }}
+    />
   );
+
+  if (control.pendingState) {
+    return (
+      <Tooltip content={tooltip}>
+        <span className="inline-flex items-center gap-1">
+          {toggle}
+          <PendingConfigIndicator pendingState={control.pendingState} />
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return <Tooltip content={tooltip}>{toggle}</Tooltip>;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
 import { buildSettingsHref } from "#product/lib/domain/settings/navigation";
@@ -25,6 +18,10 @@ import { ProviderIcon } from "@proliferate/ui/provider-icons";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { ComposerPopoverSurface } from "@proliferate/product-ui/chat/composer/ComposerPopoverSurface";
 import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
+import {
+  modelRowKey,
+  useModelPickerKeyboardNav,
+} from "#product/hooks/chat/ui/use-model-picker-keyboard-nav";
 
 interface ComposerModelSelectorControlProps {
   modelSelectorProps: ModelSelectorProps;
@@ -157,99 +154,12 @@ function ComposerModelPickerPopover({
       .filter((group): group is ModelSelectorGroup => group !== null);
   }, [orderedGroups, search]);
 
-  // Keyboard navigation: focus stays in the search field; ArrowUp/ArrowDown
-  // move a roving highlight over the flattened model rows and Enter selects
-  // it (mirrors the slash-command menu's single-focus-owner pattern). Rows are
-  // keyed `${kind}:${modelId}` so the highlight survives refiltering.
-  const flatModelKeys = useMemo(
-    () => filteredGroups.flatMap((group) =>
-      group.models.map((model) => modelRowKey(group.kind, model.modelId))
-    ),
-    [filteredGroups],
-  );
-  const selectionByKey = useMemo(() => {
-    const byKey = new Map<string, ModelSelectorSelection>();
-    for (const group of filteredGroups) {
-      for (const model of group.models) {
-        byKey.set(modelRowKey(group.kind, model.modelId), {
-          kind: group.kind,
-          modelId: model.modelId,
-        });
-      }
-    }
-    return byKey;
-  }, [filteredGroups]);
-  const initialHighlightKey = useMemo(() => {
-    for (const group of filteredGroups) {
-      const selected = group.models.find((model) => model.isSelected);
-      if (selected) {
-        return modelRowKey(group.kind, selected.modelId);
-      }
-    }
-    return flatModelKeys[0] ?? null;
-  }, [filteredGroups, flatModelKeys]);
-  const [highlightedKey, setHighlightedKey] = useState<string | null>(initialHighlightKey);
-  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
-  const effectiveHighlightedKey =
-    highlightedKey && flatModelKeys.includes(highlightedKey)
-      ? highlightedKey
-      : initialHighlightKey;
-
-  const setRowRef = useCallback((key: string, element: HTMLButtonElement | null) => {
-    if (element) {
-      rowRefs.current.set(key, element);
-    } else {
-      rowRefs.current.delete(key);
-    }
-  }, []);
-
-  const moveHighlight = useCallback((delta: number) => {
-    if (flatModelKeys.length === 0) {
-      return;
-    }
-    const currentIndex = effectiveHighlightedKey
-      ? flatModelKeys.indexOf(effectiveHighlightedKey)
-      : -1;
-    const nextIndex = Math.min(
-      flatModelKeys.length - 1,
-      Math.max(0, (currentIndex < 0 ? (delta > 0 ? -1 : 0) : currentIndex) + delta),
-    );
-    const nextKey = flatModelKeys[nextIndex];
-    if (nextKey !== undefined) {
-      setHighlightedKey(nextKey);
-      rowRefs.current.get(nextKey)?.scrollIntoView({ block: "nearest" });
-    }
-  }, [effectiveHighlightedKey, flatModelKeys]);
-
-  // Refiltering can leave the effective highlight on a row that just scrolled
-  // out of the visible window; keep it in view.
-  useEffect(() => {
-    if (effectiveHighlightedKey) {
-      rowRefs.current.get(effectiveHighlightedKey)?.scrollIntoView({ block: "nearest" });
-    }
-  }, [effectiveHighlightedKey]);
-
-  const handleSearchKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      moveHighlight(1);
-      return;
-    }
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      moveHighlight(-1);
-      return;
-    }
-    if (event.key === "Enter") {
-      event.preventDefault();
-      const selection = effectiveHighlightedKey
-        ? selectionByKey.get(effectiveHighlightedKey)
-        : undefined;
-      if (selection) {
-        onSelect(selection);
-      }
-    }
-  }, [effectiveHighlightedKey, moveHighlight, onSelect, selectionByKey]);
+  const {
+    highlightedKey: effectiveHighlightedKey,
+    setHighlightedKey,
+    setRowRef,
+    handleSearchKeyDown,
+  } = useModelPickerKeyboardNav(filteredGroups, onSelect);
 
   return (
     <ComposerPopoverSurface className="flex w-72 flex-col p-0">
@@ -308,10 +218,6 @@ function ComposerModelPickerPopover({
       </div>
     </ComposerPopoverSurface>
   );
-}
-
-function modelRowKey(kind: string, modelId: string): string {
-  return `${kind}:${modelId}`;
 }
 
 function ModelPickerGroup({

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { useNavigate } from "react-router-dom";
 import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
 import { buildSettingsHref } from "#product/lib/domain/settings/navigation";
@@ -150,6 +157,100 @@ function ComposerModelPickerPopover({
       .filter((group): group is ModelSelectorGroup => group !== null);
   }, [orderedGroups, search]);
 
+  // Keyboard navigation: focus stays in the search field; ArrowUp/ArrowDown
+  // move a roving highlight over the flattened model rows and Enter selects
+  // it (mirrors the slash-command menu's single-focus-owner pattern). Rows are
+  // keyed `${kind}:${modelId}` so the highlight survives refiltering.
+  const flatModelKeys = useMemo(
+    () => filteredGroups.flatMap((group) =>
+      group.models.map((model) => modelRowKey(group.kind, model.modelId))
+    ),
+    [filteredGroups],
+  );
+  const selectionByKey = useMemo(() => {
+    const byKey = new Map<string, ModelSelectorSelection>();
+    for (const group of filteredGroups) {
+      for (const model of group.models) {
+        byKey.set(modelRowKey(group.kind, model.modelId), {
+          kind: group.kind,
+          modelId: model.modelId,
+        });
+      }
+    }
+    return byKey;
+  }, [filteredGroups]);
+  const initialHighlightKey = useMemo(() => {
+    for (const group of filteredGroups) {
+      const selected = group.models.find((model) => model.isSelected);
+      if (selected) {
+        return modelRowKey(group.kind, selected.modelId);
+      }
+    }
+    return flatModelKeys[0] ?? null;
+  }, [filteredGroups, flatModelKeys]);
+  const [highlightedKey, setHighlightedKey] = useState<string | null>(initialHighlightKey);
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const effectiveHighlightedKey =
+    highlightedKey && flatModelKeys.includes(highlightedKey)
+      ? highlightedKey
+      : initialHighlightKey;
+
+  const setRowRef = useCallback((key: string, element: HTMLButtonElement | null) => {
+    if (element) {
+      rowRefs.current.set(key, element);
+    } else {
+      rowRefs.current.delete(key);
+    }
+  }, []);
+
+  const moveHighlight = useCallback((delta: number) => {
+    if (flatModelKeys.length === 0) {
+      return;
+    }
+    const currentIndex = effectiveHighlightedKey
+      ? flatModelKeys.indexOf(effectiveHighlightedKey)
+      : -1;
+    const nextIndex = Math.min(
+      flatModelKeys.length - 1,
+      Math.max(0, (currentIndex < 0 ? (delta > 0 ? -1 : 0) : currentIndex) + delta),
+    );
+    const nextKey = flatModelKeys[nextIndex];
+    if (nextKey !== undefined) {
+      setHighlightedKey(nextKey);
+      rowRefs.current.get(nextKey)?.scrollIntoView({ block: "nearest" });
+    }
+  }, [effectiveHighlightedKey, flatModelKeys]);
+
+  // Refiltering can leave the effective highlight on a row that just scrolled
+  // out of the visible window; keep it in view.
+  useEffect(() => {
+    if (effectiveHighlightedKey) {
+      rowRefs.current.get(effectiveHighlightedKey)?.scrollIntoView({ block: "nearest" });
+    }
+  }, [effectiveHighlightedKey]);
+
+  const handleSearchKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveHighlight(1);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveHighlight(-1);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const selection = effectiveHighlightedKey
+        ? selectionByKey.get(effectiveHighlightedKey)
+        : undefined;
+      if (selection) {
+        onSelect(selection);
+      }
+    }
+  }, [effectiveHighlightedKey, moveHighlight, onSelect, selectionByKey]);
+
   return (
     <ComposerPopoverSurface className="flex w-72 flex-col p-0">
       <div className="shrink-0 border-b border-border">
@@ -158,6 +259,7 @@ function ComposerModelPickerPopover({
           onChange={setSearch}
           placeholder="Search models"
           autoFocus
+          onKeyDown={handleSearchKeyDown}
         />
       </div>
 
@@ -169,6 +271,9 @@ function ComposerModelPickerPopover({
             currentKind={currentKind}
             showSeparator={index > 0}
             onSelect={onSelect}
+            highlightedKey={effectiveHighlightedKey}
+            onHighlight={setHighlightedKey}
+            setRowRef={setRowRef}
           />
         ))}
 
@@ -205,16 +310,26 @@ function ComposerModelPickerPopover({
   );
 }
 
+function modelRowKey(kind: string, modelId: string): string {
+  return `${kind}:${modelId}`;
+}
+
 function ModelPickerGroup({
   group,
   currentKind,
   showSeparator,
   onSelect,
+  highlightedKey,
+  onHighlight,
+  setRowRef,
 }: {
   group: ModelSelectorGroup;
   currentKind: string | null;
   showSeparator: boolean;
   onSelect: (selection: ModelSelectorSelection) => void;
+  highlightedKey: string | null;
+  onHighlight: (key: string) => void;
+  setRowRef: (key: string, element: HTMLButtonElement | null) => void;
 }) {
   const hasSelectedModel = group.models.some((model) => model.isSelected);
 
@@ -241,12 +356,17 @@ function ModelPickerGroup({
           && group.kind !== currentKind;
 
         const nameParts = splitProviderDisplayName(model.displayName);
+        const rowKey = modelRowKey(group.kind, model.modelId);
+        const isHighlighted = highlightedKey === rowKey;
 
         return (
           <PopoverMenuItem
             key={model.modelId}
+            ref={(element: HTMLButtonElement | null) => setRowRef(rowKey, element)}
             data-model-option={model.modelId}
             data-model-selected={model.isSelected ? "true" : "false"}
+            aria-selected={isHighlighted}
+            onMouseEnter={() => onHighlight(rowKey)}
             icon={<ProviderIcon kind={group.kind} className="size-3 shrink-0 text-muted-foreground" />}
             label={(
               <span className="flex items-center gap-1.5">
@@ -266,7 +386,13 @@ function ModelPickerGroup({
               </span>
             )}
             labelClassName="text-composer"
-            className={`px-2.5 py-2 ${model.isSelected ? "bg-popover-accent" : ""}`}
+            className={`px-2.5 py-2 ${
+              model.isSelected
+                ? "bg-popover-accent"
+                : isHighlighted
+                  ? "bg-list-hover"
+                  : ""
+            }`}
             onClick={() => onSelect({ kind: group.kind, modelId: model.modelId })}
           />
         );

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
 
@@ -24,8 +24,10 @@ export function ComposerOptionRow({
   description,
   destructive = false,
   selected = false,
+  highlighted = false,
   disabled = false,
   onSelect,
+  onHover,
 }: {
   /** 0-based option index; renders as a 1-based number-key badge. */
   index: number;
@@ -33,8 +35,12 @@ export function ComposerOptionRow({
   description?: ReactNode;
   destructive?: boolean;
   selected?: boolean;
+  /** Keyboard roving-highlight cursor (arrow keys); styled like hover. */
+  highlighted?: boolean;
   disabled?: boolean;
   onSelect: () => void;
+  /** Keeps the keyboard highlight in sync when the mouse takes over. */
+  onHover?: () => void;
 }) {
   return (
     <Button
@@ -43,9 +49,11 @@ export function ComposerOptionRow({
       size="unstyled"
       disabled={disabled}
       onClick={onSelect}
+      onMouseEnter={onHover}
+      aria-selected={highlighted || undefined}
       className={twMerge(
         "group/option flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent",
-        selected ? "bg-accent" : "",
+        selected || highlighted ? "bg-accent" : "",
       )}
     >
       <ComposerOptionKeyBadge>{index + 1}</ComposerOptionKeyBadge>
@@ -55,7 +63,7 @@ export function ComposerOptionRow({
             "text-ui transition-colors",
             destructive
               ? "text-destructive"
-              : selected
+              : selected || highlighted
                 ? "text-foreground"
                 : "text-muted-foreground group-hover/option:text-foreground",
           )}
@@ -81,6 +89,16 @@ function isTypingTarget(target: EventTarget | null): boolean {
     || target instanceof HTMLTextAreaElement
     || target.isContentEditable
   );
+}
+
+function isEmptyTypingTarget(target: EventTarget | null): boolean {
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return target.value === "";
+  }
+  if (target instanceof HTMLElement && target.isContentEditable) {
+    return (target.textContent ?? "") === "";
+  }
+  return false;
 }
 
 /**
@@ -117,4 +135,70 @@ export function useComposerOptionNumberKeys(
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [enabled, onSelectIndex, optionCount]);
+}
+
+/**
+ * Arrow-key (ArrowUp/ArrowDown + Enter) roving highlight for a visible option
+ * list. Listens on the capture phase so an open card wins over the composer
+ * textarea's own ArrowUp (edit-last-queued) and Enter (submit) handling — but
+ * only while the user is not mid-text: keystrokes inside a NON-EMPTY
+ * input/textarea/contenteditable are always left alone, so arrows keep moving
+ * the caret and Enter keeps submitting a typed draft. Enter selects only once
+ * a highlight exists (set by arrows or hover); until then it falls through.
+ *
+ * `resetKey` clears the highlight when it changes (e.g. the question index in
+ * a multi-question card).
+ */
+export function useComposerOptionArrowKeys(
+  optionCount: number,
+  onSelectIndex: (index: number) => void,
+  options?: { enabled?: boolean; resetKey?: unknown },
+) {
+  const enabled = options?.enabled ?? true;
+  const resetKey = options?.resetKey;
+  const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
+  const highlightedIndexRef = useRef<number | null>(null);
+
+  const highlight = useCallback((index: number | null) => {
+    highlightedIndexRef.current = index;
+    setHighlightedIndex(index);
+  }, []);
+
+  useEffect(() => {
+    highlight(null);
+  }, [enabled, highlight, optionCount, resetKey]);
+
+  useEffect(() => {
+    if (!enabled || optionCount <= 0) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+        return;
+      }
+      if (isTypingTarget(event.target) && !isEmptyTypingTarget(event.target)) {
+        return;
+      }
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        const current = highlightedIndexRef.current;
+        const next = event.key === "ArrowDown"
+          ? (current === null ? 0 : Math.min(optionCount - 1, current + 1))
+          : (current === null ? optionCount - 1 : Math.max(0, current - 1));
+        highlight(next);
+        return;
+      }
+      if (event.key === "Enter" && highlightedIndexRef.current !== null) {
+        event.preventDefault();
+        event.stopPropagation();
+        onSelectIndex(highlightedIndexRef.current);
+      }
+    };
+    // Capture phase: beats the composer textarea's own key handling.
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [enabled, highlight, onSelectIndex, optionCount]);
+
+  return { highlightedIndex, highlight };
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx
@@ -91,14 +91,17 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
-function isEmptyTypingTarget(target: EventTarget | null): boolean {
-  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
-    return target.value === "";
-  }
-  if (target instanceof HTMLElement && target.isContentEditable) {
-    return (target.textContent ?? "") === "";
-  }
-  return false;
+/**
+ * Only the main composer draft editor may cede its arrow/Enter keys to a
+ * docked option card — and only while empty. Any OTHER typing surface (a
+ * popover search field, the question card's own free-text inputs) keeps its
+ * keystrokes unconditionally: hijacking those turns "pick a model" into an
+ * accidental permission decision.
+ */
+function isCardNavigableTypingTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLTextAreaElement
+    && target.hasAttribute("data-chat-composer-editor")
+    && target.value === "";
 }
 
 /**
@@ -141,10 +144,11 @@ export function useComposerOptionNumberKeys(
  * Arrow-key (ArrowUp/ArrowDown + Enter) roving highlight for a visible option
  * list. Listens on the capture phase so an open card wins over the composer
  * textarea's own ArrowUp (edit-last-queued) and Enter (submit) handling — but
- * only while the user is not mid-text: keystrokes inside a NON-EMPTY
- * input/textarea/contenteditable are always left alone, so arrows keep moving
- * the caret and Enter keeps submitting a typed draft. Enter selects only once
- * a highlight exists (set by arrows or hover); until then it falls through.
+ * ONLY when the keystroke lands outside every typing surface, or inside the
+ * EMPTY main composer draft editor. Every other input keeps its keys: the
+ * model-picker search field navigates its own list, and the question card's
+ * free-text fields keep Enter-to-advance. Enter selects only once a highlight
+ * exists (set by arrows or hover); until then it falls through.
  *
  * `resetKey` clears the highlight when it changes (e.g. the question index in
  * a multi-question card).
@@ -176,7 +180,7 @@ export function useComposerOptionArrowKeys(
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
         return;
       }
-      if (isTypingTarget(event.target) && !isEmptyTypingTarget(event.target)) {
+      if (isTypingTarget(event.target) && !isCardNavigableTypingTarget(event.target)) {
         return;
       }
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -3,12 +3,28 @@ import {
   reasoningLadderTopsOutAtUltra,
   resolveReasoningEffortEmphasis,
   resolveReasoningEffortPresentation,
+  resolveReasoningEffortTierTone,
+  type ReasoningEffortTierTone,
 } from "#product/lib/domain/chat/session-controls/session-reasoning-effort-control";
 import { resolveSessionControlTooltip } from "#product/lib/domain/chat/session-controls/session-toggle-control";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
+import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
 import { LevelBarsButton } from "@proliferate/ui/primitives/LevelBarsButton";
 import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
+
+// Tier-label tint ladder. Ultra keeps the codex-convention purple (same hue
+// as --color-pr-merged); max keeps the app special blue the bars already use.
+// Tinted tiers pin their color through hover (the control button's base
+// `hover:text-current` would otherwise wash the tint back to plain ink);
+// gray tiers keep the standard muted→full hover promotion.
+const TIER_TONE_CLASSES: Readonly<Record<ReasoningEffortTierTone, string>> = {
+  muted: "text-[color:var(--color-composer-control-muted-foreground)]",
+  secondary: "text-foreground-secondary hover:!text-foreground",
+  foreground: "text-foreground",
+  special: "text-[color:var(--color-special)] hover:!text-[color:var(--color-special)]",
+  ultra: "text-[color:var(--color-pr-merged)] hover:!text-[color:var(--color-pr-merged)]",
+};
 
 interface ComposerReasoningEffortBarsProps {
   control: LiveSessionControlDescriptor;
@@ -28,7 +44,8 @@ export function ComposerReasoningEffortBars({ control }: ComposerReasoningEffort
   const effectiveIndex = currentIndex >= 0 ? currentIndex : 0;
   const emphasis = resolveReasoningEffortEmphasis(control.options);
   // Ultra-capable ladders name their tier in the chip ("Ultra" / "Max" /
-  // "X High"); every other model keeps the compact icon-only bars.
+  // "X High") INSTEAD of the bars — the word plus its tier tint is the whole
+  // signal; every other model keeps the compact icon-only bars.
   const showsTierLabel = reasoningLadderTopsOutAtUltra(control.options);
 
   const currentOption = control.options[effectiveIndex] ?? null;
@@ -45,18 +62,39 @@ export function ComposerReasoningEffortBars({ control }: ComposerReasoningEffort
     currentOption?.description ?? null,
   ) + ". Click to step.";
 
-  const bars = (
-    <LevelBarsButton
-      levels={levels}
-      currentIndex={effectiveIndex}
-      onStep={(nextValue: string) => control.onSelect(nextValue)}
-      iconOnly={!showsTierLabel}
-      emphasis={emphasis}
-      disabled={!control.settable}
-      title={tooltip}
-      aria-label={ariaLabel}
-    />
-  );
+  const stepToNext = () => {
+    const nextIndex = (effectiveIndex + 1) % control.options.length;
+    const nextValue = control.options[nextIndex]?.value;
+    if (nextValue !== undefined) {
+      control.onSelect(nextValue);
+    }
+  };
+
+  const tierTone = resolveReasoningEffortTierTone(currentOption?.value ?? null);
+  const bars = showsTierLabel
+    ? (
+      <ComposerControlButton
+        label={currentLevel}
+        onClick={stepToNext}
+        disabled={!control.settable}
+        title={tooltip}
+        aria-label={ariaLabel}
+        className={TIER_TONE_CLASSES[tierTone]}
+        labelClassName="text-current"
+      />
+    )
+    : (
+      <LevelBarsButton
+        levels={levels}
+        currentIndex={effectiveIndex}
+        onStep={(nextValue: string) => control.onSelect(nextValue)}
+        iconOnly
+        emphasis={emphasis}
+        disabled={!control.settable}
+        title={tooltip}
+        aria-label={ariaLabel}
+      />
+    );
 
   if (control.pendingState) {
     return (

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerSlashCommandSearch.tsx
@@ -31,7 +31,9 @@ export function ComposerSlashCommandSearch({
       data-composer-overlay-floating-ui
       data-telemetry-mask
       className={twMerge(
-        "mb-2 overflow-hidden rounded-2xl border border-border bg-popover/90 p-1 text-popover-foreground shadow-popover backdrop-blur-sm",
+        // One step darker than the standard popover surface (Pablo: the pane
+        // should sit visually below the composer, not float brighter than it).
+        "mb-2 overflow-hidden rounded-2xl border border-border bg-surface-elevated/95 p-1 text-popover-foreground shadow-popover backdrop-blur-sm",
         className,
       )}
     >
@@ -55,7 +57,7 @@ export function ComposerSlashCommandSearch({
               />
             ))
           ) : (
-            <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+            <div className="px-2 py-4 text-center text-ui-sm text-muted-foreground">
               No matching slash commands.
             </div>
           )}
@@ -87,13 +89,19 @@ function SlashCommandRow({
   const tooltipContent = [command.displayName, command.description, command.inputHint]
     .filter(Boolean)
     .join("\n");
+  // The leading slash renders as its own, slightly larger glyph so the
+  // command name reads as name-after-slash instead of one undifferentiated
+  // token (composer-size slash + ui-size name share a baseline).
+  const commandName = command.displayName.startsWith("/")
+    ? command.displayName.slice(1)
+    : command.displayName;
 
   return (
     <>
       {showGroupLabel ? (
         <>
           <div data-slash-command-group-label-marker="" />
-          <div className="px-2.5 py-1 text-xs text-muted-foreground">
+          <div className="px-2.5 py-1 text-ui-sm text-muted-foreground">
             {command.group}
           </div>
         </>
@@ -114,20 +122,21 @@ function SlashCommandRow({
           className={twMerge(
             // Color-token hover promotion, not row opacity — opacity flips
             // re-rasterize the glyphs and read as shimmer (styling.md).
-            "flex w-full shrink-0 cursor-pointer items-baseline gap-2 overflow-hidden whitespace-normal rounded-lg px-2.5 py-[5px] text-left text-composer outline-none hover:bg-accent focus:bg-accent",
+            "flex w-full shrink-0 cursor-pointer items-baseline gap-2 overflow-hidden whitespace-normal rounded-lg px-2.5 py-1 text-left text-ui outline-none hover:bg-accent focus:bg-accent",
             selected && "bg-accent",
           )}
         >
           <span className="flex-none truncate text-popover-foreground">
-            {command.displayName}
+            <span className="text-composer">/</span>
+            {commandName}
           </span>
           {detail ? (
-            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+            <span className="min-w-0 flex-1 truncate text-ui-sm text-muted-foreground">
               {detail}
             </span>
           ) : null}
           {command.inputHint && command.description ? (
-            <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">
+            <span className="ml-auto shrink-0 truncate text-ui-sm text-muted-foreground">
               {command.inputHint}
             </span>
           ) : null}

--- a/apps/packages/product-client/src/components/workspace/chat/input/UserInputCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/UserInputCard.tsx
@@ -14,6 +14,7 @@ import {
 import {
   ComposerOptionKeyBadge,
   ComposerOptionRow,
+  useComposerOptionArrowKeys,
   useComposerOptionNumberKeys,
 } from "#product/components/workspace/chat/input/ComposerOptionRow";
 
@@ -164,6 +165,11 @@ export function UserInputCard({
     chooseOption,
     !!currentQuestion,
   );
+  const { highlightedIndex, highlight } = useComposerOptionArrowKeys(
+    options.length,
+    chooseOption,
+    { enabled: !!currentQuestion, resetKey: questionIndex },
+  );
 
   if (!currentQuestion) {
     return (
@@ -212,6 +218,8 @@ export function UserInputCard({
               label={option.label}
               description={option.description}
               selected={draft.selectedOptionLabel === option.label}
+              highlighted={highlightedIndex === index}
+              onHover={() => highlight(index)}
               onSelect={() => chooseOption(index)}
             />
           ))}
@@ -221,6 +229,8 @@ export function UserInputCard({
               index={syntheticIndex}
               hasAgentOptions={agentOptionCount > 0}
               selected={draft.selectedOptionLabel === OTHER_OPTION_LABEL}
+              highlighted={highlightedIndex === syntheticIndex}
+              onHover={() => highlight(syntheticIndex)}
               onSelect={() => chooseOption(syntheticIndex)}
             />
           )}
@@ -303,12 +313,16 @@ function SyntheticOptionRow({
   index,
   hasAgentOptions,
   selected,
+  highlighted = false,
   onSelect,
+  onHover,
 }: {
   index: number;
   hasAgentOptions: boolean;
   selected: boolean;
+  highlighted?: boolean;
   onSelect: () => void;
+  onHover?: () => void;
 }) {
   return (
     <div className={hasAgentOptions ? "mt-1 border-t border-border/60 pt-1" : ""}>
@@ -317,9 +331,11 @@ function SyntheticOptionRow({
         variant="unstyled"
         size="unstyled"
         onClick={onSelect}
+        onMouseEnter={onHover}
+        aria-selected={highlighted || undefined}
         className={twMerge(
           "group/option flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-accent",
-          selected ? "bg-accent" : "",
+          selected || highlighted ? "bg-accent" : "",
         )}
       >
         <ComposerOptionKeyBadge>{index + 1}</ComposerOptionKeyBadge>
@@ -327,7 +343,7 @@ function SyntheticOptionRow({
           <span
             className={twMerge(
               "text-ui transition-colors",
-              selected
+              selected || highlighted
                 ? "text-muted-foreground"
                 : "text-faint group-hover/option:text-muted-foreground",
             )}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/StreamingIndicator.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/StreamingIndicator.tsx
@@ -24,7 +24,10 @@ export function StreamingIndicator({
 
   return (
     <DebugProfiler id="streaming-indicator">
-      <div className="flex min-h-5 items-end gap-1.5 py-1 text-muted-foreground">
+      {/* items-baseline, not items-end: the label (20px line box) and the
+          smaller suffix (14px line box) must share a text baseline — bottom-
+          aligning the boxes leaves the suffix visually sunk below the label. */}
+      <div className="flex min-h-5 items-baseline gap-1.5 py-1 text-muted-foreground">
         <ThinkingText
           text={label}
           motionOriginMs={startedMs}

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadRow.tsx
@@ -36,9 +36,11 @@ export function CoworkThreadRow({
     <ProductSidebarThreadRow
       active={active}
       onSelect={onSelect}
-      status={(
+      // Activity lives in the trailing slot, matching the workspace rows'
+      // right-side convention — the leading well stays free of stacked glyphs.
+      trailingStatus={activityIndicator ? (
         <SidebarStatusIndicatorView indicator={activityIndicator} />
-      )}
+      ) : null}
       label={coworkThreadTitle(thread)}
       trailingLabel={formatSidebarRelativeTime(thread.updatedAt)}
       expandControl={canExpand ? (

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
@@ -179,7 +179,8 @@ describe("CoworkThreadsSection", () => {
     render(<CoworkThreadsSection />);
 
     expect(screen.getByText("Cowork thread")).not.toBeNull();
-    expect(screen.getByText("Setting up")).not.toBeNull();
+    // The trailing spinner alone marks the pending row (trailingStatus wins
+    // over any trailing label, so the row no longer carries "Setting up").
     expect(screen.getByTestId("status-iterating")).not.toBeNull();
     expect(screen.getByTestId("thread-row").getAttribute("data-active")).toBe("true");
     expect(screen.queryByText("No chats yet")).toBeNull();

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
@@ -74,16 +74,19 @@ vi.mock("@proliferate/product-ui/sidebar/ProductSidebarThreads", () => ({
     active,
     label,
     status,
+    trailingStatus,
     trailingLabel,
   }: {
     active?: boolean;
     label: ReactNode;
     status?: ReactNode;
+    trailingStatus?: ReactNode;
     trailingLabel?: string | null;
   }) => (
     <div data-testid="thread-row" data-active={String(!!active)}>
       {status}
       <span>{label}</span>
+      {trailingStatus}
       {trailingLabel ? <span>{trailingLabel}</span> : null}
     </div>
   ),

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
@@ -123,7 +123,7 @@ export function CoworkThreadsSection() {
           {showPendingCoworkThread && pendingCoworkEntry && (
             <ProductSidebarThreadRow
               active={pendingCoworkThreadActive}
-              status={(
+              trailingStatus={(
                 <SidebarStatusIndicatorView
                   indicator={{ kind: "iterating", tooltip: "Creating chat" }}
                 />

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
@@ -129,7 +129,6 @@ export function CoworkThreadsSection() {
                 />
               )}
               label={pendingCoworkEntry.displayName}
-              trailingLabel="Setting up"
             />
           )}
           {statusLoading || threadsLoading ? (

--- a/apps/packages/product-client/src/hooks/chat/ui/use-model-picker-keyboard-nav.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-model-picker-keyboard-nav.ts
@@ -1,0 +1,126 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import type {
+  ModelSelectorGroup,
+  ModelSelectorSelection,
+} from "#product/lib/domain/chat/models/model-selector-types";
+
+export function modelRowKey(kind: string, modelId: string): string {
+  return `${kind}:${modelId}`;
+}
+
+/**
+ * Keyboard navigation for the composer model picker: focus stays in the
+ * search field; ArrowUp/ArrowDown move a roving highlight over the flattened
+ * model rows and Enter selects it (mirrors the slash-command menu's
+ * single-focus-owner pattern). Rows are keyed `${kind}:${modelId}` so the
+ * highlight survives refiltering; when the highlighted row is filtered out,
+ * the highlight falls back to the selected model, else the first row.
+ */
+export function useModelPickerKeyboardNav(
+  filteredGroups: ModelSelectorGroup[],
+  onSelect: (selection: ModelSelectorSelection) => void,
+) {
+  const flatModelKeys = useMemo(
+    () => filteredGroups.flatMap((group) =>
+      group.models.map((model) => modelRowKey(group.kind, model.modelId))
+    ),
+    [filteredGroups],
+  );
+  const selectionByKey = useMemo(() => {
+    const byKey = new Map<string, ModelSelectorSelection>();
+    for (const group of filteredGroups) {
+      for (const model of group.models) {
+        byKey.set(modelRowKey(group.kind, model.modelId), {
+          kind: group.kind,
+          modelId: model.modelId,
+        });
+      }
+    }
+    return byKey;
+  }, [filteredGroups]);
+  const initialHighlightKey = useMemo(() => {
+    for (const group of filteredGroups) {
+      const selected = group.models.find((model) => model.isSelected);
+      if (selected) {
+        return modelRowKey(group.kind, selected.modelId);
+      }
+    }
+    return flatModelKeys[0] ?? null;
+  }, [filteredGroups, flatModelKeys]);
+  const [highlightedKey, setHighlightedKey] = useState<string | null>(initialHighlightKey);
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const effectiveHighlightedKey =
+    highlightedKey && flatModelKeys.includes(highlightedKey)
+      ? highlightedKey
+      : initialHighlightKey;
+
+  const setRowRef = useCallback((key: string, element: HTMLButtonElement | null) => {
+    if (element) {
+      rowRefs.current.set(key, element);
+    } else {
+      rowRefs.current.delete(key);
+    }
+  }, []);
+
+  const moveHighlight = useCallback((delta: number) => {
+    if (flatModelKeys.length === 0) {
+      return;
+    }
+    const currentIndex = effectiveHighlightedKey
+      ? flatModelKeys.indexOf(effectiveHighlightedKey)
+      : -1;
+    const nextIndex = Math.min(
+      flatModelKeys.length - 1,
+      Math.max(0, (currentIndex < 0 ? (delta > 0 ? -1 : 0) : currentIndex) + delta),
+    );
+    const nextKey = flatModelKeys[nextIndex];
+    if (nextKey !== undefined) {
+      setHighlightedKey(nextKey);
+      rowRefs.current.get(nextKey)?.scrollIntoView({ block: "nearest" });
+    }
+  }, [effectiveHighlightedKey, flatModelKeys]);
+
+  // Refiltering can leave the effective highlight on a row that just scrolled
+  // out of the visible window; keep it in view.
+  useEffect(() => {
+    if (effectiveHighlightedKey) {
+      rowRefs.current.get(effectiveHighlightedKey)?.scrollIntoView({ block: "nearest" });
+    }
+  }, [effectiveHighlightedKey]);
+
+  const handleSearchKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveHighlight(1);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveHighlight(-1);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const selection = effectiveHighlightedKey
+        ? selectionByKey.get(effectiveHighlightedKey)
+        : undefined;
+      if (selection) {
+        onSelect(selection);
+      }
+    }
+  }, [effectiveHighlightedKey, moveHighlight, onSelect, selectionByKey]);
+
+  return {
+    highlightedKey: effectiveHighlightedKey,
+    setHighlightedKey,
+    setRowRef,
+    handleSearchKeyDown,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog-types.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog-types.ts
@@ -81,7 +81,21 @@ export interface DesktopLaunchModelRegistryModel {
    * selected model would reject at session creation.
    */
   modeValues?: string[] | null;
+  /**
+   * Per-model tuning-control vocabulary from the catalog matrix, keyed by
+   * desktop control key (`reasoning_effort` folds into `effort`). Unlike
+   * `sessionDefaultControls` this does NOT fall back to the agent-level
+   * vocabulary: a key absent here is a control the model does not support
+   * (e.g. sonnet carries no `fast_mode`, gpt-5.5 caps effort at `xhigh`).
+   * `null` when the model has no per-model controls matrix at all, in which
+   * case the agent-level launch controls apply unscoped.
+   */
+  tuningControlValues?: DesktopModelTuningControlValues | null;
 }
+
+export type DesktopModelTuningControlValues = Partial<
+  Record<"reasoning" | "effort" | "fast_mode", string[]>
+>;
 
 export interface DesktopAgentLaunchModel extends DesktopLaunchModelRegistryModel {
   aliases: string[];

--- a/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog.ts
@@ -12,6 +12,7 @@ import type {
 } from "#product/lib/domain/agents/cloud-launch-catalog-types";
 import {
   projectCloudControl,
+  projectModelTuningControlValues,
   projectSessionDefaultControls,
 } from "#product/lib/domain/agents/cloud-launch-controls";
 import { gateModelList, type ActiveAuthContextIds } from "#product/lib/domain/agents/model-availability";
@@ -32,6 +33,7 @@ export type {
   DesktopAgentLaunchModel,
   DesktopLaunchModelRegistry,
   DesktopLaunchModelRegistryModel,
+  DesktopModelTuningControlValues,
   DesktopSessionDefaultControl,
   DesktopSessionDefaultControlValue,
   RuntimeAgentLaunchOptions,
@@ -150,6 +152,7 @@ export function mergeRuntimeLaunchOptionsIntoDesktopLaunchAgents(
           availability: cloudModel?.availability ?? null,
           sessionDefaultControls: cloudModel?.sessionDefaultControls ?? [],
           modeValues: cloudModel?.modeValues ?? null,
+          tuningControlValues: cloudModel?.tuningControlValues ?? null,
         };
       }),
       launchControls: cloud?.launchControls ?? [],
@@ -338,6 +341,7 @@ function projectCloudModel(
     availability: anyOf.length > 0 ? { anyOf: [...anyOf] } : null,
     sessionDefaultControls: projectSessionDefaultControls(model, sessionControls),
     modeValues: projectModelModeValues(model),
+    tuningControlValues: projectModelTuningControlValues(model),
   };
 }
 

--- a/apps/packages/product-client/src/lib/domain/agents/cloud-launch-controls.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/cloud-launch-controls.ts
@@ -2,6 +2,7 @@ import type {
   CloudAgentCatalogControlInput,
   CloudAgentCatalogModelInput,
   DesktopAgentLaunchControl,
+  DesktopModelTuningControlValues,
   DesktopSessionDefaultControl,
 } from "#product/lib/domain/agents/cloud-launch-catalog-types";
 
@@ -49,6 +50,31 @@ export function projectSessionDefaultControls(
     }
     return [];
   });
+}
+
+/**
+ * The model's own tuning-control vocabulary (`model.controls`), with NO
+ * agent-level fallback — absence of a key means the model does not support
+ * that control. Every probed model carries a controls matrix, so `null`
+ * (no matrix at all) only happens for unprobed catalog entries.
+ */
+export function projectModelTuningControlValues(
+  model: CloudAgentCatalogModelInput,
+): DesktopModelTuningControlValues | null {
+  if (!model.controls) {
+    return null;
+  }
+  const projected: DesktopModelTuningControlValues = {};
+  for (const { key, catalogKeys } of SESSION_DEFAULT_CONTROL_KEYS) {
+    for (const catalogKey of catalogKeys) {
+      const values = model.controls[catalogKey]?.values;
+      if (values && values.length > 0) {
+        projected[key] = [...values];
+        break;
+      }
+    }
+  }
+  return projected;
 }
 
 /**

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts
@@ -124,6 +124,92 @@ describe("buildLaunchControlDescriptors mode scoping", () => {
   });
 });
 
+describe("buildLaunchControlDescriptors tuning-control scoping", () => {
+  const preferences = {
+    defaultSessionModeByAgentKind: {},
+    defaultLiveSessionControlValuesByAgentKind: {},
+  };
+
+  it("drops fast_mode when the selected model's controls matrix has no fast_mode entry", () => {
+    // Regression: sonnet carries no `fast_mode` in its per-model matrix, but
+    // the agent-level claude launch controls list one. Rendering it produced a
+    // clickable toggle the session could never honour.
+    const controls = buildLaunchControlDescriptors({
+      selection: { kind: "claude", modelId: "sonnet" },
+      launchAgents: [
+        {
+          kind: "claude",
+          launchControls: [
+            control("effort", "Effort", "medium"),
+            control("fast_mode", "Fast Mode", "off"),
+          ],
+          models: [
+            {
+              id: "sonnet",
+              tuningControlValues: { effort: ["medium", "high"] },
+            },
+          ],
+        },
+      ],
+      preferences,
+      pendingConfigChanges: null,
+      onSelect: () => {},
+    });
+
+    expect(controls.map((candidate) => candidate.key)).toEqual(["effort"]);
+  });
+
+  it("scopes effort values to the model's vocabulary and ignores an unsupported persisted preference", () => {
+    const [effort] = buildLaunchControlDescriptors({
+      selection: { kind: "claude", modelId: "sonnet" },
+      launchAgents: [
+        {
+          kind: "claude",
+          launchControls: [control("effort", "Effort", "medium")],
+          models: [
+            {
+              id: "sonnet",
+              tuningControlValues: { effort: ["medium", "high"], fast_mode: ["off", "on"] },
+            },
+          ],
+        },
+      ],
+      preferences: {
+        defaultSessionModeByAgentKind: {},
+        // `off` exists in the agent-level vocabulary but not in the model's
+        // scoped effort list — it must not be selected.
+        defaultLiveSessionControlValuesByAgentKind: { claude: { effort: "off" } },
+      },
+      pendingConfigChanges: null,
+      onSelect: () => {},
+    });
+
+    expect(effort?.options.map((option) => option.value)).toEqual(["medium", "high"]);
+    expect(effort?.options.find((option) => option.selected)?.value).toBe("medium");
+  });
+
+  it("keeps agent-level tuning controls unscoped when the model has no controls matrix", () => {
+    const controls = buildLaunchControlDescriptors({
+      selection: { kind: "claude", modelId: "sonnet" },
+      launchAgents: [
+        {
+          kind: "claude",
+          launchControls: [
+            control("effort", "Effort", "medium"),
+            control("fast_mode", "Fast Mode", "off"),
+          ],
+          models: [{ id: "sonnet", tuningControlValues: null }],
+        },
+      ],
+      preferences,
+      pendingConfigChanges: null,
+      onSelect: () => {},
+    });
+
+    expect(controls.map((candidate) => candidate.key)).toEqual(["effort", "fast_mode"]);
+  });
+});
+
 describe("buildLaunchControlDescriptors", () => {
   it("builds descriptors from agent launch controls", () => {
     const controls = buildLaunchControlDescriptors({

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts
@@ -7,7 +7,10 @@ import {
   getPendingSessionConfigChange,
   type PendingSessionConfigChanges,
 } from "@proliferate/product-domain/sessions/pending-config";
-import type { DesktopAgentLaunchControl } from "#product/lib/domain/agents/cloud-launch-catalog";
+import type {
+  DesktopAgentLaunchControl,
+  DesktopModelTuningControlValues,
+} from "#product/lib/domain/agents/cloud-launch-catalog";
 
 export interface LaunchControlPreferences {
   defaultSessionModeByAgentKind: Record<string, string>;
@@ -23,6 +26,7 @@ export interface BuildLaunchControlDescriptorsInput {
       id: string;
       aliases?: string[];
       modeValues?: string[] | null;
+      tuningControlValues?: DesktopModelTuningControlValues | null;
     }>;
   }>;
   preferences: LaunchControlPreferences;
@@ -51,22 +55,31 @@ export function buildLaunchControlDescriptors(
   const selectedModel = agent.models.find((candidate) =>
     candidate.id === selectedModelId || (candidate.aliases ?? []).includes(selectedModelId));
   const selectedModelModeValues = selectedModel?.modeValues ?? null;
+  const selectedModelTuningControlValues = selectedModel?.tuningControlValues ?? null;
 
   return (agent.launchControls ?? [])
     .flatMap((control) => launchControlToDescriptor({
       agentKind: agent.kind,
       control,
       modelModeValues: selectedModelModeValues,
+      modelTuningControlValues: selectedModelTuningControlValues,
       pendingConfigChanges: input.pendingConfigChanges,
       preferences: input.preferences,
       onSelect: input.onSelect,
     }));
 }
 
+const MODEL_SCOPED_TUNING_KEYS = new Set<SupportedLiveControlKey>([
+  "reasoning",
+  "effort",
+  "fast_mode",
+]);
+
 function launchControlToDescriptor(input: {
   agentKind: string;
   control: DesktopAgentLaunchControl;
   modelModeValues?: string[] | null;
+  modelTuningControlValues?: DesktopModelTuningControlValues | null;
   pendingConfigChanges: PendingSessionConfigChanges | null;
   preferences: LaunchControlPreferences;
   onSelect: (
@@ -80,14 +93,30 @@ function launchControlToDescriptor(input: {
   if (!key || input.control.values.length === 0) {
     return [];
   }
+  // Tuning controls (effort/reasoning/fast_mode) are gated by the selected
+  // model's own controls matrix: a model without a matrix entry does not
+  // support the control at all (sonnet has no fast_mode), so the agent-level
+  // launch control must not render for it.
+  const modelTuningValues = MODEL_SCOPED_TUNING_KEYS.has(key) && input.modelTuningControlValues
+    ? input.modelTuningControlValues[key as keyof DesktopModelTuningControlValues] ?? null
+    : null;
+  if (
+    MODEL_SCOPED_TUNING_KEYS.has(key)
+    && input.modelTuningControlValues
+    && (!modelTuningValues || modelTuningValues.length === 0)
+  ) {
+    return [];
+  }
   const rawConfigId = input.control.createField === "modeId" ? "mode" : input.control.key;
-  // Scope the `mode` control to the modes the selected model actually supports
-  // (the agent-level vocabulary is a superset — e.g. gateway/bedrock models
-  // reject `auto`). Fall back to the full list if scoping would empty it.
-  const controlValues = key === "mode" && input.modelModeValues && input.modelModeValues.length > 0
+  // Scope control values to what the selected model actually supports (the
+  // agent-level vocabulary is a superset — e.g. gateway/bedrock models reject
+  // `auto`; sonnet's effort caps at `max` while opus adds `xhigh`). Fall back
+  // to the full list if scoping would empty it.
+  const modelScopedValues = key === "mode" ? input.modelModeValues : modelTuningValues;
+  const controlValues = modelScopedValues && modelScopedValues.length > 0
     ? (() => {
       const scoped = input.control.values.filter(
-        (value) => input.modelModeValues!.includes(value.value),
+        (value) => modelScopedValues.includes(value.value),
       );
       return scoped.length > 0 ? scoped : input.control.values;
     })()
@@ -97,26 +126,21 @@ function launchControlToDescriptor(input: {
     rawConfigId,
   );
 
-  // For `mode`, only honour a stored/default preference if the selected model
-  // still supports it, so a persisted `auto` doesn't survive onto a model that
-  // rejects it. Non-mode controls keep their existing resolution.
-  const modeSupports = (value: string | null | undefined): boolean =>
+  // Only honour a stored/default preference if the selected model still
+  // supports it, so a persisted `auto` mode or `xhigh` effort doesn't survive
+  // onto a model whose scoped vocabulary rejects it.
+  const supports = (value: string | null | undefined): boolean =>
     !!value && controlValues.some((candidate) => candidate.value === value);
-  const selectedValue = key === "mode"
-    ? (modeSupports(pendingChange?.value) ? pendingChange?.value : null)
-      || (modeSupports(input.preferences.defaultSessionModeByAgentKind[input.agentKind])
-        ? input.preferences.defaultSessionModeByAgentKind[input.agentKind]
-        : null)
-      || (modeSupports(input.control.defaultValue) ? input.control.defaultValue : null)
-      || controlValues.find((value) => value.isDefault)?.value
-      || controlValues[0]?.value
-      || null
-    : pendingChange?.value
-      || input.preferences.defaultLiveSessionControlValuesByAgentKind[input.agentKind]?.[key]
-      || input.control.defaultValue
-      || input.control.values.find((value) => value.isDefault)?.value
-      || input.control.values[0]?.value
-      || null;
+  const preferredValue = key === "mode"
+    ? input.preferences.defaultSessionModeByAgentKind[input.agentKind]
+    : input.preferences.defaultLiveSessionControlValuesByAgentKind[input.agentKind]?.[key];
+  const selectedValue =
+    (supports(pendingChange?.value) ? pendingChange?.value : null)
+    || (supports(preferredValue) ? preferredValue : null)
+    || (supports(input.control.defaultValue) ? input.control.defaultValue : null)
+    || controlValues.find((value) => value.isDefault)?.value
+    || controlValues[0]?.value
+    || null;
   const detail =
     controlValues.find((value) => value.value === selectedValue)?.label
     ?? selectedValue;

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
@@ -31,6 +31,32 @@ export function reasoningLadderTopsOutAtUltra(
   return options[options.length - 1]?.value.toLowerCase() === "ultra";
 }
 
+export type ReasoningEffortTierTone =
+  | "muted"
+  | "secondary"
+  | "foreground"
+  | "special"
+  | "ultra";
+
+// Tint ladder for the tier-label chip (ultra-capable ladders show the tier
+// by name instead of bars): quiet grays through the working range, the app
+// special blue at max, and the codex-convention purple for ultra.
+const TIER_TONES: Readonly<Record<string, ReasoningEffortTierTone>> = {
+  minimal: "muted",
+  low: "muted",
+  medium: "secondary",
+  high: "foreground",
+  xhigh: "foreground",
+  max: "special",
+  ultra: "ultra",
+};
+
+export function resolveReasoningEffortTierTone(
+  value: string | null,
+): ReasoningEffortTierTone {
+  return TIER_TONES[value?.toLowerCase() ?? ""] ?? "secondary";
+}
+
 const TITLE_CASE_SPLIT = /[^a-z0-9]+/i;
 
 export function resolveReasoningEffortPresentation(

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
@@ -4,11 +4,23 @@ import { SidebarRowSurface } from "@proliferate/ui/layout/SidebarRowSurface";
 
 export interface ProductSidebarThreadRowProps extends Omit<HTMLAttributes<HTMLElement>, "children" | "onClick" | "onSelect"> {
   active?: boolean;
+  /**
+   * Legacy LEADING-well indicator slot (web row-view consumers). Desktop
+   * thread rows put live activity in `trailingStatus` instead, matching the
+   * workspace rows' right-slot convention.
+   */
   status?: ReactNode;
   label: ReactNode;
   subtitle?: string | null;
   detail?: ReactNode;
   trailingLabel?: string | null;
+  /**
+   * Activity indicator (spinner / waiting / error) in the TRAILING cell,
+   * same precedence as ProductSidebarWorkspaceRow: it wins over
+   * `trailingLabel` and fades out on hover/focus like the other trailing
+   * content.
+   */
+  trailingStatus?: ReactNode;
   hoverAction?: ReactNode;
   expandControl?: ReactNode;
   onSelect?: () => void;
@@ -21,6 +33,7 @@ export function ProductSidebarThreadRow({
   subtitle = null,
   detail = null,
   trailingLabel = null,
+  trailingStatus = null,
   hoverAction = null,
   expandControl = null,
   onSelect,
@@ -65,7 +78,11 @@ export function ProductSidebarThreadRow({
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
-          {trailingLabel && !active && !expandControl ? (
+          {trailingStatus ? (
+            <div className="flex size-5 items-center justify-center transition-opacity duration-150 group-focus-within:opacity-0 group-hover:opacity-0">
+              {trailingStatus}
+            </div>
+          ) : trailingLabel && !active && !expandControl ? (
             <div className="truncate text-right text-ui tabular-nums text-sidebar-muted-foreground group-focus-within:opacity-0 group-hover:opacity-0">
               {trailingLabel}
             </div>

--- a/apps/packages/ui/src/primitives/PopoverMenuItem.tsx
+++ b/apps/packages/ui/src/primitives/PopoverMenuItem.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, MouseEvent, ReactNode } from "react";
+import type { ButtonHTMLAttributes, MouseEvent, ReactNode, Ref } from "react";
 import { twMerge } from "../utils/tw-merge";
 
 export type PopoverMenuItemVariant = "default" | "sidebar";
@@ -13,6 +13,8 @@ export interface PopoverMenuItemProps extends ButtonHTMLAttributes<HTMLButtonEle
   iconClassName?: string;
   labelClassName?: string;
   trailingClassName?: string;
+  /** React 19 ref-as-prop; lands on the underlying button element. */
+  ref?: Ref<HTMLButtonElement>;
 }
 
 export function PopoverMenuItem({

--- a/apps/packages/ui/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/ui/src/primitives/PopoverSearchField.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEventHandler } from "react";
 import { Search } from "../icons/core";
 import { Input } from "./Input";
 
@@ -8,6 +9,11 @@ export interface PopoverSearchFieldProps {
   autoFocus?: boolean;
   /** Accessible name when the placeholder alone is not descriptive enough. */
   ariaLabel?: string;
+  /**
+   * List-navigation hook: the search input keeps focus while the picker's
+   * rows are navigated, so ArrowUp/ArrowDown/Enter handling belongs here.
+   */
+  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 }
 
 /**
@@ -23,6 +29,7 @@ export function PopoverSearchField({
   placeholder = "Search",
   autoFocus,
   ariaLabel,
+  onKeyDown,
 }: PopoverSearchFieldProps) {
   return (
     <div className="flex items-center gap-2 px-2.5 py-[7px]">
@@ -33,6 +40,7 @@ export function PopoverSearchField({
         placeholder={placeholder}
         autoFocus={autoFocus}
         aria-label={ariaLabel}
+        onKeyDown={onKeyDown}
         className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui shadow-none focus:ring-0"
       />
     </div>


### PR DESCRIPTION
## Summary
Chat input / transcript polish pass, built and verified live with Pablo.

- **Per-model launch-control gating**: fast_mode/effort launch controls are now scoped by the selected model's own catalog controls matrix (mirrors the existing per-model `mode` scoping). Fixes the dead Fast toggle on Sonnet 4.6 (model has no `fast_mode`), phantom `xhigh` on Sonnet, and phantom `max`/`ultra` on gpt-5.5. Persisted preferences the model can't honor no longer survive model switches.
- **Zap stability**: the queued-pending indicator renders as a sibling of the fixed-width icon-only button instead of inside it (the reasoning bars' existing pattern), eliminating the glyph shove while a change is queued.
- **Tier-label chip**: ultra-capable ladders (gpt-5.6 Sol/Terra) show the tier name instead of bars, tinted per tier — muted grays through the working range, special blue at Max, codex-convention purple at Ultra — with the tint pinned through hover.
- **Arrow-key navigation**: model picker (roving highlight, focus stays in the search field, Enter selects), approval card + question card (ArrowUp/Down + Enter alongside the existing 1–9 digit keys; capture-phase listeners that yield while typing in a non-empty field).
- **Slash-command pane**: darker surface (`surface-elevated`), 11px rows / 10px detail, slash glyph one step larger than the command name, tighter rows.
- **Sidebar consistency**: thread rows put the activity indicator in the trailing slot, matching workspace rows' right-side convention (new `trailingStatus` slot on `ProductSidebarThreadRow`).
- **StreamingIndicator**: elapsed suffix ("· 16s") baseline-aligns with the label.

## Verification
- Desktop typecheck green; touched-area vitest green (new regression tests for the gating). Pre-existing `FileChangeCall` clipboard-fixture failure on main is unrelated (fails with this diff stashed).
- Live-verified in browser mode (profile `chat-input-polish`): Sonnet hides the zap and caps at Max; Sol steps Low→Ultra with the purple chip; arrow-key selection in picker + both cards; slash pane styling; thinking baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)