### PR TITLE
fix(transcript): surface native subagent activity

### DIFF
--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/metadata.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/metadata.rs
@@ -1,16 +1,18 @@
-use super::normalization::meta::parse_meta;
 use super::SessionEventSink;
+use super::normalization::meta::parse_meta;
 
 impl SessionEventSink {
     pub(super) fn meta_parent_tool_call_id(
         &self,
         meta: Option<&serde_json::Value>,
     ) -> Option<String> {
-        if self.source_agent_kind != "claude" {
-            return None;
-        }
-        parse_meta(meta)
-            .claude_code
-            .and_then(|meta| meta.parent_tool_use_id)
+        let meta = parse_meta(meta);
+        meta.anyharness
+            .and_then(|meta| meta.parent_tool_call_id)
+            .or_else(|| {
+                (self.source_agent_kind == "claude")
+                    .then(|| meta.claude_code.and_then(|meta| meta.parent_tool_use_id))
+                    .flatten()
+            })
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/state.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/state.rs
@@ -87,6 +87,7 @@ pub(super) struct AnyHarnessMeta {
     pub(super) transcript_event: Option<String>,
     pub(super) native_tool_name: Option<String>,
     pub(super) tool_kind: Option<String>,
+    pub(super) parent_tool_call_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use serde_json::json;
 use tokio::sync::broadcast;
 
+mod native_subagents;
 mod support;
 
 use super::{AcpChunkPayload, SessionEventSink};
@@ -73,110 +74,6 @@ fn assistant_chunking_emits_one_item_lifecycle_with_monotonic_seq() {
     assert_eq!(sink.next_seq(), events.len() as i64 + 1);
 }
 
-#[test]
-fn provider_neutral_subagent_metadata_persists_nested_live_events_for_replay() {
-    let store = seeded_store();
-    let (tx, mut rx) = broadcast::channel(32);
-    let mut sink = SessionEventSink::new(
-        "session-1".to_string(),
-        "codex".to_string(),
-        PathBuf::from("/tmp/workspace"),
-        tx,
-        Arc::new(store.clone()),
-    );
-
-    sink.begin_turn("delegate".to_string(), None, Vec::new(), None);
-    sink.tool_call(super::AcpToolPayload {
-        tool_call_id: "agent-1".to_string(),
-        title: Some("Inspect the repository".to_string()),
-        kind: Some("think".to_string()),
-        status: Some("in_progress".to_string()),
-        meta: Some(json!({
-            "anyharness": {
-                "nativeToolName": "Agent",
-                "toolKind": "subagent"
-            }
-        })),
-        ..Default::default()
-    });
-    sink.agent_message_chunk(AcpChunkPayload {
-        content: json!("Inspecting README.md"),
-        message_id: Some("child-message-1".to_string()),
-        meta: Some(json!({
-            "anyharness": { "parentToolCallId": "agent-1" }
-        })),
-    });
-    sink.tool_call(super::AcpToolPayload {
-        tool_call_id: "child-read-1".to_string(),
-        title: Some("Read README.md".to_string()),
-        kind: Some("read".to_string()),
-        status: Some("completed".to_string()),
-        meta: Some(json!({
-            "anyharness": {
-                "nativeToolName": "Read",
-                "parentToolCallId": "agent-1"
-            }
-        })),
-        ..Default::default()
-    });
-    sink.tool_call_update(super::AcpToolPayload {
-        tool_call_id: "agent-1".to_string(),
-        status: Some("completed".to_string()),
-        raw_output: Some(json!({ "summary": "The first heading is Proliferate." })),
-        ..Default::default()
-    });
-    sink.turn_ended(StopReason::EndTurn);
-
-    let live = drain_events(&mut rx);
-    let replay = store.list_events("session-1").expect("persisted replay");
-    assert_eq!(
-        replay.iter().map(|event| event.seq).collect::<Vec<_>>(),
-        live.iter().map(|event| event.seq).collect::<Vec<_>>()
-    );
-
-    let nested = live
-        .iter()
-        .filter_map(|envelope| match &envelope.event {
-            SessionEvent::ItemStarted(event) => Some(&event.item),
-            SessionEvent::ItemCompleted(event) => Some(&event.item),
-            _ => None,
-        })
-        .filter(|item| item.parent_tool_call_id.as_deref() == Some("agent-1"))
-        .collect::<Vec<_>>();
-    assert!(nested.iter().any(|item| {
-        matches!(item.kind, TranscriptItemKind::AssistantMessage)
-            && item.message_id.as_deref() == Some("child-message-1")
-    }));
-    assert!(nested.iter().any(|item| {
-        matches!(item.kind, TranscriptItemKind::ToolInvocation)
-            && item.tool_call_id.as_deref() == Some("child-read-1")
-    }));
-
-    let replay_events = replay
-        .iter()
-        .map(|record| {
-            serde_json::from_str::<SessionEvent>(&record.payload_json)
-                .expect("deserialize persisted event")
-        })
-        .collect::<Vec<_>>();
-    let replay_nested = replay_events
-        .iter()
-        .filter_map(|event| match event {
-            SessionEvent::ItemStarted(event) => Some(&event.item),
-            SessionEvent::ItemCompleted(event) => Some(&event.item),
-            _ => None,
-        })
-        .filter(|item| item.parent_tool_call_id.as_deref() == Some("agent-1"))
-        .collect::<Vec<_>>();
-    assert!(replay_nested.iter().any(|item| {
-        matches!(item.kind, TranscriptItemKind::AssistantMessage)
-            && item.message_id.as_deref() == Some("child-message-1")
-    }));
-    assert!(replay_nested.iter().any(|item| {
-        matches!(item.kind, TranscriptItemKind::ToolInvocation)
-            && item.tool_call_id.as_deref() == Some("child-read-1")
-    }));
-}
 
 #[test]
 fn injected_runtime_event_persists_strictly_and_keeps_sequence() {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
@@ -74,6 +74,111 @@ fn assistant_chunking_emits_one_item_lifecycle_with_monotonic_seq() {
 }
 
 #[test]
+fn provider_neutral_subagent_metadata_persists_nested_live_events_for_replay() {
+    let store = seeded_store();
+    let (tx, mut rx) = broadcast::channel(32);
+    let mut sink = SessionEventSink::new(
+        "session-1".to_string(),
+        "codex".to_string(),
+        PathBuf::from("/tmp/workspace"),
+        tx,
+        Arc::new(store.clone()),
+    );
+
+    sink.begin_turn("delegate".to_string(), None, Vec::new(), None);
+    sink.tool_call(super::AcpToolPayload {
+        tool_call_id: "agent-1".to_string(),
+        title: Some("Inspect the repository".to_string()),
+        kind: Some("think".to_string()),
+        status: Some("in_progress".to_string()),
+        meta: Some(json!({
+            "anyharness": {
+                "nativeToolName": "Agent",
+                "toolKind": "subagent"
+            }
+        })),
+        ..Default::default()
+    });
+    sink.agent_message_chunk(AcpChunkPayload {
+        content: json!("Inspecting README.md"),
+        message_id: Some("child-message-1".to_string()),
+        meta: Some(json!({
+            "anyharness": { "parentToolCallId": "agent-1" }
+        })),
+    });
+    sink.tool_call(super::AcpToolPayload {
+        tool_call_id: "child-read-1".to_string(),
+        title: Some("Read README.md".to_string()),
+        kind: Some("read".to_string()),
+        status: Some("completed".to_string()),
+        meta: Some(json!({
+            "anyharness": {
+                "nativeToolName": "Read",
+                "parentToolCallId": "agent-1"
+            }
+        })),
+        ..Default::default()
+    });
+    sink.tool_call_update(super::AcpToolPayload {
+        tool_call_id: "agent-1".to_string(),
+        status: Some("completed".to_string()),
+        raw_output: Some(json!({ "summary": "The first heading is Proliferate." })),
+        ..Default::default()
+    });
+    sink.turn_ended(StopReason::EndTurn);
+
+    let live = drain_events(&mut rx);
+    let replay = store.list_events("session-1").expect("persisted replay");
+    assert_eq!(
+        replay.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        live.iter().map(|event| event.seq).collect::<Vec<_>>()
+    );
+
+    let nested = live
+        .iter()
+        .filter_map(|envelope| match &envelope.event {
+            SessionEvent::ItemStarted(event) => Some(&event.item),
+            SessionEvent::ItemCompleted(event) => Some(&event.item),
+            _ => None,
+        })
+        .filter(|item| item.parent_tool_call_id.as_deref() == Some("agent-1"))
+        .collect::<Vec<_>>();
+    assert!(nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::AssistantMessage)
+            && item.message_id.as_deref() == Some("child-message-1")
+    }));
+    assert!(nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::ToolInvocation)
+            && item.tool_call_id.as_deref() == Some("child-read-1")
+    }));
+
+    let replay_events = replay
+        .iter()
+        .map(|record| {
+            serde_json::from_str::<SessionEvent>(&record.payload_json)
+                .expect("deserialize persisted event")
+        })
+        .collect::<Vec<_>>();
+    let replay_nested = replay_events
+        .iter()
+        .filter_map(|event| match event {
+            SessionEvent::ItemStarted(event) => Some(&event.item),
+            SessionEvent::ItemCompleted(event) => Some(&event.item),
+            _ => None,
+        })
+        .filter(|item| item.parent_tool_call_id.as_deref() == Some("agent-1"))
+        .collect::<Vec<_>>();
+    assert!(replay_nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::AssistantMessage)
+            && item.message_id.as_deref() == Some("child-message-1")
+    }));
+    assert!(replay_nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::ToolInvocation)
+            && item.tool_call_id.as_deref() == Some("child-read-1")
+    }));
+}
+
+#[test]
 fn injected_runtime_event_persists_strictly_and_keeps_sequence() {
     let store = seeded_store();
     let (tx, mut rx) = broadcast::channel(32);

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests/native_subagents.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests/native_subagents.rs
@@ -1,0 +1,114 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyharness_contract::v1::{SessionEvent, StopReason, TranscriptItemKind};
+use serde_json::json;
+use tokio::sync::broadcast;
+
+use super::super::{AcpChunkPayload, AcpToolPayload, SessionEventSink};
+use super::support::{drain_events, seeded_store};
+
+#[test]
+fn provider_neutral_subagent_metadata_persists_nested_live_events_for_replay() {
+    let store = seeded_store();
+    let (tx, mut rx) = broadcast::channel(32);
+    let mut sink = SessionEventSink::new(
+        "session-1".to_string(),
+        "codex".to_string(),
+        PathBuf::from("/tmp/workspace"),
+        tx,
+        Arc::new(store.clone()),
+    );
+
+    sink.begin_turn("delegate".to_string(), None, Vec::new(), None);
+    sink.tool_call(AcpToolPayload {
+        tool_call_id: "agent-1".to_string(),
+        title: Some("Inspect the repository".to_string()),
+        kind: Some("think".to_string()),
+        status: Some("in_progress".to_string()),
+        meta: Some(json!({
+            "anyharness": {
+                "nativeToolName": "Agent",
+                "toolKind": "subagent"
+            }
+        })),
+        ..Default::default()
+    });
+    sink.agent_message_chunk(AcpChunkPayload {
+        content: json!("Inspecting README.md"),
+        message_id: Some("child-message-1".to_string()),
+        meta: Some(json!({
+            "anyharness": { "parentToolCallId": "agent-1" }
+        })),
+    });
+    sink.tool_call(AcpToolPayload {
+        tool_call_id: "child-read-1".to_string(),
+        title: Some("Read README.md".to_string()),
+        kind: Some("read".to_string()),
+        status: Some("completed".to_string()),
+        meta: Some(json!({
+            "anyharness": {
+                "nativeToolName": "Read",
+                "parentToolCallId": "agent-1"
+            }
+        })),
+        ..Default::default()
+    });
+    sink.tool_call_update(AcpToolPayload {
+        tool_call_id: "agent-1".to_string(),
+        status: Some("completed".to_string()),
+        raw_output: Some(json!({ "summary": "The first heading is Proliferate." })),
+        ..Default::default()
+    });
+    sink.turn_ended(StopReason::EndTurn);
+
+    let live = drain_events(&mut rx);
+    let replay = store.list_events("session-1").expect("persisted replay");
+    assert_eq!(
+        replay.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        live.iter().map(|event| event.seq).collect::<Vec<_>>()
+    );
+
+    let nested = live
+        .iter()
+        .filter_map(|envelope| match &envelope.event {
+            SessionEvent::ItemStarted(event) => Some(&event.item),
+            SessionEvent::ItemCompleted(event) => Some(&event.item),
+            _ => None,
+        })
+        .filter(|item| item.parent_tool_call_id.as_deref() == Some("agent-1"))
+        .collect::<Vec<_>>();
+    assert!(nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::AssistantMessage)
+            && item.message_id.as_deref() == Some("child-message-1")
+    }));
+    assert!(nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::ToolInvocation)
+            && item.tool_call_id.as_deref() == Some("child-read-1")
+    }));
+
+    let replay_events = replay
+        .iter()
+        .map(|record| {
+            serde_json::from_str::<SessionEvent>(&record.payload_json)
+                .expect("deserialize persisted event")
+        })
+        .collect::<Vec<_>>();
+    let replay_nested = replay_events
+        .iter()
+        .filter_map(|event| match event {
+            SessionEvent::ItemStarted(event) => Some(&event.item),
+            SessionEvent::ItemCompleted(event) => Some(&event.item),
+            _ => None,
+        })
+        .filter(|item| item.parent_tool_call_id.as_deref() == Some("agent-1"))
+        .collect::<Vec<_>>();
+    assert!(replay_nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::AssistantMessage)
+            && item.message_id.as_deref() == Some("child-message-1")
+    }));
+    assert!(replay_nested.iter().any(|item| {
+        matches!(item.kind, TranscriptItemKind::ToolInvocation)
+            && item.tool_call_id.as_deref() == Some("child-read-1")
+    }));
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tools.rs
@@ -111,14 +111,20 @@ impl SessionEventSink {
                 }
             })
             .or_else(|| previous.and_then(|prev| prev.item.native_tool_name.clone()));
