### PR TITLE
docs(wdu): resolve committed conflict markers in unification READMEs

### DIFF
--- a/specs/codebase/systems/product/clients/web-desktop-unification/README.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/README.md
@@ -600,20 +600,20 @@ enforcement. Shared `product.css`, Desktop-only CSS, and ProductClient Tailwind
 scanning are established separately. The embedded workspace browser and its
 native child-WebView capability have been removed.
 
-<<<<<<< HEAD
 Desktop now mounts the product through the typed host boundary and, after the
 mechanical extraction, is a thin native host: the working product source moved
 into `@proliferate/product-client` while native UI, local runtime, files,
 credentials, SSH, updater, support, shared identity, navigation, storage, and
 telemetry all route through that boundary. See
-[the Desktop product move](migration/d1h.md).
+[the Desktop product move](migration/d1h.md) — PR #1215, merge `c6e094b41`.
 
-The legacy Web replacement has also landed (pending review). The duplicate Web
-product is deleted and `apps/web` is now a thin browser host that mounts the
-same compiled ProductClient with `desktop: null`, keeping only browser-owned
+The legacy Web replacement has also landed. The duplicate Web product is
+deleted and `apps/web` is now a thin browser host that mounts the same
+compiled ProductClient with `desktop: null`, keeping only browser-owned
 auth/callback, storage, links, clipboard, telemetry, deployment, and
-Cloud-client adapters. See [the legacy Web replacement](migration/d1i.md). The
-durable inputs and proofs across the extraction and replacement are:
+Cloud-client adapters. See [the legacy Web replacement](migration/d1i.md) —
+PR #1229, merge `d8ceabb4e`. The durable inputs and proofs across the
+extraction and replacement are:
 
 - [landed extraction proof](migration/d1g.md);
 - [application-entry contract](entry-contract.md);
@@ -624,26 +624,6 @@ durable inputs and proofs across the extraction and replacement are:
 
 The next step is to qualify Desktop and hosted Web against the shared
 implementation and cut over hosted Web. The remaining order and cutover gates
-=======
-Desktop mounts the product through the typed host boundary. Native UI, local
-runtime, files, credentials, SSH, updater, support, shared identity,
-navigation, storage, and telemetry all route through that boundary.
-
-The extraction mechanics landed, and the mechanical move has since completed:
-the package entry shape was proven from Desktop and a minimal browser host,
-the source move ran against a checked ledger with a deterministic and
-idempotent import codemod, and Desktop's product source now lives in
-`@proliferate/product-client` — Desktop is a thin native host. The durable
-records are:
-
-- [extraction-mechanics proof](migration/d1g.md);
-- [completed Desktop move](migration/d1h.md) — PR #1215, merge `c6e094b41`;
-- [application-entry contract](entry-contract.md); and
-- [source move ledger](move-ledger.md).
-
-The next step is to replace the legacy Web product with a thin browser host
-mounting the same ProductClient. The remaining order and Web cutover gates
->>>>>>> origin/main
 live in the
 [rollout procedure](../../../../../developing/deploying/web-desktop-unification-rollout.md).
 

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/README.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/README.md
@@ -3,21 +3,15 @@
 - [ProductClient extraction mechanics](d1g.md) records the landed build,
   packaging, ledger, codemod, and browser-host proof consumed by the
   mechanical extraction.
-<<<<<<< HEAD
 - [Desktop product move](d1h.md) records the mechanical move of the working
   Desktop product into `@proliferate/product-client`, leaving Desktop a thin
-  native host.
+  native host — PR #1215, merge `c6e094b41`.
 - [Legacy Web replacement](d1i.md) records deleting the duplicate Web product
   and mounting the shared ProductClient from a thin browser host with
-  `desktop: null`.
+  `desktop: null` — PR #1229, merge `d8ceabb4e`.
 - [`web-bundle-baseline-c6e094b41.json`](web-bundle-baseline-c6e094b41.json) is
   the binding legacy-Web bundle baseline for the phase-6 cutover no-regression
   gate, captured on the untouched base `c6e094b41`.
-=======
-- [Move the Desktop Product into ProductClient](d1h.md) records the completed
-  mechanical move and seam architecture, plus the post-merge reconciliation
-  against `origin/main` — PR #1215, merge `c6e094b41`.
->>>>>>> origin/main
 
 Completed incremental delivery specs live in Git history. Current architecture
 and migration state live in the [parent system contract](../README.md).


### PR DESCRIPTION
## What

Two Web/Desktop-unification README files landed on `main` with **unresolved git merge conflict markers** (`<<<<<<<` / `=======` / `>>>>>>>`):

- `specs/codebase/systems/product/clients/web-desktop-unification/README.md` (lines 603–646)
- `specs/codebase/systems/product/clients/web-desktop-unification/migration/README.md` (lines 6–20)

## Resolution

Resolved to the **truthful current state**. The `HEAD` side was accurate — both the Desktop product move (#1215, `c6e094b41`) and the legacy-Web replacement (#1229, `d8ceabb4e`) have landed, and the next step is phase-6 hosted-Web qualification and cutover. The `origin/main` side was stale (still described legacy-Web replacement as the *next* step). Grafted the PR/merge-commit provenance from the stale side onto the accurate file list.

## Proof

- No residual conflict markers anywhere under the WDU spec tree.
- `python3 scripts/check_docs.py` → passed (212 Markdown files); all six referenced doc targets exist on disk.
- Docs-only change; no code touched.

Scoped lane per the migration controller instruction to repair committed WDU README conflict markers in a separate reviewed PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)