### PR TITLE
feat(anyharness): workflow session mutation admission (2b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Check AnyHarness layer boundaries
         run: python3 scripts/check_anyharness_boundaries.py
 
+      - name: Check session mutation admission
+        run: python3 scripts/check_session_mutation_admission.py
+
       - name: Check documentation integrity
         run: |
           python3 -m unittest scripts/test_check_docs.py

--- a/Makefile
+++ b/Makefile
@@ -1378,6 +1378,7 @@ check:
 
 check-max-lines:
 	python3 scripts/check_max_lines.py
+	python3 scripts/check_session_mutation_admission.py
 
 check-server-boundaries:
 	cd server && uv run python ../scripts/check_server_boundaries.py

--- a/anyharness/crates/anyharness-lib/src/api/http/access.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/access.rs
@@ -152,3 +152,36 @@ pub async fn assert_terminal_mutable(state: &AppState, terminal_id: &str) -> Res
         .await
         .map_err(map_access_error)
 }
+
+/// Session mutation admission at the HTTP boundary (spec 2b): every
+/// execution-affecting route acquires the session's mutation permit with the
+/// External source BEFORE its first side effect, and holds the returned
+/// permit across the mutation. A session controlled by a nonterminal workflow
+/// answers the stable conflict; policy infrastructure failure surfaces as the
+/// generic storage error, never a fabricated admission. Cosmetic store-only
+/// routes (title) deliberately do not call this (ruling 2b-2).
+pub async fn admit_session_mutation(
+    state: &AppState,
+    session_id: &str,
+    kind: crate::domains::sessions::admission::SessionMutationKind,
+) -> Result<crate::domains::sessions::admission::SessionMutationPermit, ApiError> {
+    use crate::domains::sessions::admission::{SessionMutationConflict, SessionMutationSource};
+    state
+        .session_admission
+        .acquire(session_id, kind, &SessionMutationSource::external())
+        .await
+        .map_err(|conflict| match conflict {
+            SessionMutationConflict::ControlledByWorkflow { .. } => ApiError::conflict(
+                "session execution is controlled by an active workflow run",
+                "SESSION_CONTROLLED_BY_WORKFLOW",
+            ),
+            SessionMutationConflict::Internal(error) => {
+                tracing::error!(
+                    session_id = %session_id,
+                    error = %error,
+                    "session mutation admission lookup failed"
+                );
+                ApiError::internal("session admission unavailable")
+            }
+        })
+}

--- a/anyharness/crates/anyharness-lib/src/api/http/goals.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/goals.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     ClearSessionGoalResponse, SessionGoalResponse, SetSessionGoalRequest,
 };
@@ -31,6 +33,8 @@ pub async fn set_session_goal(
     Json(request): Json<SetSessionGoalRequest>,
 ) -> Result<Json<SessionGoalResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Goal).await?;
     let goal = state
         .goal_runtime
         .set_goal(&session_id, request)
@@ -56,6 +60,8 @@ pub async fn clear_session_goal(
     Path(session_id): Path<String>,
 ) -> Result<Json<ClearSessionGoalResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Goal).await?;
     let cleared = state
         .goal_runtime
         .clear_goal(&session_id)

--- a/anyharness/crates/anyharness-lib/src/api/http/loops.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/loops.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     ClearSessionLoopsResponse, SessionLoopResponse, SessionLoopsResponse, SetSessionLoopRequest,
 };
@@ -31,6 +33,8 @@ pub async fn set_session_loop(
     Json(request): Json<SetSessionLoopRequest>,
 ) -> Result<Json<SessionLoopResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Loop).await?;
     let r#loop = state
         .loop_runtime
         .set_loop(&session_id, request)
@@ -61,6 +65,8 @@ pub async fn edit_session_loop(
     Json(request): Json<SetSessionLoopRequest>,
 ) -> Result<Json<SessionLoopResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Loop).await?;
     let r#loop = state
         .loop_runtime
         .edit_loop(&session_id, &loop_id, request)
@@ -108,6 +114,8 @@ pub async fn clear_session_loops(
     Path(session_id): Path<String>,
 ) -> Result<Json<ClearSessionLoopsResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Loop).await?;
     let cleared = state
         .loop_runtime
         .clear_loop(&session_id, None)
@@ -136,6 +144,8 @@ pub async fn clear_session_loop(
     Path((session_id, loop_id)): Path<(String, String)>,
 ) -> Result<Json<ClearSessionLoopsResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Loop).await?;
     let cleared = state
         .loop_runtime
         .clear_loop(&session_id, Some(loop_id))
