### PR TITLE
fix(dev): build product-client in make shared-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ DEV_FRONTEND_ARTIFACTS := \
 	apps/packages/product-domain/dist \
 	apps/packages/ui/dist \
 	apps/packages/product-ui/dist \
-	apps/packages/product-surfaces/dist
+	apps/packages/product-surfaces/dist \
+	apps/packages/product-client/dist
 PROFILE_DB_READY_COMMAND = make server-db-ready;
 PROFILE_DB_ENSURE_COMMAND = LOCAL_PGHOST="$(LOCAL_PGHOST)" LOCAL_PGPORT="$(LOCAL_PGPORT)" LOCAL_PGUSER="$(LOCAL_PGUSER)" LOCAL_PGPASSWORD="$(LOCAL_PGPASSWORD)" USE_EXISTING_POSTGRES="$(USE_EXISTING_POSTGRES)" node scripts/dev.mjs ensure-db --db-name "$$PROLIFERATE_DEV_DB_NAME";
 PROFILE_REDIS_READY_COMMAND = make server-redis-ready;
@@ -1148,6 +1149,7 @@ shared-build:
 	pnpm --filter @proliferate/ui build
 	pnpm --filter @proliferate/product-ui build
 	pnpm --filter @proliferate/product-surfaces build
+	pnpm --filter @proliferate/product-client build
 
 # SKIP_RUST=1 skips both cargo builds — for frontend-only worktrees (UI waves)
 # that run against a shared prebuilt runtime via ANYHARNESS_DEV_RUNTIME_BIN.


### PR DESCRIPTION
## Problem

Since #1215 moved the desktop product into `@proliferate/product-client`, the desktop app consumes that package as a **built dist** — but the make graph never builds it. On a fresh checkout (or any checkout without a manually-built dist), `make desktop-build` fails with ~40 errors like:

```
src/main.tsx(4,31): error TS2307: Cannot find module '@proliferate/product-client/ProductClient' or its corresponding type declarations.
```

which breaks `make build` / `make rebuild dev PROFILE=...` (the `pdev` flow) from main. The desktop `package.json` build scripts do chain the package build, but the Makefile's `desktop-build` recipe bypasses them (`pnpm exec tsc && pnpm exec vite build`) and relies on make-level deps, which were not updated for #1215.

## Fix

- Add `pnpm --filter @proliferate/product-client build` to `shared-build` (after `product-surfaces`, which it depends on).
- Add `apps/packages/product-client/dist` to `DEV_FRONTEND_ARTIFACTS` so `dev-artifacts-ready` checks it like the other shared dists.

## Verification

With this change, `make rebuild dev PROFILE=main` on a checkout whose product-client dist was stale (only `host/`) built desktop cleanly and brought the full dev stack up (runtime, API, web, desktop Vite + Tauri).

🤖 Generated with [Claude Code](https://claude.com/claude-code)