### PR TITLE
fix(product-client): repair the 17 stale test failures gating shared-frontend-packages

### DIFF
--- a/apps/packages/product-client/src/components/automations/controls/AutomationRunLocationSelector.test.tsx
+++ b/apps/packages/product-client/src/components/automations/controls/AutomationRunLocationSelector.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AutomationRunLocationSelector } from "#product/components/automations/controls/AutomationRunLocationSelector";
 import type {
@@ -147,9 +147,17 @@ describe("AutomationRunLocationSelector", () => {
     fireEvent.click(screen.getByRole("button", {
       name: "Run location: Team Organization cloud",
     }));
-    expect(screen.getByText("Organization cloud")).toBeTruthy();
+    // "Organization cloud" renders several times (trigger label, Team owner
+    // option detail, section header, and the team target row), so target the
+    // team target row by its exact accessible name to keep the single-match intent.
+    const popover = within(screen.getByRole("dialog"));
+    // The row's accessible name leads with "Organization cloud" (then the repo
+    // label); the Team owner option is "Team Organization cloud", so anchor to
+    // the start to select the row uniquely.
+    const teamRow = popover.getByRole("button", { name: /^Organization cloud/ });
+    expect(teamRow).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /Organization cloud/ }));
+    fireEvent.click(teamRow);
     expect(onSelectOwner).toHaveBeenCalledWith("organization");
     expect(onSelectTarget).toHaveBeenCalledWith(cloudTarget);
   });

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createElement, isValidElement } from "react";
+import { createElement, isValidElement, type ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AnyHarnessRuntime } from "@anyharness/sdk-react";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
 import { ChatComposerDock } from "#product/components/workspace/chat/input/ChatComposerDock";
 import { SCENARIOS, type ScenarioKey } from "#product/config/playground";
 import { renderDelegationSlot } from "#product/components/playground/delegation/PlaygroundComposerDelegation";
@@ -68,6 +73,34 @@ const QUEUE_COMPOSER_SCENARIOS: ScenarioKey[] = [
   "subagents-queued-wake-with-approval",
 ];
 
