### PR TITLE
fix(product-client): satisfy tsc overloads in playground composer-surface wrapper

### DIFF
--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -80,23 +80,23 @@ function renderComposerSurfaceMarkup(scenario: ScenarioKey): string {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  // ProductHostProvider and AnyHarnessRuntime declare `children` as a required
+  // prop, so createElement needs it inside the props object to typecheck.
   return renderToStaticMarkup(
     createElement(
       QueryClientProvider,
       { client: queryClient },
-      createElement(
-        ProductHostProvider,
-        { host: makeTestProductHost() },
-        createElement(
-          AnyHarnessRuntime,
-          { runtimeUrl: null },
-          createElement(
+      createElement(ProductHostProvider, {
+        host: makeTestProductHost(),
+        children: createElement(AnyHarnessRuntime, {
+          runtimeUrl: null,
+          children: createElement(
             MemoryRouter,
             null,
             renderComposerSurfaceForScenario(scenario) as ReactElement,
           ),
-        ),
-      ),
+        }),
+      }),
     ),
   );
 }


### PR DESCRIPTION
## Summary

#1225 merged moments before its follow-up typing fix was pushed to the branch, so `main` inherited two `TS2769` errors in `playground.test.ts` (the composer-surface wrapper's `createElement` overloads), which turn the Shared frontend packages and Web frontend build jobs red. This cherry-picks the one-commit fix: `children` passed inside the props object where the provider types require it.

`pnpm --filter @proliferate/product-client typecheck` green on this head.

## Impact

Unblocks the red CI on `main`. Tests-only.