### PR TITLE
fix(agent-routing): scope models to active auth route

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/agent_auth.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agent_auth.rs
@@ -6,12 +6,14 @@
 //! where every session launch reads it fresh.
 
 use anyharness_contract::v1::ApplyAgentAuthStateResponse;
-use axum::{body::Bytes, extract::State, Json};
+use axum::{body::Bytes, extract::State, http::StatusCode, Json};
 
 use super::error::ApiError;
 use crate::app::AppState;
 use crate::domains::agents::route_auth::state::SOURCE_KIND_GATEWAY;
-use crate::domains::agents::route_auth::{apply_state_file, AgentAuthState, RouteAuthError};
+use crate::domains::agents::route_auth::{
+    apply_state_file, clear_state_file, AgentAuthState, RouteAuthError,
+};
 
 #[utoipa::path(
     put,
@@ -54,6 +56,22 @@ pub async fn put_agent_auth_state(
         applied: true,
         revision: document.revision,
     }))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/agent-auth/state",
+    responses(
+        (status = 204, description = "Persisted route state cleared; native auth is active"),
+        (status = 500, description = "State could not be cleared", body = anyharness_contract::v1::ProblemDetails),
+    ),
+    tag = "agent-auth"
+)]
+pub async fn delete_agent_auth_state(
+    State(state): State<AppState>,
+) -> Result<StatusCode, ApiError> {
+    clear_state_file(&state.runtime_home).map_err(map_route_auth_error)?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Kick a background probe per gateway source in the just-applied document.

--- a/anyharness/crates/anyharness-lib/src/api/openapi.rs
+++ b/anyharness/crates/anyharness-lib/src/api/openapi.rs
@@ -133,6 +133,7 @@ use anyharness_contract::v1::{
         super::http::agents::reconcile_agents,
         super::http::auth::push_revoked_jtis,
         super::http::agent_auth::put_agent_auth_state,
+        super::http::agent_auth::delete_agent_auth_state,
         super::http::catalogs::apply_agent_catalog,
         super::http::agent_gateway_catalog::get_gateway_models,
         super::http::agent_gateway_catalog::refresh_gateway_models,

--- a/anyharness/crates/anyharness-lib/src/api/openapi.rs
+++ b/anyharness/crates/anyharness-lib/src/api/openapi.rs
@@ -1,5 +1,3 @@
-use utoipa::OpenApi;
-
 use anyharness_contract::v1::{
     AdvanceReplaySessionResponse, AgentCliAuthState, AgentCredentialState, AgentInstallState,
     AgentLaunchModelOption, AgentLaunchOption, AgentLaunchOptionsResponse,
@@ -111,6 +109,7 @@ use anyharness_contract::v1::{
     WorktreeNameConflictPolicy, WorktreeStorageEstimate, WriteWorkspaceFileRequest,
     WriteWorkspaceFileResponse,
 };
+use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(

--- a/anyharness/crates/anyharness-lib/src/api/router.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router.rs
@@ -11,12 +11,12 @@ use subtle::ConstantTimeEq;
 use url::form_urlencoded;
 
 use super::http::{
-    agent_auth, agent_gateway_catalog, agents, auth as http_auth, catalogs, cowork, files, git,
-    goals, health, hosting, loops, mobility, plans, processes, product_mcp, replay, repo_roots,
-    reviews, sessions, sessions_config, sessions_events, sessions_fork, sessions_interactions,
-    sessions_lifecycle, sessions_prompt, sessions_resume, subagents, terminals, workflow_runs,
-    workspaces, workspaces_lifecycle, workspaces_purge, workspaces_setup, workspaces_worktrees,
-    worktrees,
+    agent_auth::{delete_agent_auth_state, put_agent_auth_state},
+    agent_gateway_catalog, agents, auth as http_auth, catalogs, cowork, files, git, goals, health,
+    hosting, loops, mobility, plans, processes, product_mcp, replay, repo_roots, reviews, sessions,
+    sessions_config, sessions_events, sessions_fork, sessions_interactions, sessions_lifecycle,
+    sessions_prompt, sessions_resume, subagents, terminals, workflow_runs, workspaces,
+    workspaces_lifecycle, workspaces_purge, workspaces_setup, workspaces_worktrees, worktrees,
 };
 use super::sse::sessions as sse_sessions;
 use super::ws::activity as ws_activity;
@@ -68,11 +68,8 @@ pub fn build_router(state: AppState) -> Router {
             post(agents::start_agent_login_terminal),
         )
         .route("/auth/revoked-jtis", put(http_auth::push_revoked_jtis))
-        // Agent-auth state (desktop-pushed local-surface state.json)
-        .route(
-            "/agent-auth/state",
-            put(agent_auth::put_agent_auth_state).delete(agent_auth::delete_agent_auth_state),
-        )
+        .route("/agent-auth/state", put(put_agent_auth_state))
+        .route("/agent-auth/state", delete(delete_agent_auth_state))
         // Catalogs (worker-pushed agent catalog document)
         .route("/catalogs/agents", put(catalogs::apply_agent_catalog))
         .route(

--- a/anyharness/crates/anyharness-lib/src/api/router.rs
+++ b/anyharness/crates/anyharness-lib/src/api/router.rs
@@ -69,7 +69,10 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route("/auth/revoked-jtis", put(http_auth::push_revoked_jtis))
         // Agent-auth state (desktop-pushed local-surface state.json)
-        .route("/agent-auth/state", put(agent_auth::put_agent_auth_state))
+        .route(
+            "/agent-auth/state",
+            put(agent_auth::put_agent_auth_state).delete(agent_auth::delete_agent_auth_state),
+        )
         // Catalogs (worker-pushed agent catalog document)
         .route("/catalogs/agents", put(catalogs::apply_agent_catalog))
         .route(

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/launch_facts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/launch_facts.rs
@@ -162,6 +162,10 @@ pub(crate) fn collect_launch_env_facts_with_ambient(
 }
 
 #[cfg(test)]
+#[path = "launch_facts_route_transition_tests.rs"]
+mod route_transition_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use anyharness_credential_discovery::CredentialFact;
@@ -589,74 +593,5 @@ mod tests {
             baseline_visible.iter().map(|m| &m.id).collect::<Vec<_>>(),
             visible.iter().map(|m| &m.id).collect::<Vec<_>>()
         );
-    }
-
-    /// Regression for gateway -> native -> API-key route changes. A Codex
-    /// native credential may be present throughout, but an explicit route is
-    /// authoritative for single-source harnesses. In particular, the native-
-    /// only `gpt-5.6-sol` model must be rejected while gateway is selected and
-    /// become valid again for native and explicit OpenAI API-key launches.
-    #[test]
-    fn codex_route_transitions_scope_model_validation_to_the_effective_provider() {
-        use crate::domains::agents::auth::context::classify;
-        use crate::domains::agents::catalog::bundled::bundled_agent_catalog_document;
-        use crate::domains::agents::catalog::service::{ActiveCatalog, SelectionUnsupported};
-        use crate::domains::agents::model::AgentKind;
-        use crate::domains::agents::registry::built_in_registry;
-        use std::sync::Arc;
-
-        let home = temp_home();
-        let document = Arc::new(bundled_agent_catalog_document().clone());
-        let contexts = document
-            .agents
-            .iter()
-            .find(|agent| agent.kind == "codex")
-            .map(|agent| agent.auth_contexts.as_slice())
-            .expect("codex auth contexts");
-        let descriptor = built_in_registry()
-            .into_iter()
-            .find(|descriptor| descriptor.kind == AgentKind::Codex)
-            .expect("codex descriptor");
-        let catalog = ActiveCatalog::new(Arc::clone(&document));
-        let native_key_env = BTreeMap::from([(
-            "OPENAI_API_KEY".to_string(),
-            "present-but-never-inspected".to_string(),
-        )]);
-
-        write_state(
-            &home,
-            r#"{"version":2,"revision":1,"harnesses":[
-                {"harness_kind":"codex","sources":[
-                    {"kind":"gateway","base_url":"https://gw","key":"sk-vk"}]}]}"#,
-        );
-        let gateway_facts = collect_launch_env_facts("codex", &native_key_env, &home);
-        let gateway_contexts = classify(&descriptor, contexts, &gateway_facts);
-        assert_eq!(gateway_contexts.ids(), &["gateway".to_string()]);
-        assert!(matches!(
-            catalog.validate_launch("codex", &gateway_contexts, Some("gpt-5.6-sol"), None,),
-            Err(SelectionUnsupported::ModelGated { .. })
-        ));
-
-        std::fs::remove_file(home.join("agent-auth/state.json")).expect("clear to native");
-        let native_facts = collect_launch_env_facts("codex", &native_key_env, &home);
-        let native_contexts = classify(&descriptor, contexts, &native_facts);
-        catalog
-            .validate_launch("codex", &native_contexts, Some("gpt-5.6-sol"), None)
-            .expect("native OpenAI route accepts native model");
-
-        write_state(
-            &home,
-            r#"{"version":2,"revision":2,"harnesses":[
-                {"harness_kind":"codex","sources":[
-                    {"kind":"api_key","env_var_name":"OPENAI_API_KEY","value":"sk-raw"}]}]}"#,
-        );
-        let api_key_facts = collect_launch_env_facts("codex", &BTreeMap::new(), &home);
-        let api_key_contexts = classify(&descriptor, contexts, &api_key_facts);
-        assert_eq!(api_key_contexts.ids(), &["openai-api".to_string()]);
-        catalog
-            .validate_launch("codex", &api_key_contexts, Some("gpt-5.6-sol"), None)
-            .expect("explicit OpenAI API-key route accepts native model");
-
-        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/launch_facts.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/launch_facts.rs
@@ -25,38 +25,55 @@ use std::path::{Path, PathBuf};
 use anyharness_credential_discovery::{route_kinds, CredentialFact};
 
 use crate::domains::agents::registry::bundled::bundled_agent_registry_document;
-use crate::domains::agents::registry::schema::{AgentRegistryAuthSlotEnvVar, AgentRegistryEnvVarKind};
-use crate::domains::agents::route_auth::profile::{
-    resolve_profile, AgentRuntimeAuthProfile, ResolvedSource,
+use crate::domains::agents::registry::schema::{
+    AgentRegistryAuthSlotEnvVar, AgentRegistryEnvVarKind,
 };
-use crate::domains::agents::route_auth::state::load_state_file;
+use crate::domains::agents::route_auth::profile::{AgentRuntimeAuthProfile, ResolvedSource};
+use crate::domains::agents::route_auth::resolve_launch_auth_profile;
 
-/// Collect credential facts for classification, merging composed workspace env
-/// with registry-bounded ambient process env, AND the enrolled-route facts
-/// resolved from workspace-scoped `agent-auth/state.json`. Both call sites
-/// (launch_options and create_session) go through this single entry point.
+/// Collect credential facts for classification from the auth profile the
+/// launcher will actually use. Native profiles merge composed workspace env
+/// with registry-bounded ambient process env. Explicit sources replace those
+/// native facts for single-source harnesses; OpenCode intentionally composes
+/// both. Both call sites (launch_options and create_session) go through this
+/// single entry point.
 ///
 /// `runtime_home` is the AnyHarness home whose `agent-auth/state.json` the
-/// route reader consults. It uses the same resolution as `route_auth` at
-/// launch. A missing, native, or non-gateway state yields no route fact;
-/// classification then falls through exactly as before.
+/// route reader consults, including the same server-origin guard as launch.
 pub fn collect_launch_env_facts(
     agent_kind: &str,
     readiness_env: &BTreeMap<String, String>,
     runtime_home: &Path,
 ) -> Vec<CredentialFact> {
     let ambient: BTreeMap<String, String> = std::env::vars().collect();
-    let mut facts = collect_launch_env_facts_with_ambient(agent_kind, readiness_env, &ambient);
-    facts.extend(collect_enrolled_source_facts(agent_kind, runtime_home));
-    facts
+    let native_facts =
+        || collect_launch_env_facts_with_ambient(agent_kind, readiness_env, &ambient);
+    match resolve_launch_auth_profile(runtime_home, agent_kind) {
+        Ok(profile @ AgentRuntimeAuthProfile::Sources(_)) => {
+            let mut facts = collect_enrolled_source_facts(&profile);
+            // OpenCode intentionally composes injected sources with its native
+            // providers. Every other supported routed harness is single-source:
+            // its selected route must mask ambient/native credentials exactly as
+            // the launch renderer does.
+            if agent_kind == "opencode" {
+                facts.extend(native_facts());
+            }
+            facts
+        }
+        Ok(AgentRuntimeAuthProfile::Native) => native_facts(),
+        Err(error) => {
+            tracing::debug!(agent_kind, %error, "route profile unresolved; native facts govern");
+            native_facts()
+        }
+    }
 }
 
 /// Facts derived from the enrolled credential sources in workspace-scoped
-/// `agent-auth/state.json`. Reuses `route_auth::resolve_profile` — one reader,
-/// two consumers (this collector and the launch-time renderer) — so a
-/// classification-visible context exactly tracks a source the launcher would
-/// inject. A malformed state file is tolerated as "no facts" (stale in the SAFE
-/// direction: contexts stay gated until the file heals), never an error here.
+/// `agent-auth/state.json`. Reuses the launch-time route resolver — one reader,
+/// two consumers (this collector and the renderer) — so a classification-
+/// visible context exactly tracks a source the launcher would inject. Route
+/// resolution errors are logged and leave native/composed facts in control,
+/// preserving the collector's existing non-fatal behavior.
 ///
 /// Per source kind:
 /// - `gateway` → a single [`CredentialFact::Route`] for the gateway route
@@ -69,16 +86,9 @@ pub fn collect_launch_env_facts(
 ///   `Env(ANTHROPIC_API_KEY)`) never activates and the model menu comes back
 ///   empty. The Env fact carries presence only; the raw value is still rendered
 ///   into the launch env by the existing `render_profile` path at spawn time.
-fn collect_enrolled_source_facts(agent_kind: &str, runtime_home: &Path) -> Vec<CredentialFact> {
-    let state = match load_state_file(runtime_home) {
-        Ok(state) => state,
-        Err(error) => {
-            tracing::debug!(agent_kind, %error, "route state unreadable; no source facts");
-            return Vec::new();
-        }
-    };
-    match resolve_profile(state.as_ref(), agent_kind) {
-        Ok(AgentRuntimeAuthProfile::Sources(sources)) => {
+fn collect_enrolled_source_facts(profile: &AgentRuntimeAuthProfile) -> Vec<CredentialFact> {
+    match profile {
+        AgentRuntimeAuthProfile::Sources(sources) => {
             let mut facts = Vec::new();
             let mut has_gateway = false;
             for source in &sources.sources {
@@ -98,11 +108,7 @@ fn collect_enrolled_source_facts(agent_kind: &str, runtime_home: &Path) -> Vec<C
             }
             facts
         }
-        Ok(AgentRuntimeAuthProfile::Native) => Vec::new(),
-        Err(error) => {
-            tracing::debug!(agent_kind, %error, "route profile unresolved; no source facts");
-            Vec::new()
-        }
+        AgentRuntimeAuthProfile::Native => Vec::new(),
     }
 }
 
@@ -311,7 +317,7 @@ mod tests {
     }
 
     /// A gateway source in `agent-auth/state.json` emits a `Route` fact for
-    /// that harness, collected beside the env facts.
+    /// that harness instead of native credential facts.
     #[test]
     fn gateway_source_in_state_emits_route_fact() {
         let home = temp_home();
@@ -583,5 +589,74 @@ mod tests {
             baseline_visible.iter().map(|m| &m.id).collect::<Vec<_>>(),
             visible.iter().map(|m| &m.id).collect::<Vec<_>>()
         );
+    }
+
+    /// Regression for gateway -> native -> API-key route changes. A Codex
+    /// native credential may be present throughout, but an explicit route is
+    /// authoritative for single-source harnesses. In particular, the native-
+    /// only `gpt-5.6-sol` model must be rejected while gateway is selected and
+    /// become valid again for native and explicit OpenAI API-key launches.
+    #[test]
+    fn codex_route_transitions_scope_model_validation_to_the_effective_provider() {
+        use crate::domains::agents::auth::context::classify;
+        use crate::domains::agents::catalog::bundled::bundled_agent_catalog_document;
+        use crate::domains::agents::catalog::service::{ActiveCatalog, SelectionUnsupported};
+        use crate::domains::agents::model::AgentKind;
+        use crate::domains::agents::registry::built_in_registry;
+        use std::sync::Arc;
+
+        let home = temp_home();
+        let document = Arc::new(bundled_agent_catalog_document().clone());
+        let contexts = document
+            .agents
+            .iter()
+            .find(|agent| agent.kind == "codex")
+            .map(|agent| agent.auth_contexts.as_slice())
+            .expect("codex auth contexts");
+        let descriptor = built_in_registry()
+            .into_iter()
+            .find(|descriptor| descriptor.kind == AgentKind::Codex)
+            .expect("codex descriptor");
+        let catalog = ActiveCatalog::new(Arc::clone(&document));
+        let native_key_env = BTreeMap::from([(
+            "OPENAI_API_KEY".to_string(),
+            "present-but-never-inspected".to_string(),
+        )]);
+
+        write_state(
+            &home,
+            r#"{"version":2,"revision":1,"harnesses":[
+                {"harness_kind":"codex","sources":[
+                    {"kind":"gateway","base_url":"https://gw","key":"sk-vk"}]}]}"#,
+        );
+        let gateway_facts = collect_launch_env_facts("codex", &native_key_env, &home);
+        let gateway_contexts = classify(&descriptor, contexts, &gateway_facts);
+        assert_eq!(gateway_contexts.ids(), &["gateway".to_string()]);
+        assert!(matches!(
+            catalog.validate_launch("codex", &gateway_contexts, Some("gpt-5.6-sol"), None,),
+            Err(SelectionUnsupported::ModelGated { .. })
+        ));
+
+        std::fs::remove_file(home.join("agent-auth/state.json")).expect("clear to native");
+        let native_facts = collect_launch_env_facts("codex", &native_key_env, &home);
+        let native_contexts = classify(&descriptor, contexts, &native_facts);
+        catalog
+            .validate_launch("codex", &native_contexts, Some("gpt-5.6-sol"), None)
+            .expect("native OpenAI route accepts native model");
+
+        write_state(
+            &home,
+            r#"{"version":2,"revision":2,"harnesses":[
+                {"harness_kind":"codex","sources":[
+                    {"kind":"api_key","env_var_name":"OPENAI_API_KEY","value":"sk-raw"}]}]}"#,
+        );
+        let api_key_facts = collect_launch_env_facts("codex", &BTreeMap::new(), &home);
+        let api_key_contexts = classify(&descriptor, contexts, &api_key_facts);
+        assert_eq!(api_key_contexts.ids(), &["openai-api".to_string()]);
+        catalog
+            .validate_launch("codex", &api_key_contexts, Some("gpt-5.6-sol"), None)
+            .expect("explicit OpenAI API-key route accepts native model");
+
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/auth/launch_facts_route_transition_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/auth/launch_facts_route_transition_tests.rs
@@ -1,0 +1,87 @@
+//! Provider-scoped route-transition regression tests for launch facts.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::collect_launch_env_facts;
+use crate::domains::agents::auth::context::classify;
+use crate::domains::agents::catalog::bundled::bundled_agent_catalog_document;
+use crate::domains::agents::catalog::service::{ActiveCatalog, SelectionUnsupported};
+use crate::domains::agents::model::AgentKind;
+use crate::domains::agents::registry::built_in_registry;
+
+fn temp_home() -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "anyharness-route-transition-facts-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(path.join("agent-auth")).expect("create agent-auth dir");
+    path
+}
+
+fn write_state(home: &Path, json: &str) {
+    std::fs::write(home.join("agent-auth").join("state.json"), json).expect("write state");
+}
+
+/// Regression for gateway -> native -> API-key route changes. A Codex
+/// native credential may be present throughout, but an explicit route is
+/// authoritative for single-source harnesses. In particular, the native-
+/// only `gpt-5.6-sol` model must be rejected while gateway is selected and
+/// become valid again for native and explicit OpenAI API-key launches.
+#[test]
+fn codex_route_transitions_scope_model_validation_to_the_effective_provider() {
+    let home = temp_home();
+    let document = Arc::new(bundled_agent_catalog_document().clone());
+    let contexts = document
+        .agents
+        .iter()
+        .find(|agent| agent.kind == "codex")
+        .map(|agent| agent.auth_contexts.as_slice())
+        .expect("codex auth contexts");
+    let descriptor = built_in_registry()
+        .into_iter()
+        .find(|descriptor| descriptor.kind == AgentKind::Codex)
+        .expect("codex descriptor");
+    let catalog = ActiveCatalog::new(Arc::clone(&document));
+    let native_key_env = BTreeMap::from([(
+        "OPENAI_API_KEY".to_string(),
+        "present-but-never-inspected".to_string(),
+    )]);
+
+    write_state(
+        &home,
+        r#"{"version":2,"revision":1,"harnesses":[
+            {"harness_kind":"codex","sources":[
+                {"kind":"gateway","base_url":"https://gw","key":"sk-vk"}]}]}"#,
+    );
+    let gateway_facts = collect_launch_env_facts("codex", &native_key_env, &home);
+    let gateway_contexts = classify(&descriptor, contexts, &gateway_facts);
+    assert_eq!(gateway_contexts.ids(), &["gateway".to_string()]);
+    assert!(matches!(
+        catalog.validate_launch("codex", &gateway_contexts, Some("gpt-5.6-sol"), None,),
+        Err(SelectionUnsupported::ModelGated { .. })
+    ));
+
+    std::fs::remove_file(home.join("agent-auth/state.json")).expect("clear to native");
+    let native_facts = collect_launch_env_facts("codex", &native_key_env, &home);
+    let native_contexts = classify(&descriptor, contexts, &native_facts);
+    catalog
+        .validate_launch("codex", &native_contexts, Some("gpt-5.6-sol"), None)
+        .expect("native OpenAI route accepts native model");
+
+    write_state(
+        &home,
+        r#"{"version":2,"revision":2,"harnesses":[
+            {"harness_kind":"codex","sources":[
+                {"kind":"api_key","env_var_name":"OPENAI_API_KEY","value":"sk-raw"}]}]}"#,
+    );
+    let api_key_facts = collect_launch_env_facts("codex", &BTreeMap::new(), &home);
+    let api_key_contexts = classify(&descriptor, contexts, &api_key_facts);
+    assert_eq!(api_key_contexts.ids(), &["openai-api".to_string()]);
+    catalog
+        .validate_launch("codex", &api_key_contexts, Some("gpt-5.6-sol"), None)
+        .expect("explicit OpenAI API-key route accepts native model");
+
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
@@ -38,7 +38,9 @@ use std::path::{Path, PathBuf};
 pub use plan::{GatewayModelPlan, GatewayModelResolve};
 pub use profile::{resolve_profile, AgentRuntimeAuthProfile};
 pub use render::{render_profile, RenderedRouteAuth};
