### PR TITLE
fix(supervisor): activation logging + skip doomed post-rollback re-gate

### DIFF
--- a/anyharness/crates/proliferate-supervisor/src/update/activate/mod.rs
+++ b/anyharness/crates/proliferate-supervisor/src/update/activate/mod.rs
@@ -30,7 +30,7 @@ use proliferate_runtime_update_protocol::{
     UpdateComponent, UpdateOutcome, UpdateRequestV1, UpdateResultV1,
 };
 use sha2::{Digest, Sha256};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{
     config::SupervisorConfig,
@@ -106,6 +106,15 @@ pub async fn run_pending<H: ActivationHost>(
     while let Some(pending) = request::next_pending(&config.update_request_dir)? {
         match activate_one(config, host, &pending).await {
             ActivationStep::Terminal(result) => {
+                // A successful mailbox-triggered activation deserves the same
+                // visibility as the run loop's spawn logging (smoke follow-up:
+                // only retries were logged before).
+                info!(
+                    request_id = %result.request_id,
+                    outcome = ?result.outcome,
+                    observed_version = ?result.observed_version,
+                    "update request reached a terminal result"
+                );
                 request::record_result(&config.update_request_dir, &result)?;
             }
             ActivationStep::Retry(reason) => {
@@ -287,11 +296,14 @@ async fn roll_back<H: ActivationHost>(
 ) -> UpdateResultV1 {
     match plan.apply() {
         Ok(()) => {
-            // Best-effort: bring the restored last-good back up and re-gate. The
-            // outcome is RolledBack — the point is that the new version is never
-            // reported active and a genuine last-good is now serving.
+            // Best-effort: bring the restored last-good back up and wait for
+            // plain reachability. Deliberately NOT `health_gate(request)` — that
+            // asserts the FAILED request's version, which the restored binary can
+            // never report, so it burned a full attempts×delay cycle for nothing
+            // (smoke follow-up). The outcome is RolledBack — the point is that
+            // the new version is never reported active and last-good is serving.
             let _ = restart_in_order(host, request.component).await;
-            let _ = health_gate(host, request).await;
+            let _ = host.anyharness_healthy(None).await;
             UpdateResultV1 {
                 request_id: request.request_id.clone(),
                 outcome: UpdateOutcome::RolledBack,

--- a/anyharness/crates/proliferate-supervisor/src/update/activate/mod.rs
+++ b/anyharness/crates/proliferate-supervisor/src/update/activate/mod.rs
@@ -296,14 +296,23 @@ async fn roll_back<H: ActivationHost>(
 ) -> UpdateResultV1 {
     match plan.apply() {
         Ok(()) => {
-            // Best-effort: bring the restored last-good back up and wait for
-            // plain reachability. Deliberately NOT `health_gate(request)` — that
-            // asserts the FAILED request's version, which the restored binary can
-            // never report, so it burned a full attempts×delay cycle for nothing
-            // (smoke follow-up). The outcome is RolledBack — the point is that
-            // the new version is never reported active and last-good is serving.
+            // Best-effort: bring the restored last-good back up and probe plain
+            // reachability of the WHOLE runtime. Deliberately NOT
+            // `health_gate(request)` — that asserts the FAILED request's version,
+            // which the restored binary can never report, so it burned a full
+            // attempts×delay cycle for nothing (smoke follow-up). But the probe
+            // must still cover BOTH legs: AnyHarness answering /health (no version
+            // asserted) AND the Worker live after its restart. SUF-001: swapping
+            // health_gate for a bare `anyharness_healthy(None)` silently dropped
+            // the Worker-liveness leg, so a Worker that failed to come back on
+            // rollback went unobserved. Evaluate both, no short-circuit, so the
+            // Worker is always probed. The outcome is RolledBack regardless — the
+            // point is that the new version is never reported active and last-good
+            // is serving.
             let _ = restart_in_order(host, request.component).await;
-            let _ = host.anyharness_healthy(None).await;
+            let anyharness_reachable = host.anyharness_healthy(None).await;
+            let worker_reachable = host.worker_alive().await;
+            let _ = anyharness_reachable && worker_reachable;
             UpdateResultV1 {
                 request_id: request.request_id.clone(),
                 outcome: UpdateOutcome::RolledBack,

--- a/anyharness/crates/proliferate-supervisor/src/update/activate/test_support.rs
+++ b/anyharness/crates/proliferate-supervisor/src/update/activate/test_support.rs
@@ -102,6 +102,9 @@ pub(super) struct FakeHost {
     /// request, `Some(false)` => a different version (bytes/label mismatch,
     /// R9R-001). Default `None` keeps existing worker tests tolerant.
     pub(super) worker_reports: Option<bool>,
+    /// How many times `worker_alive` was probed, so a test can assert the
+    /// Worker-liveness leg still fires on the rollback path (SUF-001).
+    pub(super) worker_alive_calls: u32,
 }
 
 impl ActivationHost for FakeHost {
@@ -149,6 +152,7 @@ impl ActivationHost for FakeHost {
     }
 
     async fn worker_alive(&mut self) -> bool {
+        self.worker_alive_calls += 1;
         self.worker_live
     }
 

--- a/anyharness/crates/proliferate-supervisor/src/update/activate/tests.rs
+++ b/anyharness/crates/proliferate-supervisor/src/update/activate/tests.rs
@@ -330,6 +330,16 @@ async fn unhealthy_activation_rolls_back_to_last_good() {
         host.restart_log,
         vec!["anyharness", "worker", "anyharness", "worker"]
     );
+    // SUF-001 regression: the rollback reachability probe must still cover the
+    // Worker-liveness leg. The activation health gate short-circuits on the
+    // unhealthy AnyHarness before ever reaching `worker_alive`, so the only path
+    // that can bump this counter is the post-rollback probe. Before the fix it
+    // was 0 (the probe checked AnyHarness only) — a Worker that failed to come
+    // back on rollback went unobserved.
+    assert_eq!(
+        host.worker_alive_calls, 1,
+        "rollback must probe Worker liveness, not only AnyHarness /health"
+    );
 }
 
 #[tokio::test]

--- a/specs/codebase/structures/proliferate-supervisor/README.md
+++ b/specs/codebase/structures/proliferate-supervisor/README.md
@@ -155,6 +155,18 @@ before/around the restart select, so an update in flight cannot race an
 unrelated child-exit restart. This is the core Supervisor primitive. Keep it
 legible.
 
+
+## Operational Notes
+
+- A persistent TLS-trust failure fetching an update artifact (e.g. an expired or
+  wrong certificate at the CDN) is classified as a transient `DownloadTransport`
+  error, so the mailbox request is retried indefinitely rather than latching a
+  terminal `Invalid` (consistent with R9-002's "network blips retry" intent).
+  Operationally this means a genuinely broken artifact host shows up as a
+  never-converging update, not a failed one — watch heartbeat staleness /
+  desired-vs-observed divergence rather than expecting a terminal result. A
+  bounded-retry cap is a possible future refinement.
+
 ## Boundary Model
 
 ```text


### PR DESCRIPTION
## PR #1223 follow-ups (from the real-process smoke)

Three non-blocking follow-ups surfaced by the post-merge real-process smoke of the supervisor-owned update mechanism (#1223). No correctness change — all deterministic tests still green.

1. **Observability** — emit an `info!` when an update request reaches a terminal result (activated / rolled_back / invalid). Previously only retries logged, so a successful mailbox-triggered activation was silent versus the run-loop's spawn logging.
2. **Efficiency** — after a rollback, wait for plain AnyHarness reachability (`anyharness_healthy(None)`) instead of re-running the version-gated `health_gate` against the *failed* request's version. That re-gate could never pass on the just-restored last-good binary, so it burned a full `health_check_attempts × delay` cycle (~10s in a typical config) for a result that's explicitly discarded (`let _ =`).
3. **Docs** — record in the supervisor structure README (new Operational Notes) that a persistent TLS-trust failure at the artifact CDN buckets as a transient `DownloadTransport` error (retried forever, never terminal `Invalid`) — consistent with R9-002's intent, but worth an ops note; watch heartbeat staleness / desired-vs-observed divergence.

**Proofs:** `cargo test -p proliferate-supervisor` 40 pass; clippy clean; repo-shape + server-boundary checks pass. `supervisor_owned_runtime` stays OFF (flag untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
