### PR TITLE
fix(product-client): recover ready workspace composer

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
@@ -72,6 +72,30 @@ describe("TranscriptPendingPromptRow", () => {
     expect(actions.retryPrompt).toHaveBeenCalledWith("prompt-1");
   });
 
+  it("shows an actionable retry when projected session launch requires login", () => {
+    const actions = {
+      retryPrompt: vi.fn(),
+      dismissPrompt: vi.fn(),
+    };
+    render(
+      <TranscriptPendingPromptRow
+        activeSessionId="client-session:claude:1"
+        rowIndex={0}
+        prompt={createOptimisticPendingPrompt("Run after login", "prompt-1", NOW)}
+        outboxEntry={failedOutboxEntry(
+          "agent 'claude' is not ready (status: LoginRequired)",
+        )}
+        optimisticTrailingStatus={null}
+        outboxActions={actions}
+      />,
+    );
+
+    expect(screen.getByText(/LoginRequired/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(actions.retryPrompt).toHaveBeenCalledWith("prompt-1");
+  });
+
   it("shows the delivery error and retry for unconfirmed dispatches", () => {
     const actions = {
       retryPrompt: vi.fn(),

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts
@@ -8,13 +8,10 @@ import {
   resolveChatInputAvailability,
   type ChatInputAvailabilityState,
 } from "#product/lib/domain/chat/composer/chat-input";
-import { launchSelectionIsAvailable } from "#product/lib/domain/chat/models/launch-selection-defaults";
-import { getProviderDisplayName } from "#product/lib/domain/agents/provider-display";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useConfiguredLaunchReadiness } from "#product/hooks/chat/derived/use-configured-launch-readiness";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
-import { useActiveSessionLaunchState } from "#product/hooks/chat/derived/use-active-session-config-state";
 
 export type ChatAvailabilityState = ChatInputAvailabilityState;
 
@@ -39,7 +36,6 @@ export function useChatAvailabilityState(options?: {
   const { data: workspaceCollections } = useWorkspaces();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
   const configuredLaunch = useConfiguredLaunchReadiness();
-  const { currentLaunchIdentity } = useActiveSessionLaunchState();
 
   const selectedCloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
   const selectedCloudWorkspace =
@@ -56,18 +52,6 @@ export function useChatAvailabilityState(options?: {
     selectedCloudRuntimePhase: selectedCloudRuntime.state?.phase ?? null,
     selectedCloudRuntimeActionBlockReason: selectedCloudRuntime.state?.actionBlockReason ?? null,
     activeSessionId,
-    activeSessionLaunchDisabledReason:
-      activeSessionId
-      && currentLaunchIdentity
-      && !launchSelectionIsAvailable(
-        configuredLaunch.launchCatalog.launchAgents,
-        currentLaunchIdentity,
-      )
-        ? `${
-          getProviderDisplayName(currentLaunchIdentity.kind)
-          ?? currentLaunchIdentity.kind
-        } isn't ready on this target. Open a new chat with a ready agent.`
-        : null,
     isConfiguredLaunchLoading: configuredLaunch.isLoading,
     hasReadyConfiguredLaunch: configuredLaunch.isReady,
     configuredLaunchDisabledReason: configuredLaunch.disabledReason,
@@ -79,8 +63,6 @@ export function useChatAvailabilityState(options?: {
     configuredLaunch.disabledReason,
     configuredLaunch.isLoading,
     configuredLaunch.isReady,
-    configuredLaunch.launchCatalog.launchAgents,
-    currentLaunchIdentity,
     pendingWorkspaceEntry,
     primaryPendingInteractionKind,
     selectedCloudRuntime.state?.actionBlockReason,

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSelectedCloudRuntimeRehydration } from "#product/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration";
+import type { SelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const mocks = vi.hoisted(() => ({
+  bootstrapWorkspace: vi.fn(),
+  materializePendingWorkspaceSessions: vi.fn(),
+  materializeReadyWorkspaceProjectedSessions: vi.fn(),
+  withFreshCloudSandboxGatewayAccessToken: vi.fn(async <T,>(connectionInfo: T) => connectionInfo),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-bootstrap-actions", () => ({
+  useWorkspaceBootstrapActions: () => ({
+    bootstrapWorkspace: mocks.bootstrapWorkspace,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-pending-workspace-session-materialization", () => ({
+  usePendingWorkspaceSessionMaterialization: () =>
+    mocks.materializePendingWorkspaceSessions,
+  useReadyWorkspaceProjectedSessionMaterialization: () =>
+    mocks.materializeReadyWorkspaceProjectedSessions,
+}));
+
+vi.mock("#product/hooks/workspaces/lifecycle/workspace-bootstrap-memory", () => ({
+  hasWorkspaceBootstrappedInSession: () => true,
+}));
+
+vi.mock("#product/lib/access/cloud/cloud-sandbox-gateway", () => ({
+  withFreshCloudSandboxGatewayAccessToken:
+    mocks.withFreshCloudSandboxGatewayAccessToken,
+}));
+
+vi.mock("#product/lib/infra/measurement/measurement-port", () => ({
+  logLatency: vi.fn(),
+  startLatencyTimer: vi.fn(() => 0),
+}));
+
+describe("useSelectedCloudRuntimeRehydration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.getState().clearSelection();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("recovers an unmaterialized projected root session in an already-ready workspace", async () => {
+    useSessionSelectionStore.setState({
+      selectedLogicalWorkspaceId: "cloud:workspace-real",
+      selectedWorkspaceId: "workspace-real",
+      pendingWorkspaceEntry: null,
+      activeSessionId: "client-session:claude:1",
+    });
+    putSessionRecord({
+      ...createEmptySessionRecord("client-session:claude:1", "claude", {
+        workspaceId: "workspace-real",
+        materializedSessionId: null,
+        modelId: "opus",
+        requestedModelId: "opus",
+        sessionRelationship: { kind: "root" },
+      }),
+      status: "errored",
+      transcriptHydrated: true,
+    });
+
+    renderHook(() => useSelectedCloudRuntimeRehydration(readyCloudRuntime()));
+
+    await waitFor(() => {
+      expect(mocks.materializeReadyWorkspaceProjectedSessions).toHaveBeenCalledWith(
+        "workspace-real",
+        { eventPrefix: "workspace.cloud_runtime_rehydration" },
+      );
+    });
+    expect(mocks.bootstrapWorkspace).not.toHaveBeenCalled();
+    expect(mocks.materializePendingWorkspaceSessions).not.toHaveBeenCalled();
+  });
+});
+
+function readyCloudRuntime(): SelectedCloudRuntimeState {
+  return {
+    workspaceId: "workspace-real",
+    cloudWorkspaceId: "workspace-real",
+    state: {
+      phase: "ready",
+      variant: "warm",
+      tone: "pending",
+      title: null,
+      subtitle: null,
+      actionBlockReason: null,
+      preserveVisibleContent: false,
+      showRetry: false,
+      showClaim: false,
+    },
+    connectionInfo: {
+      runtimeUrl: "https://runtime.invalid",
+      accessToken: "test-token",
+      anyharnessWorkspaceId: "anyharness-workspace-1",
+    } as SelectedCloudRuntimeState["connectionInfo"],
+    retry: null,
+    claim: null,
+    claimPending: false,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
@@ -12,6 +12,9 @@ import { hasWorkspaceBootstrappedInSession } from "#product/hooks/workspaces/lif
 import type { SelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { withFreshCloudSandboxGatewayAccessToken } from "#product/lib/access/cloud/cloud-sandbox-gateway";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  isProjectedSessionMaterializationCandidate,
+} from "#product/lib/domain/sessions/creation/projected-session-materialization";
 
 export function useSelectedCloudRuntimeRehydration(
   selectedCloudRuntime: SelectedCloudRuntimeState,
@@ -34,9 +37,7 @@ export function useSelectedCloudRuntimeRehydration(
     return (state.sessionIdsByWorkspaceId[workspaceId] ?? [])
       .filter((sessionId) => {
         const entry = state.entriesById[sessionId];
-        return !!entry
-          && !entry.materializedSessionId
-          && entry.sessionRelationship.kind === "pending";
+        return entry ? isProjectedSessionMaterializationCandidate(entry) : false;
       })
       .join("|");
   });
@@ -81,7 +82,12 @@ export function useSelectedCloudRuntimeRehydration(
       return;
     }
 
-    if (!shouldRehydrateOnReadyRef.current && isBootstrapped && !hasAwaitingPendingWorkspaceEntry) {
+    if (
+      !shouldRehydrateOnReadyRef.current
+      && isBootstrapped
+      && !hasAwaitingPendingWorkspaceEntry
+      && !hasUnmaterializedProjectedSessions
+    ) {
       return;
     }
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx
@@ -88,6 +88,7 @@ describe("usePendingWorkspaceSessionMaterialization", () => {
       modelId: "opus",
       modeId: "default",
       hasAttemptedPrompt: true,
+      sessionRelationship: { kind: "root" },
     }));
 
     const materializeReadyWorkspaceProjectedSessions =

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts
@@ -13,6 +13,9 @@ import type {
   CreateEmptySessionWithResolvedConfigOptions,
 } from "#product/hooks/sessions/workflows/session-creation-types";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
+import {
+  isProjectedSessionMaterializationCandidate,
+} from "#product/lib/domain/sessions/creation/projected-session-materialization";
 
 interface PendingWorkspaceSessionMaterializationOptions {
   eventPrefix?: string;
@@ -157,10 +160,7 @@ export function useReadyWorkspaceProjectedSessionMaterialization() {
   ): PendingWorkspaceSessionMaterializationResult => {
     const eventPrefix = options?.eventPrefix ?? "workspace.ready_projected_session";
     const projectedSessions = Object.values(getWorkspaceSessionRecords(workspaceId))
-      .filter((session) =>
-        !session.materializedSessionId
-        && session.sessionRelationship.kind === "pending"
-      );
+      .filter(isProjectedSessionMaterializationCandidate);
     const projectedSessionIds = projectedSessions.map((session) => session.sessionId);
 
     let materializationStartCount = 0;

--- a/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts
@@ -106,6 +106,49 @@ describe("resolveChatInputAvailability", () => {
     });
   });
 
+  it("keeps a ready workspace composer queueable when its projected session launch fails", () => {
+    expect(resolveChatInputAvailability({
+      selectedWorkspaceId: "cloud:workspace-1",
+      isCloudWorkspaceSelected: true,
+      connectionState: "healthy",
+      selectedCloudWorkspaceStatus: "ready",
+      selectedCloudWorkspaceActionBlockReason: null,
+      selectedCloudRuntimePhase: "ready",
+      selectedCloudRuntimeActionBlockReason: null,
+      activeSessionId: "client-session:claude:1",
+      isConfiguredLaunchLoading: false,
+      hasReadyConfiguredLaunch: false,
+      configuredLaunchDisabledReason: "agent 'claude' is not ready (status: LoginRequired)",
+      pendingWorkspaceEntry: null,
+    })).toEqual({
+      isDisabled: false,
+      disabledReason: null,
+      areRuntimeControlsDisabled: false,
+      selectedWorkspaceKind: "cloud",
+    });
+  });
+
+  it("still blocks a new session when no configured launch is ready", () => {
+    expect(resolveChatInputAvailability({
+      selectedWorkspaceId: "cloud:workspace-1",
+      isCloudWorkspaceSelected: true,
+      connectionState: "healthy",
+      selectedCloudWorkspaceStatus: "ready",
+      selectedCloudWorkspaceActionBlockReason: null,
+      selectedCloudRuntimePhase: "ready",
+      selectedCloudRuntimeActionBlockReason: null,
+      activeSessionId: null,
+      isConfiguredLaunchLoading: false,
+      hasReadyConfiguredLaunch: false,
+      configuredLaunchDisabledReason: "Choose a ready agent.",
+      pendingWorkspaceEntry: null,
+    })).toMatchObject({
+      isDisabled: true,
+      disabledReason: "Choose a ready agent.",
+      areRuntimeControlsDisabled: false,
+    });
+  });
+
   it("keeps pending approval, user-input, and MCP elicitation as chat blockers", () => {
     const base = {
       selectedWorkspaceId: "workspace-1",

--- a/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.ts
@@ -7,7 +7,6 @@ interface ChatInputAvailabilityArgs {
   selectedCloudRuntimePhase: "ready" | "resuming" | "failed" | "claim_required" | null;
   selectedCloudRuntimeActionBlockReason: string | null;
   activeSessionId: string | null;
-  activeSessionLaunchDisabledReason?: string | null;
   isConfiguredLaunchLoading: boolean;
   hasReadyConfiguredLaunch: boolean;
   configuredLaunchDisabledReason: string | null;
@@ -71,7 +70,6 @@ export function resolveChatInputAvailability({
   selectedCloudRuntimePhase,
   selectedCloudRuntimeActionBlockReason,
   activeSessionId,
-  activeSessionLaunchDisabledReason = null,
   isConfiguredLaunchLoading,
   hasReadyConfiguredLaunch,
   configuredLaunchDisabledReason,
@@ -154,15 +152,6 @@ export function resolveChatInputAvailability({
     return {
       isDisabled: true,
       disabledReason: configuredLaunchDisabledReason ?? "Your chosen default agent is not ready yet.",
-      areRuntimeControlsDisabled: false,
-      selectedWorkspaceKind,
-    };
-  }
-
-  if (activeSessionId && activeSessionLaunchDisabledReason) {
-    return {
-      isDisabled: true,
-      disabledReason: activeSessionLaunchDisabledReason,
       areRuntimeControlsDisabled: false,
       selectedWorkspaceKind,
     };

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/projected-session-materialization.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/projected-session-materialization.ts
@@ -1,0 +1,16 @@
+import type { SessionDirectoryEntry } from "#product/lib/domain/sessions/directory/directory-entry";
+
+/**
+ * A client-owned root session may exist before AnyHarness assigns its runtime
+ * session id. `pending` is retained for older/pre-classification records, but
+ * child sessions are materialized by their owning parent-session flow.
+ */
+export function isProjectedSessionMaterializationCandidate(
+  session: SessionDirectoryEntry,
+): boolean {
+  return session.materializedSessionId === null
+    && (
+      session.sessionRelationship.kind === "root"
+      || session.sessionRelationship.kind === "pending"
+    );
+}


### PR DESCRIPTION
## Summary

- Keep the composer writable and queueable after a cloud workspace/runtime reaches ready, even when its projected agent session fails to launch.
- Recover unmaterialized projected root sessions through the ready-workspace lifecycle instead of filtering them out as non-pending relationships.
- Preserve intentional blockers for provisioning/runtime readiness and new-session launches, while retaining the existing transcript-level error with Retry/Dismiss for genuine session launch failures.

## Readiness

- [ ] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Reproduction and root cause

In signed-in hosted Web, creating a cloud workspace entered a stable workspace route and the workspace reported Ready. The initial prompt then failed with `agent 'claude' is not ready (status: LoginRequired)`, while the composer remained read-only with a misleading `Waiting for workspace` state. This confirmed that control-plane workspace creation completed and the stuck state was in session initialization/UI readiness.

Two state-separation bugs combined:

1. Projected sessions are created as `sessionRelationship.kind === "root"`, but ready-workspace recovery only selected `"pending"` relationships. An additional bootstrapped-workspace guard also returned before recovering an unmaterialized projected session.
2. Composer availability treated an unavailable active session launch identity as a workspace/chat blocker. That prevented typing and queuing work even though the projected session and prompt-intent outbox were the correct owners of recovery.

The fix classifies unmaterialized root/pre-classification sessions as materialization candidates, lets ready bootstrapped workspaces recover them, and scopes catalog-readiness blocking to opening a new session. Existing-session prompts remain queueable; a genuine launch failure stays visible in the transcript and its existing Retry action rematerializes the same client session.

## Verification

- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client build`
- From `apps/packages/product-client`:
  `pnpm exec vitest run src/lib/domain/chat/composer/chat-input.test.ts src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.test.tsx src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx`
  - 4 files passed, 19 tests passed.
- Manual pre-fix validation: hosted Web cloud create -> Ready workspace route -> projected session `LoginRequired` failure -> disabled/misleading composer. Browser console had no related errors.

## Assumptions and residual risk

- The hosted Web build used for reproduction may lag current `main`; the fix is applied to the shared ProductClient now owned by both Desktop and Web.
- No branch deployment was created, so manual post-fix validation is represented by focused state-transition/UI tests rather than a hosted candidate pass.
- Agent authentication remains an intentional session-level failure. Retry can only succeed after that agent becomes ready; until then the queued prompt remains explicit and recoverable.
- No documentation changed because the authoritative pending-shell contract already requires projected chat work to remain usable before runtime acknowledgement.