### PR TITLE
fix(cowork): stabilize thread presentation states

### DIFF
--- a/apps/packages/product-client/src/components/feedback/ThinkingText.test.tsx
+++ b/apps/packages/product-client/src/components/feedback/ThinkingText.test.tsx
@@ -127,6 +127,7 @@ describe("StreamingIndicator", () => {
     expect(html).toContain("Thinking");
     expect(html).toContain("34s");
     expect(html).toContain("tabular-nums");
+    expect(html).toContain("items-baseline");
   });
 
   it("threads a context label instead of the universal Thinking", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -164,6 +164,17 @@ describe("ChatInputControlRow", () => {
     expect(screen.getByText("Medium").className).toContain("sr-only");
   });
 
+  it("does not reserve a pending glyph beside reasoning", () => {
+    const controls = createControls();
+    const effortControl = controls.find((control) => control.key === "effort")!;
+    effortControl.pendingState = "queued";
+
+    renderControlRow({ sessionConfigControls: controls });
+
+    const reasoning = screen.getByRole("button", { name: "Reasoning: Medium" });
+    expect(reasoning.parentElement?.querySelector("svg")).toBeNull();
+  });
+
   it("renders working mode as text with a subtle disclosure chevron", () => {
     renderControlRow();
     const mode = screen.getByRole("button", { name: "Mode: Default" });

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -11,7 +11,6 @@ import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/sess
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
 import { LevelBarsButton } from "@proliferate/ui/primitives/LevelBarsButton";
-import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
 
 // Tier-label tint ladder. Ultra keeps the codex-convention purple (same hue
 // as --color-pr-merged); max keeps the app special blue the bars already use.
@@ -95,17 +94,6 @@ export function ComposerReasoningEffortBars({ control }: ComposerReasoningEffort
         aria-label={ariaLabel}
       />
     );
-
-  if (control.pendingState) {
-    return (
-      <Tooltip content={tooltip}>
-        <span className="inline-flex items-center gap-1">
-          {bars}
-          <PendingConfigIndicator pendingState={control.pendingState} />
-        </span>
-      </Tooltip>
-    );
-  }
 
   return <Tooltip content={tooltip}>{bars}</Tooltip>;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
@@ -12,6 +12,8 @@ interface ToolCallSummaryProps {
   showWorkDivider?: boolean;
   /** Always-visible completion UI that remains part of the work block. */
   completionContent?: React.ReactNode;
+  /** Fade in only when a mounted live turn becomes completed history. */
+  animateCompletion?: boolean;
 }
 
 export function ToolCallSummary({
@@ -23,6 +25,7 @@ export function ToolCallSummary({
   defaultExpanded = false,
   showWorkDivider = false,
   completionContent = null,
+  animateCompletion = false,
 }: ToolCallSummaryProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const renderedChildren = expanded || (itemCount !== undefined && itemCount <= 1)
@@ -34,7 +37,10 @@ export function ToolCallSummary({
   }
 
   return (
-    <div className="min-w-0">
+    <div
+      className={`min-w-0 ${animateCompletion ? "motion-safe:animate-status-crossfade" : ""}`}
+      data-completed-work-transition={animateCompletion ? "true" : undefined}
+    >
       <TurnSeparator
         label={showWorkDivider ? _label : summary}
         interactive

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
@@ -13,6 +13,7 @@ import {
   CompletedHistorySequence,
   resolveTurnItemFrontierBlockKey,
   shouldRenderCompletedArtifactCards,
+  TurnItemSequence,
 } from "#product/components/workspace/chat/transcript/TurnItemSequence";
 
 vi.mock("./TranscriptTreeNode", () => ({
@@ -80,3 +81,69 @@ describe("completion-only frontier prelude", () => {
     })).toBe(true);
   });
 });
+
+describe("completed-work transition", () => {
+  it("fades the collapsed summary only on a mounted live-to-complete handoff", () => {
+    const transcript = createTranscriptState("session-1");
+    const liveTurn = turnRecord(["read"]);
+    transcript.itemsById = {
+      read: toolItem("read", liveTurn.turnId, 1, "file_read", "in_progress"),
+    };
+    const { container, rerender } = renderTurnItemSequence({
+      turn: liveTurn,
+      transcript,
+    });
+
+    const completedTurn = turnRecord(["read", "answer"], "2026-04-04T00:00:10Z");
+    transcript.itemsById.read = toolItem("read", completedTurn.turnId, 1, "file_read", "completed");
+    transcript.itemsById.answer = assistantItem("answer", completedTurn.turnId, 2);
+    rerender(turnItemSequence({ turn: completedTurn, transcript }));
+
+    const transition = container.querySelector("[data-completed-work-transition='true']");
+    expect(transition?.className).toContain("motion-safe:animate-status-crossfade");
+    expect(transition?.className).not.toContain("height");
+
+    rerender(turnItemSequence({ turn: completedTurn, transcript }));
+    expect(container.querySelector("[data-completed-work-transition='true']"))
+      .toBe(transition);
+
+    cleanup();
+    const hydrated = renderTurnItemSequence({ turn: completedTurn, transcript });
+    expect(hydrated.container.querySelector("[data-completed-work-transition]")).toBeNull();
+  });
+});
+
+function renderTurnItemSequence({
+  turn,
+  transcript,
+}: {
+  turn: ReturnType<typeof turnRecord>;
+  transcript: ReturnType<typeof createTranscriptState>;
+}) {
+  return render(turnItemSequence({ turn, transcript }));
+}
+
+function turnItemSequence({
+  turn,
+  transcript,
+}: {
+  turn: ReturnType<typeof turnRecord>;
+  transcript: ReturnType<typeof createTranscriptState>;
+}) {
+  const presentation = buildTurnPresentation(turn, transcript);
+  return (
+    <TurnItemSequence
+      turn={turn}
+      transcript={transcript}
+      isTurnComplete={turn.completedAt !== null}
+      presentation={presentation}
+      autoFollowCollapsedActionBlockId={null}
+      tailAssistantProseRootId={presentation.finalAssistantItemId}
+      completedHistoryLabel={null}
+      animateActivityEntry={false}
+      showCompletedArtifactFallback={false}
+      workspaceId={null}
+      onOpenArtifact={vi.fn()}
+    />
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -3,7 +3,7 @@ import type {
   TranscriptState,
   TurnRecord,
 } from "@anyharness/sdk";
-import { Fragment, type ReactNode } from "react";
+import { Fragment, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { CoworkArtifactTurnCard } from "#product/components/workspace/chat/tool-calls/CoworkArtifactTurnCard";
 import {
   ToolCallSummary,
@@ -61,6 +61,9 @@ export function TurnItemSequence({
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
   const artifactToolCalls = collectTurnCoworkArtifactToolCalls(turn, transcript);
+  const animateCompletedHistory = useCompletedHistoryTransition(
+    isTurnComplete && presentation.completedHistorySummary !== null,
+  );
   const completedArtifactToolCalls = isTurnComplete
     ? artifactToolCalls.filter((item) => item.status === "completed")
     : [];
@@ -119,6 +122,7 @@ export function TurnItemSequence({
               summary={formatCollapsedSummary(presentation.completedHistorySummary)}
               showWorkDivider={tailAssistantProseRootId !== null}
               completionContent={completedHistoryOwnsPrelude ? frontierPrelude : null}
+              animateCompletion={animateCompletedHistory}
               renderChildren={() => (
                 <CompletedHistorySequence>
                   {presentation.displayBlocks
@@ -181,6 +185,20 @@ export function TurnItemSequence({
       {frontierBlockKey === null ? standaloneFrontierPrelude : null}
     </>
   );
+}
+
+function useCompletedHistoryTransition(eligible: boolean): boolean {
+  const wasEligibleRef = useRef(eligible);
+  const [transitionClaimed, setTransitionClaimed] = useState(false);
+
+  useLayoutEffect(() => {
+    if (eligible && !wasEligibleRef.current) {
+      setTransitionClaimed(true);
+    }
+    wasEligibleRef.current = eligible;
+  }, [eligible]);
+
+  return transitionClaimed;
 }
 
 export function shouldRenderCompletedArtifactCards({

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactsPanel.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactsPanel.test.tsx
@@ -1,0 +1,85 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CoworkArtifactsPanel } from "#product/components/workspace/cowork/CoworkArtifactsPanel";
+
+const artifactState = vi.hoisted(() => ({
+  artifacts: [] as Array<{ id: string; description?: string | null }>,
+  isLoading: false,
+  isFetching: false,
+  refresh: vi.fn(async () => undefined),
+  selectedArtifactId: null as string | null,
+  setSelectedArtifactId: vi.fn(),
+}));
+
+vi.mock("@proliferate/ui/layout/AutoHideScrollArea", () => ({
+  AutoHideScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("#product/hooks/access/anyharness/cowork/use-cowork-artifact-manifest", () => ({
+  useCoworkArtifactManifest: () => ({
+    artifacts: artifactState.artifacts,
+    isLoading: artifactState.isLoading,
+    isFetching: artifactState.isFetching,
+  }),
+}));
+
+vi.mock("#product/hooks/access/anyharness/cowork/use-cowork-artifact-detail", () => ({
+  useCoworkArtifactDetail: () => ({
+    artifactDetail: null,
+    isLoading: false,
+    isFetching: false,
+    errorMessage: null,
+  }),
+}));
+
+vi.mock("#product/hooks/cowork/lifecycle/use-cowork-artifact-refresh", () => ({
+  useCoworkArtifactRefresh: () => ({ refresh: artifactState.refresh }),
+}));
+
+vi.mock("#product/stores/cowork/cowork-ui-store", () => ({
+  useCoworkUiStore: (selector: (state: {
+    selectedArtifactIdByWorkspaceId: Record<string, string | null>;
+    setSelectedArtifactId: typeof artifactState.setSelectedArtifactId;
+  }) => unknown) => selector({
+    selectedArtifactIdByWorkspaceId: {
+      "workspace-cowork": artifactState.selectedArtifactId,
+    },
+    setSelectedArtifactId: artifactState.setSelectedArtifactId,
+  }),
+}));
+
+vi.mock("#product/components/workspace/cowork/CoworkArtifactRow", () => ({
+  CoworkArtifactRow: ({ artifact }: { artifact: { id: string } }) => <div>{artifact.id}</div>,
+}));
+
+vi.mock("#product/components/workspace/cowork/CoworkArtifactViewer", () => ({
+  CoworkArtifactViewer: () => <div>Artifact viewer</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  artifactState.artifacts = [];
+  artifactState.isLoading = false;
+  artifactState.isFetching = false;
+  artifactState.selectedArtifactId = null;
+  artifactState.refresh.mockClear();
+  artifactState.setSelectedArtifactId.mockClear();
+});
+
+describe("CoworkArtifactsPanel", () => {
+  it("renders an intentional empty state with a single refresh action", () => {
+    const { container } = render(<CoworkArtifactsPanel workspaceId="workspace-cowork" />);
+
+    expect(screen.getByRole("heading", { name: "No artifacts yet" })).toBeTruthy();
+    expect(screen.getByText("Artifacts created by this thread will appear here.")).toBeTruthy();
+    const refreshButtons = screen.getAllByRole("button", { name: "Refresh" });
+    expect(refreshButtons).toHaveLength(1);
+    expect(container.querySelector(".border-dashed")).not.toBeNull();
+
+    fireEvent.click(refreshButtons[0]!);
+    expect(artifactState.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactsPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkArtifactsPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ArrowLeft } from "@proliferate/ui/icons";
 import { AutoHideScrollArea } from "@proliferate/ui/layout/AutoHideScrollArea";
+import { EmptyState } from "@proliferate/ui/layout/EmptyState";
 import { useCoworkArtifactDetail } from "#product/hooks/access/anyharness/cowork/use-cowork-artifact-detail";
 import { useCoworkArtifactManifest } from "#product/hooks/access/anyharness/cowork/use-cowork-artifact-manifest";
 import { useCoworkArtifactRefresh } from "#product/hooks/cowork/lifecycle/use-cowork-artifact-refresh";
@@ -28,6 +29,17 @@ export function CoworkArtifactsPanel({
   const artifactDetailQuery = useCoworkArtifactDetail(workspaceId, selectedArtifact?.id ?? null);
   const { refresh } = useCoworkArtifactRefresh(workspaceId, selectedArtifact?.id ?? null);
   const isViewingArtifact = selectedArtifact !== null;
+  const isEmpty = artifacts.length === 0 && !isLoading;
+  const refreshButton = (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => { void refresh(); }}
+      loading={isFetching}
+    >
+      Refresh
+    </Button>
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-tl-lg border-l border-t border-border bg-sidebar-background">
@@ -65,10 +77,13 @@ export function CoworkArtifactsPanel({
             viewportClassName="px-3 py-3"
             contentClassName="flex flex-col gap-1"
           >
-            {artifacts.length === 0 && !isLoading ? (
-              <div className="px-2 py-8 text-center text-sm text-muted-foreground">
-                No artifacts yet.
-              </div>
+            {isEmpty ? (
+              <EmptyState
+                title="No artifacts yet"
+                description="Artifacts created by this thread will appear here."
+                action={refreshButton}
+                className="min-h-52 bg-background/40"
+              />
             ) : (
               artifacts.map((artifact) => (
                 <CoworkArtifactRow
@@ -83,16 +98,11 @@ export function CoworkArtifactsPanel({
         </div>
       )}
 
-      <div className="flex items-center justify-end border-t border-sidebar-border/70 px-3 py-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => { void refresh(); }}
-          loading={isFetching}
-        >
-          Refresh
-        </Button>
-      </div>
+      {!isEmpty && (
+        <div className="flex items-center justify-end border-t border-sidebar-border/70 px-3 py-2">
+          {refreshButton}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadRow.test.tsx
@@ -1,0 +1,72 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { CoworkThread } from "@anyharness/sdk";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CoworkThreadRow } from "#product/components/workspace/cowork/sidebar/CoworkThreadRow";
+
+vi.mock("@proliferate/ui/icons", () => ({
+  ChevronDown: () => <span />,
+  ChevronRight: () => <span />,
+}));
+
+vi.mock("@proliferate/ui/primitives/IconButton", () => ({
+  IconButton: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+}));
+
+vi.mock("#product/components/workspace/shell/sidebar/SidebarIndicators", () => ({
+  SidebarStatusIndicatorView: () => <span data-testid="activity-indicator" />,
+}));
+
+vi.mock("@proliferate/product-ui/sidebar/ProductSidebarThreads", () => ({
+  ProductSidebarThreadRow: ({
+    status,
+    trailingStatus,
+  }: {
+    status?: ReactNode;
+    trailingStatus?: ReactNode;
+  }) => (
+    <div>
+      <div data-testid="leading-status">{status}</div>
+      <div data-testid="trailing-status">{trailingStatus}</div>
+    </div>
+  ),
+}));
+
+afterEach(cleanup);
+
+describe("CoworkThreadRow", () => {
+  it("puts iterating activity in the workspace-convention trailing slot", () => {
+    render(
+      <CoworkThreadRow
+        thread={thread()}
+        active
+        activity="iterating"
+        canExpand={false}
+        expanded={false}
+        onToggleExpanded={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("leading-status").children).toHaveLength(0);
+    expect(screen.getByTestId("trailing-status").querySelector("[data-testid='activity-indicator']"))
+      .not.toBeNull();
+  });
+});
+
+function thread(): CoworkThread {
+  return {
+    id: "thread-1",
+    workspaceId: "workspace-cowork",
+    sessionId: "session-cowork",
+    repoRootId: "repo-root-1",
+    branchName: "cowork/thread-1",
+    agentKind: "codex",
+    title: null,
+    createdAt: "2026-07-15T12:00:00Z",
+    updatedAt: "2026-07-15T12:00:00Z",
+    workspaceDelegationEnabled: false,
+  };
+}

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
@@ -160,7 +160,7 @@ describe("CoworkThreadsSection", () => {
       attemptId: "attempt-1",
       selectedWorkspaceId: null,
       source: "cowork-created",
-      displayName: "Cowork thread",
+      displayName: "Untitled chat",
       request: {
         kind: "cowork",
         input: {
@@ -178,7 +178,7 @@ describe("CoworkThreadsSection", () => {
 
     render(<CoworkThreadsSection />);
 
-    expect(screen.getByText("Cowork thread")).not.toBeNull();
+    expect(screen.getByText("Untitled chat")).not.toBeNull();
     // The trailing spinner alone marks the pending row (trailingStatus wins
     // over any trailing label, so the row no longer carries "Setting up").
     expect(screen.getByTestId("status-iterating")).not.toBeNull();
@@ -187,12 +187,12 @@ describe("CoworkThreadsSection", () => {
     expect(screen.queryByTestId("threads-skeleton")).toBeNull();
   });
 
-  it("does not duplicate the pending row after the real cowork thread appears", () => {
+  it("keeps the pending projection and suppresses its real row until handoff completes", () => {
     const pendingEntry = buildSubmittingPendingWorkspaceEntry({
       attemptId: "attempt-2",
       selectedWorkspaceId: null,
       source: "cowork-created",
-      displayName: "Cowork thread",
+      displayName: "Untitled chat",
       request: {
         kind: "cowork",
         input: {
@@ -225,7 +225,135 @@ describe("CoworkThreadsSection", () => {
 
     render(<CoworkThreadsSection />);
 
-    expect(screen.queryByText("Setting up")).toBeNull();
+    expect(screen.getByText("Untitled chat")).not.toBeNull();
+    expect(screen.getByTestId("status-iterating")).not.toBeNull();
+    expect(screen.queryByTestId("real-thread-row")).toBeNull();
+  });
+
+  it("shows the real thread after the pending handoff clears", () => {
+    coworkState.threads = [{
+      id: "thread-1",
+      agentKind: "claude",
+      branchName: "main",
+      createdAt: "2026-01-01T00:00:00Z",
+      lastActivityAt: null,
+      repoRootId: "repo-root-1",
+      requestedModelId: "sonnet",
+      sessionId: "session-1",
+      title: "Real thread",
+      updatedAt: "2026-01-01T00:00:00Z",
+      workspaceDelegationEnabled: false,
+      workspaceId: "workspace-cowork",
+    }];
+
+    render(<CoworkThreadsSection />);
+
+    expect(screen.queryByTestId("thread-row")).toBeNull();
     expect(screen.getByTestId("real-thread-row").textContent).toBe("Real thread");
+  });
+
+  it("keeps the selected error projection when a materialized pending entry fails", () => {
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-failed",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Untitled chat",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "claude",
+          modelId: "sonnet",
+          sourceWorkspaceId: null,
+        },
+      },
+    });
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: {
+        ...pendingEntry,
+        stage: "failed",
+        workspaceId: "workspace-cowork",
+        errorMessage: "Couldn't apply launch defaults",
+      },
+    });
+    coworkState.threads = [{
+      id: "thread-1",
+      agentKind: "claude",
+      branchName: "main",
+      createdAt: "2026-01-01T00:00:00Z",
+      lastActivityAt: null,
+      repoRootId: "repo-root-1",
+      requestedModelId: "sonnet",
+      sessionId: "session-1",
+      title: "Real thread",
+      updatedAt: "2026-01-01T00:00:00Z",
+      workspaceDelegationEnabled: false,
+      workspaceId: "workspace-cowork",
+    }];
+
+    render(<CoworkThreadsSection />);
+
+    expect(screen.getByTestId("thread-row")).not.toBeNull();
+    expect(screen.getByTestId("status-error")).not.toBeNull();
+    expect(screen.queryByTestId("real-thread-row")).toBeNull();
+  });
+
+  it("shows an error status when creation fails before materialization", () => {
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-failed-before-create",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Untitled chat",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "claude",
+          modelId: "sonnet",
+          sourceWorkspaceId: null,
+        },
+      },
+    });
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: {
+        ...pendingEntry,
+        stage: "failed",
+        errorMessage: "Couldn't create chat",
+      },
+    });
+
+    render(<CoworkThreadsSection />);
+
+    expect(screen.getByTestId("status-error")).not.toBeNull();
+    expect(screen.queryByTestId("status-iterating")).toBeNull();
+  });
+
+  it("keeps a failed materialized row visible until the real query row arrives", () => {
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-failed-awaiting-query",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Untitled chat",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "claude",
+          modelId: "sonnet",
+          sourceWorkspaceId: null,
+        },
+      },
+    });
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: {
+        ...pendingEntry,
+        stage: "failed",
+        workspaceId: "workspace-cowork",
+        errorMessage: "Couldn't apply launch defaults",
+      },
+    });
+
+    render(<CoworkThreadsSection />);
+
+    expect(screen.getByTestId("thread-row")).not.toBeNull();
+    expect(screen.getByTestId("status-error")).not.toBeNull();
+    expect(screen.queryByText("No chats yet")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
@@ -39,10 +39,21 @@ export function CoworkThreadsSection() {
   const pendingCoworkUiKey = pendingCoworkEntry
     ? buildPendingWorkspaceUiKey(pendingCoworkEntry)
     : null;
-  const showPendingCoworkThread = Boolean(
-    pendingCoworkEntry
-    && !threads.some((thread) => thread.workspaceId === pendingCoworkEntry.workspaceId),
-  );
+  const pendingCoworkOwnsRow = pendingCoworkEntry !== null;
+  const pendingCoworkWorkspaceIdToSuppress = pendingCoworkOwnsRow
+    ? pendingCoworkEntry?.workspaceId ?? null
+    : null;
+  // The pending row remains the single presentation owner until activation
+  // clears it. Once creation has a real workspace id, suppress that query row
+  // instead of swapping identities partway through materialization. Failed
+  // entries keep owning the row so their selected shell and error state remain
+  // truthful until retry, navigation, or finalization clears the projection.
+  const listedThreads = useMemo(() => (
+    pendingCoworkWorkspaceIdToSuppress
+      ? threads.filter((thread) => thread.workspaceId !== pendingCoworkWorkspaceIdToSuppress)
+      : threads
+  ), [pendingCoworkWorkspaceIdToSuppress, threads]);
+  const showPendingCoworkThread = pendingCoworkOwnsRow;
   const pendingCoworkThreadActive = Boolean(
     pendingCoworkEntry
     && (
@@ -53,7 +64,7 @@ export function CoworkThreadsSection() {
       )
     ),
   );
-  const renderedThreadCount = threads.length + (showPendingCoworkThread ? 1 : 0);
+  const renderedThreadCount = listedThreads.length + (showPendingCoworkThread ? 1 : 0);
 
   const [expandedThreadIds, setExpandedThreadIds] = useState<Set<string>>(new Set());
   const toggleThreadExpanded = useCallback((threadId: string) => {
@@ -65,17 +76,17 @@ export function CoworkThreadsSection() {
     });
   }, []);
 
-  const overLimit = threads.length > DEFAULT_VISIBLE_THREAD_COUNT;
+  const overLimit = listedThreads.length > DEFAULT_VISIBLE_THREAD_COUNT;
   const selectedThreadIndex = useMemo(() => (
     selectedWorkspaceId
-      ? threads.findIndex((thread) => thread.workspaceId === selectedWorkspaceId)
+      ? listedThreads.findIndex((thread) => thread.workspaceId === selectedWorkspaceId)
       : -1
-  ), [selectedWorkspaceId, threads]);
+  ), [listedThreads, selectedWorkspaceId]);
   const forceExpanded = !expanded && selectedThreadIndex >= DEFAULT_VISIBLE_THREAD_COUNT;
   const isEffectivelyExpanded = expanded || forceExpanded;
   const visibleThreads = isEffectivelyExpanded
-    ? threads
-    : threads.slice(0, DEFAULT_VISIBLE_THREAD_COUNT);
+    ? listedThreads
+    : listedThreads.slice(0, DEFAULT_VISIBLE_THREAD_COUNT);
   const toggleLabel: "Show more" | "Show less" | null = !overLimit
     ? null
     : forceExpanded
@@ -125,7 +136,12 @@ export function CoworkThreadsSection() {
               active={pendingCoworkThreadActive}
               trailingStatus={(
                 <SidebarStatusIndicatorView
-                  indicator={{ kind: "iterating", tooltip: "Creating chat" }}
+                  indicator={pendingCoworkEntry.stage === "failed"
+                    ? {
+                        kind: "error",
+                        tooltip: pendingCoworkEntry.errorMessage ?? "Couldn't start chat",
+                      }
+                    : { kind: "iterating", tooltip: "Creating chat" }}
                 />
               )}
               label={pendingCoworkEntry.displayName}
@@ -139,7 +155,7 @@ export function CoworkThreadsSection() {
                 <p className="sr-only">Loading threads</p>
               </div>
             )
-          ) : threads.length === 0 ? (
+          ) : listedThreads.length === 0 ? (
             showPendingCoworkThread ? null : (
               <div className="px-2 py-2 text-xs text-sidebar-muted-foreground">
                 {isCreatingThread ? "Creating chat" : "No chats yet"}

--- a/apps/packages/product-client/src/lib/domain/cowork/threads.ts
+++ b/apps/packages/product-client/src/lib/domain/cowork/threads.ts
@@ -1,5 +1,7 @@
 import type { CoworkThread } from "@anyharness/sdk";
 
+export const UNTITLED_COWORK_THREAD_TITLE = "Untitled chat";
+
 export function coworkThreadTitle(thread: CoworkThread): string {
-  return thread.title?.trim() || "Untitled chat";
+  return thread.title?.trim() || UNTITLED_COWORK_THREAD_TITLE;
 }

--- a/apps/packages/product-client/src/lib/workflows/cowork/create-cowork-thread.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/cowork/create-cowork-thread.test.ts
@@ -1,0 +1,129 @@
+import type {
+  CreateCoworkThreadResponse,
+  Session,
+} from "@anyharness/sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCoworkThreadWorkflow,
+  type CreateCoworkThreadWorkflowDeps,
+} from "#product/lib/workflows/cowork/create-cowork-thread";
+import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
+
+describe("createCoworkThreadWorkflow", () => {
+  it("keeps one Untitled chat identity while the real workspace materializes", async () => {
+    const response = coworkThreadResponse();
+    const launchDefaults = deferred<Session>();
+    let pendingEntry: PendingWorkspaceEntry | null = null;
+    const setPendingWorkspaceEntry = vi.fn((entry: PendingWorkspaceEntry | null) => {
+      pendingEntry = entry;
+    });
+    const beginPendingWorkspace = vi.fn<
+      CreateCoworkThreadWorkflowDeps["beginPendingWorkspace"]
+    >(() => "projected-session");
+    const applyLaunchDefaults = vi.fn(() => launchDefaults.promise);
+
+    const deps = {
+      createPendingWorkspaceAttemptId: vi.fn(() => "attempt-1"),
+      nowMs: vi.fn(() => 100),
+      nowIso: vi.fn(() => "2026-07-15T12:00:00Z"),
+      startLatencyTimer: vi.fn(() => 0),
+      elapsedMs: vi.fn(() => 10),
+      elapsedSince: vi.fn(() => 10),
+      logLatency: vi.fn(),
+      getSelectedWorkspaceId: vi.fn(() => null),
+      getPendingWorkspaceEntry: vi.fn(() => pendingEntry),
+      isAttemptCurrent: vi.fn(() => true),
+      setThreadsCollapsed: vi.fn(),
+      beginPendingWorkspace,
+      navigateToWorkspaceShell: vi.fn(),
+      createCoworkThread: vi.fn(async () => response),
+      applyLaunchDefaults,
+      upsertLocalWorkspace: vi.fn(),
+      upsertWorkspaceSessionRecord: vi.fn(),
+      recordCreatedSession: vi.fn(),
+      setDraftText: vi.fn(),
+      clearDraft: vi.fn(),
+      setPendingWorkspaceEntry,
+      activateWorkspace: vi.fn(),
+      rememberLastViewedSession: vi.fn(),
+      trackWorkspaceInteraction: vi.fn(),
+      markWorkspaceViewed: vi.fn(),
+      markWorkspaceBootstrappedInSession: vi.fn(),
+      initWorkspace: vi.fn(async () => undefined),
+      showToast: vi.fn(),
+    } satisfies CreateCoworkThreadWorkflowDeps;
+
+    const workflow = createCoworkThreadWorkflow({
+      agentKind: "codex",
+      modelId: "gpt-5.6-codex",
+      coworkWorkspaceDelegationEnabled: false,
+      runtimeUrl: "http://127.0.0.1:4317",
+    }, deps);
+
+    await vi.waitFor(() => expect(applyLaunchDefaults).toHaveBeenCalledTimes(1));
+
+    expect(beginPendingWorkspace.mock.calls[0]?.[0].displayName).toBe("Untitled chat");
+    expect(setPendingWorkspaceEntry).toHaveBeenCalledWith(expect.objectContaining({
+      attemptId: "attempt-1",
+      displayName: "Untitled chat",
+      workspaceId: "workspace-cowork",
+      request: { kind: "select-existing", workspaceId: "workspace-cowork" },
+    }));
+
+    launchDefaults.resolve(response.session);
+    await expect(workflow).resolves.toMatchObject({
+      workspace: { id: "workspace-cowork" },
+      projectedSessionId: "projected-session",
+    });
+    expect(setPendingWorkspaceEntry).toHaveBeenLastCalledWith(null);
+  });
+});
+
+function coworkThreadResponse(): CreateCoworkThreadResponse {
+  const createdAt = "2026-07-15T12:00:00Z";
+  return {
+    workspace: {
+      id: "workspace-cowork",
+      path: "/tmp/workspace-cowork",
+      repoRootId: "repo-root-1",
+      surface: "cowork",
+      kind: "local",
+      lifecycleState: "active",
+      cleanupState: "none",
+      createdAt,
+      updatedAt: createdAt,
+    },
+    session: {
+      id: "session-cowork",
+      workspaceId: "workspace-cowork",
+      agentKind: "codex",
+      status: "idle",
+      actionCapabilities: {},
+      createdAt,
+      updatedAt: createdAt,
+    },
+    thread: {
+      id: "thread-cowork",
+      workspaceId: "workspace-cowork",
+      sessionId: "session-cowork",
+      repoRootId: "repo-root-1",
+      branchName: "cowork/thread-cowork",
+      agentKind: "codex",
+      title: null,
+      createdAt,
+      updatedAt: createdAt,
+      workspaceDelegationEnabled: false,
+    },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/lib/workflows/cowork/create-cowork-thread.ts
+++ b/apps/packages/product-client/src/lib/workflows/cowork/create-cowork-thread.ts
@@ -4,6 +4,7 @@ import type {
   Session,
 } from "@anyharness/sdk";
 import { resolveCoworkDefaultSessionModeId } from "#product/lib/domain/cowork/session-mode-defaults";
+import { UNTITLED_COWORK_THREAD_TITLE } from "#product/lib/domain/cowork/threads";
 import { workspaceFileTreeStateKey } from "#product/lib/domain/workspaces/cloud/collections";
 import {
   buildPendingWorkspaceOriginTarget,
@@ -119,7 +120,7 @@ export async function createCoworkThreadWorkflow(
     attemptId: deps.createPendingWorkspaceAttemptId(),
     source: "cowork-created",
     stage: "submitting",
-    displayName: "Cowork thread",
+    displayName: UNTITLED_COWORK_THREAD_TITLE,
     repoLabel: null,
     baseBranchName: null,
     workspaceId: null,
@@ -182,6 +183,18 @@ export async function createCoworkThreadWorkflow(
       return null;
     }
 
+    // Materialization must preserve the pending projection's identity. The
+    // create mutation invalidates the real thread list immediately, while
+    // launch-default application can still be in flight. Associate the real
+    // workspace before that await so the sidebar can suppress the duplicate
+    // query row throughout the handoff.
+    const materializedEntry: PendingWorkspaceEntry = {
+      ...entry,
+      workspaceId: result.workspace.id,
+      request: { kind: "select-existing", workspaceId: result.workspace.id },
+    };
+    deps.setPendingWorkspaceEntry(materializedEntry);
+
     const launchedSession = await deps.applyLaunchDefaults({
       session: result.session,
       agentKind: input.agentKind,
@@ -211,11 +224,6 @@ export async function createCoworkThreadWorkflow(
     }
 
     const selectionStartedAt = deps.startLatencyTimer();
-    deps.setPendingWorkspaceEntry({
-      ...entry,
-      workspaceId: result.workspace.id,
-      request: { kind: "select-existing", workspaceId: result.workspace.id },
-    });
     deps.activateWorkspace({
       logicalWorkspaceId: null,
       workspaceId: result.workspace.id,


### PR DESCRIPTION
## Summary

- Keep the pending Cowork row as the single presentation owner while the created workspace materializes, using the canonical `Untitled chat` identity and suppressing the matching query row until activation clears the projection.
- Render a deliberate artifacts empty state, remove the reasoning control's pending glyph, and crossfade the live-work summary into completed history without animating layout dimensions.
- Lock current-main sidebar/status geometry with focused regressions: Cowork activity stays in the trailing row slot and streaming text stays baseline-aligned.

### Reproduction and root cause

In the signed-in Desktop product, creating a Cowork thread could briefly render both `Cowork thread` and `Untitled chat`. The create mutation invalidated the real thread query before the workflow associated the returned workspace id with its pending projection; launch-default application left enough time for both identities to render. The composer also rendered a separate queued indicator next to reasoning, the artifacts pane used an underspecified text-only placeholder with a detached refresh action, and live activity was replaced by completed history without a transition.

Current `main` already owns two of the reported geometry corrections: Cowork activity is passed through the workspace-row trailing slot, and the streaming indicator uses baseline alignment. This PR adds regression coverage for those owners instead of introducing duplicate paths. Production web does not expose Cowork, so reproduction was Desktop-only.

### Changes

- Associate the returned Cowork workspace id with the pending entry before awaiting launch defaults.
- Use `Untitled chat` for both pending and untitled materialized identities; keep pending success/error projection ownership truthful until selection finalizes.
- Use the shared `EmptyState` component with one in-context refresh action.
- Preserve optimistic reasoning selection feedback without a separate pending icon.
- Claim a one-shot, `motion-safe` opacity crossfade when a mounted live turn becomes completed history; hydrated history remains static and no height animation is introduced.
- Add workflow and component/state coverage for identity handoff, failure states, empty artifacts, reasoning status, status placement/baseline, and completion transitions.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/packages/product-client`
- Focused Vitest suite: 8 files / 44 tests passed
- `python3 scripts/check_docs.py` (211 Markdown files passed)
- `make setup PROFILE=c082-cowork-ui`
- `make build PROFILE=c082-cowork-ui`
- `make run PROFILE=c082-cowork-ui`: runtime and backend health checks returned HTTP 200 and the native Desktop process launched
- `git diff --check` and staged credential-pattern scan passed

### Manual validation, assumptions, and residual risk

- Base: `cd00510bd9460307714758e18274232c8aa66a06` (current `origin/main` at publication).
- Assumption: a Cowork pending shell owns its sidebar row in both submitting and failed stages until retry, navigation, or successful finalization clears it.
- Assumption: the canonical initial identity is `Untitled chat`; no server or product contract changes are required.
- The local native after-state could not be visually exercised because macOS locked during the validation pass. The same build launched successfully and its local services were healthy; signed-in Desktop supplied the before-state reproduction and focused tests cover the changed state transitions.
- Turns split into completion rows at 24+ items mount as completed history and intentionally do not replay the live-to-complete crossfade. Ordinary mounted turns crossfade once and retain the claimed class across immediate rerenders.