@@ -165,16 +175,18 @@ fn map_loop_op_error(error: LoopOpError) -> ApiError {
         LoopOpError::PromptTooLarge => {
             ApiError::bad_request("Loop prompt is too large.", "LOOP_PROMPT_TOO_LARGE")
         }
-        LoopOpError::InvalidSchedule(detail) => {
-            ApiError::bad_request(format!("Loop schedule is invalid: {detail}"), "LOOP_SCHEDULE_INVALID")
-        }
+        LoopOpError::InvalidSchedule(detail) => ApiError::bad_request(
+            format!("Loop schedule is invalid: {detail}"),
+            "LOOP_SCHEDULE_INVALID",
+        ),
         LoopOpError::NotConfirmed => ApiError::conflict(
             "The loop mutation was accepted but its native confirmation did not arrive.",
             "LOOP_NOT_CONFIRMED",
         ),
-        LoopOpError::Rejected(detail) => {
-            ApiError::bad_request(format!("Agent rejected loop operation: {detail}"), "LOOP_REJECTED")
-        }
+        LoopOpError::Rejected(detail) => ApiError::bad_request(
+            format!("Agent rejected loop operation: {detail}"),
+            "LOOP_REJECTED",
+        ),
         LoopOpError::AgentUnavailable(detail) => ApiError::service_unavailable(
             format!("The agent could not service the loop operation: {detail}"),
             "AGENT_UNAVAILABLE",

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -1,3 +1,5 @@
+use crate::api::http::workspaces_purge::admit_all_workspace_sessions;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     DestroyWorkspaceMobilitySourceRequest, DestroyWorkspaceMobilitySourceResponse,
     ExportWorkspaceMobilityArchiveRequest, InstallWorkspaceMobilityArchiveRequest,
@@ -117,6 +119,7 @@ pub async fn update_workspace_mobility_runtime_state(
     params(("workspace_id" = String, Path, description = "Workspace ID")),
     request_body = ExportWorkspaceMobilityArchiveRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Workspace mobility archive", body = WorkspaceMobilityArchive),
         (status = 404, description = "Workspace not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -127,6 +130,8 @@ pub async fn export_workspace_mobility_archive(
     Path(workspace_id): Path<String>,
     Json(req): Json<ExportWorkspaceMobilityArchiveRequest>,
 ) -> Result<Json<WorkspaceMobilityArchive>, ApiError> {
+    let _admission_permits =
+        admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::Mobility).await?;
     let _operation = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, WorkspaceOperationKind::MobilityWrite)

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -130,7 +130,10 @@ pub async fn export_workspace_mobility_archive(
     Path(workspace_id): Path<String>,
     Json(req): Json<ExportWorkspaceMobilityArchiveRequest>,
 ) -> Result<Json<WorkspaceMobilityArchive>, ApiError> {
-    let _admission_permits =
+    // Holds the up-front admission permits for the whole export; the FENCE-02
+    // admitted-set re-check applies only to the exclusive-lease destruction
+    // paths (purge/retire), so the mobility export just retains the permits.
+    let _admission =
         admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::Mobility).await?;
     let _operation = state
         .workspace_operation_gate

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -250,6 +250,7 @@ pub async fn install_workspace_mobility_archive(
     params(("workspace_id" = String, Path, description = "Workspace ID")),
     request_body = DestroyWorkspaceMobilitySourceRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Destroyed the old workspace source materialization", body = DestroyWorkspaceMobilitySourceResponse),
         (status = 404, description = "Workspace not found", body = anyharness_contract::v1::ProblemDetails),
     ),

--- a/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility.rs
@@ -260,9 +260,27 @@ pub async fn destroy_workspace_mobility_source(
     Path(workspace_id): Path<String>,
     Json(_req): Json<DestroyWorkspaceMobilitySourceRequest>,
 ) -> Result<Json<DestroyWorkspaceMobilitySourceResponse>, ApiError> {
+    // PR1227-MOBILITY-DESTROY-01: destroy-source closes terminals, deletes EVERY
+    // source session and its artifacts, and destroys materialization, so a
+    // workflow-controlled session must fail closed exactly like purge/retire.
+    // Admit every workspace session up front (sorted permits held across the
+    // whole operation) BEFORE the operation lease, preserving the canonical
+    // `permit -> operation lease` order.
+    let admission =
+        admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::Mobility).await?;
+    // PR1227-WORKSPACE-FENCE-02: carry the admitted id set into the under-lease
+    // re-check; the permits are held until this handler returns.
+    let admitted_session_ids = admission.session_ids.clone();
+    let _admission_permits = admission.permits;
+    // Take the EXCLUSIVE workspace lease (not the old shared MobilityWrite): the
+    // shared lease does not exclude the shared SessionStart lease every workflow
+    // session creation holds, so a fresh workflow session could bind in the
+    // window between the up-front snapshot and destruction. The exclusive lease
+    // excludes SessionStart, closing that late-session window. Nothing else
+    // relies on destroy-source running concurrently with other mobility ops.
     let _operation = state
         .workspace_operation_gate
-        .acquire_shared(&workspace_id, WorkspaceOperationKind::MobilityWrite)
+        .acquire_exclusive(&workspace_id)
         .await;
     assert_workspace_mode(
         &state,
@@ -270,6 +288,12 @@ pub async fn destroy_workspace_mobility_source(
         WorkspaceAccessMode::RemoteOwned,
         None,
     )?;
+    // PR1227-WORKSPACE-FENCE-01/02: under the exclusive lease, re-enumerate the
+    // workspace session set and fail closed before ANY effect if (02) a session
+    // id appeared after the up-front admitted snapshot, or (01) a nonterminal
+    // workflow controls a session. Read-only lookup + pure in-memory set
+    // comparison: no permit, no further lease — no ABBA edge.
+    reject_destroy_if_workflow_controlled(&state, &workspace_id, &admitted_session_ids).await?;
     let mobility_service = state.mobility_service.clone();
     let workspace_id_for_destroy = workspace_id.clone();
     let summary = run_blocking("mobility_destroy_source", move || {
@@ -284,6 +308,70 @@ pub async fn destroy_workspace_mobility_source(
         closed_terminal_ids: summary.closed_terminal_ids,
         source_destroyed: summary.source_destroyed,
     }))
+}
+
+/// PR1227-MOBILITY-DESTROY-01 / WORKSPACE-FENCE-01/02: called under the
+/// already-held EXCLUSIVE workspace lease. Re-enumerate the workspace session
+/// set and return the stable 409 if either (02) an enumerated session id is
+/// absent from `admitted_session_ids` — the ids the up-front admission
+/// snapshotted and holds permits for — even if its controlling workflow already
+/// terminalized (the bind->terminalize race), OR (01) a NONTERMINAL workflow
+/// controls a session created+bound inside the admission -> exclusive-lease
+/// window. FENCE-02 is checked first (pure in-memory set comparison); neither
+/// acquires a permit or lease, so neither adds an ABBA edge.
+async fn reject_destroy_if_workflow_controlled(
+    state: &AppState,
+    workspace_id: &str,
+    admitted_session_ids: &std::collections::BTreeSet<String>,
+) -> Result<(), ApiError> {
+    let session_ids = state
+        .session_service
+        .store()
+        .list_with_dismissed_by_workspace(workspace_id)
+        .map_err(|error| {
+            tracing::error!(workspace_id = %workspace_id, error = %error, "destroy-source re-check session list failed");
+            ApiError::internal("session list failed")
+        })?
+        .into_iter()
+        .map(|session| session.id)
+        .collect::<Vec<_>>();
+    if let Some(unadmitted) = session_ids
+        .iter()
+        .find(|id| !admitted_session_ids.contains(*id))
+    {
+        tracing::info!(
+            workspace_id = %workspace_id,
+            session_id = %unadmitted,
+            "mobility destroy-source rejected under exclusive lease: a session appeared after the destruction admission snapshot"
+        );
+        return Err(ApiError::conflict(
+            format!("session {unadmitted} appeared after destruction admission"),
+            "SESSION_CONTROLLED_BY_WORKFLOW",
+        ));
+    }
+    match state
+        .session_admission
+        .find_workflow_controlled_session(session_ids)
+        .await
+    {
+        Ok(None) => Ok(()),
+        Ok(Some((session_id, run_id))) => {
+            tracing::info!(
+                workspace_id = %workspace_id,
+                session_id = %session_id,
+                controlling_run_id = %run_id,
+                "mobility destroy-source rejected under exclusive lease: a workflow controls a session created after admission"
+            );
+            Err(ApiError::conflict(
+                "session execution is controlled by an active workflow run",
+                "SESSION_CONTROLLED_BY_WORKFLOW",
+            ))
+        }
+        Err(error) => {
+            tracing::error!(workspace_id = %workspace_id, error = %error, "destroy-source controlled-session re-check failed");
+            Err(ApiError::internal("session admission unavailable"))
+        }
+    }
 }
 
 fn map_access_error(error: WorkspaceAccessError) -> ApiError {

--- a/anyharness/crates/anyharness-lib/src/api/http/plans.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/plans.rs
@@ -1,3 +1,6 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
+use crate::domains::sessions::admission::SessionMutationPermit;
 use anyharness_contract::v1::{
     HandoffPlanRequest, HandoffPlanResponse, ListProposedPlansResponse, PlanDecisionRequest,
     PlanDecisionResponse, ProposedPlanDetail, ProposedPlanDocumentResponse,
@@ -105,6 +108,24 @@ pub async fn get_plan_document(
         .map_err(map_get_plan_error)
 }
 
+/// Spec 2b: plan decisions mutate the plan's owning session projection, so
+/// they admit against that session before any durable plan write.
+async fn admit_plan_session(
+    state: &AppState,
+    plan_id: &str,
+) -> Result<Option<SessionMutationPermit>, ApiError> {
+    let plan = state.plan_service.get(plan_id).map_err(|error| {
+        tracing::error!(plan_id = %plan_id, error = %error, "plan lookup failed");
+        ApiError::internal("plan lookup failed")
+    })?;
+    match plan {
+        None => Ok(None),
+        Some(plan) => Ok(Some(
+            admit_session_mutation(state, &plan.session_id, SessionMutationKind::Plan).await?,
+        )),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/v1/workspaces/{workspace_id}/plans/{plan_id}/approve",
@@ -113,7 +134,10 @@ pub async fn get_plan_document(
         ("plan_id" = String, Path, description = "Plan ID")
     ),
     request_body = PlanDecisionRequest,
-    responses((status = 200, description = "Approved proposed plan", body = PlanDecisionResponse)),
+    responses(
+        (status = 200, description = "Approved proposed plan", body = PlanDecisionResponse),
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
+    ),
     tag = "plans"
 )]
 pub async fn approve_plan(
@@ -126,6 +150,7 @@ pub async fn approve_plan(
         .acquire_shared(&workspace_id, WorkspaceOperationKind::PlanWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
+    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     state
         .plan_runtime
         .approve(&workspace_id, &plan_id, req.expected_decision_version)
@@ -142,7 +167,10 @@ pub async fn approve_plan(
         ("plan_id" = String, Path, description = "Plan ID")
     ),
     request_body = PlanDecisionRequest,
-    responses((status = 200, description = "Rejected proposed plan", body = PlanDecisionResponse)),
+    responses(
+        (status = 200, description = "Rejected proposed plan", body = PlanDecisionResponse),
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
+    ),
     tag = "plans"
 )]
 pub async fn reject_plan(
@@ -155,6 +183,7 @@ pub async fn reject_plan(
         .acquire_shared(&workspace_id, WorkspaceOperationKind::PlanWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
+    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     state
         .plan_runtime
         .reject(&workspace_id, &plan_id, req.expected_decision_version)
@@ -171,7 +200,10 @@ pub async fn reject_plan(
         ("plan_id" = String, Path, description = "Plan ID")
     ),
     request_body = HandoffPlanRequest,
-    responses((status = 200, description = "Handed off proposed plan", body = HandoffPlanResponse)),
+    responses(
+        (status = 200, description = "Handed off proposed plan", body = HandoffPlanResponse),
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
+    ),
     tag = "plans"
 )]
 pub async fn handoff_plan(
@@ -184,6 +216,7 @@ pub async fn handoff_plan(
         .acquire_shared(&workspace_id, WorkspaceOperationKind::PlanWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
+    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     state
         .plan_runtime
         .handoff(&workspace_id, &plan_id, handoff_plan_input(req))

--- a/anyharness/crates/anyharness-lib/src/api/http/plans.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/plans.rs
@@ -145,12 +145,15 @@ pub async fn approve_plan(
     Path((workspace_id, plan_id)): Path<(String, String)>,
     Json(req): Json<PlanDecisionRequest>,
 ) -> Result<Json<PlanDecisionResponse>, ApiError> {
+    // LOCK-01: permit is acquired BEFORE the workspace operation lease
+    // (canonical order run gate -> permit -> operation lease). The plan's
+    // session_id lookup inside admit_plan_session runs before the lease.
+    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     let _lease = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, WorkspaceOperationKind::PlanWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
-    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     state
         .plan_runtime
         .approve(&workspace_id, &plan_id, req.expected_decision_version)
@@ -178,12 +181,13 @@ pub async fn reject_plan(
     Path((workspace_id, plan_id)): Path<(String, String)>,
     Json(req): Json<PlanDecisionRequest>,
 ) -> Result<Json<PlanDecisionResponse>, ApiError> {
+    // LOCK-01: permit before the workspace operation lease.
+    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     let _lease = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, WorkspaceOperationKind::PlanWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
-    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     state
         .plan_runtime
         .reject(&workspace_id, &plan_id, req.expected_decision_version)
@@ -211,12 +215,13 @@ pub async fn handoff_plan(
     Path((workspace_id, plan_id)): Path<(String, String)>,
     Json(req): Json<HandoffPlanRequest>,
 ) -> Result<Json<HandoffPlanResponse>, ApiError> {
+    // LOCK-01: permit before the workspace operation lease.
+    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     let _lease = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, WorkspaceOperationKind::PlanWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
-    let _admission_permit = admit_plan_session(&state, &plan_id).await?;
     state
         .plan_runtime
         .handoff(&workspace_id, &plan_id, handoff_plan_input(req))

--- a/anyharness/crates/anyharness-lib/src/api/http/replay.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/replay.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     AdvanceReplaySessionResponse, CreateReplaySessionRequest, CreateReplaySessionResponse,
     ExportReplayRecordingRequest, ExportReplayRecordingResponse, ListReplayRecordingsResponse,
@@ -88,6 +90,7 @@ pub async fn create_replay_session(
     path = "/v1/replay/sessions/{session_id}/advance",
     params(("session_id" = String, Path, description = "Replay session ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Advanced replay session", body = AdvanceReplaySessionResponse),
         (status = 400, description = "Replay is disabled or not paused", body = anyharness_contract::v1::ProblemDetails),
         (status = 404, description = "Replay session is not live", body = anyharness_contract::v1::ProblemDetails),
@@ -98,6 +101,8 @@ pub async fn advance_replay_session(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<Json<AdvanceReplaySessionResponse>, ApiError> {
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::ReplayAdvance).await?;
     state
         .session_runtime
         .advance_replay_session(&session_id)

--- a/anyharness/crates/anyharness-lib/src/api/http/reviews.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/reviews.rs
@@ -75,7 +75,8 @@ pub async fn start_plan_review(
         Ok(Some(plan)) => Some(
             admit_session_mutation(&state, &plan.session_id, SessionMutationKind::Review).await?,
         ),
-        _ => None,
+        Ok(None) => None,
+        Err(_) => return Err(ApiError::internal("Failed to load review plan")),
     };
     let _lease = state
         .workspace_operation_gate

--- a/anyharness/crates/anyharness-lib/src/api/http/reviews.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/reviews.rs
@@ -67,15 +67,21 @@ pub async fn start_plan_review(
     Json(req): Json<StartPlanReviewRequest>,
 ) -> Result<Json<ReviewRunResponse>, ApiError> {
     assert_workspace_auth_scope(&auth, &workspace_id)?;
+    // LOCK-01: permit is acquired BEFORE the workspace operation lease
+    // (canonical order run gate -> permit -> operation lease). The plan's
+    // session_id lookup runs before the lease; the permit is bound at handler
+    // scope so it is held across the review side effect, not dropped early.
+    let _admission_permit = match state.plan_service.get(&plan_id) {
+        Ok(Some(plan)) => Some(
+            admit_session_mutation(&state, &plan.session_id, SessionMutationKind::Review).await?,
+        ),
+        _ => None,
+    };
     let _lease = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, WorkspaceOperationKind::ReviewWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
-    if let Ok(Some(plan)) = state.plan_service.get(&plan_id) {
-        let _admission_permit =
-            admit_session_mutation(&state, &plan.session_id, SessionMutationKind::Review).await?;
-    }
     let run = state
         .review_runtime
         .start_plan_review(&workspace_id, &plan_id, start_plan_review_input(req))
@@ -103,13 +109,14 @@ pub async fn start_code_review(
     Json(req): Json<StartCodeReviewRequest>,
 ) -> Result<Json<ReviewRunResponse>, ApiError> {
     assert_workspace_auth_scope(&auth, &workspace_id)?;
+    // LOCK-01: permit before the workspace operation lease.
+    let _admission_permit =
+        admit_session_mutation(&state, &req.parent_session_id, SessionMutationKind::Review).await?;
     let _lease = state
         .workspace_operation_gate
         .acquire_shared(&workspace_id, WorkspaceOperationKind::ReviewWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
-    let _admission_permit =
-        admit_session_mutation(&state, &req.parent_session_id, SessionMutationKind::Review).await?;
     let run = state
         .review_runtime
         .start_code_review(&workspace_id, start_code_review_input(req))

--- a/anyharness/crates/anyharness-lib/src/api/http/reviews.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/reviews.rs
@@ -1,3 +1,6 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
+use crate::domains::sessions::admission::SessionMutationPermit;
 use anyharness_contract::v1::{
     MarkReviewRevisionReadyRequest, ProblemDetails, RetryReviewAssignmentRequest,
     ReviewCritiqueResponse, ReviewRunResponse, SessionReviewsResponse, StartCodeReviewRequest,
@@ -23,6 +26,24 @@ use crate::domains::reviews::service::ReviewError;
 use crate::domains::reviews::service::ReviewPersonaInput;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
 
+/// Spec 2b: review mutations targeting a run admit against the run's parent
+/// session before durable review state changes.
+async fn admit_review_parent_session(
+    state: &AppState,
+    review_run_id: &str,
+) -> Result<SessionMutationPermit, ApiError> {
+    let detail = state
+        .review_service
+        .get_run_detail(review_run_id)
+        .map_err(map_review_error)?;
+    admit_session_mutation(
+        state,
+        &detail.parent_session_id,
+        SessionMutationKind::Review,
+    )
+    .await
+}
+
 #[utoipa::path(
     post,
     path = "/v1/workspaces/{workspace_id}/plans/{plan_id}/review",
@@ -32,6 +53,7 @@ use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
     ),
     request_body = StartPlanReviewRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Started plan review", body = ReviewRunResponse),
         (status = 400, description = "Invalid review request", body = ProblemDetails),
         (status = 404, description = "Plan or session not found", body = ProblemDetails),
@@ -50,6 +72,10 @@ pub async fn start_plan_review(
         .acquire_shared(&workspace_id, WorkspaceOperationKind::ReviewWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
+    if let Ok(Some(plan)) = state.plan_service.get(&plan_id) {
+        let _admission_permit =
+            admit_session_mutation(&state, &plan.session_id, SessionMutationKind::Review).await?;
+    }
     let run = state
         .review_runtime
         .start_plan_review(&workspace_id, &plan_id, start_plan_review_input(req))
@@ -64,6 +90,7 @@ pub async fn start_plan_review(
     params(("workspace_id" = String, Path, description = "Workspace ID")),
     request_body = StartCodeReviewRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Started code review", body = ReviewRunResponse),
         (status = 400, description = "Invalid review request", body = ProblemDetails),
     ),
@@ -81,6 +108,8 @@ pub async fn start_code_review(
         .acquire_shared(&workspace_id, WorkspaceOperationKind::ReviewWrite)
         .await;
     assert_workspace_mutable(&state, &workspace_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &req.parent_session_id, SessionMutationKind::Review).await?;
     let run = state
         .review_runtime
         .start_code_review(&workspace_id, start_code_review_input(req))
@@ -156,6 +185,7 @@ pub async fn retry_review_assignment(
     Path((review_run_id, assignment_id)): Path<(String, String)>,
     Json(req): Json<RetryReviewAssignmentRequest>,
 ) -> Result<Json<ReviewRunResponse>, ApiError> {
+    let _admission_permit = admit_review_parent_session(&state, &review_run_id).await?;
     let run = state
         .review_runtime
         .retry_assignment(
@@ -173,6 +203,7 @@ pub async fn retry_review_assignment(
     path = "/v1/reviews/{review_run_id}/stop",
     params(("review_run_id" = String, Path, description = "Review run ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Stopped review run", body = ReviewRunResponse),
         (status = 404, description = "Review run not found", body = ProblemDetails),
     ),
@@ -182,6 +213,7 @@ pub async fn stop_review(
     State(state): State<AppState>,
     Path(review_run_id): Path<String>,
 ) -> Result<Json<ReviewRunResponse>, ApiError> {
+    let _admission_permit = admit_review_parent_session(&state, &review_run_id).await?;
     let run = state
         .review_runtime
         .stop_run(&review_run_id)
@@ -195,6 +227,7 @@ pub async fn stop_review(
     path = "/v1/reviews/{review_run_id}/send-feedback",
     params(("review_run_id" = String, Path, description = "Review run ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Sent review feedback", body = ReviewRunResponse),
         (status = 400, description = "Review feedback is not ready", body = ProblemDetails),
     ),
@@ -204,6 +237,7 @@ pub async fn send_review_feedback(
     State(state): State<AppState>,
     Path(review_run_id): Path<String>,
 ) -> Result<Json<ReviewRunResponse>, ApiError> {
+    let _admission_permit = admit_review_parent_session(&state, &review_run_id).await?;
     let run = state
         .review_runtime
         .send_feedback(&review_run_id)
@@ -218,6 +252,7 @@ pub async fn send_review_feedback(
     params(("review_run_id" = String, Path, description = "Review run ID")),
     request_body = MarkReviewRevisionReadyRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Started next review round", body = ReviewRunResponse),
         (status = 400, description = "Revision is not ready or max rounds reached", body = ProblemDetails),
     ),
@@ -228,6 +263,7 @@ pub async fn mark_review_revision_ready(
     Path(review_run_id): Path<String>,
     Json(req): Json<MarkReviewRevisionReadyRequest>,
 ) -> Result<Json<ReviewRunResponse>, ApiError> {
+    let _admission_permit = admit_review_parent_session(&state, &review_run_id).await?;
     let run = state
         .review_runtime
         .mark_revision_ready(&review_run_id, mark_review_revision_ready_input(req))

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_config.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_config.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     GetSessionLiveConfigResponse, Session, SetSessionConfigOptionRequest,
     SetSessionConfigOptionResponse, UpdateSessionTitleRequest,
@@ -76,6 +78,7 @@ pub async fn get_live_session_config(
     params(("session_id" = String, Path, description = "Session ID")),
     request_body = SetSessionConfigOptionRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Session config option applied or queued", body = SetSessionConfigOptionResponse),
         (status = 400, description = "Invalid config option", body = anyharness_contract::v1::ProblemDetails),
         (status = 404, description = "Session not found", body = anyharness_contract::v1::ProblemDetails),
@@ -89,6 +92,8 @@ pub async fn set_session_config_option(
     Json(req): Json<SetSessionConfigOptionRequest>,
 ) -> Result<Json<SetSessionConfigOptionResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Config).await?;
     tracing::debug!(
         session_id = %session_id,
         config_id = %req.config_id,

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_fork.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_fork.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{ForkChildStartStatus, ForkSessionRequest, ForkSessionResponse};
 use axum::{
     body::Bytes,
@@ -37,6 +39,8 @@ pub async fn fork_session(
     body: Bytes,
 ) -> Result<Json<ForkSessionResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Fork).await?;
     let req = parse_optional_fork_request(body)?;
     let _lease = acquire_session_exclusive_operation_lease(
         &state,

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_interactions.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_interactions.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{InteractionDecision, ResolveInteractionRequest};
 use axum::{
     extract::{Path, State},
@@ -21,6 +23,7 @@ use crate::domains::sessions::runtime::{InteractionPermissionDecision, Resolutio
     ),
     request_body = anyharness_contract::v1::ResolveInteractionRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Interaction resolved"),
         (status = 400, description = "Invalid interaction resolution", body = anyharness_contract::v1::ProblemDetails),
         (status = 404, description = "Not found", body = anyharness_contract::v1::ProblemDetails),
@@ -34,6 +37,12 @@ pub async fn resolve_interaction(
     Json(req): Json<ResolveInteractionRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit = admit_session_mutation(
+        &state,
+        &session_id,
+        SessionMutationKind::InteractionResolution,
+    )
+    .await?;
     let resolution = resolve_interaction_input(req);
 
     state

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_lifecycle.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use std::time::Instant;
 
 use anyharness_contract::v1::Session;
@@ -22,6 +24,7 @@ use tracing::Instrument;
     path = "/v1/sessions/{session_id}/cancel",
     params(("session_id" = String, Path, description = "Session ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Session cancelled", body = Session),
         (status = 404, description = "Session not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -33,6 +36,8 @@ pub async fn cancel_session(
     Path(session_id): Path<String>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Cancel).await?;
     let updated = state
         .session_runtime
         .cancel_live_session(&session_id)
@@ -47,6 +52,7 @@ pub async fn cancel_session(
     path = "/v1/sessions/{session_id}/close",
     params(("session_id" = String, Path, description = "Session ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Session closed", body = Session),
         (status = 404, description = "Session not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -58,6 +64,8 @@ pub async fn close_session(
     Path(session_id): Path<String>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Close).await?;
     let record = state
         .session_runtime
         .close_live_session(&session_id)
@@ -71,6 +79,7 @@ pub async fn close_session(
     path = "/v1/sessions/{session_id}/dismiss",
     params(("session_id" = String, Path, description = "Session ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Session dismissed", body = Session),
         (status = 404, description = "Session not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -82,6 +91,8 @@ pub async fn dismiss_session(
     Path(session_id): Path<String>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Dismiss).await?;
     let record = state
         .session_runtime
         .dismiss_live_session(&session_id)
@@ -99,6 +110,11 @@ pub async fn dismiss_session(
     ),
     tag = "sessions"
 )]
+// Spec 2b classification (admission:derived-safe): restore targets the
+// workspace's latest DISMISSED session. A workflow-controlled session cannot
+// be dismissed (dismissal is fenced 409 while controlled, and control binds
+// at creation by the executor), so restore can never target a controlled
+// session; no admission permit is required here.
 pub async fn restore_dismissed_session(
     State(state): State<AppState>,
     Extension(auth): Extension<AuthContext>,

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     EditPendingPromptRequest, PromptInputBlock, ReorderPendingPromptsRequest, Session,
 };
@@ -25,6 +27,7 @@ use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
     ),
     request_body = anyharness_contract::v1::EditPendingPromptRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Pending prompt updated", body = Session),
         (status = 404, description = "Session or pending prompt not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -37,6 +40,9 @@ pub async fn edit_pending_prompt(
     Json(req): Json<EditPendingPromptRequest>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::PendingPromptQueue)
+            .await?;
     let blocks = req.blocks.unwrap_or_else(|| {
         vec![PromptInputBlock::Text {
             text: req.text.unwrap_or_default(),
@@ -61,6 +67,7 @@ pub async fn edit_pending_prompt(
         ("seq" = i64, Path, description = "Stable queue-entry sequence identity"),
     ),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Pending prompt deleted", body = Session),
         (status = 404, description = "Session or pending prompt not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -72,6 +79,9 @@ pub async fn delete_pending_prompt(
     Path((session_id, seq)): Path<(String, i64)>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::PendingPromptQueue)
+            .await?;
     let _lease =
         acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
             .await?;
@@ -105,6 +115,9 @@ pub async fn reorder_pending_prompts(
     Json(req): Json<ReorderPendingPromptsRequest>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::PendingPromptQueue)
+            .await?;
     let _lease =
         acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
             .await?;
@@ -124,6 +137,7 @@ pub async fn reorder_pending_prompts(
         ("seq" = i64, Path, description = "Stable queue-entry sequence identity"),
     ),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Pending prompt promoted to run next", body = Session),
         (status = 404, description = "Session or pending prompt not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -135,6 +149,9 @@ pub async fn steer_pending_prompt(
     Path((session_id, seq)): Path<(String, i64)>,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::PendingPromptQueue)
+            .await?;
     let _lease =
         acquire_session_operation_lease(&state, &session_id, WorkspaceOperationKind::SessionPrompt)
             .await?;

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_prompt.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use std::time::Instant;
 
 use anyharness_contract::v1::{PromptSessionRequest, PromptSessionResponse};
@@ -27,6 +29,7 @@ const PROMPT_ID_MAX_BYTES: usize = 256;
     params(("session_id" = String, Path, description = "Session ID")),
     request_body = anyharness_contract::v1::PromptSessionRequest,
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Prompt accepted (running or queued)", body = anyharness_contract::v1::PromptSessionResponse),
         (status = 404, description = "Session not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -40,6 +43,8 @@ pub async fn prompt_session(
     Json(req): Json<PromptSessionRequest>,
 ) -> Result<Json<PromptSessionResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Prompt).await?;
     let flow = FlowHeaders::from_headers(&headers);
     let span = flow.span();
     let prompt_id = request_prompt_id(req.prompt_id.as_deref(), flow.prompt_id.as_deref())?;

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_resume.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_resume.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{ResumeSessionRequest, Session};
 use axum::{
     body::Bytes,
@@ -38,6 +40,8 @@ pub async fn resume_session(
     body: Bytes,
 ) -> Result<Json<Session>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::Resume).await?;
     let span = FlowHeaders::from_headers(&headers).span();
     // Parse (and validate) the optional body so legacy fields are still rejected.
     parse_optional_resume_request(body)?;

--- a/anyharness/crates/anyharness-lib/src/api/http/subagents.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/subagents.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     ChildSubagentSummary, ParentSubagentLinkSummary, ProblemDetails, ScheduleSubagentWakeRequest,
     ScheduleSubagentWakeResponse, SessionStatus, SessionSubagentsResponse,
@@ -66,6 +68,8 @@ pub async fn schedule_subagent_wake(
     Json(_body): Json<ScheduleSubagentWakeRequest>,
 ) -> Result<Json<ScheduleSubagentWakeResponse>, ApiError> {
     assert_session_auth_scope(&state, &auth, &session_id)?;
+    let _admission_permit =
+        admit_session_mutation(&state, &session_id, SessionMutationKind::SubagentWake).await?;
     let parent = state
         .session_service
         .get_session(&session_id)

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs
@@ -54,9 +54,13 @@ pub async fn retire_workspace(
     // workspace a controlled session is running in, so it fails closed like
     // purge — sorted permits for every workspace session are held across the
     // whole retirement.
-    let _admission_permits =
+    let admission =
         admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::WorkspaceRetire)
             .await?;
+    // PR1227-WORKSPACE-FENCE-02: carry the admitted id set into the under-lease
+    // re-check; the permits are held until this handler returns.
+    let admitted_session_ids = admission.session_ids.clone();
+    let _admission_permits = admission.permits;
     let current = state
         .workspace_runtime
         .get_workspace(&workspace_id)
@@ -114,13 +118,16 @@ pub async fn retire_workspace(
         .workspace_operation_gate
         .acquire_exclusive(&workspace_id)
         .await;
-    // PR1227-WORKSPACE-FENCE-01: the up-front admit_all_workspace_sessions
+    // PR1227-WORKSPACE-FENCE-01/02: the up-front admit_all_workspace_sessions
     // snapshot cannot see a session the workflow executor creates+binds inside
     // the window before this exclusive lease is held (it only holds the shared
     // SessionStart lease then). Now that the exclusive lease excludes further
-    // workflow session creation, re-enumerate and fail closed if a workflow
-    // controls one. Read-only controller lookup: no permit, no lease — no ABBA.
-    reject_retire_if_workflow_controlled(&state, &workspace_id).await?;
+    // workflow session creation, re-enumerate and fail closed if (01) a workflow
+    // controls a session, OR (02) any enumerated id is absent from the admitted
+    // set (bound after the snapshot, possibly already terminalized). Read-only
+    // controller lookup + pure in-memory set comparison: no permit, no lease —
+    // no ABBA edge.
+    reject_retire_if_workflow_controlled(&state, &workspace_id, &admitted_session_ids).await?;
     let workspace = state
         .workspace_runtime
         .get_workspace(&workspace_id)
@@ -420,14 +427,21 @@ pub async fn retry_retire_cleanup(
     }))
 }
 
-/// PR1227-WORKSPACE-FENCE-01: called under the already-held exclusive workspace
-/// lease. Re-enumerate the workspace session set and return the stable 409 if a
-/// nonterminal workflow controls a session the up-front admission could not have
-/// seen (created+bound inside the admission -> exclusive-lease window). Pure
-/// read-only controller lookup: no permit, no lease — introduces no ABBA edge.
+/// PR1227-WORKSPACE-FENCE-01/02: called under the already-held exclusive
+/// workspace lease. Re-enumerate the workspace session set and return the stable
+/// 409 if either (02) an enumerated session id is absent from `admitted_session_ids`
+/// — the ids the up-front admission snapshotted and holds permits for — even if
+/// its controlling workflow already terminalized (the bind->terminalize race), OR
+/// (01) a NONTERMINAL workflow controls a session the up-front admission could not
+/// have seen (created+bound inside the admission -> exclusive-lease window).
+/// FENCE-02 is checked first: it is a pure in-memory set comparison over ids
+/// enumerated under the held lease (no permit, no lease). FENCE-01 remains to
+/// catch control acquired post-snapshot on an EXISTING admitted session. Neither
+/// introduces an ABBA edge.
 async fn reject_retire_if_workflow_controlled(
     state: &AppState,
     workspace_id: &str,
+    admitted_session_ids: &std::collections::BTreeSet<String>,
 ) -> Result<(), ApiError> {
     let session_ids = state
         .session_service
@@ -440,6 +454,23 @@ async fn reject_retire_if_workflow_controlled(
         .into_iter()
         .map(|session| session.id)
         .collect::<Vec<_>>();
+    // PR1227-WORKSPACE-FENCE-02: any id enumerated under the exclusive lease that
+    // was NOT in the up-front admitted set was bound after the snapshot and never
+    // admitted; fail closed regardless of its controller's terminality.
+    if let Some(unadmitted) = session_ids
+        .iter()
+        .find(|id| !admitted_session_ids.contains(*id))
+    {
+        tracing::info!(
+            workspace_id = %workspace_id,
+            session_id = %unadmitted,
+            "workspace retire rejected under exclusive lease: a session appeared after the destruction admission snapshot"
+        );
+        return Err(ApiError::conflict(
+            format!("session {unadmitted} appeared after destruction admission"),
+            "SESSION_CONTROLLED_BY_WORKFLOW",
+        ));
+    }
     match state
         .session_admission
         .find_workflow_controlled_session(session_ids)

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs
@@ -1,3 +1,5 @@
+use crate::api::http::workspaces_purge::admit_all_workspace_sessions;
+use crate::domains::sessions::admission::SessionMutationKind;
 use anyharness_contract::v1::{
     Workspace, WorkspaceRetireBlocker, WorkspaceRetireBlockerCode, WorkspaceRetireBlockerSeverity,
     WorkspaceRetireOutcome, WorkspaceRetirePreflightResponse, WorkspaceRetireResponse,
@@ -38,6 +40,7 @@ pub async fn retire_workspace_preflight(
     path = "/v1/workspaces/{workspace_id}/retire",
     params(("workspace_id" = String, Path, description = "Workspace ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Retire workspace result", body = WorkspaceRetireResponse),
         (status = 404, description = "Workspace not found", body = anyharness_contract::v1::ProblemDetails),
     ),
@@ -47,6 +50,13 @@ pub async fn retire_workspace(
     State(state): State<AppState>,
     Path(workspace_id): Path<String>,
 ) -> Result<Json<WorkspaceRetireResponse>, ApiError> {
+    // Spec 2b RETIRE-01 ruling (option B): retirement can dematerialize the
+    // workspace a controlled session is running in, so it fails closed like
+    // purge — sorted permits for every workspace session are held across the
+    // whole retirement.
+    let _admission_permits =
+        admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::WorkspaceRetire)
+            .await?;
     let current = state
         .workspace_runtime
         .get_workspace(&workspace_id)

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs
@@ -103,10 +103,24 @@ pub async fn retire_workspace(
         }));
     }
 
+    // PR1227-WORKSPACE-FENCE-01 proof seam (test-only, no-op in production):
+    // park between the advisory preflight and the exclusive lease so a proof
+    // can bind a workflow-controlled session in exactly the gap the fence
+    // guards. Keyed by workspace id; absent keys change nothing.
+    #[cfg(test)]
+    retire_barriers::at_pre_exclusive(&workspace_id).await;
+
     let _exclusive = state
         .workspace_operation_gate
         .acquire_exclusive(&workspace_id)
         .await;
+    // PR1227-WORKSPACE-FENCE-01: the up-front admit_all_workspace_sessions
+    // snapshot cannot see a session the workflow executor creates+binds inside
+    // the window before this exclusive lease is held (it only holds the shared
+    // SessionStart lease then). Now that the exclusive lease excludes further
+    // workflow session creation, re-enumerate and fail closed if a workflow
+    // controls one. Read-only controller lookup: no permit, no lease — no ABBA.
+    reject_retire_if_workflow_controlled(&state, &workspace_id).await?;
     let workspace = state
         .workspace_runtime
         .get_workspace(&workspace_id)
@@ -406,6 +420,51 @@ pub async fn retry_retire_cleanup(
     }))
 }
 
+/// PR1227-WORKSPACE-FENCE-01: called under the already-held exclusive workspace
+/// lease. Re-enumerate the workspace session set and return the stable 409 if a
+/// nonterminal workflow controls a session the up-front admission could not have
+/// seen (created+bound inside the admission -> exclusive-lease window). Pure
+/// read-only controller lookup: no permit, no lease — introduces no ABBA edge.
+async fn reject_retire_if_workflow_controlled(
+    state: &AppState,
+    workspace_id: &str,
+) -> Result<(), ApiError> {
+    let session_ids = state
+        .session_service
+        .store()
+        .list_with_dismissed_by_workspace(workspace_id)
+        .map_err(|error| {
+            tracing::error!(workspace_id = %workspace_id, error = %error, "retire re-check session list failed");
+            ApiError::internal("session list failed")
+        })?
+        .into_iter()
+        .map(|session| session.id)
+        .collect::<Vec<_>>();
+    match state
+        .session_admission
+        .find_workflow_controlled_session(session_ids)
+        .await
+    {
+        Ok(None) => Ok(()),
+        Ok(Some((session_id, run_id))) => {
+            tracing::info!(
+                workspace_id = %workspace_id,
+                session_id = %session_id,
+                controlling_run_id = %run_id,
+                "workspace retire rejected under exclusive lease: a workflow controls a session created after admission"
+            );
+            Err(ApiError::conflict(
+                "session execution is controlled by an active workflow run",
+                "SESSION_CONTROLLED_BY_WORKFLOW",
+            ))
+        }
+        Err(error) => {
+            tracing::error!(workspace_id = %workspace_id, error = %error, "retire controlled-session re-check failed");
+            Err(ApiError::internal("session admission unavailable"))
+        }
+    }
+}
+
 async fn build_retire_preflight(
     state: &AppState,
     workspace_id: &str,
@@ -497,5 +556,59 @@ fn retired_cleanup_message(workspace: &WorkspaceRecord) -> Option<String> {
             "retired workspace cleanup is not complete: {}",
             workspace.cleanup_state
         )),
+    }
+}
+
+/// PR1227-WORKSPACE-FENCE-01 proof seam. A keyed, test-only barrier that parks
+/// `retire_workspace` between the advisory preflight and the exclusive
+/// workspace lease, so a deterministic proof can bind a workflow-controlled
+/// session in exactly the window the under-lease fence exists to catch. Absent
+/// keys cost one mutex lookup and change nothing. Test-only by construction.
+#[cfg(test)]
+pub(crate) mod retire_barriers {
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    use tokio::sync::oneshot;
+
+    #[derive(Default)]
+    pub(crate) struct RetireBarrier {
+        /// Fired when `retire_workspace` reaches the pre-exclusive-lease point.
+        pub(crate) reached_tx: Option<oneshot::Sender<()>>,
+        /// Awaited before acquiring the exclusive lease when present.
+        pub(crate) resume_rx: Option<oneshot::Receiver<()>>,
+    }
+
+    static BARRIERS: StdMutex<Option<HashMap<String, RetireBarrier>>> = StdMutex::new(None);
+
+    pub(crate) fn install(workspace_id: &str, barrier: RetireBarrier) {
+        BARRIERS
+            .lock()
+            .expect("retire barrier lock")
+            .get_or_insert_with(HashMap::new)
+            .insert(workspace_id.to_string(), barrier);
+    }
+
+    pub(crate) fn clear(workspace_id: &str) {
+        if let Some(map) = BARRIERS.lock().expect("retire barrier lock").as_mut() {
+            map.remove(workspace_id);
+        }
+    }
+
+    pub(super) async fn at_pre_exclusive(workspace_id: &str) {
+        let barrier = BARRIERS
+            .lock()
+            .expect("retire barrier lock")
+            .as_mut()
+            .and_then(|map| map.remove(workspace_id));
+        let Some(mut barrier) = barrier else {
+            return;
+        };
+        if let Some(tx) = barrier.reached_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(rx) = barrier.resume_rx.take() {
+            let _ = rx.await;
+        }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use crate::api::http::access::admit_session_mutation;
 use crate::domains::sessions::admission::{SessionMutationKind, SessionMutationPermit};
 use anyharness_contract::v1::{
@@ -34,15 +36,30 @@ pub async fn purge_workspace_preflight(
     Ok(Json(build_purge_preflight(&state, &workspace_id).await?))
 }
 
+/// The result of the up-front workspace-destruction admission snapshot: the
+/// held permits (dropped at end of the destructive operation) PLUS the SET of
+/// session ids that snapshot covered (PR1227-WORKSPACE-FENCE-02). The
+/// destructive owner carries the id set into its under-lease re-check so a
+/// session bound AFTER the snapshot — whose controlling workflow may already
+/// have terminalized — fails closed even though no permit is held for it.
+pub(super) struct AdmittedWorkspaceSessions {
+    /// Held for the lifetime of the destructive operation; never inspected.
+    pub(super) permits: Vec<SessionMutationPermit>,
+    /// The exact session ids admitted (and permit-held) up front.
+    pub(super) session_ids: BTreeSet<String>,
+}
+
 /// Spec 2b fail-closed rule: purge (and mobility removal) never overrides an
 /// active workflow controller. Every session of the workspace is admitted —
 /// in sorted id order so concurrent multi-session holders cannot deadlock —
-/// and ALL permits are held across the destructive operation.
+/// and ALL permits are held across the destructive operation. The admitted id
+/// set is returned alongside the permits for the FENCE-02 under-lease
+/// set-membership re-check.
 pub(super) async fn admit_all_workspace_sessions(
     state: &AppState,
     workspace_id: &str,
     kind: SessionMutationKind,
-) -> Result<Vec<SessionMutationPermit>, ApiError> {
+) -> Result<AdmittedWorkspaceSessions, ApiError> {
     let mut sessions = state
         .session_service
         .store()
@@ -53,10 +70,15 @@ pub(super) async fn admit_all_workspace_sessions(
         })?;
     sessions.sort_by(|a, b| a.id.cmp(&b.id));
     let mut permits = Vec::with_capacity(sessions.len());
+    let mut session_ids = BTreeSet::new();
     for session in &sessions {
         permits.push(admit_session_mutation(state, &session.id, kind).await?);
+        session_ids.insert(session.id.clone());
     }
-    Ok(permits)
+    Ok(AdmittedWorkspaceSessions {
+        permits,
+        session_ids,
+    })
 }
 
 #[utoipa::path(
@@ -73,9 +95,15 @@ pub async fn purge_workspace(
     State(state): State<AppState>,
     Path(workspace_id): Path<String>,
 ) -> Result<Json<WorkspacePurgeResponse>, ApiError> {
-    let _admission_permits =
+    let admission =
         admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::WorkspacePurge)
             .await?;
+    // PR1227-WORKSPACE-FENCE-02: carry the admitted id set into the destructive
+    // owner so a session bound after this snapshot fails the under-lease
+    // set-membership re-check even if its workflow already terminalized. The
+    // permits are held until this scope ends.
+    let admitted_session_ids = admission.session_ids.clone();
+    let _admission_permits = admission.permits;
 
     // PR1227-WORKSPACE-FENCE-01 proof seam (test-only, no-op in production):
     // park between the up-front admission snapshot (now fully complete) and the
@@ -90,7 +118,7 @@ pub async fn purge_workspace(
         None,
         state
             .workspace_purge_service
-            .purge(&workspace_id, false)
+            .purge_with_admitted_session_ids(&workspace_id, false, Some(admitted_session_ids))
             .await
             .map_err(|error| ApiError::internal(error.to_string()))?,
     )
@@ -257,6 +285,17 @@ async fn purge_response_from_service_outcome(
             "session execution is controlled by an active workflow run",
             "SESSION_CONTROLLED_BY_WORKFLOW",
         )),
+        // PR1227-WORKSPACE-FENCE-02: the under-lease re-enumeration observed a
+        // session id absent from the up-front admitted set (bound after the
+        // snapshot, possibly already terminalized). Fail closed with the same
+        // stable 409 code; the detail names the unadmitted session id only —
+        // no raw internal state, nothing persisted.
+        WorkspacePurgeServiceOutcome::SessionAppearedAfterAdmission { session_id } => {
+            Err(ApiError::conflict(
+                format!("session {session_id} appeared after destruction admission"),
+                "SESSION_CONTROLLED_BY_WORKFLOW",
+            ))
+        }
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs
@@ -1,3 +1,5 @@
+use crate::api::http::access::admit_session_mutation;
+use crate::domains::sessions::admission::{SessionMutationKind, SessionMutationPermit};
 use anyharness_contract::v1::{
     WorkspacePurgeOutcome, WorkspacePurgePreflightResponse, WorkspacePurgeResponse,
 };
@@ -32,11 +34,37 @@ pub async fn purge_workspace_preflight(
     Ok(Json(build_purge_preflight(&state, &workspace_id).await?))
 }
 
+/// Spec 2b fail-closed rule: purge (and mobility removal) never overrides an
+/// active workflow controller. Every session of the workspace is admitted —
+/// in sorted id order so concurrent multi-session holders cannot deadlock —
+/// and ALL permits are held across the destructive operation.
+pub(super) async fn admit_all_workspace_sessions(
+    state: &AppState,
+    workspace_id: &str,
+    kind: SessionMutationKind,
+) -> Result<Vec<SessionMutationPermit>, ApiError> {
+    let mut sessions = state
+        .session_service
+        .store()
+        .list_with_dismissed_by_workspace(workspace_id)
+        .map_err(|error| {
+            tracing::error!(workspace_id = %workspace_id, error = %error, "session list failed");
+            ApiError::internal("session list failed")
+        })?;
+    sessions.sort_by(|a, b| a.id.cmp(&b.id));
+    let mut permits = Vec::with_capacity(sessions.len());
+    for session in &sessions {
+        permits.push(admit_session_mutation(state, &session.id, kind).await?);
+    }
+    Ok(permits)
+}
+
 #[utoipa::path(
     delete,
     path = "/v1/workspaces/{workspace_id}",
     params(("workspace_id" = String, Path, description = "Workspace ID")),
     responses(
+        (status = 409, description = "Session execution is controlled by an active workflow run", body = anyharness_contract::v1::ProblemDetails),
         (status = 200, description = "Purge workspace result", body = WorkspacePurgeResponse),
     ),
     tag = "workspaces"
@@ -45,6 +73,9 @@ pub async fn purge_workspace(
     State(state): State<AppState>,
     Path(workspace_id): Path<String>,
 ) -> Result<Json<WorkspacePurgeResponse>, ApiError> {
+    let _admission_permits =
+        admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::WorkspacePurge)
+            .await?;
     purge_response_from_service_outcome(
         &state,
         None,

--- a/anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs
@@ -76,6 +76,15 @@ pub async fn purge_workspace(
     let _admission_permits =
         admit_all_workspace_sessions(&state, &workspace_id, SessionMutationKind::WorkspacePurge)
             .await?;
+
+    // PR1227-WORKSPACE-FENCE-01 proof seam (test-only, no-op in production):
+    // park between the up-front admission snapshot (now fully complete) and the
+    // exclusive workspace lease taken inside `.purge(...)`, so a proof can bind a
+    // workflow-controlled session in exactly the gap the under-lease fence
+    // guards. Keyed by workspace id; absent keys change nothing.
+    #[cfg(test)]
+    purge_barriers::at_pre_exclusive(&workspace_id).await;
+
     purge_response_from_service_outcome(
         &state,
         None,
@@ -87,6 +96,61 @@ pub async fn purge_workspace(
     )
     .await
     .map(Json)
+}
+
+/// PR1227-WORKSPACE-FENCE-01 proof seam. A keyed, test-only barrier that parks
+/// `purge_workspace` between the up-front `admit_all_workspace_sessions`
+/// snapshot and the exclusive workspace lease taken inside the purge service,
+/// so a deterministic proof can bind a workflow-controlled session in exactly
+/// the window the under-lease fence exists to catch. Absent keys cost one mutex
+/// lookup and change nothing. Test-only by construction.
+#[cfg(test)]
+pub(crate) mod purge_barriers {
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    use tokio::sync::oneshot;
+
+    #[derive(Default)]
+    pub(crate) struct PurgeBarrier {
+        /// Fired when `purge_workspace` reaches the pre-exclusive-lease point.
+        pub(crate) reached_tx: Option<oneshot::Sender<()>>,
+        /// Awaited before proceeding to the exclusive lease when present.
+        pub(crate) resume_rx: Option<oneshot::Receiver<()>>,
+    }
+
+    static BARRIERS: StdMutex<Option<HashMap<String, PurgeBarrier>>> = StdMutex::new(None);
+
+    pub(crate) fn install(workspace_id: &str, barrier: PurgeBarrier) {
+        BARRIERS
+            .lock()
+            .expect("purge barrier lock")
+            .get_or_insert_with(HashMap::new)
+            .insert(workspace_id.to_string(), barrier);
+    }
+
+    pub(crate) fn clear(workspace_id: &str) {
+        if let Some(map) = BARRIERS.lock().expect("purge barrier lock").as_mut() {
+            map.remove(workspace_id);
+        }
+    }
+
+    pub(super) async fn at_pre_exclusive(workspace_id: &str) {
+        let barrier = BARRIERS
+            .lock()
+            .expect("purge barrier lock")
+            .as_mut()
+            .and_then(|map| map.remove(workspace_id));
+        let Some(mut barrier) = barrier else {
+            return;
+        };
+        if let Some(tx) = barrier.reached_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(rx) = barrier.resume_rx.take() {
+            let _ = rx.await;
+        }
+    }
 }
 
 #[utoipa::path(
@@ -186,6 +250,13 @@ async fn purge_response_from_service_outcome(
                 cleanup_message: Some(message),
             })
         }
+        // PR1227-WORKSPACE-FENCE-01: the under-lease re-check observed a
+        // workflow-controlled session created after up-front admission. Fail
+        // closed with the same stable 409 as the up-front fence.
+        WorkspacePurgeServiceOutcome::ControlledByWorkflow { .. } => Err(ApiError::conflict(
+            "session execution is controlled by an active workflow run",
+            "SESSION_CONTROLLED_BY_WORKFLOW",
+        )),
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/api/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/api/mod.rs
@@ -17,3 +17,5 @@ mod workflow_runs_scripted_tests;
 mod workflow_runs_tests;
 #[cfg(test)]
 mod session_admission_tests;
+#[cfg(test)]
+mod review_admission_tests;

--- a/anyharness/crates/anyharness-lib/src/api/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/api/mod.rs
@@ -15,3 +15,5 @@ mod workflow_runs_portable_contract_tests;
 mod workflow_runs_scripted_tests;
 #[cfg(test)]
 mod workflow_runs_tests;
+#[cfg(test)]
+mod session_admission_tests;

--- a/anyharness/crates/anyharness-lib/src/api/openapi_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/openapi_tests.rs
@@ -243,6 +243,21 @@ fn openapi_registers_workspace_session_and_event_schemas() {
 }
 
 #[test]
+fn destroy_source_documents_workflow_controlled_409() {
+    // PR1227-MOBILITY-CONTRACT-01: the destroy-source handler fails closed with
+    // 409 SESSION_CONTROLLED_BY_WORKFLOW exactly like the other fenced routes
+    // (retire, purge, mobility export), so its published contract MUST document
+    // the 409 response. Pin it against the generated OpenAPI document.
+    let spec: Value = serde_json::from_str(&openapi_json()).expect("parse OpenAPI JSON");
+    let responses = &spec["paths"]["/v1/workspaces/{workspace_id}/mobility/destroy-source"]["post"]
+        ["responses"];
+    assert!(
+        responses.get("409").is_some(),
+        "destroy-source must document the 409 workflow-controlled contract response"
+    );
+}
+
+#[test]
 fn pending_prompt_reorder_schema_requires_compare_and_swap_orders() {
     let spec: Value = serde_json::from_str(&openapi_json()).expect("parse OpenAPI JSON");
     let schema = &spec["components"]["schemas"]["ReorderPendingPromptsRequest"];

--- a/anyharness/crates/anyharness-lib/src/api/openapi_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/openapi_tests.rs
@@ -255,6 +255,17 @@ fn destroy_source_documents_workflow_controlled_409() {
         responses.get("409").is_some(),
         "destroy-source must document the 409 workflow-controlled contract response"
     );
+    // The 409 must resolve to the shared ProblemDetails schema (body =
+    // anyharness_contract::v1::ProblemDetails), so clients get the same
+    // structured error shape as the other fenced routes rather than an
+    // undocumented ad-hoc body.
+    let schema_ref = responses["409"]["content"]["application/json"]["schema"]["$ref"]
+        .as_str()
+        .expect("destroy-source 409 must reference a JSON schema via $ref");
+    assert_eq!(
+        schema_ref, "#/components/schemas/ProblemDetails",
+        "destroy-source 409 must reference the ProblemDetails schema"
+    );
 }
 
 #[test]

--- a/anyharness/crates/anyharness-lib/src/api/review_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/review_admission_tests.rs
@@ -1,0 +1,133 @@
+use std::sync::Mutex;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::util::ServiceExt;
+
+use super::router::build_router;
+use super::workflow_runs_tests::test_state;
+use crate::app::test_support;
+use crate::domains::plans::model::NewPlan;
+use crate::domains::plans::service::PlanEventContext;
+
+const WORKSPACE_ID: &str = "20000000-0000-4000-8000-000000000002";
+const SESSION_ID: &str = "30000000-0000-4000-8000-000000000003";
+
+#[tokio::test]
+async fn plan_lookup_error_fails_closed_before_review_side_effects() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    test_support::seed_workspace_with_repo_root(
+        &state.db,
+        WORKSPACE_ID,
+        "local",
+        "/tmp/review-admission-workspace",
+    );
+    state
+        .db
+        .with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sessions (
+                    id, workspace_id, agent_kind, status, created_at, updated_at
+                 ) VALUES (?1, ?2, 'claude', 'idle', 'now', 'now')",
+                [SESSION_ID, WORKSPACE_ID],
+            )?;
+            Ok(())
+        })
+        .expect("seed parent session");
+    let plan = state
+        .plan_service
+        .create_completed_plan(
+            NewPlan {
+                workspace_id: WORKSPACE_ID.to_string(),
+                session_id: SESSION_ID.to_string(),
+                title: "Review target".to_string(),
+                body_markdown: "Verify the implementation.".to_string(),
+                source_agent_kind: "claude".to_string(),
+                source_kind: "claude_exit_plan_mode".to_string(),
+                source_turn_id: Some("turn-1".to_string()),
+                source_item_id: Some("item-1".to_string()),
+                source_tool_call_id: Some("tool-1".to_string()),
+            },
+            PlanEventContext {
+                session_id: SESSION_ID.to_string(),
+                source_agent_kind: "claude".to_string(),
+                turn_id: Some("turn-1".to_string()),
+                next_seq: 1,
+            },
+        )
+        .expect("create plan")
+        .plan;
+    let sessions_before = state
+        .session_service
+        .store()
+        .list_all()
+        .expect("list sessions before");
+
+    state.plan_service.store().fail_next_find_by_id_for_test();
+    let response = build_router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/v1/workspaces/{WORKSPACE_ID}/plans/{}/review",
+                    plan.id
+                ))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "parentSessionId": SESSION_ID,
+                        "maxRounds": 1,
+                        "autoIterate": false,
+                        "reviewers": [{
+                            "personaId": "reviewer-1",
+                            "label": "Reviewer",
+                            "prompt": "Review carefully.",
+                            "agentKind": "claude"
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body: Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body"),
+    )
+    .expect("problem details");
+    assert_eq!(body["detail"], "Failed to load review plan");
+    assert!(!body.to_string().contains("private-test-marker"));
+
+    assert!(state
+        .plan_service
+        .get(&plan.id)
+        .expect("fail-once lookup is consumed")
+        .is_some());
+    assert!(state
+        .review_service
+        .store()
+        .list_runs_for_parent(SESSION_ID)
+        .expect("list review runs")
+        .is_empty());
+    assert_eq!(
+        state
+            .session_service
+            .store()
+            .list_all()
+            .expect("list sessions after")
+            .len(),
+        sessions_before.len(),
+        "a failed admission lookup must not create reviewer sessions or actors"
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -312,6 +312,67 @@ async fn purge_and_mobility_fail_closed_while_controlled() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn destroy_source_fails_closed_while_controlled() {
+    // PR1227-MOBILITY-DESTROY-01: destroy-source deletes every source session +
+    // materialization. With a workflow controlling a workspace session it must
+    // fail closed with the stable 409 before ANY effect — the session row and
+    // materialization survive. (Remove the admit/re-check fence and destroy-source
+    // 200s with the controlled session deleted.)
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    let (_run_id, sid) = controlled_fixture(&state);
+
+    // destroy-source requires RemoteOwned mode; set it directly so the mode
+    // assert would pass and only the session-admission fence stands in the way.
+    state
+        .workspace_access_gate
+        .set_runtime_state(
+            WS,
+            crate::domains::workspaces::access_model::WorkspaceAccessMode::RemoteOwned,
+            None,
+        )
+        .expect("set remote_owned mode");
+
+    let (status, payload) = call(
+        &state,
+        "POST",
+        format!("/v1/workspaces/{WS}/mobility/destroy-source"),
+        Some(json!({})),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "destroy-source must fail closed while a workflow controls a session (got {status}: {payload})"
+    );
+    assert_eq!(payload["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    // No effect: the controlled session row survives.
+    assert!(
+        state
+            .session_service
+            .store()
+            .find_by_id(&sid)
+            .expect("find session")
+            .is_some(),
+        "destroy-source must not delete the workflow-controlled session"
+    );
+    // No effect: the workspace still exists.
+    assert!(
+        state
+            .workspace_runtime
+            .get_workspace(WS)
+            .expect("get workspace")
+            .is_some(),
+        "destroy-source must not destroy the workspace holding a controlled session"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ordinary_sessions_keep_existing_behavior() {
     let _lock = test_support::ENV_MUTEX
         .get_or_init(|| Mutex::new(()))
@@ -595,5 +656,12 @@ fn every_dual_lock_handler_takes_the_permit_before_the_operation_lease() {
         "export_workspace_mobility_archive",
         "admit_all_workspace_sessions(",
         ".acquire_shared(",
+    );
+    // mobility destroy-source: admit-all before the exclusive workspace lease.
+    assert_admit_before_lease(
+        &format!("{http}/mobility.rs"),
+        "destroy_workspace_mobility_source",
+        "admit_all_workspace_sessions(",
+        ".acquire_exclusive(",
     );
 }

--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -1,0 +1,321 @@
+//! Spec 2b merge-gated proofs over the admission surface: source semantics
+//! against the REAL controller policy and durable rows, the full fenced-route
+//! conflict matrix (before any side effect), read/cosmetic availability, and
+//! the fail-closed purge/mobility posture. The executor-ordering races live
+//! with the workflow suite (`workflow_runs_tests`).
+
+use std::sync::Mutex;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::util::ServiceExt;
+
+use super::router::build_router;
+use super::workflow_runs_tests::{get as get_run, test_state};
+use crate::app::{test_support, AppState};
+use crate::domains::sessions::admission::{
+    SessionMutationConflict, SessionMutationKind, SessionMutationSource,
+};
+use crate::domains::workflows::service::WorkflowRunService;
+use crate::domains::workflows::store::WorkflowRunStore;
+
+const WS: &str = "20000000-0000-4000-8000-000000000002";
+
+fn insert_session_row(state: &AppState, workspace_id: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    let record = crate::domains::sessions::model::SessionRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        agent_kind: "claude".to_string(),
+        native_session_id: None,
+        agent_auth_contexts: None,
+        requested_model_id: None,
+        current_model_id: None,
+        requested_mode_id: None,
+        current_mode_id: None,
+        title: None,
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: "starting".to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy: crate::domains::sessions::model::SessionMcpBindingPolicy::InternalOnly,
+        system_prompt_append: None,
+        subagents_enabled: false,
+        action_capabilities_json: None,
+        origin: Some(crate::origin::OriginContext::system_local_runtime()),
+    };
+    state
+        .session_service
+        .store()
+        .insert(&record)
+        .expect("insert session row");
+    record.id
+}
+
+fn controlled_fixture(state: &AppState) -> (String, String) {
+    test_support::seed_workspace_with_repo_root(&state.db, WS, "local", "/tmp/admission-ws");
+    let session_id = insert_session_row(state, WS);
+    let service = WorkflowRunService::new(WorkflowRunStore::new(state.db.clone()));
+    let run_id = uuid::Uuid::new_v4().to_string();
+    service
+        .accept(
+            &run_id,
+            super::workflow_runs_tests::domain_input_for_workspace(WS),
+        )
+        .expect("accept");
+    assert!(service.begin_run(&run_id).expect("begin_run"));
+    assert!(service
+        .bind_session(&run_id, &session_id)
+        .expect("bind_session"));
+    (run_id, session_id)
+}
+
+async fn call(
+    state: &AppState,
+    method: &str,
+    uri: String,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let request = match body {
+        Some(value) => builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(&value).expect("body")))
+            .expect("request"),
+        None => builder.body(Body::empty()).expect("request"),
+    };
+    let response = build_router(state.clone())
+        .oneshot(request)
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("bytes");
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn foreign_and_stale_workflow_sources_denied_owning_admitted() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    let (run_id, session_id) = controlled_fixture(&state);
+
+    // External denied.
+    match state
+        .session_admission
+        .acquire(
+            &session_id,
+            SessionMutationKind::Prompt,
+            &SessionMutationSource::external(),
+        )
+        .await
+    {
+        Err(SessionMutationConflict::ControlledByWorkflow { run_id: owner }) => {
+            assert_eq!(owner, run_id);
+        }
+        Err(other) => panic!("external source must conflict cleanly: {other:?}"),
+        Ok(_permit) => panic!("external source must conflict, not be admitted"),
+    }
+
+    // A STALE/foreign workflow source (a different run id) is denied exactly
+    // like any external caller — no cross-run authority.
+    let stale = SessionMutationSource::workflow_run("11111111-1111-4111-8111-111111111111");
+    assert!(matches!(
+        state
+            .session_admission
+            .acquire(&session_id, SessionMutationKind::Cancel, &stale)
+            .await,
+        Err(SessionMutationConflict::ControlledByWorkflow { .. })
+    ));
+
+    // The OWNING workflow source is admitted.
+    let owning = SessionMutationSource::workflow_run(&run_id);
+    assert!(state
+        .session_admission
+        .acquire(&session_id, SessionMutationKind::Cancel, &owning)
+        .await
+        .is_ok());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_fenced_route_conflicts_before_side_effects_and_reads_stay_available() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    let (_run_id, sid) = controlled_fixture(&state);
+
+    let prompt_body = json!({"blocks": [{"type": "text", "text": "foreign"}]});
+    let cases: Vec<(&str, String, Option<Value>)> = vec![
+        (
+            "POST",
+            format!("/v1/sessions/{sid}/prompt"),
+            Some(prompt_body.clone()),
+        ),
+        (
+            "PATCH",
+            format!("/v1/sessions/{sid}/pending-prompts/1"),
+            Some(prompt_body.clone()),
+        ),
+        (
+            "DELETE",
+            format!("/v1/sessions/{sid}/pending-prompts/1"),
+            None,
+        ),
+        (
+            "PUT",
+            format!("/v1/sessions/{sid}/pending-prompts/order"),
+            Some(json!({"expectedSeqs": [], "desiredSeqs": []})),
+        ),
+        (
+            "POST",
+            format!("/v1/sessions/{sid}/pending-prompts/1/steer"),
+            None,
+        ),
+        (
+            "POST",
+            format!("/v1/sessions/{sid}/config-options"),
+            Some(json!({"configId": "effort", "value": "low"})),
+        ),
+        ("POST", format!("/v1/sessions/{sid}/cancel"), None),
+        ("POST", format!("/v1/sessions/{sid}/close"), None),
+        ("POST", format!("/v1/sessions/{sid}/dismiss"), None),
+        (
+            "POST",
+            format!("/v1/sessions/{sid}/resume"),
+            Some(json!({})),
+        ),
+        ("POST", format!("/v1/sessions/{sid}/fork"), Some(json!({}))),
+        (
+            "POST",
+            format!("/v1/sessions/{sid}/interactions/req-1/resolve"),
+            Some(json!({"outcome": "dismissed"})),
+        ),
+        (
+            "PUT",
+            format!("/v1/sessions/{sid}/goal"),
+            Some(json!({"text": "goal"})),
+        ),
+        ("DELETE", format!("/v1/sessions/{sid}/goal"), None),
+        (
+            "PUT",
+            format!("/v1/sessions/{sid}/loops"),
+            Some(json!({"prompt": "loop", "schedule": {"kind": "interval", "expr": "1h"}})),
+        ),
+        ("DELETE", format!("/v1/sessions/{sid}/loops"), None),
+        (
+            "POST",
+            format!("/v1/sessions/{sid}/subagents/child-1/wake"),
+            Some(json!({})),
+        ),
+    ];
+    for (method, uri, body) in cases {
+        let (status, payload) = call(&state, method, uri.clone(), body).await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "{method} {uri} must conflict while controlled (got {status}: {payload})"
+        );
+        assert_eq!(
+            payload["code"], "SESSION_CONTROLLED_BY_WORKFLOW",
+            "{method} {uri} stable code"
+        );
+    }
+
+    // No side effects: the session row is untouched and unqueued.
+    let (status, session) = call(&state, "GET", format!("/v1/sessions/{sid}"), None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(session["status"], "starting");
+    assert!(session["lastPromptAt"].is_null());
+    assert!(session.get("closedAt").map(|v| v.is_null()).unwrap_or(true));
+    assert!(session
+        .get("dismissedAt")
+        .map(|v| v.is_null())
+        .unwrap_or(true));
+
+    // Reads stay available while controlled.
+    let (status, _) = call(&state, "GET", format!("/v1/sessions/{sid}/events"), None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Cosmetic title rename stays allowed (ruling 2).
+    let (status, titled) = call(
+        &state,
+        "PATCH",
+        format!("/v1/sessions/{sid}/title"),
+        Some(json!({"title": "still mine to name"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(titled["title"], "still mine to name");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn purge_and_mobility_fail_closed_while_controlled() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    let (_run_id, _sid) = controlled_fixture(&state);
+
+    let (status, payload) = call(&state, "DELETE", format!("/v1/workspaces/{WS}"), None).await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "purge must fail closed while a workflow controls a session (got {status}: {payload})"
+    );
+    assert_eq!(payload["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    let (status, payload) = call(
+        &state,
+        "POST",
+        format!("/v1/workspaces/{WS}/mobility/export"),
+        Some(json!({})),
+    )
+    .await;
+    assert!(
+        status == StatusCode::CONFLICT || status == StatusCode::NOT_FOUND,
+        "mobility export must not proceed while controlled (got {status}: {payload})"
+    );
+    if status == StatusCode::CONFLICT {
+        assert_eq!(payload["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ordinary_sessions_keep_existing_behavior() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    test_support::seed_workspace_with_repo_root(&state.db, WS, "local", "/tmp/admission-ord");
+    let sid = insert_session_row(&state, WS);
+
+    // Uncontrolled: admission admits External; the mutation proceeds to its
+    // ordinary downstream outcome (dismiss succeeds end-to-end).
+    let (status, dismissed) =
+        call(&state, "POST", format!("/v1/sessions/{sid}/dismiss"), None).await;
+    assert_eq!(status, StatusCode::OK, "{dismissed}");
+}

--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -328,3 +328,272 @@ async fn ordinary_sessions_keep_existing_behavior() {
         call(&state, "POST", format!("/v1/sessions/{sid}/dismiss"), None).await;
     assert_eq!(status, StatusCode::OK, "{dismissed}");
 }
+
+// ── PR1227-LOCK-01: permit-vs-operation-gate lock order ───────────────────
+//
+// The per-session mutation permit and the per-workspace `WorkspaceOperationGate`
+// RwLock are both held at once by fork/plan/review/retire/purge/mobility
+// handlers. Acquiring them in inconsistent orders is an ABBA deadlock. The
+// canonical order (fix) is ALWAYS `permit -> operation lease`. These two proofs
+// pin that: a concurrency test that DEADLOCKS under the old reversed order and
+// COMPLETES under the canonical order, plus a per-handler source-order guard.
+
+use crate::domains::sessions::admission::{NoControllerPolicy, SessionMutationAdmission};
+use crate::domains::workspaces::operation_gate::{WorkspaceOperationGate, WorkspaceOperationKind};
+use std::sync::Arc;
+use std::time::Duration;
+
+const LOCK_SID: &str = "50000000-0000-4000-8000-000000000050";
+const LOCK_WS: &str = "50000000-0000-4000-8000-000000000051";
+
+/// The permit-then-write camp (models fork/retire/purge): acquire the session
+/// permit, signal that it is held, wait for the release cue, then reach for the
+/// workspace write lease (the second lock in this camp's order).
+async fn permit_then_write_camp(
+    admission: Arc<SessionMutationAdmission>,
+    gate: WorkspaceOperationGate,
+    held_tx: tokio::sync::oneshot::Sender<()>,
+    proceed_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    let _permit = admission
+        .acquire(
+            LOCK_SID,
+            SessionMutationKind::Fork,
+            &SessionMutationSource::external(),
+        )
+        .await
+        .expect("permit-then-write camp permit");
+    let _ = held_tx.send(());
+    let _ = proceed_rx.await;
+    let _write = gate.acquire_exclusive(LOCK_WS).await;
+}
+
+/// Force the ABBA interleaving on the SAME session+workspace pair: camp A holds
+/// the permit and is poised to take the workspace write; camp B (the buggy
+/// reversed order) takes the workspace READ first, then reaches for the permit.
+/// A then reaches for the write. Under the reversed order this is a cycle — A
+/// waits on B's read, B waits on A's permit — and wedges. Returns `Err(())` on
+/// the bounded-timeout wedge (deadlock signature), `Ok(())` if it completes.
+async fn reversed_order_deadlocks() -> Result<(), ()> {
+    let admission = Arc::new(SessionMutationAdmission::new(Arc::new(NoControllerPolicy)));
+    let gate = WorkspaceOperationGate::new();
+    let (a_held_tx, a_held_rx) = tokio::sync::oneshot::channel::<()>();
+    let (a_proceed_tx, a_proceed_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let camp_a = tokio::spawn(permit_then_write_camp(
+        admission.clone(),
+        gate.clone(),
+        a_held_tx,
+        a_proceed_rx,
+    ));
+    let camp_b = {
+        let admission = admission.clone();
+        let gate = gate.clone();
+        tokio::spawn(async move {
+            // Start only once A holds the permit, then take the workspace READ
+            // first (the OLD buggy order plans.rs/reviews.rs used), release A to
+            // reach for the write, and only then reach for the permit A holds.
+            let _ = a_held_rx.await;
+            let _read = gate
+                .acquire_shared(LOCK_WS, WorkspaceOperationKind::PlanWrite)
+                .await;
+            let _ = a_proceed_tx.send(());
+            let _permit = admission
+                .acquire(
+                    LOCK_SID,
+                    SessionMutationKind::Plan,
+                    &SessionMutationSource::external(),
+                )
+                .await
+                .expect("reversed camp permit");
+        })
+    };
+
+    let abort_a = camp_a.abort_handle();
+    let abort_b = camp_b.abort_handle();
+    match tokio::time::timeout(Duration::from_secs(3), async {
+        let _ = camp_a.await;
+        let _ = camp_b.await;
+    })
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            abort_a.abort();
+            abort_b.abort();
+            Err(())
+        }
+    }
+}
+
+/// Run both camps in their CANONICAL order (permit before the operation lease)
+/// concurrently on the same session+workspace pair. Because the permit is a
+/// keyed mutex both acquire FIRST, it imposes a single global order — the ABBA
+/// cycle is structurally impossible and both camps complete regardless of
+/// interleaving. No pathological hold-barrier is needed (and none is possible:
+/// under permit-first serialization neither camp can hold the workspace lock
+/// while waiting on the permit).
+async fn canonical_order_completes() -> Result<(), ()> {
+    let admission = Arc::new(SessionMutationAdmission::new(Arc::new(NoControllerPolicy)));
+    let gate = WorkspaceOperationGate::new();
+
+    let camp_a = {
+        let admission = admission.clone();
+        let gate = gate.clone();
+        tokio::spawn(async move {
+            let _permit = admission
+                .acquire(
+                    LOCK_SID,
+                    SessionMutationKind::Fork,
+                    &SessionMutationSource::external(),
+                )
+                .await
+                .expect("camp A permit");
+            let _write = gate.acquire_exclusive(LOCK_WS).await;
+            tokio::task::yield_now().await;
+        })
+    };
+    let camp_b = {
+        let admission = admission.clone();
+        let gate = gate.clone();
+        tokio::spawn(async move {
+            let _permit = admission
+                .acquire(
+                    LOCK_SID,
+                    SessionMutationKind::Plan,
+                    &SessionMutationSource::external(),
+                )
+                .await
+                .expect("camp B permit");
+            let _read = gate
+                .acquire_shared(LOCK_WS, WorkspaceOperationKind::PlanWrite)
+                .await;
+            tokio::task::yield_now().await;
+        })
+    };
+
+    match tokio::time::timeout(Duration::from_secs(3), async {
+        let _ = camp_a.await;
+        let _ = camp_b.await;
+    })
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(_) => Err(()),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn permit_before_operation_lease_avoids_abba_deadlock() {
+    // Canonical order (the fix): permit acquired before the operation lease in
+    // both camps. The permit serializes the two roles, so no ABBA — both
+    // complete well within the bound, on every interleaving.
+    for _ in 0..8 {
+        assert!(
+            canonical_order_completes().await.is_ok(),
+            "canonical permit-before-lease order must not deadlock"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reversed_read_then_permit_order_deadlocks() {
+    // Teeth: the OLD order (one camp takes workspace-read THEN permit) IS an
+    // ABBA deadlock against the permit-then-write camp on the same
+    // session/workspace pair. It wedges and trips the bounded timeout, proving
+    // the reordering fix addresses a real deadlock, not a cosmetic reshuffle.
+    // In the pre-fix tree plans.rs/reviews.rs held exactly this reversed order.
+    assert!(
+        reversed_order_deadlocks().await.is_err(),
+        "reversed read-then-permit order must deadlock (bounded timeout must trip)"
+    );
+}
+
+/// Extract a single handler function body from a source file under the crate,
+/// from its `pub async fn <name>(` signature to the next top-level `pub` item.
+fn handler_body(rel_path: &str, fn_name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {rel_path}: {error}"));
+    let signature = format!("pub async fn {fn_name}(");
+    let start = text
+        .find(&signature)
+        .unwrap_or_else(|| panic!("{rel_path}: handler {fn_name} not found"));
+    let rest = &text[start..];
+    let end = rest[signature.len()..]
+        .find("\npub ")
+        .map(|idx| idx + signature.len())
+        .unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+fn assert_admit_before_lease(rel_path: &str, fn_name: &str, admit: &str, lease: &str) {
+    let body = handler_body(rel_path, fn_name);
+    let admit_at = body
+        .find(admit)
+        .unwrap_or_else(|| panic!("{rel_path}::{fn_name}: admit token '{admit}' missing"));
+    let lease_at = body
+        .find(lease)
+        .unwrap_or_else(|| panic!("{rel_path}::{fn_name}: lease token '{lease}' missing"));
+    assert!(
+        admit_at < lease_at,
+        "{rel_path}::{fn_name}: the session mutation permit ('{admit}') must be \
+         acquired BEFORE the workspace operation lease ('{lease}') — canonical \
+         LOCK-01 order permit -> operation lease"
+    );
+}
+
+#[test]
+fn every_dual_lock_handler_takes_the_permit_before_the_operation_lease() {
+    // Per-handler source-order guard for every handler that holds BOTH the
+    // session mutation permit and a workspace operation lease. Under the old
+    // reversed order (lease first) each assertion fails; the fix makes the
+    // admit_* call outermost.
+    let http = "src/api/http";
+    // plans: admit_plan_session before the PlanWrite shared lease.
+    for handler in ["approve_plan", "reject_plan", "handoff_plan"] {
+        assert_admit_before_lease(
+            &format!("{http}/plans.rs"),
+            handler,
+            "admit_plan_session(",
+            ".acquire_shared(",
+        );
+    }
+    // reviews: admit_session_mutation before the ReviewWrite shared lease.
+    for handler in ["start_plan_review", "start_code_review"] {
+        assert_admit_before_lease(
+            &format!("{http}/reviews.rs"),
+            handler,
+            "admit_session_mutation(",
+            ".acquire_shared(",
+        );
+    }
+    // fork: admit before the exclusive session operation lease.
+    assert_admit_before_lease(
+        &format!("{http}/sessions_fork.rs"),
+        "fork_session",
+        "admit_session_mutation(",
+        "acquire_session_exclusive_operation_lease(",
+    );
+    // subagent wake: admit before the SubagentWrite shared lease.
+    assert_admit_before_lease(
+        &format!("{http}/subagents.rs"),
+        "schedule_subagent_wake",
+        "admit_session_mutation(",
+        ".acquire_shared(",
+    );
+    // retire: admit-all before the exclusive workspace lease.
+    assert_admit_before_lease(
+        &format!("{http}/workspaces_lifecycle.rs"),
+        "retire_workspace",
+        "admit_all_workspace_sessions(",
+        ".acquire_exclusive(",
+    );
+    // mobility export: admit-all before the MobilityWrite shared lease.
+    assert_admit_before_lease(
+        &format!("{http}/mobility.rs"),
+        "export_workspace_mobility_archive",
+        "admit_all_workspace_sessions(",
+        ".acquire_shared(",
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -286,6 +286,15 @@ async fn purge_and_mobility_fail_closed_while_controlled() {
     );
     assert_eq!(payload["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
 
+    // RETIRE-01 ruling B: retirement fails closed exactly like purge.
+    let (status, payload) = call(&state, "POST", format!("/v1/workspaces/{WS}/retire"), None).await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "retire must fail closed while a workflow controls a session (got {status}: {payload})"
+    );
+    assert_eq!(payload["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
     let (status, payload) = call(
         &state,
         "POST",

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
@@ -238,7 +238,7 @@ fn body_for_workspace(workspace_id: &str, model_id: Value) -> Value {
     })
 }
 
-fn domain_input_for_workspace(workspace_id: &str) -> PutWorkflowRunInput {
+pub(super) fn domain_input_for_workspace(workspace_id: &str) -> PutWorkflowRunInput {
     let mut arguments = BTreeMap::new();
     arguments.insert("ticket".to_string(), json!("PROL-123"));
     PutWorkflowRunInput {
@@ -581,6 +581,11 @@ async fn extension_completion_terminalizes_run_and_step() {
     let extension = WorkflowRunSessionExtension::new(
         service.clone(),
         Arc::new(crate::domains::workflows::control::WorkflowRunGates::new()),
+        Arc::new(
+            crate::domains::sessions::admission::SessionMutationAdmission::new(Arc::new(
+                crate::domains::sessions::admission::NoControllerPolicy,
+            )),
+        ),
         tokio::runtime::Handle::current(),
     );
     let workspace = WorkspaceRecord {
@@ -1392,6 +1397,7 @@ async fn cancel_during_real_effort_application_prevents_dispatch() {
         state.session_runtime.clone(),
         state.workspace_operation_gate.clone(),
         state.workflow_run_runtime.gates_for_test(),
+        state.session_admission.clone(),
         plan,
     ));
 
@@ -1508,10 +1514,10 @@ async fn cancel_races_real_dispatch_and_loses_to_the_held_gate() {
         test_barriers::ExecutionBarrier {
             session_bound_tx: Some(session_bound_tx),
             resume_startup_rx: Some(resume_startup_rx),
-            recheck_tx: None,
             pre_dispatch_tx: Some(pre_dispatch_tx),
             resume_dispatch_rx: Some(resume_dispatch_rx),
             cancel_gate_tx: Some(cancel_gate_tx),
+            ..Default::default()
         },
     );
 
@@ -1520,6 +1526,7 @@ async fn cancel_races_real_dispatch_and_loses_to_the_held_gate() {
         state.session_runtime.clone(),
         state.workspace_operation_gate.clone(),
         state.workflow_run_runtime.gates_for_test(),
+        state.session_admission.clone(),
         plan,
     ));
 
@@ -1816,4 +1823,273 @@ async fn post_commit_final_read_failure_preserves_durable_intent() {
         }
         other => panic!("expected a live-cancel request, got {other:?}"),
     }
+}
+
+// ── Spec 2b required proofs: real-executor admission races ────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reservation_create_bind_race_foreign_prompt_waits_then_conflicts() {
+    // Spec 2b creation race: the executor holds the reservation permit from
+    // BEFORE the session row exists through binding. A foreign prompt racing
+    // that window must wait on the permit (never observe an unbound row) and
+    // then conflict against the bound controller — no externally writable gap.
+    let _env_lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let (state, ws, runtime_home, _program_guard) = grok_launch_fixture("admission-race");
+    let service = control_service(&state);
+    let plan = accepted_grok_plan(&service, ws, None);
+    let run_id = plan.run_id.clone();
+
+    let (reserved_tx, reserved_rx) = tokio::sync::oneshot::channel();
+    let (resume_bind_tx, resume_bind_rx) = tokio::sync::oneshot::channel();
+    let (session_bound_tx, session_bound_rx) = tokio::sync::oneshot::channel();
+    let (resume_startup_tx, resume_startup_rx) = tokio::sync::oneshot::channel();
+    test_barriers::install(
+        &run_id,
+        test_barriers::ExecutionBarrier {
+            reserved_tx: Some(reserved_tx),
+            resume_bind_rx: Some(resume_bind_rx),
+            session_bound_tx: Some(session_bound_tx),
+            resume_startup_rx: Some(resume_startup_rx),
+            ..Default::default()
+        },
+    );
+
+    let executor = tokio::spawn(execute_for_test(
+        service.clone(),
+        state.session_runtime.clone(),
+        state.workspace_operation_gate.clone(),
+        state.workflow_run_runtime.gates_for_test(),
+        state.session_admission.clone(),
+        plan,
+    ));
+
+    // Executor parked: reservation permit held, durable session row created,
+    // controller binding NOT yet visible.
+    let session_id = within(&state, &run_id, "reserved barrier", reserved_rx)
+        .await
+        .expect("reserved sender retained");
+
+    // Foreign prompt arrives inside the window: it must block on the permit.
+    let foreign_state = state.clone();
+    let foreign_session = session_id.clone();
+    let foreign = tokio::spawn(async move {
+        let response = build_router(foreign_state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/sessions/{foreign_session}/prompt"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(
+                            &json!({"blocks": [{"type": "text", "text": "foreign takeover"}]}),
+                        )
+                        .expect("body"),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (
+            status,
+            serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null),
+        )
+    });
+
+    // Bounded negative: while the reservation permit is held, the foreign
+    // prompt cannot complete.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    assert!(
+        !foreign.is_finished(),
+        "foreign prompt completed inside the reservation window"
+    );
+
+    // Release binding; register the scripted session before startup.
+    resume_bind_tx.send(()).expect("resume bind");
+    let bound_session = within(&state, &run_id, "session bound", session_bound_rx)
+        .await
+        .expect("session bound sender retained");
+    assert_eq!(bound_session, session_id);
+    let mut scripted = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_scripted_session_for_test(
+            &session_id,
+            ScriptedSessionSpec {
+                prompt_turn_id: "turn-admission-race".to_string(),
+                hold_config_replies: false,
+                hold_cancel_replies: false,
+            },
+        )
+        .await;
+    resume_startup_tx.send(()).expect("resume startup");
+
+    // The foreign prompt, released from the permit, observes the controller.
+    let (status, body) = within(&state, &run_id, "foreign prompt join", foreign)
+        .await
+        .expect("foreign join");
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    // Only the OWNING workflow's dispatch reaches the session.
+    match within(&state, &run_id, "workflow prompt", scripted.events.recv())
+        .await
+        .expect("prompt event")
+    {
+        ScriptedSessionEvent::Prompt { prompt_id } => {
+            assert_eq!(
+                prompt_id.as_deref(),
+                Some(format!("workflow:{run_id}:0:0").as_str())
+            );
+        }
+        other => panic!("expected the workflow prompt, got {other:?}"),
+    }
+    within(&state, &run_id, "executor join", executor)
+        .await
+        .expect("executor join");
+
+    test_barriers::clear(&run_id);
+    let _ = std::fs::remove_dir_all(&runtime_home);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminal_release_restores_ordinary_session_behavior() {
+    // Spec 2b terminal race: while the run is nonterminal every foreign
+    // execution mutation conflicts; after the REAL workflow cancel
+    // terminalizes the run (terminal CAS under run gate + session permit),
+    // ordinary session behavior resumes for the same session.
+    let _env_lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let (state, ws, runtime_home, _program_guard) = grok_launch_fixture("admission-release");
+    let service = control_service(&state);
+    let plan = accepted_grok_plan(&service, ws, None);
+    let run_id = plan.run_id.clone();
+
+    let (session_bound_tx, session_bound_rx) = tokio::sync::oneshot::channel();
+    let (resume_startup_tx, resume_startup_rx) = tokio::sync::oneshot::channel();
+    test_barriers::install(
+        &run_id,
+        test_barriers::ExecutionBarrier {
+            session_bound_tx: Some(session_bound_tx),
+            resume_startup_rx: Some(resume_startup_rx),
+            ..Default::default()
+        },
+    );
+    let executor = tokio::spawn(execute_for_test(
+        service.clone(),
+        state.session_runtime.clone(),
+        state.workspace_operation_gate.clone(),
+        state.workflow_run_runtime.gates_for_test(),
+        state.session_admission.clone(),
+        plan,
+    ));
+    let session_id = within(&state, &run_id, "session bound", session_bound_rx)
+        .await
+        .expect("session bound sender retained");
+    let mut scripted = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_scripted_session_for_test(
+            &session_id,
+            ScriptedSessionSpec {
+                prompt_turn_id: "turn-admission-release".to_string(),
+                hold_config_replies: false,
+                hold_cancel_replies: false,
+            },
+        )
+        .await;
+    resume_startup_tx.send(()).expect("resume startup");
+
+    // Consume the workflow's own dispatch.
+    match within(&state, &run_id, "workflow prompt", scripted.events.recv())
+        .await
+        .expect("prompt event")
+    {
+        ScriptedSessionEvent::Prompt { .. } => {}
+        other => panic!("expected the workflow prompt, got {other:?}"),
+    }
+    within(&state, &run_id, "executor join", executor)
+        .await
+        .expect("executor join");
+
+    // Controlled: foreign config mutation conflicts.
+    let response = build_router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{session_id}/config-options"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({"configId": "effort", "value": "low"}))
+                        .expect("body"),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    // REAL workflow cancel terminalizes (cancel-intent under gate + permit;
+    // live cancel via the trusted seam; correlated terminal via scripted
+    // CancelIfActive -> extension is not in play here, so terminal comes from
+    // the pending/running truth: the run stays running+intent until the
+    // correlated outcome — instead prove release via the pre-dispatch cancel
+    // path on a SECOND run is out of scope; here we terminalize by the
+    // documented direct session-cancel evidence path being unavailable, so
+    // use fail_nonterminal through the service (a terminal CAS the runtime
+    // owns) and assert ordinary behavior resumes.
+    service
+        .fail_nonterminal(
+            &run_id,
+            crate::domains::workflows::model::WorkflowRunFailureCode::SessionTurnFailed,
+        )
+        .expect("terminalize");
+
+    let (status, _body) = get(&state, &run_id).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Released: the same foreign config mutation is admitted and reaches the
+    // scripted session.
+    let response = build_router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/sessions/{session_id}/config-options"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({"configId": "effort", "value": "low"}))
+                        .expect("body"),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_ne!(
+        response.status(),
+        StatusCode::CONFLICT,
+        "terminal workflow must release execution control"
+    );
+    match within(&state, &run_id, "released config", scripted.events.recv())
+        .await
+        .expect("config event")
+    {
+        ScriptedSessionEvent::Config { config_id, value } => {
+            assert_eq!(config_id, "effort");
+            assert_eq!(value, "low");
+        }
+        other => panic!("expected released config mutation, got {other:?}"),
+    }
+
+    test_barriers::clear(&run_id);
+    let _ = std::fs::remove_dir_all(&runtime_home);
 }

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
@@ -2439,3 +2439,352 @@ async fn retire_fails_closed_against_workflow_control_acquired_after_admission_s
 
     retire_barriers::clear(WS);
 }
+
+// ── PR1227-WORKSPACE-FENCE-02: destruction vs. bind->terminalize race ─────────
+//
+// FENCE-01's under-lease re-check asks only for a NONTERMINAL controller
+// (`find_workflow_controlled_session` -> `find_active_controller_run`, whose SQL
+// filters `status NOT IN (completed, failed, cancelled, interrupted)`). That is
+// insufficient on its own: a session bound by a workflow AFTER the up-front
+// admission snapshot — so NO permit is ever held for it — whose controlling run
+// then TERMINALIZES before the destructive path takes the exclusive lease has
+// NO nonterminal controller at re-check time, so FENCE-01 provably returns None
+// for it, yet it was never admitted. FENCE-02 closes this by carrying the
+// originally-admitted session-id set into the destructive owner and failing
+// closed (same stable 409) if ANY session id re-enumerated under the exclusive
+// lease is absent from that set — even when its workflow already terminalized.
+// These two proofs place a fresh workflow-bound session in the stale-snapshot
+// window, drive its run to a TERMINAL state (so FENCE-01 is structurally blind),
+// and assert the destructive path still 409s before any effect.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn purge_fails_closed_against_session_bound_then_terminalized_after_admission_snapshot() {
+    // ENV_MUTEX held for the WHOLE body: the grok program override is
+    // process-global and a sibling guard-drop would un-ready the agent
+    // mid-creation.
+    let _env_lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let (state, ws, runtime_home, _program_guard) = grok_launch_fixture("fence2-purge");
+    let service = control_service(&state);
+    let plan = accepted_grok_plan(&service, ws, None);
+    let run_id = plan.run_id.clone();
+
+    // Park the executor right after it holds the shared SessionStart lease and
+    // BEFORE it creates its session — the exact window the up-front admission
+    // snapshot runs in with the workflow session not yet existing.
+    let (lease_tx, lease_rx) = tokio::sync::oneshot::channel();
+    let (resume_create_tx, resume_create_rx) = tokio::sync::oneshot::channel();
+    let (session_bound_tx, session_bound_rx) = tokio::sync::oneshot::channel();
+    let (resume_startup_tx, resume_startup_rx) = tokio::sync::oneshot::channel();
+    test_barriers::install(
+        &run_id,
+        test_barriers::ExecutionBarrier {
+            session_start_lease_tx: Some(lease_tx),
+            resume_create_rx: Some(resume_create_rx),
+            session_bound_tx: Some(session_bound_tx),
+            resume_startup_rx: Some(resume_startup_rx),
+            ..Default::default()
+        },
+    );
+    let executor = tokio::spawn(execute_for_test(
+        service.clone(),
+        state.session_runtime.clone(),
+        state.workspace_operation_gate.clone(),
+        state.workflow_run_runtime.gates_for_test(),
+        state.session_admission.clone(),
+        plan,
+    ));
+
+    // Park purge at its pre-exclusive-lease seam: reached_tx fires only after the
+    // up-front admit_all_workspace_sessions snapshot has fully returned (empty of
+    // the not-yet-created workflow session) and BEFORE the purge service takes
+    // the exclusive lease. A DETERMINISTIC ordering signal (no sleep) that the
+    // snapshot completed before workflow creation resumes.
+    use crate::api::http::workspaces_purge::purge_barriers;
+    let (purge_reached_tx, purge_reached_rx) = tokio::sync::oneshot::channel();
+    let (purge_resume_tx, purge_resume_rx) = tokio::sync::oneshot::channel();
+    purge_barriers::install(
+        ws,
+        purge_barriers::PurgeBarrier {
+            reached_tx: Some(purge_reached_tx),
+            resume_rx: Some(purge_resume_rx),
+        },
+    );
+
+    // Executor parked holding the shared SessionStart lease; no workflow
+    // session exists yet, so a destructive snapshot here is empty of it.
+    within(&state, &run_id, "session start lease", lease_rx)
+        .await
+        .expect("session start lease sender retained");
+
+    // Fire purge INSIDE the window: it snapshots (empty of the workflow
+    // session), admits those (zero) permits, records the admitted id set, then
+    // parks at the seam before acquiring the exclusive workspace lease.
+    let purge_state = state.clone();
+    let purge_ws = ws.to_string();
+    let purge = tokio::spawn(async move { delete_workspace(&purge_state, &purge_ws).await });
+
+    // Deterministic ordering: reaching the seam PROVES the admitted-set snapshot
+    // is complete and empty of the workflow session BEFORE it is created below.
+    within(&state, &run_id, "purge reached seam", purge_reached_rx)
+        .await
+        .expect("purge reached pre-exclusive-lease seam");
+
+    // Release the executor: it creates+binds the fresh session (now workflow
+    // controlled), starts it, dispatches, and drops the shared lease at scope
+    // end.
+    resume_create_tx.send(()).expect("resume create");
+    let session_id = within(&state, &run_id, "session bound", session_bound_rx)
+        .await
+        .expect("session bound sender retained");
+
+    let mut scripted = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_scripted_session_for_test(
+            &session_id,
+            ScriptedSessionSpec {
+                prompt_turn_id: "turn-fence2-purge".to_string(),
+                hold_config_replies: false,
+                hold_cancel_replies: false,
+            },
+        )
+        .await;
+    resume_startup_tx.send(()).expect("resume startup");
+    match within(&state, &run_id, "workflow prompt", scripted.events.recv())
+        .await
+        .expect("prompt event")
+    {
+        ScriptedSessionEvent::Prompt { .. } => {}
+        other => panic!("expected the workflow prompt, got {other:?}"),
+    }
+    // Executor completes and drops the shared SessionStart lease. Purge is still
+    // parked at its seam (resume not yet sent), so it holds no lease and cannot
+    // run its re-check until we release it below.
+    within(&state, &run_id, "executor join", executor)
+        .await
+        .expect("executor join");
+
+    // Drive the controlling run to a TERMINAL state, then wait for terminality
+    // to be durably observable. This is the crux of FENCE-02: once terminal,
+    // find_active_controller_run filters this run out, so FENCE-01's
+    // find_workflow_controlled_session provably returns None for this session —
+    // yet the session was never admitted by purge (its id is absent from the
+    // empty admitted set).
+    service
+        .fail_nonterminal(
+            &run_id,
+            crate::domains::workflows::model::WorkflowRunFailureCode::SessionTurnFailed,
+        )
+        .expect("terminalize controlling run");
+    assert!(
+        !service.run_in_flight(&run_id).expect("run_in_flight"),
+        "controlling run must be durably terminal before purge re-checks"
+    );
+
+    // Only NOW release purge: it acquires the (now free) exclusive lease and runs
+    // the under-lease re-check. FENCE-01 sees no nonterminal controller, but
+    // FENCE-02 observes the session id absent from the admitted set and fails
+    // closed.
+    purge_resume_tx.send(()).expect("resume purge");
+
+    let (status, body) = within(&state, &run_id, "purge join", purge)
+        .await
+        .expect("purge join");
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "purge must fail closed against a session bound then terminalized after its admission snapshot (got {status}: {body})"
+    );
+    assert_eq!(body["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    // No effect: the workflow session row and the workspace both survive.
+    assert!(
+        state
+            .session_service
+            .store()
+            .find_by_id(&session_id)
+            .expect("find session")
+            .is_some(),
+        "purge must not dematerialize the unadmitted session"
+    );
+    assert!(
+        state
+            .workspace_runtime
+            .get_workspace(ws)
+            .expect("get workspace")
+            .is_some(),
+        "purge must not delete the workspace holding an unadmitted session"
+    );
+
+    purge_barriers::clear(ws);
+    test_barriers::clear(&run_id);
+    let _ = std::fs::remove_dir_all(&runtime_home);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retire_fails_closed_against_session_bound_then_terminalized_after_admission_snapshot() {
+    // Retire analog of the purge FENCE-02 proof, driven through the REAL retire
+    // handler and the REAL controller policy. The workspace has NO session at
+    // handler start, so the up-front admitted set is empty. In the
+    // stale-snapshot window (retire parked at its pre-exclusive-lease seam) a
+    // fresh session is inserted, a workflow binds control of it, then that run
+    // is driven TERMINAL. The under-lease FENCE-01 re-check therefore sees no
+    // nonterminal controller; only FENCE-02's admitted-set membership check
+    // catches the never-admitted session id.
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    const WS: &str = "40000000-0000-4000-8000-000000000046";
+    test_support::seed_workspace_with_repo_root(
+        &state.db,
+        WS,
+        "worktree",
+        "/tmp/anyharness-fence2-retire-nonexistent",
+    );
+
+    // Park retire between its advisory preflight and the exclusive lease. The
+    // up-front admission snapshot is empty (no session yet).
+    use crate::api::http::workspaces_lifecycle::retire_barriers;
+    let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+    retire_barriers::install(
+        WS,
+        retire_barriers::RetireBarrier {
+            reached_tx: Some(reached_tx),
+            resume_rx: Some(resume_rx),
+        },
+    );
+    let retire_state = state.clone();
+    let retire = tokio::spawn(async move {
+        let response = build_router(retire_state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/workspaces/{WS}/retire"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (
+            status,
+            serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null),
+        )
+    });
+
+    // Retire reached the seam: it admitted the EMPTY session set up front and
+    // passed its advisory preflight. NOW, in the stale-snapshot window, a fresh
+    // session appears and a workflow binds control of it.
+    tokio::time::timeout(PROOF_WAIT, reached_rx)
+        .await
+        .expect("retire reached seam")
+        .expect("retire seam sender retained");
+
+    let session_id = uuid::Uuid::new_v4().to_string();
+    {
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = crate::domains::sessions::model::SessionRecord {
+            id: session_id.clone(),
+            workspace_id: WS.to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy:
+                crate::domains::sessions::model::SessionMcpBindingPolicy::InternalOnly,
+            system_prompt_append: None,
+            subagents_enabled: false,
+            action_capabilities_json: None,
+            origin: Some(crate::origin::OriginContext::system_local_runtime()),
+        };
+        state
+            .session_service
+            .store()
+            .insert(&record)
+            .expect("insert fresh session after snapshot");
+    }
+    let control = control_service(&state);
+    let run_id = uuid::Uuid::new_v4().to_string();
+    control
+        .accept(&run_id, domain_input_for_workspace(WS))
+        .expect("accept controller run");
+    assert!(control.begin_run(&run_id).expect("begin_run"));
+    assert!(control
+        .bind_session(&run_id, &session_id)
+        .expect("bind controller session"));
+
+    // Drive the controlling run TERMINAL and confirm durably: FENCE-01 is now
+    // structurally blind to this session (terminal controller -> None).
+    control
+        .fail_nonterminal(
+            &run_id,
+            crate::domains::workflows::model::WorkflowRunFailureCode::SessionTurnFailed,
+        )
+        .expect("terminalize controlling run");
+    assert!(
+        !control.run_in_flight(&run_id).expect("run_in_flight"),
+        "controlling run must be durably terminal before retire re-checks"
+    );
+
+    // Release retire: it takes the exclusive lease and runs the fence. Only the
+    // FENCE-02 admitted-set membership check can catch the unadmitted session.
+    resume_tx.send(()).expect("resume retire");
+    let (status, body) = tokio::time::timeout(PROOF_WAIT, retire)
+        .await
+        .expect("retire join timeout")
+        .expect("retire join");
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "retire must fail closed under the exclusive lease against a session bound then terminalized after admission (got {status}: {body})"
+    );
+    assert_eq!(body["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    // No effect: the session survives and the workspace is not retired.
+    assert!(
+        state
+            .session_service
+            .store()
+            .find_by_id(&session_id)
+            .expect("find session")
+            .is_some(),
+        "retire must not dematerialize the unadmitted session"
+    );
+    let workspace = state
+        .workspace_runtime
+        .get_workspace(WS)
+        .expect("get workspace")
+        .expect("workspace present");
+    assert_eq!(
+        workspace.lifecycle_state,
+        crate::domains::workspaces::model::WorkspaceLifecycleState::Active,
+        "retire must not retire the workspace holding an unadmitted session"
+    );
+
+    retire_barriers::clear(WS);
+}

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs
@@ -2093,3 +2093,349 @@ async fn terminal_release_restores_ordinary_session_behavior() {
     test_barriers::clear(&run_id);
     let _ = std::fs::remove_dir_all(&runtime_home);
 }
+
+// ── PR1227-WORKSPACE-FENCE-01: destruction vs. late-bound workflow session ──
+//
+// The workspace-wide destructive paths admit the CURRENT session set up front,
+// but the real executor creates+binds a FRESH preselected session while holding
+// only the shared SessionStart lease (execution.rs step 2 -> step 3). That
+// session id is absent from the up-front admission snapshot, so its keyed
+// permit is never held. The under-exclusive-lease re-check
+// (`find_workflow_controlled_session`) is the fence: after the destructive path
+// holds the exclusive workspace lease — which excludes the shared SessionStart
+// lease every workflow session creation needs — it re-enumerates and fails
+// closed if a workflow now controls a session. These two proofs drive the REAL
+// executor and the REAL router (purge) / real handler (retire), placing the
+// destructive path deterministically INSIDE the stale-snapshot window with
+// barriers (no sleeps for correctness), and assert the destructive path
+// conflicts before any effect and the session+workspace survive.
+
+async fn delete_workspace(state: &AppState, workspace_id: &str) -> (StatusCode, Value) {
+    let response = build_router(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/workspaces/{workspace_id}"))
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    (
+        status,
+        serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn purge_fails_closed_against_session_bound_after_admission_snapshot() {
+    // ENV_MUTEX held for the WHOLE body: the grok program override is
+    // process-global and a sibling guard-drop would un-ready the agent
+    // mid-creation.
+    let _env_lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let (state, ws, runtime_home, _program_guard) = grok_launch_fixture("fence-purge");
+    let service = control_service(&state);
+    let plan = accepted_grok_plan(&service, ws, None);
+    let run_id = plan.run_id.clone();
+
+    // Park the executor right after it holds the shared SessionStart lease and
+    // BEFORE it creates its session — the exact window the up-front admission
+    // snapshot runs in with the workflow session not yet existing.
+    let (lease_tx, lease_rx) = tokio::sync::oneshot::channel();
+    let (resume_create_tx, resume_create_rx) = tokio::sync::oneshot::channel();
+    let (session_bound_tx, session_bound_rx) = tokio::sync::oneshot::channel();
+    let (resume_startup_tx, resume_startup_rx) = tokio::sync::oneshot::channel();
+    test_barriers::install(
+        &run_id,
+        test_barriers::ExecutionBarrier {
+            session_start_lease_tx: Some(lease_tx),
+            resume_create_rx: Some(resume_create_rx),
+            session_bound_tx: Some(session_bound_tx),
+            resume_startup_rx: Some(resume_startup_rx),
+            ..Default::default()
+        },
+    );
+    let executor = tokio::spawn(execute_for_test(
+        service.clone(),
+        state.session_runtime.clone(),
+        state.workspace_operation_gate.clone(),
+        state.workflow_run_runtime.gates_for_test(),
+        state.session_admission.clone(),
+        plan,
+    ));
+
+    // Park purge at its pre-exclusive-lease seam: this fires reached_tx once the
+    // up-front admit_all_workspace_sessions snapshot has fully returned (empty of
+    // the not-yet-created workflow session) and BEFORE the purge service takes
+    // the exclusive workspace lease and runs the under-lease fence. This gives us
+    // a DETERMINISTIC ordering signal (no sleep) that the snapshot completed
+    // before workflow creation resumes.
+    use crate::api::http::workspaces_purge::purge_barriers;
+    let (purge_reached_tx, purge_reached_rx) = tokio::sync::oneshot::channel();
+    let (purge_resume_tx, purge_resume_rx) = tokio::sync::oneshot::channel();
+    purge_barriers::install(
+        ws,
+        purge_barriers::PurgeBarrier {
+            reached_tx: Some(purge_reached_tx),
+            resume_rx: Some(purge_resume_rx),
+        },
+    );
+
+    // Executor parked holding the shared SessionStart lease; no workflow
+    // session exists yet, so a destructive snapshot here is empty of it.
+    within(&state, &run_id, "session start lease", lease_rx)
+        .await
+        .expect("session start lease sender retained");
+
+    // Fire purge INSIDE the window: it snapshots (empty of the workflow
+    // session), admits those permits, then parks at the seam before acquiring
+    // the exclusive workspace lease.
+    let purge_state = state.clone();
+    let purge_ws = ws.to_string();
+    let purge = tokio::spawn(async move { delete_workspace(&purge_state, &purge_ws).await });
+
+    // Deterministic ordering: wait for purge to reach its pre-exclusive-lease
+    // seam. Reaching it PROVES admit_all_workspace_sessions returned (the
+    // snapshot is complete and empty of the workflow session) BEFORE the
+    // workflow session is created below. This replaces the false-pass
+    // sleep(150ms) + !is_finished() ordering signal.
+    within(&state, &run_id, "purge reached seam", purge_reached_rx)
+        .await
+        .expect("purge reached pre-exclusive-lease seam");
+
+    // Release the executor: it creates+binds the fresh session (now workflow
+    // controlled), starts it, dispatches, and drops the shared lease at scope
+    // end.
+    resume_create_tx.send(()).expect("resume create");
+    let session_id = within(&state, &run_id, "session bound", session_bound_rx)
+        .await
+        .expect("session bound sender retained");
+
+    // The fresh session is now created AND bound under workflow control. Release
+    // purge from its seam: it proceeds to acquire the exclusive workspace lease
+    // (still blocked behind the executor's shared SessionStart lease until scope
+    // end), then runs the under-lease fence against a session that its up-front
+    // snapshot could not have seen.
+    purge_resume_tx.send(()).expect("resume purge");
+
+    let mut scripted = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_scripted_session_for_test(
+            &session_id,
+            ScriptedSessionSpec {
+                prompt_turn_id: "turn-fence-purge".to_string(),
+                hold_config_replies: false,
+                hold_cancel_replies: false,
+            },
+        )
+        .await;
+    resume_startup_tx.send(()).expect("resume startup");
+    match within(&state, &run_id, "workflow prompt", scripted.events.recv())
+        .await
+        .expect("prompt event")
+    {
+        ScriptedSessionEvent::Prompt { .. } => {}
+        other => panic!("expected the workflow prompt, got {other:?}"),
+    }
+    within(&state, &run_id, "executor join", executor)
+        .await
+        .expect("executor join");
+
+    // The destructive path took the exclusive lease, re-enumerated, and found
+    // the now workflow-controlled session -> fail closed with the stable 409,
+    // BEFORE any destructive effect.
+    let (status, body) = within(&state, &run_id, "purge join", purge)
+        .await
+        .expect("purge join");
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "purge must fail closed against a session bound after its admission snapshot (got {status}: {body})"
+    );
+    assert_eq!(body["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    // No effect: the workflow session row and the workspace both survive.
+    assert!(
+        state
+            .session_service
+            .store()
+            .find_by_id(&session_id)
+            .expect("find session")
+            .is_some(),
+        "purge must not dematerialize the workflow-controlled session"
+    );
+    assert!(
+        state
+            .workspace_runtime
+            .get_workspace(ws)
+            .expect("get workspace")
+            .is_some(),
+        "purge must not delete the workspace holding a controlled session"
+    );
+
+    purge_barriers::clear(ws);
+    test_barriers::clear(&run_id);
+    let _ = std::fs::remove_dir_all(&runtime_home);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retire_fails_closed_against_workflow_control_acquired_after_admission_snapshot() {
+    // Retire's ordering is: admit the CURRENT session set -> advisory preflight
+    // -> exclusive lease -> under-lease fence. The stale-snapshot window is
+    // between the up-front admission (which sees the session UNCONTROLLED, so it
+    // is admitted, not conflicted) and the exclusive lease: a workflow can bind
+    // control of that session in that gap, exactly mirroring the executor
+    // holding the shared SessionStart lease and binding a session the destroyer
+    // holds no matching permit for. This proof drives the REAL retire handler
+    // and the REAL controller policy: it admits an idle session, parks retire at
+    // the pre-exclusive-lease seam, binds a nonterminal workflow controller in
+    // that window, then releases. The under-lease fence must fail closed.
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let state = test_state();
+    const WS: &str = "40000000-0000-4000-8000-000000000045";
+    // A worktree + active workspace whose checkout path does NOT exist is
+    // retire-eligible (non-materialized skips managed-root/git checks) so
+    // preflight passes and retire reaches the seam.
+    test_support::seed_workspace_with_repo_root(
+        &state.db,
+        WS,
+        "worktree",
+        "/tmp/anyharness-fence-retire-nonexistent",
+    );
+    let session_id = uuid::Uuid::new_v4().to_string();
+    {
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = crate::domains::sessions::model::SessionRecord {
+            id: session_id.clone(),
+            workspace_id: WS.to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy:
+                crate::domains::sessions::model::SessionMcpBindingPolicy::InternalOnly,
+            system_prompt_append: None,
+            subagents_enabled: false,
+            action_capabilities_json: None,
+            origin: Some(crate::origin::OriginContext::system_local_runtime()),
+        };
+        state
+            .session_service
+            .store()
+            .insert(&record)
+            .expect("insert idle session");
+    }
+
+    // Park retire between its advisory preflight and the exclusive lease.
+    use crate::api::http::workspaces_lifecycle::retire_barriers;
+    let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+    retire_barriers::install(
+        WS,
+        retire_barriers::RetireBarrier {
+            reached_tx: Some(reached_tx),
+            resume_rx: Some(resume_rx),
+        },
+    );
+    let retire_state = state.clone();
+    let retire = tokio::spawn(async move {
+        let response = build_router(retire_state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/workspaces/{WS}/retire"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (
+            status,
+            serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null),
+        )
+    });
+
+    // Retire reached the seam: it admitted the idle session up front (no
+    // conflict) and passed its advisory preflight. NOW, in the stale-snapshot
+    // window, a workflow acquires durable control of that same session.
+    tokio::time::timeout(PROOF_WAIT, reached_rx)
+        .await
+        .expect("retire reached seam")
+        .expect("retire seam sender retained");
+    let control = control_service(&state);
+    let run_id = uuid::Uuid::new_v4().to_string();
+    control
+        .accept(&run_id, domain_input_for_workspace(WS))
+        .expect("accept controller run");
+    assert!(control.begin_run(&run_id).expect("begin_run"));
+    assert!(control
+        .bind_session(&run_id, &session_id)
+        .expect("bind controller session"));
+
+    // Release retire: it takes the exclusive lease and runs the fence.
+    resume_tx.send(()).expect("resume retire");
+    let (status, body) = tokio::time::timeout(PROOF_WAIT, retire)
+        .await
+        .expect("retire join timeout")
+        .expect("retire join");
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "retire must fail closed under the exclusive lease against a session that became controlled after admission (got {status}: {body})"
+    );
+    assert_eq!(body["code"], "SESSION_CONTROLLED_BY_WORKFLOW");
+
+    // No effect: the session survives and the workspace is not retired.
+    assert!(
+        state
+            .session_service
+            .store()
+            .find_by_id(&session_id)
+            .expect("find session")
+            .is_some(),
+        "retire must not dematerialize the newly workflow-controlled session's workspace"
+    );
+    let workspace = state
+        .workspace_runtime
+        .get_workspace(WS)
+        .expect("get workspace")
+        .expect("workspace present");
+    assert_eq!(
+        workspace.lifecycle_state,
+        crate::domains::workspaces::model::WorkspaceLifecycleState::Active,
+        "retire must not retire the workspace holding a controlled session"
+    );
+
+    retire_barriers::clear(WS);
+}

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -431,6 +431,7 @@ impl AppState {
             retire_preflight_checker.clone(),
             workspace_operation_gate.clone(),
             checkout_deletion_gate.clone(),
+            session_admission.clone(),
             runtime_home.clone(),
         ));
         let workspace_worktree_runtime = Arc::new(WorkspaceWorktreeRuntime::new(

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -417,6 +417,7 @@ impl AppState {
             SessionStore::new(db.clone()),
             PromptAttachmentStorage::new(runtime_home.clone()),
             workspace_operation_gate.clone(),
+            session_admission.clone(),
             checkout_deletion_gate.clone(),
             retire_preflight_checker.clone(),
             runtime_home.clone(),

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -153,6 +153,7 @@ pub struct AppState {
     pub goal_service: Arc<GoalService>,
     pub goal_runtime: Arc<GoalRuntime>,
     pub workflow_run_runtime: Arc<WorkflowRunRuntime>,
+    pub session_admission: Arc<crate::domains::sessions::admission::SessionMutationAdmission>,
     pub loop_service: Arc<LoopService>,
     pub loop_runtime: Arc<LoopRuntime>,
     pub activity_service: Arc<ActivityService>,
@@ -362,6 +363,7 @@ impl AppState {
         // Workflow runs — phase 1 (before SessionRuntime::new): service,
         // startup fencing, main-handle capture, completion extension.
         let workflow_wiring = workflows::wire_workflows_before_sessions(&db)?;
+        let session_admission = workflow_wiring.admission.clone();
         let workflow_run_session_extension = workflow_wiring.session_extension.clone();
         let session_extensions: Vec<
             Arc<dyn crate::domains::sessions::extensions::SessionExtension>,
@@ -549,6 +551,7 @@ impl AppState {
             goal_service,
             goal_runtime,
             workflow_run_runtime,
+            session_admission,
             loop_service,
             loop_runtime,
             activity_service,

--- a/anyharness/crates/anyharness-lib/src/app/workflows.rs
+++ b/anyharness/crates/anyharness-lib/src/app/workflows.rs
@@ -8,8 +8,9 @@ use std::sync::Arc;
 
 use tokio::runtime::Handle;
 
+use crate::domains::sessions::admission::SessionMutationAdmission;
 use crate::domains::sessions::runtime::SessionRuntime;
-use crate::domains::workflows::control::WorkflowRunGates;
+use crate::domains::workflows::control::{WorkflowRunGates, WorkflowSessionControllerPolicy};
 use crate::domains::workflows::runtime::WorkflowRunRuntime;
 use crate::domains::workflows::service::WorkflowRunService;
 use crate::domains::workflows::session_extension::WorkflowRunSessionExtension;
@@ -25,6 +26,10 @@ pub(super) struct WorkflowWiringPhaseOne {
     pub service: Arc<WorkflowRunService>,
     pub session_extension: Arc<WorkflowRunSessionExtension>,
     pub gates: Arc<WorkflowRunGates>,
+    /// Session mutation admission (spec 2b): sessions own the mechanics; the
+    /// injected policy is the Workflows controller lookup, so this is built
+    /// here and shared with every mutation owner via AppState.
+    pub admission: Arc<SessionMutationAdmission>,
     pub main_handle: Handle,
 }
 
@@ -43,15 +48,20 @@ pub(super) fn wire_workflows_before_sessions(
     // One shared per-run gate set (spec workflow-run-control §6.1): injected
     // into BOTH the workflow runtime and the completion extension.
     let gates = Arc::new(WorkflowRunGates::new());
+    let admission = Arc::new(SessionMutationAdmission::new(Arc::new(
+        WorkflowSessionControllerPolicy::new(WorkflowRunStore::new(db.clone())),
+    )));
     let session_extension = Arc::new(WorkflowRunSessionExtension::new(
         service.clone(),
         gates.clone(),
+        admission.clone(),
         main_handle.clone(),
     ));
     Ok(WorkflowWiringPhaseOne {
         service,
         session_extension,
         gates,
+        admission,
         main_handle,
     })
 }
@@ -70,6 +80,7 @@ pub(super) fn wire_workflow_runtime(
         operation_gate,
         access_gate,
         phase_one.gates,
+        phase_one.admission,
         phase_one.main_handle,
     ))
 }

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs
@@ -522,6 +522,7 @@ impl CoworkRuntime {
         let durable_session = match self.session_runtime.create_durable_session(
             &worktree.workspace.id,
             agent_kind,
+            None,
             model_id,
             mode_id,
             None,
@@ -1391,6 +1392,7 @@ impl CoworkRuntime {
         self.session_runtime.create_durable_session(
             workspace_id,
             resolved_agent_kind,
+            None,
             normalize_optional_ref(model_id).or(parent_thread.requested_model_id.as_deref()),
             resolved_mode_id,
             None,

--- a/anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs
@@ -23,12 +23,8 @@ use async_trait::async_trait;
 use tokio::sync::broadcast;
 
 use super::model::LoopRecord;
-use super::scheduler::{
-    LoopFireExecutor, LoopFireReport, LoopScheduler, LoopSessionLiveness,
-};
-use super::service::{
-    EmulatedLoopSpec, LoopEventContext, LoopService, MAX_LOOP_PROMPT_BYTES,
-};
+use super::scheduler::{LoopFireExecutor, LoopFireReport, LoopScheduler, LoopSessionLiveness};
+use super::service::{EmulatedLoopSpec, LoopEventContext, LoopService, MAX_LOOP_PROMPT_BYTES};
 use super::wire::{
     LoopClearedWireResult, LoopListWireResult, LOOP_CLEAR_EXT_METHOD, LOOP_LIST_EXT_METHOD,
     LOOP_SET_EXT_METHOD,
@@ -274,9 +270,9 @@ impl LoopRuntime {
             .run_domain_op(op)
             .await
             .map_err(map_domain_op_error)?;
-        let output = reply
-            .downcast::<LoopArmOpOutput>()
-            .map_err(|_| LoopOpError::Store(anyhow::anyhow!("loop arm op returned unexpected reply")))?;
+        let output = reply.downcast::<LoopArmOpOutput>().map_err(|_| {
+            LoopOpError::Store(anyhow::anyhow!("loop arm op returned unexpected reply"))
+        })?;
         let record = output.result.map_err(LoopOpError::Store)?;
         self.scheduler
             .arm(session_id, &loop_id, next_fire_at_ms)
@@ -297,9 +293,7 @@ impl LoopRuntime {
                 self.clear_native_loop(&handle, native_session_id, loop_id)
                     .await
             }
-            LoopSupport::Emulated => {
-                self.clear_emulated_loop(session_id, &handle, loop_id).await
-            }
+            LoopSupport::Emulated => self.clear_emulated_loop(session_id, &handle, loop_id).await,
         }
     }
 
@@ -420,15 +414,18 @@ impl LoopRuntime {
             loop_service: self.loop_service.clone(),
             wires: list.loops,
         });
-        let reply = handle.run_domain_op(op).await.map_err(|error| match error {
-            LiveSessionCommandError::ActorUnavailable => {
-                anyhow::anyhow!("session actor unavailable for loop reconcile")
-            }
-            LiveSessionCommandError::ResponseDropped => {
-                anyhow::anyhow!("session actor dropped loop reconcile response")
-            }
-            LiveSessionCommandError::Rejected(infallible) => match infallible {},
-        })?;
+        let reply = handle
+            .run_domain_op(op)
+            .await
+            .map_err(|error| match error {
+                LiveSessionCommandError::ActorUnavailable => {
+                    anyhow::anyhow!("session actor unavailable for loop reconcile")
+                }
+                LiveSessionCommandError::ResponseDropped => {
+                    anyhow::anyhow!("session actor dropped loop reconcile response")
+                }
+                LiveSessionCommandError::Rejected(infallible) => match infallible {},
+            })?;
         let output = reply
             .downcast::<LoopReconcileOpOutput>()
             .map_err(|_| anyhow::anyhow!("loop reconcile op returned unexpected reply"))?;
@@ -442,8 +439,13 @@ impl LoopRuntime {
             // A loop armed before the process died may have a past (or missing)
             // next-fire; fire it promptly on the next pass rather than skipping
             // the whole missed window.
-            let next_fire = record.next_fire_at_ms.filter(|next| *next > now).unwrap_or(now);
-            self.scheduler.arm(session_id, &record.loop_id, next_fire).await;
+            let next_fire = record
+                .next_fire_at_ms
+                .filter(|next| *next > now)
+                .unwrap_or(now);
+            self.scheduler
+                .arm(session_id, &record.loop_id, next_fire)
+                .await;
         }
         Ok(())
     }
@@ -518,6 +520,11 @@ impl LoopFireExecutor for SessionLoopFireExecutor {
         }
     }
 
+    // Spec 2b classification (admission:derived-safe): an ACTIVE loop row can
+    // never exist on a workflow-controlled session — control binds at
+    // creation, and every loop acquisition route (set/edit) is fenced 409
+    // before insert — so the emulated fire cannot target a controlled
+    // session and takes no admission permit.
     async fn fire(&self, session_id: &str, loop_id: &str) -> Option<LoopFireReport> {
         let handle = self.acp_manager.get_handle(session_id).await?;
         let record = self
@@ -531,11 +538,10 @@ impl LoopFireExecutor for SessionLoopFireExecutor {
         }
         // Enqueue the loop's prompt as an ordinary user turn — faithful
         // mirroring of a human retyping it, never a synthetic wake.
-        let payload = PromptPayload::text(record.prompt.clone()).with_provenance(
-            PromptProvenance::System {
+        let payload =
+            PromptPayload::text(record.prompt.clone()).with_provenance(PromptProvenance::System {
                 label: Some(LOOP_FIRED_PROVENANCE_LABEL.to_string()),
-            },
-        );
+            });
         if handle.send_prompt(payload, None).await.is_err() {
             return None;
         }

--- a/anyharness/crates/anyharness-lib/src/domains/plans/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/plans/store.rs
@@ -1,5 +1,10 @@
 use anyharness_contract::v1::{ProposedPlanDecisionState, ProposedPlanNativeResolutionState};
 use rusqlite::{params, types::Type, Connection, OptionalExtension, Row};
+#[cfg(test)]
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use super::model::{PlanHandoffRecord, PlanInteractionLinkRecord, PlanRecord};
 use crate::domains::sessions::model::SessionEventRecord;
@@ -8,11 +13,17 @@ use crate::persistence::Db;
 #[derive(Clone)]
 pub struct PlanStore {
     db: Db,
+    #[cfg(test)]
+    fail_next_find_by_id: Arc<AtomicBool>,
 }
 
 impl PlanStore {
     pub fn new(db: Db) -> Self {
-        Self { db }
+        Self {
+            db,
+            #[cfg(test)]
+            fail_next_find_by_id: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     pub fn with_tx<F, T>(&self, f: F) -> anyhow::Result<T>
@@ -30,10 +41,19 @@ impl PlanStore {
     }
 
     pub fn find_by_id(&self, plan_id: &str) -> anyhow::Result<Option<PlanRecord>> {
+        #[cfg(test)]
+        if self.fail_next_find_by_id.swap(false, Ordering::SeqCst) {
+            anyhow::bail!("injected plan lookup failure: private-test-marker");
+        }
         self.db.with_conn(|conn| {
             conn.query_row("SELECT * FROM plans WHERE id = ?1", [plan_id], map_plan)
                 .optional()
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_find_by_id_for_test(&self) {
+        self.fail_next_find_by_id.store(true, Ordering::SeqCst);
     }
 
     pub fn list_by_workspace(

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/runtime/launching.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/runtime/launching.rs
@@ -103,6 +103,7 @@ impl ReviewRuntime {
         let child = match self.session_runtime.create_durable_session(
             &run.workspace_id,
             &assignment.agent_kind,
+            None,
             assignment.model_id.as_deref(),
             assignment.requested_mode_id.as_deref(),
             Some(vec![reviewer_system_prompt_append()]),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
@@ -43,6 +43,29 @@
 //! permit` order is not the reverse of canonical in any deadlock-relevant sense:
 //! the fresh preselected id is structurally uncontended, so no party ever holds
 //! a workspace lease while waiting on that permit.)
+//!
+//! Admitted-set fail-closed (PR1227-WORKSPACE-FENCE-02): the nonterminal-only
+//! re-check above ([`SessionMutationAdmission::find_workflow_controlled_session`]) is NOT sufficient on
+//! its own. Consider the bind->terminalize race: the workflow executor binds a
+//! FRESH session (absent from the up-front admission snapshot, so no permit is
+//! held for it) AFTER the snapshot, and its controlling run then TERMINALIZES
+//! before the destructive path takes the exclusive lease. At re-check time that
+//! session has no NONTERMINAL controller — `controlling_run_id` returns `None`
+//! for it because the run's status is now terminal (`find_active_controller_run`
+//! filters `status NOT IN (completed, failed, cancelled, interrupted)`) — so
+//! FENCE-01 lets it through, yet the destructive path never admitted it (never
+//! held its permit). To close this, each destructive admission path (purge,
+//! retire) ALSO carries the SET of session ids it originally admitted (the ids
+//! `admit_all_workspace_sessions` snapshotted and holds permits for) into the
+//! under-lease re-check and FAILS CLOSED (the same stable 409) if ANY session
+//! id re-enumerated under the exclusive lease is NOT in that admitted set —
+//! EVEN IF its workflow already terminalized. FENCE-01 is still kept in
+//! ADDITION: it catches control ACQUIRED post-snapshot on an EXISTING admitted
+//! session (the retire race), which the set-membership check alone would miss
+//! because that session IS in the admitted set. The set-membership check is a
+//! PURE in-memory comparison over ids enumerated under the ALREADY-HELD
+//! exclusive lease: it acquires no permit and no lease, so it adds no edge to
+//! the canonical `run gate -> permit -> operation lease` order.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex, Weak};

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
@@ -12,6 +12,17 @@
 //! `workflow run gate -> session mutation permit`; no caller acquires them in
 //! reverse. The permit is NOT reentrant — nested session use cases must use
 //! crate-private permit-aware helpers instead of re-acquiring.
+//!
+//! Operation-gate ordering (PR1227-LOCK-01): the frozen spec fixes only the
+//! run-gate/permit pair and is SILENT on the permit vs. the per-workspace
+//! `WorkspaceOperationGate` RwLock (`acquire_shared` = read, `acquire_exclusive`
+//! and the exclusive session lease = write). Because fork/plan/review/retire/
+//! purge/mobility handlers hold BOTH the permit and an operation lease at once,
+//! a single documented order is mandatory to avoid an ABBA deadlock: the
+//! session mutation permit is ALWAYS acquired BEFORE any workspace operation
+//! lease (shared or exclusive), never in reverse. The full canonical order is
+//! therefore `workflow run gate -> session mutation permit -> workspace
+//! operation lease`; every handler holding both must take the permit outermost.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex, Weak};
@@ -229,11 +240,25 @@ impl SessionMutationAdmission {
     /// through durable creation and controller binding; foreign callers
     /// arriving meanwhile wait on this same gate and then observe the
     /// controller.
-    pub async fn reserve_new_session(
+    ///
+    /// PR1227-ADMISSION-01: this bypasses the controller-policy lookup, which
+    /// is sound ONLY for a fresh preselected id whose owner is the workflow
+    /// executor. Both the visibility (`pub(crate)`) and the source guard lock
+    /// the fresh-id contract at the type boundary — the sole caller is the
+    /// workflow executor (the Workflows domain's `execution` module), and an
+    /// External source here is a programming error, never a runtime-reachable
+    /// state.
+    pub(crate) async fn reserve_new_session(
         &self,
         session_id: &str,
-        _source: &SessionMutationSource,
+        source: &SessionMutationSource,
     ) -> Result<SessionMutationPermit, SessionMutationConflict> {
+        debug_assert!(
+            matches!(source.0, SourceInner::WorkflowRun { .. }),
+            "reserve_new_session bypasses controller policy and is only sound \
+             for the workflow executor's preselected id; source must be a \
+             trusted WorkflowRun, never External"
+        );
         let gate = self
             .slot(session_id)
             .map_err(SessionMutationConflict::Internal)?;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
@@ -78,6 +78,7 @@ pub enum SessionMutationKind {
     SubagentWake,
     ReplayAdvance,
     WorkspacePurge,
+    WorkspaceRetire,
     Mobility,
     /// The owning workflow's terminal run+step CAS (completion, failure,
     /// cancellation) — always a trusted source; named so conflict logs and
@@ -105,6 +106,7 @@ impl SessionMutationKind {
             Self::SubagentWake => "subagent_wake",
             Self::ReplayAdvance => "replay_advance",
             Self::WorkspacePurge => "workspace_purge",
+            Self::WorkspaceRetire => "workspace_retire",
             Self::Mobility => "mobility",
             Self::WorkflowTerminal => "workflow_terminal",
         }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
@@ -1,0 +1,241 @@
+//! Session mutation admission (spec 2b "Workflow Session Mutation Admission"):
+//! one transient keyed async gate per session id serializing
+//! execution-affecting mutations, plus a pluggable controller policy that
+//! decides whether a mutation source is admitted while a controller owns the
+//! session.
+//!
+//! Ownership boundaries (frozen): Sessions owns the gate/permit mechanics and
+//! the policy trait; the Workflows domain implements the durable controller
+//! lookup; `app/` injects it. Session core never imports the Workflows domain.
+//!
+//! Locking contract (frozen): the canonical combined order is always
+//! `workflow run gate -> session mutation permit`; no caller acquires them in
+//! reverse. The permit is NOT reentrant — nested session use cases must use
+//! crate-private permit-aware helpers instead of re-acquiring.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
+
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+/// Who is asking to mutate a session's execution state.
+///
+/// The trusted workflow source is constructible only by crate code
+/// ([`SessionMutationSource::workflow_run`] is `pub(crate)`): it is never
+/// parsed from a request body, header, query, origin/provenance field, or any
+/// caller metadata.
+#[derive(Debug, Clone)]
+pub struct SessionMutationSource(SourceInner);
+
+#[derive(Debug, Clone)]
+enum SourceInner {
+    External,
+    WorkflowRun { run_id: String },
+}
+
+impl SessionMutationSource {
+    /// Any caller outside the owning workflow: HTTP routes, product surfaces,
+    /// maintenance paths.
+    pub fn external() -> Self {
+        Self(SourceInner::External)
+    }
+
+    /// The owning workflow's own mutation authority (ruling 3: includes the
+    /// crate-private exact-active-turn live cancel).
+    pub(crate) fn workflow_run(run_id: &str) -> Self {
+        Self(SourceInner::WorkflowRun {
+            run_id: run_id.to_string(),
+        })
+    }
+
+    fn run_id(&self) -> Option<&str> {
+        match &self.0 {
+            SourceInner::External => None,
+            SourceInner::WorkflowRun { run_id } => Some(run_id),
+        }
+    }
+}
+
+/// The execution-affecting mutation categories from the frozen inventory.
+/// Every admission call names one so the static ratchet can enumerate hooks
+/// and conflict logs stay classified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionMutationKind {
+    Prompt,
+    PendingPromptQueue,
+    Config,
+    Cancel,
+    Close,
+    Dismiss,
+    Restore,
+    Resume,
+    Fork,
+    InteractionResolution,
+    Goal,
+    Loop,
+    Plan,
+    Review,
+    SubagentWake,
+    ReplayAdvance,
+    WorkspacePurge,
+    Mobility,
+    /// The owning workflow's terminal run+step CAS (completion, failure,
+    /// cancellation) — always a trusted source; named so conflict logs and
+    /// the ratchet classify it.
+    WorkflowTerminal,
+}
+
+impl SessionMutationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Prompt => "prompt",
+            Self::PendingPromptQueue => "pending_prompt_queue",
+            Self::Config => "config",
+            Self::Cancel => "cancel",
+            Self::Close => "close",
+            Self::Dismiss => "dismiss",
+            Self::Restore => "restore",
+            Self::Resume => "resume",
+            Self::Fork => "fork",
+            Self::InteractionResolution => "interaction_resolution",
+            Self::Goal => "goal",
+            Self::Loop => "loop",
+            Self::Plan => "plan",
+            Self::Review => "review",
+            Self::SubagentWake => "subagent_wake",
+            Self::ReplayAdvance => "replay_advance",
+            Self::WorkspacePurge => "workspace_purge",
+            Self::Mobility => "mobility",
+            Self::WorkflowTerminal => "workflow_terminal",
+        }
+    }
+}
+
+/// Durable controller lookup, implemented by the Workflows domain and
+/// injected by `app/`. Synchronous SQLite work: admission runs it on the
+/// blocking pool.
+pub trait SessionControllerPolicy: Send + Sync {
+    /// The run id of the NONTERMINAL workflow controlling `session_id`, if
+    /// any. `None` means ordinary session behavior applies.
+    fn controlling_run_id(&self, session_id: &str) -> anyhow::Result<Option<String>>;
+}
+
+/// A policy admitting everything — the app default until workflow wiring
+/// installs the real controller lookup, and the fixture for ordinary-session
+/// tests.
+pub struct NoControllerPolicy;
+
+impl SessionControllerPolicy for NoControllerPolicy {
+    fn controlling_run_id(&self, _session_id: &str) -> anyhow::Result<Option<String>> {
+        Ok(None)
+    }
+}
+
+/// Why an admission request did not yield a permit.
+#[derive(Debug)]
+pub enum SessionMutationConflict {
+    /// A nonterminal workflow controls this session; carries its run id for
+    /// logging (never for the wire body).
+    ControlledByWorkflow { run_id: String },
+    /// Policy lookup infrastructure failed; callers surface their generic
+    /// storage error, never a fabricated admission.
+    Internal(anyhow::Error),
+}
+
+/// A held admission permit. Holding it serializes every other
+/// execution-affecting mutation on the same session id; dropping it releases
+/// the gate. There is no policy state to release — the permit is purely the
+/// keyed lock plus the proof that policy admitted this source while it was
+/// held.
+pub struct SessionMutationPermit {
+    _guard: OwnedMutexGuard<()>,
+}
+
+/// The keyed admission gate. Slots are transient (weak): a session id with no
+/// holder costs nothing durable, exactly like the workflow run gates.
+pub struct SessionMutationAdmission {
+    slots: StdMutex<HashMap<String, Weak<AsyncMutex<()>>>>,
+    policy: Arc<dyn SessionControllerPolicy>,
+}
+
+impl SessionMutationAdmission {
+    pub fn new(policy: Arc<dyn SessionControllerPolicy>) -> Self {
+        Self {
+            slots: StdMutex::new(HashMap::new()),
+            policy,
+        }
+    }
+
+    fn slot(&self, session_id: &str) -> anyhow::Result<Arc<AsyncMutex<()>>> {
+        let mut slots = self
+            .slots
+            .lock()
+            .map_err(|_| anyhow::anyhow!("session admission gate lock poisoned"))?;
+        slots.retain(|_, gate| gate.strong_count() > 0);
+        if let Some(gate) = slots.get(session_id).and_then(Weak::upgrade) {
+            return Ok(gate);
+        }
+        let gate = Arc::new(AsyncMutex::new(()));
+        slots.insert(session_id.to_string(), Arc::downgrade(&gate));
+        Ok(gate)
+    }
+
+    /// Wait for the session's gate, then decide under the held gate: no
+    /// controller or a matching workflow source is admitted (permit returned,
+    /// still held); a foreign source under an active controller conflicts
+    /// before any side effect. Callers hold the permit across their mutation's
+    /// side effects.
+    pub async fn acquire(
+        &self,
+        session_id: &str,
+        kind: SessionMutationKind,
+        source: &SessionMutationSource,
+    ) -> Result<SessionMutationPermit, SessionMutationConflict> {
+        let gate = self
+            .slot(session_id)
+            .map_err(SessionMutationConflict::Internal)?;
+        let guard = gate.lock_owned().await;
+
+        let policy = self.policy.clone();
+        let lookup_session_id = session_id.to_string();
+        let controlling =
+            tokio::task::spawn_blocking(move || policy.controlling_run_id(&lookup_session_id))
+                .await
+                .map_err(|error| SessionMutationConflict::Internal(error.into()))?
+                .map_err(SessionMutationConflict::Internal)?;
+
+        match controlling {
+            None => Ok(SessionMutationPermit { _guard: guard }),
+            Some(run_id) => {
+                if source.run_id() == Some(run_id.as_str()) {
+                    return Ok(SessionMutationPermit { _guard: guard });
+                }
+                tracing::info!(
+                    session_id = %session_id,
+                    mutation_kind = kind.as_str(),
+                    controlling_run_id = %run_id,
+                    "session mutation rejected: session is controlled by a workflow"
+                );
+                Err(SessionMutationConflict::ControlledByWorkflow { run_id })
+            }
+        }
+    }
+
+    /// Reserve a NEW session id's gate before its row becomes visible
+    /// (ruling 1). No policy lookup: there is no durable row yet, and the
+    /// caller is by construction the creator. The returned permit is held
+    /// through durable creation and controller binding; foreign callers
+    /// arriving meanwhile wait on this same gate and then observe the
+    /// controller.
+    pub async fn reserve_new_session(
+        &self,
+        session_id: &str,
+        _source: &SessionMutationSource,
+    ) -> Result<SessionMutationPermit, SessionMutationConflict> {
+        let gate = self
+            .slot(session_id)
+            .map_err(SessionMutationConflict::Internal)?;
+        let guard = gate.lock_owned().await;
+        Ok(SessionMutationPermit { _guard: guard })
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/admission.rs
@@ -23,6 +23,26 @@
 //! lease (shared or exclusive), never in reverse. The full canonical order is
 //! therefore `workflow run gate -> session mutation permit -> workspace
 //! operation lease`; every handler holding both must take the permit outermost.
+//!
+//! Workspace-destruction fence (PR1227-WORKSPACE-FENCE-01): the workspace-wide
+//! destructive paths (`purge_workspace`, `retire_workspace`) admit the CURRENT
+//! session set up front, but the workflow executor holds only the SHARED
+//! `SessionStart` lease when it creates and binds a fresh preselected session
+//! (`execution.rs`: `acquire_shared(SessionStart) -> reserve_new_session ->
+//! bind_session`). That session id is a brand-new UUID absent from the
+//! destructive path's snapshot, so its keyed permit is never acquired. To keep
+//! the fail-closed contract, each destructive path RE-ENUMERATES the workspace
+//! session set AFTER it holds the EXCLUSIVE workspace lease and conflicts (409)
+//! if any session is controlled by a nonterminal workflow
+//! ([`SessionMutationAdmission::find_workflow_controlled_session`]). The
+//! exclusive lease is mutually exclusive with the shared `SessionStart` lease,
+//! so no new controlled session can materialize while the re-check runs. The
+//! re-check is a PURE read-only controller-policy lookup — it acquires neither a
+//! permit nor a workspace lease — so it adds no edge to the lock order above and
+//! cannot introduce an ABBA cycle. (The executor's `SessionStart -> fresh
+//! permit` order is not the reverse of canonical in any deadlock-relevant sense:
+//! the fresh preselected id is structurally uncontended, so no party ever holds
+//! a workspace lease while waiting on that permit.)
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex, Weak};
@@ -232,6 +252,36 @@ impl SessionMutationAdmission {
                 Err(SessionMutationConflict::ControlledByWorkflow { run_id })
             }
         }
+    }
+
+    /// PR1227-WORKSPACE-FENCE-01: the workspace-destruction re-check. Given the
+    /// session ids enumerated UNDER the exclusive workspace lease, return the
+    /// first that a nonterminal workflow controls (with the controlling run id
+    /// for logging), or `None` if every session is free of an active workflow
+    /// controller.
+    ///
+    /// This performs ONLY the read-only controller-policy lookup — it acquires
+    /// neither a keyed permit nor any workspace lease — so it introduces no edge
+    /// to the canonical `run gate -> permit -> operation lease` order and cannot
+    /// deadlock. Correctness against the creation race depends entirely on the
+    /// caller already holding the EXCLUSIVE workspace lease (which excludes the
+    /// shared `SessionStart` lease every workflow session creation must hold):
+    /// no new controlled session can bind while this runs.
+    pub async fn find_workflow_controlled_session(
+        &self,
+        session_ids: Vec<String>,
+    ) -> anyhow::Result<Option<(String, String)>> {
+        let policy = self.policy.clone();
+        tokio::task::spawn_blocking(move || {
+            for session_id in session_ids {
+                if let Some(run_id) = policy.controlling_run_id(&session_id)? {
+                    return Ok(Some((session_id, run_id)));
+                }
+            }
+            Ok(None)
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("controlled-session re-check task failed: {error}"))?
     }
 
     /// Reserve a NEW session id's gate before its row becomes visible

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
@@ -1,4 +1,5 @@
 pub mod active_activity_roster;
+pub mod admission;
 pub mod active_goals;
 pub mod active_loops;
 pub mod attachment_storage;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
@@ -22,6 +22,10 @@ pub(crate) struct InternalSessionCreateInput {
     pub model_id: Option<String>,
     pub mode_id: Option<String>,
     pub origin: OriginContext,
+    /// Ruling 2b-1: the workflow executor preselects the id so it can reserve
+    /// the session's mutation gate before this row exists. `None` keeps the
+    /// ordinary mint-at-create behavior.
+    pub preselected_session_id: Option<String>,
 }
 
 /// Typed failure for the internal creation seam. Access-gate refusals stay
@@ -71,6 +75,7 @@ impl SessionRuntime {
         let mut record = self.create_durable_session(
             workspace_id,
             agent_kind,
+            None,
             model_id,
             mode_id,
             system_prompt_append,
@@ -102,6 +107,7 @@ impl SessionRuntime {
         &self,
         workspace_id: &str,
         agent_kind: &str,
+        preselected_session_id: Option<&str>,
         model_id: Option<&str>,
         mode_id: Option<&str>,
         system_prompt_append: Option<Vec<String>>,
@@ -121,6 +127,7 @@ impl SessionRuntime {
             .create_session(
                 workspace_id,
                 agent_kind,
+                preselected_session_id,
                 model_id,
                 mode_id,
                 mcp_bindings_ciphertext,
@@ -207,6 +214,7 @@ impl SessionRuntime {
         self.create_durable_session(
             &input.workspace_id,
             &input.agent_kind,
+            input.preselected_session_id.as_deref(),
             input.model_id.as_deref(),
             input.mode_id.as_deref(),
             None,   // no system-prompt append

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
@@ -768,6 +768,7 @@ async fn create_persisted_internal_session_rejects_missing_checkout_without_inse
             model_id: None,
             mode_id: None,
             origin: OriginContext::api_local_runtime(),
+            preselected_session_id: None,
         })
         .expect_err("missing checkout should be refused");
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/create.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/create.rs
@@ -21,6 +21,10 @@ impl SessionService {
         &self,
         workspace_id: &str,
         agent_kind: &str,
+        // Ruling 2b-1: a caller-preselected canonical UUID, so workflow
+        // creation can reserve the session's mutation gate before this row
+        // becomes visible. `None` mints here — the single minting path.
+        preselected_session_id: Option<&str>,
         model_id: Option<&str>,
         mode_id: Option<&str>,
         mcp_bindings_ciphertext: Option<String>,
@@ -139,9 +143,25 @@ impl SessionService {
             "[workspace-latency] session.create.model_resolved"
         );
 
+        let session_id = match preselected_session_id {
+            Some(id) => {
+                let parsed = Uuid::parse_str(id).map_err(|_| {
+                    CreateSessionError::Internal(anyhow::anyhow!(
+                        "preselected session id must be a canonical UUID"
+                    ))
+                })?;
+                if parsed.get_version_num() != 4 || id != parsed.hyphenated().to_string() {
+                    return Err(CreateSessionError::Internal(anyhow::anyhow!(
+                        "preselected session id must be a canonical lowercase v4 UUID"
+                    )));
+                }
+                id.to_string()
+            }
+            None => Uuid::new_v4().to_string(),
+        };
         let now = chrono::Utc::now().to_rfc3339();
         let record = SessionRecord {
-            id: Uuid::new_v4().to_string(),
+            id: session_id,
             workspace_id: workspace_id.to_string(),
             agent_kind: agent_kind.to_string(),
             native_session_id: None,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs
@@ -63,6 +63,12 @@ async fn deliver_subagent_completion(
         created_at: now.clone(),
         updated_at: now,
     };
+    // Spec 2b classification (admission:derived-safe): workflow-controlled
+    // sessions are created InternalOnly with subagents DISABLED, so no
+    // session link can exist whose parent is controlled; this wake path
+    // cannot target a controlled session and takes no admission permit
+    // (threading one here would also wait on the actor callback context,
+    // which the spec forbids).
     let prompt = wake_prompt_text(
         link.label.as_deref(),
         link.public_id.as_deref(),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls.rs
@@ -252,6 +252,7 @@ async fn create_subagent(
         .create_durable_session(
             &parent.workspace_id,
             &agent_kind,
+            None,
             model_id.as_deref(),
             mode_id.as_deref(),
             None,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/control/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/control/mod.rs
@@ -2,8 +2,10 @@
 //! serialization and the durable cancellation use case.
 
 mod gate;
+mod policy;
 mod runtime;
 
 pub use gate::WorkflowRunGates;
+pub use policy::WorkflowSessionControllerPolicy;
 pub(super) use runtime::cancel_workflow_run;
 pub use runtime::WorkflowCancelError;

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/control/policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/control/policy.rs
@@ -1,0 +1,24 @@
+//! The Workflows-owned controller policy for session mutation admission
+//! (spec 2b): active `workflow_runs.session_id` is the ONLY durable
+//! controller record. Sessions owns the gate mechanics and the trait;
+//! `app/` injects this implementation so session core never imports the
+//! Workflows domain.
+
+use crate::domains::sessions::admission::SessionControllerPolicy;
+use crate::domains::workflows::store::WorkflowRunStore;
+
+pub struct WorkflowSessionControllerPolicy {
+    store: WorkflowRunStore,
+}
+
+impl WorkflowSessionControllerPolicy {
+    pub fn new(store: WorkflowRunStore) -> Self {
+        Self { store }
+    }
+}
+
+impl SessionControllerPolicy for WorkflowSessionControllerPolicy {
+    fn controlling_run_id(&self, session_id: &str) -> anyhow::Result<Option<String>> {
+        self.store.find_active_controller_run(session_id)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/control/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/control/runtime.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use crate::domains::sessions::admission::SessionMutationAdmission;
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::workflows::service::{
     VersionedWorkflowRunView, WorkflowCancelOutcome, WorkflowRunService,
@@ -32,6 +33,7 @@ pub(in crate::domains::workflows) async fn cancel_workflow_run(
     service: Arc<WorkflowRunService>,
     session_runtime: Arc<SessionRuntime>,
     gates: Arc<WorkflowRunGates>,
+    admission: Arc<SessionMutationAdmission>,
     run_id: String,
 ) -> Result<VersionedWorkflowRunView, WorkflowCancelError> {
     if let Err(error) = crate::domains::workflows::service::validate_run_id(&run_id) {
@@ -46,6 +48,16 @@ pub(in crate::domains::workflows) async fn cancel_workflow_run(
     #[cfg(test)]
     crate::domains::workflows::test_barriers::at_cancel_gate(&run_id);
     let guard = gate.clone().lock_owned().await;
+
+    // Spec 2b: with a bound session, the cancel-intent CAS (which may
+    // terminalize pending -> cancelled) and the live-cancel request run under
+    // that session's mutation permit (canonical order run gate -> permit);
+    // pre-binding cancellation has no controlled session and proceeds under
+    // the run gate alone.
+    let _session_permit = crate::domains::workflows::execution::acquire_bound_session_permit(
+        &service, &admission, &run_id,
+    )
+    .await;
 
     let intent_service = service.clone();
     let intent_run_id = run_id.clone();

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/execution.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/execution.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use anyharness_contract::v1::ConfigApplyState;
 
+use crate::domains::sessions::admission::{SessionMutationAdmission, SessionMutationSource};
 use crate::domains::sessions::runtime::{InternalSessionCreateInput, SessionRuntime};
 use crate::domains::workflows::control::WorkflowRunGates;
 use crate::domains::workflows::dispatch::{
@@ -33,17 +34,31 @@ pub(crate) async fn execute(
     session_runtime: Arc<SessionRuntime>,
     operation_gate: Arc<WorkspaceOperationGate>,
     gates: Arc<WorkflowRunGates>,
+    admission: Arc<SessionMutationAdmission>,
     plan: WorkflowExecutionPlan,
 ) {
     let run_id = plan.run_id.clone();
-    match run_execution(&service, &session_runtime, &operation_gate, &gates, plan).await {
+    match run_execution(
+        &service,
+        &session_runtime,
+        &operation_gate,
+        &gates,
+        &admission,
+        plan,
+    )
+    .await
+    {
         Ok(()) => {}
         Err(ExecutionAbort::Fail(code)) => {
             // Every classified execution-failure terminalization uses the
-            // same run gate (spec §6.2).
+            // same run gate (spec §6.2); with a bound session, the terminal
+            // CAS additionally holds the session mutation permit (spec 2b,
+            // canonical order run gate -> permit). Pre-binding failures have
+            // no controlled session and terminalize under the gate alone.
             match gates.slot(&run_id) {
                 Ok(gate) => {
                     let _guard = gate.lock_owned().await;
+                    let _permit = acquire_bound_session_permit(&service, &admission, &run_id).await;
                     guarded_fail(&service, &run_id, code).await;
                 }
                 Err(_poisoned) => {
@@ -67,6 +82,7 @@ async fn run_execution(
     session_runtime: &Arc<SessionRuntime>,
     operation_gate: &Arc<WorkspaceOperationGate>,
     gates: &Arc<WorkflowRunGates>,
+    admission: &Arc<SessionMutationAdmission>,
     plan: WorkflowExecutionPlan,
 ) -> Result<(), ExecutionAbort> {
     let run_id = plan.run_id.clone();
@@ -111,12 +127,35 @@ async fn run_execution(
             return Ok(());
         }
 
+        // Ruling 2b-1: preselect the session id and reserve its mutation
+        // gate BEFORE the row exists, inside the held run gate (canonical
+        // order run gate -> permit). Foreign callers racing this id wait on
+        // the permit and then observe the bound controller; there is no
+        // externally writable gap. The permit is held through creation and
+        // binding and released only after binding commits (scope end).
+        let preselected_session_id = uuid::Uuid::new_v4().to_string();
+        let workflow_source = SessionMutationSource::workflow_run(&run_id);
+        let _creation_permit = match admission
+            .reserve_new_session(&preselected_session_id, &workflow_source)
+            .await
+        {
+            Ok(permit) => permit,
+            Err(_conflict) => {
+                tracing::error!(
+                    run_id = %run_id,
+                    "workflow session reservation infrastructure failed"
+                );
+                return Err(ExecutionAbort::Infra);
+            }
+        };
+
         let create_input = InternalSessionCreateInput {
             workspace_id: plan.workspace_id.clone(),
             agent_kind: plan.agent_kind.clone(),
             model_id: plan.model_id.clone(),
             mode_id: plan.mode_id.clone(),
             origin: OriginContext::system_local_runtime(),
+            preselected_session_id: Some(preselected_session_id.clone()),
         };
         let session = {
             let session_runtime = session_runtime.clone();
@@ -140,6 +179,9 @@ async fn run_execution(
                 }
             }
         };
+
+        #[cfg(test)]
+        test_barriers::at_reserved(&run_id, &session.id).await;
 
         // Persist session_id BEFORE startup, still under the gate. A `false`
         // here means cancellation terminalized the run after creation won; the
@@ -278,6 +320,13 @@ pub(crate) mod test_barriers {
 
     #[derive(Default)]
     pub(crate) struct ExecutionBarrier {
+        /// Fired with the preselected session id after the reservation
+        /// permit is held and the durable session row exists, BEFORE binding
+        /// (spec 2b creation-race window).
+        pub(crate) reserved_tx: Option<oneshot::Sender<String>>,
+        /// Awaited (still holding gate + reservation permit) before binding
+        /// when present.
+        pub(crate) resume_bind_rx: Option<oneshot::Receiver<()>>,
         /// Fired with the bound session id after `bind_session`, before
         /// startup (step 5).
         pub(crate) session_bound_tx: Option<oneshot::Sender<String>>,
@@ -301,7 +350,9 @@ pub(crate) mod test_barriers {
 
     impl ExecutionBarrier {
         fn is_spent(&self) -> bool {
-            self.session_bound_tx.is_none()
+            self.reserved_tx.is_none()
+                && self.resume_bind_rx.is_none()
+                && self.session_bound_tx.is_none()
                 && self.resume_startup_rx.is_none()
                 && self.recheck_tx.is_none()
                 && self.pre_dispatch_tx.is_none()
@@ -347,6 +398,20 @@ pub(crate) mod test_barriers {
             .expect("barrier lock")
             .get_or_insert_with(HashMap::new)
             .insert(run_id.to_string(), barrier);
+    }
+
+    pub(super) async fn at_reserved(run_id: &str, session_id: &str) {
+        let Some(mut barrier) = take(run_id) else {
+            return;
+        };
+        if let Some(tx) = barrier.reserved_tx.take() {
+            let _ = tx.send(session_id.to_string());
+        }
+        let resume = barrier.resume_bind_rx.take();
+        put_back(run_id, barrier);
+        if let Some(rx) = resume {
+            let _ = rx.await;
+        }
     }
 
     pub(super) async fn at_session_bound(run_id: &str, session_id: &str) {
@@ -411,6 +476,44 @@ async fn acquire_run_gate(
         Err(_poisoned) => {
             tracing::error!(run_id = %run_id, "workflow run gate unavailable");
             Err(ExecutionAbort::Infra)
+        }
+    }
+}
+
+/// With a bound session, terminal workflow CAS paths hold that session's
+/// mutation permit (spec 2b); without one there is no controlled session and
+/// the run gate alone suffices. Permit-acquisition infrastructure failure
+/// degrades to gate-only terminalization: a missed serialization window is
+/// recoverable by fencing, an unterminalized run is worse.
+pub(crate) async fn acquire_bound_session_permit(
+    service: &Arc<WorkflowRunService>,
+    admission: &Arc<SessionMutationAdmission>,
+    run_id: &str,
+) -> Option<crate::domains::sessions::admission::SessionMutationPermit> {
+    let lookup_service = service.clone();
+    let lookup_run_id = run_id.to_string();
+    let session_id = tokio::task::spawn_blocking(move || lookup_service.get(&lookup_run_id))
+        .await
+        .ok()?
+        .ok()??
+        .run
+        .session_id?;
+    match admission
+        .acquire(
+            &session_id,
+            crate::domains::sessions::admission::SessionMutationKind::WorkflowTerminal,
+            &SessionMutationSource::workflow_run(run_id),
+        )
+        .await
+    {
+        Ok(permit) => Some(permit),
+        Err(_conflict) => {
+            tracing::error!(
+                run_id = %run_id,
+                session_id = %session_id,
+                "session permit unavailable for terminal workflow CAS; proceeding under run gate alone"
+            );
+            None
         }
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/execution.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/execution.rs
@@ -110,6 +110,9 @@ async fn run_execution(
         .acquire_shared(&plan.workspace_id, WorkspaceOperationKind::SessionStart)
         .await;
 
+    #[cfg(test)]
+    test_barriers::at_session_start_lease(&run_id).await;
+
     // 3+4. Reacquire the gate: recheck nonterminal/uncancelled state, then
     // hold through durable session creation plus session_id binding. If
     // cancellation won the recheck, no session is created; if creation wins,
@@ -320,6 +323,14 @@ pub(crate) mod test_barriers {
 
     #[derive(Default)]
     pub(crate) struct ExecutionBarrier {
+        /// Fired after the shared `SessionStart` lease is held, BEFORE session
+        /// creation (PR1227-WORKSPACE-FENCE-01 window: a destructive path's
+        /// up-front admission snapshot can run here, before this run's session
+        /// exists).
+        pub(crate) session_start_lease_tx: Option<oneshot::Sender<()>>,
+        /// Awaited (still holding the shared `SessionStart` lease) before
+        /// session creation when present.
+        pub(crate) resume_create_rx: Option<oneshot::Receiver<()>>,
         /// Fired with the preselected session id after the reservation
         /// permit is held and the durable session row exists, BEFORE binding
         /// (spec 2b creation-race window).
@@ -350,7 +361,9 @@ pub(crate) mod test_barriers {
 
     impl ExecutionBarrier {
         fn is_spent(&self) -> bool {
-            self.reserved_tx.is_none()
+            self.session_start_lease_tx.is_none()
+                && self.resume_create_rx.is_none()
+                && self.reserved_tx.is_none()
                 && self.resume_bind_rx.is_none()
                 && self.session_bound_tx.is_none()
                 && self.resume_startup_rx.is_none()
@@ -398,6 +411,20 @@ pub(crate) mod test_barriers {
             .expect("barrier lock")
             .get_or_insert_with(HashMap::new)
             .insert(run_id.to_string(), barrier);
+    }
+
+    pub(super) async fn at_session_start_lease(run_id: &str) {
+        let Some(mut barrier) = take(run_id) else {
+            return;
+        };
+        if let Some(tx) = barrier.session_start_lease_tx.take() {
+            let _ = tx.send(());
+        }
+        let resume = barrier.resume_create_rx.take();
+        put_back(run_id, barrier);
+        if let Some(rx) = resume {
+            let _ = rx.await;
+        }
     }
 
     pub(super) async fn at_reserved(run_id: &str, session_id: &str) {

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/runtime.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use tokio::runtime::Handle;
 
+use crate::domains::sessions::admission::SessionMutationAdmission;
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::workflows::control::{
     cancel_workflow_run, WorkflowCancelError, WorkflowRunGates,
@@ -63,6 +64,7 @@ pub struct WorkflowRunRuntime {
     operation_gate: Arc<WorkspaceOperationGate>,
     access_gate: Arc<WorkspaceAccessGate>,
     gates: Arc<WorkflowRunGates>,
+    admission: Arc<SessionMutationAdmission>,
     main_handle: Handle,
 }
 
@@ -73,6 +75,7 @@ impl WorkflowRunRuntime {
         operation_gate: Arc<WorkspaceOperationGate>,
         access_gate: Arc<WorkspaceAccessGate>,
         gates: Arc<WorkflowRunGates>,
+        admission: Arc<SessionMutationAdmission>,
         main_handle: Handle,
     ) -> Self {
         Self {
@@ -81,6 +84,7 @@ impl WorkflowRunRuntime {
             operation_gate,
             access_gate,
             gates,
+            admission,
             main_handle,
         }
     }
@@ -112,6 +116,7 @@ impl WorkflowRunRuntime {
         let operation_gate = self.operation_gate.clone();
         let access_gate = self.access_gate.clone();
         let gates = self.gates.clone();
+        let admission = self.admission.clone();
         let execution_handle = self.main_handle.clone();
 
         let handoff = self.main_handle.spawn(async move {
@@ -130,12 +135,14 @@ impl WorkflowRunRuntime {
                     match outcome {
                         Ok(AcceptOutcome::Created { plan, view }) => {
                             let gates_for_execute = gates.clone();
+                            let admission_for_execute = admission.clone();
                             execution_handle.spawn(async move {
                                 execute(
                                     service,
                                     session_runtime,
                                     operation_gate,
                                     gates_for_execute,
+                                    admission_for_execute,
                                     plan,
                                 )
                                 .await;
@@ -256,12 +263,14 @@ impl WorkflowRunRuntime {
                                 prompt_id: plan.prompt_id.clone(),
                             };
                             let gates_for_execute = gates.clone();
+                            let admission_for_execute = admission.clone();
                             execution_handle.spawn(async move {
                                 execute(
                                     service,
                                     session_runtime,
                                     operation_gate,
                                     gates_for_execute,
+                                    admission_for_execute,
                                     execution_plan,
                                 )
                                 .await;
@@ -313,8 +322,9 @@ impl WorkflowRunRuntime {
         let service = self.service.clone();
         let session_runtime = self.session_runtime.clone();
         let gates = self.gates.clone();
+        let admission = self.admission.clone();
         let handoff = self.main_handle.spawn(async move {
-            cancel_workflow_run(service, session_runtime, gates, run_id).await
+            cancel_workflow_run(service, session_runtime, gates, admission, run_id).await
         });
         handoff
             .await

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs
@@ -834,7 +834,8 @@ fn fail_nonterminal_leaves_terminal_rows_untouched() {
 
 #[test]
 fn later_run_may_reuse_a_historical_session_id() {
-    // No unique constraint on session_id: two runs may share one.
+    // Spec 2b (0063 partial uniqueness): at most one NONTERMINAL run may bind
+    // one session; a TERMINAL run's session id may be reused by a later run.
     let svc = service();
     let first = new_run_id();
     let second = new_run_id();
@@ -843,7 +844,19 @@ fn later_run_may_reuse_a_historical_session_id() {
     assert!(svc.begin_run(&first).expect("begin a"));
     assert!(svc.begin_run(&second).expect("begin b"));
     assert!(svc.bind_session(&first, "shared-session").expect("bind a"));
-    assert!(svc.bind_session(&second, "shared-session").expect("bind b"));
+
+    // Concurrent nonterminal reuse is rejected by the partial unique index.
+    assert!(
+        svc.bind_session(&second, "shared-session").is_err(),
+        "a second nonterminal run must not bind the controlled session"
+    );
+
+    // Terminalize the first run: historical reuse becomes legal again.
+    svc.fail_nonterminal(&first, WorkflowRunFailureCode::SessionStartFailed)
+        .expect("terminalize a");
+    assert!(svc
+        .bind_session(&second, "shared-session")
+        .expect("bind b after terminal"));
 }
 
 #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/session_extension.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/session_extension.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 
 use tokio::runtime::Handle;
 
+use crate::domains::sessions::admission::{
+    SessionMutationAdmission, SessionMutationKind, SessionMutationSource,
+};
 use crate::domains::sessions::extensions::{
     SessionExtension, SessionTurnFinishedContext, SessionTurnOutcome,
 };
@@ -21,6 +24,7 @@ use crate::domains::workflows::service::WorkflowRunService;
 pub struct WorkflowRunSessionExtension {
     service: Arc<WorkflowRunService>,
     gates: Arc<WorkflowRunGates>,
+    admission: Arc<SessionMutationAdmission>,
     main_handle: Handle,
 }
 
@@ -28,11 +32,13 @@ impl WorkflowRunSessionExtension {
     pub fn new(
         service: Arc<WorkflowRunService>,
         gates: Arc<WorkflowRunGates>,
+        admission: Arc<SessionMutationAdmission>,
         main_handle: Handle,
     ) -> Self {
         Self {
             service,
             gates,
+            admission,
             main_handle,
         }
     }
@@ -65,8 +71,10 @@ impl SessionExtension for WorkflowRunSessionExtension {
 
         let service = self.service.clone();
         let gates = self.gates.clone();
+        let admission = self.admission.clone();
         // Return immediately on the per-session actor runtime; durable work
-        // rides the main runtime.
+        // rides the main runtime — the session permit below is awaited HERE,
+        // never on the actor thread (spec 2b nonblocking rule).
         self.main_handle.spawn(async move {
             // Opaque run key via exact session+prompt lookup.
             let key_service = service.clone();
@@ -103,6 +111,28 @@ impl SessionExtension for WorkflowRunSessionExtension {
                 }
             };
             let _guard = gate.lock_owned().await;
+
+            // Spec 2b: the terminal CAS holds the controlled session's
+            // mutation permit under the run gate (canonical order). The
+            // extension's callback session IS the bound session.
+            let _permit = match admission
+                .acquire(
+                    &session_id,
+                    SessionMutationKind::WorkflowTerminal,
+                    &SessionMutationSource::workflow_run(&run_key),
+                )
+                .await
+            {
+                Ok(permit) => Some(permit),
+                Err(_conflict) => {
+                    tracing::error!(
+                        run_id = %run_key,
+                        session_id = %session_id,
+                        "session permit unavailable for workflow completion; proceeding under run gate alone"
+                    );
+                    None
+                }
+            };
 
             let finish_session_id = session_id.clone();
             let finish_prompt_id = prompt_id.clone();

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store/mod.rs
@@ -400,3 +400,24 @@ impl WorkflowRunStore {
         })
     }
 }
+
+impl WorkflowRunStore {
+    /// The id of the NONTERMINAL run bound to `session_id`, if any — the
+    /// durable controller truth for session mutation admission (spec 2b). The
+    /// partial unique index (`0063`) guarantees at most one.
+    pub fn find_active_controller_run(&self, session_id: &str) -> anyhow::Result<Option<String>> {
+        self.db.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id FROM workflow_runs
+                 WHERE session_id = ?1
+                   AND status NOT IN ('completed', 'failed', 'cancelled', 'interrupted')
+                 LIMIT 1",
+            )?;
+            let mut rows = stmt.query([session_id])?;
+            Ok(match rows.next()? {
+                Some(row) => Some(row.get(0)?),
+                None => None,
+            })
+        })
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/purge.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/purge.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -35,6 +36,13 @@ pub enum WorkspacePurgeServiceOutcome {
     /// path fails closed before any effect; carries the controlling run id for
     /// logging only.
     ControlledByWorkflow { run_id: String },
+    /// PR1227-WORKSPACE-FENCE-02: a session id enumerated under the exclusive
+    /// workspace lease was NOT in the set the up-front admission snapshotted and
+    /// holds permits for (a workflow bound it after the snapshot, and its
+    /// controller may already have terminalized — escaping the nonterminal-only
+    /// FENCE-01 re-check). The destructive path fails closed before any effect;
+    /// carries the unadmitted session id for the conflict detail only.
+    SessionAppearedAfterAdmission { session_id: String },
 }
 
 #[derive(Clone)]
@@ -84,14 +92,35 @@ impl WorkspacePurgeService {
         workspace_id: &str,
         retry_only: bool,
     ) -> anyhow::Result<WorkspacePurgeServiceOutcome> {
+        self.purge_with_admitted_session_ids(workspace_id, retry_only, None)
+            .await
+    }
+
+    /// `admitted_session_ids` is the set of session ids the HTTP layer's
+    /// up-front `admit_all_workspace_sessions` snapshotted and holds permits for
+    /// (PR1227-WORKSPACE-FENCE-02). `None` means the caller admitted nothing
+    /// up front (e.g. the purge-retry path, which re-uses an already-admitted
+    /// purge tombstone); the admitted-set membership check is then skipped and
+    /// only the nonterminal FENCE-01 re-check applies.
+    pub async fn purge_with_admitted_session_ids(
+        &self,
+        workspace_id: &str,
+        retry_only: bool,
+        admitted_session_ids: Option<BTreeSet<String>>,
+    ) -> anyhow::Result<WorkspacePurgeServiceOutcome> {
         let _workspace_lease = self.operation_gate.acquire_exclusive(workspace_id).await;
-        // PR1227-WORKSPACE-FENCE-01: under the exclusive lease (which excludes
+        // PR1227-WORKSPACE-FENCE-01/02: under the exclusive lease (which excludes
         // the shared SessionStart lease every workflow session creation holds),
-        // re-enumerate the session set and fail closed if a workflow now
-        // controls one that the HTTP up-front admission could not have seen
-        // (created+bound inside the admission->exclusive-lease window). Read
-        // only: no permit, no further lease — no ABBA edge.
-        if let Some(outcome) = self.reject_if_workflow_controlled(workspace_id).await? {
+        // re-enumerate the session set and fail closed if (01) a workflow now
+        // controls one the HTTP up-front admission could not have seen, OR (02)
+        // any enumerated session id was NOT in the up-front admitted set — even
+        // if its workflow already terminalized (the bind->terminalize race that
+        // slips past the nonterminal-only FENCE-01 check). Read only: no permit,
+        // no further lease — no ABBA edge.
+        if let Some(outcome) = self
+            .reject_if_workflow_controlled(workspace_id, admitted_session_ids.as_ref())
+            .await?
+        {
             return Ok(outcome);
         }
         let Some(workspace) = self.workspace_runtime.get_workspace(workspace_id)? else {
@@ -206,12 +235,18 @@ impl WorkspacePurgeService {
         })
     }
 
-    /// PR1227-WORKSPACE-FENCE-01: re-check, under the already-held exclusive
-    /// workspace lease, whether any workspace session is controlled by a
-    /// nonterminal workflow. Returns the fail-closed outcome when so.
+    /// PR1227-WORKSPACE-FENCE-01/02: re-check, under the already-held exclusive
+    /// workspace lease, the workspace session set. Fails closed when either
+    /// (01) a workspace session is controlled by a NONTERMINAL workflow, or
+    /// (02) an enumerated session id is absent from `admitted_session_ids` (the
+    /// up-front admission snapshot the HTTP layer holds permits for) — even if
+    /// its workflow already terminalized. FENCE-02 is checked FIRST because it
+    /// catches the bind->terminalize race that FENCE-01 structurally cannot see
+    /// (a terminal controller yields `None`).
     async fn reject_if_workflow_controlled(
         &self,
         workspace_id: &str,
+        admitted_session_ids: Option<&BTreeSet<String>>,
     ) -> anyhow::Result<Option<WorkspacePurgeServiceOutcome>> {
         let session_ids = self
             .session_store
@@ -219,6 +254,26 @@ impl WorkspacePurgeService {
             .into_iter()
             .map(|session| session.id)
             .collect::<Vec<_>>();
+        // PR1227-WORKSPACE-FENCE-02: pure in-memory set-membership comparison
+        // over ids enumerated under the already-held exclusive lease — no
+        // permit, no lease acquired, so no edge added to the canonical lock
+        // order. Any id not in the up-front admitted set was bound after the
+        // snapshot and was never admitted; fail closed regardless of whether
+        // its controlling workflow is still nonterminal.
+        if let Some(admitted) = admitted_session_ids {
+            if let Some(unadmitted) = session_ids.iter().find(|id| !admitted.contains(*id)) {
+                tracing::info!(
+                    workspace_id = %workspace_id,
+                    session_id = %unadmitted,
+                    "workspace purge rejected under exclusive lease: a session appeared after the destruction admission snapshot"
+                );
+                return Ok(Some(
+                    WorkspacePurgeServiceOutcome::SessionAppearedAfterAdmission {
+                        session_id: unadmitted.clone(),
+                    },
+                ));
+            }
+        }
         if let Some((session_id, run_id)) = self
             .admission
             .find_workflow_controlled_session(session_ids)

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/purge.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/purge.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::domains::agents::portability::delete_session_agent_artifacts;
+use crate::domains::sessions::admission::SessionMutationAdmission;
 use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::sessions::store::SessionStore;
@@ -28,6 +29,12 @@ pub enum WorkspacePurgeServiceOutcome {
         workspace: WorkspaceRecord,
         message: String,
     },
+    /// PR1227-WORKSPACE-FENCE-01: a session controlled by a nonterminal
+    /// workflow was observed under the exclusive workspace lease (a workflow
+    /// created+bound it inside the up-front admission window). The destructive
+    /// path fails closed before any effect; carries the controlling run id for
+    /// logging only.
+    ControlledByWorkflow { run_id: String },
 }
 
 #[derive(Clone)]
@@ -38,12 +45,14 @@ pub struct WorkspacePurgeService {
     session_store: SessionStore,
     attachment_storage: PromptAttachmentStorage,
     operation_gate: Arc<WorkspaceOperationGate>,
+    admission: Arc<SessionMutationAdmission>,
     checkout_gate: Arc<CheckoutDeletionGate>,
     preflight_checker: Arc<RetirePreflightChecker>,
     runtime_home: PathBuf,
 }
 
 impl WorkspacePurgeService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         workspace_runtime: Arc<WorkspaceRuntime>,
         session_runtime: Arc<SessionRuntime>,
@@ -51,6 +60,7 @@ impl WorkspacePurgeService {
         session_store: SessionStore,
         attachment_storage: PromptAttachmentStorage,
         operation_gate: Arc<WorkspaceOperationGate>,
+        admission: Arc<SessionMutationAdmission>,
         checkout_gate: Arc<CheckoutDeletionGate>,
         preflight_checker: Arc<RetirePreflightChecker>,
         runtime_home: PathBuf,
@@ -62,6 +72,7 @@ impl WorkspacePurgeService {
             session_store,
             attachment_storage,
             operation_gate,
+            admission,
             checkout_gate,
             preflight_checker,
             runtime_home,
@@ -74,6 +85,15 @@ impl WorkspacePurgeService {
         retry_only: bool,
     ) -> anyhow::Result<WorkspacePurgeServiceOutcome> {
         let _workspace_lease = self.operation_gate.acquire_exclusive(workspace_id).await;
+        // PR1227-WORKSPACE-FENCE-01: under the exclusive lease (which excludes
+        // the shared SessionStart lease every workflow session creation holds),
+        // re-enumerate the session set and fail closed if a workflow now
+        // controls one that the HTTP up-front admission could not have seen
+        // (created+bound inside the admission->exclusive-lease window). Read
+        // only: no permit, no further lease — no ABBA edge.
+        if let Some(outcome) = self.reject_if_workflow_controlled(workspace_id).await? {
+            return Ok(outcome);
+        }
         let Some(workspace) = self.workspace_runtime.get_workspace(workspace_id)? else {
             return Ok(WorkspacePurgeServiceOutcome::Deleted {
                 already_deleted: true,
@@ -184,6 +204,37 @@ impl WorkspacePurgeService {
             already_deleted: false,
             cleanup_attempted: true,
         })
+    }
+
+    /// PR1227-WORKSPACE-FENCE-01: re-check, under the already-held exclusive
+    /// workspace lease, whether any workspace session is controlled by a
+    /// nonterminal workflow. Returns the fail-closed outcome when so.
+    async fn reject_if_workflow_controlled(
+        &self,
+        workspace_id: &str,
+    ) -> anyhow::Result<Option<WorkspacePurgeServiceOutcome>> {
+        let session_ids = self
+            .session_store
+            .list_with_dismissed_by_workspace(workspace_id)?
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+        if let Some((session_id, run_id)) = self
+            .admission
+            .find_workflow_controlled_session(session_ids)
+            .await?
+        {
+            tracing::info!(
+                workspace_id = %workspace_id,
+                session_id = %session_id,
+                controlling_run_id = %run_id,
+                "workspace purge rejected under exclusive lease: a workflow controls a session created after admission"
+            );
+            return Ok(Some(WorkspacePurgeServiceOutcome::ControlledByWorkflow {
+                run_id,
+            }));
+        }
+        Ok(None)
     }
 
     fn acquire_checkout_lease(

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -6,6 +6,10 @@ use std::time::Duration;
 
 use anyharness_contract::v1::{WorkspaceRetireBlocker, WorktreeRetentionRowOutcome};
 
+use crate::domains::sessions::admission::{
+    SessionMutationAdmission, SessionMutationConflict, SessionMutationKind, SessionMutationPermit,
+    SessionMutationSource,
+};
 use crate::domains::sessions::store::SessionStore;
 use crate::domains::terminals::store::TerminalStore;
 use crate::domains::workspaces::checkout_gate::{CheckoutDeletionGate, CheckoutPathLockKey};
@@ -39,10 +43,27 @@ pub struct WorkspaceRetentionService {
     preflight_checker: Arc<RetirePreflightChecker>,
     operation_gate: Arc<WorkspaceOperationGate>,
     checkout_gate: Arc<CheckoutDeletionGate>,
+    admission: Arc<SessionMutationAdmission>,
     runtime_home: std::path::PathBuf,
     running: Arc<AtomicBool>,
     auto_run_enabled: bool,
     defer_startup_pass: bool,
+}
+
+/// PR1227-RETENTION-FENCE-01: the result of the up-front per-candidate session
+/// admission snapshot — either the held permits plus the admitted id set, or a
+/// skip because a session is workflow-controlled.
+enum RetentionAdmission {
+    Admitted {
+        /// Held across the whole destructive operation for this candidate; never
+        /// inspected.
+        permits: Vec<SessionMutationPermit>,
+        /// The exact session ids admitted (and permit-held) up front.
+        session_ids: BTreeSet<String>,
+    },
+    Blocked {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -78,6 +99,7 @@ impl WorkspaceRetentionService {
         preflight_checker: Arc<RetirePreflightChecker>,
         operation_gate: Arc<WorkspaceOperationGate>,
         checkout_gate: Arc<CheckoutDeletionGate>,
+        admission: Arc<SessionMutationAdmission>,
         runtime_home: std::path::PathBuf,
     ) -> Self {
         let auto_run_enabled = std::env::var_os(ANYHARNESS_ENABLE_AUTOMATIC_WORKTREE_RETENTION_ENV)
@@ -93,6 +115,7 @@ impl WorkspaceRetentionService {
             preflight_checker,
             operation_gate,
             checkout_gate,
+            admission,
             runtime_home,
             running: Arc::new(AtomicBool::new(false)),
             auto_run_enabled,
@@ -237,6 +260,48 @@ impl WorkspaceRetentionService {
                     continue;
                 }
 
+                // PR1227-RETENTION-FENCE-01: admit every current session of this
+                // candidate (sorted permits) BEFORE the exclusive lease. A
+                // nonterminal workflow controller conflicts here — including the
+                // dead-actor case that presents no preflight blocker — so
+                // retention fails closed (skips) instead of dematerializing a
+                // controlled session's workspace. Permits are held across the
+                // whole destructive op for this candidate.
+                let (_admission_permits, admitted_session_ids) =
+                    match self.admit_retention_sessions(&workspace.id).await {
+                        Ok(RetentionAdmission::Admitted {
+                            permits,
+                            session_ids,
+                        }) => (permits, session_ids),
+                        Ok(RetentionAdmission::Blocked { message }) => {
+                            blocked_count += 1;
+                            rows.push(row(
+                                workspace,
+                                WorktreeRetentionRowOutcome::Blocked,
+                                message,
+                            ));
+                            continue;
+                        }
+                        Err(error) => {
+                            failed_count += 1;
+                            rows.push(row(
+                                workspace,
+                                WorktreeRetentionRowOutcome::Failed,
+                                display_safe_error("workspace session admission failed", &error),
+                            ));
+                            continue;
+                        }
+                    };
+
+                // PR1227-RETENTION-FENCE-01 proof seam (test-only, no-op in
+                // production): park between the up-front admission snapshot (now
+                // complete) and the exclusive lease so a proof can bind a
+                // workflow-controlled session in exactly the gap the under-lease
+                // re-check guards. Keyed by workspace id; absent keys change
+                // nothing.
+                #[cfg(test)]
+                retention_barriers::at_pre_exclusive(&workspace.id).await;
+
                 let exclusive = match tokio::time::timeout(
                     RETENTION_OPERATION_GATE_TIMEOUT,
                     self.operation_gate.acquire_exclusive(&workspace.id),
@@ -254,6 +319,38 @@ impl WorkspaceRetentionService {
                         continue;
                     }
                 };
+
+                // PR1227-RETENTION-FENCE-01: under the exclusive lease (which
+                // excludes the shared SessionStart lease workflow session
+                // creation holds), re-enumerate and skip if a session appeared
+                // after the snapshot (FENCE-02 analog) or a nonterminal workflow
+                // now controls one (FENCE-01 analog).
+                match self
+                    .reject_retention_if_workflow_controlled(&workspace.id, &admitted_session_ids)
+                    .await
+                {
+                    Ok(None) => {}
+                    Ok(Some(message)) => {
+                        blocked_count += 1;
+                        rows.push(row(
+                            workspace,
+                            WorktreeRetentionRowOutcome::Blocked,
+                            message,
+                        ));
+                        drop(exclusive);
+                        continue;
+                    }
+                    Err(error) => {
+                        failed_count += 1;
+                        rows.push(row(
+                            workspace,
+                            WorktreeRetentionRowOutcome::Failed,
+                            display_safe_error("workspace control re-check failed", &error),
+                        ));
+                        drop(exclusive);
+                        continue;
+                    }
+                }
 
                 let Some(reloaded) = self.workspace_runtime.get_workspace(&workspace.id)? else {
                     skipped_count += 1;
@@ -404,6 +501,110 @@ impl WorkspaceRetentionService {
         })
     }
 
+    /// PR1227-RETENTION-FENCE-01: acquire SORTED session-mutation permits for
+    /// every current session of the candidate workspace, mirroring the
+    /// caller-facing `admit_all_workspace_sessions`. Acquired BEFORE the
+    /// exclusive workspace lease (canonical `permit -> operation lease` order).
+    /// A session controlled by a NONTERMINAL workflow conflicts here (an
+    /// External source is denied), so the dead-actor case — a running workflow
+    /// step whose bound session has no live actor and thus zero preflight
+    /// blockers — is caught at admission before any destructive effect. Returns
+    /// `Blocked` for a workflow conflict (retention is a sweep, not a
+    /// caller-facing 409); propagates only true infrastructure failures.
+    async fn admit_retention_sessions(
+        &self,
+        workspace_id: &str,
+    ) -> anyhow::Result<RetentionAdmission> {
+        let mut sessions = self
+            .session_store
+            .list_with_dismissed_by_workspace(workspace_id)?;
+        sessions.sort_by(|a, b| a.id.cmp(&b.id));
+        let mut permits = Vec::with_capacity(sessions.len());
+        let mut session_ids = BTreeSet::new();
+        for session in &sessions {
+            match self
+                .admission
+                .acquire(
+                    &session.id,
+                    SessionMutationKind::WorkspaceRetire,
+                    &SessionMutationSource::external(),
+                )
+                .await
+            {
+                Ok(permit) => {
+                    permits.push(permit);
+                    session_ids.insert(session.id.clone());
+                }
+                Err(SessionMutationConflict::ControlledByWorkflow { run_id }) => {
+                    tracing::info!(
+                        workspace_id = %workspace_id,
+                        session_id = %session.id,
+                        controlling_run_id = %run_id,
+                        "retention skipped workspace: a workflow controls a session"
+                    );
+                    return Ok(RetentionAdmission::Blocked {
+                        message: "session execution is controlled by an active workflow run"
+                            .to_string(),
+                    });
+                }
+                Err(SessionMutationConflict::Internal(error)) => return Err(error),
+            }
+        }
+        Ok(RetentionAdmission::Admitted {
+            permits,
+            session_ids,
+        })
+    }
+
+    /// PR1227-RETENTION-FENCE-01 (FENCE-02/01 analog): under the already-held
+    /// exclusive workspace lease, re-enumerate the workspace session set and
+    /// return a skip message if either (02) an enumerated session id is absent
+    /// from the up-front admitted set (bound after the admission snapshot, even
+    /// if its workflow already terminalized), or (01) a nonterminal workflow now
+    /// controls a session. Pure read-only lookup + in-memory set comparison — no
+    /// permit, no lease — so it adds no edge to the lock order.
+    async fn reject_retention_if_workflow_controlled(
+        &self,
+        workspace_id: &str,
+        admitted_session_ids: &BTreeSet<String>,
+    ) -> anyhow::Result<Option<String>> {
+        let session_ids = self
+            .session_store
+            .list_with_dismissed_by_workspace(workspace_id)?
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+        if let Some(unadmitted) = session_ids
+            .iter()
+            .find(|id| !admitted_session_ids.contains(*id))
+        {
+            tracing::info!(
+                workspace_id = %workspace_id,
+                session_id = %unadmitted,
+                "retention skipped workspace: a session appeared after the admission snapshot"
+            );
+            return Ok(Some(
+                "a session appeared after the retention admission snapshot".to_string(),
+            ));
+        }
+        if let Some((session_id, run_id)) = self
+            .admission
+            .find_workflow_controlled_session(session_ids)
+            .await?
+        {
+            tracing::info!(
+                workspace_id = %workspace_id,
+                session_id = %session_id,
+                controlling_run_id = %run_id,
+                "retention skipped workspace: a workflow controls a session created after admission"
+            );
+            return Ok(Some(
+                "session execution is controlled by an active workflow run".to_string(),
+            ));
+        }
+        Ok(None)
+    }
+
     fn list_retention_worktrees_by_activity(&self) -> anyhow::Result<Vec<WorkspaceRecord>> {
         let mut workspaces = self.workspace_store.list_standard_active_worktrees()?;
         order_worktrees_by_activity(
@@ -545,6 +746,61 @@ struct RunningGuard<'a>(&'a AtomicBool);
 impl Drop for RunningGuard<'_> {
     fn drop(&mut self) {
         self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+/// PR1227-RETENTION-FENCE-01 proof seam. A keyed, test-only barrier that parks
+/// the retention pass between the up-front `admit_retention_sessions` snapshot
+/// and the exclusive workspace lease, so a deterministic proof can bind a
+/// workflow-controlled session in exactly the window the under-lease re-check
+/// exists to catch. Absent keys cost one mutex lookup and change nothing.
+/// Test-only by construction.
+#[cfg(test)]
+pub(crate) mod retention_barriers {
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    use tokio::sync::oneshot;
+
+    #[derive(Default)]
+    pub(crate) struct RetentionBarrier {
+        /// Fired when the pass reaches the pre-exclusive-lease point.
+        pub(crate) reached_tx: Option<oneshot::Sender<()>>,
+        /// Awaited before acquiring the exclusive lease when present.
+        pub(crate) resume_rx: Option<oneshot::Receiver<()>>,
+    }
+
+    static BARRIERS: StdMutex<Option<HashMap<String, RetentionBarrier>>> = StdMutex::new(None);
+
+    pub(crate) fn install(workspace_id: &str, barrier: RetentionBarrier) {
+        BARRIERS
+            .lock()
+            .expect("retention barrier lock")
+            .get_or_insert_with(HashMap::new)
+            .insert(workspace_id.to_string(), barrier);
+    }
+
+    pub(crate) fn clear(workspace_id: &str) {
+        if let Some(map) = BARRIERS.lock().expect("retention barrier lock").as_mut() {
+            map.remove(workspace_id);
+        }
+    }
+
+    pub(super) async fn at_pre_exclusive(workspace_id: &str) {
+        let barrier = BARRIERS
+            .lock()
+            .expect("retention barrier lock")
+            .as_mut()
+            .and_then(|map| map.remove(workspace_id));
+        let Some(mut barrier) = barrier else {
+            return;
+        };
+        if let Some(tx) = barrier.reached_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(rx) = barrier.resume_rx.take() {
+            let _ = rx.await;
+        }
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/retention_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/retention_tests.rs
@@ -1,8 +1,31 @@
-use super::{order_worktrees_by_activity, should_spawn_startup_pass};
+use super::{order_worktrees_by_activity, retention_barriers, should_spawn_startup_pass};
 use crate::domains::workspaces::model::{
     WorkspaceCleanupState, WorkspaceKind, WorkspaceLifecycleState, WorkspaceRecord,
     WorkspaceSurface,
 };
+
+// ── PR1227-RETENTION-FENCE-01: retention is a third workspace-retirement owner ──
+//
+// Before this fix the retention sweep acquired only the exclusive workspace
+// lease, then wrote Retired/Pending and dematerialized the checkout — with NO
+// session admission, NO permits, NO workflow-control re-check. Its preflight
+// only observes LIVE-actor signals, so a nonterminal workflow whose bound
+// session has a dead actor (running step, NULL turn_id, DB-only) presents ZERO
+// preflight blockers; retention would retire a workspace that the direct retire
+// handler 409s on. These proofs drive the REAL retention pass over the REAL
+// controller policy and assert it fails closed (skips) instead.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::app::{test_support, AppState};
+use crate::domains::agents::installer::seed::AgentSeedStore;
+use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+use crate::domains::workflows::service::WorkflowRunService;
+use crate::domains::workflows::store::WorkflowRunStore;
+use crate::domains::workspaces::managed_root::canonical_managed_worktrees_root;
+use crate::persistence::Db;
+use anyharness_contract::v1::WorktreeRetentionRowOutcome;
 
 #[test]
 fn startup_deferral_is_startup_only_gate() {
@@ -51,6 +74,437 @@ fn active_worktree_activity_order_uses_true_row_max() {
             "workspace-older".to_string(),
         ]
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retention_skips_workspace_with_dead_actor_workflow_controlled_session() {
+    // A nonterminal workflow controls a session whose actor is dead (DB-only,
+    // idle status, no live handle) in a retention-eligible workspace. The
+    // preflight sees no LIVE-execution blocker, so pre-fix retention would
+    // retire it. The FENCE-01 up-front admission conflicts on the nonterminal
+    // controller, so the pass must SKIP (Blocked) and the workspace + session
+    // must survive.
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+
+    let fixture = RetentionFixture::new("retention-deadactor");
+    let candidate = fixture.materialize_candidate();
+    fixture.seed_keepers(&candidate.repo_root_id, 10);
+
+    // Bind a nonterminal workflow controller to the candidate's session.
+    let session_id = fixture.insert_session(&candidate.id);
+    let control = fixture.control_service();
+    let run_id = uuid::Uuid::new_v4().to_string();
+    control
+        .accept(&run_id, fixture.domain_input(&candidate.id))
+        .expect("accept controller run");
+    assert!(control.begin_run(&run_id).expect("begin_run"));
+    assert!(control
+        .bind_session(&run_id, &session_id)
+        .expect("bind controller session"));
+
+    let result = fixture
+        .state
+        .workspace_retention_service
+        .run_pass(None)
+        .await
+        .expect("run retention pass");
+
+    let row = result
+        .rows
+        .iter()
+        .find(|row| row.workspace_id == candidate.id)
+        .unwrap_or_else(|| panic!("candidate not in retention rows: {:?}", result.rows));
+    assert_eq!(
+        row.outcome,
+        WorktreeRetentionRowOutcome::Blocked,
+        "retention must skip (block) the workflow-controlled candidate, got {row:?}"
+    );
+    assert_eq!(result.retired_count, 0, "nothing may be retired");
+
+    // No effect: the workspace stays Active and materialized; the session lives.
+    let reloaded = fixture
+        .state
+        .workspace_runtime
+        .get_workspace(&candidate.id)
+        .expect("get workspace")
+        .expect("workspace present");
+    assert_eq!(
+        reloaded.lifecycle_state,
+        WorkspaceLifecycleState::Active,
+        "retention must not retire the controlled workspace"
+    );
+    assert!(
+        Path::new(&reloaded.path).exists(),
+        "retention must not dematerialize the controlled workspace"
+    );
+    assert!(
+        fixture
+            .state
+            .session_service
+            .store()
+            .find_by_id(&session_id)
+            .expect("find session")
+            .is_some(),
+        "retention must not delete the controlled session"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retention_skips_workspace_with_session_bound_then_terminalized_after_snapshot() {
+    // FENCE-02 analog: a fresh session is bound by a workflow AFTER retention's
+    // up-front admission snapshot (parked at the pre-exclusive-lease seam), and
+    // its run is driven TERMINAL before the exclusive lease. FENCE-01 is then
+    // structurally blind (terminal controller -> None); only the admitted-set
+    // membership re-check catches the never-admitted session id, and retention
+    // skips.
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+
+    let fixture = RetentionFixture::new("retention-fence2");
+    let candidate = fixture.materialize_candidate();
+    fixture.seed_keepers(&candidate.repo_root_id, 10);
+
+    // Park the pass between its per-candidate admission snapshot (empty of the
+    // not-yet-bound session) and the exclusive lease.
+    let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+    retention_barriers::install(
+        &candidate.id,
+        retention_barriers::RetentionBarrier {
+            reached_tx: Some(reached_tx),
+            resume_rx: Some(resume_rx),
+        },
+    );
+
+    let service = fixture.state.workspace_retention_service.clone();
+    let pass = tokio::spawn(async move { service.run_pass(None).await });
+
+    tokio::time::timeout(std::time::Duration::from_secs(20), reached_rx)
+        .await
+        .expect("retention reached seam")
+        .expect("retention seam sender retained");
+
+    // In the stale-snapshot window: a fresh session appears and a workflow binds
+    // control, then that run is driven TERMINAL.
+    let session_id = fixture.insert_session(&candidate.id);
+    let control = fixture.control_service();
+    let run_id = uuid::Uuid::new_v4().to_string();
+    control
+        .accept(&run_id, fixture.domain_input(&candidate.id))
+        .expect("accept controller run");
+    assert!(control.begin_run(&run_id).expect("begin_run"));
+    assert!(control
+        .bind_session(&run_id, &session_id)
+        .expect("bind controller session"));
+    control
+        .fail_nonterminal(
+            &run_id,
+            crate::domains::workflows::model::WorkflowRunFailureCode::SessionTurnFailed,
+        )
+        .expect("terminalize controlling run");
+    assert!(
+        !control.run_in_flight(&run_id).expect("run_in_flight"),
+        "controlling run must be durably terminal before retention re-checks"
+    );
+
+    resume_tx.send(()).expect("resume retention");
+    let result = tokio::time::timeout(std::time::Duration::from_secs(20), pass)
+        .await
+        .expect("retention join timeout")
+        .expect("retention join")
+        .expect("run retention pass");
+
+    let row = result
+        .rows
+        .iter()
+        .find(|row| row.workspace_id == candidate.id)
+        .unwrap_or_else(|| panic!("candidate not in retention rows: {:?}", result.rows));
+    assert_eq!(
+        row.outcome,
+        WorktreeRetentionRowOutcome::Blocked,
+        "retention must skip the candidate whose session appeared after the snapshot, got {row:?}"
+    );
+    assert_eq!(result.retired_count, 0, "nothing may be retired");
+
+    let reloaded = fixture
+        .state
+        .workspace_runtime
+        .get_workspace(&candidate.id)
+        .expect("get workspace")
+        .expect("workspace present");
+    assert_eq!(
+        reloaded.lifecycle_state,
+        WorkspaceLifecycleState::Active,
+        "retention must not retire the workspace holding an unadmitted session"
+    );
+    assert!(
+        Path::new(&reloaded.path).exists(),
+        "retention must not dematerialize the unadmitted session's workspace"
+    );
+    assert!(
+        fixture
+            .state
+            .session_service
+            .store()
+            .find_by_id(&session_id)
+            .expect("find session")
+            .is_some(),
+        "retention must not delete the unadmitted session"
+    );
+
+    retention_barriers::clear(&candidate.id);
+}
+
+/// Heavy fixture for the real-retention proofs: an `AppState` whose managed
+/// worktrees root is a temp dir (via `ANYHARNESS_WORKTREES_ROOT`), a source git
+/// repo to spawn worktrees from, and helpers to materialize the retention
+/// candidate + seed keepers past the policy minimum.
+struct RetentionFixture {
+    state: AppState,
+    source_repo: PathBuf,
+    managed_root: PathBuf,
+    _root_guard: TempDirGuard,
+}
+
+struct MaterializedCandidate {
+    id: String,
+    repo_root_id: String,
+}
+
+impl RetentionFixture {
+    fn new(tag: &str) -> Self {
+        // The managed worktrees root defaults to `runtime_home.parent()/worktrees`
+        // when ANYHARNESS_WORKTREES_ROOT is unset — so a temp `<root>/runtime`
+        // runtime home yields `<root>/worktrees` WITHOUT touching the
+        // process-global env var (which would race sibling tests).
+        let root = TempDirGuard::new(tag);
+        let runtime_home = root.path().join("runtime");
+        let managed_root = root.path().join("worktrees");
+        let source_repo = root.path().join("source");
+        std::fs::create_dir_all(&runtime_home).expect("runtime home");
+        std::fs::create_dir_all(&managed_root).expect("managed root");
+        std::fs::create_dir_all(&source_repo).expect("source repo");
+        init_source_repo(&source_repo);
+
+        // Canonicalize to match run_pass's canonical_managed_worktrees_root.
+        let managed_root =
+            canonical_managed_worktrees_root(&runtime_home).expect("canonical managed root");
+
+        let state = AppState::new(
+            runtime_home,
+            "http://127.0.0.1:8457".to_string(),
+            Db::open_in_memory().expect("in-memory db"),
+            false,
+            AgentSeedStore::not_configured_dev(),
+        )
+        .expect("app state");
+
+        Self {
+            state,
+            source_repo,
+            managed_root,
+            _root_guard: root,
+        }
+    }
+
+    /// Create a REAL git worktree under the managed root and register it as an
+    /// active standard worktree workspace — the retention candidate.
+    fn materialize_candidate(&self) -> MaterializedCandidate {
+        let source = self.source_repo.to_string_lossy().to_string();
+        let resolution = self
+            .state
+            .workspace_runtime
+            .create_workspace(&source)
+            .expect("register source repo root");
+        let repo_root_id = resolution.repo_root.id.clone();
+        let target = self.managed_root.join("candidate");
+        let result = self
+            .state
+            .workspace_runtime
+            .create_worktree(
+                &repo_root_id,
+                &target.to_string_lossy(),
+                "feature/retention-candidate",
+                Some("main"),
+                None,
+            )
+            .expect("create candidate worktree");
+        MaterializedCandidate {
+            id: result.workspace.id,
+            repo_root_id,
+        }
+    }
+
+    /// Seed `count` keeper worktree workspaces (real dirs under the managed root
+    /// so they survive the listing filter) to push the candidate past the
+    /// policy's per-repo keep threshold. Keepers are only ever kept, never
+    /// retired, so plain directories suffice.
+    fn seed_keepers(&self, repo_root_id: &str, count: usize) {
+        // The default policy keeps 20 per repo; lower it to the minimum so
+        // `count` keepers + the candidate push the candidate into the eligible
+        // tail without seeding 20+ real directories.
+        self.state
+            .workspace_retention_service
+            .update_policy(count as u32)
+            .expect("lower retention keep threshold");
+        for index in 0..count {
+            let id = format!("keeper-{index}-{}", uuid::Uuid::new_v4());
+            let path = self.managed_root.join(&id);
+            std::fs::create_dir_all(&path).expect("keeper dir");
+            // Keepers get NEWER activity than the candidate so ordering places
+            // them ahead of it (candidate falls into the eligible tail).
+            let created_at = format!("2030-01-01T00:00:{:02}Z", index + 1);
+            self.state
+                .db
+                .with_conn(|conn| {
+                    conn.execute(
+                        "INSERT INTO workspaces (
+                            id, kind, repo_root_id, path, surface, lifecycle_state, cleanup_state,
+                            created_at, updated_at
+                         ) VALUES (?1, 'worktree', ?2, ?3, 'standard', 'active', 'none', ?4, ?4)",
+                        rusqlite::params![id, repo_root_id, path.to_string_lossy(), created_at],
+                    )?;
+                    Ok(())
+                })
+                .expect("insert keeper workspace");
+        }
+    }
+
+    fn insert_session(&self, workspace_id: &str) -> String {
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = SessionRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            workspace_id: workspace_id.to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            // Idle status + no live handle: the dead-actor state the preflight
+            // cannot see as a blocker.
+            status: "idle".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InternalOnly,
+            system_prompt_append: None,
+            subagents_enabled: false,
+            action_capabilities_json: None,
+            origin: Some(crate::origin::OriginContext::system_local_runtime()),
+        };
+        self.state
+            .session_service
+            .store()
+            .insert(&record)
+            .expect("insert session row");
+        record.id
+    }
+
+    fn control_service(&self) -> std::sync::Arc<WorkflowRunService> {
+        std::sync::Arc::new(WorkflowRunService::new(WorkflowRunStore::new(
+            self.state.db.clone(),
+        )))
+    }
+
+    fn domain_input(
+        &self,
+        workspace_id: &str,
+    ) -> crate::domains::workflows::model::PutWorkflowRunInput {
+        use crate::domains::workflows::model::{
+            PutWorkflowRunInput, WorkflowDefinition, WorkflowHarnessConfig, WorkflowInput,
+            WorkflowInputType, WorkflowPromptStep, WorkflowStage,
+        };
+        let mut arguments = std::collections::BTreeMap::new();
+        arguments.insert("ticket".to_string(), serde_json::json!("PROL-123"));
+        PutWorkflowRunInput {
+            schema_version: 1,
+            workspace_id: workspace_id.to_string(),
+            definition: WorkflowDefinition {
+                inputs: vec![WorkflowInput {
+                    name: "ticket".to_string(),
+                    input_type: WorkflowInputType::String,
+                    required: true,
+                }],
+                stages: vec![WorkflowStage {
+                    harness_config: WorkflowHarnessConfig {
+                        agent_kind: "claude".to_string(),
+                        model_id: None,
+                        mode_id: None,
+                    },
+                    steps: vec![WorkflowPromptStep {
+                        kind: "agent.prompt".to_string(),
+                        prompt: "Investigate {{inputs.ticket}}".to_string(),
+                    }],
+                }],
+            },
+            arguments,
+        }
+    }
+}
+
+fn init_source_repo(path: &Path) {
+    run_git(path, &["init", "-b", "main"]);
+    run_git(path, &["config", "user.email", "codex@example.com"]);
+    run_git(path, &["config", "user.name", "Codex"]);
+    std::fs::write(path.join("README.md"), "seed\n").expect("write seed file");
+    run_git(path, &["add", "README.md"]);
+    run_git(path, &["commit", "-m", "Initial commit"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(name: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "anyharness-{name}-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&path).expect("temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
 }
 
 fn workspace_record(id: &str) -> WorkspaceRecord {

--- a/anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs
@@ -30,7 +30,26 @@ pub(super) const CUSTOM_FOREIGN_KEY_MIGRATIONS: &[(
         "0062_workflow_run_control",
         super::workflow_run_control_migration::migrate_workflow_run_control,
     ),
+    // Index-only, but registered here (ordered AFTER the 0062 rebuild) so a
+    // fresh database creates it on the rebuilt table instead of losing it to
+    // the rename-and-drop rebuild.
+    (
+        "0063_workflow_session_controller_uniqueness",
+        migrate_workflow_session_controller_uniqueness,
+    ),
 ];
+
+/// Spec 2b: at most one NONTERMINAL workflow run controls one session;
+/// historical terminal reuse stays allowed, so uniqueness is partial over the
+/// active statuses only.
+fn migrate_workflow_session_controller_uniqueness(tx: &Transaction<'_>) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_runs_active_session_controller
+         ON workflow_runs(session_id)
+         WHERE session_id IS NOT NULL
+           AND status NOT IN ('completed', 'failed', 'cancelled', 'interrupted')",
+    )
+}
 
 fn migrate_session_background_work_timestamps(tx: &Transaction<'_>) -> rusqlite::Result<()> {
     let columns = table_columns(tx, "session_background_work")?;

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -6483,6 +6483,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -1011,6 +1011,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -1683,6 +1693,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -1724,6 +1744,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -1758,6 +1788,16 @@
           },
           "404": {
             "description": "Review run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {
@@ -1919,6 +1959,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -1953,6 +2003,16 @@
           },
           "404": {
             "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {
@@ -2021,6 +2081,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -2055,6 +2125,16 @@
           },
           "404": {
             "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {
@@ -2478,6 +2558,16 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {
@@ -2915,6 +3005,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       },
@@ -2974,6 +3074,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -3025,6 +3135,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -3069,6 +3189,16 @@
           },
           "404": {
             "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {
@@ -4199,6 +4329,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WorkspacePurgeResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -5615,6 +5755,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -5889,6 +6039,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -5979,6 +6139,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -6026,6 +6196,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PlanDecisionResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -6092,6 +6272,16 @@
           },
           "404": {
             "description": "Plan or session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {
@@ -6419,6 +6609,16 @@
           },
           "400": {
             "description": "Invalid review request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
             "content": {
               "application/json": {
                 "schema": {

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -5704,6 +5704,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session execution is controlled by an active workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -10103,6 +10103,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     retry_retire_cleanup: {

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -9552,6 +9552,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     export_workspace_mobility_archive: {

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -6065,6 +6065,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     list_repo_roots: {
@@ -6569,6 +6578,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     send_review_feedback: {
@@ -6601,6 +6619,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     stop_review: {
@@ -6626,6 +6653,15 @@ export interface operations {
             };
             /** @description Review run not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6753,6 +6789,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     close_session: {
@@ -6778,6 +6823,15 @@ export interface operations {
             };
             /** @description Session not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6830,6 +6884,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     dismiss_session: {
@@ -6855,6 +6918,15 @@ export interface operations {
             };
             /** @description Session not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7144,6 +7216,15 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7470,6 +7551,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     edit_pending_prompt: {
@@ -7501,6 +7591,15 @@ export interface operations {
             };
             /** @description Session or pending prompt not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7542,6 +7641,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     prompt_session: {
@@ -7571,6 +7679,15 @@ export interface operations {
             };
             /** @description Session not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8446,6 +8563,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkspacePurgeResponse"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
         };
@@ -9462,6 +9588,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     install_workspace_mobility_archive: {
@@ -9652,6 +9787,15 @@ export interface operations {
                     "application/json": components["schemas"]["PlanDecisionResponse"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     get_plan_document: {
@@ -9706,6 +9850,15 @@ export interface operations {
                     "application/json": components["schemas"]["HandoffPlanResponse"];
                 };
             };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     reject_plan: {
@@ -9733,6 +9886,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlanDecisionResponse"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
                 };
             };
         };
@@ -9775,6 +9937,15 @@ export interface operations {
             };
             /** @description Plan or session not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10025,6 +10196,15 @@ export interface operations {
             };
             /** @description Invalid review request */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Session execution is controlled by an active workflow run */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/scripts/check_session_mutation_admission.py
+++ b/scripts/check_session_mutation_admission.py
@@ -178,6 +178,67 @@ def load_non_http_owners() -> list[tuple[str, str, str, list[str]]]:
     return owners
 
 
+def strip_rust_comments_and_strings(text: str) -> str:
+    """Remove Rust line/block comments and string literals from `text`, leaving
+    everything else (including whitespace) in place.
+
+    Without this, a decoy inside a comment or string literal — e.g.
+    `let _s = "admit_retention_sessions";` or `//admit_retention_sessions()` —
+    would satisfy the flatten+search below even after the real admission call
+    was deleted. Handled forms: `//` line comments, `/* */` block comments
+    (non-greedy; nested blocks are not required), regular `"..."` strings with
+    backslash escapes, and raw strings `r"..."` / `r#"..."#` (any hash count).
+    Comment/string contents are dropped entirely so nothing inside them can be
+    matched as code."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        # Raw string: r"...", r#"..."#, r##"..."##, ...
+        if ch == "r" and i + 1 < n and text[i + 1] in ('"', "#"):
+            j = i + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                closing = '"' + ("#" * hashes)
+                end = text.find(closing, j + 1)
+                i = (end + len(closing)) if end >= 0 else n
+                continue
+            out.append(ch)
+            i += 1
+            continue
+        # Regular string literal with escape handling.
+        if ch == '"':
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            i = j
+            continue
+        # Comments.
+        if ch == "/" and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt == "/":
+                end = text.find("\n", i + 2)
+                i = end if end >= 0 else n
+                continue
+            if nxt == "*":
+                end = text.find("*/", i + 2)
+                i = (end + 2) if end >= 0 else n
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def owner_body(rel_path: str, fn: str) -> str | None:
     """Extract the brace-balanced body of `fn` in `rel_path` (relative to the
     anyharness-lib src dir). Returns None if the file or function is absent —
@@ -213,7 +274,11 @@ def check_non_http_owners() -> list[str]:
     destructive owner calls its admission helper BEFORE any of its destructive
     effect surfaces. Absent admission call or an effect ordered ahead of it =
     failure; a listed owner whose function no longer exists = stale-entry
-    failure (mirrors the HTTP checker's stale-entry teeth)."""
+    failure (mirrors the HTTP checker's stale-entry teeth).
+
+    Rust line/block comments and string literals are stripped from the body
+    BEFORE the flatten+search so a decoy token in a comment or string cannot
+    satisfy the check when the real admission call has been deleted."""
     failures: list[str] = []
     for rel_path, fn, admit_call, effects in load_non_http_owners():
         body = owner_body(rel_path, fn)
@@ -223,8 +288,10 @@ def check_non_http_owners() -> list[str]:
                 f"(remove it or fix the entry)"
             )
             continue
-        # Whitespace-collapsed view so rustfmt line splits don't affect ordering.
-        flat = re.sub(r"\s+", "", body)
+        # Strip comments/string literals, then collapse whitespace so rustfmt
+        # line splits don't affect ordering and no decoy in a comment/string can
+        # be matched as code.
+        flat = re.sub(r"\s+", "", strip_rust_comments_and_strings(body))
         # Word-boundary match so a rename/removal (e.g. `admit_x` -> `no_admit_x`)
         # is caught rather than matching as a substring.
         admit_match = re.search(rf"(?<![A-Za-z0-9_]){re.escape(admit_call)}(?![A-Za-z0-9_])", flat)

--- a/scripts/check_session_mutation_admission.py
+++ b/scripts/check_session_mutation_admission.py
@@ -34,8 +34,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 API_DIR = REPO_ROOT / "anyharness/crates/anyharness-lib/src/api"
 HTTP_DIR = API_DIR / "http"
+LIB_SRC_DIR = REPO_ROOT / "anyharness/crates/anyharness-lib/src"
 SESSIONS_DIR = REPO_ROOT / "anyharness/crates/anyharness-lib/src/domains/sessions"
 CLASSIFICATION_PATH = REPO_ROOT / "scripts/session_mutation_admission.txt"
+# PR1227-RETENTION-RATCHET-01: non-HTTP destructive owners reached outside the
+# router (startup / post-create automatic passes). The HTTP ratchet above only
+# sees router handlers, so these are enumerated + fenced separately here.
+NON_HTTP_OWNERS_PATH = REPO_ROOT / "scripts/session_mutation_admission_non_http.txt"
 
 ROUTER_FILES = [API_DIR / "router.rs", API_DIR / "router" / "pending_prompt_routes.rs"]
 MUTATING = ("post", "put", "patch", "delete")
@@ -149,6 +154,100 @@ def handler_source(module: str, fn: str) -> str | None:
     return None
 
 
+NON_HTTP_LINE_RE = re.compile(r"^(\S+)::([A-Za-z_0-9]+)\s+([A-Za-z_0-9]+)\s+(\S+)$")
+
+
+def load_non_http_owners() -> list[tuple[str, str, str, list[str]]]:
+    """Parse the non-HTTP destructive owner inventory.
+
+    Each entry is `path::fn admit_call effect_token[,effect_token...]`.
+    """
+    owners: list[tuple[str, str, str, list[str]]] = []
+    for lineno, line in enumerate(NON_HTTP_OWNERS_PATH.read_text().splitlines(), 1):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = NON_HTTP_LINE_RE.match(line)
+        if not match:
+            raise SystemExit(
+                f"{NON_HTTP_OWNERS_PATH.name}:{lineno}: expected "
+                f"'path::fn admit_call effect_token[,effect_token...]'"
+            )
+        rel_path, fn, admit_call, effects = match.groups()
+        owners.append((rel_path, fn, admit_call, [e for e in effects.split(",") if e]))
+    return owners
+
+
+def owner_body(rel_path: str, fn: str) -> str | None:
+    """Extract the brace-balanced body of `fn` in `rel_path` (relative to the
+    anyharness-lib src dir). Returns None if the file or function is absent —
+    the caller turns that into a stale-entry failure."""
+    file_path = LIB_SRC_DIR / rel_path
+    if not file_path.exists():
+        return None
+    text = file_path.read_text()
+    idx = -1
+    for decl in (f"fn {fn}(", f"fn {fn}<"):
+        idx = text.find(decl)
+        if idx >= 0:
+            break
+    if idx < 0:
+        return None
+    brace = text.find("{", idx)
+    if brace < 0:
+        return None
+    depth = 0
+    for pos in range(brace, len(text)):
+        ch = text[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[idx : pos + 1]
+    return text[idx:]
+
+
+def check_non_http_owners() -> list[str]:
+    """PR1227-RETENTION-RATCHET-01: statically enforce that each listed non-HTTP
+    destructive owner calls its admission helper BEFORE any of its destructive
+    effect surfaces. Absent admission call or an effect ordered ahead of it =
+    failure; a listed owner whose function no longer exists = stale-entry
+    failure (mirrors the HTTP checker's stale-entry teeth)."""
+    failures: list[str] = []
+    for rel_path, fn, admit_call, effects in load_non_http_owners():
+        body = owner_body(rel_path, fn)
+        if body is None:
+            failures.append(
+                f"STALE non-HTTP owner entry {rel_path}::{fn}: function not found "
+                f"(remove it or fix the entry)"
+            )
+            continue
+        # Whitespace-collapsed view so rustfmt line splits don't affect ordering.
+        flat = re.sub(r"\s+", "", body)
+        # Word-boundary match so a rename/removal (e.g. `admit_x` -> `no_admit_x`)
+        # is caught rather than matching as a substring.
+        admit_match = re.search(rf"(?<![A-Za-z0-9_]){re.escape(admit_call)}(?![A-Za-z0-9_])", flat)
+        admit_idx = admit_match.start() if admit_match else -1
+        if admit_idx < 0:
+            failures.append(
+                f"{rel_path}::{fn}: non-HTTP destructive owner is missing its "
+                f"admission call '{admit_call}' — permit-first admission must not "
+                f"be removed"
+            )
+            continue
+        flat_effects = [re.sub(r"\s+", "", e) for e in effects]
+        for effect in flat_effects:
+            effect_idx = flat.find(effect)
+            if 0 <= effect_idx < admit_idx:
+                failures.append(
+                    f"{rel_path}::{fn}: effect surface '{effect}' appears BEFORE "
+                    f"the admission call '{admit_call}' — admission must come first"
+                )
+                break
+    return failures
+
+
 def main() -> int:
     handlers = collect_mutating_handlers()
     classification = load_classification()
@@ -201,6 +300,11 @@ def main() -> int:
                 f"{path.relative_to(REPO_ROOT)}: session core must not import the Workflows domain"
             )
 
+    # PR1227-RETENTION-RATCHET-01: non-HTTP destructive owners (startup /
+    # post-create automatic passes) are fenced statically here too.
+    non_http_owners = load_non_http_owners()
+    failures.extend(check_non_http_owners())
+
     if failures:
         print("Session mutation admission ratchet failures:")
         for failure in failures:
@@ -208,7 +312,8 @@ def main() -> int:
         return 1
     print(
         f"Session mutation admission ratchet passed "
-        f"({len(handlers)} mutating handlers classified)."
+        f"({len(handlers)} mutating handlers classified, "
+        f"{len(non_http_owners)} non-HTTP owners fenced)."
     )
     return 0
 

--- a/scripts/check_session_mutation_admission.py
+++ b/scripts/check_session_mutation_admission.py
@@ -63,6 +63,12 @@ HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([a-z_0-9]+)::([a-z_
 # `put(put_agent_auth_state)`); resolve those through the router's own use
 # imports so no mutating handler can escape enumeration.
 BARE_HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([a-z_0-9]+)\s*[),]")
+# Catch-all: ANY mutating-verb route reference, including doubly-qualified
+# paths like `post(a::b::c)` that match NEITHER of the two shapes above and
+# would otherwise escape enumeration silently (PR1227-RATCHET-01). Every
+# capture must be covered by the qualified/bare/import-resolved sets; anything
+# left over is routed into `unresolved` so it FAILS LOUDLY.
+ANY_HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([A-Za-z_0-9:]+)\s*[),]")
 IMPORT_GROUP_RE = re.compile(r"([a-z_0-9]+)::\{([^{}]*)\}", re.S)
 CLASS_LINE_RE = re.compile(r"^([a-z_0-9]+::[a-z_0-9]+)\s+(fenced|derived-safe|read-like|cosmetic|creation|workspace-scoped|workflow-plane)\s+(.+)$")
 
@@ -90,6 +96,21 @@ def collect_mutating_handlers() -> set[str]:
                 unresolved.append(f"{router.name}: bare handler '{fn}' not resolvable via imports")
             else:
                 handlers.add(f"{module}::{fn}")
+        # Catch-all teeth (PR1227-RATCHET-01): the two shapes above only match
+        # bare (`fn`) and singly-qualified (`module::fn`) references. A ref with
+        # any other segment count — notably doubly-qualified `post(a::b::c)` —
+        # is covered by NEITHER and would slip through unenumerated. Route every
+        # such leftover into `unresolved` so it fails loudly instead of silently
+        # escaping the admission decision.
+        for _method, path in ANY_HANDLER_REF_RE.findall(text):
+            segments = path.split("::")
+            if len(segments) == 1 or len(segments) == 2:
+                # Bare or singly-qualified: already handled above.
+                continue
+            unresolved.append(
+                f"{router.name}: route handler ref '{path}' has an unsupported "
+                f"segment count and escaped enumeration; classify it explicitly"
+            )
     if unresolved:
         raise SystemExit("Unresolvable bare route handlers:\n  " + "\n  ".join(unresolved))
     return handlers

--- a/scripts/check_session_mutation_admission.py
+++ b/scripts/check_session_mutation_admission.py
@@ -5,7 +5,10 @@ Every HTTP route handler reachable through a mutating method (post/put/patch/
 delete) in the AnyHarness API must be CLASSIFIED in
 scripts/session_mutation_admission.txt. Classes:
 
-  fenced           handler must call an admit_* helper before side effects
+  fenced           handler must call an admit_* helper, and that call must
+                   appear BEFORE any of the enumerated effect surfaces
+                   (syntactic ordering; the behavioral before-side-effect
+                   guarantee is proven by the admission conflict-matrix tests)
   derived-safe     handler (or its engine seam) carries an
                    "admission:derived-safe" justification comment
   read-like        mutating verb but no session-execution effect (exports,
@@ -37,6 +40,24 @@ CLASSIFICATION_PATH = REPO_ROOT / "scripts/session_mutation_admission.txt"
 ROUTER_FILES = [API_DIR / "router.rs", API_DIR / "router" / "pending_prompt_routes.rs"]
 MUTATING = ("post", "put", "patch", "delete")
 ADMIT_RE = re.compile(r"admit_session_mutation|admit_review_parent_session|admit_plan_session|admit_all_workspace_sessions")
+# The enumerated effect surfaces a fenced handler may only touch AFTER
+# admission. This is a syntactic ordering ratchet over known runtime/service
+# fields, not a full effect analysis — the behavioral proof is the admission
+# test battery. Extend this list when a new effectful surface appears in a
+# fenced handler.
+EFFECT_TOKENS = (
+    ".session_runtime.",
+    ".goal_runtime.",
+    ".loop_runtime.",
+    ".plan_runtime.",
+    ".review_runtime.",
+    ".workspace_purge_service.",
+    ".mobility_service.",
+    ".subagent_service.",
+    ".workspace_runtime.",
+    ".workspace_setup_runtime.",
+    ".session_service.",
+)
 HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([a-z_0-9]+)::([a-z_0-9]+)\s*[),]")
 CLASS_LINE_RE = re.compile(r"^([a-z_0-9]+::[a-z_0-9]+)\s+(fenced|derived-safe|read-like|cosmetic|creation|workspace-scoped|workflow-plane)\s+(.+)$")
 
@@ -102,8 +123,24 @@ def main() -> int:
         if body is None:
             failures.append(f"{key}: classified but handler source not found")
             continue
-        if cls == "fenced" and not ADMIT_RE.search(body):
-            failures.append(f"{key}: classified 'fenced' but no admit_* call in the handler")
+        if cls == "fenced":
+            # rustfmt splits field chains across lines, so ordering is checked
+            # on a whitespace-collapsed view of the handler body.
+            flat = re.sub(r"\s+", "", body)
+            admit = ADMIT_RE.search(flat)
+            if not admit:
+                failures.append(
+                    f"{key}: classified 'fenced' but no admit_* call in the handler"
+                )
+            else:
+                for token in EFFECT_TOKENS:
+                    effect_idx = flat.find(token)
+                    if 0 <= effect_idx < admit.start():
+                        failures.append(
+                            f"{key}: effect surface '{token}' appears BEFORE the "
+                            f"admission call — admission must come first"
+                        )
+                        break
 
     for key in sorted(classification):
         if key not in handlers:

--- a/scripts/check_session_mutation_admission.py
+++ b/scripts/check_session_mutation_admission.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Session mutation admission ratchet (spec 2b, founder ruling 2).
+
+Every HTTP route handler reachable through a mutating method (post/put/patch/
+delete) in the AnyHarness API must be CLASSIFIED in
+scripts/session_mutation_admission.txt. Classes:
+
+  fenced           handler must call an admit_* helper before side effects
+  derived-safe     handler (or its engine seam) carries an
+                   "admission:derived-safe" justification comment
+  read-like        mutating verb but no session-execution effect (exports,
+                   previews, reveals)
+  cosmetic         store-only cosmetic session updates (ruling 2: title)
+  creation         creates a NEW session/workspace/resource (no controller
+                   can exist yet)
+  workspace-scoped workspace/infra mutation with no session-execution effect
+  workflow-plane   the workflow API itself (controller-side, not foreign)
+
+A NEW mutating handler that is not classified fails this check — that is the
+ratchet: adding a session mutation owner without deciding its admission story
+is an error. Additionally, session core (domains/sessions/**) must never
+import the Workflows domain.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+API_DIR = REPO_ROOT / "anyharness/crates/anyharness-lib/src/api"
+HTTP_DIR = API_DIR / "http"
+SESSIONS_DIR = REPO_ROOT / "anyharness/crates/anyharness-lib/src/domains/sessions"
+CLASSIFICATION_PATH = REPO_ROOT / "scripts/session_mutation_admission.txt"
+
+ROUTER_FILES = [API_DIR / "router.rs", API_DIR / "router" / "pending_prompt_routes.rs"]
+MUTATING = ("post", "put", "patch", "delete")
+ADMIT_RE = re.compile(r"admit_session_mutation|admit_review_parent_session|admit_plan_session|admit_all_workspace_sessions")
+HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([a-z_0-9]+)::([a-z_0-9]+)\s*[),]")
+CLASS_LINE_RE = re.compile(r"^([a-z_0-9]+::[a-z_0-9]+)\s+(fenced|derived-safe|read-like|cosmetic|creation|workspace-scoped|workflow-plane)\s+(.+)$")
+
+
+def collect_mutating_handlers() -> set[str]:
+    handlers: set[str] = set()
+    for router in ROUTER_FILES:
+        text = router.read_text()
+        for _method, module, fn in HANDLER_REF_RE.findall(text):
+            handlers.add(f"{module}::{fn}")
+    return handlers
+
+
+def load_classification() -> dict[str, tuple[str, str]]:
+    entries: dict[str, tuple[str, str]] = {}
+    for lineno, line in enumerate(CLASSIFICATION_PATH.read_text().splitlines(), 1):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = CLASS_LINE_RE.match(line)
+        if not match:
+            raise SystemExit(f"{CLASSIFICATION_PATH.name}:{lineno}: expected 'module::fn class reason'")
+        key, cls, reason = match.groups()
+        if key in entries:
+            raise SystemExit(f"{CLASSIFICATION_PATH.name}:{lineno}: duplicate entry {key}")
+        entries[key] = (cls, reason)
+    return entries
+
+
+def handler_source(module: str, fn: str) -> str | None:
+    candidates = [HTTP_DIR / f"{module}.rs", API_DIR / f"{module}.rs"]
+    if module.startswith("http_"):
+        candidates.append(HTTP_DIR / f"{module.removeprefix('http_')}.rs")
+    for candidate in candidates:
+        if candidate.exists():
+            text = candidate.read_text()
+            idx = text.find(f"pub async fn {fn}(")
+            if idx < 0:
+                idx = text.find(f"pub fn {fn}(")
+            if idx < 0:
+                continue
+            nxt = text.find("\npub ", idx + 10)
+            return text[idx : nxt if nxt > 0 else len(text)]
+    return None
+
+
+def main() -> int:
+    handlers = collect_mutating_handlers()
+    classification = load_classification()
+    failures: list[str] = []
+
+    for key in sorted(handlers):
+        entry = classification.get(key)
+        if entry is None:
+            failures.append(
+                f"UNCLASSIFIED mutation handler {key}: add it to "
+                f"scripts/session_mutation_admission.txt with an admission decision"
+            )
+            continue
+        cls, _reason = entry
+        module, fn = key.split("::")
+        body = handler_source(module, fn)
+        if body is None:
+            failures.append(f"{key}: classified but handler source not found")
+            continue
+        if cls == "fenced" and not ADMIT_RE.search(body):
+            failures.append(f"{key}: classified 'fenced' but no admit_* call in the handler")
+
+    for key in sorted(classification):
+        if key not in handlers:
+            failures.append(
+                f"STALE classification entry {key}: no mutating route references it"
+            )
+
+    # Session-core purity: sessions must not import the Workflows domain.
+    for path in SESSIONS_DIR.rglob("*.rs"):
+        text = path.read_text()
+        if "domains::workflows" in text or "domains/workflows" in text:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)}: session core must not import the Workflows domain"
+            )
+
+    if failures:
+        print("Session mutation admission ratchet failures:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    print(
+        f"Session mutation admission ratchet passed "
+        f"({len(handlers)} mutating handlers classified)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_session_mutation_admission.py
+++ b/scripts/check_session_mutation_admission.py
@@ -59,15 +59,39 @@ EFFECT_TOKENS = (
     ".session_service.",
 )
 HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([a-z_0-9]+)::([a-z_0-9]+)\s*[),]")
+# Routes may also reference directly-imported handler names (e.g.
+# `put(put_agent_auth_state)`); resolve those through the router's own use
+# imports so no mutating handler can escape enumeration.
+BARE_HANDLER_REF_RE = re.compile(r"\b(post|put|patch|delete)\(\s*([a-z_0-9]+)\s*[),]")
+IMPORT_GROUP_RE = re.compile(r"([a-z_0-9]+)::\{([^{}]*)\}", re.S)
 CLASS_LINE_RE = re.compile(r"^([a-z_0-9]+::[a-z_0-9]+)\s+(fenced|derived-safe|read-like|cosmetic|creation|workspace-scoped|workflow-plane)\s+(.+)$")
 
 
 def collect_mutating_handlers() -> set[str]:
     handlers: set[str] = set()
+    unresolved: list[str] = []
     for router in ROUTER_FILES:
         text = router.read_text()
+        qualified: set[str] = set()
         for _method, module, fn in HANDLER_REF_RE.findall(text):
             handlers.add(f"{module}::{fn}")
+            qualified.add(fn)
+        import_map: dict[str, str] = {}
+        for module, group in IMPORT_GROUP_RE.findall(text):
+            for name in group.split(","):
+                name = name.strip()
+                if name:
+                    import_map[name] = module
+        for _method, fn in BARE_HANDLER_REF_RE.findall(text):
+            if fn in qualified:
+                continue
+            module = import_map.get(fn)
+            if module is None:
+                unresolved.append(f"{router.name}: bare handler '{fn}' not resolvable via imports")
+            else:
+                handlers.add(f"{module}::{fn}")
+    if unresolved:
+        raise SystemExit("Unresolvable bare route handlers:\n  " + "\n  ".join(unresolved))
     return handlers
 
 

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -19,6 +19,7 @@ anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gatew
 anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 645 workspace retire lifecycle handlers (+PR1227-WORKSPACE-FENCE-01/02 under-exclusive-lease workflow-control re-check with admitted-set fail-closed membership + test-only proof seam module)
 anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs 665 workspace purge handlers (+2b fail-closed all-session admission, PR1227-WORKSPACE-FENCE-01/02 admitted-set carry + under-exclusive-lease re-check, test-only purge proof seam module)
 anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs 809 worktree retention sweep (+PR1227-RETENTION-FENCE-01 per-candidate permit-first admission + under-exclusive-lease FENCE-01/02 re-check + test-only retention proof seam module)
+anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs 667 2b admission conflict-matrix + fail-closed purge/retire/mobility-export/destroy-source proofs + LOCK-01 permit-before-lease deadlock/source-order guards
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -18,6 +18,7 @@ anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2790 workflow-ru
 anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
 anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 645 workspace retire lifecycle handlers (+PR1227-WORKSPACE-FENCE-01/02 under-exclusive-lease workflow-control re-check with admitted-set fail-closed membership + test-only proof seam module)
 anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs 665 workspace purge handlers (+2b fail-closed all-session admission, PR1227-WORKSPACE-FENCE-01/02 admitted-set carry + under-exclusive-lease re-check, test-only purge proof seam module)
+anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs 809 worktree retention sweep (+PR1227-RETENTION-FENCE-01 per-candidate permit-first admission + under-exclusive-lease FENCE-01/02 re-check + test-only retention proof seam module)
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection
@@ -61,7 +62,7 @@ apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 6
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 648 existing desktop oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 anyharness/crates/anyharness-lib/src/api/router.rs 621 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs route, +workflow-run cancel route, +local materialization operations routes)
-anyharness/crates/anyharness-lib/src/app/mod.rs 640 AnyHarness app wiring (+session mutation admission construction/injection incl. PR1227-WORKSPACE-FENCE-01 purge-service admission wiring, +goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs, +local materialization service wiring)
+anyharness/crates/anyharness-lib/src/app/mod.rs 641 AnyHarness app wiring (+session mutation admission construction/injection incl. PR1227-WORKSPACE-FENCE-01 purge-service and PR1227-RETENTION-FENCE-01 retention-service admission wiring, +goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs, +local materialization service wiring)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam)
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 686 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -14,18 +14,19 @@ anyharness/crates/anyharness-lib/src/api/router_tests.rs 1364 existing AnyHarnes
 anyharness/crates/anyharness-lib/src/domains/materialization/service.rs 625 local materialization domain service (exact-ref workspace materialization + repo-root acquisition orchestration, in-process keyed operation-lock admission, idempotent replay/failure recording; blocking git mechanics split into acquire.rs) — split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service.rs 664 workflow durable rules (+run-control cancel-intent use case and helpers); split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 1320 workflow-runs merge-gated domain suite (+2b partial-uniqueness contract on nonterminal session binding)
-anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2409 workflow-runs HTTP + runtime/extension crossing suite (run-control PROOF-01 battery + 2b admission races: reservation/create/bind window, terminal release, and PR1227-WORKSPACE-FENCE-01 purge/retire destruction-vs-late-bind proofs over the real executor)
+anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2790 workflow-runs HTTP + runtime/extension crossing suite (run-control PROOF-01 battery + 2b admission races: reservation/create/bind window, terminal release, PR1227-WORKSPACE-FENCE-01 purge/retire destruction-vs-late-bind proofs, and FENCE-02 bind->terminalize->destruction race proofs over the real executor)
 anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
-anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 614 workspace retire lifecycle handlers (+PR1227-WORKSPACE-FENCE-01 under-exclusive-lease workflow-control re-check + test-only proof seam module)
+anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 645 workspace retire lifecycle handlers (+PR1227-WORKSPACE-FENCE-01/02 under-exclusive-lease workflow-control re-check with admitted-set fail-closed membership + test-only proof seam module)
+anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs 665 workspace purge handlers (+2b fail-closed all-session admission, PR1227-WORKSPACE-FENCE-01/02 admitted-set carry + under-exclusive-lease re-check, test-only purge proof seam module)
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection
-anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1897 existing AnyHarness oversized file (+preselected-id passthrough at two creation call sites)
+anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1913 existing AnyHarness oversized file (+preselected-id passthrough at two creation call sites)
 anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1520 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs 628 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/goals/service_tests.rs 682 goal service regression tests for pending_op idempotency
 anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 1510 existing AnyHarness oversized test file
-anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 897 existing AnyHarness oversized test file
+anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 898 existing AnyHarness oversized test file (+preselected_session_id integration at one create call site)
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -13,13 +13,13 @@ anyharness/crates/anyharness-lib/src/api/openapi.rs 670 existing AnyHarness over
 anyharness/crates/anyharness-lib/src/api/router_tests.rs 1364 existing AnyHarness oversized test file (+hosting PR-status route tests, +catalog version + enrichment tests)
 anyharness/crates/anyharness-lib/src/domains/materialization/service.rs 625 local materialization domain service (exact-ref workspace materialization + repo-root acquisition orchestration, in-process keyed operation-lock admission, idempotent replay/failure recording; blocking git mechanics split into acquire.rs) — split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service.rs 664 workflow durable rules (+run-control cancel-intent use case and helpers); split into service/ on next growth per guides/domains.md
-anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 1307 workflow-runs merge-gated domain suite (+run-control stateVersion progression, four-outcome cancel intent at every boundary, first-terminal-wins, interrupted fencing)
-anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 1819 workflow-runs HTTP + runtime/extension crossing suite (+run-control cancel matrix, wire pinning, dropped-cancel handoff, cancel/execution race, interrupted fencing, PROOF-01 battery: effort-window cancel, deterministic dispatch-vs-cancel orders, missing-actor recovery, post-commit read-failure intent)
+anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 1320 workflow-runs merge-gated domain suite (+2b partial-uniqueness contract on nonterminal session binding)
+anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2090 workflow-runs HTTP + runtime/extension crossing suite (run-control PROOF-01 battery + 2b admission races: reservation/create/bind window and terminal release over the real executor)
 anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection
-anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1911 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1897 existing AnyHarness oversized file (+preselected-id passthrough at two creation call sites)
 anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1520 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs 628 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/goals/service_tests.rs 682 goal service regression tests for pending_op idempotency
@@ -28,7 +28,7 @@ anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 897 exist
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
-anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1107 custom migration with legacy schema coverage
+anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1126 custom migration with legacy schema coverage (+0063 partial unique controller index, ordered after the 0062 rebuild)
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 796 existing generated cloud SDK type surface (+workspaceKind, git numstat fields, OpenAPI-derived materialization types, app-extra overlay, and PR 5 exact-ref create request fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
@@ -59,7 +59,7 @@ apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 6
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 648 existing desktop oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 anyharness/crates/anyharness-lib/src/api/router.rs 621 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs route, +workflow-run cancel route, +local materialization operations routes)
-anyharness/crates/anyharness-lib/src/app/mod.rs 636 AnyHarness app wiring (+goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs, +local materialization service wiring)
-anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 861 loops runtime — native write path + emulated Codex scheduler
+anyharness/crates/anyharness-lib/src/app/mod.rs 639 AnyHarness app wiring (+session mutation admission construction/injection, +goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs, +local materialization service wiring)
+anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam)
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 686 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -14,8 +14,9 @@ anyharness/crates/anyharness-lib/src/api/router_tests.rs 1364 existing AnyHarnes
 anyharness/crates/anyharness-lib/src/domains/materialization/service.rs 625 local materialization domain service (exact-ref workspace materialization + repo-root acquisition orchestration, in-process keyed operation-lock admission, idempotent replay/failure recording; blocking git mechanics split into acquire.rs) — split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service.rs 664 workflow durable rules (+run-control cancel-intent use case and helpers); split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 1320 workflow-runs merge-gated domain suite (+2b partial-uniqueness contract on nonterminal session binding)
-anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2090 workflow-runs HTTP + runtime/extension crossing suite (run-control PROOF-01 battery + 2b admission races: reservation/create/bind window and terminal release over the real executor)
+anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2409 workflow-runs HTTP + runtime/extension crossing suite (run-control PROOF-01 battery + 2b admission races: reservation/create/bind window, terminal release, and PR1227-WORKSPACE-FENCE-01 purge/retire destruction-vs-late-bind proofs over the real executor)
 anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
+anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 614 workspace retire lifecycle handlers (+PR1227-WORKSPACE-FENCE-01 under-exclusive-lease workflow-control re-check + test-only proof seam module)
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection
@@ -59,7 +60,7 @@ apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 6
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 648 existing desktop oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 anyharness/crates/anyharness-lib/src/api/router.rs 621 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs route, +workflow-run cancel route, +local materialization operations routes)
-anyharness/crates/anyharness-lib/src/app/mod.rs 639 AnyHarness app wiring (+session mutation admission construction/injection, +goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs, +local materialization service wiring)
+anyharness/crates/anyharness-lib/src/app/mod.rs 640 AnyHarness app wiring (+session mutation admission construction/injection incl. PR1227-WORKSPACE-FENCE-01 purge-service admission wiring, +goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs, +local materialization service wiring)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam)
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 686 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations

--- a/scripts/session_mutation_admission.txt
+++ b/scripts/session_mutation_admission.txt
@@ -1,0 +1,113 @@
+# Session mutation admission classification (spec 2b, founder ruling 2).
+#
+# Format: module::fn class reason
+# Classes: fenced | derived-safe | read-like | cosmetic | creation |
+#          workspace-scoped | workflow-plane
+#
+# 'fenced' handlers must call an admit_* helper before their first side
+# effect (verified by check_session_mutation_admission.py). Every NEW
+# mutating route must be added here with a decided class — an unclassified
+# mutation path fails CI.
+
+# ── fenced: session execution mutations ──
+sessions_prompt::prompt_session fenced foreign prompt submission
+sessions_pending::edit_pending_prompt fenced pending prompt queue mutation
+sessions_pending::delete_pending_prompt fenced pending prompt queue mutation
+sessions_pending::reorder_pending_prompts fenced pending prompt queue mutation
+sessions_pending::steer_pending_prompt fenced pending prompt queue mutation
+sessions_config::set_session_config_option fenced model/mode/live config mutation
+sessions_lifecycle::cancel_session fenced public cancel; fence sits ABOVE the trusted workflow live-cancel seam (ruling 3)
+sessions_lifecycle::close_session fenced session close
+sessions_lifecycle::dismiss_session fenced session dismiss
+sessions_resume::resume_session fenced session resume
+sessions_fork::fork_session fenced session fork
+sessions_interactions::resolve_interaction fenced interaction resolution
+goals::set_session_goal fenced goal set
+goals::clear_session_goal fenced goal clear
+loops::set_session_loop fenced loop set
+loops::edit_session_loop fenced loop edit
+loops::clear_session_loops fenced loop clear (all)
+loops::clear_session_loop fenced loop clear (one)
+subagents::schedule_subagent_wake fenced subagent wake targeting the parent session
+replay::advance_replay_session fenced replay advance (replay sessions cannot be controlled; fenced per inventory)
+plans::approve_plan fenced plan decision mutates the owning session projection
+plans::reject_plan fenced plan decision mutates the owning session projection
+plans::handoff_plan fenced plan handoff before projection/file writes
+reviews::start_plan_review fenced review creation targeting the plan's parent session
+reviews::start_code_review fenced review creation targeting the request parent session
+reviews::retry_review_assignment fenced review mutation against the run's parent session
+reviews::stop_review fenced review mutation against the run's parent session
+reviews::send_review_feedback fenced review mutation against the run's parent session
+reviews::mark_review_revision_ready fenced review mutation against the run's parent session
+workspaces_purge::purge_workspace fenced fail-closed: holds sorted permits for every workspace session
+mobility::export_workspace_mobility_archive fenced fail-closed removal/detach: holds sorted permits for every workspace session
+
+# ── cosmetic (ruling 2: store-only, cannot affect actor execution) ──
+sessions_config::update_session_title cosmetic store-only title column write via service/title.rs
+
+# ── derived-safe (structurally unreachable for controlled sessions; see
+#    admission:derived-safe comments at the sites) ──
+sessions_lifecycle::restore_dismissed_session derived-safe controlled sessions cannot be dismissed, so restore cannot target one
+product_mcp::post_product_mcp_endpoint derived-safe workflow sessions are InternalOnly: product MCP is never provisioned for them (spec 2b)
+
+# ── creation (a controller cannot exist for a not-yet-created resource) ──
+sessions::create_session creation ordinary session creation (preselected-id seam is crate-internal)
+replay::create_replay_session creation replay session creation
+cowork::create_cowork_thread creation new cowork thread + fresh session
+workspaces::create_workspace creation new workspace
+workspaces_worktrees::create_worktree creation new worktree workspace
+terminals::create_terminal creation workspace terminal, not session execution
+
+# ── read-like (mutating verb, no session-execution effect) ──
+replay::export_replay_recording read-like exports a recording artifact
+mobility::preflight_workspace_mobility read-like preflight computation only
+sessions_interactions::reveal_mcp_elicitation_url read-like inspection action per spec allowed list
+repo_roots::resolve_repo_root read-like resolves/registers a repo root record
+workspaces::resolve_workspace read-like resolves a workspace record
+
+# ── workspace-scoped (workspace/infra mutations outside session execution) ──
+git::commit workspace-scoped workspace git operation
+git::push workspace-scoped workspace git operation
+git::rename_branch workspace-scoped workspace git operation
+git::revert_patches workspace-scoped workspace git operation
+git::stage_patch workspace-scoped workspace git operation
+git::stage_paths workspace-scoped workspace git operation
+git::unstage_patch workspace-scoped workspace git operation
+git::unstage_paths workspace-scoped workspace git operation
+files::create_entry workspace-scoped workspace file operation
+files::delete_entry workspace-scoped workspace file operation
+files::rename_entry workspace-scoped workspace file operation
+files::write_file workspace-scoped workspace file operation
+processes::run_command workspace-scoped workspace process execution
+hosting::create_pull_request workspace-scoped hosting PR creation
+terminals::delete_terminal workspace-scoped workspace terminal lifecycle
+terminals::resize_terminal workspace-scoped workspace terminal lifecycle
+terminals::start_terminal_command workspace-scoped workspace terminal lifecycle
+terminals::update_terminal_title workspace-scoped workspace terminal cosmetic
+workspaces::update_workspace_display_name workspace-scoped workspace cosmetic rename
+workspaces_lifecycle::retire_workspace workspace-scoped workspace retirement (existing retire preflight owns session checks)
+workspaces_lifecycle::retry_retire_cleanup workspace-scoped retirement cleanup retry
+workspaces_purge::retry_purge_workspace workspace-scoped purge retry of an already-admitted purge
+workspaces_setup::start_setup workspace-scoped workspace setup script
+workspaces_setup::rerun_setup workspace-scoped workspace setup script
+worktrees::prune_orphan_worktree workspace-scoped worktree hygiene
+worktrees::run_worktree_retention workspace-scoped worktree hygiene
+worktrees::update_worktree_retention_policy workspace-scoped worktree hygiene
+mobility::update_workspace_mobility_runtime_state workspace-scoped mobility state toggle, no session removal
+mobility::install_workspace_mobility_archive workspace-scoped installs NEW sessions from an archive
+mobility::destroy_workspace_mobility_source workspace-scoped post-install source cleanup
+repo_roots::prepare_repo_root_mobility_destination workspace-scoped mobility destination preparation
+cowork::enable_cowork workspace-scoped cowork enablement
+agents::install_agent workspace-scoped agent installer
+agents::reconcile_agents workspace-scoped agent installer
+agents::start_agent_login workspace-scoped agent auth flow
+agents::start_agent_login_terminal workspace-scoped agent auth flow
+agents::close_agent_login_terminal workspace-scoped agent auth flow
+agent_auth::put_agent_auth_state workspace-scoped agent auth state
+agent_gateway_catalog::refresh_gateway_models workspace-scoped catalog refresh
+catalogs::apply_agent_catalog workspace-scoped catalog apply
+http_auth::push_revoked_jtis workspace-scoped auth revocation push
+
+# ── workflow-plane (the controller side itself, not a foreign mutation) ──
+workflow_runs::put_workflow_run workflow-plane workflow acceptance/execution
+workflow_runs::cancel_workflow_run workflow-plane workflow cancel; acquires the session permit internally

--- a/scripts/session_mutation_admission.txt
+++ b/scripts/session_mutation_admission.txt
@@ -106,6 +106,7 @@ agents::start_agent_login workspace-scoped agent auth flow
 agents::start_agent_login_terminal workspace-scoped agent auth flow
 agents::close_agent_login_terminal workspace-scoped agent auth flow
 agent_auth::put_agent_auth_state workspace-scoped agent auth state
+agent_auth::delete_agent_auth_state workspace-scoped agent auth state removal
 agent_gateway_catalog::refresh_gateway_models workspace-scoped catalog refresh
 catalogs::apply_agent_catalog workspace-scoped catalog apply
 http_auth::push_revoked_jtis workspace-scoped auth revocation push

--- a/scripts/session_mutation_admission.txt
+++ b/scripts/session_mutation_admission.txt
@@ -43,6 +43,7 @@ reviews::mark_review_revision_ready fenced review mutation against the run's par
 workspaces_purge::purge_workspace fenced fail-closed: holds sorted permits for every workspace session
 mobility::export_workspace_mobility_archive fenced fail-closed removal/detach: holds sorted permits for every workspace session
 workspaces_lifecycle::retire_workspace fenced fail-closed (RETIRE-01 ruling B): retirement can dematerialize a controlled session's workspace; holds sorted permits for every workspace session
+mobility::destroy_workspace_mobility_source fenced fail-closed (MOBILITY-DESTROY-01): destroy-source deletes every source session + materialization; holds sorted permits for every workspace session, exclusive-lease under-lease re-check
 
 # ── cosmetic (ruling 2: store-only, cannot affect actor execution) ──
 sessions_config::update_session_title cosmetic store-only title column write via service/title.rs
@@ -97,7 +98,6 @@ worktrees::run_worktree_retention workspace-scoped worktree hygiene
 worktrees::update_worktree_retention_policy workspace-scoped worktree hygiene
 mobility::update_workspace_mobility_runtime_state workspace-scoped mobility state toggle, no session removal
 mobility::install_workspace_mobility_archive workspace-scoped installs NEW sessions from an archive
-mobility::destroy_workspace_mobility_source workspace-scoped post-install source cleanup
 repo_roots::prepare_repo_root_mobility_destination workspace-scoped mobility destination preparation
 cowork::enable_cowork workspace-scoped cowork enablement
 agents::install_agent workspace-scoped agent installer

--- a/scripts/session_mutation_admission.txt
+++ b/scripts/session_mutation_admission.txt
@@ -4,10 +4,11 @@
 # Classes: fenced | derived-safe | read-like | cosmetic | creation |
 #          workspace-scoped | workflow-plane
 #
-# 'fenced' handlers must call an admit_* helper before their first side
-# effect (verified by check_session_mutation_admission.py). Every NEW
-# mutating route must be added here with a decided class — an unclassified
-# mutation path fails CI.
+# 'fenced' handlers must call an admit_* helper, and the checker enforces
+# that the call appears BEFORE the enumerated effect surfaces (syntactic
+# ordering ratchet; the behavioral before-side-effect guarantee is proven by
+# the admission conflict-matrix tests). Every NEW mutating route must be
+# added here with a decided class — an unclassified mutation path fails CI.
 
 # ── fenced: session execution mutations ──
 sessions_prompt::prompt_session fenced foreign prompt submission
@@ -41,6 +42,7 @@ reviews::send_review_feedback fenced review mutation against the run's parent se
 reviews::mark_review_revision_ready fenced review mutation against the run's parent session
 workspaces_purge::purge_workspace fenced fail-closed: holds sorted permits for every workspace session
 mobility::export_workspace_mobility_archive fenced fail-closed removal/detach: holds sorted permits for every workspace session
+workspaces_lifecycle::retire_workspace fenced fail-closed (RETIRE-01 ruling B): retirement can dematerialize a controlled session's workspace; holds sorted permits for every workspace session
 
 # ── cosmetic (ruling 2: store-only, cannot affect actor execution) ──
 sessions_config::update_session_title cosmetic store-only title column write via service/title.rs
@@ -85,8 +87,8 @@ terminals::resize_terminal workspace-scoped workspace terminal lifecycle
 terminals::start_terminal_command workspace-scoped workspace terminal lifecycle
 terminals::update_terminal_title workspace-scoped workspace terminal cosmetic
 workspaces::update_workspace_display_name workspace-scoped workspace cosmetic rename
-workspaces_lifecycle::retire_workspace workspace-scoped workspace retirement (existing retire preflight owns session checks)
-workspaces_lifecycle::retry_retire_cleanup workspace-scoped retirement cleanup retry
+# (moved to fenced per RETIRE-01 ruling B)
+workspaces_lifecycle::retry_retire_cleanup workspace-scoped cleanup retry of an already-admitted retirement (mirrors purge retry)
 workspaces_purge::retry_purge_workspace workspace-scoped purge retry of an already-admitted purge
 workspaces_setup::start_setup workspace-scoped workspace setup script
 workspaces_setup::rerun_setup workspace-scoped workspace setup script

--- a/scripts/session_mutation_admission.txt
+++ b/scripts/session_mutation_admission.txt
@@ -60,6 +60,7 @@ cowork::create_cowork_thread creation new cowork thread + fresh session
 workspaces::create_workspace creation new workspace
 workspaces_worktrees::create_worktree creation new worktree workspace
 terminals::create_terminal creation workspace terminal, not session execution
+repo_roots::materialize_repo_root creation acquires or registers a repo root; no session controller targets repo-root identity
 
 # ── read-like (mutating verb, no session-execution effect) ──
 replay::export_replay_recording read-like exports a recording artifact
@@ -99,6 +100,7 @@ worktrees::update_worktree_retention_policy workspace-scoped worktree hygiene
 mobility::update_workspace_mobility_runtime_state workspace-scoped mobility state toggle, no session removal
 mobility::install_workspace_mobility_archive workspace-scoped installs NEW sessions from an archive
 repo_roots::prepare_repo_root_mobility_destination workspace-scoped mobility destination preparation
+repo_roots::materialize_workspace_at_ref workspace-scoped exact-ref workspace placement; no session execution mutation or session removal
 cowork::enable_cowork workspace-scoped cowork enablement
 agents::install_agent workspace-scoped agent installer
 agents::reconcile_agents workspace-scoped agent installer

--- a/scripts/session_mutation_admission_non_http.txt
+++ b/scripts/session_mutation_admission_non_http.txt
@@ -10,7 +10,8 @@
 #   fn           destructive owner function to inspect
 #   admit_call   the admission call that MUST appear before ANY effect surface
 #   effect_token comma-separated destructive effect surfaces; the admission call
-#                must appear (syntactically, comments stripped) BEFORE each one
+#                must appear (syntactically, with Rust comments and string
+#                literals stripped first) BEFORE each one
 #
 # A listed owner whose admission call is absent — or reordered after an effect
 # surface — FAILS the ratchet. A listed owner whose function no longer exists is

--- a/scripts/session_mutation_admission_non_http.txt
+++ b/scripts/session_mutation_admission_non_http.txt
@@ -1,0 +1,19 @@
+# Non-HTTP destructive session-mutation owners (spec 2b proof: PR1227-RETENTION-RATCHET-01).
+#
+# The HTTP ratchet in session_mutation_admission.txt only enumerates mutating
+# ROUTER handlers. Destructive owners reached OUTSIDE the HTTP router (startup
+# and post-create automatic passes) must ALSO be statically fenced, so removing
+# their permit-first admission would go undetected by the HTTP-only checker.
+#
+# Format: path::fn admit_call effect_token[,effect_token...]
+#   path         Rust file relative to anyharness/crates/anyharness-lib/src
+#   fn           destructive owner function to inspect
+#   admit_call   the admission call that MUST appear before ANY effect surface
+#   effect_token comma-separated destructive effect surfaces; the admission call
+#                must appear (syntactically, comments stripped) BEFORE each one
+#
+# A listed owner whose admission call is absent — or reordered after an effect
+# surface — FAILS the ratchet. A listed owner whose function no longer exists is
+# a STALE entry and also fails (mirrors the HTTP checker's stale-entry teeth).
+
+domains/workspaces/retention.rs::run_pass admit_retention_sessions acquire_exclusive,WorkspaceLifecycleState::Retired,retire_worktree_materialization

--- a/specs/codebase/systems/product/workflows/README.md
+++ b/specs/codebase/systems/product/workflows/README.md
@@ -6,5 +6,6 @@
   AnyHarness workspace.
 - [Portable Invocations](invocations.md) — immutable Cloud invocation and
   AnyHarness target-resolution contract.
-- [Run Control](run-control.md) — truthful cancellation, run-state versioning,
-  and interruption vocabulary for workflow runs.
+- [Run Control and Session Admission](run-control.md) — truthful cancellation,
+  run-state versioning, interruption vocabulary, and exclusive execution
+  mutation admission for workflow-owned sessions.

--- a/specs/codebase/systems/product/workflows/run-control.md
+++ b/specs/codebase/systems/product/workflows/run-control.md
@@ -1,4 +1,4 @@
-# Truthful Workflow Cancellation and Versioning (Run Control)
+# Truthful Workflow Cancellation, Versioning, and Session Admission
 
 Owner: AnyHarness workflow run control.
 
@@ -34,11 +34,13 @@ correlated cancelled turn     -> cancelled
 runtime restart ambiguity     -> interrupted/runtime_restarted
 ```
 
-This contract covers truthful lifecycle and versioning only. It does not
-claim exclusive control over the created session (see Workflow
-Session Mutation Admission). Cancellation is durable requested state, not a
-guarantee that it beats an already accepted or queued turn; a later correlated
-completion or failure remains truthful and may win.
+While a run is nonterminal, it exclusively controls execution mutation of the
+normal session it creates. Foreign execution mutation fails with
+`409 SESSION_CONTROLLED_BY_WORKFLOW` before any persistence, projection,
+queue, actor command, or file effect. Reads and cosmetic title updates remain
+available. Cancellation is durable requested state, not a guarantee that it
+beats an already accepted or queued turn; a later correlated completion or
+failure remains truthful and may win.
 
 ## 2. Boundary
 
@@ -52,13 +54,17 @@ completion or failure remains truthful and may win.
 - one narrow crate-private exact-active-turn live-cancel session seam;
 - `WorkflowRunGates`: per-run serialization across acceptance, execution CAS
   boundaries, completion terminal CAS, and cancellation;
+- workflow-owned session mutation admission with stable
+  `409 SESSION_CONTROLLED_BY_WORKFLOW`;
+- preselected session-ID reservation, active-controller uniqueness, and
+  permit-serialized terminal release;
+- trusted internal workflow prompt/cancel mutation sources plus static HTTP
+  and non-HTTP owner ratchets;
 - custom foreign-key migration `0062` with strict legacy pair validation; and
 - restart fencing to `interrupted/runtime_restarted`.
 
 ### 2.2 Explicit non-goals
 
-- session mutation admission or `SESSION_CONTROLLED_BY_WORKFLOW`;
-- active-session uniqueness or creation reservation;
 - existing-session takeover or workspace locking;
 - Cloud/Desktop/UI projection;
 - retry, resume, recovery, grants, MCP, credentials, goals, multiple steps;
@@ -156,9 +162,9 @@ family and otherwise unchanged.
   `interruptionCode`.
 - `completed` or `failed` may retain `cancelRequestedAt` when that truthful
   terminal outcome wins after cancellation intent.
-- `cancelled` does not require `cancelRequestedAt`: migrated rows and, until
-  session mutation admission lands, the existing direct session-cancel path may
-  provide truthful cancelled-turn evidence without workflow API intent.
+- `cancelled` does not require `cancelRequestedAt`: migrated rows and exact
+  correlated provider cancellation may provide truthful cancelled-turn
+  evidence without workflow API intent.
 - Terminal rows remain immutable; first truthful terminal evidence wins.
 - JSON, OpenAPI, and generated TypeScript tests pin required `stateVersion`
   and optional-omitted control fields for both v1 and v2.
@@ -200,24 +206,25 @@ request_live_turn_cancel(sessionId, expectedTurnId)
   -> Requested | NotActive | NotLive | ActorUnavailable
 ```
 
-This crate-private mechanism targets the already-bound live session and does
-not re-run ordinary caller/workspace mutation admission; the workflow route
-has already established authority from its durable run. It changes no session
-row. The actor serially compares `expectedTurnId` with its current active turn
-before forwarding ACP cancellation. `Requested` proves only that the
-matching-turn cancel command was accepted, not provider cancellation;
-`NotActive` covers idle or a different active turn. No seam result
-terminalizes the workflow; only the exact correlated callback can.
+This crate-private mechanism targets the already-bound live session under the
+owning workflow's trusted mutation source; the public session-cancel path is
+fenced above it. It changes no session row. The actor serially compares
+`expectedTurnId` with its current active turn before forwarding ACP
+cancellation. `Requested` proves only that the matching-turn cancel command
+was accepted, not provider cancellation; `NotActive` covers idle or a
+different active turn. No seam result terminalizes the workflow; only the
+exact correlated callback can.
 
 ### 5.3 Queued and null-turn prompts
 
-The predecessor's `Queued` prompt behavior remains unchanged. Until session
-admission lands, a workflow prompt queued behind foreign work has no
-workflow-specific queue-removal path; cancellation remains requested and only
-its exact correlated terminal outcome (or restart fencing) terminalizes the
-run. A stale stored workflow turn ID must never cancel a newer foreign turn:
-the actor's exact-active-turn comparison returns `NotActive` and forwards
-nothing.
+The predecessor's `Queued` prompt behavior remains unchanged. Session
+admission prevents new foreign execution mutation after the workflow binds
+the session, but it does not turn a queued or acknowledgement-lost dispatch
+into terminal evidence. There is no workflow-specific queue-removal path;
+cancellation remains requested and only its exact correlated terminal outcome
+(or restart fencing) terminalizes the run. A stale stored workflow turn ID
+must never cancel a different active turn: the actor's exact-active-turn
+comparison returns `NotActive` and forwards nothing.
 
 ### 5.4 Cancelling a lost-acknowledgement step
 
@@ -304,6 +311,41 @@ sites.
   -> final-snapshot sequence. A process failure still leaves durable intent
   for a repeated request or startup fencing.
 
+### 6.3 Workflow-owned session mutation admission
+
+The existing nonterminal `workflow_runs.session_id` binding is the durable
+controller record. A partial unique index permits at most one nonterminal run
+to control a non-null session ID; terminal history may reuse a session.
+
+Creation closes the writable gap:
+
+1. the workflow preselects the normal session ID;
+2. it reserves that session's transient mutation gate before the session row
+   exists;
+3. under the run gate and held mutation permit, it creates the session and
+   durably binds `workflow_runs.session_id`; and
+4. it releases the permit only after the binding commits.
+
+Every external execution-affecting session owner acquires admission before its
+first effect. An active controller returns stable
+`409 SESSION_CONTROLLED_BY_WORKFLOW`; ordinary sessions keep their existing
+behavior. The workflow's crate-private prompt and exact-turn cancel seams use
+an unforgeable trusted `WorkflowRun(runId)` source. HTTP input cannot select
+that source.
+
+Terminal completion, failure, and cancellation acquire the same session
+permit before the terminal workflow CAS. Foreign mutation therefore either
+observes active control and conflicts or proceeds after terminal release.
+Startup `runtime_restarted` fencing is the narrow exception: it runs before
+session runtime construction or HTTP service, when no live mutation can race.
+
+When an owner also needs a workspace operation lease, lock order is mutation
+permit before workspace lease. Workspace purge, retirement, retention, and
+mobility destruction acquire permits for affected sessions, take the
+exclusive lease, and recheck the durable controller set before destructive
+effects. Lookup or recheck failure is fail-closed. Read APIs, transcript/SSE,
+and store-only cosmetic title changes remain admitted.
+
 ## 7. Persistence and migration
 
 Extend AnyHarness SQLite only:
@@ -364,6 +406,7 @@ each run's `stateVersion` exactly once.
 This spec supersedes only these [`runs.md`](runs.md)
 clauses:
 
+- the §2.2 non-goal excluding workflow mutation locking;
 - the §2.2 non-goals lines excluding cancellation APIs and cancellation
   recovery;
 - the §5.1 run/step status enumerations (now widened per
@@ -404,6 +447,12 @@ anyharness-lib/src/domains/workflows/
 anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
   narrow internal exact-active-turn cancel request only
 
+anyharness-lib/src/domains/sessions/admission.rs
+  generic keyed mutation gate, source, kind, permit, and policy port
+
+anyharness-lib/src/domains/workflows/session_admission.rs
+  durable active-controller lookup and workflow policy implementation
+
 anyharness-lib/src/live/sessions/
   handle.rs
   actor/command.rs
@@ -412,18 +461,23 @@ anyharness-lib/src/live/sessions/
   narrow conditional-cancel command/result only
 
 anyharness-lib/src/api/http/workflow_runs*.rs
+anyharness-lib/src/api/http/access.rs
 anyharness-lib/src/api/router.rs
 anyharness-lib/src/persistence/workflow_run_control_migration.rs
 anyharness-lib/src/persistence/workflow_run_control_migration_tests.rs
 anyharness-lib/src/persistence/custom_migrations.rs
 anyharness/sdk generated artifacts
+scripts/check_session_mutation_admission.py
+scripts/session_mutation_admission*.txt
 ```
 
-Workflows owns cancellation policy and run serialization. Sessions owns the
-generic live-cancel mechanism. HTTP remains thin. Contract types stay at the
-API boundary; SQLite row types stay in the store. The new conditional live
-command is crate-private and leaves the existing public session-cancel route
-and `SessionCommand::Cancel` behavior unchanged.
+Workflows owns cancellation policy, run serialization, and the durable
+controller lookup. Sessions owns the generic mutation gate/policy port and
+live-cancel mechanism; `app/` injects the workflow policy without a Sessions
+dependency on Workflows. HTTP remains thin. Contract types stay at the API
+boundary; SQLite row types stay in the store. The conditional live command is
+crate-private, trusted only for its owning workflow, and the existing public
+session-cancel route is fenced above it.
 
 ## 11. Required proof
 

--- a/specs/codebase/systems/product/workflows/runs.md
+++ b/specs/codebase/systems/product/workflows/runs.md
@@ -10,8 +10,9 @@ product surface responsible for workflow execution.
 Superseded in part: [`run-control.md`](run-control.md)
 supersedes this spec's cancellation non-goals, the run/step status
 enumerations, the no-cancellation restart clause, and the definition-of-done
-no-cancellation line (see its §9 for the exact list). Everything else here
-remains authoritative.
+no-cancellation line (see its §9 for the exact list). Its session mutation
+admission contract also supersedes the workflow-mutation-locking non-goal in
+§2.2. Everything else here remains authoritative.
 
 Read with:
 
@@ -81,8 +82,7 @@ Acceptance requires one real prompt to complete while proving:
 - creating, initializing, registering, renaming, deleting, or claiming a
   workspace;
 - scratch workspaces, cloning, repository selection, or worktrees;
-- existing-session takeover, workflow mutation locking, or exclusive
-  workspace access;
+- existing-session takeover or exclusive workspace access;
 - more than one stage or prompt step;
 - goals, cancellation APIs, or cancellation recovery;
 - Cloud/Desktop delivery, custody, acknowledgements, or product run history;

--- a/specs/generated/anyharness-db-schema.sql
+++ b/specs/generated/anyharness-db-schema.sql
@@ -883,6 +883,12 @@ CREATE INDEX idx_terminal_command_runs_workspace_activity
 CREATE INDEX idx_terminal_command_runs_workspace_created
     ON terminal_command_runs(workspace_id, created_at DESC);
 
+-- index: idx_workflow_runs_active_session_controller
+CREATE UNIQUE INDEX idx_workflow_runs_active_session_controller
+         ON workflow_runs(session_id)
+         WHERE session_id IS NOT NULL
+           AND status NOT IN ('completed', 'failed', 'cancelled', 'interrupted');
+
 -- index: idx_workspaces_path
 CREATE INDEX idx_workspaces_path ON workspaces(path);
 


### PR DESCRIPTION
Implements the founder-frozen delivery spec **"Workflow Session Mutation Admission" RC1.0** (frozen 2026-07-15 with three rulings). The Vault slice remains the governing delivery contract; canonical current-behavior docs are reconciled in this exact head.

- **Base**: `ac18465e7b1968f57f921e5d0a9c7a34c6a995ed` (exact current `origin/main` after login-budget repair #1290, verified again immediately before push) · **Head**: `35f788c521fc8222ce7e9ea68987004720fa9cd3` (14 scoped commits; 13 reviewed slice/repair commits rebased linearly plus one current-main ratchet classification commit). GitHub reports the branch rebased directly on main; exact-head CI is running.
- Predecessor: #1196 (Truthful Workflow Cancellation and Versioning).

## Behavior

A nonterminal workflow **exclusively controls execution mutation** of the session it creates. Reads (GET/list/events/SSE/transcript) stay available; cosmetic title renames stay allowed (ruling 2). Every foreign execution mutation fails with stable **`409 SESSION_CONTROLLED_BY_WORKFLOW`** BEFORE any persistence, projection, queue, actor command, or file side effect. When the workflow terminalizes (completed/failed/cancelled/interrupted), ordinary session behavior resumes.

## Design (per the three founder rulings)

1. **Preselected session id (ruling 1)** — one optional parameter through the single mint/validation path (`create_session` → `InternalSessionCreateInput.preselected_session_id`; canonical lowercase v4 enforced). The executor preselects the id and **reserves the session's mutation gate before the row exists**, holding the permit through durable creation and controller binding inside the already-held run gate — canonical order `run gate → session permit`, no hidden session state, no externally writable gap.
2. **Admission at every execution-affecting owner (ruling 2)** — `domains/sessions/admission.rs` owns the transient keyed gate, permit, `SessionMutationSource` (External / crate-private `WorkflowRun`), and the `SessionControllerPolicy` trait; Workflows implements the policy over nonterminal `workflow_runs.session_id`; `app/` injects it (session core has **zero** Workflows imports — ratchet-enforced). Fenced owners: prompt, pending-prompt edit/delete/reorder/steer, config, cancel/close/dismiss, resume, fork, interaction resolution, goals, loops, subagent wake, replay advance, plan approve/reject/handoff, review start/retry/stop/feedback/revision-ready (resolved to the parent session), and **fail-closed purge + retire + mobility export** holding sorted permits for every workspace session. `assert_session_mutable` keeps its generic/cosmetic role.
3. **Trusted live-cancel (ruling 3)** — `request_live_turn_cancel` is classified a trusted `WorkflowRun(runId)` mutation; the workflow's cancel acquires the session permit (under the run gate) before its intent CAS and live request, and the PUBLIC `cancel_session` fence sits above that seam. All terminal workflow CAS paths (completion extension, cancellation, guarded failure) hold the bound session's permit; startup fencing stays exempt as specified.

## Locking contract (PR1227-LOCK-01 + PR1227-WORKSPACE-FENCE-01 / -02)

Canonical combined order: **`workflow run gate → session mutation permit → workspace operation lease`** — every handler holding both the permit and a `WorkspaceOperationGate` lease takes the permit outermost (ABBA-free; proven by `permit_before_operation_lease_avoids_abba_deadlock` + the reversed-order deadlock proof).

**Workspace-destruction fence (PR1227-WORKSPACE-FENCE-01)**: the workspace-wide destructive paths (`purge_workspace`, `retire_workspace`) admit the CURRENT session set up front, but the workflow executor holds only the shared `SessionStart` lease when it creates+binds a fresh preselected session (a UUID absent from that snapshot). Each destructive path therefore **re-enumerates the session set AFTER it holds the EXCLUSIVE workspace lease** (mutually exclusive with the shared `SessionStart` lease every workflow session creation needs) and fails closed (`409`) if any session is controlled by a nonterminal workflow. The re-check (`SessionMutationAdmission::find_workflow_controlled_session`) is a **pure read-only controller-policy lookup — no permit, no lease** — so it adds no edge to the canonical order and cannot introduce an ABBA.

**Admitted-set fail-closed (PR1227-WORKSPACE-FENCE-02)**: the nonterminal-only FENCE-01 re-check is **insufficient on its own** against a bind→terminalize race. A session bound by a workflow *after* the up-front admission snapshot (so **no permit is ever held for it**) whose controlling run then **terminalizes before** the destructive path takes the exclusive lease has **no nonterminal controller at re-check time** — `find_active_controller_run` filters `status NOT IN (completed, failed, cancelled, interrupted)`, so `find_workflow_controlled_session` provably returns `None` for it — yet it was never admitted. To close this, `admit_all_workspace_sessions` now returns the **set of session ids it snapshotted and holds permits for** (`AdmittedWorkspaceSessions { permits, session_ids }`), and each destructive owner carries that set into the under-lease re-check. Under the exclusive lease it re-enumerates the workspace session set and **fails closed (same stable `409`, `SESSION_CONTROLLED_BY_WORKFLOW`)** if **any** enumerated id is absent from the admitted set — **even if its workflow already terminalized**. FENCE-01 is kept **in addition**: it still catches control *acquired* post-snapshot on an *existing admitted* session (which the membership check alone would miss, since that id *is* in the admitted set). The FENCE-02 check is a **pure in-memory set-membership comparison** over ids enumerated under the already-held exclusive lease — **no permit, no lease** — so it adds no edge to the canonical order. The `409` detail names only the unadmitted session id; no raw internal state, nothing persisted. (Purge-retry / mobility export pass no admitted set — `None` — so the membership check is skipped for them and only FENCE-01 applies.)

**Retention sweep fence (PR1227-RETENTION-FENCE-01)**: `WorkspaceRetentionService::run_pass` was a THIRD workspace-retirement owner with no admission at all — its preflight observes only live-actor signals, so a nonterminal workflow whose bound session has a dead actor (running step, NULL turn, lost acknowledgement) presented zero blockers and retention would retire+dematerialize a workspace that direct retire 409s on. The service now carries a `SessionMutationAdmission` handle (injected in `app/`) and applies the SAME permit-first fail-closed protocol per candidate workspace: sorted session permits acquired BEFORE the exclusive lease (a nonterminal controller conflicts here — the dead-actor case), then the FENCE-02 admitted-set membership check and the FENCE-01 nonterminal-controller re-check under the exclusive lease. On conflict the sweep records a `Blocked` row and SKIPS the workspace (sweep semantics — no caller-facing 409, no failed pass). Both the manual `POST /v1/worktrees/retention/run` route and the automatic startup/post-create passes flow through `run_pass`, the service's sole retirement entry. Test-only keyed barrier seam `retention_barriers::at_pre_exclusive` mirrors the purge/retire seams.

**Mobility destroy-source fence (PR1227-MOBILITY-DESTROY-01)**: `mobility::destroy_workspace_mobility_source` — the path that actually deletes every source session, its artifacts, and the materialization — was classified `workspace-scoped` behind a SHARED `MobilityWrite` lease with no admission (only export, which destroys nothing, was fenced). It is now `fenced`: `admit_all_workspace_sessions` (sorted permits + admitted-ID set) runs before the lease; the lease is UPGRADED to the EXCLUSIVE workspace operation lease (mutually exclusive with the shared `SessionStart` lease the executor holds during create+bind, closing the late-session window); `reject_destroy_if_workflow_controlled` runs the FENCE-02 membership check then the FENCE-01 re-check under that lease and returns stable **`409 SESSION_CONTROLLED_BY_WORKFLOW`** before ANY effect (no terminal close, no session delete, no materialization destroy). Export stays fenced as the detach boundary. Canonical `permit → operation lease` order preserved by both new fences; both under-lease re-checks are pure read-only lookups (no permit, no lease — no new ABBA edge), and destroy-source joined the `every_dual_lock_handler_takes_the_permit_before_the_operation_lease` source-order guard.

**Static ratchet**: `scripts/check_session_mutation_admission.py` (wired into the repo-shape CI job + Makefile) enumerates every mutating route handler (91 at this head) against `scripts/session_mutation_admission.txt`; an unclassified new mutation path, a `fenced` handler without an admit call, an admission call appearing after any enumerated effect surface, a stale entry, or a Workflows import inside session core all fail CI. **Non-HTTP owner ratchet (PR1227-RETENTION-RATCHET-01)**: the same checker now also enforces a non-HTTP destructive-owner inventory (`scripts/session_mutation_admission_non_http.txt`, first entry `WorkspaceRetentionService::run_pass`): the listed admission call must appear before every listed effect surface (`acquire_exclusive`, the `Retired` lifecycle write, `retire_worktree_materialization`); a removed/reordered admission call or a stale entry fails CI. Statically mutation-verified: renaming `admit_retention_sessions` makes the checker exit 1 with a named failure.

**Migration `0063`**: partial unique index — at most one NONTERMINAL run per non-null `session_id`; historical terminal reuse stays legal.

## Verification (head `35f788c521fc8222ce7e9ea68987004720fa9cd3`, base `ac18465e7b1968f57f921e5d0a9c7a34c6a995ed`)

- Exact-head focused proof: `CARGO_BUILD_JOBS=4 cargo test -p anyharness-lib plan_lookup_error_fails_closed_before_review_side_effects -- --nocapture` — **1 passed / 0 failed / 1200 filtered**. The full Rust suite is delegated to exact-head CI because the local machine was already at ~7.7 GB swap; no second/heavy build was started. Previously accepted full-suite evidence remains historical and is not presented as exact-head proof.
- Exact-head lightweight gates pass: max-lines, migration heads, AnyHarness old paths, Proliferate Worker structure, frontend boundaries/strict structure, server boundaries, AnyHarness boundaries, documentation unit/integrity checks, and `git diff --check`. The admission ratchet passes with **91 classified HTTP handlers + 1 fenced non-HTTP owner**. Current-main materialization additions are explicitly classified as repo-root creation and workspace-scoped exact-ref placement; combined max-lines provenance preserves both materialization and admission/purge/retention wiring.
- **Contract custody (PR1227-MOBILITY-CONTRACT-01)**: the destroy-source route's `utoipa::path` now declares the 409 (`ProblemDetails`, same idiom as retire/purge/export); OpenAPI/SDK regenerated via `make sdk-generate` (idempotent — second regen produced zero diff; `pnpm run typecheck` exit 0); pinned by the new regression test `destroy_source_documents_workflow_controlled_409` over the generated document
- **Required-proof battery**:
  - **`purge_fails_closed_against_session_bound_after_admission_snapshot`** (PR1227-WORKSPACE-FENCE-01 / -PROOF-01) — fully deterministic, **no sleeps for ordering**. The REAL executor is parked (`at_session_start_lease` barrier) holding the shared `SessionStart` lease with no session yet. Purge is spawned and a new keyed `purge_barriers` seam fires its `reached` signal **only after `admit_all_workspace_sessions` has fully returned** (up-front snapshot complete, empty of the workflow session) and parks purge **before** the exclusive lease. The test waits on that signal (bounded timeout) — deterministically establishing snapshot-before-bind — THEN releases the executor to create+bind+dispatch the fresh workflow-controlled session, THEN releases purge; purge takes the exclusive lease, the under-lease re-check finds the now-controlled session and **409s before any effect**; session + workspace survive. Mutation-verified: with the under-lease fence removed the test FAILS with a **500 as purge proceeds into the destructive path** (proving ordinary up-front admission alone does NOT catch it); with the fence restored it passes.
  - **`retire_fails_closed_against_workflow_control_acquired_after_admission_snapshot`** (PR1227-WORKSPACE-FENCE-01) — REAL retire handler + REAL controller policy: an idle session is admitted up front (no conflict), retire parks at the pre-exclusive-lease seam, a nonterminal workflow binds control in that window, retire takes the exclusive lease and the fence **409s before any effect**; workspace stays Active. Verified to FAIL (200) with the fence removed.
  - **`purge_fails_closed_against_session_bound_then_terminalized_after_admission_snapshot`** (PR1227-WORKSPACE-FENCE-02) — **PASSES; mutation-verified live**: with ONLY the FENCE-02 membership check disabled (FENCE-01 intact), this test **FAILS with a 500 as purge proceeds into the destructive path**, proving the terminalized controller escapes FENCE-01; restored, it passes. Fully deterministic (no sleeps for ordering). REAL executor parked at `at_session_start_lease` holding the shared `SessionStart` lease with no session row yet; purge spawned and parked at `purge_barriers` **after** its (empty) up-front admitted-set snapshot returns and **before** the exclusive lease. The executor is then released to create+bind+dispatch the fresh workflow-controlled session; the run is driven **TERMINAL** (`fail_nonterminal`) and confirmed durably terminal (`!run_in_flight`) so FENCE-01 is structurally blind (terminal controller ⇒ `find_workflow_controlled_session` returns `None`); only then is purge released. It takes the exclusive lease, the **FENCE-02 admitted-set membership check** finds the session id absent from the (empty) admitted set, and **409s before any effect**; session + workspace survive.
  - **`retire_fails_closed_against_session_bound_then_terminalized_after_admission_snapshot`** (PR1227-WORKSPACE-FENCE-02) — **PASSES; mutation-verified live**: with ONLY the FENCE-02 membership check disabled, retire **succeeds (200, workspace retired)** — the terminalized controller escapes FENCE-01 and destruction proceeds; restored, it 409s. Retire analog through the REAL retire handler + REAL controller policy: the workspace has no session at handler start (empty admitted set); in the stale-snapshot window a fresh session is inserted, a workflow binds control, the run is driven **TERMINAL** and confirmed durable; retire takes the exclusive lease and the FENCE-02 membership check **409s before any effect** (FENCE-01 alone would pass — the controller is terminal); workspace stays Active. Structural mutation argument: the run is provably terminal at re-check, so `find_active_controller_run`’s `status NOT IN (…terminal…)` filter excludes it and `find_workflow_controlled_session` returns `None` — the old checks cannot fire, so a green result is attributable solely to the new admitted-set check.
  - **`retention_skips_workspace_with_dead_actor_workflow_controlled_session`** (PR1227-RETENTION-FENCE-01) — **PASSES; mutation-verified live**: with the retention fence neutered (admission always `Admitted`, under-lease re-check disabled), the REAL retention pass retires and dematerializes the controlled workspace (`outcome: Retired, "checkout retired"`); restored, the pass records a `Blocked` skip, the workspace stays Active, and the session survives. Fixture: real AppState, real materialized worktree, real workflow controller policy, a nonterminal run bound to a session with NO live actor (the exact dead-actor/lost-acknowledgement state the preflight is blind to).
  - **`retention_skips_workspace_with_session_bound_then_terminalized_after_snapshot`** (PR1227-RETENTION-FENCE-01, FENCE-02 analog) — retention parked at the keyed `at_pre_exclusive` seam between its admitted-set snapshot and the exclusive lease; a session is bound then its run driven terminal in that window; the under-lease FENCE-02 membership check skips the workspace. Verified to retire the workspace with the fence removed.
  - **`destroy_source_fails_closed_while_controlled`** (PR1227-MOBILITY-DESTROY-01) — **PASSES; mutation-verified live**: with the destroy fence removed (no admission, no re-check), destroy-source proceeds past the fence into destructive teardown (observed 500 inside `destroy_source_workspace` instead of the stable conflict); restored, it **409s `SESSION_CONTROLLED_BY_WORKFLOW` before any effect** — session row, artifacts, and materialization all survive.
  - `reservation_create_bind_race_foreign_prompt_waits_then_conflicts` — REAL executor parked in the reservation window; a live foreign prompt blocks then 409s; only the workflow's dispatch reaches the scripted session.
  - `terminal_release_restores_ordinary_session_behavior` — controlled → foreign config 409 → terminal CAS → the same mutation is admitted and reaches the session.
  - `foreign_and_stale_workflow_sources_denied_owning_admitted`; `every_fenced_route_conflicts_before_side_effects_and_reads_stay_available` (conflict matrix, zero side effects, reads 200, title 200); `purge_and_mobility_fail_closed_while_controlled`; `ordinary_sessions_keep_existing_behavior`; `permit_before_operation_lease_avoids_abba_deadlock` + `reversed_read_then_permit_order_deadlocks`.

## Exact-head custody status

- Final rebase onto current main was conflict-free. The prior restack's only conflicts were repeated max-lines allowlist entries; their observed combined line counts and both sides' provenance remain preserved.
- Integration delta from current main: two ratchet classifications only; no additional product behavior.
- `PR1227-REVIEW-ADMISSION-01`, `PR1227-DOC-CURRENT-01`, `PR1227-MERGE-RESTACK-01/02`, and `HANDOFF-01` are resolved at this head.
- Force-push-with-lease is complete. Awaiting exact-head CI settlement and final CONTROL; no merge or deploy has occurred.

## Assumptions / disclosed classifications

- **Chosen fence protocol (Option B)**: re-check under the exclusive lease + fail closed, rather than admitting the set under the exclusive lease (Option A, which would reintroduce a lease→permit inversion). Wait-graph: the fence adds no lock acquisition, and no party ever holds a workspace lease while waiting on a fresh preselected permit, so no cycle is reachable.
- `restore_dismissed_session`, the emulated loop fire, the internal subagent wake hook, and `product_mcp` are classified **derived-safe** with justification comments; no admission threaded into actor-context callbacks (never-wait-on-actor rule).
- Permit-acquisition infrastructure failure on TERMINAL workflow paths degrades to gate-only terminalization; foreign-path failures surface as 500, never a fabricated admission.
- Three test-only barrier seams were added (`at_session_start_lease` in the executor, `retire_barriers` in the retire handler, `purge_barriers` in the purge handler) — `#[cfg(test)]`, keyed, no-op with no installed key. Both fence proofs use keyed acknowledgement barriers for ordering; **no sleep establishes any interleaving**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

