### PR TITLE
fix(settings): show truthful billing and staged GitHub setup

### DIFF
--- a/apps/packages/product-surfaces/src/settings/BillingManagementCards.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingManagementCards.tsx
@@ -3,6 +3,7 @@ import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
 import { ExternalLink } from "@proliferate/ui/icons";
 import { Badge } from "@proliferate/ui/primitives/Badge";
 import { Button } from "@proliferate/ui/primitives/Button";
+import { SkeletonBlock } from "@proliferate/ui/primitives/Skeleton";
 import { Switch } from "@proliferate/ui/primitives/Switch";
 import type { BillingSettingsOrganization } from "./BillingSettingsSurface";
 
@@ -18,43 +19,68 @@ export function BillingPlanCard({
   organization,
   organizationLoading,
   loading,
+  errorMessage,
+  unavailableMessage,
   actionError,
+  onRetry,
   onManage,
 }: {
-  plan: BillingPlanPresentation;
+  plan: BillingPlanPresentation | null;
   organization: BillingSettingsOrganization | null;
   organizationLoading: boolean;
   loading: boolean;
+  errorMessage: string | null;
+  unavailableMessage: string | null;
   actionError: string | null;
+  onRetry: () => void;
   onManage: () => void;
 }) {
   const context = organizationLoading
     ? "Billing details for this organization."
     : organization
       ? `Billing for ${organization.name}.`
-      : "Shared billing and credits for this workspace.";
+      : "Billing for your personal account.";
+
+  const label = loading && !plan
+    ? "Loading billing plan"
+    : errorMessage
+      ? "Billing plan unavailable"
+      : unavailableMessage
+        ? "Billing unavailable"
+        : plan
+          ? (
+              <span className="flex flex-wrap items-center gap-2">
+                {plan.name}
+                <span className="font-normal text-muted-foreground">{plan.price}</span>
+                <Badge tone={plan.badgeTone}>{plan.badge}</Badge>
+              </span>
+            )
+          : "Billing plan unavailable";
+
+  const description = errorMessage ?? unavailableMessage ?? context;
 
   return (
     <SettingsSection title="Plan">
       <SettingsRow
-        label={(
-          <span className="flex flex-wrap items-center gap-2">
-            {plan.name}
-            <span className="font-normal text-muted-foreground">{plan.price}</span>
-            <Badge tone={plan.badgeTone}>{plan.badge}</Badge>
-          </span>
-        )}
-        description={context}
+        label={label}
+        description={description}
       >
-        <Button
-          type="button"
-          variant="primary"
-          loading={loading}
-          disabled={organizationLoading}
-          onClick={onManage}
-        >
-          Manage
-        </Button>
+        {loading && !plan ? (
+          <SkeletonBlock className="h-8 w-20" />
+        ) : errorMessage ? (
+          <Button type="button" variant="secondary" onClick={onRetry}>
+            Retry
+          </Button>
+        ) : plan ? (
+          <Button
+            type="button"
+            variant="primary"
+            disabled={organizationLoading}
+            onClick={onManage}
+          >
+            Manage
+          </Button>
+        ) : null}
       </SettingsRow>
       {actionError ? (
         <p className="pt-2 text-ui-sm text-destructive">{actionError}</p>

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
@@ -13,6 +13,7 @@ const cloudHooks = vi.hoisted(() => ({
   createRefillCheckout: vi.fn(),
   updateOverageEnabled: vi.fn(),
   refetch: vi.fn(),
+  refetchLlmBalance: vi.fn(),
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
@@ -36,6 +37,7 @@ function billingPlan(overrides: Record<string, unknown> = {}) {
     concurrentSandboxLimit: 1,
     activeSandboxCount: 0,
     isPaidCloud: false,
+    paymentHealthy: true,
     overageEnabled: false,
     hostedInvoiceUrl: null,
     startBlocked: false,
@@ -63,7 +65,14 @@ describe("BillingSettingsSurface", () => {
     cloudHooks.updateOverageEnabled.mockResolvedValue({});
     cloudHooks.useCloudBilling.mockImplementation((owner: { ownerScope?: string } | undefined) => ({
       data: owner?.ownerScope === "organization"
-        ? billingPlan({ plan: "pro", isPaidCloud: true, repoEnvironmentLimit: 20 })
+        ? billingPlan({
+            plan: "pro",
+            proBillingEnabled: true,
+            isPaidCloud: true,
+            includedManagedCloudHours: 40,
+            remainingManagedCloudHours: 37.7,
+            repoEnvironmentLimit: 20,
+          })
         : billingPlan(),
       isLoading: false,
       isError: false,
@@ -83,6 +92,7 @@ describe("BillingSettingsSurface", () => {
       data: { grantedUsd: 12000, usedUsd: 7400, remainingUsd: 4600 },
       isLoading: false,
       isError: false,
+      refetch: cloudHooks.refetchLlmBalance,
     });
   });
 
@@ -126,13 +136,13 @@ describe("BillingSettingsSurface", () => {
 
     expect(screen.getAllByRole("heading", { name: "Billing" }).length).toBeGreaterThan(0);
     expect(screen.getByText("Plan")).toBeTruthy();
-    expect(screen.getByText(/tracked, budgeted, and topped up separately/)).toBeTruthy();
-    expect(screen.getByText("360 PCUs")).toBeTruthy();
-    expect(screen.getByText("$12,000.00")).toBeTruthy();
+    expect(screen.getByText(/tracked and topped up separately/)).toBeTruthy();
+    expect(screen.getByText(/37.7 PCUs of 40 PCUs available/)).toBeTruthy();
+    expect(screen.queryByText("360 PCUs")).toBeNull();
+    expect(screen.getByText(/\$4,600.00 of \$12,000.00 available/)).toBeTruthy();
     expect(screen.queryByText("Loading")).toBeNull();
     expect(screen.getByRole<HTMLButtonElement>("button", { name: "Add compute units" }).disabled).toBe(true);
     expect(screen.getByRole<HTMLButtonElement>("button", { name: "Add LLM credits" }).disabled).toBe(true);
-    expect(screen.getAllByText("Credit pack checkout for organizations is coming soon.")).toHaveLength(2);
     expect(screen.getByLabelText("Auto top-up")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Manage" }));
@@ -202,5 +212,106 @@ describe("BillingSettingsSurface", () => {
     await waitFor(() => {
       expect(within(dialog).queryByText("checkout offline")).not.toBeNull();
     });
+  });
+
+  it("uses returned free-plan balances instead of fabricated compute values", () => {
+    render(
+      <BillingSettingsSurface
+        organization={null}
+        onOpenUrl={vi.fn()}
+        onOpenOrganizationSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Free plan")).toBeTruthy();
+    expect(screen.getByText(/4 PCUs of 5 PCUs available/)).toBeTruthy();
+    expect(screen.queryByText("360 PCUs")).toBeNull();
+    expect(screen.queryByText("Mocked")).toBeNull();
+  });
+
+  it("renders retryable errors without inventing plan or balance data", () => {
+    cloudHooks.useCloudBilling.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: cloudHooks.refetch,
+    });
+    cloudHooks.useLlmBalance.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: cloudHooks.refetchLlmBalance,
+    });
+
+    render(
+      <BillingSettingsSurface
+        organization={{
+          id: "org_1",
+          name: "Team One",
+          canManageBilling: true,
+          loading: false,
+        }}
+        onOpenUrl={vi.fn()}
+        onOpenOrganizationSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Billing plan unavailable")).toBeTruthy();
+    expect(screen.getByText("Could not load compute units.")).toBeTruthy();
+    expect(screen.getByText("Could not load LLM credits.")).toBeTruthy();
+    expect(screen.queryByText("Core plan")).toBeNull();
+    expect(screen.queryByText("360 PCUs")).toBeNull();
+    expect(screen.queryByText("$0.00")).toBeNull();
+
+    const retryButtons = screen.getAllByRole("button", { name: "Retry" });
+    retryButtons.forEach((button) => fireEvent.click(button));
+    expect(cloudHooks.refetch).toHaveBeenCalledTimes(2);
+    expect(cloudHooks.refetchLlmBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads the selected organization plan for members without billing admin access", () => {
+    render(
+      <BillingSettingsSurface
+        organization={{
+          id: "org_1",
+          name: "Team One",
+          canManageBilling: false,
+          loading: false,
+        }}
+        onOpenUrl={vi.fn()}
+        onOpenOrganizationSettings={vi.fn()}
+      />,
+    );
+
+    expect(cloudHooks.useCloudBilling).toHaveBeenCalledWith(
+      { ownerScope: "organization", organizationId: "org_1" },
+      true,
+    );
+    expect(screen.getByText("Core plan")).toBeTruthy();
+    expect(screen.getByText("Billing for Team One.")).toBeTruthy();
+  });
+
+  it("shows backend payment health instead of an unconditional active badge", () => {
+    cloudHooks.useCloudBilling.mockReturnValue({
+      data: billingPlan({
+        plan: "pro",
+        isPaidCloud: true,
+        paymentHealthy: false,
+      }),
+      isLoading: false,
+      isError: false,
+      refetch: cloudHooks.refetch,
+    });
+
+    render(
+      <BillingSettingsSurface
+        organization={null}
+        onOpenUrl={vi.fn()}
+        onOpenOrganizationSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Payment issue")).toBeTruthy();
+    expect(screen.queryByText("Active")).toBeNull();
   });
 });

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx
@@ -1,25 +1,23 @@
 import { useEffect, useState } from "react";
-import type { BillingReturnSurface, LlmBalance } from "@proliferate/cloud-sdk";
+import type { BillingReturnSurface } from "@proliferate/cloud-sdk";
 import {
   useCloudBilling,
   useCloudBillingActions,
   useLlmBalance,
 } from "@proliferate/cloud-sdk-react";
-import {
-  BillingSettingsPane,
-  type BillingPlanView,
-} from "@proliferate/product-ui/billing/BillingSettingsPane";
+import { BillingSettingsPane } from "@proliferate/product-ui/billing/BillingSettingsPane";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
 import {
   BillingAutoTopUpCard,
   BillingPlanCard,
   BillingPortalCard,
-  type BillingPlanPresentation,
 } from "./BillingManagementCards";
+import { BillingUsageUnitsSection } from "./BillingUsageUnitsSection";
 import {
-  BillingUsageUnitsSection,
-  type BillingUnitBalancePresentation,
-} from "./BillingUsageUnitsSection";
+  billingUnitBalances,
+  planKeyForBilling,
+  planSummary,
+} from "./billing-settings-presentation";
 
 export type BillingCheckoutReturnState = "success" | "cancel" | null;
 
@@ -40,22 +38,6 @@ export interface BillingSettingsSurfaceProps {
   onOpenPricingPage?: () => void | Promise<void>;
   onOpenOrganizationSettings: () => void;
 }
-
-const COMPUTE_UNIT_COPY = {
-  kind: "compute",
-  title: "Compute units",
-  description: "Used by hosted runtime, sandboxes, and execution time.",
-  topUpLabel: "Add compute units",
-  lowBalanceCopy: "Need more runtime capacity? Add compute units any time.",
-} as const;
-
-const LLM_UNIT_COPY = {
-  kind: "llm",
-  title: "LLM credits",
-  description: "Used by model gateway calls, inference-backed tools, and managed model access.",
-  topUpLabel: "Add LLM credits",
-  lowBalanceCopy: "Need more model usage? Add LLM credits any time.",
-} as const;
 
 export function BillingSettingsSurface({
   organization,
@@ -270,269 +252,4 @@ export function BillingSettingsSurface({
       </BillingSettingsPane>
     </section>
   );
-}
-
-type BillingPlanViewKey = "free" | "core" | "enterprise";
-
-function planKeyForBilling(plan: BillingPlanView | null | undefined): BillingPlanViewKey | null {
-  if (!plan) {
-    return null;
-  }
-  if (plan.isUnlimited && !plan.isPaidCloud) {
-    return "enterprise";
-  }
-  return plan.isPaidCloud ? "core" : "free";
-}
-
-function planSummary(
-  planKey: BillingPlanViewKey | null,
-  plan: BillingPlanView,
-): BillingPlanPresentation {
-  const status = planStatusSummary(plan);
-  if (planKey === "enterprise") {
-    return {
-      name: "Enterprise plan",
-      price: "custom",
-      ...status,
-    };
-  }
-  if (planKey === "core") {
-    return {
-      name: "Core plan",
-      price: "$20/month",
-      ...status,
-    };
-  }
-  return {
-    name: "Free plan",
-    price: "$0/month",
-    ...status,
-  };
-}
-
-function planStatusSummary(plan: BillingPlanView): Pick<
-  BillingPlanPresentation,
-  "badge" | "badgeTone"
-> {
-  if (plan.billingMode === "enforce" && plan.startBlocked) {
-    return { badge: "Paused", badgeTone: "warning" };
-  }
-  if (plan.paymentHealthy === false) {
-    return { badge: "Payment issue", badgeTone: "destructive" };
-  }
-  if (plan.legacyCloudSubscription) {
-    return { badge: "Legacy Cloud", badgeTone: "info" };
-  }
-  if (plan.isUnlimited) {
-    return { badge: "Unlimited", badgeTone: "success" };
-  }
-  return {
-    badge: "Active",
-    badgeTone: plan.isPaidCloud ? "success" : "neutral",
-  };
-}
-
-function billingUnitBalances({
-  plan,
-  planLoading,
-  planError,
-  onRetryPlan,
-  llmBalance,
-  llmBalanceLoading,
-  llmBalanceError,
-  onRetryLlmBalance,
-  enabled,
-}: {
-  plan: BillingPlanView | null | undefined;
-  planLoading: boolean;
-  planError: boolean;
-  onRetryPlan: () => void;
-  llmBalance: LlmBalance | null | undefined;
-  llmBalanceLoading: boolean;
-  llmBalanceError: boolean;
-  onRetryLlmBalance: () => void;
-  enabled: boolean;
-}): BillingUnitBalancePresentation[] {
-  return [
-    computeBalanceSummary(plan, {
-      enabled,
-      loading: planLoading,
-      error: planError,
-      onRetry: onRetryPlan,
-    }),
-    llmBalanceSummary(llmBalance, {
-      enabled,
-      loading: llmBalanceLoading,
-      error: llmBalanceError,
-      onRetry: onRetryLlmBalance,
-    }),
-  ];
-}
-
-function llmBalanceSummary(
-  llmBalance: LlmBalance | null | undefined,
-  query: BillingUnitQueryState,
-): BillingUnitBalancePresentation {
-  const unavailable = unavailableUnitBalance(LLM_UNIT_COPY, query, Boolean(llmBalance));
-  if (unavailable) {
-    return unavailable;
-  }
-  const granted = Math.max(llmBalance?.grantedUsd ?? 0, 0);
-  const used = Math.max(llmBalance?.usedUsd ?? 0, 0);
-  const remaining = Math.max(llmBalance?.remainingUsd ?? 0, 0);
-  return {
-    ...LLM_UNIT_COPY,
-    purchased: formatUsd(granted),
-    available: formatUsd(remaining),
-    used: formatUsd(used),
-    availablePercent: granted > 0 ? Math.round((remaining / granted) * 100) : null,
-    state: "ready",
-  };
-}
-
-function computeBalanceSummary(
-  plan: BillingPlanView | null | undefined,
-  query: BillingUnitQueryState,
-): BillingUnitBalancePresentation {
-  const unavailable = unavailableUnitBalance(COMPUTE_UNIT_COPY, query, Boolean(plan));
-  if (unavailable) {
-    return unavailable;
-  }
-  if (!plan) {
-    throw new Error("Compute balance requires billing plan data.");
-  }
-
-  const visibleGrants = (plan.grantAllocations ?? []).filter((grant) =>
-    grant.active || grant.consumedSeconds > 0 || grant.remainingSeconds > 0
-  );
-  if (visibleGrants.length > 0) {
-    const purchased = visibleGrants.reduce(
-      (total, grant) => total + secondsToCredits(grant.totalSeconds),
-      0,
-    );
-    const available = visibleGrants.reduce(
-      (total, grant) => total + secondsToCredits(grant.remainingSeconds),
-      0,
-    );
-    const used = visibleGrants.reduce(
-      (total, grant) => total + secondsToCredits(grant.consumedSeconds),
-      0,
-    );
-    return {
-      ...COMPUTE_UNIT_COPY,
-      purchased: formatCredits(purchased),
-      available: formatCredits(available),
-      used: formatCredits(used),
-      availablePercent: purchased > 0 ? Math.round((available / purchased) * 100) : null,
-      state: "ready",
-    };
-  }
-
-  const available = plan.proBillingEnabled && plan.isPaidCloud
-    ? plan.remainingManagedCloudHours
-    : plan.remainingSandboxHours;
-  const purchased = plan.proBillingEnabled && plan.isPaidCloud
-    ? plan.includedManagedCloudHours
-    : plan.freeSandboxHours;
-  const used = plan.proBillingEnabled && plan.isPaidCloud
-    ? purchased !== null && purchased !== undefined
-      && available !== null && available !== undefined
-      ? Math.max(purchased - available, 0)
-      : null
-    : plan.usedSandboxHours;
-
-  return {
-    ...COMPUTE_UNIT_COPY,
-    purchased: formatCredits(purchased),
-    available: formatCredits(available),
-    used: formatCredits(used),
-    availablePercent: purchased && purchased > 0 && available !== null && available !== undefined
-      ? Math.round((available / purchased) * 100)
-      : null,
-    state: "ready",
-  };
-}
-
-interface BillingUnitQueryState {
-  enabled: boolean;
-  loading: boolean;
-  error: boolean;
-  onRetry: () => void;
-}
-
-function unavailableUnitBalance(
-  copy: typeof COMPUTE_UNIT_COPY | typeof LLM_UNIT_COPY,
-  query: BillingUnitQueryState,
-  hasData: boolean,
-): BillingUnitBalancePresentation | null {
-  if (hasData) {
-    return null;
-  }
-  if (!query.enabled) {
-    return {
-      ...copy,
-      purchased: "",
-      available: "",
-      used: "",
-      availablePercent: null,
-      state: "unavailable",
-      stateMessage: `${copy.title} are unavailable for this deployment.`,
-    };
-  }
-  if (query.loading) {
-    return {
-      ...copy,
-      purchased: "",
-      available: "",
-      used: "",
-      availablePercent: null,
-      state: "loading",
-    };
-  }
-  if (query.error) {
-    return {
-      ...copy,
-      purchased: "",
-      available: "",
-      used: "",
-      availablePercent: null,
-      state: "error",
-      stateMessage: `Could not load ${copy.kind === "llm" ? "LLM credits" : "compute units"}.`,
-      onRetry: query.onRetry,
-    };
-  }
-  return {
-    ...copy,
-    purchased: "",
-    available: "",
-    used: "",
-    availablePercent: null,
-    state: "unavailable",
-    stateMessage: `${copy.title} were not returned for this account.`,
-  };
-}
-
-function secondsToCredits(seconds: number | null | undefined): number {
-  return Math.max(seconds ?? 0, 0) / 3600;
-}
-
-function formatUsd(value: number | null | undefined): string {
-  if (value === null || value === undefined) {
-    return "Unlimited";
-  }
-  return `$${Math.max(value, 0).toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-}
-
-function formatCredits(value: number | null | undefined): string {
-  if (value === null || value === undefined) {
-    return "Unlimited";
-  }
-  const rounded = Math.round(Math.max(value, 0) * 10) / 10;
-  const formatted = rounded.toLocaleString(undefined, {
-    maximumFractionDigits: Number.isInteger(rounded) ? 0 : 1,
-  });
-  return `${formatted} ${rounded === 1 ? "PCU" : "PCUs"}`;
 }

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx
@@ -41,17 +41,21 @@ export interface BillingSettingsSurfaceProps {
   onOpenOrganizationSettings: () => void;
 }
 
-const MOCK_COMPUTE_BALANCE: BillingUnitBalancePresentation = {
+const COMPUTE_UNIT_COPY = {
   kind: "compute",
   title: "Compute units",
   description: "Used by hosted runtime, sandboxes, and execution time.",
-  purchased: "360 PCUs",
-  available: "118 PCUs",
-  used: "242 PCUs",
-  availablePercent: 33,
   topUpLabel: "Add compute units",
   lowBalanceCopy: "Need more runtime capacity? Add compute units any time.",
-};
+} as const;
+
+const LLM_UNIT_COPY = {
+  kind: "llm",
+  title: "LLM credits",
+  description: "Used by model gateway calls, inference-backed tools, and managed model access.",
+  topUpLabel: "Add LLM credits",
+  lowBalanceCopy: "Need more model usage? Add LLM credits any time.",
+} as const;
 
 export function BillingSettingsSurface({
   organization,
@@ -64,7 +68,7 @@ export function BillingSettingsSurface({
   onOpenOrganizationSettings,
 }: BillingSettingsSurfaceProps) {
   const billingReturnOptions = { returnSurface: billingReturnSurface };
-  const comparisonOwner = organization?.canManageBilling
+  const comparisonOwner = organization
     ? { ownerScope: "organization" as const, organizationId: organization.id }
     : undefined;
   const comparisonBilling = useCloudBilling(comparisonOwner, enabled);
@@ -127,8 +131,31 @@ export function BillingSettingsSurface({
 
   const billingPlan = comparisonBilling.data;
   const currentPlanKey = planKeyForBilling(billingPlan);
-  const plan = planSummary(currentPlanKey, billingPlan);
-  const unitBalances = billingUnitBalances(billingPlan, llmBalance.data, llmBalance.isLoading);
+  const plan = billingPlan ? planSummary(currentPlanKey, billingPlan) : null;
+  const billingLoading = enabled && comparisonBilling.isLoading && !billingPlan;
+  const billingErrorMessage = enabled && comparisonBilling.isError
+    ? "Could not load the billing plan. Retry to refresh it from Proliferate Cloud."
+    : null;
+  const billingUnavailableMessage = !enabled
+    ? "Billing is unavailable for this deployment."
+    : !billingLoading && !billingErrorMessage && !billingPlan
+      ? "No billing plan was returned for this account."
+      : null;
+  const unitBalances = billingUnitBalances({
+    plan: billingPlan,
+    planLoading: billingLoading,
+    planError: comparisonBilling.isError,
+    onRetryPlan: () => {
+      void comparisonBilling.refetch();
+    },
+    llmBalance: llmBalance.data,
+    llmBalanceLoading: enabled && llmBalance.isLoading && !llmBalance.data,
+    llmBalanceError: llmBalance.isError,
+    onRetryLlmBalance: () => {
+      void llmBalance.refetch();
+    },
+    enabled,
+  });
   const topUpEnabled = Boolean(
     billingPlan?.managedCloudOverageEnabled || billingPlan?.overageEnabled,
   );
@@ -136,7 +163,9 @@ export function BillingSettingsSurface({
   const paidPlan = billingPlan?.isPaidCloud === true;
   const comparisonActionDisabled = !enabled
     || organizationLoading
-    || (canManage ? comparisonBilling.isLoading : false);
+    || comparisonBilling.isLoading
+    || comparisonBilling.isError
+    || !billingPlan;
   const billingActionDisabled = comparisonActionDisabled || !canManage || !paidPlan;
   const coreActionLoading = billingPlan?.isPaidCloud
     ? comparisonActions.creatingBillingPortal
@@ -202,8 +231,13 @@ export function BillingSettingsSurface({
           plan={plan}
           organization={organization}
           organizationLoading={organizationLoading}
-          loading={canManage ? comparisonBilling.isLoading : false}
+          loading={billingLoading}
+          errorMessage={billingErrorMessage}
+          unavailableMessage={billingUnavailableMessage}
           actionError={comparisonActionError}
+          onRetry={() => {
+            void comparisonBilling.refetch();
+          }}
           onManage={openPlanManagement}
         />
 
@@ -213,22 +247,26 @@ export function BillingSettingsSurface({
           addCreditsDisabled
         />
 
-        <BillingAutoTopUpCard
-          enabled={topUpEnabled}
-          disabled={billingActionDisabled || comparisonActions.updatingOverage}
-          saving={comparisonActions.updatingOverage}
-          onEnabledChange={(value) => {
-            void updateComparisonTopUp(value);
-          }}
-        />
+        {billingPlan ? (
+          <>
+            <BillingAutoTopUpCard
+              enabled={topUpEnabled}
+              disabled={billingActionDisabled || comparisonActions.updatingOverage}
+              saving={comparisonActions.updatingOverage}
+              onEnabledChange={(value) => {
+                void updateComparisonTopUp(value);
+              }}
+            />
 
-        <BillingPortalCard
-          loading={comparisonActions.creatingBillingPortal}
-          disabled={billingActionDisabled}
-          onOpenPortal={() => {
-            void openComparisonBillingAction("portal");
-          }}
-        />
+            <BillingPortalCard
+              loading={comparisonActions.creatingBillingPortal}
+              disabled={billingActionDisabled}
+              onOpenPortal={() => {
+                void openComparisonBillingAction("portal");
+              }}
+            />
+          </>
+        ) : null}
       </BillingSettingsPane>
     </section>
   );
@@ -248,77 +286,120 @@ function planKeyForBilling(plan: BillingPlanView | null | undefined): BillingPla
 
 function planSummary(
   planKey: BillingPlanViewKey | null,
-  plan: BillingPlanView | null | undefined,
+  plan: BillingPlanView,
 ): BillingPlanPresentation {
-  if (!plan) {
-    return {
-      name: "Core plan",
-      price: "$20/month",
-      badge: "Mocked",
-      badgeTone: "neutral",
-    };
-  }
+  const status = planStatusSummary(plan);
   if (planKey === "enterprise") {
     return {
       name: "Enterprise plan",
       price: "custom",
-      badge: "Active",
-      badgeTone: "success",
+      ...status,
     };
   }
   if (planKey === "core") {
     return {
       name: "Core plan",
       price: "$20/month",
-      badge: "Active",
-      badgeTone: "success",
+      ...status,
     };
   }
   return {
     name: "Free plan",
     price: "$0/month",
-    badge: "Active",
-    badgeTone: "neutral",
+    ...status,
   };
 }
 
-function billingUnitBalances(
-  plan: BillingPlanView | null | undefined,
-  llmBalance: LlmBalance | null | undefined,
-  llmBalanceLoading: boolean,
-): BillingUnitBalancePresentation[] {
+function planStatusSummary(plan: BillingPlanView): Pick<
+  BillingPlanPresentation,
+  "badge" | "badgeTone"
+> {
+  if (plan.billingMode === "enforce" && plan.startBlocked) {
+    return { badge: "Paused", badgeTone: "warning" };
+  }
+  if (plan.paymentHealthy === false) {
+    return { badge: "Payment issue", badgeTone: "destructive" };
+  }
+  if (plan.legacyCloudSubscription) {
+    return { badge: "Legacy Cloud", badgeTone: "info" };
+  }
+  if (plan.isUnlimited) {
+    return { badge: "Unlimited", badgeTone: "success" };
+  }
+  return {
+    badge: "Active",
+    badgeTone: plan.isPaidCloud ? "success" : "neutral",
+  };
+}
+
+function billingUnitBalances({
+  plan,
+  planLoading,
+  planError,
+  onRetryPlan,
+  llmBalance,
+  llmBalanceLoading,
+  llmBalanceError,
+  onRetryLlmBalance,
+  enabled,
+}: {
+  plan: BillingPlanView | null | undefined;
+  planLoading: boolean;
+  planError: boolean;
+  onRetryPlan: () => void;
+  llmBalance: LlmBalance | null | undefined;
+  llmBalanceLoading: boolean;
+  llmBalanceError: boolean;
+  onRetryLlmBalance: () => void;
+  enabled: boolean;
+}): BillingUnitBalancePresentation[] {
   return [
-    computeBalanceSummary(plan),
-    llmBalanceSummary(llmBalance, llmBalanceLoading),
+    computeBalanceSummary(plan, {
+      enabled,
+      loading: planLoading,
+      error: planError,
+      onRetry: onRetryPlan,
+    }),
+    llmBalanceSummary(llmBalance, {
+      enabled,
+      loading: llmBalanceLoading,
+      error: llmBalanceError,
+      onRetry: onRetryLlmBalance,
+    }),
   ];
 }
 
 function llmBalanceSummary(
   llmBalance: LlmBalance | null | undefined,
-  loading: boolean,
+  query: BillingUnitQueryState,
 ): BillingUnitBalancePresentation {
+  const unavailable = unavailableUnitBalance(LLM_UNIT_COPY, query, Boolean(llmBalance));
+  if (unavailable) {
+    return unavailable;
+  }
   const granted = Math.max(llmBalance?.grantedUsd ?? 0, 0);
   const used = Math.max(llmBalance?.usedUsd ?? 0, 0);
   const remaining = Math.max(llmBalance?.remainingUsd ?? 0, 0);
   return {
-    kind: "llm",
-    title: "LLM credits",
-    description: "Used by model gateway calls, inference-backed tools, and managed model access.",
+    ...LLM_UNIT_COPY,
     purchased: formatUsd(granted),
     available: formatUsd(remaining),
     used: formatUsd(used),
     availablePercent: granted > 0 ? Math.round((remaining / granted) * 100) : null,
-    topUpLabel: "Add LLM credits",
-    lowBalanceCopy: "Need more model usage? Add LLM credits any time.",
-    loading: loading && !llmBalance,
+    state: "ready",
   };
 }
 
 function computeBalanceSummary(
   plan: BillingPlanView | null | undefined,
+  query: BillingUnitQueryState,
 ): BillingUnitBalancePresentation {
+  const unavailable = unavailableUnitBalance(COMPUTE_UNIT_COPY, query, Boolean(plan));
+  if (unavailable) {
+    return unavailable;
+  }
   if (!plan) {
-    return MOCK_COMPUTE_BALANCE;
+    throw new Error("Compute balance requires billing plan data.");
   }
 
   const visibleGrants = (plan.grantAllocations ?? []).filter((grant) =>
@@ -338,15 +419,97 @@ function computeBalanceSummary(
       0,
     );
     return {
-      ...MOCK_COMPUTE_BALANCE,
+      ...COMPUTE_UNIT_COPY,
       purchased: formatCredits(purchased),
       available: formatCredits(available),
       used: formatCredits(used),
       availablePercent: purchased > 0 ? Math.round((available / purchased) * 100) : null,
+      state: "ready",
     };
   }
 
-  return MOCK_COMPUTE_BALANCE;
+  const available = plan.proBillingEnabled && plan.isPaidCloud
+    ? plan.remainingManagedCloudHours
+    : plan.remainingSandboxHours;
+  const purchased = plan.proBillingEnabled && plan.isPaidCloud
+    ? plan.includedManagedCloudHours
+    : plan.freeSandboxHours;
+  const used = plan.proBillingEnabled && plan.isPaidCloud
+    ? purchased !== null && purchased !== undefined
+      && available !== null && available !== undefined
+      ? Math.max(purchased - available, 0)
+      : null
+    : plan.usedSandboxHours;
+
+  return {
+    ...COMPUTE_UNIT_COPY,
+    purchased: formatCredits(purchased),
+    available: formatCredits(available),
+    used: formatCredits(used),
+    availablePercent: purchased && purchased > 0 && available !== null && available !== undefined
+      ? Math.round((available / purchased) * 100)
+      : null,
+    state: "ready",
+  };
+}
+
+interface BillingUnitQueryState {
+  enabled: boolean;
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+}
+
+function unavailableUnitBalance(
+  copy: typeof COMPUTE_UNIT_COPY | typeof LLM_UNIT_COPY,
+  query: BillingUnitQueryState,
+  hasData: boolean,
+): BillingUnitBalancePresentation | null {
+  if (hasData) {
+    return null;
+  }
+  if (!query.enabled) {
+    return {
+      ...copy,
+      purchased: "",
+      available: "",
+      used: "",
+      availablePercent: null,
+      state: "unavailable",
+      stateMessage: `${copy.title} are unavailable for this deployment.`,
+    };
+  }
+  if (query.loading) {
+    return {
+      ...copy,
+      purchased: "",
+      available: "",
+      used: "",
+      availablePercent: null,
+      state: "loading",
+    };
+  }
+  if (query.error) {
+    return {
+      ...copy,
+      purchased: "",
+      available: "",
+      used: "",
+      availablePercent: null,
+      state: "error",
+      stateMessage: `Could not load ${copy.kind === "llm" ? "LLM credits" : "compute units"}.`,
+      onRetry: query.onRetry,
+    };
+  }
+  return {
+    ...copy,
+    purchased: "",
+    available: "",
+    used: "",
+    availablePercent: null,
+    state: "unavailable",
+    stateMessage: `${copy.title} were not returned for this account.`,
+  };
 }
 
 function secondsToCredits(seconds: number | null | undefined): number {

--- a/apps/packages/product-surfaces/src/settings/BillingUsageUnitsSection.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingUsageUnitsSection.tsx
@@ -15,7 +15,9 @@ export interface BillingUnitBalancePresentation {
   availablePercent: number | null;
   topUpLabel: string;
   lowBalanceCopy: string;
-  loading?: boolean;
+  state: "ready" | "loading" | "error" | "unavailable";
+  stateMessage?: string;
+  onRetry?: () => void;
 }
 
 export function BillingUsageUnitsSection({
@@ -55,13 +57,28 @@ function BillingUnitPoolRow({
 }) {
   const percent = balance.availablePercent ?? 0;
 
-  if (balance.loading) {
+  if (balance.state === "loading") {
     return (
       <SettingsRow label={balance.title} description={balance.description}>
         <div className="flex flex-col gap-1.5" role="status" aria-label={`Loading ${balance.title}`}>
           <SkeletonBlock className="h-3 w-32" style={shimmerDelay(0)} />
           <SkeletonBlock className="h-1 w-24 rounded-full" style={shimmerDelay(1)} />
         </div>
+      </SettingsRow>
+    );
+  }
+
+  if (balance.state !== "ready") {
+    return (
+      <SettingsRow
+        label={balance.title}
+        description={balance.stateMessage ?? `${balance.title} are unavailable.`}
+      >
+        {balance.state === "error" && balance.onRetry ? (
+          <Button type="button" variant="secondary" size="sm" onClick={balance.onRetry}>
+            Retry
+          </Button>
+        ) : null}
       </SettingsRow>
     );
   }

--- a/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/CloudEnvironmentsSettingsSurface.test.tsx
@@ -375,6 +375,13 @@ describe("CloudEnvironmentsSettingsSurface", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add cloud environment" }));
 
     expect(screen.queryByRole("heading", { name: "Authorize GitHub App" })).not.toBeNull();
+    expect(screen.getByLabelText("GitHub setup progress")).toBeTruthy();
+    expect(screen.getByText("Authorize your GitHub identity")).toBeTruthy();
+    expect(screen.getByText("Install for repository access")).toBeTruthy();
+    expect(screen.getByText("Choose a repository")).toBeTruthy();
+    expect(
+      screen.getByText("GitHub opens in your browser, then returns you to Proliferate Desktop."),
+    ).toBeTruthy();
     expect(screen.queryByLabelText("Search GitHub repositories")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Authorize GitHub App" }));
@@ -408,6 +415,10 @@ describe("CloudEnvironmentsSettingsSurface", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add cloud environment" }));
 
     expect(screen.queryByRole("heading", { name: "Install GitHub App" })).not.toBeNull();
+    expect(screen.getByText("GitHub identity authorized.")).toBeTruthy();
+    expect(
+      screen.getByText("GitHub opens in your browser, then returns you to Proliferate Desktop."),
+    ).toBeTruthy();
     expect(screen.queryByLabelText("Search GitHub repositories")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Install GitHub App" }));
@@ -421,5 +432,27 @@ describe("CloudEnvironmentsSettingsSurface", () => {
       });
     });
     expect(onOpenExternalUrl).toHaveBeenCalledWith("https://github.test/install");
+  });
+
+  it("explains the browser return path during web GitHub authorization", () => {
+    cloudHooks.useGitHubAppUserAuthorizationStatus.mockReturnValue({
+      data: { connected: false, action: "connect" },
+      isLoading: false,
+    });
+
+    render(
+      <CloudEnvironmentsSettingsSurface
+        organizationId="org-1"
+        userAuthorizationReturnTo="https://web.proliferate.com/settings/environments"
+        onSelectCloudEnvironment={vi.fn()}
+        onBackToList={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add cloud environment" }));
+
+    expect(
+      screen.getByText("GitHub opens and returns you to Proliferate in this browser."),
+    ).toBeTruthy();
   });
 });

--- a/apps/packages/product-surfaces/src/settings/billing-settings-presentation.ts
+++ b/apps/packages/product-surfaces/src/settings/billing-settings-presentation.ts
@@ -1,0 +1,287 @@
+import type { LlmBalance } from "@proliferate/cloud-sdk";
+import type { BillingPlanView } from "@proliferate/product-ui/billing/BillingSettingsPane";
+import type { BillingPlanPresentation } from "./BillingManagementCards";
+import type { BillingUnitBalancePresentation } from "./BillingUsageUnitsSection";
+
+const COMPUTE_UNIT_COPY = {
+  kind: "compute",
+  title: "Compute units",
+  description: "Used by hosted runtime, sandboxes, and execution time.",
+  topUpLabel: "Add compute units",
+  lowBalanceCopy: "Need more runtime capacity? Add compute units any time.",
+} as const;
+
+const LLM_UNIT_COPY = {
+  kind: "llm",
+  title: "LLM credits",
+  description: "Used by model gateway calls, inference-backed tools, and managed model access.",
+  topUpLabel: "Add LLM credits",
+  lowBalanceCopy: "Need more model usage? Add LLM credits any time.",
+} as const;
+
+export type BillingPlanViewKey = "free" | "core" | "enterprise";
+
+export function planKeyForBilling(
+  plan: BillingPlanView | null | undefined,
+): BillingPlanViewKey | null {
+  if (!plan) {
+    return null;
+  }
+  if (plan.isUnlimited && !plan.isPaidCloud) {
+    return "enterprise";
+  }
+  return plan.isPaidCloud ? "core" : "free";
+}
+
+export function planSummary(
+  planKey: BillingPlanViewKey | null,
+  plan: BillingPlanView,
+): BillingPlanPresentation {
+  const status = planStatusSummary(plan);
+  if (planKey === "enterprise") {
+    return {
+      name: "Enterprise plan",
+      price: "custom",
+      ...status,
+    };
+  }
+  if (planKey === "core") {
+    return {
+      name: "Core plan",
+      price: "$20/month",
+      ...status,
+    };
+  }
+  return {
+    name: "Free plan",
+    price: "$0/month",
+    ...status,
+  };
+}
+
+export function billingUnitBalances({
+  plan,
+  planLoading,
+  planError,
+  onRetryPlan,
+  llmBalance,
+  llmBalanceLoading,
+  llmBalanceError,
+  onRetryLlmBalance,
+  enabled,
+}: {
+  plan: BillingPlanView | null | undefined;
+  planLoading: boolean;
+  planError: boolean;
+  onRetryPlan: () => void;
+  llmBalance: LlmBalance | null | undefined;
+  llmBalanceLoading: boolean;
+  llmBalanceError: boolean;
+  onRetryLlmBalance: () => void;
+  enabled: boolean;
+}): BillingUnitBalancePresentation[] {
+  return [
+    computeBalanceSummary(plan, {
+      enabled,
+      loading: planLoading,
+      error: planError,
+      onRetry: onRetryPlan,
+    }),
+    llmBalanceSummary(llmBalance, {
+      enabled,
+      loading: llmBalanceLoading,
+      error: llmBalanceError,
+      onRetry: onRetryLlmBalance,
+    }),
+  ];
+}
+
+function planStatusSummary(plan: BillingPlanView): Pick<
+  BillingPlanPresentation,
+  "badge" | "badgeTone"
+> {
+  if (plan.billingMode === "enforce" && plan.startBlocked) {
+    return { badge: "Paused", badgeTone: "warning" };
+  }
+  if (plan.paymentHealthy === false) {
+    return { badge: "Payment issue", badgeTone: "destructive" };
+  }
+  if (plan.legacyCloudSubscription) {
+    return { badge: "Legacy Cloud", badgeTone: "info" };
+  }
+  if (plan.isUnlimited) {
+    return { badge: "Unlimited", badgeTone: "success" };
+  }
+  return {
+    badge: "Active",
+    badgeTone: plan.isPaidCloud ? "success" : "neutral",
+  };
+}
+
+function llmBalanceSummary(
+  llmBalance: LlmBalance | null | undefined,
+  query: BillingUnitQueryState,
+): BillingUnitBalancePresentation {
+  const unavailable = unavailableUnitBalance(LLM_UNIT_COPY, query, Boolean(llmBalance));
+  if (unavailable) {
+    return unavailable;
+  }
+  const granted = Math.max(llmBalance?.grantedUsd ?? 0, 0);
+  const used = Math.max(llmBalance?.usedUsd ?? 0, 0);
+  const remaining = Math.max(llmBalance?.remainingUsd ?? 0, 0);
+  return {
+    ...LLM_UNIT_COPY,
+    purchased: formatUsd(granted),
+    available: formatUsd(remaining),
+    used: formatUsd(used),
+    availablePercent: granted > 0 ? Math.round((remaining / granted) * 100) : null,
+    state: "ready",
+  };
+}
+
+function computeBalanceSummary(
+  plan: BillingPlanView | null | undefined,
+  query: BillingUnitQueryState,
+): BillingUnitBalancePresentation {
+  const unavailable = unavailableUnitBalance(COMPUTE_UNIT_COPY, query, Boolean(plan));
+  if (unavailable) {
+    return unavailable;
+  }
+  if (!plan) {
+    throw new Error("Compute balance requires billing plan data.");
+  }
+
+  const visibleGrants = (plan.grantAllocations ?? []).filter((grant) =>
+    grant.active || grant.consumedSeconds > 0 || grant.remainingSeconds > 0
+  );
+  if (visibleGrants.length > 0) {
+    const purchased = visibleGrants.reduce(
+      (total, grant) => total + secondsToCredits(grant.totalSeconds),
+      0,
+    );
+    const available = visibleGrants.reduce(
+      (total, grant) => total + secondsToCredits(grant.remainingSeconds),
+      0,
+    );
+    const used = visibleGrants.reduce(
+      (total, grant) => total + secondsToCredits(grant.consumedSeconds),
+      0,
+    );
+    return {
+      ...COMPUTE_UNIT_COPY,
+      purchased: formatCredits(purchased),
+      available: formatCredits(available),
+      used: formatCredits(used),
+      availablePercent: purchased > 0 ? Math.round((available / purchased) * 100) : null,
+      state: "ready",
+    };
+  }
+
+  const available = plan.proBillingEnabled && plan.isPaidCloud
+    ? plan.remainingManagedCloudHours
+    : plan.remainingSandboxHours;
+  const purchased = plan.proBillingEnabled && plan.isPaidCloud
+    ? plan.includedManagedCloudHours
+    : plan.freeSandboxHours;
+  const used = plan.proBillingEnabled && plan.isPaidCloud
+    ? purchased !== null && purchased !== undefined
+      && available !== null && available !== undefined
+      ? Math.max(purchased - available, 0)
+      : null
+    : plan.usedSandboxHours;
+
+  return {
+    ...COMPUTE_UNIT_COPY,
+    purchased: formatCredits(purchased),
+    available: formatCredits(available),
+    used: formatCredits(used),
+    availablePercent: purchased && purchased > 0 && available !== null && available !== undefined
+      ? Math.round((available / purchased) * 100)
+      : null,
+    state: "ready",
+  };
+}
+
+interface BillingUnitQueryState {
+  enabled: boolean;
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+}
+
+function unavailableUnitBalance(
+  copy: typeof COMPUTE_UNIT_COPY | typeof LLM_UNIT_COPY,
+  query: BillingUnitQueryState,
+  hasData: boolean,
+): BillingUnitBalancePresentation | null {
+  if (hasData) {
+    return null;
+  }
+  if (!query.enabled) {
+    return {
+      ...copy,
+      purchased: "",
+      available: "",
+      used: "",
+      availablePercent: null,
+      state: "unavailable",
+      stateMessage: `${copy.title} are unavailable for this deployment.`,
+    };
+  }
+  if (query.loading) {
+    return {
+      ...copy,
+      purchased: "",
+      available: "",
+      used: "",
+      availablePercent: null,
+      state: "loading",
+    };
+  }
+  if (query.error) {
+    return {
+      ...copy,
+      purchased: "",
+      available: "",
+      used: "",
+      availablePercent: null,
+      state: "error",
+      stateMessage: `Could not load ${copy.kind === "llm" ? "LLM credits" : "compute units"}.`,
+      onRetry: query.onRetry,
+    };
+  }
+  return {
+    ...copy,
+    purchased: "",
+    available: "",
+    used: "",
+    availablePercent: null,
+    state: "unavailable",
+    stateMessage: `${copy.title} were not returned for this account.`,
+  };
+}
+
+function secondsToCredits(seconds: number | null | undefined): number {
+  return Math.max(seconds ?? 0, 0) / 3600;
+}
+
+function formatUsd(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "Unlimited";
+  }
+  return `$${Math.max(value, 0).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatCredits(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "Unlimited";
+  }
+  const rounded = Math.round(Math.max(value, 0) * 10) / 10;
+  const formatted = rounded.toLocaleString(undefined, {
+    maximumFractionDigits: Number.isInteger(rounded) ? 0 : 1,
+  });
+  return `${formatted} ${rounded === 1 ? "PCU" : "PCUs"}`;
+}

--- a/apps/packages/product-surfaces/src/settings/cloud-environments/add-cloud-environment-helpers.ts
+++ b/apps/packages/product-surfaces/src/settings/cloud-environments/add-cloud-environment-helpers.ts
@@ -17,6 +17,7 @@ export function buildGitHubAppPrerequisiteBlocker({
   onAuthorizeUser,
   onInstallGitHubApp,
   onCopyAdminRequest,
+  returnSurface,
 }: {
   organizationId: string | null;
   canManageGitHubAppInstallation: boolean;
@@ -30,11 +31,22 @@ export function buildGitHubAppPrerequisiteBlocker({
   onAuthorizeUser: () => void;
   onInstallGitHubApp: () => void;
   onCopyAdminRequest: () => void;
+  returnSurface: "desktop" | "web";
 }): CloudRepoPickerBlockerView | null {
+  const returnGuidance = returnSurface === "desktop"
+    ? "GitHub opens in your browser, then returns you to Proliferate Desktop."
+    : "GitHub opens and returns you to Proliferate in this browser.";
+
   if (!organizationId) {
     return {
       title: "Organization required",
       description: "Cloud environments require an active organization before repositories can be added.",
+      steps: [
+        setupStep("Choose an organization", "Create or join an organization first.", "current"),
+        setupStep("Authorize your GitHub identity", "Connect the GitHub account that can access the repository.", "upcoming"),
+        setupStep("Install for repository access", "Choose which organization repositories Proliferate can use.", "upcoming"),
+        setupStep("Choose a repository", "Select the repository for the cloud environment.", "upcoming"),
+      ],
     };
   }
 
@@ -42,6 +54,11 @@ export function buildGitHubAppPrerequisiteBlocker({
     return {
       title: "Checking GitHub App access",
       description: "Proliferate is checking your GitHub authorization and organization installation.",
+      steps: setupSteps({
+        userAuthorized: userAuthorizationConnected,
+        installationInstalled,
+        returnGuidance,
+      }),
     };
   }
 
@@ -51,6 +68,11 @@ export function buildGitHubAppPrerequisiteBlocker({
         ? "Reauthorize GitHub App"
         : "Authorize GitHub App",
       description: "Authorize the Proliferate GitHub App so Cloud can use your GitHub identity for repository access.",
+      steps: setupSteps({
+        userAuthorized: false,
+        installationInstalled: false,
+        returnGuidance,
+      }),
       actionLabel: userAuthorizationNeedsReconnect
         ? "Reauthorize GitHub App"
         : "Authorize GitHub App",
@@ -64,6 +86,11 @@ export function buildGitHubAppPrerequisiteBlocker({
       return {
         title: "Install GitHub App",
         description: "Install the Proliferate GitHub App for this organization before adding Cloud environments.",
+        steps: setupSteps({
+          userAuthorized: true,
+          installationInstalled: false,
+          returnGuidance,
+        }),
         actionLabel: "Install GitHub App",
         actionLoading: installingGitHubApp,
         onAction: onInstallGitHubApp,
@@ -72,12 +99,57 @@ export function buildGitHubAppPrerequisiteBlocker({
     return {
       title: "GitHub App installation required",
       description: "Ask an organization admin to install the Proliferate GitHub App before adding Cloud environments.",
+      steps: setupSteps({
+        userAuthorized: true,
+        installationInstalled: false,
+        returnGuidance: "An organization owner or admin must choose repository access before you can continue.",
+      }),
       actionLabel: "Copy admin request",
       onAction: onCopyAdminRequest,
     };
   }
 
   return null;
+}
+
+function setupSteps({
+  userAuthorized,
+  installationInstalled,
+  returnGuidance,
+}: {
+  userAuthorized: boolean;
+  installationInstalled: boolean;
+  returnGuidance: string;
+}): NonNullable<CloudRepoPickerBlockerView["steps"]> {
+  return [
+    setupStep(
+      "Authorize your GitHub identity",
+      userAuthorized ? "GitHub identity authorized." : returnGuidance,
+      userAuthorized ? "complete" : "current",
+    ),
+    setupStep(
+      "Install for repository access",
+      installationInstalled
+        ? "Organization repository access installed."
+        : userAuthorized
+          ? returnGuidance
+          : "Choose organization repository access after authorization.",
+      installationInstalled ? "complete" : userAuthorized ? "current" : "upcoming",
+    ),
+    setupStep(
+      "Choose a repository",
+      "Select the repository for the cloud environment.",
+      userAuthorized && installationInstalled ? "current" : "upcoming",
+    ),
+  ];
+}
+
+function setupStep(
+  label: string,
+  description: string,
+  status: "complete" | "current" | "upcoming",
+): NonNullable<CloudRepoPickerBlockerView["steps"]>[number] {
+  return { label, description, status };
 }
 
 export function mergeRepositories(

--- a/apps/packages/product-surfaces/src/settings/cloud-environments/use-add-cloud-environment.ts
+++ b/apps/packages/product-surfaces/src/settings/cloud-environments/use-add-cloud-environment.ts
@@ -172,6 +172,10 @@ export function useAddCloudEnvironment({
       void installGitHubApp();
     },
     onCopyAdminRequest: copyAdminRequest,
+    returnSurface: githubSetupReturnSurface(
+      userAuthorizationReturnTo,
+      installationReturnTo,
+    ),
   });
 
   const repositoryById = useMemo(() => {
@@ -292,6 +296,16 @@ export function useAddCloudEnvironment({
       }
     },
   };
+}
+
+function githubSetupReturnSurface(
+  userAuthorizationReturnTo: string | null,
+  installationReturnTo: string | null,
+): "desktop" | "web" {
+  const returnTargets = [userAuthorizationReturnTo, installationReturnTo].filter(Boolean);
+  return returnTargets.some((target) => target?.startsWith("proliferate"))
+    ? "desktop"
+    : "web";
 }
 
 function useDebouncedValue(value: string, delayMs: number): string {

--- a/apps/packages/product-ui/src/billing/billing-types.ts
+++ b/apps/packages/product-ui/src/billing/billing-types.ts
@@ -14,6 +14,7 @@ export interface BillingPlanView {
   concurrentSandboxLimit?: number | null;
   activeSandboxCount: number;
   isPaidCloud: boolean;
+  paymentHealthy?: boolean;
   overageEnabled: boolean;
   hostedInvoiceUrl?: string | null;
   startBlocked: boolean;

--- a/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
+++ b/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
@@ -19,6 +19,7 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { PopoverSearchField } from "@proliferate/ui/primitives/PopoverSearchField";
 import { SkeletonBlock, shimmerDelay } from "@proliferate/ui/primitives/Skeleton";
+import { CloudRepoPickerBlocker } from "./CloudRepoPickerBlocker";
 
 export type CloudRepoConfigState = "missing" | "disabled" | "configured";
 
@@ -186,73 +187,6 @@ export function CloudRepoPicker({
           Add
         </Button>
       </form>
-    </div>
-  );
-}
-
-/** Staged prerequisite state with one primary action for the current step. */
-function CloudRepoPickerBlocker({
-  blocker,
-}: {
-  blocker: CloudRepoPickerBlockerView;
-}) {
-  return (
-    <div>
-      <div className="flex items-start gap-3 py-1">
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-surface-control text-muted-foreground">
-          <ShieldAlert size={15} aria-hidden />
-        </span>
-        <span className="min-w-0 flex-1">
-          <h3 className="text-ui font-medium leading-5 text-foreground">{blocker.title}</h3>
-          <p className="mt-0.5 text-ui-sm leading-[1.45] text-muted-foreground">
-            {blocker.description}
-          </p>
-        </span>
-      </div>
-      {blocker.steps?.length ? (
-        <ol className="mt-4 space-y-3" aria-label="GitHub setup progress">
-          {blocker.steps.map((step, index) => (
-            <li
-              key={step.label}
-              className="flex items-start gap-3"
-              aria-current={step.status === "current" ? "step" : undefined}
-            >
-              <span
-                className={[
-                  "flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-medium",
-                  step.status === "complete"
-                    ? "bg-success-subtle text-success"
-                    : step.status === "current"
-                      ? "bg-foreground text-background"
-                      : "bg-surface-control text-muted-foreground",
-                ].join(" ")}
-                aria-hidden
-              >
-                {step.status === "complete" ? <Check size={12} /> : index + 1}
-              </span>
-              <span className="min-w-0">
-                <span className="block text-ui font-medium text-foreground">{step.label}</span>
-                <span className="mt-0.5 block text-ui-sm leading-[1.45] text-muted-foreground">
-                  {step.description}
-                </span>
-              </span>
-            </li>
-          ))}
-        </ol>
-      ) : null}
-      {blocker.actionLabel && blocker.onAction ? (
-        <div className="mt-4 flex justify-end">
-          <Button
-            type="button"
-            variant="primary"
-            size="md"
-            loading={blocker.actionLoading}
-            onClick={blocker.onAction}
-          >
-            {blocker.actionLabel}
-          </Button>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
+++ b/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
@@ -43,9 +43,16 @@ export interface CloudRepoPickerRepositoryView {
 export interface CloudRepoPickerBlockerView {
   title: string;
   description: string;
+  steps?: readonly CloudRepoPickerSetupStepView[];
   actionLabel?: string | null;
   actionLoading?: boolean;
   onAction?: (() => void) | null;
+}
+
+export interface CloudRepoPickerSetupStepView {
+  label: string;
+  description: string;
+  status: "complete" | "current" | "upcoming";
 }
 
 export interface CloudRepoPickerProps {
@@ -183,7 +190,7 @@ export function CloudRepoPicker({
   );
 }
 
-/** Compact prerequisite state: icon + one-liner + a single primary action. */
+/** Staged prerequisite state with one primary action for the current step. */
 function CloudRepoPickerBlocker({
   blocker,
 }: {
@@ -202,6 +209,37 @@ function CloudRepoPickerBlocker({
           </p>
         </span>
       </div>
+      {blocker.steps?.length ? (
+        <ol className="mt-4 space-y-3" aria-label="GitHub setup progress">
+          {blocker.steps.map((step, index) => (
+            <li
+              key={step.label}
+              className="flex items-start gap-3"
+              aria-current={step.status === "current" ? "step" : undefined}
+            >
+              <span
+                className={[
+                  "flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-medium",
+                  step.status === "complete"
+                    ? "bg-success-subtle text-success"
+                    : step.status === "current"
+                      ? "bg-foreground text-background"
+                      : "bg-surface-control text-muted-foreground",
+                ].join(" ")}
+                aria-hidden
+              >
+                {step.status === "complete" ? <Check size={12} /> : index + 1}
+              </span>
+              <span className="min-w-0">
+                <span className="block text-ui font-medium text-foreground">{step.label}</span>
+                <span className="mt-0.5 block text-ui-sm leading-[1.45] text-muted-foreground">
+                  {step.description}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : null}
       {blocker.actionLabel && blocker.onAction ? (
         <div className="mt-4 flex justify-end">
           <Button

--- a/apps/packages/product-ui/src/repos/CloudRepoPickerBlocker.tsx
+++ b/apps/packages/product-ui/src/repos/CloudRepoPickerBlocker.tsx
@@ -1,0 +1,70 @@
+import { Check, ShieldAlert } from "lucide-react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import type { CloudRepoPickerBlockerView } from "./CloudRepoPicker";
+
+/** Staged prerequisite state with one primary action for the current step. */
+export function CloudRepoPickerBlocker({
+  blocker,
+}: {
+  blocker: CloudRepoPickerBlockerView;
+}) {
+  return (
+    <div>
+      <div className="flex items-start gap-3 py-1">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-surface-control text-muted-foreground">
+          <ShieldAlert size={15} aria-hidden />
+        </span>
+        <span className="min-w-0 flex-1">
+          <h3 className="text-ui font-medium leading-5 text-foreground">{blocker.title}</h3>
+          <p className="mt-0.5 text-ui-sm leading-[1.45] text-muted-foreground">
+            {blocker.description}
+          </p>
+        </span>
+      </div>
+      {blocker.steps?.length ? (
+        <ol className="mt-4 space-y-3" aria-label="GitHub setup progress">
+          {blocker.steps.map((step, index) => (
+            <li
+              key={step.label}
+              className="flex items-start gap-3"
+              aria-current={step.status === "current" ? "step" : undefined}
+            >
+              <span
+                className={[
+                  "flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-medium",
+                  step.status === "complete"
+                    ? "bg-success-subtle text-success"
+                    : step.status === "current"
+                      ? "bg-foreground text-background"
+                      : "bg-surface-control text-muted-foreground",
+                ].join(" ")}
+                aria-hidden
+              >
+                {step.status === "complete" ? <Check size={12} /> : index + 1}
+              </span>
+              <span className="min-w-0">
+                <span className="block text-ui font-medium text-foreground">{step.label}</span>
+                <span className="mt-0.5 block text-ui-sm leading-[1.45] text-muted-foreground">
+                  {step.description}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+      {blocker.actionLabel && blocker.onAction ? (
+        <div className="mt-4 flex justify-end">
+          <Button
+            type="button"
+            variant="primary"
+            size="md"
+            loading={blocker.actionLoading}
+            onClick={blocker.onAction}
+          >
+            {blocker.actionLabel}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/specs/codebase/platforms/product/billing.md
+++ b/specs/codebase/platforms/product/billing.md
@@ -121,6 +121,12 @@ matching client contracts.
 Desktop and Web both reuse the same
 [`BillingSettingsSurface`](../../../../apps/packages/product-surfaces/src/settings/BillingSettingsSurface.tsx).
 That shared surface does not make their organization navigation identical.
+It reads the selected owner's plan and both unit balances independently. The
+surface must preserve loading, error, deployment-disabled, and absent-data
+states; it must not present a default plan, active status, zero balance, or
+sample compute balance when the corresponding backend read is unavailable.
+Plan status reflects returned entitlement and health fields, including holds,
+payment health, legacy status, and unlimited access where applicable.
 Mobile has a smaller personal
 [`Billing section`](../../../../apps/mobile/src/components/settings/MobileSettingsScreen.tsx)
 that shows plan and usage state and exposes the available portal, checkout, or

--- a/specs/codebase/platforms/product/sandbox-github-auth.md
+++ b/specs/codebase/platforms/product/sandbox-github-auth.md
@@ -64,6 +64,15 @@ Existing Cloud repo:
   unavailable until authority is restored
 ```
 
+The add-repository UI presents user authorization, organization installation,
+and repository selection as separate ordered steps. It identifies the current
+step, preserves completed prerequisites, and exposes only the action for the
+current blocker. Redirect guidance is host-aware: Web explains that GitHub
+returns to the current browser, while Desktop explains that GitHub opens in a
+browser and then returns to Proliferate Desktop. A member who cannot install
+the app gets an actionable organization-admin request instead of an install
+control they cannot use.
+
 ## Token Model
 
 GitHub App user access tokens are the only sandbox Git credential source.

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -366,7 +366,7 @@ Members
     sign-in. Domain auto-join uses the same link but is Enterprise-only.
 
 Billing
-  maturity: mixed real-now + mocked-ui
+  maturity: real-now; plan comparison remains described separately below
   owns:
     current plan, Manage action, Proliferate Credits summary, add credits,
     auto top-up, and billing portal.
@@ -374,10 +374,10 @@ Billing
     Desktop and Web reuse BillingSettingsSurface. The Billing page starts with
     current plan and credits. Plan comparison and upgrade detail live inside
     the Manage modal. Stripe portal is the cancellation/payment-method
-    surface.
-  mocked-ui:
-    when plan or visible grant data is unavailable, the shared surface uses a
-    labeled plan fallback and deterministic compute-balance values.
+    surface. Current plan, status, compute units, and LLM credits come only
+    from the selected billing owner's server state. Loading, error, disabled,
+    and absent-data states are explicit and never substitute deterministic
+    plan or balance values.
 
 Usage & Limits
   maturity: real-now, admin-only on Desktop


### PR DESCRIPTION
## Summary

- replace mocked billing plan and 360/118/242 PCU fallbacks with selected-owner plan, entitlement, health, compute, and LLM states from Cloud
- render explicit loading, error, retry, deployment-disabled, and absent-data states without presenting invented plan or balance values
- stage GitHub Cloud setup as authorization → organization installation → repository selection, with Web/Desktop return guidance and the existing admin-request path
- update the authoritative billing, settings IA, and sandbox GitHub auth contracts

### Reproduction and root cause

Signed-in production Web inspection showed the real organization billing state as Core with 37.7 of 40 PCUs available. A source and route audit found no relevant literal “Computer”; the founder report is treated as “Compute” because the billing surface was the only matching user-visible concept.

The shared billing surface returned a hard-coded Core/$20 “Mocked” plan and 360/118/242 PCUs whenever plan or visible grant data was missing. It also ignored query errors, unconditionally labeled returned plans Active, and queried personal billing for non-admin organization members while labeling the result as organization billing.

The Cloud repository picker enforced the correct authorization and installation prerequisites, but reduced each blocker to a one-line card. It did not expose the ordered journey or explain whether GitHub would return to Web or Desktop.

### Implementation

- organization selection now controls billing reads independently of billing-admin mutation permission
- plan badges reflect returned blocked, payment-health, legacy, unlimited, paid, and free state
- compute falls back only to real returned plan totals when grant allocations are absent; LLM and compute failures remain independent and retryable
- GitHub blocker view models include completed/current/upcoming setup steps and derive return guidance from the existing host return URL
- deterministic billing fallback language was removed from the target settings contract

### Assumptions and residual risk

- “Computer” is interpreted as “Compute”; repository search and signed-in UI inspection found no billing/plan surface using the literal noun “Computer”
- the signed-in account already had GitHub authorization and installation, so no live access was revoked to force a missing-prerequisite state; both missing states and both host return paths are covered by rendered integration tests
- host-aware guidance uses the established `proliferate://`/Desktop return target versus an HTTP/Web target

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm --filter @proliferate/product-surfaces exec vitest run src/settings/BillingSettingsSurface.test.tsx src/settings/CloudEnvironmentsSettingsSurface.test.tsx --reporter=dot` (17 passed)
- `pnpm --filter @proliferate/product-surfaces exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @proliferate/product-ui test -- --reporter=dot` (184 passed)
- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- signed-in production Web baseline: Billing showed the backend-backed Core state and 37.7/40 PCUs; Settings → Environments opened the installed-app repository picker without external mutations