-pub use state::{apply_state_file, load_state_file, state_file_path, AgentAuthState};
+pub use state::{
+    apply_state_file, clear_state_file, load_state_file, state_file_path, AgentAuthState,
+};
 
 /// Errors from the route-auth render plane.
 #[derive(Debug, thiserror::Error)]
@@ -100,6 +102,25 @@ fn current_server_origin() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// Resolve the auth profile that a launch will actually use, including the
+/// desktop server-origin guard. Catalog classification calls this same seam so
+/// model availability cannot be computed from a route the launcher will ignore.
+pub(crate) fn resolve_launch_auth_profile(
+    runtime_home: &Path,
+    harness_kind: &str,
+) -> Result<AgentRuntimeAuthProfile, RouteAuthError> {
+    let state = load_effective_state(runtime_home, current_server_origin().as_deref())?;
+    resolve_profile(state.as_ref(), harness_kind)
+}
+
+fn load_effective_state(
+    runtime_home: &Path,
+    current_server_origin: Option<&str>,
+) -> Result<Option<AgentAuthState>, RouteAuthError> {
+    Ok(load_state_file(runtime_home)?
+        .filter(|state| state.matches_server_origin(current_server_origin)))
+}
+
 /// End-to-end at launch: load the state file, resolve the profile for
 /// `harness_kind`, resolve the catalog-driven [`GatewayModelPlan`], render its
 /// env delta (PURE), then apply the rendered file specs to disk (materializing
