### PR TITLE
fix(cloud): gate repository access and make removal truthful

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -265,7 +265,7 @@ export function HomeNextScreen() {
                   onClick={() => configureCloud()}
                   className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
                 >
-                  Configure
+                  {homeNext.cloudRepoAction.label}
                 </Button>
               ) : null
             }

--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
@@ -110,15 +110,18 @@ describe("HomeTargetPicker", () => {
     expect(callbacks.onSelectRuntime).toHaveBeenCalledWith("local");
   });
 
-  it("routes unconfigured cloud choices to cloud setup", () => {
+  it("routes repository-access gates to cloud setup with precise copy", () => {
     const callbacks = renderPicker({
       cloudActionBySourceRoot: {
-        [keystoneRepository.sourceRoot]: { kind: "configure", label: "Configure cloud" },
+        [keystoneRepository.sourceRoot]: {
+          kind: "configure",
+          label: "Grant repository access",
+        },
       },
     });
 
     fireEvent.click(screen.getByRole("button", { name: /New worktree/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Set up cloud/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Grant repository access/i }));
 
     expect(callbacks.onConfigureCloud).toHaveBeenCalledWith(keystoneRepository);
     expect(callbacks.onSelectRuntime).not.toHaveBeenCalledWith("cloud");

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -122,6 +122,10 @@ vi.mock("#product/hooks/cloud/facade/use-cloud-billing", () => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useRemoveCloudRepoEnvironment: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
   useRepositories: () => ({ data: { repositories: [] }, isPending: false }),
 }));
 

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
-import { useRepositories } from "@proliferate/cloud-sdk-react";
+import { useRemoveCloudRepoEnvironment, useRepositories } from "@proliferate/cloud-sdk-react";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { SidebarAccountFooter } from "#product/components/app/sidebar/SidebarAccountFooter";
@@ -21,6 +21,7 @@ import {
   isDefaultSidebarWorkspaceTypes,
 } from "#product/lib/domain/workspaces/sidebar/sidebar-workspace-types";
 import { buildConfiguredCloudRepoKeys } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
+import { cloudRepositoryKey } from "#product/lib/domain/settings/repositories";
 import {
   titleForStartBlockReason,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-status-presentation";
@@ -76,6 +77,7 @@ export const MainSidebar = memo(function MainSidebar() {
     isPending: isRepoConfigsPending,
   } = useRepositories(cloudActive);
   const showToast = useToastStore((state) => state.show);
+  const removeCloudRepoEnvironment = useRemoveCloudRepoEnvironment();
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
   const {
     sidebarOpen,
@@ -112,7 +114,6 @@ export const MainSidebar = memo(function MainSidebar() {
   const archiveWorkspace = useWorkspaceUiStore((s) => s.archiveWorkspace);
   const hideRepoRoot = useWorkspaceUiStore((s) => s.hideRepoRoot);
   const unarchiveWorkspace = useWorkspaceUiStore((s) => s.unarchiveWorkspace);
-  const unarchiveWorkspaces = useWorkspaceUiStore((s) => s.unarchiveWorkspaces);
   const { updateWorkspaceDisplayName } = useWorkspaceDisplayNameActions();
   const handleRenameWorkspace = useCallback(
     (workspaceId: string, displayName: string | null) =>
@@ -150,16 +151,28 @@ export const MainSidebar = memo(function MainSidebar() {
     selectedLogicalWorkspaceId,
   });
 
-  const handleRemoveRepo = useCallback((sourceRoot: string) => {
+  const handleRemoveRepo = useCallback(async (sourceRoot: string) => {
     const group = groups.find((g) => g.sourceRoot === sourceRoot);
-    if (group) {
-      unarchiveWorkspaces(group.allLogicalWorkspaceIds);
-      if (group.repoRootId) {
-        hideRepoRoot(group.repoRootId);
-      }
+    if (!group) {
+      return;
+    }
+    if (group.cloudRepoTarget && configuredCloudRepoKeys.has(cloudRepositoryKey(
+      group.cloudRepoTarget.gitOwner,
+      group.cloudRepoTarget.gitRepoName,
+    ))) {
+      await removeCloudRepoEnvironment.mutateAsync(group.cloudRepoTarget);
+    }
+    if (group.repoRootId) {
+      hideRepoRoot(group.repoRootId);
     }
     clearRepoGroupShowMore(sourceRoot);
-  }, [clearRepoGroupShowMore, groups, hideRepoRoot, unarchiveWorkspaces]);
+  }, [
+    clearRepoGroupShowMore,
+    configuredCloudRepoKeys,
+    groups,
+    hideRepoRoot,
+    removeCloudRepoEnvironment,
+  ]);
 
   const resolveArchiveTargetForSidebarItem = useCallback((
     workspaceId: string,
@@ -325,6 +338,7 @@ export const MainSidebar = memo(function MainSidebar() {
               onToggleRepoShowMore={handleToggleRepoShowMore}
               configuredCloudRepoKeys={configuredCloudRepoKeys}
               cloudRepoConfigsInitialLoading={cloudRepoConfigsInitialLoading}
+              cloudConnected={cloudActive}
               cloudWorkspaceEnabled={cloudActive && !cloudWorkspaceBlocked}
               cloudWorkspaceTooltip={cloudWorkspaceTooltip}
               onCreateWorktreeWorkspace={actions.handleCreateWorktreeWorkspace}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RepoGroup } from "#product/components/workspace/shell/sidebar/RepoGroup";
@@ -58,7 +58,24 @@ vi.mock("@proliferate/ui/primitives/PopoverMenuItem", () => ({
 }));
 
 vi.mock("@proliferate/ui/primitives/ConfirmationDialog", () => ({
-  ConfirmationDialog: () => null,
+  ConfirmationDialog: ({
+    description,
+    loading,
+    onConfirm,
+    open,
+  }: {
+    description: string;
+    loading?: boolean;
+    onConfirm: () => void;
+    open: boolean;
+  }) => open ? (
+    <div role="dialog">
+      <span>{description}</span>
+      <button type="button" disabled={loading} onClick={onConfirm}>
+        {loading ? "Removing repository" : "Confirm removal"}
+      </button>
+    </div>
+  ) : null,
 }));
 
 vi.mock("@proliferate/ui/layout/ShortcutBadge", () => ({
@@ -159,5 +176,54 @@ describe("RepoGroup new workspace command scope", () => {
     );
 
     expect(document.querySelector('[data-icon="folder-remote"]')).toBeTruthy();
+  });
+
+  it("keeps removal pending until the Cloud mutation settles", async () => {
+    let resolveRemoval!: () => void;
+    const removal = new Promise<void>((resolve) => {
+      resolveRemoval = resolve;
+    });
+    render(
+      <RepoGroup
+        name="Repo A"
+        count={0}
+        collapsed={false}
+        environmentKind="cloud"
+        onToggleCollapsed={vi.fn()}
+        onRemoveRepo={() => removal}
+      >
+        <div />
+      </RepoGroup>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove repository" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm removal" }));
+    expect(
+      screen.getByRole("button", { name: "Removing repository" }).hasAttribute("disabled"),
+    ).toBe(true);
+
+    resolveRemoval();
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("keeps removal failure visible for retry", async () => {
+    render(
+      <RepoGroup
+        name="Repo A"
+        count={0}
+        collapsed={false}
+        environmentKind="cloud"
+        onToggleCollapsed={vi.fn()}
+        onRemoveRepo={() => Promise.reject(new Error("Repository is still in use."))}
+      >
+        <div />
+      </RepoGroup>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove repository" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm removal" }));
+
+    expect(await screen.findByText(/Repository is still in use\./)).toBeTruthy();
+    expect(screen.getByRole("dialog")).toBeTruthy();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.tsx
@@ -33,7 +33,7 @@ interface RepoGroupProps {
   cloudWorkspaceLabel?: string;
   cloudWorkspaceEnabled?: boolean;
   cloudWorkspaceTooltip?: string;
-  onRemoveRepo?: () => void;
+  onRemoveRepo?: () => Promise<void> | void;
   onOpenSettings?: () => void;
 }
 
@@ -59,18 +59,28 @@ export function RepoGroup({
   onOpenSettings,
 }: RepoGroupProps) {
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
+  const [removePending, setRemovePending] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
   const setActiveNewWorkspaceScope = useNewWorkspaceCommandScopeStore((state) => state.setActiveScope);
   const clearActiveNewWorkspaceScope = useNewWorkspaceCommandScopeStore((state) => state.clearActiveScope);
   const handleRequestRemove = () => requestRepoRemovalConfirmation(
     () => setRemoveConfirmOpen(true),
   );
-  const handleConfirmRemove = () => {
-    confirmRepoRemoval({
-      closeConfirmation: () => setRemoveConfirmOpen(false),
-      removeRepo: onRemoveRepo,
-    });
+  const handleConfirmRemove = async () => {
+    setRemovePending(true);
+    setRemoveError(null);
+    try {
+      await confirmRepoRemoval({
+        closeConfirmation: () => setRemoveConfirmOpen(false),
+        removeRepo: onRemoveRepo,
+      });
+    } catch (error) {
+      setRemoveError(error instanceof Error ? error.message : "Could not remove repository.");
+    } finally {
+      setRemovePending(false);
+    }
   };
-  const removeConfirmationCopy = repoRemovalConfirmationCopy(name);
+  const removeConfirmationCopy = repoRemovalConfirmationCopy(name, environmentKind !== "local");
   const { onContextMenuCapture } = useRepoGroupNativeContextMenu({
     canOpenSettings: !!onOpenSettings,
     canRemoveRepo: !!onRemoveRepo,
@@ -216,11 +226,18 @@ export function RepoGroup({
       <ConfirmationDialog
         open={removeConfirmOpen}
         title={removeConfirmationCopy.title}
-        description={removeConfirmationCopy.description}
+        description={removeError
+          ? `${removeConfirmationCopy.description} ${removeError}`
+          : removeConfirmationCopy.description}
         confirmLabel={removeConfirmationCopy.confirmLabel}
         confirmVariant={removeConfirmationCopy.confirmVariant}
-        onClose={() => setRemoveConfirmOpen(false)}
-        onConfirm={handleConfirmRemove}
+        disableClose={removePending}
+        loading={removePending}
+        onClose={() => {
+          setRemoveConfirmOpen(false);
+          setRemoveError(null);
+        }}
+        onConfirm={() => void handleConfirmRemove()}
       />
 
       {/* Workspace items */}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -1,6 +1,7 @@
-import {
-  resolveCloudRepoActionState,
-  type CloudWorkspaceRepoTarget,
+import type { ReactNode } from "react";
+import type {
+  CloudRepoActionState,
+  CloudWorkspaceRepoTarget,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
 import { cloudRepositoryKey } from "#product/lib/domain/settings/repositories";
 import {
@@ -16,6 +17,7 @@ import { useWorkspaceCopyActions } from "#product/hooks/workspaces/workflows/use
 import { RepoGroup, type RepoGroupEnvironmentKind } from "#product/components/workspace/shell/sidebar/RepoGroup";
 import { SidebarShowToggleRow } from "#product/components/workspace/shell/sidebar/SidebarShowToggleRow";
 import { WorkspaceItem } from "#product/components/workspace/shell/sidebar/WorkspaceItem";
+import { useCloudRepoActionState } from "#product/hooks/cloud/derived/use-cloud-repo-action-state";
 
 interface SidebarWorkspaceContentProps {
   emptyState: SidebarEmptyState;
@@ -27,6 +29,7 @@ interface SidebarWorkspaceContentProps {
   onToggleRepoShowMore: (sourceRoot: string) => void;
   configuredCloudRepoKeys: ReadonlySet<string>;
   cloudRepoConfigsInitialLoading: boolean;
+  cloudConnected: boolean;
   cloudWorkspaceEnabled: boolean;
   cloudWorkspaceTooltip: string;
   onCreateWorktreeWorkspace: (repoRootId: string | null, repoGroupKeyToExpand: string) => void;
@@ -49,7 +52,7 @@ interface SidebarWorkspaceContentProps {
     workspaceId: string,
     displayName: string | null,
   ) => Promise<unknown>;
-  onRemoveRepo: (sourceRoot: string) => void;
+  onRemoveRepo: (sourceRoot: string) => Promise<void>;
   onOpenRepoSettings: (sourceRoot: string) => void;
 }
 
@@ -74,6 +77,7 @@ export function SidebarWorkspaceContent({
   onToggleRepoShowMore,
   configuredCloudRepoKeys,
   cloudRepoConfigsInitialLoading,
+  cloudConnected,
   cloudWorkspaceEnabled,
   cloudWorkspaceTooltip,
   onCreateWorktreeWorkspace,
@@ -138,11 +142,6 @@ export function SidebarWorkspaceContent({
       : isShownMore
         ? "Show less"
         : "Show more";
-    const cloudRepoAction = resolveCloudRepoActionState({
-      repoTarget: group.cloudRepoTarget,
-      configuredRepoKeys: configuredCloudRepoKeys,
-      isInitialConfigLoad: cloudRepoConfigsInitialLoading,
-    });
     const cloudRepoTarget = group.cloudRepoTarget;
     const hasArchivedHiddenItems =
       group.items.length === 0 && group.allLogicalWorkspaceIds.length > 0;
@@ -154,8 +153,15 @@ export function SidebarWorkspaceContent({
     });
 
     return (
-      <RepoGroup
+      <CloudRepoActionGate
         key={`${group.sourceRoot}:${group.repoRootId ?? "no-repo-root"}:${groupIndex}`}
+        repoTarget={group.cloudRepoTarget}
+        configuredRepoKeys={configuredCloudRepoKeys}
+        isInitialConfigLoad={cloudRepoConfigsInitialLoading}
+        cloudConnected={cloudConnected}
+      >
+        {(cloudRepoAction) => (
+      <RepoGroup
         name={group.name}
         count={group.items.length}
         collapsed={collapsedRepoGroupKeys.has(group.sourceRoot)}
@@ -256,8 +262,32 @@ export function SidebarWorkspaceContent({
           </>
         )}
       </RepoGroup>
+        )}
+      </CloudRepoActionGate>
     );
   });
+}
+
+function CloudRepoActionGate({
+  repoTarget,
+  configuredRepoKeys,
+  isInitialConfigLoad,
+  cloudConnected,
+  children,
+}: {
+  repoTarget: CloudWorkspaceRepoTarget | null;
+  configuredRepoKeys: ReadonlySet<string>;
+  isInitialConfigLoad: boolean;
+  cloudConnected: boolean;
+  children: (state: CloudRepoActionState) => ReactNode;
+}) {
+  const state = useCloudRepoActionState({
+    repoTarget,
+    configuredRepoKeys,
+    isInitialConfigLoad,
+    cloudConnected,
+  });
+  return children(state);
 }
 
 function resolveRepoGroupEnvironmentKind(

--- a/apps/packages/product-client/src/hooks/access/cloud/repository-removal-invalidation.test.ts
+++ b/apps/packages/product-client/src/hooks/access/cloud/repository-removal-invalidation.test.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { invalidateCloudRepoEnvironmentRemoval } from "@proliferate/cloud-sdk-react";
+
+describe("cloud repository removal invalidation", () => {
+  it("invalidates every repository authority and environment consumer", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    await invalidateCloudRepoEnvironmentRemoval(queryClient, "https://api.example.test", {
+      gitOwner: "acme",
+      gitRepoName: "rocket",
+    });
+
+    expect(invalidate.mock.calls.map(([filters]) => filters?.queryKey)).toEqual([
+      ["cloud", "repositories"],
+      ["cloud", "git-repositories"],
+      ["cloud", "github-app", "https://api.example.test"],
+      ["cloud", "secrets", "repos", "acme", "rocket"],
+    ]);
+  });
+});

--- a/apps/packages/product-client/src/hooks/app/workflows/use-app-command-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/workflows/use-app-command-actions.test.tsx
@@ -52,6 +52,11 @@ vi.mock("#product/hooks/cloud/facade/use-cloud-billing", () => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useGitHubRepoAuthority: () => ({
+    data: undefined,
+    isPending: false,
+    isError: false,
+  }),
   useRepositories: () => ({
     data: {
       repositories: [{

--- a/apps/packages/product-client/src/hooks/app/workflows/use-app-new-workspace-command-actions.ts
+++ b/apps/packages/product-client/src/hooks/app/workflows/use-app-new-workspace-command-actions.ts
@@ -14,8 +14,8 @@ import { useWorkspaceNavigationWorkflow } from "#product/hooks/workspaces/workfl
 import { buildCloudRepoSettingsHref } from "#product/lib/domain/settings/navigation";
 import {
   buildConfiguredCloudRepoKeys,
-  resolveCloudRepoActionState,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
+import { useCloudRepoActionState } from "#product/hooks/cloud/derived/use-cloud-repo-action-state";
 import {
   buildRepositoryNewWorkspaceCommandScope,
   buildSelectedWorkspaceNewWorkspaceCommandScope,
@@ -117,18 +117,12 @@ export function useAppNewWorkspaceCommandActions(): AppNewWorkspaceCommandAction
     activeNewWorkspaceScope
     ?? homeNewWorkspaceScope
     ?? selectedNewWorkspaceScope;
-  const commandCloudRepoAction = useMemo(
-    () => resolveCloudRepoActionState({
-      repoTarget: newWorkspaceCommandScope?.cloudRepoTarget ?? null,
-      configuredRepoKeys: configuredCloudRepoKeys,
-      isInitialConfigLoad: cloudRepoConfigsInitialLoading,
-    }),
-    [
-      cloudRepoConfigsInitialLoading,
-      configuredCloudRepoKeys,
-      newWorkspaceCommandScope?.cloudRepoTarget,
-    ],
-  );
+  const commandCloudRepoAction = useCloudRepoActionState({
+    repoTarget: newWorkspaceCommandScope?.cloudRepoTarget ?? null,
+    configuredRepoKeys: configuredCloudRepoKeys,
+    isInitialConfigLoad: cloudRepoConfigsInitialLoading,
+    cloudConnected: cloudActive,
+  });
 
   const showDisabledShortcutToast = useCallback((
     invocation: AppCommandInvocation,

--- a/apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-action-state.ts
+++ b/apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-action-state.ts
@@ -1,0 +1,34 @@
+import { useGitHubRepoAuthority } from "@proliferate/cloud-sdk-react";
+import {
+  resolveCloudRepoActionState,
+  type CloudWorkspaceRepoTarget,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
+import { cloudRepositoryKey } from "#product/lib/domain/settings/repositories";
+
+export function useCloudRepoActionState(args: {
+  repoTarget: CloudWorkspaceRepoTarget | null;
+  configuredRepoKeys: ReadonlySet<string>;
+  isInitialConfigLoad: boolean;
+  cloudConnected: boolean;
+}) {
+  const configured = args.repoTarget
+    ? args.configuredRepoKeys.has(cloudRepositoryKey(
+      args.repoTarget.gitOwner,
+      args.repoTarget.gitRepoName,
+    ))
+    : false;
+  const shouldCheckAuthority = args.cloudConnected
+    && configured
+    && !args.isInitialConfigLoad;
+  const authority = useGitHubRepoAuthority({
+    gitOwner: args.repoTarget?.gitOwner,
+    gitRepoName: args.repoTarget?.gitRepoName,
+  }, shouldCheckAuthority);
+
+  return resolveCloudRepoActionState({
+    ...args,
+    repoAuthority: authority.data,
+    isInitialAuthorityLoad: shouldCheckAuthority && authority.isPending && !authority.data,
+    authorityError: shouldCheckAuthority && authority.isError,
+  });
+}

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-repository-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-repository-selection.ts
@@ -8,7 +8,6 @@ import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use
 import {
   buildCloudRepoActionBySourceRoot,
   buildConfiguredCloudRepoKeys,
-  resolveCloudRepoActionState,
   type CloudRepoActionState,
   type CloudWorkspaceRepoTarget,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
@@ -27,6 +26,7 @@ import { expandLogicalWorkspaceRelatedIdSet } from "#product/lib/domain/workspac
 import { buildSettingsRepositoryEntries } from "#product/lib/domain/settings/repositories";
 import { useRepoPreferencesStore } from "#product/stores/preferences/repo-preferences-store";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useCloudRepoActionState } from "#product/hooks/cloud/derived/use-cloud-repo-action-state";
 
 const EMPTY_WORKSPACES: Workspace[] = [];
 const EMPTY_REPO_ROOTS: RepoRoot[] = [];
@@ -136,7 +136,7 @@ export function useHomeNextRepositorySelection({
   );
   const cloudRepoConfigsInitialLoading =
     cloudActive && repoConfigsQuery.isPending && !repoConfigsQuery.data;
-  const cloudRepoActionBySourceRoot = useMemo(() => buildCloudRepoActionBySourceRoot({
+  const baseCloudRepoActionBySourceRoot = useMemo(() => buildCloudRepoActionBySourceRoot({
     repositories,
     cloudActive,
     configuredRepoKeys: configuredCloudRepoKeys,
@@ -147,14 +147,21 @@ export function useHomeNextRepositorySelection({
     configuredCloudRepoKeys,
     repositories,
   ]);
-  const cloudRepoAction = useMemo<CloudRepoActionState>(
-    () => resolveCloudRepoActionState({
-      repoTarget: cloudRepoTarget,
-      configuredRepoKeys: configuredCloudRepoKeys,
-      isInitialConfigLoad: cloudRepoConfigsInitialLoading,
-    }),
-    [cloudRepoConfigsInitialLoading, cloudRepoTarget, configuredCloudRepoKeys],
-  );
+  const cloudRepoAction: CloudRepoActionState = useCloudRepoActionState({
+    repoTarget: cloudRepoTarget,
+    configuredRepoKeys: configuredCloudRepoKeys,
+    isInitialConfigLoad: cloudRepoConfigsInitialLoading,
+    cloudConnected: cloudActive,
+  });
+  const cloudRepoActionBySourceRoot = useMemo(() => {
+    if (!selectedRepository) {
+      return baseCloudRepoActionBySourceRoot;
+    }
+    return {
+      ...baseCloudRepoActionBySourceRoot,
+      [selectedRepository.sourceRoot]: cloudRepoAction,
+    };
+  }, [baseCloudRepoActionBySourceRoot, cloudRepoAction, selectedRepository]);
 
   const launchTarget = useMemo<HomeLaunchTarget | null>(() =>
     resolveHomeLaunchTarget({

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.ts
@@ -86,7 +86,7 @@ export function useHomeNextState({
         return "Loading cloud configuration";
       }
       if (repository.cloudRepoAction.kind === "configure") {
-        return "Configure cloud for this repository";
+        return repository.cloudRepoAction.label;
       }
       if (repository.cloudRepoAction.kind !== "create") {
         return "Cloud is unavailable for this repository";

--- a/apps/packages/product-client/src/lib/domain/home/home-target-picker.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-target-picker.ts
@@ -39,7 +39,7 @@ export function homeTargetRuntimeOptionLabel(input: {
     return input.cloudAction.label;
   }
   if (input.cloudAction.kind === "configure") {
-    return "Set up cloud";
+    return input.cloudAction.label;
   }
   if (input.cloudAction.kind === "hidden") {
     return "Cloud unavailable";

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts
@@ -65,25 +65,59 @@ describe("cloud workspace creation helpers", () => {
       repoTarget: null,
       configuredRepoKeys: new Set(),
       isInitialConfigLoad: false,
-    })).toEqual({ kind: "hidden", label: null });
+    })).toEqual({ kind: "hidden", label: null, accessState: "hidden" });
 
     expect(resolveCloudRepoActionState({
       repoTarget: { gitOwner: "acme", gitRepoName: "rocket" },
       configuredRepoKeys: new Set(),
       isInitialConfigLoad: true,
-    })).toEqual({ kind: "loading", label: "Loading cloud..." });
+    })).toEqual({ kind: "loading", label: "Loading cloud...", accessState: "loading" });
 
     expect(resolveCloudRepoActionState({
       repoTarget: { gitOwner: "acme", gitRepoName: "rocket" },
       configuredRepoKeys: new Set(),
       isInitialConfigLoad: false,
-    })).toEqual({ kind: "configure", label: "Configure cloud" });
+    })).toEqual({
+      kind: "configure",
+      label: "Configure cloud",
+      accessState: "repository_not_configured",
+    });
 
     expect(resolveCloudRepoActionState({
       repoTarget: { gitOwner: "acme", gitRepoName: "rocket" },
       configuredRepoKeys: new Set(["acme::rocket"]),
       isInitialConfigLoad: false,
-    })).toEqual({ kind: "create", label: "New cloud workspace" });
+    })).toEqual({ kind: "create", label: "New cloud workspace", accessState: "ready" });
+  });
+
+  it.each([
+    ["missing_user_authorization", "Connect GitHub App", "github_app_missing"],
+    ["expired_user_authorization", "Reconnect GitHub App", "github_app_expired"],
+    ["missing_installation", "Install Proliferate GitHub App", "github_app_not_installed"],
+    ["repo_not_covered", "Grant repository access", "repository_not_granted"],
+  ] as const)("gates configured repositories for %s", (status, label, accessState) => {
+    expect(resolveCloudRepoActionState({
+      repoTarget: { gitOwner: "acme", gitRepoName: "rocket" },
+      configuredRepoKeys: new Set(["acme::rocket"]),
+      isInitialConfigLoad: false,
+      repoAuthority: { authorized: false, status, action: null, message: null },
+    })).toEqual({ kind: "configure", label, accessState });
+  });
+
+  it("does not offer creation while repository authority is loading or failed", () => {
+    const base = {
+      repoTarget: { gitOwner: "acme", gitRepoName: "rocket" },
+      configuredRepoKeys: new Set(["acme::rocket"]),
+      isInitialConfigLoad: false,
+    };
+    expect(resolveCloudRepoActionState({
+      ...base,
+      isInitialAuthorityLoad: true,
+    })).toEqual({ kind: "loading", label: "Checking GitHub access...", accessState: "loading" });
+    expect(resolveCloudRepoActionState({
+      ...base,
+      authorityError: true,
+    })).toEqual({ kind: "configure", label: "Check GitHub access", accessState: "error" });
   });
 
   it("builds cloud action state independently for each repository row", () => {
@@ -110,9 +144,17 @@ describe("cloud workspace creation helpers", () => {
       isInitialConfigLoad: false,
     });
 
-    expect(actions["/repos/rocket"]).toEqual({ kind: "create", label: "New cloud workspace" });
-    expect(actions["/repos/draft"]).toEqual({ kind: "configure", label: "Configure cloud" });
-    expect(actions["/repos/local-only"]).toEqual({ kind: "hidden", label: null });
+    expect(actions["/repos/rocket"]).toEqual({
+      kind: "create",
+      label: "New cloud workspace",
+      accessState: "ready",
+    });
+    expect(actions["/repos/draft"]).toEqual({
+      kind: "configure",
+      label: "Configure cloud",
+      accessState: "repository_not_configured",
+    });
+    expect(actions["/repos/local-only"]).toEqual({ kind: "hidden", label: null, accessState: "hidden" });
   });
 
   it("derives taken slugs from the active branch prefix only", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
@@ -3,7 +3,7 @@ import {
   type CloudWorkspaceSummary,
   type CreateCloudWorkspaceRequest,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
-import type { RepoConfigResponse } from "@proliferate/cloud-sdk";
+import type { GitHubRepoAuthorityResponse, RepoConfigResponse } from "@proliferate/cloud-sdk";
 import type { AuthUser } from "#product/lib/domain/auth/auth-user";
 import type { BranchPrefixType } from "#product/lib/domain/preferences/user/model";
 import { generateWorkspaceSlug } from "#product/lib/domain/workspaces/creation/workspace-slug";
@@ -23,10 +23,21 @@ export type CloudWorkspaceCreateInput =
   | CreateCloudWorkspaceRequest;
 
 export type CloudRepoActionState =
-  | { kind: "hidden"; label: null }
-  | { kind: "loading"; label: "Loading cloud..." }
-  | { kind: "configure"; label: "Configure cloud" }
-  | { kind: "create"; label: "New cloud workspace" };
+  | { kind: "hidden"; label: null; accessState?: "hidden" }
+  | { kind: "loading"; label: string; accessState?: "loading" }
+  | {
+    kind: "configure";
+    label: string;
+    accessState?:
+      | "disconnected"
+      | "repository_not_configured"
+      | "github_app_missing"
+      | "github_app_expired"
+      | "github_app_not_installed"
+      | "repository_not_granted"
+      | "error";
+  }
+  | { kind: "create"; label: "New cloud workspace"; accessState?: "ready" };
 
 interface CloudRepoActionRepository {
   sourceRoot: string;
@@ -48,19 +59,66 @@ export function resolveCloudRepoActionState(args: {
   repoTarget: CloudWorkspaceRepoTarget | null;
   configuredRepoKeys: ReadonlySet<string>;
   isInitialConfigLoad: boolean;
+  cloudConnected?: boolean;
+  repoAuthority?: GitHubRepoAuthorityResponse | null;
+  isInitialAuthorityLoad?: boolean;
+  authorityError?: boolean;
 }): CloudRepoActionState {
   if (!args.repoTarget) {
-    return { kind: "hidden", label: null };
+    return { kind: "hidden", label: null, accessState: "hidden" };
+  }
+  if (args.cloudConnected === false) {
+    return { kind: "configure", label: "Connect cloud", accessState: "disconnected" };
   }
   if (args.isInitialConfigLoad) {
-    return { kind: "loading", label: "Loading cloud..." };
+    return { kind: "loading", label: "Loading cloud...", accessState: "loading" };
   }
-
-  return args.configuredRepoKeys.has(
+  const configured = args.configuredRepoKeys.has(
     cloudRepositoryKey(args.repoTarget.gitOwner, args.repoTarget.gitRepoName),
-  )
-    ? { kind: "create", label: "New cloud workspace" }
-    : { kind: "configure", label: "Configure cloud" };
+  );
+  if (!configured) {
+    return {
+      kind: "configure",
+      label: "Configure cloud",
+      accessState: "repository_not_configured",
+    };
+  }
+  if (args.isInitialAuthorityLoad) {
+    return { kind: "loading", label: "Checking GitHub access...", accessState: "loading" };
+  }
+  if (args.authorityError) {
+    return { kind: "configure", label: "Check GitHub access", accessState: "error" };
+  }
+  if (!args.repoAuthority) {
+    // Callers that do not own an authority query retain the configured-repo behavior.
+    return { kind: "create", label: "New cloud workspace", accessState: "ready" };
+  }
+  if (args.repoAuthority.authorized && args.repoAuthority.status === "ready") {
+    return { kind: "create", label: "New cloud workspace", accessState: "ready" };
+  }
+  switch (args.repoAuthority.status) {
+    case "missing_user_authorization":
+    case "missing_user_repo_access":
+      return { kind: "configure", label: "Connect GitHub App", accessState: "github_app_missing" };
+    case "expired_user_authorization":
+      return { kind: "configure", label: "Reconnect GitHub App", accessState: "github_app_expired" };
+    case "missing_installation":
+      return {
+        kind: "configure",
+        label: "Install Proliferate GitHub App",
+        accessState: "github_app_not_installed",
+      };
+    case "repo_not_covered":
+      return {
+        kind: "configure",
+        label: "Grant repository access",
+        accessState: "repository_not_granted",
+      };
+    case "error":
+    case "ready":
+    default:
+      return { kind: "configure", label: "Check GitHub access", accessState: "error" };
+  }
 }
 
 export function buildCloudRepoActionBySourceRoot(args: {
@@ -82,7 +140,7 @@ export function buildCloudRepoActionBySourceRoot(args: {
         configuredRepoKeys: args.configuredRepoKeys,
         isInitialConfigLoad: args.isInitialConfigLoad,
       })
-      : { kind: "hidden", label: null };
+      : { kind: "configure", label: "Connect cloud", accessState: "disconnected" };
   }
   return actions;
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/new-workspace-command.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/new-workspace-command.test.ts
@@ -222,11 +222,10 @@ describe("new workspace command targets", () => {
     expect(resolveNewWorkspaceCommandTarget({
       commandKind: "cloud",
       scope,
-      cloudRepoAction: { kind: "configure", label: "Configure cloud" },
-    })).toMatchObject({
+      cloudRepoAction: { kind: "configure", label: "Install Proliferate GitHub App" },
+    })).toEqual({
       commandKind: "cloud",
-      cloudActionKind: "configure",
-      disabledReason: null,
+      disabledReason: "Install Proliferate GitHub App",
     });
 
     expect(resolveNewWorkspaceCommandTarget({

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/new-workspace-command.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/new-workspace-command.ts
@@ -266,6 +266,9 @@ export function resolveNewWorkspaceCommandTarget(
   if (cloudRepoAction.kind === "loading") {
     return disabledTarget("cloud", "Cloud repository settings are loading.");
   }
+  if (cloudRepoAction.kind === "configure") {
+    return disabledTarget("cloud", cloudRepoAction.label);
+  }
 
   return {
     commandKind: "cloud",

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/repo-context-menu.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/repo-context-menu.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   confirmRepoRemoval,
   repoRemovalConfirmationCopy,
@@ -7,12 +7,18 @@ import {
 
 describe("repoRemovalConfirmationCopy", () => {
   it("models removal as destructive confirmation outside the menu", () => {
-    expect(repoRemovalConfirmationCopy("proliferate")).toEqual({
+    expect(repoRemovalConfirmationCopy("proliferate", true)).toEqual({
       title: "Remove repository?",
-      description: "Remove proliferate from the sidebar. Local files and workspaces are not deleted.",
+      description: "Remove proliferate from Cloud and this sidebar. Local files and workspaces are not deleted.",
       confirmLabel: "Remove repository",
       confirmVariant: "destructive",
     });
+  });
+
+  it("does not claim a Cloud mutation for local-only repositories", () => {
+    expect(repoRemovalConfirmationCopy("proliferate").description).toBe(
+      "Remove proliferate from the sidebar. Local files and workspaces are not deleted.",
+    );
   });
 
   it("opens confirmation from the menu command", () => {
@@ -24,13 +30,24 @@ describe("repoRemovalConfirmationCopy", () => {
     expect(open).toBe(true);
   });
 
-  it("resets confirmation state before removing the repo", () => {
+  it("closes confirmation only after removing the repo", async () => {
     const calls: string[] = [];
-    confirmRepoRemoval({
+    await confirmRepoRemoval({
       closeConfirmation: () => calls.push("close"),
-      removeRepo: () => calls.push("remove"),
+      removeRepo: () => {
+        calls.push("remove");
+      },
     });
 
-    expect(calls).toEqual(["close", "remove"]);
+    expect(calls).toEqual(["remove", "close"]);
+  });
+
+  it("keeps confirmation open when removal fails", async () => {
+    const close = vi.fn();
+    await expect(confirmRepoRemoval({
+      closeConfirmation: close,
+      removeRepo: () => Promise.reject(new Error("server rejected removal")),
+    })).rejects.toThrow("server rejected removal");
+    expect(close).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/repo-context-menu.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/repo-context-menu.ts
@@ -5,10 +5,15 @@ export interface RepoRemovalConfirmationCopy {
   confirmVariant: "destructive";
 }
 
-export function repoRemovalConfirmationCopy(repoName: string): RepoRemovalConfirmationCopy {
+export function repoRemovalConfirmationCopy(
+  repoName: string,
+  removesCloud = false,
+): RepoRemovalConfirmationCopy {
   return {
     title: "Remove repository?",
-    description: `Remove ${repoName} from the sidebar. Local files and workspaces are not deleted.`,
+    description: removesCloud
+      ? `Remove ${repoName} from Cloud and this sidebar. Local files and workspaces are not deleted.`
+      : `Remove ${repoName} from the sidebar. Local files and workspaces are not deleted.`,
     confirmLabel: "Remove repository",
     confirmVariant: "destructive",
   };
@@ -18,13 +23,13 @@ export function requestRepoRemovalConfirmation(openConfirmation: () => void) {
   openConfirmation();
 }
 
-export function confirmRepoRemoval({
+export async function confirmRepoRemoval({
   closeConfirmation,
   removeRepo,
 }: {
   closeConfirmation: () => void;
-  removeRepo?: () => void;
+  removeRepo?: () => Promise<void> | void;
 }) {
+  await removeRepo?.();
   closeConfirmation();
-  removeRepo?.();
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-detail-indicators.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-detail-indicators.ts
@@ -49,7 +49,11 @@ export function detailIndicatorsForWorkspace(
 ): SidebarDetailIndicator[] {
   const creator = creatorDetailIndicator(workspace);
   const cloudAccess = cloudAccessDetailIndicator(workspace);
-  const cloudExposure = cloudExposureDetailIndicator(workspace);
+  // Managed Cloud already has a materialization indicator. Exposure only describes
+  // a locally running workspace that is separately reachable through Cloud.
+  const cloudExposure = workspace.effectiveOwner === "cloud"
+    ? null
+    : cloudExposureDetailIndicator(workspace);
   const origin = originDetailIndicator(workspace, creator);
   return [
     ...(creator ? [creator] : []),

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
@@ -314,7 +314,6 @@ describe("sidebar indicators", () => {
       preferredMaterializationId: cloudWorkspaceSyntheticId(cloudWorkspace.id),
       lifecycle: "cloud_active",
     };
-
     const groups = buildGroups({
       logicalWorkspaces: [dualCloudEffective],
       workspaceActivities: {
@@ -322,16 +321,11 @@ describe("sidebar indicators", () => {
         [cloudWorkspaceSyntheticId(cloudWorkspace.id)]: "iterating",
       },
     });
-
     expect(groups[0]?.items[0]?.statusIndicator?.kind).toBe("iterating");
-    expect(groups[0]?.items[0]?.detailIndicators).toContainEqual(
+    expect(groups[0]?.items[0]?.detailIndicators).toEqual([
       expect.objectContaining({ kind: "materialization", variant: "cloud" }),
-    );
-    expect(groups[0]?.items[0]?.detailIndicators).not.toContainEqual(
-      expect.objectContaining({ kind: "cloud_exposure" }),
-    );
+    ]);
   });
-
   it("shows cloud workspace errors in the left status channel", () => {
     const groups = buildGroups({
       logicalWorkspaces: [

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
@@ -324,6 +324,12 @@ describe("sidebar indicators", () => {
     });
 
     expect(groups[0]?.items[0]?.statusIndicator?.kind).toBe("iterating");
+    expect(groups[0]?.items[0]?.detailIndicators).toContainEqual(
+      expect.objectContaining({ kind: "materialization", variant: "cloud" }),
+    );
+    expect(groups[0]?.items[0]?.detailIndicators).not.toContainEqual(
+      expect.objectContaining({ kind: "cloud_exposure" }),
+    );
   });
 
   it("shows cloud workspace errors in the left status channel", () => {

--- a/cloud/sdk-react/src/hooks/repositories.ts
+++ b/cloud/sdk-react/src/hooks/repositories.ts
@@ -1,6 +1,12 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import {
   listRepositories,
+  removeCloudRepoEnvironment,
   saveRepoEnvironment,
   updateRepoConfig,
   type RepoConfigResponse,
@@ -86,6 +92,47 @@ export function useSaveRepoEnvironment() {
           queryKey: workspaceCloudSecretsKey(gitOwner, gitRepoName),
         });
       }
+    },
+  });
+}
+
+export interface RemoveCloudRepoEnvironmentInput {
+  gitOwner: string;
+  gitRepoName: string;
+}
+
+export function invalidateCloudRepoEnvironmentRemoval(
+  queryClient: Pick<QueryClient, "invalidateQueries">,
+  clientBaseUrl: string,
+  input: RemoveCloudRepoEnvironmentInput,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: repositoriesKey() }),
+    queryClient.invalidateQueries({ queryKey: cloudGitRepositoriesRootKey() }),
+    queryClient.invalidateQueries({ queryKey: githubAppRootKey(clientBaseUrl) }),
+    queryClient.invalidateQueries({
+      queryKey: workspaceCloudSecretsKey(input.gitOwner, input.gitRepoName),
+    }),
+  ]);
+}
+
+export function useRemoveCloudRepoEnvironment() {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, RemoveCloudRepoEnvironmentInput>({
+    mutationFn: ({ gitOwner, gitRepoName }) =>
+      removeCloudRepoEnvironment(gitOwner, gitRepoName, client),
+    onSuccess: (_, { gitOwner, gitRepoName }) => {
+      queryClient.removeQueries({
+        queryKey: repoEnvironmentKey(gitOwner, gitRepoName, "cloud"),
+        exact: true,
+      });
+    },
+    onSettled: (_, __, { gitOwner, gitRepoName }) => {
+      return invalidateCloudRepoEnvironmentRemoval(queryClient, client.baseUrl, {
+        gitOwner,
+        gitRepoName,
+      });
     },
   });
 }

--- a/cloud/sdk/src/client/repositories.ts
+++ b/cloud/sdk/src/client/repositories.ts
@@ -49,3 +49,18 @@ export async function saveRepoEnvironment(
     body,
   });
 }
+
+export async function removeCloudRepoEnvironment(
+  gitOwner: string,
+  gitRepoName: string,
+  client: ProliferateCloudClient = getProliferateClient(),
+): Promise<void> {
+  await client.requestJson<unknown>({
+    method: "DELETE",
+    path: "/v1/cloud/repositories/{git_owner}/{git_repo_name}/environment",
+    pathParams: {
+      git_owner: gitOwner,
+      git_repo_name: gitRepoName,
+    },
+  });
+}

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -816,7 +816,8 @@ export interface paths {
         /** Save Repo Environment Endpoint */
         put: operations["save_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environment_put"];
         post?: never;
-        delete?: never;
+        /** Remove Cloud Repo Environment Endpoint */
+        delete: operations["remove_cloud_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environment_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -8223,6 +8224,36 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["RepoEnvironmentResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_cloud_repo_environment_endpoint_v1_cloud_repositories__git_owner___git_repo_name__environment_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                git_owner: string;
+                git_repo_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/server/proliferate/db/store/automation_environment_references.py
+++ b/server/proliferate/db/store/automation_environment_references.py
@@ -1,0 +1,31 @@
+"""Persistence checks for repository-environment automation references."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import exists, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.automations import Automation, AutomationRun
+
+
+async def repo_environment_has_automation_references(
+    db: AsyncSession,
+    *,
+    repo_environment_id: UUID,
+) -> bool:
+    definition_exists = await db.scalar(
+        select(exists().where(Automation.repo_environment_id == repo_environment_id))
+    )
+    if definition_exists:
+        return True
+    return bool(
+        await db.scalar(
+            select(
+                exists().where(
+                    AutomationRun.repo_environment_id_snapshot == repo_environment_id
+                )
+            )
+        )
+    )

--- a/server/proliferate/db/store/automation_environment_references.py
+++ b/server/proliferate/db/store/automation_environment_references.py
@@ -23,9 +23,7 @@ async def repo_environment_has_automation_references(
     return bool(
         await db.scalar(
             select(
-                exists().where(
-                    AutomationRun.repo_environment_id_snapshot == repo_environment_id
-                )
+                exists().where(AutomationRun.repo_environment_id_snapshot == repo_environment_id)
             )
         )
     )

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from sqlalchemy import Select, select
+from sqlalchemy import Select, exists, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -84,6 +84,22 @@ async def list_active_workspace_branches_for_repo_environment(
         )
     )
     return {value for value in rows.scalars().all() if value}
+
+
+async def repo_environment_has_workspaces(
+    db: AsyncSession,
+    *,
+    repo_environment_id: UUID,
+) -> bool:
+    """Return whether any active or archived workspace still owns this environment."""
+
+    return bool(
+        await db.scalar(
+            select(
+                exists().where(CloudWorkspace.repo_environment_id == repo_environment_id)
+            )
+        )
+    )
 
 
 async def get_cloud_workspace_for_user(

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -95,9 +95,7 @@ async def repo_environment_has_workspaces(
 
     return bool(
         await db.scalar(
-            select(
-                exists().where(CloudWorkspace.repo_environment_id == repo_environment_id)
-            )
+            select(exists().where(CloudWorkspace.repo_environment_id == repo_environment_id))
         )
     )
 

--- a/server/proliferate/db/store/repositories.py
+++ b/server/proliferate/db/store/repositories.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from sqlalchemy import select
@@ -201,10 +202,44 @@ async def get_cloud_repo_environment(
     user_id: UUID,
     git_owner: str,
     git_repo_name: str,
+    lock_mode: Literal["key_share", "update"] | None = None,
 ) -> RepoEnvironmentValue | None:
+    statement = (
+        select(RepoEnvironment, RepoConfig)
+        .join(RepoConfig, RepoEnvironment.repo_config_id == RepoConfig.id)
+        .where(
+            RepoConfig.user_id == user_id,
+            RepoConfig.git_provider == GitProvider.github,
+            RepoConfig.git_owner == git_owner,
+            RepoConfig.git_repo_name == git_repo_name,
+            RepoConfig.deleted_at.is_(None),
+            RepoEnvironment.environment_kind == RepoEnvironmentKind.cloud,
+            RepoEnvironment.deleted_at.is_(None),
+        )
+    )
+    if lock_mode == "key_share":
+        statement = statement.with_for_update(read=True, key_share=True)
+    elif lock_mode == "update":
+        statement = statement.with_for_update()
+    row = (await db.execute(statement)).one_or_none()
+    if row is None:
+        return None
+    environment, repo = row
+    return _environment_value(environment, repo)
+
+
+async def remove_cloud_repo_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_owner: str,
+    git_repo_name: str,
+) -> bool:
+    """Soft-delete one user's active Cloud environment; missing is idempotent."""
+
     row = (
         await db.execute(
-            select(RepoEnvironment, RepoConfig)
+            select(RepoEnvironment)
             .join(RepoConfig, RepoEnvironment.repo_config_id == RepoConfig.id)
             .where(
                 RepoConfig.user_id == user_id,
@@ -216,11 +251,15 @@ async def get_cloud_repo_environment(
                 RepoEnvironment.deleted_at.is_(None),
             )
         )
-    ).one_or_none()
+    ).scalar_one_or_none()
     if row is None:
-        return None
-    environment, repo = row
-    return _environment_value(environment, repo)
+        return False
+
+    now = utcnow()
+    row.deleted_at = now
+    row.updated_at = now
+    await db.flush()
+    return True
 
 
 async def get_repo_environment_by_id(

--- a/server/proliferate/server/cloud/repositories/api.py
+++ b/server/proliferate/server/cloud/repositories/api.py
@@ -30,6 +30,7 @@ from proliferate.server.cloud.repositories.models import (
 )
 from proliferate.server.cloud.repositories.service import (
     list_repositories,
+    remove_cloud_repo_environment,
     repo_config_response,
     repo_environment_response,
     save_repo_environment,
@@ -135,3 +136,24 @@ async def save_repo_environment_endpoint(
         body=body,
     )
     return await repo_environment_response(db, user_id=user.id, environment=value)
+
+
+@router.delete(
+    "/repositories/{git_owner}/{git_repo_name}/environment",
+    status_code=204,
+)
+async def remove_cloud_repo_environment_endpoint(
+    git_owner: str,
+    git_repo_name: str,
+    db: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_product_user),
+) -> None:
+    try:
+        await remove_cloud_repo_environment(
+            db,
+            user_id=user.id,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+        )
+    except CloudApiError as error:
+        raise_cloud_error(error)

--- a/server/proliferate/server/cloud/repositories/service.py
+++ b/server/proliferate/server/cloud/repositories/service.py
@@ -6,18 +6,24 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.db.store import automation_environment_references as automations_store
 from proliferate.db.store import cloud_repo_environment_materializations as repo_mat_store
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
+from proliferate.db.store import cloud_workspaces as cloud_workspaces_store
 from proliferate.db.store.cloud_repo_environment_materializations import (
     CloudRepoEnvironmentMaterializationValue,
 )
 from proliferate.db.store.repositories import (
     RepoConfigValue,
     RepoEnvironmentValue,
+    get_cloud_repo_environment,
     list_repo_configs_for_user,
     update_repo_config_commit_instructions,
     upsert_cloud_repo_environment,
     upsert_local_repo_environment,
+)
+from proliferate.db.store.repositories import (
+    remove_cloud_repo_environment as remove_cloud_repo_environment_row,
 )
 from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandboxes_service
 from proliferate.server.cloud.errors import CloudApiError
@@ -229,4 +235,46 @@ async def save_repo_environment(
         git_owner=git_owner,
         git_repo_name=git_repo_name,
         body=body,
+    )
+
+
+async def remove_cloud_repo_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    git_owner: str,
+    git_repo_name: str,
+) -> None:
+    environment = await get_cloud_repo_environment(
+        db,
+        user_id=user_id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+        lock_mode="update",
+    )
+    if environment is None:
+        return
+    if await cloud_workspaces_store.repo_environment_has_workspaces(
+        db,
+        repo_environment_id=environment.id,
+    ):
+        raise CloudApiError(
+            "cloud_repository_in_use",
+            "Delete this repository's cloud workspaces before removing it.",
+            status_code=409,
+        )
+    if await automations_store.repo_environment_has_automation_references(
+        db,
+        repo_environment_id=environment.id,
+    ):
+        raise CloudApiError(
+            "cloud_repository_in_use",
+            "Delete this repository's automations and run history before removing it.",
+            status_code=409,
+        )
+    await remove_cloud_repo_environment_row(
+        db,
+        user_id=user_id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
     )

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -142,6 +142,7 @@ async def create_cloud_workspace_for_user(
         user_id=user.id,
         git_owner=git_owner,
         git_repo_name=git_repo_name,
+        lock_mode="key_share",
     )
     if repo_environment is None:
         raise CloudApiError(

--- a/server/tests/unit/test_cloud_repository_removal.py
+++ b/server/tests/unit/test_cloud_repository_removal.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repositories import service
+
+
+@pytest.mark.asyncio
+async def test_remove_cloud_repo_environment_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    removed = False
+
+    async def get_environment(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        return None
+
+    async def remove_row(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        nonlocal removed
+        removed = True
+
+    monkeypatch.setattr(service, "get_cloud_repo_environment", get_environment)
+    monkeypatch.setattr(service, "remove_cloud_repo_environment_row", remove_row)
+
+    await service.remove_cloud_repo_environment(
+        object(),
+        user_id=uuid.uuid4(),
+        git_owner="acme",
+        git_repo_name="rocket",
+    )
+
+    assert removed is False
+
+
+@pytest.mark.asyncio
+async def test_remove_cloud_repo_environment_blocks_preserved_workspaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment_id = uuid.uuid4()
+
+    async def get_environment(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args, kwargs
+        return SimpleNamespace(id=environment_id)
+
+    async def has_workspaces(*args: object, **kwargs: object) -> bool:
+        del args, kwargs
+        return True
+
+    monkeypatch.setattr(service, "get_cloud_repo_environment", get_environment)
+    monkeypatch.setattr(
+        service.cloud_workspaces_store,
+        "repo_environment_has_workspaces",
+        has_workspaces,
+    )
+
+    with pytest.raises(CloudApiError) as raised:
+        await service.remove_cloud_repo_environment(
+            object(),
+            user_id=uuid.uuid4(),
+            git_owner="acme",
+            git_repo_name="rocket",
+        )
+
+    assert raised.value.code == "cloud_repository_in_use"
+    assert raised.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_remove_cloud_repo_environment_deletes_unused_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment_id = uuid.uuid4()
+    calls: list[tuple[str, str]] = []
+
+    async def get_environment(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args, kwargs
+        return SimpleNamespace(id=environment_id)
+
+    async def has_workspaces(*args: object, **kwargs: object) -> bool:
+        del args, kwargs
+        return False
+
+    async def has_automations(*args: object, **kwargs: object) -> bool:
+        del args, kwargs
+        return False
+
+    async def remove_row(*args: object, **kwargs: object) -> bool:
+        del args
+        calls.append((str(kwargs["git_owner"]), str(kwargs["git_repo_name"])))
+        return True
+
+    monkeypatch.setattr(service, "get_cloud_repo_environment", get_environment)
+    monkeypatch.setattr(
+        service.cloud_workspaces_store,
+        "repo_environment_has_workspaces",
+        has_workspaces,
+    )
+    monkeypatch.setattr(
+        service.automations_store,
+        "repo_environment_has_automation_references",
+        has_automations,
+    )
+    monkeypatch.setattr(service, "remove_cloud_repo_environment_row", remove_row)
+
+    await service.remove_cloud_repo_environment(
+        object(),
+        user_id=uuid.uuid4(),
+        git_owner="acme",
+        git_repo_name="rocket",
+    )
+
+    assert calls == [("acme", "rocket")]
+
+
+@pytest.mark.asyncio
+async def test_remove_cloud_repo_environment_blocks_automation_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment_id = uuid.uuid4()
+
+    async def get_environment(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args
+        assert kwargs["lock_mode"] == "update"
+        return SimpleNamespace(id=environment_id)
+
+    async def no_workspaces(*args: object, **kwargs: object) -> bool:
+        del args, kwargs
+        return False
+
+    async def has_automations(*args: object, **kwargs: object) -> bool:
+        del args, kwargs
+        return True
+
+    monkeypatch.setattr(service, "get_cloud_repo_environment", get_environment)
+    monkeypatch.setattr(
+        service.cloud_workspaces_store,
+        "repo_environment_has_workspaces",
+        no_workspaces,
+    )
+    monkeypatch.setattr(
+        service.automations_store,
+        "repo_environment_has_automation_references",
+        has_automations,
+    )
+
+    with pytest.raises(CloudApiError) as raised:
+        await service.remove_cloud_repo_environment(
+            object(),
+            user_id=uuid.uuid4(),
+            git_owner="acme",
+            git_repo_name="rocket",
+        )
+
+    assert raised.value.code == "cloud_repository_in_use"

--- a/specs/codebase/platforms/product/workspace-provisioning.md
+++ b/specs/codebase/platforms/product/workspace-provisioning.md
@@ -66,6 +66,7 @@ GET /v1/cloud/repositories/catalog
 GET /v1/cloud/repositories
 GET /v1/cloud/repositories/{owner}/{repo}/branches
 PUT /v1/cloud/repositories/{owner}/{repo}/environment
+DELETE /v1/cloud/repositories/{owner}/{repo}/environment
 ```
 
 Workspace routes:
@@ -96,6 +97,21 @@ after the request transaction commits.
 That scheduled task is best-effort process-local work. Its persisted status
 and `last_error` are evidence; saving the environment successfully is not by
 itself evidence that the repository exists in E2B.
+
+## Remove A Cloud Repository Environment
+
+The repository environment `DELETE` route is user-scoped and idempotent. It
+soft-deletes only the active Cloud `repo_environment`; local environments,
+repository preferences, local files, and workspaces are not deleted. Removal
+is rejected with `cloud_repository_in_use` while any active or archived Cloud
+workspace, automation, or automation-run snapshot still references the
+environment, because hiding an environment that those records need would make
+the removal state untruthful. Workspace creation holds a key-share lock on the
+environment while removal holds an update lock, so a concurrent create cannot
+race the dependency check. Clients
+must keep removal pending until the request succeeds and invalidate repository,
+catalog, GitHub-authority, and workspace-secret queries after it settles so all
+surfaces converge on server truth.
 
 ## Create A Workspace
 


### PR DESCRIPTION
## Summary

- add a truthful, idempotent Cloud repository-environment removal path across server, generated OpenAPI, SDK, React Query, and sidebar UX
- preflight GitHub App repository authority before Cloud workspace actions in the sidebar, Home, and global commands, with explicit loading/disconnected/install/grant/ready states
- remove the contradictory Cloud-exposure indicator from managed Cloud rows while retaining it for locally running remote-access workspaces

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Reproduction and root cause

Base revision: `cd00510bd9460307714758e18274232c8aa66a06` (`origin/main` at investigation and publication).

Read-only validation in the signed-in Web product confirmed that Cloud-only repository rows exposed Cloud materialization styling without per-repository GitHub authority state. The available test account was already fully authorized, so I did not mutate its GitHub App installation merely to manufacture a missing-authorization state.

Code tracing confirmed three defects:

1. Sidebar “Remove repository” only mutated local hidden-root state. A Cloud-only group has no local root, so the action made no server request and visibly did nothing.
2. Configured repositories were offered “New cloud workspace” before querying `GET /v1/cloud/github-app/repos/{owner}/{repo}/authority`; the first authoritative failure could therefore arrive only inside workspace creation as “Could not refresh GitHub App authorization.”
3. Managed Cloud workspaces could render both a Cloud materialization indicator and a separate `untracked` exposure indicator described as “Cloud access disabled.”

## Changes

- add `DELETE /v1/cloud/repositories/{owner}/{repo}/environment` as a user-scoped, idempotent soft delete
- reject removal with `409 cloud_repository_in_use` while active/archived workspaces, automations, or automation-run snapshots still reference the environment
- serialize workspace creation and removal with `FOR KEY SHARE` / `FOR UPDATE` locks so a concurrent create cannot race the dependency check
- keep the removal dialog pending through server success and awaited query convergence; preserve the dialog and surface the error on failure
- invalidate repository lists, repository catalog, GitHub App authority, and workspace-secret caches after every removal attempt
- map repository authority into explicit action states and precise copy: Connect Cloud, Connect/Reconnect GitHub App, Install Proliferate GitHub App, Grant repository access, Check GitHub access, and New cloud workspace
- route Home/sidebar setup actions to repository Cloud settings and disable the global create command until authority is ready
- suppress exposure iconography for managed Cloud while preserving it for locally running remote-access workspaces
- document the removal contract and regenerate the OpenAPI client

## Verification

- `DEBUG=true uv run --python 3.12 --extra dev python -m pytest -q tests/unit/test_cloud_repository_removal.py` — 4 passed
- focused product-client Vitest command covering Home gates, command gates, removal pending/failure, invalidation, authority rendering, and indicator ownership — 65 passed
- `pnpm --filter @proliferate/cloud-sdk-react typecheck` — passed
- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/packages/product-client` — passed
- focused Ruff check for touched server modules/tests — passed
- `make cloud-client-generate` — passed
- `python3 scripts/check_docs.py` — passed (211 Markdown files)
- `git diff --check` and changed-file sensitive-data scan — clean

## Manual validation

- confirmed the pre-fix Cloud-only removal and state-clarity paths in the signed-in Web product without changing GitHub permissions or deleting production repository configuration
- confirmed the authorized account reports user authorization, installation, and repository access as ready
- post-fix state transitions are covered by focused component/domain tests; a real unauthorized GitHub App installation was not destructively created in production

## Assumptions and residual risks

- “Remove repository” removes only the Cloud environment and sidebar presence; it never deletes local files or workspaces. Existing Cloud workspaces and automation history intentionally block removal instead of becoming orphaned.
- removal soft-deletes control-plane configuration but does not garbage-collect a previously materialized checkout from the personal sandbox filesystem; provider/runtime cleanup remains a separate lifecycle concern.
- general Cloud chat-input and provider-auth flows remain outside this slice.
