### PR TITLE
fix(product-client): assert slash-command tray by rendered text, not markup bytes

### DIFF
--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -101,6 +101,17 @@ function renderComposerSurfaceMarkup(scenario: ScenarioKey): string {
   );
 }
 
+function visibleText(html: string): string {
+  let out = "";
+  let inTag = false;
+  for (const ch of html) {
+    if (ch === "<") inTag = true;
+    else if (ch === ">") inTag = false;
+    else if (!inTag) out += ch;
+  }
+  return out;
+}
+
 describe("playground scenarios", () => {
   it("includes user-input card scenarios for visual iteration", () => {
     expect(Object.keys(SCENARIOS)).toEqual(expect.arrayContaining(USER_INPUT_SCENARIOS));
@@ -233,8 +244,9 @@ describe("playground scenarios", () => {
 
     const groupedHtml = renderComposerSurfaceMarkup("slash-command-search");
     // The tray renders the leading slash in its own styled span, so assert the
-    // user-visible text rather than raw markup bytes.
-    const groupedText = groupedHtml.replace(/<[^>]*>/g, "");
+    // user-visible text rather than raw markup bytes. Character-wise scan (not
+    // a sanitizer): drop everything between tag delimiters.
+    const groupedText = visibleText(groupedHtml);
     expect(groupedText).toContain("/compact");
     expect(groupedText).toContain("MCP");
 

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -232,8 +232,11 @@ describe("playground scenarios", () => {
     expect(PLAYGROUND_SLASH_COMMANDS.some((command) => command.group === "MCP")).toBe(true);
 
     const groupedHtml = renderComposerSurfaceMarkup("slash-command-search");
-    expect(groupedHtml).toContain("/compact");
-    expect(groupedHtml).toContain("MCP");
+    // The tray renders the leading slash in its own styled span, so assert the
+    // user-visible text rather than raw markup bytes.
+    const groupedText = groupedHtml.replace(/<[^>]*>/g, "");
+    expect(groupedText).toContain("/compact");
+    expect(groupedText).toContain("MCP");
 
     const emptyHtml = renderComposerSurfaceMarkup("slash-command-empty");
     expect(emptyHtml).toContain("No matching slash commands.");


### PR DESCRIPTION
## Summary

#1221's composer polish renders the slash-command leading `/` in its own styled span, so the playground test's raw-HTML `toContain("/compact")` assertion went stale again (red on `main`'s Shared frontend packages job wherever it runs, and on every PR merge-ref). This asserts the user-visible tray text (tags stripped) instead of markup byte layout.

Test-only, one assertion site. Suite green locally.