@@ -140,8 +161,7 @@ fn resolve_launch_route_auth_for_server(
     resolver: &dyn GatewayModelResolve,
     current_server_origin: Option<&str>,
 ) -> Result<RenderedRouteAuth, RouteAuthError> {
-    let state = load_state_file(runtime_home)?;
-    let state = state.filter(|state| state.matches_server_origin(current_server_origin));
+    let state = load_effective_state(runtime_home, current_server_origin)?;
     let revision = state.as_ref().map(|state| state.revision).unwrap_or(0);
     let profile = resolve_profile(state.as_ref(), harness_kind)?;
     let plan = resolver.resolve_gateway_models(harness_kind, revision);
@@ -184,7 +204,7 @@ fn launch_route_provides_credentials_for_server(
     harness_kind: &str,
     current_server_origin: Option<&str>,
 ) -> bool {
-    let state = match load_state_file(runtime_home) {
+    let state = match load_effective_state(runtime_home, current_server_origin) {
         Ok(state) => state,
         Err(error) => {
             tracing::debug!(
@@ -195,7 +215,6 @@ fn launch_route_provides_credentials_for_server(
             return false;
         }
     };
-    let state = state.filter(|state| state.matches_server_origin(current_server_origin));
     matches!(
         resolve_profile(state.as_ref(), harness_kind),
         Ok(AgentRuntimeAuthProfile::Sources(_))

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
@@ -193,6 +193,23 @@ pub fn apply_state_file(runtime_home: &Path, state: &AgentAuthState) -> Result<(
     super::materialize::write_private_file(&path, &serialized)
 }
 
+/// Clear the delivered route state and return the runtime to native auth.
+///
+/// Clearing is a separate operation from revisioned replacement because native
+/// auth is represented by the absence of route state at the runtime. Making
+/// the reset explicit avoids weakening stale-write protection for ordinary
+/// state documents.
+pub fn clear_state_file(runtime_home: &Path) -> Result<(), RouteAuthError> {
+    let path = state_file_path(runtime_home);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(RouteAuthError::Materialize {
+            detail: format!("failed to remove {}: {error}", path.display()),
+        }),
+    }
+}
+
 pub(super) fn load_state_from_path(path: &Path) -> Result<Option<AgentAuthState>, RouteAuthError> {
     let contents = match fs::read(path) {
         Ok(contents) => contents,
@@ -475,5 +492,25 @@ mod tests {
         apply_state_file(home.path(), &state_with_revision(3)).expect("heal");
         let loaded = load_state_file(home.path()).expect("load").expect("state");
         assert_eq!(loaded.revision, 3);
+    }
+
+    #[test]
+    fn clear_state_file_resets_revision_lineage_for_native_then_new_route() {
+        let home = TempHome::new("clear-native");
+        apply_state_file(home.path(), &state_with_revision(7)).expect("apply gateway state");
+
+        clear_state_file(home.path()).expect("clear to native");
+        assert!(load_state_file(home.path())
+            .expect("load cleared state")
+            .is_none());
+
+        apply_state_file(home.path(), &state_with_revision(1)).expect("apply new route lineage");
+        assert_eq!(
+            load_state_file(home.path())
+                .expect("load replacement")
+                .expect("replacement state")
+                .revision,
+            1
+        );
     }
 }

--- a/anyharness/sdk-react/src/index.ts
+++ b/anyharness/sdk-react/src/index.ts
@@ -36,6 +36,7 @@ export {
   anyHarnessAgentReconcileStatusKey,
   anyHarnessReconcileAgentsMutationKey,
   anyHarnessAgentGatewayModelsKey,
+  anyHarnessAgentGatewayModelsPrefixKey,
   anyHarnessRuntimeWorkspacesKey,
   anyHarnessWorkspaceRetirePreflightKey,
   anyHarnessWorkspacePurgePreflightKey,

--- a/anyharness/sdk-react/src/lib/query-keys.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.ts
@@ -73,6 +73,13 @@ export function anyHarnessAgentGatewayModelsKey(
   return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "gateway-models", kind ?? null] as const;
 }
 
+export function anyHarnessAgentGatewayModelsPrefixKey(
+  runtimeUrl: string | null | undefined,
+  cacheScopeKey: string | null | undefined,
+) {
+  return [...anyHarnessAgentsKey(runtimeUrl, cacheScopeKey), "gateway-models"] as const;
+}
+
 export function anyHarnessReconcileAgentsMutationKey(
   runtimeUrl: string | null | undefined,
   cacheScopeKey: string | null | undefined,

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -79,6 +79,27 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "agent-auth"
+        ],
+        "operationId": "delete_agent_auth_state",
+        "responses": {
+          "204": {
+            "description": "Persisted route state cleared; native auth is active"
+          },
+          "500": {
+            "description": "State could not be cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/agents": {

--- a/anyharness/sdk/src/client/agent-auth.test.ts
+++ b/anyharness/sdk/src/client/agent-auth.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import type { AnyHarnessTransport } from "./core.js";
+import { AgentAuthClient } from "./agent-auth.js";
+
+describe("AgentAuthClient.clearState", () => {
+  it("deletes the persisted route state", async () => {
+    const calls: string[] = [];
+    const transport = {
+      delete: async (path: string) => {
+        calls.push(path);
+      },
+    } as unknown as AnyHarnessTransport;
+    const client = new AgentAuthClient(transport);
+
+    await client.clearState();
+
+    expect(calls).toEqual(["/v1/agent-auth/state"]);
+  });
+});

--- a/anyharness/sdk/src/client/agent-auth.ts
+++ b/anyharness/sdk/src/client/agent-auth.ts
@@ -17,4 +17,8 @@ export class AgentAuthClient {
       options,
     );
   }
+
+  async clearState(options?: AnyHarnessRequestOptions): Promise<void> {
+    await this.transport.delete("/v1/agent-auth/state", options);
+  }
 }

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -30,7 +30,7 @@ export interface paths {
         get?: never;
         put: operations["put_agent_auth_state"];
         post?: never;
-        delete?: never;
+        delete: operations["delete_agent_auth_state"];
         options?: never;
         head?: never;
         patch?: never;
@@ -5183,6 +5183,33 @@ export interface operations {
             };
             /** @description Stale revision; persisted state unchanged */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetails"];
+                };
+            };
+        };
+    };
+    delete_agent_auth_state: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Persisted route state cleared; native auth is active */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description State could not be cleared */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -406,7 +406,7 @@ describe("HarnessPane authentication", () => {
         harnessKind: "claude",
         surface: "local",
         body: {
-          sources: [],
+          sources: [{ sourceKind: "gateway", enabled: false }],
         },
       },
       expect.anything(),

--- a/apps/packages/product-client/src/hooks/access/anyharness/agents/use-agent-resources-cache.test.tsx
+++ b/apps/packages/product-client/src/hooks/access/anyharness/agents/use-agent-resources-cache.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAgentResourcesCache } from "#product/hooks/access/anyharness/agents/use-agent-resources-cache";
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  anyHarnessAgentsKey: (runtimeUrl: string, scope: string) =>
+    ["anyharness", scope, "runtime", runtimeUrl, "agents"],
+  anyHarnessAgentReconcileStatusKey: (runtimeUrl: string, scope: string) =>
+    ["anyharness", scope, "runtime", runtimeUrl, "agents", "reconcile-status"],
+  anyHarnessAgentLaunchOptionsPrefixKey: (runtimeUrl: string, scope: string) =>
+    ["anyharness", scope, "runtime", runtimeUrl, "agents", "launch-options"],
+  anyHarnessAgentGatewayModelsPrefixKey: (runtimeUrl: string, scope: string) =>
+    ["anyharness", scope, "runtime", runtimeUrl, "agents", "gateway-models"],
+  useAnyHarnessCacheScopeKey: () => "account-1",
+}));
+
+describe("useAgentResourcesCache", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("invalidates launch options and gateway models after an auth-route change", async () => {
+    mocks.invalidateQueries.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useAgentResourcesCache());
+
+    await act(async () => {
+      await result.current.invalidateAgentLaunchReadinessResources("http://runtime.test");
+    });
+
+    const keys = mocks.invalidateQueries.mock.calls.map(([input]) => input.queryKey);
+    expect(keys).toContainEqual([
+      "anyharness",
+      "account-1",
+      "runtime",
+      "http://runtime.test",
+      "agents",
+      "launch-options",
+    ]);
+    expect(keys).toContainEqual([
+      "anyharness",
+      "account-1",
+      "runtime",
+      "http://runtime.test",
+      "agents",
+      "gateway-models",
+    ]);
+  });
+});

