### PR TITLE
docs(specs): record the completed ProductClient move

### DIFF
--- a/specs/codebase/systems/product/clients/web-desktop-unification/README.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/README.md
@@ -600,22 +600,25 @@ enforcement. Shared `product.css`, Desktop-only CSS, and ProductClient Tailwind
 scanning are established separately. The embedded workspace browser and its
 native child-WebView capability have been removed.
 
-Desktop now mounts the product through the typed host boundary. Native UI,
-local runtime, files, credentials, SSH, updater, support, shared identity,
-navigation, storage, and telemetry all route through that boundary while the
-product source still lives under `apps/desktop`.
+Desktop mounts the product through the typed host boundary. Native UI, local
+runtime, files, credentials, SSH, updater, support, shared identity,
+navigation, storage, and telemetry all route through that boundary.
 
-The extraction mechanics have also landed: the package entry shape is proven
-from Desktop and a minimal browser host, the source move has a checked ledger,
-and the import codemod is deterministic and idempotent. The durable inputs to
-the mechanical extraction are:
+The extraction mechanics landed, and the mechanical move has since completed:
+the package entry shape was proven from Desktop and a minimal browser host,
+the source move ran against a checked ledger with a deterministic and
+idempotent import codemod, and Desktop's product source now lives in
+`@proliferate/product-client` — Desktop is a thin native host. The durable
+records are:
 
-- [landed extraction proof](migration/d1g.md);
+- [extraction-mechanics proof](migration/d1g.md);
+- [completed Desktop move](migration/d1h.md) — PR #1215, merge `c6e094b41`;
 - [application-entry contract](entry-contract.md); and
 - [source move ledger](move-ledger.md).
 
-The next step is to perform that mechanical extraction and leave Desktop as a
-thin native host. The remaining order and Web cutover gates live in the
+The next step is to replace the legacy Web product with a thin browser host
+mounting the same ProductClient. The remaining order and Web cutover gates
+live in the
 [rollout procedure](../../../../../developing/deploying/web-desktop-unification-rollout.md).
 
 Related authoritative docs:

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/README.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/README.md
@@ -1,8 +1,11 @@
 # Web/Desktop Unification Migration Evidence
 
 - [ProductClient extraction mechanics](d1g.md) records the landed build,
-  packaging, ledger, codemod, and browser-host proof consumed by the current
+  packaging, ledger, codemod, and browser-host proof consumed by the
   mechanical extraction.
+- [Move the Desktop Product into ProductClient](d1h.md) records the completed
+  mechanical move and seam architecture, plus the post-merge reconciliation
+  against `origin/main` — PR #1215, merge `c6e094b41`.
 
 Completed incremental delivery specs live in Git history. Current architecture
 and migration state live in the [parent system contract](../README.md).

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/d1h.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/d1h.md
@@ -1,15 +1,53 @@
 # Move the Desktop Product into ProductClient (D1h)
 