-        let parent_tool_call_id = if self.source_agent_kind == "claude" {
-            meta.claude_code
-                .as_ref()
-                .and_then(|meta| meta.parent_tool_use_id.clone())
-                .or_else(|| previous.and_then(|prev| prev.item.parent_tool_call_id.clone()))
-        } else {
-            previous.and_then(|prev| prev.item.parent_tool_call_id.clone())
-        };
+        let parent_tool_call_id = meta
+            .anyharness
+            .as_ref()
+            .and_then(|meta| meta.parent_tool_call_id.clone())
+            .or_else(|| {
+                (self.source_agent_kind == "claude")
+                    .then(|| {
+                        meta.claude_code
+                            .as_ref()
+                            .and_then(|meta| meta.parent_tool_use_id.clone())
+                    })
+                    .flatten()
+            })
+            .or_else(|| previous.and_then(|prev| prev.item.parent_tool_call_id.clone()));
 
         let title = payload
             .title

--- a/anyharness/sdk/src/reducer/__tests__/native-subagent-fixtures.ts
+++ b/anyharness/sdk/src/reducer/__tests__/native-subagent-fixtures.ts
@@ -1,0 +1,105 @@
+import type { SessionEventEnvelope } from "../../index.js";
+
+export type NativeSubagentFixture = {
+  provider: "claude" | "codex";
+  parentId: string;
+  childMessageId: string;
+  childToolId: string;
+  events: SessionEventEnvelope[];
+};
+
+export const nativeSubagentFixtures: NativeSubagentFixture[] = [
+  nativeSubagentFixture("claude"),
+  nativeSubagentFixture("codex"),
+];
+
+function nativeSubagentFixture(provider: "claude" | "codex"): NativeSubagentFixture {
+  const sessionId = `${provider}-session`;
+  const turnId = `${provider}-turn`;
+  const parentId = `${provider}-agent`;
+  const childMessageId = `${provider}-child-message`;
+  const childToolId = `${provider}-child-tool`;
+  const envelope = (
+    seq: number,
+    event: SessionEventEnvelope["event"],
+    itemId?: string,
+  ): SessionEventEnvelope => ({
+    sessionId,
+    seq,
+    timestamp: `2026-07-15T00:00:0${seq}Z`,
+    turnId,
+    ...(itemId ? { itemId } : {}),
+    event,
+  });
+  const parentItem = (status: "in_progress" | "completed") => ({
+    kind: "tool_invocation" as const,
+    status,
+    sourceAgentKind: provider,
+    toolCallId: parentId,
+    nativeToolName: "Agent",
+    title: "Inspect the repository",
+    rawInput: { prompt: "Read README.md", description: "Inspect the repository" },
+    rawOutput: status === "completed" ? { summary: "Found the heading." } : undefined,
+    contentParts: [{
+      type: "tool_call" as const,
+      toolCallId: parentId,
+      title: "Inspect the repository",
+      toolKind: "subagent",
+      nativeToolName: "Agent",
+    }],
+  });
+
+  return {
+    provider,
+    parentId,
+    childMessageId,
+    childToolId,
+    events: [
+      envelope(1, { type: "turn_started" }),
+      envelope(2, { type: "item_started", item: parentItem("in_progress") }, parentId),
+      envelope(3, {
+        type: "item_started",
+        item: {
+          kind: "assistant_message",
+          status: "in_progress",
+          sourceAgentKind: provider,
+          messageId: childMessageId,
+          parentToolCallId: parentId,
+          contentParts: [{ type: "text", text: "Inspecting README.md" }],
+        },
+      }, childMessageId),
+      envelope(4, {
+        type: "item_completed",
+        item: {
+          kind: "assistant_message",
+          status: "completed",
+          sourceAgentKind: provider,
+          messageId: childMessageId,
+          parentToolCallId: parentId,
+          contentParts: [{ type: "text", text: "Inspecting README.md" }],
+        },
+      }, childMessageId),
+      envelope(5, {
+        type: "item_completed",
+        item: {
+          kind: "tool_invocation",
+          status: "completed",
+          sourceAgentKind: provider,
+          toolCallId: childToolId,
+          nativeToolName: "Read",
+          parentToolCallId: parentId,
+          title: "Read README.md",
+          contentParts: [{
+            type: "tool_call",
+            toolCallId: childToolId,
+            title: "Read README.md",
+            toolKind: "read",
+            nativeToolName: "Read",
+          }],
+        },
+      }, childToolId),
+      envelope(6, { type: "item_completed", item: parentItem("completed") }, parentId),
+      envelope(7, { type: "turn_ended", stopReason: "end_turn" }),
+    ],
+  };
+}