--- a/apps/packages/product-client/src/hooks/access/anyharness/agents/use-agent-resources-cache.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/agents/use-agent-resources-cache.ts
@@ -1,5 +1,6 @@
 import {
   anyHarnessAgentLaunchOptionsPrefixKey,
+  anyHarnessAgentGatewayModelsPrefixKey,
   anyHarnessAgentReconcileStatusKey,
   anyHarnessAgentsKey,
   useAnyHarnessCacheScopeKey,
@@ -52,6 +53,12 @@ export function useAgentResourcesCache() {
       invalidateAgentSetupResources(normalizedRuntimeUrl),
       queryClient.invalidateQueries({
         queryKey: anyHarnessAgentLaunchOptionsPrefixKey(
+          normalizedRuntimeUrl,
+          cacheScopeKey,
+        ),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: anyHarnessAgentGatewayModelsPrefixKey(
           normalizedRuntimeUrl,
           cacheScopeKey,
         ),

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-local-auth-state-sync.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-local-auth-state-sync.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentAuthState } from "@proliferate/cloud-sdk";
+import { useLocalAuthStateSync } from "#product/hooks/agents/lifecycle/use-local-auth-state-sync";
+
+const mocks = vi.hoisted(() => ({
+  applyAgentAuthState: vi.fn(),
+  clearAgentAuthState: vi.fn(),
+  invalidateAgentLaunchReadinessResources: vi.fn(),
+  useAgentAuthState: vi.fn(),
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useAgentAuthState: mocks.useAgentAuthState,
+}));
+
+vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({
+    cloudEnabled: true,
+    authStatus: "authenticated",
+  }),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ deployment: { apiBaseUrl: "https://api.example.test/v1" } }),
+}));
+
+vi.mock("#product/lib/access/anyharness/agent-auth", () => ({
+  applyAgentAuthState: mocks.applyAgentAuthState,
+  clearAgentAuthState: mocks.clearAgentAuthState,
+}));
+
+vi.mock("#product/lib/infra/proliferate-api", () => ({
+  getProliferateApiOrigin: () => "https://api.example.test",
+}));
+
+vi.mock("#product/stores/sessions/harness-connection-store", () => ({
+  useHarnessConnectionStore: (selector: (state: {
+    connectionState: string;
+    runtimeUrl: string;
+  }) => unknown) => selector({
+    connectionState: "healthy",
+    runtimeUrl: "http://runtime.test",
+  }),
+}));
+
+vi.mock("#product/hooks/access/anyharness/agents/use-agent-resources-cache", () => ({
+  useAgentResourcesCache: () => ({
+    invalidateAgentLaunchReadinessResources:
+      mocks.invalidateAgentLaunchReadinessResources,
+  }),
+}));
+
+describe("useLocalAuthStateSync", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("applies gateway, clears to native, then applies API-key state and refreshes models", async () => {
+    let state = gatewayState();
+    const gatewayApplied = deferred<{ applied: boolean; revision: number }>();
+    const nativeCleared = deferred<void>();
+    mocks.useAgentAuthState.mockImplementation(() => ({ data: state }));
+    mocks.applyAgentAuthState
+      .mockImplementationOnce(() => gatewayApplied.promise)
+      .mockResolvedValueOnce({ applied: true, revision: 6 });
+    mocks.clearAgentAuthState.mockImplementationOnce(() => nativeCleared.promise);
+    mocks.invalidateAgentLaunchReadinessResources.mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(() => useLocalAuthStateSync());
+
+    await waitFor(() => expect(mocks.applyAgentAuthState).toHaveBeenCalledTimes(1));
+    expect(mocks.applyAgentAuthState.mock.calls[0]?.[1]).toEqual({
+      ...gatewayState(),
+      issuing_server_origin: "https://api.example.test",
+    });
+
+    state = nativeState();
+    rerender();
+    await Promise.resolve();
+    expect(mocks.clearAgentAuthState).not.toHaveBeenCalled();
+
+    state = apiKeyState();
+    rerender();
+    await Promise.resolve();
+    expect(mocks.clearAgentAuthState).not.toHaveBeenCalled();
+    expect(mocks.applyAgentAuthState).toHaveBeenCalledTimes(1);
+
+    gatewayApplied.resolve({ applied: true, revision: 5 });
+    await waitFor(() => expect(mocks.clearAgentAuthState).toHaveBeenCalledTimes(1));
+    expect(mocks.applyAgentAuthState).toHaveBeenCalledTimes(1);
+
+    nativeCleared.resolve();
+    await waitFor(() => expect(mocks.applyAgentAuthState).toHaveBeenCalledTimes(2));
+    expect(mocks.applyAgentAuthState.mock.calls[1]?.[1]).toEqual({
+      ...apiKeyState(),
+      issuing_server_origin: "https://api.example.test",
+    });
+    await waitFor(() => {
+      expect(mocks.invalidateAgentLaunchReadinessResources).toHaveBeenCalledTimes(3);
+    });
+    expect(mocks.invalidateAgentLaunchReadinessResources)
+      .toHaveBeenLastCalledWith("http://runtime.test");
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function gatewayState(): AgentAuthState {
+  return {
+    version: 2,
+    revision: 5,
+    user_id: "user-1",
+    harnesses: [{
+      harness_kind: "codex",
+      sources: [{ kind: "gateway", base_url: "https://gateway.test", key: "virtual" }],
+    }],
+  };
+}
+
+function nativeState(): AgentAuthState {
+  return {
+    version: 2,
+    revision: 0,
+    user_id: "user-1",
+    harnesses: [],
+  };
+}
+
+function apiKeyState(): AgentAuthState {
+  return {
+    version: 2,
+    revision: 6,
+    user_id: "user-1",
+    harnesses: [{
+      harness_kind: "codex",
+      sources: [{ kind: "api_key", env_var_name: "OPENAI_API_KEY", value: "provider-key" }],
+    }],
+  };
+}

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef } from "react";
 import { useAgentAuthState } from "@proliferate/cloud-sdk-react";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
-import { applyAgentAuthState } from "#product/lib/access/anyharness/agent-auth";
+import {
+  applyAgentAuthState,
+  clearAgentAuthState,
+} from "#product/lib/access/anyharness/agent-auth";
 import { getProliferateApiOrigin } from "#product/lib/infra/proliferate-api";
 import {
   planLocalAuthStatePush,
@@ -10,6 +13,7 @@ import {
   stampIssuingServerOrigin,
 } from "#product/lib/domain/agents/local-auth-state";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
+import { useAgentResourcesCache } from "#product/hooks/access/anyharness/agents/use-agent-resources-cache";
 
 /**
  * Local-surface agent-auth state writer (the desktop twin of the cloud
@@ -37,6 +41,9 @@ export function useLocalAuthStateSync() {
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
   const stateQuery = useAgentAuthState("local", authenticated && cloudEnabled);
   const lastPushedRef = useRef<string | null>(null);
+  const lastScheduledRef = useRef<string | null>(null);
+  const operationQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const { invalidateAgentLaunchReadinessResources } = useAgentResourcesCache();
 
   const state = stateQuery.data;
   const runtimeHealthy = connectionState === "healthy" && runtimeUrl.trim().length > 0;
@@ -51,24 +58,51 @@ export function useLocalAuthStateSync() {
     }
     const plan = planLocalAuthStatePush({
       state,
-      lastPushedFingerprint: lastPushedRef.current,
+      // Treat an enqueued operation as handled so unrelated renders do not
+      // enqueue the same document again while an earlier route is in flight.
+      lastPushedFingerprint: lastScheduledRef.current,
     });
-    if (!plan.shouldPush) {
+    if (plan.action === null) {
       return;
     }
-    let cancelled = false;
-    const stamped = stampIssuingServerOrigin(state, getProliferateApiOrigin(apiBaseUrl));
-    applyAgentAuthState({ runtimeUrl }, stamped)
-      .then(() => {
-        if (!cancelled) {
-          lastPushedRef.current = plan.fingerprint;
+    lastScheduledRef.current = plan.fingerprint;
+
+    // Serialize route changes. Aborting a superseded fetch does not guarantee
+    // that the local runtime stopped processing it; independent PUT/DELETE
+    // requests can otherwise land out of order during gateway -> native ->
+    // API-key transitions and leave the persisted route stale.
+    operationQueueRef.current = operationQueueRef.current.then(async () => {
+      try {
+        if (plan.action === "clear") {
+          await clearAgentAuthState({ runtimeUrl });
+        } else {
+          await applyAgentAuthState(
+            { runtimeUrl },
+            stampIssuingServerOrigin(state, getProliferateApiOrigin(apiBaseUrl)),
+          );
         }
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
+        if (lastScheduledRef.current === plan.fingerprint) {
+          lastScheduledRef.current = lastPushedRef.current;
+        }
         console.warn("[agent-auth] local state sync push failed", error);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [authenticated, cloudEnabled, runtimeHealthy, runtimeUrl, state]);
+        return;
+      }
+
+      lastPushedRef.current = plan.fingerprint;
+      try {
+        await invalidateAgentLaunchReadinessResources(runtimeUrl);
+      } catch (error: unknown) {
+        console.warn("[agent-auth] local launch resource refresh failed", error);
+      }
+    });
+  }, [
+    apiBaseUrl,
+    authenticated,
+    cloudEnabled,
+    invalidateAgentLaunchReadinessResources,
+    runtimeHealthy,
+    runtimeUrl,
+    state,
+  ]);
 }

--- a/apps/packages/product-client/src/hooks/agents/workflows/use-harness-auth-editor.ts
+++ b/apps/packages/product-client/src/hooks/agents/workflows/use-harness-auth-editor.ts
@@ -134,7 +134,7 @@ export function useHarnessAuthEditor(
     // A fresh scope starts with no pending selection — the derived state alone
     // drives the radio until the user clicks a method.
     setPendingMethod(null);
-    lastPutSigRef.current = JSON.stringify(buildDesiredSources(derived));
+    lastPutSigRef.current = JSON.stringify(buildDesiredSources(harnessKind, derived));
   }, [selections, scopeKey, harnessKind, surface]);
 
   const localAgent = agentsByKind.get(harnessKind);
@@ -188,7 +188,7 @@ export function useHarnessAuthEditor(
   function commit(next: HarnessAuthEditorState) {
     setGatewayEnabled(next.gatewayEnabled);
     setRows(next.rows);
-    const sources = buildDesiredSources(next);
+    const sources = buildDesiredSources(harnessKind, next);
     const signature = JSON.stringify(sources);
     // De-dupe redundant PUTs (e.g. blur with no effective change).
     if (signature === lastPutSigRef.current) {

--- a/apps/packages/product-client/src/lib/access/anyharness/agent-auth.ts
+++ b/apps/packages/product-client/src/lib/access/anyharness/agent-auth.ts
@@ -14,3 +14,10 @@ export function applyAgentAuthState(
 ) {
   return getAnyHarnessClient(connection).agentAuth.applyState(state, options);
 }
+
+export function clearAgentAuthState(
+  connection: AnyHarnessClientConnection,
+  options?: AnyHarnessRequestOptions,
+) {
+  return getAnyHarnessClient(connection).agentAuth.clearState(options);
+}

--- a/apps/packages/product-client/src/lib/domain/agents/local-auth-state.test.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/local-auth-state.test.ts
@@ -32,7 +32,7 @@ describe("planLocalAuthStatePush", () => {
       state: state(),
       lastPushedFingerprint: null,
     });
-    expect(plan.shouldPush).toBe(true);
+    expect(plan.action).toBe("apply");
     expect(plan.fingerprint).toBe(localAuthStateFingerprint(state()));
   });
 
@@ -41,7 +41,7 @@ describe("planLocalAuthStatePush", () => {
       state: state(),
       lastPushedFingerprint: localAuthStateFingerprint(state()),
     });
-    expect(plan.shouldPush).toBe(false);
+    expect(plan.action).toBeNull();
   });
 
   it("re-pushes when content changes without a revision bump", () => {
@@ -55,15 +55,23 @@ describe("planLocalAuthStatePush", () => {
         }),
       ),
     });
-    expect(plan.shouldPush).toBe(true);
+    expect(plan.action).toBe("apply");
   });
 
-  it("never pushes the revision-0 legacy marker", () => {
+  it("clears a previously persisted route for the revision-0 native marker", () => {
     const plan = planLocalAuthStatePush({
       state: state({ revision: 0, harnesses: [] }),
       lastPushedFingerprint: null,
     });
-    expect(plan.shouldPush).toBe(false);
+    expect(plan.action).toBe("clear");
+  });
+
+  it("clears native state even when disabled rows retain a positive revision", () => {
+    const plan = planLocalAuthStatePush({
+      state: state({ revision: 8, harnesses: [] }),
+      lastPushedFingerprint: null,
+    });
+    expect(plan.action).toBe("clear");
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/agents/local-auth-state.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/local-auth-state.ts
@@ -7,15 +7,14 @@ import type { AgentAuthStateDocument } from "@anyharness/sdk";
  * surface and pushes it verbatim to the local AnyHarness runtime, which
  * persists it at `<runtime_home>/agent-auth/state.json`.
  *
- * A push happens only when there is something scoped to deliver AND the
- * document differs from the last successful push. Revision-0 documents (the
- * user has no local selections) are never pushed: they carry nothing to
- * render, and the runtime's stale-revision protection would reject them
- * anyway once a scoped document has been persisted.
+ * A synchronization happens only when the rendered document differs from the
+ * last successful operation. A document with no harnesses explicitly clears
+ * the runtime state: native auth is an absence of route state, not a lower
+ * revisioned replacement document.
  */
 
 export interface LocalAuthStatePushPlan {
-  shouldPush: boolean;
+  action: "apply" | "clear" | null;
   fingerprint: string;
 }
 
@@ -53,13 +52,16 @@ export function planLocalAuthStatePush(input: {
   lastPushedFingerprint: string | null;
 }): LocalAuthStatePushPlan {
   const fingerprint = localAuthStateFingerprint(input.state);
-  if (input.state.revision <= 0) {
-    return { shouldPush: false, fingerprint };
-  }
   if (input.lastPushedFingerprint === fingerprint) {
-    return { shouldPush: false, fingerprint };
+    return { action: null, fingerprint };
   }
-  return { shouldPush: true, fingerprint };
+  if (input.state.harnesses.length === 0) {
+    return { action: "clear", fingerprint };
+  }
+  if (input.state.revision <= 0) {
+    return { action: null, fingerprint };
+  }
+  return { action: "apply", fingerprint };
 }
 
 /**
@@ -75,8 +77,7 @@ export function planLocalAuthStatePush(input: {
  * the runtime never received its routes and every gateway harness fell back to
  * "no launchable model". The sync needs only an authenticated session against a
  * reachable server and a healthy local runtime; when there is nothing to
- * deliver the rendered document is revision-0 and `planLocalAuthStatePush`
- * already declines to push it.
+ * deliver the sync explicitly clears any previously persisted route state.
  */
 export function shouldSyncLocalAuthState(input: {
   authenticated: boolean;

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/create-session-error.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/create-session-error.test.ts
@@ -35,7 +35,7 @@ describe("session create failure presentation", () => {
     );
   });
 
-  it("maps gated model errors to unlock guidance with the required contexts", () => {
+  it("maps gated model errors to actionable guidance without internal context ids", () => {
     const error = new AnyHarnessError({
       type: "about:blank",
       title: "Bad request",
@@ -47,16 +47,10 @@ describe("session create failure presentation", () => {
     });
 
     expect(formatSessionCreateFailureMessage(error)).toBe(
-      "This model is locked. Unlock it by signing in with or adding credentials for: anthropic-api, gateway.",
+      "This model is not available for the current authentication method. Choose an available model or change agent authentication in Settings, then try again.",
     );
-  });
-
-  it("maps gated model errors without contexts to generic unlock guidance", () => {
-    const error = anyHarnessError("SESSION_MODEL_GATED", "gated");
-
-    expect(formatSessionCreateFailureMessage(error)).toBe(
-      "This model is locked behind credentials this workspace does not have yet. Sign in, add an API key, or enable the gateway, then try again.",
-    );
+    expect(formatSessionCreateFailureMessage(error)).not.toContain("anthropic-api");
+    expect(formatSessionCreateFailureMessage(error)).not.toContain("gateway");
   });
 
   it("preserves generic errors", () => {

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/create-session-error.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/create-session-error.ts
@@ -41,7 +41,7 @@ function unsupportedSessionSelectionMessage(error: unknown): string | null {
     return null;
   }
   if (error.problem.code === GATED_SESSION_MODEL_CODE) {
-    return gatedSessionModelMessage(error);
+    return gatedSessionModelMessage();
   }
   if (error.problem.code === UNSUPPORTED_SESSION_MODEL_CODE) {
     return "This target does not support the selected model yet. Update AnyHarness on the target or choose another model.";
@@ -52,17 +52,8 @@ function unsupportedSessionSelectionMessage(error: unknown): string | null {
   return null;
 }
 
-function gatedSessionModelMessage(error: AnyHarnessError): string {
-  const contexts = requiredContexts(error);
-  if (contexts.length > 0) {
-    return `This model is locked. Unlock it by signing in with or adding credentials for: ${contexts.join(", ")}.`;
-  }
-  return "This model is locked behind credentials this workspace does not have yet. Sign in, add an API key, or enable the gateway, then try again.";
-}
-
-function requiredContexts(error: AnyHarnessError): string[] {
-  const value = (error.problem as { requiredContexts?: unknown }).requiredContexts;
-  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+function gatedSessionModelMessage(): string {
+  return "This model is not available for the current authentication method. Choose an available model or change agent authentication in Settings, then try again.";
 }
 
 function isUnsupportedSessionSelectionError(error: unknown): boolean {

--- a/apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.test.ts
@@ -110,12 +110,24 @@ describe("deriveEditorState", () => {
 describe("buildDesiredSources", () => {
   it("emits an enabled gateway source when the toggle is on", () => {
     expect(
-      buildDesiredSources({ gatewayEnabled: true, rows: [] }),
+      buildDesiredSources("claude", { gatewayEnabled: true, rows: [] }),
     ).toEqual([{ sourceKind: "gateway", enabled: true }]);
   });
 
+  it("retains a disabled gateway revision marker when the toggle is off", () => {
+    expect(
+      buildDesiredSources("claude", { gatewayEnabled: false, rows: [] }),
+    ).toEqual([{ sourceKind: "gateway", enabled: false }]);
+  });
+
+  it("keeps the native-only cursor desired set empty", () => {
+    expect(
+      buildDesiredSources("cursor", { gatewayEnabled: false, rows: [] }),
+    ).toEqual([]);
+  });
+
   it("wires only complete rows and carries enabled/providerHint through", () => {
-    const sources = buildDesiredSources({
+    const sources = buildDesiredSources("claude", {
       gatewayEnabled: false,
       rows: [
         row({ uid: "a", enabled: true }),
@@ -125,6 +137,10 @@ describe("buildDesiredSources", () => {
     });
 
     expect(sources).toEqual([
+      {
+        sourceKind: "gateway",
+        enabled: false,
+      },
       {
         sourceKind: "api_key",
         apiKeyId: "key-1",

--- a/apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.ts
@@ -71,16 +71,21 @@ export function deriveEditorState(
 }
 
 /**
- * The full desired-state PUT body (contract §5). Gateway is a single
- * always-enabled-when-present source; only complete api_key rows are wired.
+ * The full desired-state PUT body (contract §5). The gateway row is retained
+ * disabled when native/API-key auth is selected so its `updated_at` remains a
+ * monotonic surface revision marker across gateway -> native transitions.
+ * Only complete api_key rows are wired.
  */
 export function buildDesiredSources(
+  harnessKind: string,
   state: HarnessAuthEditorState,
 ): AgentAuthSource[] {
-  const sources: AgentAuthSource[] = [];
-  if (state.gatewayEnabled) {
-    sources.push({ sourceKind: "gateway", enabled: true });
-  }
+  const sources: AgentAuthSource[] = harnessKind === "cursor"
+    ? []
+    : [{
+      sourceKind: "gateway",
+      enabled: state.gatewayEnabled,
+    }];
   for (const row of state.rows) {
     if (!isRowComplete(row)) {
       continue;

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -39,7 +39,6 @@ server/proliferate/db/models/cloud/agent_gateway.py 504 agent_auth_harness_setti
 server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PUT routes added for catalog-driven per-harness settings
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
-server/tests/integration/test_agent_gateway_store.py 673 P1 auth rebuild rewrote store coverage for titled-key + agent_auth_selection model
 server/tests/integration/test_auth_flow.py 2220 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test

--- a/server/proliferate/db/store/agent_gateway/selections.py
+++ b/server/proliferate/db/store/agent_gateway/selections.py
@@ -20,6 +20,7 @@ from proliferate.constants.agent_gateway import (
     AGENT_API_KEY_STATUS_ACTIVE,
     AGENT_AUTH_HARNESS_KINDS,
     AGENT_AUTH_SOURCE_API_KEY,
+    AGENT_AUTH_SOURCE_GATEWAY,
     AGENT_AUTH_SOURCE_KINDS,
     AGENT_AUTH_SURFACES,
 )
@@ -97,7 +98,8 @@ async def put_auth_selections(
 
     Existing rows keyed by (source_kind, env_var_name) are updated in place,
     absent ones deleted, and new ones inserted — so row ids and created_at
-    survive across edits. Structural coherence (source shape, key ownership,
+    survive across edits. The disabled gateway revision marker is normalized
+    into every desired set. Structural coherence (source shape, key ownership,
     no duplicate source) is enforced; per-harness legality is the caller's.
     """
     if harness_kind not in AGENT_AUTH_HARNESS_KINDS:
@@ -117,6 +119,20 @@ async def put_auth_selections(
         if source.api_key_id is not None:
             referenced_key_ids.add(source.api_key_id)
 
+    # Every harness kind accepted by this store is gateway-capable. Keep a
+    # disabled gateway row even when an older/direct client sends the native
+    # state as ``sources=[]``. Besides representing no effective source, this
+    # row is the scope's durable revision marker: deleting the final row would
+    # reset the rendered revision to zero (or an older sibling scope), causing
+    # an AnyHarness runtime to reject the clear as stale and retain its prior
+    # gateway route.
+    gateway_key = _source_key(AGENT_AUTH_SOURCE_GATEWAY, None)
+    if gateway_key not in desired:
+        desired[gateway_key] = DesiredAuthSource(
+            source_kind=AGENT_AUTH_SOURCE_GATEWAY,
+            enabled=False,
+        )
+
     await _assert_keys_usable(db, user_id=user_id, api_key_ids=referenced_key_ids)
 
     existing_rows = (
@@ -135,9 +151,11 @@ async def put_auth_selections(
     existing = {_source_key(row.source_kind, row.env_var_name): row for row in existing_rows}
 
     now = utcnow()
+    selection_changed = False
     for key, row in existing.items():
         if key not in desired:
             await db.delete(row)
+            selection_changed = True
 
     for key, source in desired.items():
         row = existing.get(key)
@@ -156,6 +174,7 @@ async def put_auth_selections(
                     updated_at=now,
                 )
             )
+            selection_changed = True
             continue
         if (
             row.api_key_id != source.api_key_id
@@ -166,6 +185,16 @@ async def put_auth_selections(
             row.provider_hint = source.provider_hint
             row.enabled = source.enabled
             row.updated_at = now
+            selection_changed = True
+
+    # A disabled gateway row is the scope's durable revision marker while the
+    # effective route is native or API-key. Touch it for any desired-state
+    # change, including deletion of a newer API-key row; otherwise max(updated_at)
+    # can move backwards and the runtime correctly rejects the rendered state as
+    # stale. The row remains disabled and never reaches materialization.
+    gateway_marker = existing.get(gateway_key)
+    if selection_changed and gateway_marker is not None:
+        gateway_marker.updated_at = now
 
     await db.flush()
     return await get_scope_auth_selections(

--- a/server/tests/integration/test_agent_gateway_policy_enforcement.py
+++ b/server/tests/integration/test_agent_gateway_policy_enforcement.py
@@ -162,10 +162,9 @@ class TestSelectTimeEnforcement:
             sources=[],
         )
         assert cleared.status_code == 200, cleared.text
-        assert [
-            (source["sourceKind"], source["enabled"])
-            for source in cleared.json()
-        ] == [("gateway", False)]
+        assert [(source["sourceKind"], source["enabled"]) for source in cleared.json()] == [
+            ("gateway", False)
+        ]
 
     @pytest.mark.asyncio
     async def test_disallowed_harness_still_rejects_enabled_source(

--- a/server/tests/integration/test_agent_gateway_policy_enforcement.py
+++ b/server/tests/integration/test_agent_gateway_policy_enforcement.py
@@ -162,7 +162,10 @@ class TestSelectTimeEnforcement:
             sources=[],
         )
         assert cleared.status_code == 200, cleared.text
-        assert cleared.json() == []
+        assert [
+            (source["sourceKind"], source["enabled"])
+            for source in cleared.json()
+        ] == [("gateway", False)]
 
     @pytest.mark.asyncio
     async def test_disallowed_harness_still_rejects_enabled_source(

--- a/server/tests/integration/test_agent_gateway_selections.py
+++ b/server/tests/integration/test_agent_gateway_selections.py
@@ -1,0 +1,142 @@
+"""Focused CRUD and revision-lineage coverage for agent auth selections."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import proliferate.db.store.agent_gateway.selections as selections_store
+from proliferate.db.store import agent_gateway as store
+from tests.integration.test_agent_gateway_store import _api_key, _create_user, _gateway
+
+
+@pytest.mark.asyncio
+async def test_put_creates_lists_and_filters_enabled(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session, user_id=user_id, title="Anthropic", value="sk-ant-1234abcd"
+    )
+
+    rows = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        sources=[
+            _gateway(),
+            _api_key(key.id, provider_hint="anthropic", enabled=False),
+        ],
+    )
+    assert {(r.source_kind, r.enabled) for r in rows} == {
+        ("gateway", True),
+        ("api_key", False),
+    }
+    api_row = next(r for r in rows if r.source_kind == "api_key")
+    assert api_row.env_var_name == "ANTHROPIC_API_KEY"
+    assert api_row.provider_hint == "anthropic"
+
+    all_rows = await store.list_auth_selections(db_session, user_id=user_id)
+    assert len(all_rows) == 2
+    assert await store.list_auth_selections(db_session, user_id=user_id, surface="cloud") == []
+
+    # Disabled rows stay in the DB but never reach the renderer helper.
+    enabled = await store.list_enabled_auth_selections(
+        db_session, user_id=user_id, surface="local"
+    )
+    assert [r.source_kind for r in enabled] == ["gateway"]
+
+
+@pytest.mark.asyncio
+async def test_put_is_full_desired_state_replace(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session, user_id=user_id, title="Anthropic", value="sk-ant-1234abcd"
+    )
+
+    first = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="opencode",
+        surface="cloud",
+        sources=[_gateway(), _api_key(key.id)],
+    )
+    gateway_id = next(r.id for r in first if r.source_kind == "gateway")
+
+    # Dropping the api_key source deletes its row; the gateway row is kept
+    # (same id + created_at) rather than churned.
+    second = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="opencode",
+        surface="cloud",
+        sources=[_gateway()],
+    )
+    assert [r.source_kind for r in second] == ["gateway"]
+    assert second[0].id == gateway_id
+
+
+@pytest.mark.asyncio
+async def test_put_updates_row_in_place(db_session: AsyncSession) -> None:
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session, user_id=user_id, title="Anthropic", value="sk-ant-1234abcd"
+    )
+
+    first = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        sources=[_api_key(key.id, enabled=True)],
+    )
+    row_id = first[0].id
+
+    second = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="local",
+        sources=[_api_key(key.id, provider_hint="anthropic", enabled=False)],
+    )
+    assert second[0].id == row_id
+    assert second[0].enabled is False
+    assert second[0].provider_hint == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_put_normalizes_empty_sources_to_monotonic_disabled_gateway_marker(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session, user_id=user_id, title="OpenAI", value="sk-openai-1234abcd"
+    )
+    first_write = datetime(2026, 7, 15, tzinfo=UTC)
+    clear_write = first_write + timedelta(seconds=1)
+    writes = iter((first_write, clear_write))
+    monkeypatch.setattr(selections_store, "utcnow", lambda: next(writes))
+
+    first = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="codex",
+        surface="local",
+        sources=[_gateway(enabled=False), _api_key(key.id)],
+    )
+    gateway_id = next(row.id for row in first if row.source_kind == "gateway")
+
+    cleared = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="codex",
+        surface="local",
+        sources=[],
+    )
+
+    assert len(cleared) == 1
+    assert cleared[0].id == gateway_id
+    assert cleared[0].enabled is False
+    assert cleared[0].updated_at == clear_write

--- a/server/tests/integration/test_agent_gateway_store.py
+++ b/server/tests/integration/test_agent_gateway_store.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import proliferate.db.store.agent_gateway.selections as selections_store
 from proliferate.db.models.auth import User
 from proliferate.db.models.cloud.agent_gateway import AgentApiKey
 from proliferate.db.store import agent_gateway as store
@@ -220,6 +221,43 @@ async def test_put_updates_row_in_place(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_put_normalizes_empty_sources_to_monotonic_disabled_gateway_marker(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = await _create_user(db_session)
+    key = await store.create_agent_api_key(
+        db_session, user_id=user_id, title="OpenAI", value="sk-openai-1234abcd"
+    )
+    first_write = datetime(2026, 7, 15, tzinfo=UTC)
+    clear_write = first_write + timedelta(seconds=1)
+    writes = iter((first_write, clear_write))
+    monkeypatch.setattr(selections_store, "utcnow", lambda: next(writes))
+
+    first = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="codex",
+        surface="local",
+        sources=[_gateway(enabled=False), _api_key(key.id)],
+    )
+    gateway_id = next(row.id for row in first if row.source_kind == "gateway")
+
+    cleared = await store.put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="codex",
+        surface="local",
+        sources=[],
+    )
+
+    assert len(cleared) == 1
+    assert cleared[0].id == gateway_id
+    assert cleared[0].enabled is False
+    assert cleared[0].updated_at == clear_write
+
+
+@pytest.mark.asyncio
 async def test_put_rejects_duplicate_source(db_session: AsyncSession) -> None:
     user_id = await _create_user(db_session)
     key = await store.create_agent_api_key(
@@ -387,7 +425,10 @@ async def test_api_key_hard_delete_cascades_selection(db_session: AsyncSession) 
     await db_session.execute(sql_delete(AgentApiKey).where(AgentApiKey.id == key.id))
     await db_session.flush()
 
-    assert await store.list_auth_selections(db_session, user_id=user_id) == []
+    remaining = await store.list_auth_selections(db_session, user_id=user_id)
+    assert [(row.source_kind, row.enabled) for row in remaining] == [
+        ("gateway", False)
+    ]
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_agent_gateway_store.py
+++ b/server/tests/integration/test_agent_gateway_store.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import proliferate.db.store.agent_gateway.selections as selections_store
 from proliferate.db.models.auth import User
 from proliferate.db.models.cloud.agent_gateway import AgentApiKey
 from proliferate.db.store import agent_gateway as store
@@ -125,136 +124,6 @@ async def test_revoke_rejects_foreign_key(db_session: AsyncSession) -> None:
         await store.revoke_agent_api_key(db_session, user_id=other_id, api_key_id=created.id)
         is None
     )
-
-
-@pytest.mark.asyncio
-async def test_put_creates_lists_and_filters_enabled(db_session: AsyncSession) -> None:
-    user_id = await _create_user(db_session)
-    key = await store.create_agent_api_key(
-        db_session, user_id=user_id, title="Anthropic", value="sk-ant-1234abcd"
-    )
-
-    rows = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="claude",
-        surface="local",
-        sources=[
-            _gateway(),
-            _api_key(key.id, provider_hint="anthropic", enabled=False),
-        ],
-    )
-    assert {(r.source_kind, r.enabled) for r in rows} == {
-        ("gateway", True),
-        ("api_key", False),
-    }
-    api_row = next(r for r in rows if r.source_kind == "api_key")
-    assert api_row.env_var_name == "ANTHROPIC_API_KEY"
-    assert api_row.provider_hint == "anthropic"
-
-    all_rows = await store.list_auth_selections(db_session, user_id=user_id)
-    assert len(all_rows) == 2
-    assert await store.list_auth_selections(db_session, user_id=user_id, surface="cloud") == []
-
-    # Disabled rows stay in the DB but never reach the renderer helper.
-    enabled = await store.list_enabled_auth_selections(
-        db_session, user_id=user_id, surface="local"
-    )
-    assert [r.source_kind for r in enabled] == ["gateway"]
-
-
-@pytest.mark.asyncio
-async def test_put_is_full_desired_state_replace(db_session: AsyncSession) -> None:
-    user_id = await _create_user(db_session)
-    key = await store.create_agent_api_key(
-        db_session, user_id=user_id, title="Anthropic", value="sk-ant-1234abcd"
-    )
-
-    first = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="opencode",
-        surface="cloud",
-        sources=[_gateway(), _api_key(key.id)],
-    )
-    gateway_id = next(r.id for r in first if r.source_kind == "gateway")
-
-    # Dropping the api_key source deletes its row; the gateway row is kept
-    # (same id + created_at) rather than churned.
-    second = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="opencode",
-        surface="cloud",
-        sources=[_gateway()],
-    )
-    assert [r.source_kind for r in second] == ["gateway"]
-    assert second[0].id == gateway_id
-
-
-@pytest.mark.asyncio
-async def test_put_updates_row_in_place(db_session: AsyncSession) -> None:
-    user_id = await _create_user(db_session)
-    key = await store.create_agent_api_key(
-        db_session, user_id=user_id, title="Anthropic", value="sk-ant-1234abcd"
-    )
-
-    first = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="claude",
-        surface="local",
-        sources=[_api_key(key.id, enabled=True)],
-    )
-    row_id = first[0].id
-
-    second = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="claude",
-        surface="local",
-        sources=[_api_key(key.id, provider_hint="anthropic", enabled=False)],
-    )
-    assert second[0].id == row_id
-    assert second[0].enabled is False
-    assert second[0].provider_hint == "anthropic"
-
-
-@pytest.mark.asyncio
-async def test_put_normalizes_empty_sources_to_monotonic_disabled_gateway_marker(
-    db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    user_id = await _create_user(db_session)
-    key = await store.create_agent_api_key(
-        db_session, user_id=user_id, title="OpenAI", value="sk-openai-1234abcd"
-    )
-    first_write = datetime(2026, 7, 15, tzinfo=UTC)
-    clear_write = first_write + timedelta(seconds=1)
-    writes = iter((first_write, clear_write))
-    monkeypatch.setattr(selections_store, "utcnow", lambda: next(writes))
-
-    first = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="codex",
-        surface="local",
-        sources=[_gateway(enabled=False), _api_key(key.id)],
-    )
-    gateway_id = next(row.id for row in first if row.source_kind == "gateway")
-
-    cleared = await store.put_auth_selections(
-        db_session,
-        user_id=user_id,
-        harness_kind="codex",
-        surface="local",
-        sources=[],
-    )
-
-    assert len(cleared) == 1
-    assert cleared[0].id == gateway_id
-    assert cleared[0].enabled is False
-    assert cleared[0].updated_at == clear_write
 
 
 @pytest.mark.asyncio
@@ -426,9 +295,7 @@ async def test_api_key_hard_delete_cascades_selection(db_session: AsyncSession) 
     await db_session.flush()
 
     remaining = await store.list_auth_selections(db_session, user_id=user_id)
-    assert [(row.source_kind, row.enabled) for row in remaining] == [
-        ("gateway", False)
-    ]
+    assert [(row.source_kind, row.enabled) for row in remaining] == [("gateway", False)]
 
 
 @pytest.mark.asyncio

--- a/specs/codebase/platforms/product/agent-catalog-readiness.md
+++ b/specs/codebase/platforms/product/agent-catalog-readiness.md
@@ -114,8 +114,12 @@ under Bedrock rather than transparently remapped.
 Credential fact collection reads the composed launch environment plus only
 registry-declared ambient variables; composed values win. Arbitrary ambient
 values do not become classification law. Secret facts expose presence, while
-declared flag facts may expose the value required for matching. Workspace route
-facts are collected separately from workspace route state.
+declared flag facts may expose the value required for matching. The effective
+workspace route is resolved through the same server-origin guard used at
+launch. For single-source harnesses, an explicit gateway or API-key route is
+authoritative and its source facts replace native/ambient credential facts;
+OpenCode remains additive because its native providers intentionally coexist
+with injected sources.
 
 Classification is pure. Within each auth slot, the first matching catalog
 context wins; results are unioned across slots, and baseline applies when no
@@ -127,6 +131,19 @@ route resolver used at launch. Every `gatewayPolicy.seedModels` ID must have a
 gateway-available `session.models` row. Gateway model resolution uses the
 latest successful gateway probe when one exists and otherwise falls back to
 the configured seed models.
+
+Desktop local-route delivery uses revisioned `PUT /v1/agent-auth/state` for a
+non-empty rendered state and idempotent `DELETE /v1/agent-auth/state` when the
+rendered surface is native (zero harnesses). Clear is a distinct operation so
+an empty server selection can remove an older persisted route without
+weakening stale-revision protection for ordinary replacements. A successful
+apply or clear invalidates target launch options and gateway-model projections
+before the next session is created. Local route writes are serialized so a
+superseded request cannot land after the route that replaced it.
+Gateway-capable selection writes retain a disabled gateway row when another
+method is selected; the server normalizes older/direct clients' empty desired
+state to the same tombstone. It advances the surface revision across future
+gateway-to-native transitions while staying out of the rendered source list.
 
 ## Bundled Agent Inputs
 


### PR DESCRIPTION
## Summary

- Scope model capability classification to the auth profile AnyHarness will actually launch, so native-only Codex models are not projected onto gateway routes.
- Make gateway → native → API-key changes durable and ordered across server persistence, desktop sync, and runtime state, including older/direct clients that send an empty desired state.
- Invalidate launch-option and gateway-model caches after route changes and return actionable, non-sensitive model/auth guidance.

Base: `cd00510bd9460307714758e18274232c8aa66a06`

### Reproduction and root cause

Signed-in production showed duplicate `Codex · GPT-5.6 Sol` choices for a cloud sandbox while Codex was gateway-routed. Founder traces showed the selected native-only model reaching `/responses` on a provider that rejected it; switching to native auth, including for new sessions, retained the failure, while selecting an API key appeared to clear it.

The defects were:

1. Capability classification unioned ambient/native credential facts with the explicit source from `agent-auth/state.json`. Single-source harnesses could therefore expose models from both the selected gateway and the native provider even though launch rendering forced only the gateway.
2. Native is rendered as zero harnesses. The desktop ignored revision-0 documents instead of clearing the persisted runtime route, and independent PUT/DELETE requests could complete out of order.
3. Empty desired-state writes deleted the last server row, so the rendered surface revision could reset to zero or regress behind another harness. AnyHarness correctly rejected that lower revision and kept its stale route.
4. Route changes invalidated launch options but not the cached gateway-model projection.

### Changes

- Reuse the launch-time route resolver and server-origin guard for capability facts.
- Treat an explicit gateway/API-key source as authoritative for single-source harnesses; preserve OpenCode's intentional additive provider behavior.
- Add idempotent `DELETE /v1/agent-auth/state` support through AnyHarness, generated OpenAPI, SDK, and product-client access layers.
- Serialize local route operations, explicitly clear native state, and refresh both launch-option and gateway-model caches.
- Retain/normalize a disabled gateway revision marker in server persistence so empty writes from older/direct clients stay monotonic without materializing credentials.
- Improve gated-model UI copy without exposing internal catalog context identifiers.
- Update the authoritative product contract and focused regression coverage.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- AnyHarness unit regressions passed:
  - `codex_route_transitions_scope_model_validation_to_the_effective_provider`
  - `clear_state_file_resets_revision_lineage_for_native_then_new_route`
- `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/agents/local-auth-state.test.ts src/hooks/agents/lifecycle/use-local-auth-state-sync.test.tsx src/hooks/access/anyharness/agents/use-agent-resources-cache.test.tsx src/lib/domain/sessions/creation/create-session-error.test.ts src/lib/domain/settings/harness-auth-sources.test.ts src/components/settings/panes/agents/harness/HarnessPane.test.tsx` — 6 files, 55 tests passed.
- `pnpm --filter @proliferate/product-client build` — passed.
- `pnpm --filter @anyharness/sdk exec vitest run src/client/agent-auth.test.ts` — passed.
- `pnpm --filter @anyharness/sdk typecheck:contracts` — passed.
- Focused server integration coverage passed for empty-state marker normalization, policy-compatible clear, and API-key hard-delete behavior.
- `uv run --extra dev ruff check proliferate/db/store/agent_gateway/selections.py tests/integration/test_agent_gateway_store.py tests/integration/test_agent_gateway_policy_enforcement.py` — passed.
- `python3 scripts/check_docs.py` — passed (211 Markdown files).
- Generated AnyHarness OpenAPI and TypeScript types were regenerated successfully.
- Final `git diff --check`, scope review, and credential/artifact scan passed.

### Manual validation

In the signed-in production picker, the gateway-routed cloud flow exposed the native-only Codex model, corroborating the capability leak. A minimal launch then stopped at the existing `LoginRequired` readiness gate before provider dispatch, so the provider rejection itself was validated through deterministic route-transition tests rather than a completed production session.

### Assumptions

- Every harness accepted by the persisted selection store is gateway-capable; native-only Cursor remains excluded from that store.
- Native auth remains zero enabled/rendered sources. The disabled gateway row is revision metadata only and never reaches runtime materialization.

### Residual risks

- A complete live provider launch was not possible through the production test account because readiness required an agent login. The focused runtime, SDK, frontend, and real-Postgres transition tests cover the affected seams; CI should provide the broader platform matrix.