-Status: **complete — green pending review.** The mechanical move and the full
-seam architecture landed across three owner-ruling rounds (R1–R5 + G1–G7 + 9
-ratified ledger amendments). Package `tsc` **315 → 0**;
-`PRODUCT_CLIENT_FORBIDDEN_IMPORT` **272 → 0**. Package typecheck/build, the
-Desktop build (verified lazy authenticated split), desktop + package vitest, the
-qualification proof, and every boundary/structure/max-lines/docs/ledger scan pass.
-The only red is **12 base-proven pre-existing test failures across 6 files**
-(inherited, not move-caused — see "Inherited pre-existing test failures"). Rounds
-1–2 (§F1–F4 below) and the F3/F4 STOP analyses are retained as a historical
-record; the authoritative final state is **"Round 3 (G1–G7) + green — final"**.
+Status: **complete — merged.** PR #1215, merge `c6e094b41`. The mechanical
+move and the full seam architecture landed across three owner-ruling rounds
+(R1–R5 + G1–G7 + 9 ratified ledger amendments), plus a post-merge
+reconciliation against `origin/main` (see "Post-merge reconciliation" below).
+Package `tsc` **315 → 0**; `PRODUCT_CLIENT_FORBIDDEN_IMPORT` **272 → 0**.
+Package typecheck/build, the Desktop build (verified lazy authenticated
+split), desktop + package vitest, the qualification proof, and every
+boundary/structure/max-lines/docs/ledger scan pass. The only red is **12
+base-proven pre-existing test failures across 6 files** (inherited, not
+move-caused — see "Inherited pre-existing test failures"). Rounds 1–2
+(§F1–F4 below) and the F3/F4 STOP analyses are retained as a historical
+record; the authoritative final state is **"Round 3 (G1–G7) + green — final"**,
+as carried across the merge.
+
+## Post-merge reconciliation
+
+This slice's branch was cut before four unrelated feature PRs landed on
+`origin/main` — goals relight (#1206), the workspace status card + Codex
+publish dialog (#1210), git review v2 (#1214), and per-subagent identicon
+avatars (#847). Landing the move required reconciling the slice against all
+four rather than rebasing them away:
+
+- **34 content conflicts** resolved to main's logic plus the move's plumbing
+  (import paths, `#product/*` specifiers, ProductHost/DesktopBridge threading)
+  — main's feature behavior is preserved verbatim; only ownership/import shape
+  changed.
+- **27 new files** (added by the four feature PRs after this slice's branch
+  point) re-homed into `apps/packages/product-client/src` alongside the rest
+  of the move.
+- **5 delete amendments** — files the git-review-v2 and status-card PRs
+  removed on `main` after this slice's branch point (`GitReviewFileTree`,
+  `GitReviewStageAction`, `GitReviewStatusBadge`,
+  `use-composer-ultra-emphasis`, `git-file-status-presentation`) — recorded as
+  `move -> delete` ledger amendments rather than silently dropped, bringing the
+  amendments total to **23** (18 `retain -> move` + 5 `move -> delete`; see
+  `../move-ledger.md#amendments-ratified-during-the-move`).
+- Landed via a **fast-gate merge per founder directive**: the founder
+  authorized merging ahead of a full independent re-review given the
+  mechanical nature of the reconciliation (import-path and ledger-classification
+  changes only, no product-behavior delta), on the condition that the
+  post-merge battery (package build/typecheck, Desktop build, both vitest
+  lanes, qualification proof, all boundary/structure/max-lines/docs/ledger
+  scans) reran green against the merged tree before this doc records
+  completion. It did.
+
+The slice is complete and closed at `c6e094b41`. No further work is owed
+against this contract; the next contract is the legacy Web replacement (see
+the [rollout procedure](../../../../../../developing/deploying/web-desktop-unification-rollout.md)).
 
 - Exact implementation base:
   `1d00437565d4cdce47cf4dc41f2ea19eb2f31f28`

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -7,33 +7,32 @@ This document owns only the remaining execution order and cutover gates.
 ## Current handoff
 
 The ProductClient foundation, Desktop host boundary, shared identity,
-navigation, persistence, telemetry, and extraction mechanics have landed. The
-current migration step is the mechanical Desktop extraction:
+navigation, persistence, telemetry, extraction mechanics, and the mechanical
+Desktop extraction have landed. Desktop's product source now lives in
+`@proliferate/product-client`; Desktop is a thin native host. The completed
+move, its seam architecture, and the post-merge reconciliation against
+`origin/main` are recorded in
+[`d1h.md`](../../codebase/systems/product/clients/web-desktop-unification/migration/d1h.md)
+— PR #1215, merge `c6e094b41`.
 
-1. Move the working Desktop product into ProductClient according to the
-   checked [move ledger](../../codebase/systems/product/clients/web-desktop-unification/move-ledger.md).
-2. Apply the proven import codemod and create the real application entry from
-   the [entry contract](../../codebase/systems/product/clients/web-desktop-unification/entry-contract.md).
-3. Delete the temporary qualification canary and every superseded Desktop
-   product path; do not leave parallel implementations.
-4. Leave Desktop as the thin native host while preserving its current visual
-   and behavioral baseline.
-5. Run the ProductClient package build, Desktop build, browser-host build,
+The current migration step is the legacy Web replacement:
+
+1. Delete the duplicate Web pages, chat implementation, polling, stores,
+   controllers, and product-specific logic.
+2. Mount the same compiled ProductClient from a thin browser host with
+   `desktop: null`.
+3. Run the ProductClient package build, Desktop build, browser-host build,
    structure checks, and focused behavior tests before review.
 
-The landed extraction proof and known follow-ups are recorded in
+The landed extraction proof is recorded in
 [`d1g.md`](../../codebase/systems/product/clients/web-desktop-unification/migration/d1g.md).
-Refresh the live branch/worktree conflict inventory immediately before the
-large source move and agree on its landing window.
 
 ## Remaining sequence
 
-After the Desktop extraction:
+After the legacy Web replacement:
 
-1. Delete the duplicate Web product and mount the same ProductClient from a
-   thin browser host with `desktop: null`.
-2. Qualify Desktop and hosted Web, then cut over hosted Web.
-3. Add self-hosted Web configuration, deployment, and documentation.
+1. Qualify Desktop and hosted Web, then cut over hosted Web.
+2. Add self-hosted Web configuration, deployment, and documentation.
 
 Desktop remains the behavioral baseline throughout. There is no intermediate
 state in which two product implementations are maintained.


### PR DESCRIPTION
## Summary
- Marks D1h (Move the Desktop Product into ProductClient) complete at PR #1215, merge `c6e094b41`.
- Records the post-merge reconciliation against origin/main's four concurrent feature PRs (#1206, #1210, #1214, #847): 34 content conflicts resolved to main's logic plus the move's plumbing, 27 new files re-homed, 5 additional `move -> delete` ledger amendments (23 total), landed via a founder-directed fast-gate merge.
- Re-adds terse slice status under the simplified README/rollout framing from #1207 (no reintroduction of the old delivery-phase table).
- Updates `~/specs/web-desktop-unification/current-state.md` and `README.md` (outside the repo) to point Current PR at "Replace Legacy Web with the Shared Product" and adds the #1215/`c6e094b41` row.

## Test plan
- [x] `python3 scripts/check_docs.py` — green (210 Markdown files)
- [x] Manual read-through of updated cross-links and anchors

Docs-only change; not merging per standing instruction (no merge without Pablo's review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)