+// The composer surface renders ComposerModelSelectorControl, which calls
+// useNavigate(), useProductHost(), and react-query hooks; static-render it
+// inside the same provider stack the app mounts so those hooks have context.
+function renderComposerSurfaceMarkup(scenario: ScenarioKey): string {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderToStaticMarkup(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(
+        ProductHostProvider,
+        { host: makeTestProductHost() },
+        createElement(
+          AnyHarnessRuntime,
+          { runtimeUrl: null },
+          createElement(
+            MemoryRouter,
+            null,
+            renderComposerSurfaceForScenario(scenario) as ReactElement,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 describe("playground scenarios", () => {
   it("includes user-input card scenarios for visual iteration", () => {
     expect(Object.keys(SCENARIOS)).toEqual(expect.arrayContaining(USER_INPUT_SCENARIOS));
@@ -86,7 +119,7 @@ describe("playground scenarios", () => {
     expect(html).toContain("Thinking timing lab");
     expect(html).toContain("Sweep duration");
     expect(html).toContain(
-      "--thinking-text-duration: 2200ms; --thinking-text-easing: linear;",
+      "--thinking-text-duration: 2400ms; --thinking-text-easing: linear;",
     );
     expect(html).toContain("Restoring session");
     expect(html).not.toContain("data-jank-canary=\"braille\"");
@@ -198,17 +231,17 @@ describe("playground scenarios", () => {
     expect(Object.keys(SCENARIOS)).toContain("slash-command-empty");
     expect(PLAYGROUND_SLASH_COMMANDS.some((command) => command.group === "MCP")).toBe(true);
 
-    const groupedHtml = renderToStaticMarkup(renderComposerSurfaceForScenario("slash-command-search"));
+    const groupedHtml = renderComposerSurfaceMarkup("slash-command-search");
     expect(groupedHtml).toContain("/compact");
     expect(groupedHtml).toContain("MCP");
 
-    const emptyHtml = renderToStaticMarkup(renderComposerSurfaceForScenario("slash-command-empty"));
+    const emptyHtml = renderComposerSurfaceMarkup("slash-command-empty");
     expect(emptyHtml).toContain("No matching slash commands.");
   });
 
   it("renders a long composer input scenario through the shared editor surface", () => {
     expect(Object.keys(SCENARIOS)).toContain("composer-long-input");
-    const html = renderToStaticMarkup(renderComposerSurfaceForScenario("composer-long-input"));
+    const html = renderComposerSurfaceMarkup("composer-long-input");
     expect(html).toContain("data-chat-composer-editor");
     expect(html).toContain("data-telemetry-mask");
   });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-selection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createChatTranscriptSelectionHandlers } from "#product/hooks/chat/ui/chat-transcript-selection-handlers";
 import { attachChatTranscriptSelectionListeners } from "#product/hooks/chat/ui/chat-transcript-selection-listeners";
 import {
@@ -35,6 +35,18 @@ function facts(overrides: Partial<TranscriptTargetFacts> = {}): TranscriptTarget
     ...overrides,
   };
 }
+
+// Primary-modifier detection (isPrimarySelectAllEvent) is platform-derived, and
+// the keydown fixtures use Cmd (metaKey). In Node the test navigator reflects the
+// host OS, so pin macOS for deterministic select-all handling on dev machines and
+// Linux CI.
+beforeEach(() => {
+  vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function keydownEvent(target: EventTarget, overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
   return {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-empty-session.test.ts
@@ -10,7 +10,9 @@ describe("handleEmptyWorkspaceBootstrap", () => {
   it("clears remembered sessions with the logical workspace key", async () => {
     const clearLastViewedSession = vi.fn();
     const createEmptySessionWithResolvedConfig = vi.fn();
-    const ensureCloudAgentCatalog = vi.fn();
+    // The bootstrap awaits ensureCloudAgentCatalog().catch(...), so the mock must
+    // return a promise. An empty catalog yields no default launch agent.
+    const ensureCloudAgentCatalog = vi.fn().mockResolvedValue(null);
     const fetchWorkspaceSessions = vi.fn().mockResolvedValue([session("dismissed-session")]);
     const markWorkspaceBootstrappedInSession = vi.fn();
     const setActiveSessionId = vi.fn();
@@ -42,12 +44,19 @@ describe("handleEmptyWorkspaceBootstrap", () => {
       setActiveSessionId,
     });
 
+    // Core intent: the remembered-session clear keys off the logical workspace id,
+    // never the materialized one.
     expect(clearLastViewedSession).toHaveBeenCalledWith("logical-workspace-1");
     expect(clearLastViewedSession).not.toHaveBeenCalledWith("materialized-workspace-1");
-    expect(result.shouldReturn).toBe(true);
-    expect(setActiveSessionId).toHaveBeenCalledWith(null);
-    expect(markWorkspaceBootstrappedInSession).toHaveBeenCalledWith("materialized-workspace-1");
-    expect(ensureCloudAgentCatalog).not.toHaveBeenCalled();
+    // With no pending projected session the bootstrap falls through to the
+    // default-session path: it loads the launch catalog, finds no default launch
+    // (empty catalog), so it creates nothing and reports shouldReturn=false.
+    expect(ensureCloudAgentCatalog).toHaveBeenCalled();
     expect(createEmptySessionWithResolvedConfig).not.toHaveBeenCalled();
+    expect(result.shouldReturn).toBe(false);
+    // setActiveSessionId / markWorkspaceBootstrappedInSession only fire on the
+    // projected-pending-session early return, which this input does not take.
+    expect(setActiveSessionId).not.toHaveBeenCalled();
+    expect(markWorkspaceBootstrappedInSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/settings/navigation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/navigation.test.ts
@@ -105,12 +105,14 @@ describe("settings navigation", () => {
     });
   });
 
-  it("falls parked budget settings links back to general", () => {
+  it("resolves the organization limits admin section", () => {
+    // organization-limits is a live admin section (budget/limits panes), so it
+    // resolves to itself rather than falling back to general.
     expect(resolveSettingsSelection({
       rawSection: "organization-limits",
       repositories: [],
     })).toEqual({
-      activeSection: "general",
+      activeSection: "organization-limits",
       activeRepoSourceRoot: null,
       focus: {},
       joinOrganizationId: null,
@@ -344,14 +346,17 @@ describe("settings navigation", () => {
       joinOrganizationId: null,
     });
 
+    // A recognized focus still redirects: legacy cloud billing links land on
+    // the billing section. (The former target -> agent-authentication redirect
+    // is gone; the Bifrost auth pane was replaced by the API key pool page.)
     expect(resolveSettingsSelection({
       rawSection: "cloud",
-      rawTarget: "target-1",
+      rawFocus: "billing",
       repositories: [],
     })).toEqual({
-      activeSection: "agent-authentication",
+      activeSection: "billing",
       activeRepoSourceRoot: null,
-      focus: { target: "target-1" },
+      focus: {},
       joinOrganizationId: null,
     });
   });

--- a/apps/packages/product-client/src/lib/domain/shortcuts/dispatch-policy.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/dispatch-policy.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { shouldDispatchKeyboardShortcut } from "#product/lib/domain/shortcuts/dispatch-policy";
 
 describe("shortcut dispatch policy", () => {
+  // These cases use Cmd (metaKey) as the primary modifier, so the binding match
+  // is platform-sensitive. In Node the test navigator reflects the host OS; pin
+  // macOS so dispatch decisions are deterministic across dev machines and CI.
+  beforeEach(() => {
+    vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });

--- a/apps/packages/product-client/src/lib/domain/shortcuts/keyboard-resolution.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/keyboard-resolution.test.ts
@@ -56,6 +56,7 @@ describe("resolveKeyboardShortcut", () => {
       trigger: expect.objectContaining({ source: "keyboard" }),
     });
 
+    // Plain Ctrl+N is the "New workspace" default binding (workspace.new-default).
     expect(resolveKeyboardShortcut({
       key: "n",
       code: "KeyN",
@@ -63,7 +64,11 @@ describe("resolveKeyboardShortcut", () => {
       ctrlKey: true,
       shiftKey: false,
       altKey: false,
-    } as KeyboardEvent)).toBeNull();
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.new-default",
+      shortcut: expect.objectContaining({ id: "workspace.new-default" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
   });
 
   it("opens top-level app shortcuts on mac", () => {
@@ -98,6 +103,8 @@ describe("resolveKeyboardShortcut", () => {
       trigger: expect.objectContaining({ source: "keyboard" }),
     });
 
+    // Cmd+P is unbound: the plugins page (app.go-plugins) was removed in #823,
+    // replaced by workflows (app.go-automations, Cmd+U, asserted below).
     expect(resolveKeyboardShortcut({
       key: "p",
       code: "KeyP",
@@ -105,11 +112,7 @@ describe("resolveKeyboardShortcut", () => {
       ctrlKey: false,
       shiftKey: false,
       altKey: false,
-    } as KeyboardEvent)).toEqual({
-      id: "app.go-plugins",
-      shortcut: expect.objectContaining({ id: "app.go-plugins" }),
-      trigger: expect.objectContaining({ source: "keyboard" }),
-    });
+    } as KeyboardEvent)).toBeNull();
 
     expect(resolveKeyboardShortcut({
       key: "u",
@@ -214,6 +217,7 @@ describe("resolveKeyboardShortcut", () => {
       trigger: expect.objectContaining({ source: "keyboard" }),
     });
 
+    // Plain Cmd+N is the "New workspace" default binding (workspace.new-default).
     expect(resolveKeyboardShortcut({
       key: "n",
       code: "KeyN",
@@ -221,7 +225,11 @@ describe("resolveKeyboardShortcut", () => {
       ctrlKey: false,
       shiftKey: false,
       altKey: false,
-    } as KeyboardEvent)).toBeNull();
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.new-default",
+      shortcut: expect.objectContaining({ id: "workspace.new-default" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
   });
 
   it("resolves new workspace shortcuts by physical KeyN on mac", () => {
@@ -334,6 +342,7 @@ describe("resolveKeyboardShortcut", () => {
       trigger: expect.objectContaining({ source: "keyboard" }),
     });
 
+    // Cmd+Opt+digit jumps to a chat by index (workspace.tab-by-index).
     expect(resolveKeyboardShortcut({
       key: "1",
       code: "Digit1",
@@ -342,11 +351,13 @@ describe("resolveKeyboardShortcut", () => {
       shiftKey: false,
       altKey: true,
     } as KeyboardEvent)).toEqual({
-      id: "workspace.by-index",
-      shortcut: expect.objectContaining({ id: "workspace.by-index" }),
+      id: "workspace.tab-by-index",
+      shortcut: expect.objectContaining({ id: "workspace.tab-by-index" }),
       trigger: expect.objectContaining({ source: "keyboard", digit: 1 }),
     });
 
+    // Cmd+digit (no alt) overlaps the settings-section and workspace-by-index
+    // bindings; the settings overlay is declared first so it wins while open.
     expect(resolveKeyboardShortcuts({
       key: "1",
       code: "Digit1",
@@ -355,8 +366,8 @@ describe("resolveKeyboardShortcut", () => {
       shiftKey: false,
       altKey: false,
     } as KeyboardEvent).map((resolved) => resolved.id)).toEqual([
-      "workspace.tab-by-index",
       "settings.section-by-index",
+      "workspace.by-index",
     ]);
 
     expect(resolveKeyboardShortcut({

--- a/apps/packages/product-client/src/lib/domain/shortcuts/presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/presentation.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { buildShortcutRangeLabelById } from "#product/lib/domain/shortcuts/presentation";
 
 describe("shortcut presentation", () => {
+  // Labels are platform-derived (getShortcutDisplayLabel). In Node the test
+  // navigator reflects the host OS, so pin macOS for deterministic ⌘ labels
+  // across dev machines and Linux CI.
+  beforeEach(() => {
+    vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("builds labels that match range shortcut digit resolution", () => {
     const labels = buildShortcutRangeLabelById(
       Array.from({ length: 10 }, (_, index) => `workspace-${index + 1}`),

--- a/apps/packages/product-client/src/lib/infra/editor/highlighting.test.ts
+++ b/apps/packages/product-client/src/lib/infra/editor/highlighting.test.ts
@@ -16,30 +16,30 @@ describe("highlightMarkdownDiffLines", () => {
       "dark",
     );
 
-    expect(tokens[0]).toEqual([{ content: "## Development", color: "#FF678D" }]);
+    expect(tokens[0]).toEqual([{ content: "## Development", color: "#F22C3D" }]);
     expect(tokens[2]).toEqual([
-      { content: "```", color: "#79797F" },
-      { content: "bash", color: "#FBFBFB" },
+      { content: "```", color: "#FFFFFF80" },
+      { content: "bash", color: "#FFFFFF" },
     ]);
     expect(tokens[3]).toEqual([
-      { content: "make test             # Rust workspace tests", color: "#FBFBFB" },
+      { content: "make test             # Rust workspace tests", color: "#FFFFFF" },
     ]);
     expect(tokens[5]).toEqual([
-      { content: "-", color: "#FF678D" },
-      { content: " Run ", color: "#FBFBFB" },
-      { content: "`", color: "#79797F" },
-      { content: "make dev", color: "#5ECC71" },
-      { content: "`", color: "#79797F" },
-      { content: " now", color: "#FBFBFB" },
+      { content: "-", color: "#F22C3D" },
+      { content: " Run ", color: "#FFFFFF" },
+      { content: "`", color: "#FFFFFF80" },
+      { content: "make dev", color: "#00A67D" },
+      { content: "`", color: "#FFFFFF80" },
+      { content: " now", color: "#FFFFFF" },
     ]);
     expect(tokens[6]).toEqual([
-      { content: "See ", color: "#FBFBFB" },
-      { content: "[", color: "#79797F" },
-      { content: "`", color: "#79797F" },
-      { content: "specs/developing/local/dev-profiles.md", color: "#5ECC71" },
-      { content: "`", color: "#79797F" },
-      { content: "]", color: "#79797F" },
-      { content: "(specs/developing/local/dev-profiles.md)", color: "#FF678D" },
+      { content: "See ", color: "#FFFFFF" },
+      { content: "[", color: "#FFFFFF80" },
+      { content: "`", color: "#FFFFFF80" },
+      { content: "specs/developing/local/dev-profiles.md", color: "#00A67D" },
+      { content: "`", color: "#FFFFFF80" },
+      { content: "]", color: "#FFFFFF80" },
+      { content: "(specs/developing/local/dev-profiles.md)", color: "#F22C3D" },
     ]);
   });
 });


### PR DESCRIPTION
## Why

The `Shared frontend packages` CI job has been red since `c6e094b41` (#1215, "move the Desktop product into ProductClient"). The move relocated the Desktop test suite into `apps/packages/product-client`, where a set of previously-tolerated failing tests now **gate** the job. These were pre-existing failures in the Desktop lane (non-gating there); the move made them block CI. None of them are product bugs — the shipped component/config is the source of truth and the tests had drifted from it.

Two classes:
- **12 fail on every platform** (stale assertions vs shipped behavior).
- **5 are CI-only (Linux)**: Node 22 exposes `navigator.platform` reflecting the host OS, so `isApplePlatform()` returns `true` on the darwin dev machine but `false` on Linux CI. Reproduced locally by forcing a Linux navigator; fixed by pinning macOS in the affected tests (the existing `keyboard-resolution.test.ts` convention).

All fixes are in tests only — no product source changed. Full `@proliferate/product-client` suite is green (3008 passed), `apps/desktop` vitest stays green (168 passed), `check_frontend_boundaries.py` passes, `git diff --check` clean.

## Per-test root causes

| Test file | Case(s) | Root cause | Fix |
|---|---|---|---|
| `lib/infra/editor/highlighting.test.ts` | fenced markdown (1) | Old pre-#927 dark palette (`#FF678D`/`#FBFBFB`/`#79797F`/`#5ECC71`) | Update to shipped palette (`#F22C3D`/`#FFFFFF`/`#FFFFFF80`/`#00A67D`) |
| `config/playground.test.ts` | loading-states (1) | Component default is `2400ms` (`durationMs: 2_400`), test asserted stale `2200ms` | Assert `2400ms` |
| `config/playground.test.ts` | slash-command + long-input (2) | Composer surface renders the shipped control row (model selector), which needs Router + ProductHost + QueryClient + AnyHarnessRuntime | Static-render inside the same provider stack the app mounts |
| `lib/domain/shortcuts/keyboard-resolution.test.ts` | Ctrl+N / Cmd+N (2) | `workspace.new-default` ("New workspace") is now a real Cmd/Ctrl+N binding | Assert `workspace.new-default` |
| `lib/domain/shortcuts/keyboard-resolution.test.ts` | Cmd+P (1) | `app.go-plugins` removed in #823 (plugins domain deleted, replaced by workflows/Cmd+U) → Cmd+P unbound | Assert `null` |
| `lib/domain/shortcuts/keyboard-resolution.test.ts` | Cmd+Opt+digit / Cmd+digit (1) | Rebinding: Cmd+Opt+digit → `workspace.tab-by-index`; Cmd+digit → `[settings.section-by-index, workspace.by-index]` | Update ids + ordering to config |
| `lib/domain/settings/navigation.test.ts` | organization-limits (1) | `organization-limits` is a live admin section (budget/limits panes + sidebar), not parked | Assert it resolves to itself |
| `lib/domain/settings/navigation.test.ts` | legacy cloud target (1) | `cloud?target=` → `agent-authentication` redirect removed (Bifrost auth pane replaced by API-key pool) | Assert the surviving by-focus redirect (`focus=billing → billing`) |
| `components/automations/controls/AutomationRunLocationSelector.test.tsx` | org-scope rows (1) | "Organization cloud" legitimately renders 4× (trigger, Team option, section header, target row); `getByText` throws | Scope to the popover dialog and target the row button by anchored name — assertion intent preserved |
| `hooks/workspaces/workflows/workspace-bootstrap-empty-session.test.ts` | clears remembered sessions (1) | `.catch()` on a bare `vi.fn()` (returns undefined) **plus** the downstream assertions were stale after a refactor | See note below |
| `lib/domain/shortcuts/presentation.test.ts` | range labels (1) — **CI-only** | `getShortcutDisplayLabel` is platform-derived; Node navigator reflects host OS | Pin macOS navigator |
| `lib/domain/shortcuts/dispatch-policy.test.ts` | tab-cycling from text inputs (2) — **CI-only** | Cmd-modifier binding match is platform-sensitive; Node navigator reflects host OS | Pin macOS navigator |
| `hooks/chat/ui/use-chat-transcript-selection.test.ts` | select-all / stale-ownership (2) — **CI-only** | Primary-modifier (Cmd vs Ctrl) detection is platform-derived | Pin macOS navigator |

### Divergence from the handoff note — `workspace-bootstrap-empty-session`
The record flagged only the `.catch()`-on-`vi.fn()` infra fix. That fixes the crash but is **not sufficient**: the test's downstream assertions were also stale against the refactored `handleEmptyWorkspaceBootstrap`. Specifically, `setActiveSessionId` is now dead in that function (never called on any path), and with a `null` pending entry the projected-session early return isn't taken. I gave the mock a resolved promise **and** reconciled the assertions to the shipped fall-through behavior (loads catalog, no default launch from empty catalog → creates nothing, `shouldReturn === false`, no `setActiveSessionId`/`markWorkspaceBootstrappedInSession`), preserving the test's core intent (the remembered-session clear keys off the logical workspace id, never the materialized one). No product bug — the function is self-consistent and intentional.

## Verification
- `pnpm --filter @proliferate/product-client test` → 517 files / 3008 tests passed
- CI-only cases reproduced under a forced Linux navigator (temporary probe config, since removed) and confirmed green after the fix
- `pnpm --dir apps/desktop exec vitest run` → 168 passed
- `python3 scripts/check_frontend_boundaries.py` → passed
- `git diff --check` → clean

## Do not merge
Leaving this for Pablo to review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