--- a/anyharness/sdk/src/reducer/__tests__/native-subagent-transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/native-subagent-transcript.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createTranscriptState, reduceEvent, reduceEvents } from "../../index.js";
+import { nativeSubagentFixtures } from "./native-subagent-fixtures.js";
+
+describe.each(nativeSubagentFixtures)("$provider native subagent transcript", (fixture) => {
+  it("keeps stable identity, ordering, nesting, and completion in live and replay reduction", () => {
+    const replay = reduceEvents(fixture.events, `${fixture.provider}-session`, { replayMode: true });
+    const live = fixture.events.reduce(reduceEvent, createTranscriptState(`${fixture.provider}-session`));
+
+    expect(live).toEqual(replay);
+    expect(live.turnOrder).toEqual([`${fixture.provider}-turn`]);
+    expect(live.turnsById[`${fixture.provider}-turn`]?.itemOrder).toEqual([
+      fixture.parentId,
+      fixture.childMessageId,
+      fixture.childToolId,
+    ]);
+    expect(live.itemsById[fixture.parentId]).toMatchObject({
+      kind: "tool_call",
+      status: "completed",
+      nativeToolName: "Agent",
+    });
+    expect(live.itemsById[fixture.childMessageId]).toMatchObject({
+      kind: "assistant_prose",
+      status: "completed",
+      messageId: fixture.childMessageId,
+      parentToolCallId: fixture.parentId,
+    });
+    expect(live.itemsById[fixture.childToolId]).toMatchObject({
+      kind: "tool_call",
+      status: "completed",
+      parentToolCallId: fixture.parentId,
+    });
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -71,27 +71,6 @@ export function TranscriptAgentGroupBlock({
   const [expanded, setExpanded] = useState(false);
   const [workExpanded, setWorkExpanded] = useState(false);
 
-  // Native subagent lifecycle (session-activity-architecture): while a
-  // subagent is still running it lives ONLY in the composer ⑂ roster — the
-  // transcript stays quiet and shows nothing. Once finished, the item is
-  // routed to SubagentCreationGroupBlock (via buildTranscriptDisplayBlocks)
-  // and renders as a quiet done-line there. This block should NEVER receive
-  // finished subagents, but if one leaks through (e.g., stale transcript
-  // state or classification gap), hide it rather than show the old metadata
-  // block.
-  if (isRunning) {
-    return null;
-  }
-
-  // Finished subagents should have been routed to SubagentCreationGroupBlock
-  // by buildTranscriptDisplayBlocks. If one reached here, it's a
-  // classification gap — hide it silently (the roster already showed the live
-  // work, and SubagentCreationGroupBlock will render the done-line if the
-  // transcript re-classifies correctly on next update).
-  if (isWorkComplete) {
-    return null;
-  }
-
   const subagentDisplay = resolveSubagentLaunchDisplay(item);
   const normalizedPrompt = subagentDisplay.prompt?.trim() ?? "";
 
@@ -127,9 +106,8 @@ export function TranscriptAgentGroupBlock({
   const hasWork = childIds.length > 0;
   const hasLaunchLedger = !!normalizedPrompt || hasProvisioningLedger;
   const hasBodyContent = hasWork || hasLaunchLedger || !!normalizedAgentResult;
-  // Only finished subagents render here (running ones return null above and
-  // live in the composer roster), so the work view is always the collapsed
-  // done-state form.
+  // The activity roster is a session-level summary. This durable transcript
+  // item is the canonical place to inspect the native subagent's nested work.
   const renderScopedWork = () => (
     <ScopedTranscriptBlocks
       displayBlocks={scopedDisplayBlocks}

--- a/apps/packages/product-domain/src/chats/transcript/transcript-presentation.test.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-presentation.test.ts
@@ -125,7 +125,7 @@ describe("buildTurnPresentation", () => {
     ]);
   });
 
-  it("keeps native Agent calls with nested child work as normal item blocks ONLY while running", () => {
+  it("keeps running native Agent calls with nested child work as normal item blocks", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       agent: {
@@ -142,8 +142,6 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Running native Agent items produce normal item blocks (the renderer
-    // hides them with an early-return).
     expect(presentation.childrenByParentId.get("agent")).toEqual(["childRead"]);
     expect(presentation.displayBlocks).toEqual([
       { kind: "item", itemId: "agent" },
@@ -151,7 +149,7 @@ describe("buildTurnPresentation", () => {
     ]);
   });
 
-  it("routes finished foreground native Agent subagents to subagent_creations blocks", () => {
+  it("keeps finished foreground native Agent subagents in the durable transcript", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       agent: {
@@ -165,19 +163,13 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Finished foreground native Agent items route to subagent_creations
-    // blocks (rendered via SubagentCreationGroupBlock as quiet done-lines).
     expect(presentation.displayBlocks).toEqual([
-      {
-        kind: "subagent_creations",
-        blockId: "agent-agent",
-        itemIds: ["agent"],
-      },
+      { kind: "item", itemId: "agent" },
       { kind: "item", itemId: "final" },
     ]);
   });
 
-  it("routes finished background native Agent subagents to subagent_creations blocks", () => {
+  it("keeps finished background native Agent subagents in the durable transcript", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       agent: {
@@ -200,14 +192,8 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Finished background native Agent items also route to subagent_creations
-    // blocks.
     expect(presentation.displayBlocks).toEqual([
-      {
-        kind: "subagent_creations",
-        blockId: "agent-agent",
-        itemIds: ["agent"],
-      },
+      { kind: "item", itemId: "agent" },
       { kind: "item", itemId: "final" },
     ]);
   });
@@ -239,8 +225,6 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Background launches with pending state are still running, so they
-    // produce normal item blocks (the renderer hides them).
     expect(presentation.displayBlocks).toEqual([
       { kind: "item", itemId: "agent" },
     ]);

--- a/apps/packages/product-domain/src/chats/transcript/transcript-presentation.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-presentation.ts
@@ -4,7 +4,6 @@ import type {
   TurnRecord,
 } from "@anyharness/sdk";
 import { isSubagentCreationAction } from "../subagents/subagent-tool-presentation";
-import { isSubagentWorkComplete } from "../subagents/subagent-launch";
 import { isKnownModeSwitchToolCall } from "../tools/mode-switch-display";
 
 export type TurnDisplayBlock =
@@ -73,21 +72,10 @@ export function buildTranscriptDisplayBlocks({
     const item = transcript.itemsById[itemId];
     if (!item) continue;
 
-    // Route finished subagents (both MCP create_subagent and native Agent) to
-    // subagent_creations blocks. Running native subagents are hidden by the
-    // renderer (TranscriptAgentGroupBlock returns null), so they never reach
-    // this classification path.
+    // Provisioning receipts stay compact. Native Agent calls remain normal
+    // transcript items for their whole lifecycle so their nested work is
+    // visible during streaming and after durable replay.
     if (item.kind === "tool_call" && isSubagentCreationAction(item)) {
-      flushActions();
-      pendingSubagentCreationIds.push(itemId);
-      continue;
-    }
-
-    if (
-      item.kind === "tool_call"
-      && isFinishedNativeAgentSubagent(item)
-      && isSubagentWorkComplete(item)
-    ) {
       flushActions();
       pendingSubagentCreationIds.push(itemId);
       continue;
@@ -307,14 +295,4 @@ function isCollapsibleAction(
     && item.semanticKind !== "cowork_artifact_create"
     && item.semanticKind !== "cowork_artifact_update"
     && item.nativeToolName !== "Agent";
-}
-
-function isFinishedNativeAgentSubagent(
-  item: Extract<TranscriptItem, { kind: "tool_call" }>,
-): boolean {
-  // Only native Agent tool calls. MCP subagent communication tools
-  // (send_subagent_message, get_subagent_status, etc.) have semanticKind
-  // "subagent" but are NOT creation actions — they render via their own
-  // blocks (TranscriptMcpSubagentActionBlock).
-  return item.nativeToolName === "Agent";
 }

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -16,7 +16,7 @@
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
-            "gitRef": "d933c614497b88eb86200920003ab82d220252ca",
+            "gitRef": "b5f9db80fcf71d7b54b76ab18c1e2df1be7def04",
             "executableRelpath": "node_modules/.bin/claude-agent-acp"
           }
         },
@@ -1202,7 +1202,7 @@
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "938065e69331d91df0de3bbf1dcaae6e6dc6e2eb",
+            "gitRef": "20b4cff942b671cc1dabb9e4cfa61b5a783c436c",
             "packageSubdir": "npm",
             "executableRelpath": "node_modules/.bin/codex-acp"
           }

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-14.1",
+  "catalogVersion": "2026-07-15.1",
   "probedAgainst": {
-    "registryVersion": "2026-07-14.1"
+    "registryVersion": "2026-07-15.1"
   },
   "generatedAt": "2026-07-11T00:36:38.653Z",
   "defaultAgentKind": "claude",

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -25,7 +25,7 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#d933c614497b88eb86200920003ab82d220252ca",
+          "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#b5f9db80fcf71d7b54b76ab18c1e2df1be7def04",
           "packageSubdir": null,
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/claude-agent-acp"
@@ -133,7 +133,7 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/codex-acp.git#938065e69331d91df0de3bbf1dcaae6e6dc6e2eb",
+          "package": "git+https://github.com/proliferate-ai/codex-acp.git#20b4cff942b671cc1dabb9e4cfa61b5a783c436c",
           "packageSubdir": "npm",
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/codex-acp"

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "registryVersion": "2026-07-14.1",
+  "registryVersion": "2026-07-15.1",
   "generatedAt": "2026-05-31T00:00:00Z",
   "agents": [
     {

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -16,7 +16,7 @@
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
-            "gitRef": "d933c614497b88eb86200920003ab82d220252ca",
+            "gitRef": "b5f9db80fcf71d7b54b76ab18c1e2df1be7def04",
             "executableRelpath": "node_modules/.bin/claude-agent-acp"
           }
         },
@@ -1202,7 +1202,7 @@
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "938065e69331d91df0de3bbf1dcaae6e6dc6e2eb",
+            "gitRef": "20b4cff942b671cc1dabb9e4cfa61b5a783c436c",
             "packageSubdir": "npm",
             "executableRelpath": "node_modules/.bin/codex-acp"
           }

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-14.1",
+  "catalogVersion": "2026-07-15.1",
   "probedAgainst": {
-    "registryVersion": "2026-07-14.1"
+    "registryVersion": "2026-07-15.1"
   },
   "generatedAt": "2026-07-11T00:36:38.653Z",
   "defaultAgentKind": "claude",

--- a/scripts/agent-catalog/resolve-pins.mjs
+++ b/scripts/agent-catalog/resolve-pins.mjs
@@ -8,6 +8,7 @@
 // sha-verified, with no latest-fetch at install time.
 //
 //   node scripts/agent-catalog/resolve-pins.mjs [--agent claude,codex]
+//       [--agent-process-only]
 //       [--no-download]   resolve URLs only, leave sha256 empty (inspection)
 //       [--catalog PATH] [--registry PATH]
 //
@@ -25,6 +26,7 @@ const catalogPath = resolve(args.catalog ?? join(REPO_ROOT, "catalogs/agents/cat
 const registryPath = resolve(args.registry ?? join(REPO_ROOT, "catalogs/agents/registry.json"));
 const onlyAgents = args.agent ? new Set(args.agent.split(",")) : null;
 const noDownload = Boolean(args.noDownload);
+const agentProcessOnly = Boolean(args.agentProcessOnly);
 // Platforms we actually ship today: desktop (macOS arm64/x64) + cloud E2B
 // (linux x64). Override with --platforms to resolve the full matrix in CI.
 const DEFAULT_PLATFORMS = ["macos_arm64", "macos_x64", "linux_x64"];
@@ -85,12 +87,12 @@ for (const agent of catalog.agents) {
   }
   console.log(`\n── ${agent.kind}`);
 
-  if (reg.native && agent.harness.native) {
+  if (!agentProcessOnly && reg.native && agent.harness.native) {
     const { version, source } = await resolveNative(agent.kind, reg.native.install);
     agent.harness.native.version = version;
     agent.harness.native.source = source;
     console.log(`   native        ${version}  (${source.kind})`);
-  } else if (agent.harness.native) {
+  } else if (!agentProcessOnly && agent.harness.native) {
     // The probe's nativeCli attestation can leak a foreign launcher (e.g. the
     // bundled `claude` binary reported as the nativeCli for cursor/opencode)
     // onto agents that have no native artifact in the registry. Such a pin can
@@ -269,6 +271,7 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--no-download") out.noDownload = true;
+    else if (a === "--agent-process-only") out.agentProcessOnly = true;
     else if (a === "--agent") out.agent = argv[++i];
     else if (a === "--platforms") out.platforms = argv[++i];
     else if (a === "--catalog") out.catalog = argv[++i];

--- a/scripts/agent-catalog/resolve-pins.mjs
+++ b/scripts/agent-catalog/resolve-pins.mjs
@@ -9,6 +9,7 @@
 //
 //   node scripts/agent-catalog/resolve-pins.mjs [--agent claude,codex]
 //       [--agent-process-only]
+//       [--catalog-version YYYY-MM-DD.N]
 //       [--no-download]   resolve URLs only, leave sha256 empty (inspection)
 //       [--catalog PATH] [--registry PATH]
 //
@@ -110,6 +111,14 @@ for (const agent of catalog.agents) {
   if (ap.version) agent.harness.agentProcess.version = ap.version;
   agent.harness.agentProcess.source = ap.source;
   console.log(`   agentProcess  ${ap.version ?? "(kept)"}  (${ap.source.kind})`);
+}
+
+if (args.catalogVersion) {
+  catalog.catalogVersion = args.catalogVersion;
+  catalog.probedAgainst = {
+    ...(catalog.probedAgainst ?? {}),
+    registryVersion: registry.registryVersion ?? null,
+  };
 }
 
 writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
@@ -272,6 +281,7 @@ function parseArgs(argv) {
     const a = argv[i];
     if (a === "--no-download") out.noDownload = true;
     else if (a === "--agent-process-only") out.agentProcessOnly = true;
+    else if (a === "--catalog-version") out.catalogVersion = argv[++i];
     else if (a === "--agent") out.agent = argv[++i];
     else if (a === "--platforms") out.platforms = argv[++i];
     else if (a === "--catalog") out.catalog = argv[++i];

--- a/scripts/agent-catalog/resolve-pins.test.mjs
+++ b/scripts/agent-catalog/resolve-pins.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = join(dirname(fileURLToPath(import.meta.url)), "resolve-pins.mjs");
+
+test("agent-process-only updates selected adapter refs without resolving native artifacts", () => {
+  const root = mkdtempSync(join(tmpdir(), "catalog-resolve-pins-test-"));
+  try {
+    const catalogPath = join(root, "catalog.json");
+    const registryPath = join(root, "registry.json");
+    const native = {
+      version: "rust-v0.144.1",
+      source: {
+        kind: "archive",
+        targets: {
+          linux_x64: {
+            url: "https://example.test/codex.tar.gz",
+            sha256: "existing-sha",
+          },
+        },
+      },
+    };
+    writeFileSync(
+      catalogPath,
+      `${JSON.stringify(
+        {
+          agents: [
+            {
+              kind: "codex",
+              harness: {
+                native,
+                agentProcess: {
+                  version: "0.18.1-proliferate.1",
+                  source: {
+                    kind: "git",
+                    repo: "https://github.com/proliferate-ai/codex-acp.git",
+                    gitRef: "old-ref",
+                    packageSubdir: "npm",
+                    executableRelpath: "node_modules/.bin/codex-acp",
+                  },
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFileSync(
+      registryPath,
+      `${JSON.stringify(
+        {
+          agents: [
+            {
+              kind: "codex",
+              native: {
+                install: {
+                  kind: "tarball_release",
+                  versionedUrlTemplate:
+                    "https://github.com/openai/codex/releases/download/{version}/codex-{target}.tar.gz",
+                },
+              },
+              agentProcess: {
+                install: {
+                  kind: "managed_npm_package",
+                  package:
+                    "git+https://github.com/proliferate-ai/codex-acp.git#new-ref",
+                  packageSubdir: "npm",
+                  executableRelpath: "node_modules/.bin/codex-acp",
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    execFileSync(process.execPath, [
+      script,
+      "--catalog",
+      catalogPath,
+      "--registry",
+      registryPath,
+      "--agent",
+      "codex",
+      "--agent-process-only",
+    ]);
+
+    const resolved = JSON.parse(readFileSync(catalogPath, "utf8"));
+    assert.deepEqual(resolved.agents[0].harness.native, native);
+    assert.equal(
+      resolved.agents[0].harness.agentProcess.version,
+      "0.18.1-proliferate.1",
+    );
+    assert.equal(resolved.agents[0].harness.agentProcess.source.gitRef, "new-ref");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/agent-catalog/resolve-pins.test.mjs
+++ b/scripts/agent-catalog/resolve-pins.test.mjs
@@ -29,6 +29,8 @@ test("agent-process-only updates selected adapter refs without resolving native 
       catalogPath,
       `${JSON.stringify(
         {
+          catalogVersion: "2026-07-14.1",
+          probedAgainst: { registryVersion: "2026-07-14.1" },
           agents: [
             {
               kind: "codex",
@@ -56,6 +58,7 @@ test("agent-process-only updates selected adapter refs without resolving native 
       registryPath,
       `${JSON.stringify(
         {
+          registryVersion: "2026-07-15.1",
           agents: [
             {
               kind: "codex",
@@ -92,6 +95,8 @@ test("agent-process-only updates selected adapter refs without resolving native 
       "--agent",
       "codex",
       "--agent-process-only",
+      "--catalog-version",
+      "2026-07-15.1",
     ]);
 
     const resolved = JSON.parse(readFileSync(catalogPath, "utf8"));
@@ -101,6 +106,8 @@ test("agent-process-only updates selected adapter refs without resolving native 
       "0.18.1-proliferate.1",
     );
     assert.equal(resolved.agents[0].harness.agentProcess.source.gitRef, "new-ref");
+    assert.equal(resolved.catalogVersion, "2026-07-15.1");
+    assert.equal(resolved.probedAgainst.registryVersion, "2026-07-15.1");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/specs/codebase/structures/anyharness/harnesses/claude.md
+++ b/specs/codebase/structures/anyharness/harnesses/claude.md
@@ -18,6 +18,11 @@ override supplies a local adapter executable.
   assistant transcript item.
 - Transient progress uses the AnyHarness `transient_status` marker and is
   converted at the ACP boundary into typed normalized state.
+- Native Agent/Task child messages and tools retain Claude's
+  `parent_tool_use_id` as `_meta.anyharness.parentToolCallId`. The adapter uses
+  each Anthropic API message id as the stable live/replay message identity,
+  deduplicates assembled blocks already streamed as deltas, and forwards
+  assembled-only child content instead of dropping it.
 
 ## Extension Capabilities
 

--- a/specs/codebase/structures/anyharness/harnesses/codex.md
+++ b/specs/codebase/structures/anyharness/harnesses/codex.md
@@ -12,3 +12,10 @@ not by building the Rust repo at runtime.
 The Codex ACP session config surface also exposes `fast_mode` as a live control.
 That maps to Codex `service_tier = fast` for the current session, but it is not
 persisted across reload/resume by the current Codex rollout replay path.
+
+Native collaboration events are normalized by the ACP adapter before they
+reach AnyHarness. `CollabAgentSpawn*` owns the stable parent `Agent` tool item;
+interaction, wait, resume, close, and `SubAgentActivity` events become ordered
+tool items nested with `_meta.anyharness.parentToolCallId`. Terminal agent
+statuses update the original parent item rather than creating a second receipt.
+The same normalization runs for live events and Codex rollout replay.

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -168,6 +168,21 @@ Communication receipts:
 - When a valid child target exists, the whole wake/completion receipt chip and
   not a separate visible action or hover card, opens the child session.
 
+Native harness subagents use the same durable item stream as the parent turn:
+
+- The native `Agent`/spawn operation is one stable tool item from start through
+  completion or failure. It remains visible while running and after replay.
+- Child prose, reasoning, and tool activity carry
+  `parentToolCallId = <native Agent tool id>` and render inside that parent in
+  runtime sequence order.
+- Provider adapters emit `_meta.anyharness.parentToolCallId`; the sink accepts
+  Claude's older `_meta.claudeCode.parentToolUseId` only as a compatibility
+  fallback.
+- Session activity roster upserts are summary state, not transcript content.
+  They must never synthesize a second copy of native subagent work.
+- Live reduction and persisted replay consume the same normalized item events;
+  identity, nesting, ordering, and terminal status must therefore match.
+
 ## Layout Invariants
 
 Some layout dimensions are load-bearing. They are tuned together so specific


### PR DESCRIPTION
## Summary

- Surface native Codex and Claude Code subagents as durable parent transcript items with nested progress, prose, and tool activity in live streams and replay.
- Normalize provider-neutral parent identity at the adapter boundary, persist it in AnyHarness, and stop the frontend from hiding or compacting native Agent lifecycle items.
- Pin the exact companion adapter commits from [codex-acp #15](https://github.com/proliferate-ai/codex-acp/pull/15) and [claude-agent-acp #26](https://github.com/proliferate-ai/claude-agent-acp/pull/26).

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Reproduction and root cause

Confirmed at source boundaries:

- Codex ACP explicitly ignored CollabAgentSpawn, interaction, wait, resume, close, and SubAgentActivity events in both live handling and rollout replay.
- Claude ACP filtered child assistant prose, shared root stream identity with children, and omitted native parent identity during replay.
- AnyHarness accepted only the legacy Claude parent metadata key, so provider-neutral nesting was lost even when an adapter supplied it.
- Product presentation hid running native Agent items and compacted completed ones into quiet creation receipts, suppressing nested work.

A signed-in cloud product run was attempted, but Claude returned LoginRequired before an agent turn began. That confirms the environment auth constraint, not transcript behavior; no private runtime state or screenshots are included.

## Changes

- Add generic anyharness.parentToolCallId parsing with the existing Claude key retained as a compatibility fallback.
- Persist and replay nested child prose and tools under one stable native Agent tool id.
- Keep native Agent items in normal transcript presentation for running and terminal states; the activity roster remains summary-only and does not synthesize transcript copies.
- Add deterministic Claude and Codex fixtures proving live and replay equality, order, stable identity, nesting, and completion.
- Add an owner-script agent-process-only pin mode so exact adapter SHAs can be promoted without advancing unrelated native artifacts or stale probe-derived adapter versions.
- Update authoritative harness and transcript contracts.

## Verification

- cargo test -p anyharness-lib provider_neutral_subagent_metadata_persists_nested_live_events_for_replay -- --nocapture: 1 passed
- pnpm --filter @anyharness/sdk test -- native-subagent-transcript.test.ts: 14 files, 86 tests passed
- pnpm --filter @proliferate/product-domain test -- transcript-presentation.test.ts: 58 files, 548 tests passed
- pnpm --filter @proliferate/product-client typecheck: passed
- node --test scripts/agent-catalog/*.test.mjs: 17 passed
- python3 scripts/check_max_lines.py: passed
- node scripts/agent-catalog/check-version-discipline.mjs --base cd00510bd9460307714758e18274232c8aa66a06: passed
- node scripts/validate-agent-catalog.mjs: catalog 2026-07-15.1 OK, 5 agents
- python3 scripts/check_docs.py: 211 Markdown files passed
- git diff --check and staged secret-pattern review: clean
- Codex ACP companion: focused Rust fixture passed
- Claude ACP companion: build passed; 129 tests passed, 8 skipped

The full catalog probe target stopped at credential preflight because this worktree has no Anthropic API, Claude OAuth, OpenAI API, or Bedrock probe credentials. No partial probe was promoted. The scoped owner generator preserved all native and adapter versions and changed only the two reviewed Git SHAs. Global cargo fmt check currently reports unrelated repository-wide baseline drift, so formatting proof is limited to the scoped diff and successful compilation.

## Assumptions

- The session activity roster remains a compact cross-session summary; durable native subagent detail belongs only in the transcript item stream.
- Exact public companion commit SHAs are valid catalog inputs while their draft PRs are reviewed.
- Provider metadata remains additive and protocol-compatible; legacy Claude consumers continue to receive claudeCode metadata.

## Residual risks

- The current Codex native protocol exposes collaboration lifecycle and SubAgentActivity milestones, but not the full inner child-thread tool stream on the parent connection. This PR renders every available native event; deeper child tool detail requires an upstream protocol event.
- Signed-in UI validation remains blocked until the product environment has a valid Claude login. Deterministic adapter fixtures, persisted runtime replay, SDK reduction, presentation tests, and the full client typecheck are the strongest available proof.