### PR TITLE
feat(cloud): durable background runtime foundation (slice 4)

### DIFF
--- a/.github/workflows/_deploy-server.yml
+++ b/.github/workflows/_deploy-server.yml
@@ -40,6 +40,15 @@ jobs:
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
       ECS_SERVER_SERVICE: ${{ vars.ECS_SERVER_SERVICE }}
       ECS_SERVER_CONTAINER_NAME: ${{ vars.ECS_SERVER_CONTAINER_NAME || 'server' }}
+      # Background plane (optional): worker + Beat run the SAME image/SHA as the
+      # API. When these service names are unset the background steps are skipped,
+      # so environments without the plane still deploy the API unchanged.
+      ECS_WORKER_SERVICE: ${{ vars.ECS_WORKER_SERVICE }}
+      ECS_BEAT_SERVICE: ${{ vars.ECS_BEAT_SERVICE }}
+      ECS_WORKER_CONTAINER_NAME: ${{ vars.ECS_WORKER_CONTAINER_NAME || 'worker' }}
+      ECS_BEAT_CONTAINER_NAME: ${{ vars.ECS_BEAT_CONTAINER_NAME || 'beat' }}
+      BACKGROUND_MQ_BROKER_ID: ${{ vars.BACKGROUND_MQ_BROKER_ID }}
+      BACKGROUND_STORE_NAME: ${{ vars.BACKGROUND_STORE_NAME }}
       API_URL: ${{ vars.API_URL }}
       API_BASE_URL: ${{ vars.API_BASE_URL }}
       WEB_URL: ${{ vars.WEB_URL }}
@@ -99,6 +108,23 @@ jobs:
             : "${SUPPORT_GITHUB_APP_INSTALLATION_ID:?Set SUPPORT_GITHUB_APP_INSTALLATION_ID when support tracker is enabled.}"
             : "${SUPPORT_GITHUB_OWNER:?Set SUPPORT_GITHUB_OWNER when support tracker is enabled.}"
             : "${SUPPORT_GITHUB_REPO:?Set SUPPORT_GITHUB_REPO when support tracker is enabled.}"
+          fi
+          # Background plane fails CLOSED: it is either fully configured or fully
+          # absent. Worker service, Beat service, and both container names must be
+          # set together, otherwise a partial configuration would silently skip
+          # the worker/Beat rollout while still rolling an API that can enqueue a
+          # task no running worker imports. A missing container name defaults to a
+          # non-empty literal above, so only the service names are the switch;
+          # both must agree.
+          background_config="${ECS_WORKER_SERVICE:+w}${ECS_BEAT_SERVICE:+b}"
+          if [ -n "$background_config" ] && [ "$background_config" != "wb" ]; then
+            echo "Partial background-plane configuration: ECS_WORKER_SERVICE='${ECS_WORKER_SERVICE}' ECS_BEAT_SERVICE='${ECS_BEAT_SERVICE}'." >&2
+            echo "Set BOTH worker and Beat services (with their container names) to deploy the background plane, or NEITHER to skip it. Refusing to roll the API with a half-configured background plane." >&2
+            exit 1
+          fi
+          if [ -n "$background_config" ]; then
+            : "${ECS_WORKER_CONTAINER_NAME:?Set ECS_WORKER_CONTAINER_NAME for the background plane.}"
+            : "${ECS_BEAT_CONTAINER_NAME:?Set ECS_BEAT_CONTAINER_NAME for the background plane.}"
           fi
 
       - name: Configure AWS credentials
@@ -167,6 +193,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push server image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -181,6 +208,29 @@ jobs:
             RUNTIME_VERSION=${{ steps.pins.outputs.runtime_version }}
             WORKER_VERSION=${{ steps.pins.outputs.worker_version }}
             MIN_DESKTOP_VERSION=${{ steps.pins.outputs.min_desktop_version }}
+
+      # Resolve the IMMUTABLE digest reference for the image just pushed. The
+      # mutable `repo:shortsha` tag can be re-pointed at a different image after
+      # this deploy resolves it; pinning every task definition (API, worker, Beat)
+      # to `repo@sha256:...` guarantees all three planes run the byte-identical
+      # image this run built and that a later tag move cannot silently change what
+      # a rolled service runs. The digest comes from the build/push output.
+      - name: Resolve immutable image digest
+        id: digest
+        run: |
+          set -euo pipefail
+          digest="${{ steps.build.outputs.digest }}"
+          case "$digest" in
+            sha256:*) ;;
+            *)
+              echo "Build did not produce a sha256 image digest (got '${digest}'); refusing to pin a mutable tag." >&2
+              exit 1
+              ;;
+          esac
+          registry="${{ steps.ecr.outputs.registry }}"
+          image_ref="${registry}/${ECR_SERVER_REPOSITORY}@${digest}"
+          echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
+          echo "Pinning task definitions to immutable ${image_ref}"
 
       - name: Render ECS task definition
         id: task
@@ -418,7 +468,7 @@ jobs:
 
           jq \
             --arg container "$ECS_SERVER_CONTAINER_NAME" \
-            --arg image "${{ steps.image.outputs.image_uri }}" \
+            --arg image "${{ steps.digest.outputs.image_ref }}" \
             --slurpfile updates env-updates.json \
             --slurpfile secret_updates secret-updates.json \
             -f merge-task.jq \
@@ -430,6 +480,23 @@ jobs:
             --arg container "$ECS_SERVER_CONTAINER_NAME" \
             -f assert-task.jq \
             task-definition.json > /dev/null
+
+          # Fail closed unless the server container is pinned to an IMMUTABLE
+          # digest (`repo@sha256:...`), never a mutable tag. A mutable tag could be
+          # re-pointed after this deploy resolves it, so a rolled service would run
+          # a different image than this run built.
+          server_image="$(
+            jq -r --arg container "$ECS_SERVER_CONTAINER_NAME" \
+              'first(.containerDefinitions[] | select(.name == $container) | .image)' \
+              task-definition.json
+          )"
+          case "$server_image" in
+            *@sha256:*) ;;
+            *)
+              echo "Server container image '${server_image}' is not an immutable @sha256: digest reference; refusing to register a mutable tag." >&2
+              exit 1
+              ;;
+          esac
 
           new_task_definition_arn="$(
             aws ecs register-task-definition \
@@ -489,6 +556,369 @@ jobs:
             exit 1
           fi
 
+      # ── Background plane deploy order ──
+      # Contract: migrations (above) -> verify broker/store -> deploy worker+Beat
+      # from the candidate image -> verify worker/Beat health -> deploy API from
+      # the same image (below). This prevents rolling an API that enqueues a task
+      # name no running worker can import.
+
+      - name: Verify broker and scheduler store
+        if: ${{ env.ECS_WORKER_SERVICE != '' && env.ECS_BEAT_SERVICE != '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "$BACKGROUND_MQ_BROKER_ID" ]; then
+            broker_state="$(
+              aws mq describe-broker --broker-id "$BACKGROUND_MQ_BROKER_ID" \
+                --query 'BrokerState' --output text
+            )"
+            if [ "$broker_state" != "RUNNING" ]; then
+              echo "Amazon MQ broker ${BACKGROUND_MQ_BROKER_ID} is ${broker_state}, expected RUNNING." >&2
+              exit 1
+            fi
+            echo "Broker ${BACKGROUND_MQ_BROKER_ID} is RUNNING."
+          else
+            echo "BACKGROUND_MQ_BROKER_ID unset; skipping broker state check."
+          fi
+          if [ -n "$BACKGROUND_STORE_NAME" ]; then
+            store_status="$(
+              aws elasticache describe-serverless-caches \
+                --serverless-cache-name "$BACKGROUND_STORE_NAME" \
+                --query 'ServerlessCaches[0].Status' --output text
+            )"
+            if [ "$store_status" != "available" ]; then
+              echo "Scheduler store ${BACKGROUND_STORE_NAME} is ${store_status}, expected available." >&2
+              exit 1
+            fi
+            echo "Scheduler store ${BACKGROUND_STORE_NAME} is available."
+          else
+            echo "BACKGROUND_STORE_NAME unset; skipping store status check."
+          fi
+
+      - name: Deploy worker and Beat from candidate image
+        id: background
+        if: ${{ env.ECS_WORKER_SERVICE != '' && env.ECS_BEAT_SERVICE != '' }}
+        run: |
+          set -euo pipefail
+          # Re-image a celery service in place: take its current task definition,
+          # swap only the container image to the candidate, register, and roll.
+          # Environment/secrets are Terraform-owned and left intact. The candidate
+          # is the IMMUTABLE digest reference (same `repo@sha256:...` the API roll
+          # pins), so worker/Beat run the byte-identical image as the API and a
+          # later tag move cannot change what they run.
+          candidate_image="${{ steps.digest.outputs.image_ref }}"
+          case "$candidate_image" in
+            *@sha256:*) ;;
+            *)
+              echo "Candidate image '${candidate_image}' is not an immutable @sha256: digest reference; refusing to roll a mutable tag." >&2
+              exit 1
+              ;;
+          esac
+          roll_service() {
+            service="$1"; container="$2"
+            current_arn="$(
+              aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$service" \
+                --query 'services[0].taskDefinition' --output text
+            )"
+            test "$current_arn" != "None"
+            aws ecs describe-task-definition --task-definition "$current_arn" \
+              --query taskDefinition > "td-${container}.raw.json"
+            # Fail closed if the named container does not match exactly one
+            # definition: a wrong ECS_*_CONTAINER_NAME would otherwise rewrite
+            # nothing, register the OLD image, and still report success.
+            match_count="$(
+              jq --arg container "$container" \
+                '[.containerDefinitions[] | select(.name == $container)] | length' \
+                "td-${container}.raw.json"
+            )"
+            if [ "$match_count" != "1" ]; then
+              echo "Expected exactly one '${container}' container in ${service}'s task definition, found ${match_count}." >&2
+              exit 1
+            fi
+            jq \
+              --arg container "$container" \
+              --arg image "$candidate_image" '
+              del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                  .compatibilities, .registeredAt, .registeredBy)
+              | .containerDefinitions |= map(
+                  if .name == $container then .image = $image else . end
+                )
+            ' "td-${container}.raw.json" > "td-${container}.json"
+            # Assert the rewritten definition carries the candidate image on the
+            # named container before registration.
+            rewritten_image="$(
+              jq -r --arg container "$container" \
+                'first(.containerDefinitions[] | select(.name == $container) | .image)' \
+                "td-${container}.json"
+            )"
+            if [ "$rewritten_image" != "$candidate_image" ]; then
+              echo "Container '${container}' image is '${rewritten_image}', expected candidate '${candidate_image}'." >&2
+              exit 1
+            fi
+            new_arn="$(
+              aws ecs register-task-definition --cli-input-json "file://td-${container}.json" \
+                --query 'taskDefinition.taskDefinitionArn' --output text
+            )"
+            # Confirm the REGISTERED revision (not just the local file) carries the
+            # candidate image on exactly the named container.
+            registered_image="$(
+              aws ecs describe-task-definition --task-definition "$new_arn" \
+                --query "taskDefinition.containerDefinitions[?name=='${container}'].image | [0]" \
+                --output text
+            )"
+            if [ "$registered_image" != "$candidate_image" ]; then
+              echo "Registered ${service} task def ${new_arn} carries image '${registered_image}', expected '${candidate_image}'." >&2
+              exit 1
+            fi
+            aws ecs update-service --cluster "$ECS_CLUSTER" --service "$service" \
+              --task-definition "$new_arn" --force-new-deployment > /dev/null
+            echo "$new_arn"
+          }
+          worker_arn="$(roll_service "$ECS_WORKER_SERVICE" "$ECS_WORKER_CONTAINER_NAME")"
+          beat_arn="$(roll_service "$ECS_BEAT_SERVICE" "$ECS_BEAT_CONTAINER_NAME")"
+          {
+            echo "worker_task_definition_arn=$worker_arn"
+            echo "beat_task_definition_arn=$beat_arn"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify worker and Beat health
+        if: ${{ env.ECS_WORKER_SERVICE != '' && env.ECS_BEAT_SERVICE != '' }}
+        run: |
+          set -euo pipefail
+          # The live service must run the SAME immutable digest the roll pinned.
+          candidate_image="${{ steps.digest.outputs.image_ref }}"
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_WORKER_SERVICE" "$ECS_BEAT_SERVICE"
+          # (service, container) pairs so each running task def is checked against
+          # its own container name.
+          set -- \
+            "$ECS_WORKER_SERVICE:$ECS_WORKER_CONTAINER_NAME" \
+            "$ECS_BEAT_SERVICE:$ECS_BEAT_CONTAINER_NAME"
+          for pair in "$@"; do
+            service="${pair%%:*}"; container="${pair#*:}"
+            running="$(
+              aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$service" \
+                --query 'services[0].runningCount' --output text
+            )"
+            if [ "$running" -lt 1 ]; then
+              echo "Service $service has runningCount=$running after stabilizing." >&2
+              exit 1
+            fi
+            # The API must not roll until the worker/Beat the service ACTUALLY
+            # runs carry the candidate image. Read the service's live task
+            # definition and assert the named container's image before proceeding.
+            live_arn="$(
+              aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$service" \
+                --query 'services[0].taskDefinition' --output text
+            )"
+            live_image="$(
+              aws ecs describe-task-definition --task-definition "$live_arn" \
+                --query "taskDefinition.containerDefinitions[?name=='${container}'].image | [0]" \
+                --output text
+            )"
+            if [ "$live_image" != "$candidate_image" ]; then
+              echo "Service $service is running task def ${live_arn} with image '${live_image}', expected candidate '${candidate_image}' before the API roll." >&2
+              exit 1
+            fi
+            echo "Service $service healthy (runningCount=$running) on candidate image."
+          done
+
+      # ── Candidate-plane execution proof (fails closed) ──
+      # ECS resource health only proves containers are RUNNING. It does NOT prove
+      # the candidate worker/Beat can actually EXECUTE newly enqueued work: broker
+      # credentials, task routing, worker task-registry import, RedBeat scheduler
+      # state, and relay publish/consume could all be broken while runningCount is
+      # green. This step proves execution end-to-end before the API rolls:
+      #   1. enqueue ONE deterministic committed health no-op via a one-off task
+      #      on the candidate worker task definition; then
+      #   2. observe, via the plane's own CloudWatch metrics, BOTH a fresh relay
+      #      heartbeat advance (Beat dispatched background.relay -> a worker ran it
+      #      -> RedBeat/store and broker are reachable) AND a fresh health-no-op
+      #      task SUCCESS (the newly enqueued row was relayed, published, routed,
+      #      consumed, and executed by the candidate worker).
+      # Both signals are custom metrics lifted from the server log group
+      # (namespace Proliferate/Background/<env>), so this gate references NO broker
+      # or scheduler-store RESOURCE ID. The identical proof therefore covers both
+      # the managed-AWS-IDs path and the external-endpoint / no-resource-ID rebind
+      # path — it measures the app reaching whatever endpoints are configured, not
+      # the presence of a managed resource. On timeout it FAILS CLOSED so the API
+      # never rolls against a plane that cannot execute the tasks it will enqueue.
+      # CANDIDATE_PROOF_TIMEOUT_SECONDS / CANDIDATE_PROOF_POLL_SECONDS are
+      # overridable (the deploy-definition tests shrink them to drive the loop).
+      - name: Prove candidate plane executes enqueued work
+        if: ${{ env.ECS_WORKER_SERVICE != '' && env.ECS_BEAT_SERVICE != '' }}
+        run: |
+          set -euo pipefail
+          namespace="Proliferate/Background/${DEPLOY_ENVIRONMENT}"
+          # Server log group carries both the enqueue receipt line and the
+          # worker's exact-ID execution receipt. Derived from the environment
+          # name (no broker/store resource ID), overridable for tests.
+          log_group="${CANDIDATE_PROOF_LOG_GROUP:-/ecs/proliferate-server-${DEPLOY_ENVIRONMENT}}"
+          # GITHUB_RUN_ATTEMPT is part of the key so a workflow RERUN enqueues a
+          # FRESH outbox row instead of colliding (by idempotency key) with the
+          # previous attempt's already-published row and false-passing on a stale
+          # receipt. Each attempt must prove ITS OWN newly enqueued row executed.
+          proof_key="deploy-${GIT_SHA}-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
+          timeout_seconds="${CANDIDATE_PROOF_TIMEOUT_SECONDS:-300}"
+          poll_seconds="${CANDIDATE_PROOF_POLL_SECONDS:-15}"
+
+          iso_from_epoch() {
+            # GNU (ubuntu CI) then BSD (local test) form.
+            date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+              || date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ
+          }
+          # Latest per-period Sum for a metric since the proof boundary, printed
+          # as a plain number (0 when CloudWatch has no datapoint yet / "None").
+          metric_latest_sum() {
+            metric_name="$1"; shift
+            start_iso="$(iso_from_epoch "$proof_start_epoch")"
+            end_iso="$(iso_from_epoch "$(date -u +%s)")"
+            raw="$(
+              aws cloudwatch get-metric-statistics \
+                --namespace "$namespace" \
+                --metric-name "$metric_name" \
+                --start-time "$start_iso" \
+                --end-time "$end_iso" \
+                --period 60 \
+                --statistics Sum \
+                "$@" \
+                --query 'sort_by(Datapoints, &Timestamp)[-1].Sum' \
+                --output text 2>/dev/null || echo None
+            )"
+            if [ -z "$raw" ] || [ "$raw" = "None" ]; then
+              echo 0
+            else
+              echo "$raw"
+            fi
+          }
+          ge_one() { awk -v v="$1" 'BEGIN { exit !(v + 0 >= 1) }'; }
+
+          # Recover THIS deploy's exact outbox id from the enqueue receipt line
+          # (`enqueued_health_noop outbox_id=<uuid> idempotency_key=<proof_key>`).
+          # The one-off enqueue task runs on ECS, so its stdout lands in the
+          # server log group; filtering on the deterministic proof_key isolates
+          # this deploy's row even if a concurrent deploy enqueued its own.
+          recover_outbox_id() {
+            start_ms="$(( proof_start_epoch * 1000 ))"
+            aws logs filter-log-events \
+              --log-group-name "$log_group" \
+              --start-time "$start_ms" \
+              --filter-pattern "\"enqueued_health_noop\" \"idempotency_key=${proof_key}\"" \
+              --query 'events[].message' \
+              --output text 2>/dev/null \
+              | grep -oE 'outbox_id=[0-9a-fA-F-]+' \
+              | head -n1 \
+              | cut -d= -f2
+          }
+          # Count fresh EXACT-ID execution receipts for a given task id. The relay
+          # sets the celery task_id equal to the outbox id, so the worker's
+          # `background_health_receipt` line carries that same UUID. Matching on it
+          # correlates success to THIS row, not to any concurrent health no-op that
+          # would satisfy an aggregate success metric. The UUID is not a secret.
+          receipt_count_for_id() {
+            task_id="$1"
+            start_ms="$(( proof_start_epoch * 1000 ))"
+            raw="$(
+              aws logs filter-log-events \
+                --log-group-name "$log_group" \
+                --start-time "$start_ms" \
+                --filter-pattern "{ \$.background_health_receipt.task_id = \"${task_id}\" && \$.background_health_receipt.status = \"ok\" }" \
+                --query 'length(events)' \
+                --output text 2>/dev/null || echo 0
+            )"
+            if [ -z "$raw" ] || [ "$raw" = "None" ]; then
+              echo 0
+            else
+              echo "$raw"
+            fi
+          }
+
+          # Network config for the one-off enqueue task (mirror the migration run).
+          aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_WORKER_SERVICE" \
+            > proof-service.json
+          network_configuration="$(
+            jq -c '{
+              awsvpcConfiguration: {
+                subnets: .services[0].networkConfiguration.awsvpcConfiguration.subnets,
+                securityGroups: (.services[0].networkConfiguration.awsvpcConfiguration.securityGroups // []),
+                assignPublicIp: (.services[0].networkConfiguration.awsvpcConfiguration.assignPublicIp // "DISABLED")
+              }
+            }' proof-service.json
+          )"
+          worker_td="$(
+            jq -r '.services[0].taskDefinition' proof-service.json
+          )"
+
+          # Boundary BEFORE enqueue so only fresh datapoints count.
+          proof_start_epoch="$(date -u +%s)"
+
+          overrides="$(
+            jq -n --arg c "$ECS_WORKER_CONTAINER_NAME" --arg key "$proof_key" '{
+              containerOverrides: [
+                {
+                  name: $c,
+                  command: ["python", "-m", "proliferate.background.enqueue_health", "--idempotency-key", $key]
+                }
+              ]
+            }'
+          )"
+          enqueue_task="$(
+            aws ecs run-task \
+              --cluster "$ECS_CLUSTER" \
+              --launch-type FARGATE \
+              --task-definition "$worker_td" \
+              --network-configuration "$network_configuration" \
+              --overrides "$overrides" \
+              --query 'tasks[0].taskArn' \
+              --output text
+          )"
+          test "$enqueue_task" != "None"
+          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$enqueue_task"
+          enqueue_exit="$(
+            aws ecs describe-tasks \
+              --cluster "$ECS_CLUSTER" \
+              --tasks "$enqueue_task" \
+              --query "tasks[0].containers[?name=='${ECS_WORKER_CONTAINER_NAME}'].exitCode | [0]" \
+              --output text
+          )"
+          if [ "$enqueue_exit" != "0" ]; then
+            echo "Candidate-plane proof: health no-op enqueue task exited ${enqueue_exit}, expected 0." >&2
+            exit 1
+          fi
+          echo "Enqueued deterministic health no-op (key=${proof_key}); observing candidate execution..."
+
+          # Poll two signals until BOTH hold, or fail closed:
+          #   (a) a fresh RelayHeartbeat advance  -> Beat+RedBeat+broker+worker
+          #       liveness (an aggregate signal, correctly aggregate here); and
+          #   (b) an EXACT-ID execution receipt   -> the candidate worker consumed
+          #       and ran THIS deploy's exact enqueued row, not any concurrent or
+          #       replayed health no-op. Recovering the outbox id is itself part of
+          #       the gate: no receivable id => nothing to match => fail closed.
+          outbox_id=""
+          deadline="$(( $(date -u +%s) + timeout_seconds ))"
+          while :; do
+            if [ -z "$outbox_id" ]; then
+              outbox_id="$(recover_outbox_id || true)"
+            fi
+            heartbeat="$(metric_latest_sum RelayHeartbeat)"
+            if [ -n "$outbox_id" ]; then
+              receipt_count="$(receipt_count_for_id "$outbox_id")"
+            else
+              receipt_count=0
+            fi
+            if ge_one "$heartbeat" && ge_one "$receipt_count"; then
+              echo "Candidate plane proven: relay heartbeat advanced (Sum=${heartbeat}) and the EXACT enqueued health no-op executed (outbox_id=${outbox_id}, receipts=${receipt_count})."
+              break
+            fi
+            if [ "$(date -u +%s)" -ge "$deadline" ]; then
+              echo "Candidate-plane proof FAILED CLOSED after ${timeout_seconds}s: relay_heartbeat=${heartbeat}, outbox_id='${outbox_id}', exact_id_receipts=${receipt_count}. The candidate worker/Beat plane did not execute THIS deploy's newly enqueued row; refusing to roll the API." >&2
+              exit 1
+            fi
+            sleep "$poll_seconds"
+          done
+
       - name: Roll ECS service
         run: |
           set -euo pipefail
@@ -528,6 +958,14 @@ jobs:
             echo "### Server"
             echo "- Environment: $DEPLOY_ENVIRONMENT"
             echo "- Image: \`${{ steps.image.outputs.image_uri }}\`"
-            echo "- Task definition: \`${{ steps.task.outputs.task_definition_arn }}\`"
-            echo "- Service: \`$ECS_CLUSTER/$ECS_SERVER_SERVICE\`"
+            echo "- Image digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- API task definition: \`${{ steps.task.outputs.task_definition_arn }}\`"
+            echo "- API service: \`$ECS_CLUSTER/$ECS_SERVER_SERVICE\`"
+            if [ -n "$ECS_WORKER_SERVICE" ]; then
+              echo "### Background plane (same image digest as API)"
+              echo "- Worker task definition: \`${{ steps.background.outputs.worker_task_definition_arn }}\`"
+              echo "- Worker service: \`$ECS_CLUSTER/$ECS_WORKER_SERVICE\`"
+              echo "- Beat task definition: \`${{ steps.background.outputs.beat_task_definition_arn }}\`"
+              echo "- Beat service: \`$ECS_CLUSTER/$ECS_BEAT_SERVICE\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,39 @@ jobs:
           python3 -m unittest scripts/test_check_docs.py
           python3 scripts/check_docs.py
 
+  terraform-validate:
+    name: Terraform validate (server/infra)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
+
+      # background.tf and the rest of server/infra are loaded by Terraform even
+      # at zero resource counts, so a malformed provider/schema definition would
+      # otherwise only surface at a deploy gate. Parse and validate them here
+      # (no backend, no AWS credentials, no plan/apply) so the checked-in
+      # definitions are proven well-formed on every push/PR.
+      - name: Terraform fmt
+        run: terraform -chdir=server/infra fmt -check -recursive
+
+      - name: Terraform init (no backend)
+        run: terraform -chdir=server/infra init -backend=false -input=false
+
+      - name: Terraform validate
+        run: terraform -chdir=server/infra validate
+
+      # Plan-time proof of the background-plane fail-closed contract: the
+      # worker/Beat services can only be enabled with a managed broker/store OR
+      # both external endpoint secret references. Runs use `command = plan`
+      # against a mocked AWS provider (no credentials, no backend, no apply), so
+      # the invalid partial combos are proven to fail at plan time on the
+      # variable validation, and the valid managed/rebound combos plan cleanly.
+      - name: Terraform test (background plane fail-closed)
+        run: terraform -chdir=server/infra test
+
   ci-cd-config:
     name: CI/CD config checks
     runs-on: ubuntu-latest
@@ -80,6 +113,15 @@ jobs:
 
       - name: Test CI/CD scripts
         run: node --test scripts/ci-cd/*.test.mjs
+
+      # Launcher-level proof (BG4-LOCAL-01): `make run BACKGROUND=1` must start
+      # the Celery worker/Beat against the SELECTED profile database on
+      # profile-scoped broker/store ports. Renders `docker compose config` (no
+      # daemon needed; the compose CLI ships on the runner) and asserts the
+      # worker/Beat DATABASE_URL DB-name matches the profile DB and ports are
+      # profile-scoped.
+      - name: Test background launcher config
+        run: node --test scripts/dev-background-launch.test.mjs
 
       - name: Validate agent catalog generation discipline
         env:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ USE_EXISTING_REDIS ?= 0
 STRIPE_FORWARD_TO ?= http://127.0.0.1:8000/v1/billing/webhooks/stripe
 STRIPE_SNAPSHOT_EVENTS ?= checkout.session.completed,customer.subscription.created,customer.subscription.updated,customer.subscription.deleted,invoice.paid,invoice.payment_failed
 AGENT_GATEWAY ?= 0
+BACKGROUND ?= 0
 LOCAL_LITELLM_BASE_URL ?= http://127.0.0.1:14000
 LOCAL_LITELLM_MASTER_KEY ?= sk-proliferate-local-dev
 CLOUD_WORKER_TUNNEL ?= 0
@@ -108,6 +109,7 @@ endif
 
 .PHONY: catalog-view catalog-pin catalog-update setup run dev dev-init dev-list dev-local dev-desktop dev-runtime dev-server dev-mobile-auth dev-mobile-tunnel dev-web-auth seed-sso server-db-up server-db-wait \
         server-db-down server-db-ready server-redis-up server-redis-wait server-redis-down server-redis-ready \
+        server-background-up server-background-logs server-background-down \
         server-litellm-up server-litellm-wait server-litellm-down db db-local db-ah server-migrate serve install \
         check check-max-lines check-server-boundaries test test-server fmt clippy \
         dev-automation-worker \
@@ -272,6 +274,28 @@ run: dev-artifacts-ready
 		exit 1; \
 	fi; \
 	(cd server && DATABASE_URL="$$DATABASE_URL" .venv/bin/alembic upgrade head); \
+	background_mode="$(BACKGROUND)"; \
+	if [ "$$background_mode" = "1" ] || [ "$$background_mode" = "celery" ]; then \
+		if [ "$$use_profile_db" != "1" ]; then \
+			echo "ERROR: BACKGROUND=$$background_mode requires the profile database (do not set DATABASE_URL). The compose worker/beat reach the SAME host Postgres/profile DB the API uses." >&2; \
+			exit 1; \
+		fi; \
+		: "$${PROLIFERATE_RABBITMQ_HOST_PORT:?background port not allocated; run make setup PROFILE=$(PROFILE)}"; \
+		: "$${PROLIFERATE_RABBITMQ_MGMT_HOST_PORT:?background port not allocated; run make setup PROFILE=$(PROFILE)}"; \
+		: "$${PROLIFERATE_REDIS_HOST_PORT:?background port not allocated; run make setup PROFILE=$(PROFILE)}"; \
+		export PROLIFERATE_RABBITMQ_HOST_PORT PROLIFERATE_RABBITMQ_MGMT_HOST_PORT PROLIFERATE_REDIS_HOST_PORT; \
+		export PROLIFERATE_DB_HOST_PORT="$${PROLIFERATE_DB_HOST_PORT:-$(LOCAL_PGPORT)}"; \
+		: "$${DATABASE_URL:?}"; \
+		background_db_url="$$(node scripts/dev.mjs background-db-url --database-url "$$DATABASE_URL")"; \
+		if printf '%s' "$$background_db_url" | grep -Eq '@(127\.0\.0\.1|localhost|\[?::1\]?):'; then \
+			echo "ERROR: could not rewrite DATABASE_URL host to host.docker.internal for the background plane (got $$background_db_url)." >&2; \
+			exit 1; \
+		fi; \
+		export COMPOSE_PROJECT_NAME="proliferate_bg_$$(printf '%s' "$$PROLIFERATE_DEV_PROFILE" | tr '-' '_')"; \
+		export BACKGROUND_DATABASE_URL="$$background_db_url"; \
+		echo "Starting background plane (worker + beat) via compose project $$COMPOSE_PROJECT_NAME against $$background_db_url (broker :$$PROLIFERATE_RABBITMQ_HOST_PORT, store :$$PROLIFERATE_REDIS_HOST_PORT)"; \
+		docker compose -f server/docker-compose.yml --profile background up -d --no-deps --build rabbitmq redis worker beat; \
+	fi; \
 	stripe_listener_ready=0; \
 	if [ "$(STRIPE)" = "1" ]; then \
 		if command -v stripe >/dev/null 2>&1; then \
@@ -464,6 +488,30 @@ server-redis-wait:
 
 server-redis-down:
 	@docker compose -f server/docker-compose.yml stop redis
+
+# Self-contained local background plane: Postgres, RabbitMQ, Redis, migrations,
+# Celery worker, and Celery Beat, all on the same compose image. This is the
+# merge-gated same-image outbox->worker smoke vehicle. Set a per-worktree
+# COMPOSE_PROJECT_NAME plus PROLIFERATE_*_HOST_PORT overrides to run isolated
+# stacks side by side without default-port collisions.
+server-background-up:
+	@command -v docker >/dev/null 2>&1 || { \
+		echo "Docker is required for the local background plane. Install or start Docker and retry."; \
+		exit 1; \
+	}
+	@docker info >/dev/null 2>&1 || { \
+		echo "Docker is not running. Start Docker Desktop and retry."; \
+		exit 1; \
+	}
+	@docker compose -f server/docker-compose.yml --profile background up -d --build \
+		db rabbitmq redis migrate worker beat
+	@echo "Background plane up (worker + beat). Logs: make server-background-logs"
+
+server-background-logs:
+	@docker compose -f server/docker-compose.yml --profile background logs -f worker beat
+
+server-background-down:
+	@docker compose -f server/docker-compose.yml --profile background down
 
 server-litellm-up:
 	@command -v docker >/dev/null 2>&1 || { \

--- a/scripts/dev-background-launch.test.mjs
+++ b/scripts/dev-background-launch.test.mjs
@@ -1,0 +1,335 @@
+// Launcher-level proof for BG4-LOCAL-01.
+//
+// `make run PROFILE=<name> BACKGROUND=1` must start the Celery worker/Beat
+// against the ACTUAL selected profile database (same host Postgres + same
+// profile DB name the host-run API uses), on profile-scoped broker/store ports.
+// A regression here is silent: the plane comes up but observes a DIFFERENT
+// database than the API, or collides with another worktree on default ports.
+//
+// This test drives the real launcher allocation (scripts/dev.mjs) in an isolated
+// HOME, applies the exact DATABASE_URL rewrite the Makefile uses (the shared
+// backgroundDatabaseUrl helper), then renders `docker compose config` and
+// asserts:
+//   * the worker AND beat DATABASE_URL resolve to the profile DB name on
+//     host.docker.internal (never a compose-internal `db`, never a bare
+//     loopback host a container cannot reach); and
+//   * rabbitmq/redis publish the profile-scoped host ports, not the defaults.
+//
+// `docker compose config` is pure parse/interpolate and needs no daemon, but the
+// compose CLI itself may be absent; the test skips cleanly when it is.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { backgroundDatabaseUrl } from "./dev.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const devScript = path.join(repoRoot, "scripts", "dev.mjs");
+const composeFile = path.join(repoRoot, "server", "docker-compose.yml");
+const makefile = path.join(repoRoot, "Makefile");
+
+function composeAvailable() {
+  try {
+    execFileSync("docker", ["compose", "version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseEnvFile(text) {
+  const env = {};
+  for (const line of text.split("\n")) {
+    const match = line.match(/^export\s+([A-Za-z0-9_]+)=(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    if (
+      (value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"'))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[match[1]] = value;
+  }
+  return env;
+}
+
+test("background plane reaches the selected profile DB on profile-scoped ports", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "bg-launch-"));
+  try {
+    const profile = "bglaunchproof";
+    // Drive the real launcher: allocate + persist the profile env (ports, DB).
+    execFileSync("node", [devScript, "ensure", "--profile", profile], {
+      env: { ...process.env, HOME: home },
+      stdio: "ignore",
+    });
+    const profileEnvPath = path.join(
+      home,
+      ".proliferate-local",
+      "dev",
+      "profiles",
+      profile,
+      "profile.env",
+    );
+    const profileEnv = parseEnvFile(readFileSync(profileEnvPath, "utf8"));
+
+    const dbName = profileEnv.PROLIFERATE_DEV_DB_NAME;
+    assert.equal(dbName, `proliferate_dev_${profile}`);
+    for (const key of [
+      "PROLIFERATE_RABBITMQ_HOST_PORT",
+      "PROLIFERATE_RABBITMQ_MGMT_HOST_PORT",
+      "PROLIFERATE_REDIS_HOST_PORT",
+    ]) {
+      assert.ok(profileEnv[key], `${key} must be allocated for the profile`);
+    }
+
+    // The host-run API's DATABASE_URL for this profile (macOS default host is
+    // ::1, which the old sed rewrite silently failed to match — exercise it).
+    const hostDbUrl = `postgresql+asyncpg://proliferate:localdev@[::1]:5455/${dbName}`;
+    const backgroundDbUrl = backgroundDatabaseUrl(hostDbUrl);
+    // The profile DB NAME must survive the rewrite; only the host changes.
+    assert.ok(backgroundDbUrl.endsWith(`/${dbName}`));
+    assert.ok(backgroundDbUrl.includes("@host.docker.internal:5455/"));
+
+    if (!composeAvailable()) {
+      // Parse-level assertions above already hold; the render assertions need the
+      // compose CLI. Skip the render but keep the test meaningful.
+      return;
+    }
+
+    const rendered = execFileSync(
+      "docker",
+      ["compose", "-f", composeFile, "--profile", "background", "config", "--format", "json"],
+      {
+        env: {
+          ...process.env,
+          BACKGROUND_DATABASE_URL: backgroundDbUrl,
+          PROLIFERATE_RABBITMQ_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_HOST_PORT,
+          PROLIFERATE_RABBITMQ_MGMT_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_MGMT_HOST_PORT,
+          PROLIFERATE_REDIS_HOST_PORT: profileEnv.PROLIFERATE_REDIS_HOST_PORT,
+        },
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+    const config = JSON.parse(rendered);
+    const services = config.services;
+
+    // Worker AND Beat must observe the profile DB on host.docker.internal.
+    for (const name of ["worker", "beat"]) {
+      const url = services[name].environment.DATABASE_URL;
+      assert.equal(
+        url,
+        backgroundDbUrl,
+        `${name} DATABASE_URL must be the rewritten profile DB URL`,
+      );
+      assert.ok(url.endsWith(`/${dbName}`), `${name} must target the profile DB name`);
+      assert.ok(
+        url.includes("@host.docker.internal:"),
+        `${name} must reach the host Postgres, not a compose-internal db`,
+      );
+      assert.ok(
+        !/@db:5432\//.test(url),
+        `${name} must not point at the throwaway compose db`,
+      );
+    }
+
+    // Broker/store host ports must be profile-scoped, not the shared defaults.
+    const publishedHostPorts = (service) =>
+      (services[service].ports || []).map((p) => String(p.published));
+    assert.ok(
+      publishedHostPorts("rabbitmq").includes(profileEnv.PROLIFERATE_RABBITMQ_HOST_PORT),
+      "rabbitmq must publish the profile-scoped host port",
+    );
+    assert.ok(
+      publishedHostPorts("redis").includes(profileEnv.PROLIFERATE_REDIS_HOST_PORT),
+      "redis must publish the profile-scoped host port",
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+// BG4-LOCAL-02: the JS-level proof above does not touch the REAL `make run
+// BACKGROUND=1` decision seam in the Makefile. That seam (a) refuses to start the
+// background plane unless the profile DB is in use, and (b) rewrites the host-run
+// DATABASE_URL to reach the same host Postgres/profile DB from a container. It
+// previously had its OWN inline `sed` rewrite, diverging from the JS helper. The
+// tests below assert the Makefile now routes through the shared `dev.mjs
+// background-db-url` seam (one source of truth) and that the two decisions hold
+// when the actual Makefile recipe lines run — without requiring Docker.
+
+// Extract the body of the `run:` recipe from the Makefile as executable shell.
+// Recipe lines are TAB-indented and use `\`-continuations; strip the leading tab
+// and the recipe-echo `@` so the block can run under bash directly.
+function extractRunRecipe() {
+  const text = readFileSync(makefile, "utf8");
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => /^run:/.test(l));
+  assert.ok(start >= 0, "run: target must exist in the Makefile");
+  const body = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line === "" || /^[^\t]/.test(line)) break; // next target / blank ends recipe
+    body.push(line.replace(/^\t/, ""));
+  }
+  return body.join("\n");
+}
+
+test("Makefile BACKGROUND seam routes through the shared dev.mjs rewrite (no inline sed)", () => {
+  const recipe = extractRunRecipe();
+  // The background branch must derive the container DB URL via the shared
+  // subcommand, not a private sed copy that can drift from the JS helper.
+  assert.ok(
+    recipe.includes("node scripts/dev.mjs background-db-url"),
+    "run recipe must call `dev.mjs background-db-url` for the container DB rewrite",
+  );
+  assert.ok(
+    !recipe.includes("host.docker.internal:\\1/"),
+    "run recipe must not keep the private inline sed rewrite",
+  );
+});
+
+// Slice the contiguous `background_mode=...if...fi` block out of the run recipe
+// and render it as a runnable, Docker-free shell fragment: make variables become
+// concrete test values, the `docker compose up` line is neutralized to an echo so
+// no daemon is touched, and `$$` becomes a literal `$`. Everything else — the
+// profile-DB abort, the three port `:?` guards, the shared `dev.mjs` rewrite call,
+// and the loopback fail-closed check — runs verbatim.
+function backgroundSeamScript(profile) {
+  const recipe = extractRunRecipe();
+  const lines = recipe.split("\n");
+  const start = lines.findIndex((l) => l.includes('background_mode="$(BACKGROUND)"'));
+  assert.ok(start >= 0, "run recipe must contain the BACKGROUND branch");
+  // Find the `fi;` that closes the `if [ "$$background_mode" ... ]` block. After
+  // extractRunRecipe strips one leading tab, the OUTER block sits at zero indent
+  // while nested `if/fi` keep leading whitespace, so anchor on a zero-indent
+  // `fi;` (ignoring the trailing line-continuation) to skip the inner closer.
+  let end = -1;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^fi;\s*\\?$/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  assert.ok(end > start, "BACKGROUND branch must be closed by fi;");
+  const block = lines
+    .slice(start, end + 1)
+    .map((l) => l.replace(/\s*\\$/, "")) // drop trailing line-continuations
+    .join("\n")
+    // Neutralize the only Docker call: keep the surrounding branch, run no daemon.
+    .replace(/docker compose .*$/m, 'echo "COMPOSE_WOULD_RUN"')
+    // Render the make variables the branch references to concrete test values.
+    .replaceAll("$(BACKGROUND)", "1")
+    .replaceAll("$(PROFILE)", profile)
+    .replaceAll("$(LOCAL_PGPORT)", "5432")
+    // `$$` in a Makefile recipe is a literal `$` at shell runtime.
+    .replaceAll("$$", "$");
+  return block;
+}
+
+test("Makefile BACKGROUND seam decisions hold when the real recipe lines run", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "bg-make-"));
+  try {
+    const profile = "bgmakeproof";
+    execFileSync("node", [devScript, "ensure", "--profile", profile], {
+      env: { ...process.env, HOME: home },
+      stdio: "ignore",
+    });
+    const profileEnv = parseEnvFile(
+      readFileSync(
+        path.join(home, ".proliferate-local", "dev", "profiles", profile, "profile.env"),
+        "utf8",
+      ),
+    );
+    const dbName = profileEnv.PROLIFERATE_DEV_DB_NAME;
+
+    const branch = backgroundSeamScript(profile);
+    // Sanity: the guards we exercise are really present in the sliced block.
+    assert.ok(branch.includes('if [ "$use_profile_db" != "1" ]; then'));
+    assert.ok(branch.includes("PROLIFERATE_RABBITMQ_HOST_PORT:?background port not allocated"));
+    assert.ok(branch.includes("PROLIFERATE_REDIS_HOST_PORT:?background port not allocated"));
+    assert.ok(branch.includes("node scripts/dev.mjs background-db-url"));
+
+    const harness = path.join(home, "seam.sh");
+    writeFileSync(
+      harness,
+      [
+        "set -euo pipefail",
+        "cd " + JSON.stringify(repoRoot),
+        branch,
+        'echo "SEAM_OK background_db_url=$background_db_url"',
+      ].join("\n"),
+    );
+
+    // Positive: profile DB in use + ports allocated -> rewrite yields the profile
+    // DB name on host.docker.internal.
+    const ok = execFileSync("bash", [harness], {
+      env: {
+        ...process.env,
+        use_profile_db: "1",
+        PROLIFERATE_DEV_PROFILE: profile,
+        DATABASE_URL: `postgresql+asyncpg://proliferate:localdev@[::1]:5455/${dbName}`,
+        PROLIFERATE_RABBITMQ_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_HOST_PORT,
+        PROLIFERATE_RABBITMQ_MGMT_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_MGMT_HOST_PORT,
+        PROLIFERATE_REDIS_HOST_PORT: profileEnv.PROLIFERATE_REDIS_HOST_PORT,
+      },
+      encoding: "utf8",
+    });
+    assert.match(ok, /SEAM_OK background_db_url=/);
+    assert.ok(
+      ok.includes(`@host.docker.internal:5455/${dbName}`),
+      "the real Makefile seam must rewrite to the profile DB on host.docker.internal",
+    );
+
+    // Negative: DATABASE_URL override (use_profile_db=0) must abort the plane.
+    let aborted = false;
+    try {
+      execFileSync("bash", [harness], {
+        env: {
+          ...process.env,
+          use_profile_db: "0",
+          DATABASE_URL: `postgresql+asyncpg://proliferate:localdev@[::1]:5455/${dbName}`,
+          PROLIFERATE_RABBITMQ_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_HOST_PORT,
+          PROLIFERATE_RABBITMQ_MGMT_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_MGMT_HOST_PORT,
+          PROLIFERATE_REDIS_HOST_PORT: profileEnv.PROLIFERATE_REDIS_HOST_PORT,
+        },
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+    } catch (error) {
+      aborted = true;
+      assert.match(String(error.stderr), /requires the profile database/);
+    }
+    assert.ok(aborted, "BACKGROUND=1 with a DATABASE_URL override must fail closed");
+
+    // Negative: a missing profile-scoped broker port must abort (the `:?` guard).
+    let portAborted = false;
+    try {
+      execFileSync("bash", [harness], {
+        env: {
+          ...process.env,
+          use_profile_db: "1",
+          PROLIFERATE_DEV_PROFILE: profile,
+          DATABASE_URL: `postgresql+asyncpg://proliferate:localdev@[::1]:5455/${dbName}`,
+          PROLIFERATE_RABBITMQ_MGMT_HOST_PORT: profileEnv.PROLIFERATE_RABBITMQ_MGMT_HOST_PORT,
+          PROLIFERATE_REDIS_HOST_PORT: profileEnv.PROLIFERATE_REDIS_HOST_PORT,
+          // PROLIFERATE_RABBITMQ_HOST_PORT deliberately unset.
+        },
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+    } catch (error) {
+      portAborted = true;
+      assert.match(String(error.stderr), /background port not allocated/);
+    }
+    assert.ok(portAborted, "an unallocated profile broker port must fail closed");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -31,6 +31,9 @@ const persistedKeys = [
   "PROLIFERATE_MOBILE_WEB_PORT",
   "PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE",
   "ANYHARNESS_PORT",
+  "PROLIFERATE_RABBITMQ_HOST_PORT",
+  "PROLIFERATE_RABBITMQ_MGMT_HOST_PORT",
+  "PROLIFERATE_REDIS_HOST_PORT",
   "ANYHARNESS_RUNTIME_HOME",
   "ANYHARNESS_WORKTREES_ROOT",
   "PROLIFERATE_DEV_HOME",
@@ -45,6 +48,13 @@ const portKeys = [
   ["PROLIFERATE_MOBILE_WEB_PORT", 5175],
   ["PROLIFERATE_GOOGLE_WORKSPACE_MCP_PORT_BASE", 49321],
   ["ANYHARNESS_PORT", 8457],
+  // Background plane (BACKGROUND=1) broker/store host ports. Allocated,
+  // persisted, and collision-checked per profile exactly like the app ports, so
+  // two worktrees never fight over the default 5672/15672/6379 when running the
+  // Celery worker + Beat compose services side by side.
+  ["PROLIFERATE_RABBITMQ_HOST_PORT", 5672],
+  ["PROLIFERATE_RABBITMQ_MGMT_HOST_PORT", 15672],
+  ["PROLIFERATE_REDIS_HOST_PORT", 6379],
 ];
 const googleWorkspaceMcpPortPoolSize = 64;
 const portPoolSizes = new Map([
@@ -56,6 +66,7 @@ function usage() {
   node scripts/dev.mjs ensure --profile <name> [--lock]
   node scripts/dev.mjs list
   node scripts/dev.mjs database-url --db-name <name>
+  node scripts/dev.mjs background-db-url [--database-url <url>]
   node scripts/dev.mjs ensure-db --db-name <name>`);
 }
 
@@ -70,6 +81,8 @@ function parseArgs(argv) {
       options.profile = rest[++i];
     } else if (arg === "--db-name") {
       options.dbName = rest[++i];
+    } else if (arg === "--database-url") {
+      options.databaseUrl = rest[++i];
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
@@ -669,6 +682,26 @@ async function ensureProfile(options) {
   console.log(paths.launchEnv);
 }
 
+// Rewrite a host-run DATABASE_URL so a container in the background compose
+// project reaches the SAME host Postgres/profile DB. Only the host is swapped to
+// `host.docker.internal`; the port and the profile database NAME are preserved
+// exactly, so worker/beat observe the identical outbox the host-run API uses.
+// This is the single source of truth for the Makefile BACKGROUND=1 rewrite and
+// the launcher-config proof, so both agree. Loopback forms (127.0.0.1,
+// localhost, ::1 with or without brackets) all map to host.docker.internal.
+export function backgroundDatabaseUrl(databaseUrl) {
+  const rewritten = databaseUrl.replace(
+    /@\[?[^/@]*?\]?:(\d+)\//,
+    "@host.docker.internal:$1/",
+  );
+  if (/@(127\.0\.0\.1|localhost|\[?::1\]?):/.test(rewritten)) {
+    throw new Error(
+      `Could not rewrite DATABASE_URL host to host.docker.internal (got ${rewritten}).`,
+    );
+  }
+  return rewritten;
+}
+
 function dbUrlFor(dbName) {
   validateDbName(dbName);
   const host = hostForUrl(process.env.LOCAL_PGHOST || "127.0.0.1");
@@ -852,6 +885,15 @@ async function main() {
     await listProfiles();
   } else if (options.command === "database-url") {
     console.log(dbUrlFor(options.dbName));
+  } else if (options.command === "background-db-url") {
+    // Single source of truth for the Makefile BACKGROUND=1 host rewrite: the
+    // Makefile calls THIS instead of an inline sed so the launcher test and the
+    // real `make run` seam share one implementation.
+    const input = options.databaseUrl ?? process.env.DATABASE_URL;
+    if (!input) {
+      throw new Error("background-db-url requires --database-url or DATABASE_URL in the environment.");
+    }
+    console.log(backgroundDatabaseUrl(input));
   } else if (options.command === "ensure-db") {
     ensureDatabase(options.dbName);
   } else {
@@ -860,7 +902,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+// Only run the CLI when invoked directly (`node scripts/dev.mjs ...`); importing
+// this module for its exported helpers (e.g. the launcher-config proof) must not
+// trigger a CLI run.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -5,8 +5,12 @@ services:
       POSTGRES_USER: proliferate
       POSTGRES_PASSWORD: localdev
       POSTGRES_DB: proliferate
+    # Host ports are overridable so a second worktree can run an isolated stack
+    # without colliding on the default port. Container-to-container traffic uses
+    # the compose service names and is unaffected. Combine with a per-worktree
+    # COMPOSE_PROJECT_NAME to isolate container names and named volumes too.
     ports:
-      - "5432:5432"
+      - "${PROLIFERATE_DB_HOST_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -18,8 +22,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.13-management-alpine
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "${PROLIFERATE_RABBITMQ_HOST_PORT:-5672}:5672"
+      - "${PROLIFERATE_RABBITMQ_MGMT_HOST_PORT:-15672}:15672"
     volumes:
       - rabbitmqdata:/var/lib/rabbitmq
     healthcheck:
@@ -31,7 +35,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${PROLIFERATE_REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redisdata:/data
     healthcheck:
@@ -103,14 +107,92 @@ services:
       context: ..
       dockerfile: server/Dockerfile
     ports:
-      - "8000:8000"
+      - "${PROLIFERATE_API_HOST_PORT:-8000}:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://proliferate:localdev@db:5432/proliferate
       JWT_SECRET: local-dev-secret-change-in-production
       DEBUG: "true"
+      CELERY_BROKER_URL: amqp://guest:guest@rabbitmq:5672//
+      REDBEAT_REDIS_URL: redis://redis:6379/0
     depends_on:
       migrate:
         condition: service_completed_successfully
+
+  # Celery worker: consumes broker-delivered background tasks. Uses the exact
+  # same image as the API (built from server/Dockerfile) so the task registry is
+  # identical to the enqueuing process. Opt-in via the "background" profile so a
+  # plain `docker compose up` still boots only the API stack.
+  worker:
+    build:
+      context: ..
+      dockerfile: server/Dockerfile
+    profiles: ["background"]
+    # host.docker.internal lets `make run BACKGROUND=1` point the worker at the
+    # SAME host Postgres/profile DB the host-run API uses (Docker Desktop maps it
+    # automatically; host-gateway makes it resolve on Linux too).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      # Self-contained smoke (`make server-background-up`) defaults to the compose
+      # Postgres. `make run PROFILE=<name> BACKGROUND=1` overrides this to the
+      # ACTUAL selected profile database on the host (host.docker.internal + the
+      # profile's real port + the profile DB name), so worker/beat and the
+      # host-run API observe one and the same outbox — not a different compose DB.
+      DATABASE_URL: ${BACKGROUND_DATABASE_URL:-postgresql+asyncpg://proliferate:localdev@db:5432/proliferate}
+      JWT_SECRET: local-dev-secret-change-in-production
+      DEBUG: "true"
+      CELERY_BROKER_URL: amqp://guest:guest@rabbitmq:5672//
+      REDBEAT_REDIS_URL: redis://redis:6379/0
+    command:
+      - celery
+      - -A
+      - proliferate.background.celery_app:celery_app
+      - worker
+      - --loglevel=info
+      - -Q
+      - periodic.default,default,notifications
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # Celery Beat: the single scheduler process that fires background.relay. Uses
+  # the same image/SHA as the API and worker. Exactly one Beat replica per stack;
+  # RedBeat keeps schedule state in Redis and prevents duplicate ownership.
+  beat:
+    build:
+      context: ..
+      dockerfile: server/Dockerfile
+    profiles: ["background"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      # Self-contained smoke (`make server-background-up`) defaults to the compose
+      # Postgres. `make run PROFILE=<name> BACKGROUND=1` overrides this to the
+      # ACTUAL selected profile database on the host (host.docker.internal + the
+      # profile's real port + the profile DB name), so worker/beat and the
+      # host-run API observe one and the same outbox — not a different compose DB.
+      DATABASE_URL: ${BACKGROUND_DATABASE_URL:-postgresql+asyncpg://proliferate:localdev@db:5432/proliferate}
+      JWT_SECRET: local-dev-secret-change-in-production
+      DEBUG: "true"
+      CELERY_BROKER_URL: amqp://guest:guest@rabbitmq:5672//
+      REDBEAT_REDIS_URL: redis://redis:6379/0
+    command:
+      - celery
+      - -A
+      - proliferate.background.celery_app:celery_app
+      - beat
+      - --loglevel=info
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
 volumes:
   pgdata:

--- a/server/infra/background.tf
+++ b/server/infra/background.tf
@@ -1,0 +1,836 @@
+# ═══════════════════════════════════════════════════════════════════════
+# Durable background runtime: broker (Amazon MQ RabbitMQ), scheduler store
+# (ElastiCache Serverless Valkey), and the Celery worker + Beat ECS services.
+#
+# These are DEFINITIONS ONLY. Both stages gate on a count flag defaulting to
+# false so a plan against an existing environment is a no-op until the founder
+# enables the plane (or rebinds the worker/beat to already-operated managed
+# endpoints via the *_secret_arn overrides). All broker/store traffic is TLS:
+# Amazon MQ RabbitMQ exposes AMQPS (5671) only, and ElastiCache Serverless
+# enforces in-transit encryption (rediss). Staging and production isolate on
+# var.environment naming and their own broker/store instances.
+# ═══════════════════════════════════════════════════════════════════════
+
+variable "background_broker_enabled" {
+  description = "Create the Amazon MQ broker + ElastiCache Serverless store for this environment."
+  type        = bool
+  default     = false
+}
+
+variable "background_services_enabled" {
+  description = "Create the Celery worker + Beat ECS services and their alarms."
+  type        = bool
+  default     = false
+
+  # Fail closed at plan time on the invalid partial combo. A services-enabled
+  # plane MUST have connection secrets, and there are exactly two valid ways to
+  # get them: (a) the managed stage (background_broker_enabled = true) creates
+  # the broker/store and their TF-managed secrets, or (b) the founder rebinds to
+  # existing external endpoints by supplying BOTH override secret ARNs. Enabling
+  # the services while the broker is disabled AND no external secret ARNs are
+  # set would register worker/Beat task definitions with empty `secrets`, so the
+  # app would silently fall back to its loopback CELERY_BROKER_URL/REDBEAT_REDIS
+  # defaults and never reach any broker/store. Reject that combination here so it
+  # can never reach an apply. This validation references other input variables,
+  # which Terraform >= 1.9 evaluates during plan.
+  validation {
+    condition = (
+      var.background_services_enabled == false
+      || var.background_broker_enabled == true
+      || (var.celery_broker_url_secret_arn != "" && var.redbeat_redis_url_secret_arn != "")
+    )
+    error_message = "background_services_enabled = true requires either the managed stage (background_broker_enabled = true) OR both external endpoint references (celery_broker_url_secret_arn and redbeat_redis_url_secret_arn). Enabling the worker/Beat services without connection secrets would create services that fall back to loopback and cannot reach any broker/store."
+  }
+}
+
+variable "background_broker_user" {
+  description = "RabbitMQ application username for Amazon MQ."
+  type        = string
+  default     = "proliferate"
+}
+
+variable "background_broker_password" {
+  description = "RabbitMQ application password for Amazon MQ (12-250 chars, no spaces)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "background_broker_instance_type" {
+  description = "Amazon MQ RabbitMQ host instance type."
+  type        = string
+  default     = "mq.t3.micro"
+}
+
+variable "background_broker_deployment_mode" {
+  description = "SINGLE_INSTANCE (staging) or CLUSTER_MULTI_AZ (production)."
+  type        = string
+  default     = "SINGLE_INSTANCE"
+}
+
+variable "background_store_max_ecpu" {
+  description = "ElastiCache Serverless ECPU-per-second ceiling for the scheduler store."
+  type        = number
+  default     = 5000
+}
+
+variable "background_store_max_storage_gb" {
+  description = "ElastiCache Serverless data storage ceiling (GB) for the scheduler store."
+  type        = number
+  default     = 5
+}
+
+# Founder rebind hooks: when set, the worker/beat consume these existing secret
+# references instead of the TF-created broker/store URLs. Each must resolve to a
+# full amqps:// / rediss:// URL in Secrets Manager or SSM.
+variable "celery_broker_url_secret_arn" {
+  description = "Override: existing CELERY_BROKER_URL secret ARN."
+  type        = string
+  default     = ""
+}
+
+variable "redbeat_redis_url_secret_arn" {
+  description = "Override: existing REDBEAT_REDIS_URL secret ARN."
+  type        = string
+  default     = ""
+}
+
+variable "background_worker_desired_count" {
+  description = "Celery worker replica count (horizontally scalable)."
+  type        = number
+  default     = 1
+}
+
+variable "background_worker_queues" {
+  description = "Comma-separated queues the worker consumes."
+  type        = string
+  default     = "periodic.default,default,notifications"
+}
+
+variable "background_relay_oldest_due_slo_seconds" {
+  description = "Alarm threshold for oldest due-but-unpublished outbox age (5-minute reviewable default)."
+  type        = number
+  default     = 300
+}
+
+variable "background_alarm_sns_topic_arn" {
+  description = "Optional SNS topic to notify on background-plane alarms."
+  type        = string
+  default     = ""
+}
+
+# ── Security groups ──
+
+resource "aws_security_group" "background_broker" {
+  count       = var.background_broker_enabled ? 1 : 0
+  name_prefix = "proliferate-mq-"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description     = "AMQPS from ECS tasks"
+    from_port       = 5671
+    to_port         = 5671
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "proliferate-mq-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "background_store" {
+  count       = var.background_broker_enabled ? 1 : 0
+  name_prefix = "proliferate-redbeat-"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description     = "Valkey/Redis TLS from ECS tasks"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "proliferate-redbeat-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+# ── Amazon MQ (RabbitMQ) broker ──
+
+resource "aws_mq_broker" "background" {
+  count = var.background_broker_enabled ? 1 : 0
+
+  broker_name        = "proliferate-${var.environment}"
+  engine_type        = "RabbitMQ"
+  engine_version     = "3.13"
+  host_instance_type = var.background_broker_instance_type
+  deployment_mode    = var.background_broker_deployment_mode
+  # Private only; reachable via the ECS security group over AMQPS. Amazon MQ
+  # RabbitMQ terminates TLS on 5671 with no plaintext AMQP listener.
+  publicly_accessible        = false
+  auto_minor_version_upgrade = true
+  # SINGLE_INSTANCE takes exactly one subnet; CLUSTER_MULTI_AZ takes several.
+  subnet_ids = (
+    var.background_broker_deployment_mode == "SINGLE_INSTANCE"
+    ? [tolist(data.aws_subnets.default.ids)[0]]
+    : slice(tolist(data.aws_subnets.default.ids), 0, 2)
+  )
+  security_groups = [aws_security_group.background_broker[0].id]
+
+  user {
+    username = var.background_broker_user
+    password = var.background_broker_password
+  }
+
+  logs {
+    general = true
+  }
+
+  tags = {
+    Name        = "proliferate-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+# ── ElastiCache Serverless (Valkey) scheduler store ──
+
+resource "aws_elasticache_serverless_cache" "redbeat" {
+  count = var.background_broker_enabled ? 1 : 0
+
+  engine = "valkey"
+  name   = "proliferate-redbeat-${var.environment}"
+
+  cache_usage_limits {
+    data_storage {
+      maximum = var.background_store_max_storage_gb
+      unit    = "GB"
+    }
+    ecpu_per_second {
+      maximum = var.background_store_max_ecpu
+    }
+  }
+
+  major_engine_version = "8"
+  security_group_ids   = [aws_security_group.background_store[0].id]
+  subnet_ids           = slice(tolist(data.aws_subnets.default.ids), 0, 2)
+
+  tags = {
+    Name        = "proliferate-redbeat-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+# ── Connection secrets ──
+#
+# The full broker/store URLs carry credentials, so they are projected to the
+# worker/beat exclusively as ECS secrets (never plaintext environment). When the
+# founder rebinds to an existing endpoint via *_secret_arn, these TF-managed
+# secrets are not created.
+
+resource "aws_secretsmanager_secret" "celery_broker_url" {
+  count = var.background_broker_enabled && var.celery_broker_url_secret_arn == "" ? 1 : 0
+  name  = "proliferate/${var.environment}/background/celery-broker-url"
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "celery_broker_url" {
+  count     = var.background_broker_enabled && var.celery_broker_url_secret_arn == "" ? 1 : 0
+  secret_id = aws_secretsmanager_secret.celery_broker_url[0].id
+  # Inject credentials into the amqps endpoint Amazon MQ publishes.
+  secret_string = replace(
+    aws_mq_broker.background[0].instances[0].endpoints[0],
+    "amqps://",
+    "amqps://${var.background_broker_user}:${var.background_broker_password}@"
+  )
+}
+
+resource "aws_secretsmanager_secret" "redbeat_redis_url" {
+  count = var.background_broker_enabled && var.redbeat_redis_url_secret_arn == "" ? 1 : 0
+  name  = "proliferate/${var.environment}/background/redbeat-redis-url"
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "redbeat_redis_url" {
+  count     = var.background_broker_enabled && var.redbeat_redis_url_secret_arn == "" ? 1 : 0
+  secret_id = aws_secretsmanager_secret.redbeat_redis_url[0].id
+  secret_string = format(
+    "rediss://%s:%s/0",
+    aws_elasticache_serverless_cache.redbeat[0].endpoint[0].address,
+    aws_elasticache_serverless_cache.redbeat[0].endpoint[0].port,
+  )
+}
+
+locals {
+  celery_broker_url_secret_arn = (
+    var.celery_broker_url_secret_arn != ""
+    ? var.celery_broker_url_secret_arn
+    : (var.background_broker_enabled ? aws_secretsmanager_secret.celery_broker_url[0].arn : "")
+  )
+  redbeat_redis_url_secret_arn = (
+    var.redbeat_redis_url_secret_arn != ""
+    ? var.redbeat_redis_url_secret_arn
+    : (var.background_broker_enabled ? aws_secretsmanager_secret.redbeat_redis_url[0].arn : "")
+  )
+  background_connection_secret_arns = compact([
+    local.celery_broker_url_secret_arn,
+    local.redbeat_redis_url_secret_arn,
+  ])
+  # Shared with API so worker/beat reach the same Postgres outbox.
+  background_database_url = "postgresql+asyncpg://proliferate:${var.db_password}@${aws_db_instance.postgres.endpoint}/proliferate"
+  background_common_environment = [
+    { name = "DATABASE_URL", value = local.background_database_url },
+    { name = "JWT_SECRET", value = var.jwt_secret },
+    { name = "PROLIFERATE_TELEMETRY_MODE", value = var.telemetry_mode },
+    { name = "BACKGROUND_RELAY_OLDEST_DUE_SLO_SECONDS", value = tostring(var.background_relay_oldest_due_slo_seconds) },
+  ]
+  background_connection_secrets = concat(
+    local.celery_broker_url_secret_arn == "" ? [] : [
+      { name = "CELERY_BROKER_URL", valueFrom = local.celery_broker_url_secret_arn }
+    ],
+    local.redbeat_redis_url_secret_arn == "" ? [] : [
+      { name = "REDBEAT_REDIS_URL", valueFrom = local.redbeat_redis_url_secret_arn }
+    ],
+  )
+  # Whether the plane has connection secrets, decided from KNOWN inputs only.
+  # The managed stage always creates both secrets; a rebind supplies external
+  # ARNs. The background_services_enabled validation guarantees at least one of
+  # these is true whenever the services exist, so this is effectively always
+  # true for an enabled plane. Gating the IAM policy count on this (rather than
+  # length() of the computed ARN list) keeps the count predictable at plan time:
+  # a count that depended on a not-yet-created secret ARN could not be planned.
+  background_has_connection_secrets = (
+    var.background_broker_enabled
+    || var.celery_broker_url_secret_arn != ""
+    || var.redbeat_redis_url_secret_arn != ""
+  )
+}
+
+# Allow the ECS execution role to resolve the connection secrets at task start.
+data "aws_iam_policy_document" "background_connection_secrets" {
+  count = var.background_services_enabled && local.background_has_connection_secrets ? 1 : 0
+
+  statement {
+    actions   = ["secretsmanager:GetSecretValue", "ssm:GetParameters"]
+    resources = local.background_connection_secret_arns
+  }
+}
+
+resource "aws_iam_role_policy" "background_connection_secrets" {
+  count  = var.background_services_enabled && local.background_has_connection_secrets ? 1 : 0
+  name   = "background-connection-secrets"
+  role   = aws_iam_role.ecs_execution.id
+  policy = data.aws_iam_policy_document.background_connection_secrets[0].json
+}
+
+# ── Worker + Beat task definitions (same image as the API) ──
+
+resource "aws_ecs_task_definition" "background_worker" {
+  count                    = var.background_services_enabled ? 1 : 0
+  family                   = "proliferate-worker-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "worker"
+      image     = "${aws_ecr_repository.server.repository_url}:latest"
+      essential = true
+      command = [
+        "celery", "-A", "proliferate.background.celery_app:celery_app",
+        "worker", "--loglevel=info", "-Q", var.background_worker_queues,
+      ]
+      environment = concat(local.background_common_environment, [
+        { name = "CELERY_WORKER_QUEUES", value = var.background_worker_queues },
+      ])
+      secrets = local.background_connection_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.server.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "worker"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_task_definition" "background_beat" {
+  count                    = var.background_services_enabled ? 1 : 0
+  family                   = "proliferate-beat-${var.environment}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "beat"
+      image     = "${aws_ecr_repository.server.repository_url}:latest"
+      essential = true
+      command = [
+        "celery", "-A", "proliferate.background.celery_app:celery_app",
+        "beat", "--loglevel=info",
+      ]
+      environment = local.background_common_environment
+      secrets     = local.background_connection_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.server.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "beat"
+        }
+      }
+    }
+  ])
+}
+
+# ── Worker + Beat services ──
+
+resource "aws_ecs_service" "background_worker" {
+  count           = var.background_services_enabled ? 1 : 0
+  name            = "proliferate-worker-${var.environment}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.background_worker[0].arn
+  desired_count   = var.background_worker_desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = data.aws_subnets.default.ids
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+}
+
+resource "aws_ecs_service" "background_beat" {
+  count           = var.background_services_enabled ? 1 : 0
+  name            = "proliferate-beat-${var.environment}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.background_beat[0].arn
+  # Exactly one Beat scheduler per environment. RedBeat holds schedule state in
+  # the store and prevents duplicate ownership.
+  desired_count = 1
+  launch_type   = "FARGATE"
+
+  network_configuration {
+    subnets          = data.aws_subnets.default.ids
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+}
+
+# ── Metrics + alarms ──
+#
+# The relay task logs one low-cardinality metric line per tick under the field
+# `background_relay`. A CloudWatch metric filter lifts the oldest-due age and the
+# failed count into custom metrics that the SLO and repeated-failure alarms
+# watch. Worker/Beat liveness rides on the ECS RunningTaskCount metric.
+
+resource "aws_cloudwatch_log_metric_filter" "background_oldest_due_age" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-outbox-oldest-due-age"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_relay.oldest_due_pending_age_seconds = * }"
+
+  metric_transformation {
+    name          = "OutboxOldestDuePendingAgeSeconds"
+    namespace     = "Proliferate/Background/${var.environment}"
+    value         = "$.background_relay.oldest_due_pending_age_seconds"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "background_relay_failed" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-relay-failed"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_relay.failed = * }"
+
+  metric_transformation {
+    name          = "RelayFailedCount"
+    namespace     = "Proliferate/Background/${var.environment}"
+    value         = "$.background_relay.failed"
+    default_value = "0"
+  }
+}
+
+# Direct scheduler-store / relay liveness. Every completed relay tick logs
+# `relay_heartbeat=1`; a tick only runs when Beat dispatches it, which requires
+# RedBeat/Valkey to be reachable. So a steady heartbeat means Beat AND the
+# scheduler store are alive, and the ABSENCE of the heartbeat (no data) breaches
+# — this is what catches a live-Beat-but-dead-store outage that the oldest-due
+# SLO alarm (treat_missing_data = notBreaching) cannot see.
+resource "aws_cloudwatch_log_metric_filter" "background_relay_heartbeat" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-relay-heartbeat"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_relay.relay_heartbeat = * }"
+
+  metric_transformation {
+    name          = "RelayHeartbeat"
+    namespace     = "Proliferate/Background/${var.environment}"
+    value         = "$.background_relay.relay_heartbeat"
+    default_value = "0"
+  }
+}
+
+# Publishing lease-expiry recovery: rows re-claimed after a relay crash mid
+# publish. A steady nonzero stream is a signal of relay instability.
+resource "aws_cloudwatch_log_metric_filter" "background_recovered_leases" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-relay-recovered-leases"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_relay.recovered_leases = * }"
+
+  metric_transformation {
+    name          = "RelayRecoveredLeases"
+    namespace     = "Proliferate/Background/${var.environment}"
+    value         = "$.background_relay.recovered_leases"
+    default_value = "0"
+  }
+}
+
+# Supported pending rows for the health no-op family. Cardinality is bounded by
+# the relay's supported-task allowlist, so this filter set does not widen as new
+# task families are added without a matching filter.
+resource "aws_cloudwatch_log_metric_filter" "background_supported_pending_health_noop" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-supported-pending-health-noop"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_relay.supported_pending_by_family.background_health_noop = * }"
+
+  metric_transformation {
+    name          = "SupportedPendingHealthNoop"
+    namespace     = "Proliferate/Background/${var.environment}"
+    value         = "$.background_relay.supported_pending_by_family.background_health_noop"
+    default_value = "0"
+  }
+}
+
+# Worker-side task outcomes. The task_metrics signal handlers log one line per
+# success/retry/failure carrying a safe task name and error code. These filters
+# lift success/retry/failure counts into the metric plane, dimensioned by the
+# safe task name (and, for failures/retries, the safe error code) so the frozen
+# "task success/retry/failure counts by task name and safe error code" surface
+# actually exists. Both dimension sources are low-cardinality — task_name is a
+# fixed registry value and error_code is an exception class name — so the
+# dimensioned metric set stays bounded. A CloudWatch metric filter only emits a
+# data point when the matched log line carries every declared dimension field;
+# task_metrics.build_task_metric always emits task_name and error_code, so every
+# outcome line produces a fully dimensioned point.
+#
+# NOTE: a dimensioned metric transformation cannot also carry a default_value
+# (CloudWatch rejects the combination), so these three declare dimensions and
+# omit default_value; absence of any emission simply means no such outcome
+# occurred in the period.
+resource "aws_cloudwatch_log_metric_filter" "background_task_success" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-task-success"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_task.outcome = \"success\" }"
+
+  metric_transformation {
+    name      = "TaskSuccessCount"
+    namespace = "Proliferate/Background/${var.environment}"
+    value     = "$.background_task.count"
+    dimensions = {
+      task_name = "$.background_task.task_name"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "background_task_retry" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-task-retry"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_task.outcome = \"retry\" }"
+
+  metric_transformation {
+    name      = "TaskRetryCount"
+    namespace = "Proliferate/Background/${var.environment}"
+    value     = "$.background_task.count"
+    dimensions = {
+      task_name  = "$.background_task.task_name"
+      error_code = "$.background_task.error_code"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "background_task_failure" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-task-failure"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_task.outcome = \"failure\" }"
+
+  metric_transformation {
+    name      = "TaskFailureCount"
+    namespace = "Proliferate/Background/${var.environment}"
+    value     = "$.background_task.count"
+    dimensions = {
+      task_name  = "$.background_task.task_name"
+      error_code = "$.background_task.error_code"
+    }
+  }
+}
+
+# Terminal rows: only unsupported/invalid task names go terminal, so any
+# nonzero failed_rows gauge means a committed task can never execute and needs
+# an operational drain decision.
+resource "aws_cloudwatch_log_metric_filter" "background_terminal_rows" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-outbox-terminal-rows"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_relay.failed_rows = * }"
+
+  metric_transformation {
+    name          = "OutboxTerminalRows"
+    namespace     = "Proliferate/Background/${var.environment}"
+    value         = "$.background_relay.failed_rows"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "background_terminal_rows" {
+  count               = var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-outbox-terminal-rows"
+  alarm_description   = "Terminal (failed/unsupported_task) outbox rows exist; committed work is stranded."
+  namespace           = "Proliferate/Background/${var.environment}"
+  metric_name         = "OutboxTerminalRows"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "background_oldest_due_slo" {
+  count               = var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-outbox-oldest-due-slo"
+  alarm_description   = "Oldest due-but-unpublished outbox row exceeded the ${var.background_relay_oldest_due_slo_seconds}s SLO."
+  namespace           = "Proliferate/Background/${var.environment}"
+  metric_name         = "OutboxOldestDuePendingAgeSeconds"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = var.background_relay_oldest_due_slo_seconds
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "background_relay_failures" {
+  count               = var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-relay-repeated-failures"
+  alarm_description   = "Repeated relay publication failures (broker/store trouble or terminal unsupported rows)."
+  namespace           = "Proliferate/Background/${var.environment}"
+  metric_name         = "RelayFailedCount"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 3
+  threshold           = 5
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+}
+
+# Desired-vs-running truth for the worker service. RunningTaskCount is published
+# under ECS/ContainerInsights (NOT AWS/ECS, which only carries service-level
+# CPU/Memory utilization), so the namespace must be ECS/ContainerInsights or the
+# alarm would see no data and breach continuously regardless of actual health.
+# Container Insights is enabled on the cluster (aws_ecs_cluster.main sets
+# containerInsights = enabled in main.tf), so this metric is populated.
+resource "aws_cloudwatch_metric_alarm" "background_worker_running" {
+  count               = var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-worker-not-running"
+  alarm_description   = "Celery worker running task count fell below the desired replica count."
+  namespace           = "ECS/ContainerInsights"
+  metric_name         = "RunningTaskCount"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = var.background_worker_desired_count
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.background_worker[0].name
+  }
+}
+
+# Scheduler-store / relay liveness. The oldest-due SLO alarm treats missing data
+# as not-breaching, so if RedBeat/Valkey is unreachable while the Beat process is
+# still alive, relay ticks silently stop and that alarm stays healthy. This alarm
+# closes that hole directly: the relay heartbeat only advances when a tick runs,
+# which requires the scheduler store to be reachable, and missing data breaches.
+resource "aws_cloudwatch_metric_alarm" "background_relay_heartbeat" {
+  count               = var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-relay-heartbeat-missing"
+  alarm_description   = "Relay ticks stopped (Beat dead or RedBeat/Valkey scheduler store unreachable); no outbox work will publish."
+  namespace           = "Proliferate/Background/${var.environment}"
+  metric_name         = "RelayHeartbeat"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  # Absence of the heartbeat is the outage signal, so missing data breaches.
+  treat_missing_data = "breaching"
+  alarm_actions      = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+}
+
+# Broker unavailability: Amazon MQ publishes broker metrics under AWS/AmazonMQ
+# automatically. When the broker is down or unreachable the metric stream stops,
+# so missing data is treated as breaching. Scheduler-store unavailability has no
+# native ElastiCache Serverless signal; the relay-heartbeat alarm above is its
+# direct detector (a dead store halts relay ticks -> the heartbeat goes missing
+# -> that alarm breaches), rather than relying on the oldest-due SLO alarm which
+# does not fire on missing data.
+resource "aws_cloudwatch_metric_alarm" "background_broker_unreachable" {
+  count               = var.background_broker_enabled && var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-broker-unreachable"
+  alarm_description   = "Amazon MQ broker stopped reporting connection metrics (down or unreachable)."
+  namespace           = "AWS/AmazonMQ"
+  metric_name         = "ConnectionCount"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+
+  dimensions = {
+    Broker = aws_mq_broker.background[0].broker_name
+  }
+}
+
+# Per-task broker-residence LATENCY, observed on consume: worker task_prerun
+# emits `background_queue_age` carrying age_seconds = worker-consume time minus
+# relay-publish time, i.e. how long a task that DID get consumed waited in
+# RabbitMQ before a worker picked it up. This is a LAGGING signal: it is emitted
+# only when a task is actually consumed, so it goes silent exactly when
+# consumption stalls and is NOT a truthful "current oldest queued-task age".
+# Amazon MQ exposes no native oldest-message-age metric, so current-oldest-age is
+# not available from this substrate; broker backlog is instead covered by the
+# AWS/AmazonMQ MessageCount depth alarm below. Distinct from
+# OutboxOldestDuePendingAgeSeconds, which measures the row's pre-publish wait in
+# Postgres. Dimensioned by the fixed-registry task name.
+resource "aws_cloudwatch_log_metric_filter" "background_queue_age" {
+  count          = var.background_services_enabled ? 1 : 0
+  name           = "proliferate-${var.environment}-task-broker-residence-latency"
+  log_group_name = aws_cloudwatch_log_group.server.name
+  pattern        = "{ $.background_queue_age.age_seconds = * }"
+
+  metric_transformation {
+    name      = "TaskBrokerResidenceLatencySeconds"
+    namespace = "Proliferate/Background/${var.environment}"
+    value     = "$.background_queue_age.age_seconds"
+    dimensions = {
+      task_name = "$.background_queue_age.task_name"
+    }
+  }
+}
+
+# Celery queue depth: Amazon MQ publishes MessageCount (total queued messages)
+# per broker; sustained depth means workers are absent or starved. This is the
+# substrate's truthful CURRENT-backlog signal and it does NOT go silent when
+# consumption stalls (unlike the consume-time residence-latency metric above), so
+# it is what catches "tasks are piling up and not being consumed"; the residence
+# latency metric only reports lag for tasks that eventually were consumed.
+resource "aws_cloudwatch_metric_alarm" "background_queue_depth" {
+  count               = var.background_broker_enabled && var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-queue-depth"
+  alarm_description   = "Broker queue depth stayed high; workers are absent or not keeping up."
+  namespace           = "AWS/AmazonMQ"
+  metric_name         = "MessageCount"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  threshold           = 1000
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+
+  dimensions = {
+    Broker = aws_mq_broker.background[0].broker_name
+  }
+}
+
+# Desired-vs-running truth for the single Beat service. Same namespace fix as
+# the worker alarm: RunningTaskCount lives in ECS/ContainerInsights, so querying
+# AWS/ECS here would return no data and breach forever. Container Insights is
+# enabled on the cluster (see main.tf), so this metric is populated.
+resource "aws_cloudwatch_metric_alarm" "background_beat_running" {
+  count               = var.background_services_enabled ? 1 : 0
+  alarm_name          = "proliferate-${var.environment}-beat-not-running"
+  alarm_description   = "Celery Beat scheduler is not running (no relay ticks will fire)."
+  namespace           = "ECS/ContainerInsights"
+  metric_name         = "RunningTaskCount"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+  alarm_actions       = var.background_alarm_sns_topic_arn == "" ? [] : [var.background_alarm_sns_topic_arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.background_beat[0].name
+  }
+}
+
+# ── Outputs ──
+
+output "background_broker_endpoint" {
+  description = "Amazon MQ RabbitMQ AMQPS endpoint (credentials injected via secret)."
+  value       = var.background_broker_enabled ? aws_mq_broker.background[0].instances[0].endpoints[0] : ""
+}
+
+output "background_store_endpoint" {
+  description = "ElastiCache Serverless (Valkey) endpoint address for RedBeat."
+  value       = var.background_broker_enabled ? aws_elasticache_serverless_cache.redbeat[0].endpoint[0].address : ""
+}
+
+output "background_worker_service_name" {
+  value = var.background_services_enabled ? aws_ecs_service.background_worker[0].name : ""
+}
+
+output "background_beat_service_name" {
+  value = var.background_services_enabled ? aws_ecs_service.background_beat[0].name : ""
+}

--- a/server/infra/tests/background_plane.tftest.hcl
+++ b/server/infra/tests/background_plane.tftest.hcl
@@ -1,0 +1,94 @@
+# Plan-time proof for the background-plane fail-closed contract (BG4-IAC-02).
+#
+# The worker/Beat services must never be created without a reachable broker and
+# scheduler store. `background_services_enabled = true` is only valid when either
+# the managed stage is on (background_broker_enabled = true, which creates the
+# broker/store and their secrets) OR both external endpoint secret ARNs are
+# supplied (a founder rebind to already-operated managed endpoints). The invalid
+# partial combo — services on, broker off, no external secrets — would register
+# task definitions with empty `secrets` and silently fall back to loopback, so a
+# variable validation on background_services_enabled must reject it AT PLAN TIME.
+#
+# Runs use `command = plan` with a mocked AWS provider, so no AWS credentials,
+# API calls, backend, or apply are involved. Terraform still evaluates variable
+# validations against the supplied values during plan, which is exactly the gate
+# under test.
+
+mock_provider "aws" {
+  # The default AWS mock returns empty values for these data sources, which the
+  # managed path indexes/slices (subnets) or embeds as policy JSON. Supply
+  # minimal well-formed values so the VALID plans reach a real plan; the invalid
+  # runs fail earlier on the variable validation regardless.
+  mock_data "aws_subnets" {
+    defaults = {
+      ids = ["subnet-aaaa1111", "subnet-bbbb2222"]
+    }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+}
+
+variables {
+  # Required root variables (no defaults in main.tf). Values are throwaway; the
+  # mocked provider never contacts AWS.
+  db_password = "test-db-password"
+  jwt_secret  = "test-jwt-secret"
+}
+
+# Valid: managed stage on. The broker/store and their TF-managed connection
+# secrets are created, so the services have real endpoints to reach.
+run "valid_managed_plane" {
+  command = plan
+  variables {
+    background_broker_enabled   = true
+    background_services_enabled = true
+    # Satisfies the aws provider's client-side RabbitMQ password constraint
+    # (12-250 chars, >= 4 unique). Checked during plan; no AWS call.
+    background_broker_password = "test-broker-password-123"
+  }
+}
+
+# Valid: rebound to existing external endpoints. Broker stage off, but BOTH
+# override secret ARNs are supplied, so the worker/Beat consume the founder's
+# already-operated broker/store.
+run "valid_rebound_external" {
+  command = plan
+  variables {
+    background_broker_enabled    = false
+    background_services_enabled  = true
+    celery_broker_url_secret_arn = "arn:aws:secretsmanager:us-east-1:111122223333:secret:existing-broker"
+    redbeat_redis_url_secret_arn = "arn:aws:secretsmanager:us-east-1:111122223333:secret:existing-store"
+  }
+}
+
+# Invalid: services on, broker off, no external secrets. This is the partial
+# combo that would create services with no connection secrets. It must fail at
+# plan time on the background_services_enabled validation.
+run "invalid_partial_no_secrets_fails" {
+  command = plan
+  variables {
+    background_broker_enabled   = false
+    background_services_enabled = true
+  }
+  expect_failures = [
+    var.background_services_enabled,
+  ]
+}
+
+# Invalid: services on, broker off, only ONE external secret supplied. A single
+# reference is still a broken plane (the other URL falls back to loopback), so
+# this must also fail at plan time.
+run "invalid_partial_one_secret_fails" {
+  command = plan
+  variables {
+    background_broker_enabled    = false
+    background_services_enabled  = true
+    celery_broker_url_secret_arn = "arn:aws:secretsmanager:us-east-1:111122223333:secret:existing-broker"
+  }
+  expect_failures = [
+    var.background_services_enabled,
+  ]
+}

--- a/server/proliferate/background/beat_schedule.py
+++ b/server/proliferate/background/beat_schedule.py
@@ -4,16 +4,34 @@ from __future__ import annotations
 
 from celery.schedules import crontab
 
-from proliferate.background.config import CUSTOMERIO_ENGAGEMENT_SYNC_TASK
+from proliferate.background.config import (
+    BACKGROUND_RELAY_TASK,
+    CUSTOMERIO_ENGAGEMENT_SYNC_TASK,
+)
 from proliferate.config import Settings, settings
 
 BeatSchedule = dict[str, dict[str, object]]
 
+# Stable key for the single outbox-drain entry. Exactly one such entry exists so
+# a lone Beat process owns outbox relay scheduling; RedBeat preserves this entry
+# across restarts and prevents duplicate schedule ownership.
+RELAY_SCHEDULE_ENTRY = "background-outbox-relay"
+
 
 def build_beat_schedule(config: Settings = settings) -> BeatSchedule:
-    """Return the currently registered Beat schedule."""
+    """Return the currently registered Beat schedule.
 
-    schedule: BeatSchedule = {}
+    Always contains exactly one relay entry that fires the thin
+    ``background.relay`` task. Each firing runs one bounded ``relay_once`` batch
+    and exits; the schedule never carries a second outbox-drain entry.
+    """
+
+    schedule: BeatSchedule = {
+        RELAY_SCHEDULE_ENTRY: {
+            "task": BACKGROUND_RELAY_TASK,
+            "schedule": config.background_relay_interval_seconds,
+        },
+    }
 
     if config.customerio_site_id and config.customerio_api_key:
         schedule["customerio-engagement-sync"] = {

--- a/server/proliferate/background/celery_app.py
+++ b/server/proliferate/background/celery_app.py
@@ -11,7 +11,12 @@ celery_app = Celery("proliferate")
 celery_app.conf.update(build_celery_config())
 celery_app.conf.beat_schedule = build_beat_schedule()
 
-# Import task modules after app construction so decorators register on celery_app.
+# Imported after app construction so decorators/signal handlers register on
+# celery_app: the tasks.* modules register their @celery_app.task wrappers, and
+# task_metrics connects the worker-side success/retry/failure signal handlers.
+# All imported for side effects; no symbol is used directly here.
+import proliferate.background.task_metrics  # noqa: E402,F401
 import proliferate.background.tasks.customerio_sync  # noqa: E402,F401
 import proliferate.background.tasks.health  # noqa: E402,F401
 import proliferate.background.tasks.notifications  # noqa: E402,F401
+import proliferate.background.tasks.relay  # noqa: E402,F401

--- a/server/proliferate/background/config.py
+++ b/server/proliferate/background/config.py
@@ -18,11 +18,22 @@ KNOWN_QUEUE_NAMES = (
 )
 
 HEALTH_NOOP_TASK = "background.health.noop"
+BACKGROUND_RELAY_TASK = "background.relay"
+
+# Celery message header the relay stamps with the broker-publish wall-clock time
+# (epoch seconds). The worker reads it on task_prerun to emit a broker-residence
+# LATENCY (consume time minus publish time): a lagging per-task signal observed
+# only when a task is consumed, so it goes silent when consumption stalls and is
+# NOT a current "oldest queued task age". Amazon MQ exposes no native
+# oldest-message-age metric, so current backlog is covered by the broker
+# MessageCount depth alarm instead. It is a plain timestamp, never a secret.
+BACKGROUND_PUBLISH_TS_HEADER = "x_background_publish_ts"
 NOTIFICATIONS_SEND_SLACK_TASK = "notifications.send_slack"
 CUSTOMERIO_ENGAGEMENT_SYNC_TASK = "customerio.engagement_sync"
 
 TASK_ROUTES: dict[str, dict[str, str]] = {
     HEALTH_NOOP_TASK: {"queue": PERIODIC_DEFAULT_QUEUE},
+    BACKGROUND_RELAY_TASK: {"queue": PERIODIC_DEFAULT_QUEUE},
     NOTIFICATIONS_SEND_SLACK_TASK: {"queue": NOTIFICATIONS_QUEUE},
     CUSTOMERIO_ENGAGEMENT_SYNC_TASK: {"queue": PERIODIC_DEFAULT_QUEUE},
 }
@@ -64,8 +75,22 @@ def build_task_queues(queue_names: Sequence[str]) -> tuple[Queue, ...]:
 def build_celery_config(config: Settings = settings) -> dict[str, object]:
     validate_celery_urls(config)
     queue_names = enabled_worker_queues(config)
+    confirm_timeout = float(config.celery_broker_confirm_timeout_seconds)
+    if confirm_timeout <= 0:
+        raise ValueError("celery_broker_confirm_timeout_seconds must be positive")
     return {
         "broker_url": config.celery_broker_url,
+        # Enable AMQP publisher confirms on the broker connection. py-amqp then
+        # publishes via ``basic_publish_confirm``, which waits for a broker ack
+        # and raises on a nack; the relay additionally passes ``confirm_timeout``
+        # per publish so ack ambiguity raises instead of hanging. Without this a
+        # bare socket write would look like durable acceptance and the outbox row
+        # would be marked published even if RabbitMQ never accepted the message.
+        # TLS/stack-agnostic: no environment-specific value is hardcoded here.
+        "broker_transport_options": {
+            "confirm_publish": True,
+            "confirm_timeout": confirm_timeout,
+        },
         "result_backend": None,
         "task_default_queue": DEFAULT_QUEUE,
         "task_queues": build_task_queues(queue_names),

--- a/server/proliferate/background/enqueue_health.py
+++ b/server/proliferate/background/enqueue_health.py
@@ -1,0 +1,62 @@
+"""Enqueue a single committed health no-op outbox row.
+
+Run as a one-off command from the candidate server image during a deploy
+(`python -m proliferate.background.enqueue_health --idempotency-key <key>`) to
+seed a deterministic, correctness-sensitive outbox row. The deploy workflow then
+observes that this row is relayed, published, consumed, and executed by the
+candidate worker/Beat plane before the API is rolled — a live end-to-end proof
+that the plane can execute newly enqueued work, not just that its ECS resources
+report healthy.
+
+This is a thin store client, not a Celery task: it commits one row and exits.
+The health no-op handler already exists and is the frozen proof task; no Workflow
+behavior is added.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from proliferate.background.config import HEALTH_NOOP_TASK, PERIODIC_DEFAULT_QUEUE
+from proliferate.config import settings
+from proliferate.db.store.background_outbox import enqueue_outbox_task
+
+
+async def _enqueue(idempotency_key: str) -> str:
+    engine = create_async_engine(
+        settings.database_url,
+        pool_pre_ping=True,
+        connect_args={"statement_cache_size": 0},
+    )
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as db, db.begin():
+            task = await enqueue_outbox_task(
+                db,
+                task_name=HEALTH_NOOP_TASK,
+                queue=PERIODIC_DEFAULT_QUEUE,
+                idempotency_key=idempotency_key,
+            )
+        return str(task.id)
+    finally:
+        await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--idempotency-key",
+        required=True,
+        help="Deterministic idempotency key for the proof row (e.g. deploy SHA + run id).",
+    )
+    args = parser.parse_args()
+    outbox_id = asyncio.run(_enqueue(args.idempotency_key))
+    # A single stable line the deploy step can log; the row id is not a secret.
+    print(f"enqueued_health_noop outbox_id={outbox_id} idempotency_key={args.idempotency_key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/proliferate/background/relay.py
+++ b/server/proliferate/background/relay.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import random
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
@@ -11,15 +14,23 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from proliferate.background.celery_app import celery_app
 from proliferate.background.config import (
+    BACKGROUND_PUBLISH_TS_HEADER,
     HEALTH_NOOP_TASK,
 )
 from proliferate.db.store.background_outbox import (
     BackgroundOutboxTaskValue,
     claim_due_outbox_tasks,
+    get_outbox_backlog_snapshot,
     mark_outbox_task_publish_failed,
     mark_outbox_task_published,
 )
 
+# Task names the relay is allowed to publish. A committed row for any other name
+# is parked terminally (``failed`` / ``unsupported_task``) and never published,
+# so an unknown or retired task cannot loop forever against a worker that would
+# reject it. Add a name here only once a worker can import and run it. The relay
+# task itself (``background.relay``) is Beat-scheduled directly and is never
+# enqueued through the outbox, so it is intentionally absent.
 SUPPORTED_OUTBOX_TASKS = frozenset(
     {
         HEALTH_NOOP_TASK,
@@ -27,8 +38,58 @@ SUPPORTED_OUTBOX_TASKS = frozenset(
 )
 DEFAULT_RELAY_BATCH_SIZE = 50
 DEFAULT_RELAY_LEASE_SECONDS = 60.0
-DEFAULT_RELAY_RETRY_DELAY_SECONDS = 30.0
-DEFAULT_RELAY_MAX_ATTEMPTS = 5
+# Capped exponential backoff for supported broker failures. There is no attempt
+# ceiling: a correctness-sensitive committed task retries indefinitely until the
+# broker recovers. Delay is deterministic from the attempt count plus bounded
+# jitter to avoid a synchronized retry stampede across relay ticks.
+DEFAULT_RELAY_RETRY_BASE_SECONDS = 2.0
+DEFAULT_RELAY_RETRY_CAP_SECONDS = 300.0
+DEFAULT_RELAY_RETRY_JITTER_SECONDS = 5.0
+
+UNSUPPORTED_TASK_ERROR_CODE = "unsupported_task"
+UNSUPPORTED_TASK_ERROR_MESSAGE = "Outbox task name is not enabled for relay."
+PUBLISH_FAILED_ERROR_CODE = "publish_failed"
+# Deliberately generic and secret-free: the raw exception string may embed the
+# broker URL, credentials, or payload, so it is never persisted. The stable
+# class name is kept separately as the safe code.
+PUBLISH_FAILED_ERROR_MESSAGE = "Broker publish failed; will retry."
+
+
+def compute_retry_delay_seconds(
+    attempt: int,
+    *,
+    base_seconds: float = DEFAULT_RELAY_RETRY_BASE_SECONDS,
+    cap_seconds: float = DEFAULT_RELAY_RETRY_CAP_SECONDS,
+    jitter_seconds: float = DEFAULT_RELAY_RETRY_JITTER_SECONDS,
+    rng: Callable[[], float] = random.random,
+) -> float:
+    """Capped exponential backoff with bounded additive jitter.
+
+    ``attempt`` is the 1-based attempt count already recorded by the claim. The
+    exponential term is ``base * 2**(attempt - 1)`` clamped to ``cap``; jitter
+    adds ``[0, jitter_seconds)``. No ceiling is applied to the attempt count, so
+    the delay simply saturates at ``cap`` and the task keeps retrying.
+    """
+
+    safe_attempt = max(1, attempt)
+    # Clamp the exponent before the shift so a very high attempt count cannot
+    # overflow into an enormous float; the value is capped immediately after.
+    exponent = min(safe_attempt - 1, 32)
+    exponential = base_seconds * float(2**exponent)
+    capped = min(exponential, cap_seconds)
+    return capped + jitter_seconds * rng()
+
+
+def classify_publish_error(exc: BaseException) -> tuple[str, str]:
+    """Map a publish exception to a stable safe code and bounded safe message.
+
+    The code is the exception class name (stable, low-cardinality, and free of
+    secrets). The message is a fixed generic phrase. Neither includes the raw
+    exception text, broker URL, credentials, or task payload.
+    """
+
+    code = f"{PUBLISH_FAILED_ERROR_CODE}:{type(exc).__name__}"
+    return code[:128], PUBLISH_FAILED_ERROR_MESSAGE
 
 
 @dataclass(frozen=True)
@@ -51,13 +112,41 @@ class CeleryTaskPublisher:
     app: Celery = celery_app
 
     def publish(self, message: RelayMessage) -> None:
+        # Stamp the broker-publish wall-clock time as a Celery header so the
+        # worker can emit a broker-residence LATENCY on consume (a lagging
+        # per-task signal, not a current oldest-queued-age gauge). A plain
+        # timestamp, no secret.
+        #
+        # The broker connection runs with publisher confirms enabled
+        # (``confirm_publish`` in ``broker_transport_options``), so this publish
+        # goes through py-amqp's ``basic_publish_confirm``: it waits for the
+        # broker to durably ack the message and raises ``MessageNacked`` on a
+        # nack. Passing ``confirm_timeout`` bounds that wait, so a stuck confirm
+        # (ack ambiguity) raises rather than returning as if durably accepted.
+        # An unconfirmed publish therefore ALWAYS raises here, and ``relay_once``
+        # routes the exception to the retry path instead of marking the row
+        # published on a bare socket write.
         self.app.send_task(
             message.task_name,
             args=message.args,
             kwargs=message.kwargs,
             task_id=message.celery_task_id,
             queue=message.queue,
+            headers={BACKGROUND_PUBLISH_TS_HEADER: repr(time.time())},
+            confirm_timeout=self._confirm_timeout(),
         )
+
+    def _confirm_timeout(self) -> float | None:
+        # Single-source the bounded confirm timeout from the app's configured
+        # broker transport options so the publish wait matches the connection's
+        # confirm mode. Absent/misconfigured falls back to ``None`` (the
+        # connection-level default) rather than failing the publish outright.
+        conf = getattr(self.app, "conf", None)
+        options = getattr(conf, "broker_transport_options", None) or {}
+        timeout = options.get("confirm_timeout")
+        if isinstance(timeout, (int, float)) and timeout > 0:
+            return float(timeout)
+        return None
 
 
 @dataclass(frozen=True)
@@ -65,6 +154,73 @@ class RelayOnceResult:
     claimed: int
     published: int
     failed: int
+    recovered: int = 0
+
+
+@dataclass(frozen=True)
+class RelayTickResult:
+    """Everything a Beat tick needs to emit as safe metrics.
+
+    ``relay`` (the store law's only relay module) owns the store interaction:
+    it drains one bounded batch and reads the backlog snapshot behind this one
+    surface. The task wrapper stays thin — it constructs the boundary, invokes
+    ``run_relay_tick``, and emits these already-safe fields.
+    """
+
+    claimed: int
+    published: int
+    failed: int
+    recovered: int
+    due_pending: int
+    publishing: int
+    expired_publishing: int
+    failed_rows: int
+    oldest_due_pending_age_seconds: float
+    supported_pending_by_family: dict[str, int]
+
+
+async def run_relay_tick(
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+    batch_size: int = DEFAULT_RELAY_BATCH_SIZE,
+    lease_seconds: float = DEFAULT_RELAY_LEASE_SECONDS,
+    retry_base_seconds: float = DEFAULT_RELAY_RETRY_BASE_SECONDS,
+    retry_cap_seconds: float = DEFAULT_RELAY_RETRY_CAP_SECONDS,
+    retry_jitter_seconds: float = DEFAULT_RELAY_RETRY_JITTER_SECONDS,
+) -> RelayTickResult:
+    """Drain one bounded batch and read the backlog snapshot in one surface.
+
+    This is the single store-touching entry point the Beat task calls. It keeps
+    ``background/relay.py`` the only background module that reaches a store
+    (server layer law); the thin task wrapper never imports ``db.store``.
+    """
+
+    result = await relay_once(
+        session_factory=session_factory,
+        publisher=CeleryTaskPublisher(),
+        batch_size=batch_size,
+        lease_seconds=lease_seconds,
+        retry_base_seconds=retry_base_seconds,
+        retry_cap_seconds=retry_cap_seconds,
+        retry_jitter_seconds=retry_jitter_seconds,
+    )
+    async with session_factory() as db:
+        snapshot = await get_outbox_backlog_snapshot(
+            db,
+            supported_task_names=SUPPORTED_OUTBOX_TASKS,
+        )
+    return RelayTickResult(
+        claimed=result.claimed,
+        published=result.published,
+        failed=result.failed,
+        recovered=result.recovered,
+        due_pending=snapshot.due_pending_count,
+        publishing=snapshot.publishing_count,
+        expired_publishing=snapshot.expired_publishing_count,
+        failed_rows=snapshot.failed_count,
+        oldest_due_pending_age_seconds=snapshot.oldest_due_pending_age_seconds,
+        supported_pending_by_family=dict(snapshot.supported_pending_by_family),
+    )
 
 
 async def relay_once(
@@ -74,8 +230,10 @@ async def relay_once(
     worker_id: str = "background-relay",
     batch_size: int = DEFAULT_RELAY_BATCH_SIZE,
     lease_seconds: float = DEFAULT_RELAY_LEASE_SECONDS,
-    retry_delay_seconds: float = DEFAULT_RELAY_RETRY_DELAY_SECONDS,
-    max_attempts: int = DEFAULT_RELAY_MAX_ATTEMPTS,
+    retry_base_seconds: float = DEFAULT_RELAY_RETRY_BASE_SECONDS,
+    retry_cap_seconds: float = DEFAULT_RELAY_RETRY_CAP_SECONDS,
+    retry_jitter_seconds: float = DEFAULT_RELAY_RETRY_JITTER_SECONDS,
+    rng: Callable[[], float] = random.random,
 ) -> RelayOnceResult:
     async with session_factory() as db, db.begin():
         claimed = await claim_due_outbox_tasks(
@@ -87,15 +245,16 @@ async def relay_once(
 
     published = 0
     failed = 0
+    recovered = sum(1 for task in claimed if task.recovered_from_lease)
     for task in claimed:
         if task.task_name not in SUPPORTED_OUTBOX_TASKS:
             if await _mark_failed(
                 session_factory,
                 task,
-                error_code="unsupported_task",
-                error_message=f"Outbox task {task.task_name} is not enabled for relay.",
-                retry_delay_seconds=0,
-                max_attempts=0,
+                error_code=UNSUPPORTED_TASK_ERROR_CODE,
+                error_message=UNSUPPORTED_TASK_ERROR_MESSAGE,
+                retry_delay_seconds=0.0,
+                terminal=True,
             ):
                 failed += 1
             continue
@@ -104,13 +263,21 @@ async def relay_once(
         try:
             publisher.publish(message)
         except Exception as exc:
+            error_code, error_message = classify_publish_error(exc)
+            retry_delay_seconds = compute_retry_delay_seconds(
+                task.attempt_count,
+                base_seconds=retry_base_seconds,
+                cap_seconds=retry_cap_seconds,
+                jitter_seconds=retry_jitter_seconds,
+                rng=rng,
+            )
             if await _mark_failed(
                 session_factory,
                 task,
-                error_code=exc.__class__.__name__,
-                error_message=str(exc),
+                error_code=error_code,
+                error_message=error_message,
                 retry_delay_seconds=retry_delay_seconds,
-                max_attempts=max_attempts,
+                terminal=False,
             ):
                 failed += 1
             continue
@@ -118,7 +285,12 @@ async def relay_once(
         if await _mark_published(session_factory, message):
             published += 1
 
-    return RelayOnceResult(claimed=len(claimed), published=published, failed=failed)
+    return RelayOnceResult(
+        claimed=len(claimed),
+        published=published,
+        failed=failed,
+        recovered=recovered,
+    )
 
 
 def _relay_message(task: BackgroundOutboxTaskValue) -> RelayMessage:
@@ -155,7 +327,7 @@ async def _mark_failed(
     error_code: str,
     error_message: str,
     retry_delay_seconds: float,
-    max_attempts: int,
+    terminal: bool,
 ) -> bool:
     if task.publish_claim_id is None:
         return False
@@ -167,5 +339,5 @@ async def _mark_failed(
             error_code=error_code,
             error_message=error_message,
             retry_delay_seconds=retry_delay_seconds,
-            max_attempts=max_attempts,
+            terminal=terminal,
         )

--- a/server/proliferate/background/task_metrics.py
+++ b/server/proliferate/background/task_metrics.py
@@ -1,0 +1,173 @@
+"""Worker-side task outcome telemetry.
+
+Celery signal handlers project one low-cardinality JSON line per task success,
+retry, or failure so the hosted CloudWatch metric filters can build
+success/retry/failure counts dimensioned by task name and a safe error code.
+
+Only the task name (already a fixed, low-cardinality value from our registry)
+and the exception class name (stable, secret-free) are emitted. Task arguments,
+keyword arguments, return values, broker URLs, credentials, and raw traceback
+strings are never logged here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from celery.signals import task_failure, task_prerun, task_retry, task_success
+
+from proliferate.background.config import BACKGROUND_PUBLISH_TS_HEADER
+
+logger = logging.getLogger(__name__)
+
+
+def _build_metrics_logger() -> logging.Logger:
+    """Message-only logger so the JSON line is a valid standalone metric event.
+
+    Mirrors the relay metrics logger: Celery's default formatter would prefix
+    each record with ``[timestamp: level/process]``, which breaks the CloudWatch
+    JSON metric-filter patterns. A dedicated non-propagating handler emits the
+    bare JSON object instead.
+    """
+
+    metrics_logger = logging.getLogger("proliferate.background.task_metrics")
+    if not metrics_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        metrics_logger.addHandler(handler)
+        metrics_logger.setLevel(logging.INFO)
+        metrics_logger.propagate = False
+    return metrics_logger
+
+
+_metrics_logger = _build_metrics_logger()
+
+
+def _safe_task_name(sender: object) -> str:
+    name = getattr(sender, "name", None)
+    if isinstance(name, str) and name:
+        # Bounded defensively; task names in our registry are short and fixed.
+        return name[:128]
+    return "unknown"
+
+
+def _safe_error_code(exception: BaseException | None) -> str:
+    if exception is None:
+        return "none"
+    # The class name is stable and secret-free; the raw message may carry a
+    # broker URL, credentials, or payload, so it is never emitted.
+    return type(exception).__name__[:128]
+
+
+def build_task_metric(
+    outcome: str,
+    *,
+    task_name: str,
+    error_code: str = "none",
+) -> dict[str, object]:
+    """Return the safe, low-cardinality metric payload for one task outcome.
+
+    Pure and side-effect-free so it can be asserted directly. Only the outcome,
+    the (fixed-registry) task name, and the safe error code are included.
+    """
+
+    return {
+        "background_task": {
+            "outcome": outcome,
+            "task_name": task_name,
+            "error_code": error_code,
+            "count": 1,
+        }
+    }
+
+
+def parse_publish_timestamp(raw: object) -> float | None:
+    """Return the stamped broker-publish epoch seconds, or ``None`` if absent.
+
+    The relay stamps ``BACKGROUND_PUBLISH_TS_HEADER`` with ``repr(time.time())``.
+    Anything unparseable or non-finite is ignored so a malformed header can never
+    emit a bogus age or raise inside the worker signal path.
+    """
+
+    if raw is None:
+        return None
+    try:
+        value = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if value != value or value in (float("inf"), float("-inf")):  # NaN/inf guard
+        return None
+    return value
+
+
+def build_queue_age_metric(task_name: str, age_seconds: float) -> dict[str, object]:
+    """Return the safe broker-residence-latency payload for one consumed task.
+
+    ``age_seconds`` is the time the task spent in the broker between relay
+    publish and worker consume. This is a LAGGING per-task latency observed on
+    consume, NOT a current "oldest queued task age": it is emitted only when a
+    task is actually consumed, so it goes silent when consumption stalls. Amazon
+    MQ exposes no native oldest-message-age metric; current backlog is covered by
+    the broker MessageCount depth alarm instead. Dimensioned only by the
+    fixed-registry task name; the value is a duration, never a secret. Pure so it
+    can be asserted directly.
+    """
+
+    return {
+        "background_queue_age": {
+            "task_name": task_name,
+            "age_seconds": round(max(0.0, age_seconds), 3),
+        }
+    }
+
+
+def _emit(outcome: str, *, task_name: str, error_code: str = "none") -> None:
+    payload = build_task_metric(outcome, task_name=task_name, error_code=error_code)
+    _metrics_logger.info(json.dumps(payload))
+
+
+def _publish_ts_from_request(task: object) -> object:
+    request = getattr(task, "request", None)
+    if request is None:
+        return None
+    getter = getattr(request, "get", None)
+    if callable(getter):
+        return getter(BACKGROUND_PUBLISH_TS_HEADER)
+    return getattr(request, BACKGROUND_PUBLISH_TS_HEADER, None)
+
+
+@task_prerun.connect
+def _on_task_prerun(task: object = None, **_: object) -> None:
+    # Emit the broker-residence latency: the wall-clock gap between when the
+    # relay published the message and when the worker began executing it. This is
+    # a LAGGING per-task latency observed on consume, not a current oldest-age
+    # gauge — it is only emitted for tasks that actually got consumed and goes
+    # silent when consumption stalls. Missing/malformed header (e.g. tasks
+    # published without the relay stamp) simply emits nothing.
+    published_at = parse_publish_timestamp(_publish_ts_from_request(task))
+    if published_at is None:
+        return
+    age_seconds = time.time() - published_at
+    _metrics_logger.info(json.dumps(build_queue_age_metric(_safe_task_name(task), age_seconds)))
+
+
+@task_success.connect
+def _on_task_success(sender: object = None, **_: object) -> None:
+    _emit("success", task_name=_safe_task_name(sender))
+
+
+@task_retry.connect
+def _on_task_retry(sender: object = None, reason: object = None, **_: object) -> None:
+    error_code = _safe_error_code(reason if isinstance(reason, BaseException) else None)
+    _emit("retry", task_name=_safe_task_name(sender), error_code=error_code)
+
+
+@task_failure.connect
+def _on_task_failure(
+    sender: object = None,
+    exception: BaseException | None = None,
+    **_: object,
+) -> None:
+    _emit("failure", task_name=_safe_task_name(sender), error_code=_safe_error_code(exception))

--- a/server/proliferate/background/tasks/health.py
+++ b/server/proliferate/background/tasks/health.py
@@ -2,10 +2,57 @@
 
 from __future__ import annotations
 
+import json
+import logging
+
+from celery import Task
+
 from proliferate.background.celery_app import celery_app
 from proliferate.background.config import HEALTH_NOOP_TASK
 
+logger = logging.getLogger(__name__)
 
-@celery_app.task(name=HEALTH_NOOP_TASK)
-def noop() -> str:
+
+def _build_receipt_logger() -> logging.Logger:
+    """Message-only logger so the receipt is a valid standalone log event.
+
+    Mirrors the task-metrics logger: Celery's default formatter would prefix
+    each record with ``[timestamp: level/process]``, which breaks a CloudWatch
+    Logs filter/Insights match on the bare JSON object. A dedicated
+    non-propagating handler emits the receipt line unadorned.
+    """
+
+    receipt_logger = logging.getLogger("proliferate.background.health_receipt")
+    if not receipt_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        receipt_logger.addHandler(handler)
+        receipt_logger.setLevel(logging.INFO)
+        receipt_logger.propagate = False
+    return receipt_logger
+
+
+_receipt_logger = _build_receipt_logger()
+
+
+def build_health_receipt(task_id: str) -> dict[str, object]:
+    """Return the safe exact-ID execution receipt for a health no-op run.
+
+    Carries only the Celery task id (which the relay sets equal to the outbox
+    row id — a UUID, not a secret) and a stable status marker. This lets the
+    deploy proof correlate a fresh success to the EXACT row it enqueued rather
+    than to any concurrent health no-op that happened to satisfy an aggregate
+    metric. Pure so it can be asserted directly.
+    """
+
+    return {"background_health_receipt": {"task_id": task_id[:128], "status": "ok"}}
+
+
+@celery_app.task(name=HEALTH_NOOP_TASK, bind=True)
+def noop(self: Task) -> str:
+    # Bound so the task can read its own id (== the relay's outbox id) and log an
+    # exact-ID execution receipt on success. The deploy gate matches this line's
+    # task_id against the outbox id it enqueued, so an unrelated concurrent health
+    # no-op cannot satisfy the proof.
+    _receipt_logger.info(json.dumps(build_health_receipt(str(self.request.id))))
     return "ok"

--- a/server/proliferate/background/tasks/relay.py
+++ b/server/proliferate/background/tasks/relay.py
@@ -1,0 +1,133 @@
+"""Beat-fired relay task: drain one bounded outbox batch and exit.
+
+This wrapper is intentionally thin. Beat schedules ``background.relay`` on a
+short interval; each firing constructs a session factory, runs a single bounded
+``relay_once`` batch, emits safe counts/latency, and returns. Nothing here
+sleeps, polls forever, or holds a transaction open across a broker publish.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from proliferate.background.celery_app import celery_app
+from proliferate.background.config import BACKGROUND_RELAY_TASK
+from proliferate.config import settings
+
+if TYPE_CHECKING:
+    from proliferate.background.relay import RelayTickResult
+
+logger = logging.getLogger(__name__)
+
+
+def _build_metrics_logger() -> logging.Logger:
+    """Logger that writes bare JSON lines, bypassing Celery's log formatter.
+
+    The hosted CloudWatch metric filters use JSON patterns
+    (``{ $.background_relay.<field> = * }``), which only match when the whole
+    log event is valid JSON. Celery's default formatter prefixes every record
+    with ``[timestamp: level/process]``, so the metric line is emitted through a
+    dedicated non-propagating handler with a message-only format instead.
+    """
+
+    metrics_logger = logging.getLogger("proliferate.background.relay_metrics")
+    if not metrics_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        metrics_logger.addHandler(handler)
+        metrics_logger.setLevel(logging.INFO)
+        metrics_logger.propagate = False
+    return metrics_logger
+
+
+_metrics_logger = _build_metrics_logger()
+
+
+def _safe_family_key(task_name: str) -> str:
+    """Map a task name to a CloudWatch-JSON-safe field key.
+
+    CloudWatch metric-filter selectors treat dots as path separators, so the
+    emitted per-family key must not contain them. Task names are already fixed,
+    low-cardinality registry values, so this is a stable one-to-one rename
+    (``background.health.noop`` -> ``background_health_noop``).
+    """
+
+    return "".join(ch if ch.isalnum() else "_" for ch in task_name)
+
+
+async def _run_relay_batch() -> RelayTickResult:
+    # Imported lazily so this task module can be imported by ``celery_app`` while
+    # ``proliferate.background.relay`` (which imports ``celery_app``) is still
+    # initializing, without a circular import at module load. The task wrapper
+    # touches no store: ``run_relay_tick`` is the single relay-owned surface that
+    # drains the batch and reads the backlog behind the server store law.
+    from proliferate.background.relay import run_relay_tick
+
+    # A fresh engine per firing keeps asyncpg connections bound to the loop
+    # created by ``asyncio.run`` below. The relay task fires infrequently and
+    # drains a small batch, so the connect cost is negligible and this avoids
+    # reusing a global engine across short-lived per-tick event loops.
+    engine = create_async_engine(
+        settings.database_url,
+        pool_pre_ping=True,
+        connect_args={"statement_cache_size": 0},
+    )
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        return await run_relay_tick(
+            session_factory=session_factory,
+            batch_size=settings.background_relay_batch_size,
+            lease_seconds=settings.background_relay_lease_seconds,
+            retry_base_seconds=settings.background_relay_retry_base_seconds,
+            retry_cap_seconds=settings.background_relay_retry_cap_seconds,
+            retry_jitter_seconds=settings.background_relay_retry_jitter_seconds,
+        )
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name=BACKGROUND_RELAY_TASK)
+def relay() -> dict[str, object]:
+    """Run one bounded relay batch and emit low-cardinality metrics."""
+
+    started = time.perf_counter()
+    tick = asyncio.run(_run_relay_batch())
+    latency_ms = int((time.perf_counter() - started) * 1000)
+    metrics: dict[str, object] = {
+        # A tick that completed at all proves Beat AND the scheduler store are
+        # live: RedBeat/Valkey must be reachable for Beat to dispatch this task,
+        # so a steady stream of `relay_heartbeat=1` lines is the direct
+        # scheduler-store liveness signal. Its ABSENCE (no data) breaches the
+        # heartbeat alarm — unlike the oldest-due SLO, which treats missing data
+        # as not-breaching and therefore cannot detect a store outage.
+        "relay_heartbeat": 1,
+        "claimed": tick.claimed,
+        "published": tick.published,
+        "failed": tick.failed,
+        "recovered_leases": tick.recovered,
+        "latency_ms": latency_ms,
+        "due_pending": tick.due_pending,
+        "publishing": tick.publishing,
+        "expired_publishing": tick.expired_publishing,
+        "failed_rows": tick.failed_rows,
+        "oldest_due_pending_age_seconds": round(tick.oldest_due_pending_age_seconds, 3),
+        # Bounded by the supported-task allowlist, so cardinality is fixed. Keys
+        # are dot-free so CloudWatch JSON metric filters can select each family.
+        "supported_pending_by_family": {
+            _safe_family_key(name): count
+            for name, count in tick.supported_pending_by_family.items()
+        },
+    }
+    # Safe to log: only counts, latency, and backlog ages. No args/kwargs, broker
+    # URLs, credentials, or payloads. Hosted CloudWatch metric filters turn these
+    # fields into the background-plane gauges and alarms; the JSON line below is
+    # the exact shape those filters parse.
+    logger.info("background.relay tick")
+    _metrics_logger.info(json.dumps({"background_relay": metrics}))
+    return metrics

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -91,8 +91,26 @@ class Settings(BaseSettings):
     celery_task_always_eager: bool = False
     celery_task_time_limit_seconds: int = 3600
     celery_task_soft_time_limit_seconds: int = 3300
+    # Publisher-confirm timeout (seconds) for broker publishes. With confirm mode
+    # enabled the relay waits up to this long for RabbitMQ to durably ack a
+    # publish; a nack, a confirm timeout, or connection ambiguity raises so the
+    # outbox row stays retryable instead of being marked published on an
+    # unconfirmed socket write. Bounded so a wedged broker cannot hang a tick.
+    celery_broker_confirm_timeout_seconds: float = 10.0
     redbeat_redis_url: str = "redis://127.0.0.1:6379/0"
     redbeat_key_prefix: str = "redbeat:proliferate:"
+    # Outbox relay: Beat fires the thin ``background.relay`` task on this
+    # interval; each tick drains one bounded batch and exits (no in-process
+    # loop). Supported broker failures retry indefinitely with capped
+    # exponential backoff. ``oldest_due_slo_seconds`` is the alarm threshold on
+    # the oldest due-but-unpublished outbox row (5-minute reviewable default).
+    background_relay_interval_seconds: float = 1.0
+    background_relay_batch_size: int = 50
+    background_relay_lease_seconds: float = 60.0
+    background_relay_retry_base_seconds: float = 2.0
+    background_relay_retry_cap_seconds: float = 300.0
+    background_relay_retry_jitter_seconds: float = 5.0
+    background_relay_oldest_due_slo_seconds: float = 300.0
 
     # Auth
     jwt_secret: str = "CHANGE-ME-IN-PRODUCTION"

--- a/server/proliferate/db/store/background_outbox.py
+++ b/server/proliferate/db/store/background_outbox.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timedelta
+from collections.abc import Collection
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Literal
 from uuid import UUID, uuid4
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -44,13 +45,36 @@ class BackgroundOutboxTaskValue:
     publish_claim_id: UUID | None
     locked_by: str | None
     published_task_id: str | None
+    # True when this row was claimed by recovering an expired publishing lease
+    # rather than a fresh pending row. Used only for telemetry; defaulted so the
+    # frozen value stays constructible from any code path.
+    recovered_from_lease: bool = False
 
     @property
     def celery_task_id(self) -> str:
         return str(self.id)
 
 
-def _task_value(record: BackgroundOutboxTask) -> BackgroundOutboxTaskValue:
+def _normalize_available_at(available_at: datetime | None, *, now: datetime) -> datetime:
+    """Return an aware UTC instant for the outbox ``available_at`` column.
+
+    Omission means "due now". A supplied naive datetime is interpreted as UTC;
+    an aware datetime is converted to UTC. The wall-clock instant is preserved
+    unchanged so an explicit future ``available_at`` schedules exactly as asked.
+    """
+
+    if available_at is None:
+        return now
+    if available_at.tzinfo is None:
+        return available_at.replace(tzinfo=UTC)
+    return available_at.astimezone(UTC)
+
+
+def _task_value(
+    record: BackgroundOutboxTask,
+    *,
+    recovered_from_lease: bool = False,
+) -> BackgroundOutboxTaskValue:
     return BackgroundOutboxTaskValue(
         id=record.id,
         task_name=record.task_name,
@@ -64,6 +88,7 @@ def _task_value(record: BackgroundOutboxTask) -> BackgroundOutboxTaskValue:
         publish_claim_id=record.publish_claim_id,
         locked_by=record.locked_by,
         published_task_id=record.published_task_id,
+        recovered_from_lease=recovered_from_lease,
     )
 
 
@@ -76,6 +101,7 @@ async def enqueue_outbox_task(
     kwargs_json: dict[str, object] | None = None,
     task_id: UUID | None = None,
     idempotency_key: str | None = None,
+    available_at: datetime | None = None,
 ) -> BackgroundOutboxTaskValue:
     now = utcnow()
     outbox_id = task_id or uuid4()
@@ -87,7 +113,7 @@ async def enqueue_outbox_task(
         "kwargs_json": dict(kwargs_json or {}),
         "idempotency_key": idempotency_key,
         "status": OUTBOX_STATUS_PENDING,
-        "available_at": now,
+        "available_at": _normalize_available_at(available_at, now=now),
         "attempt_count": 0,
         "created_at": now,
         "updated_at": now,
@@ -175,6 +201,7 @@ async def claim_due_outbox_tasks(
     locked_until = now + timedelta(seconds=lease_seconds)
     values: list[BackgroundOutboxTaskValue] = []
     for row in rows:
+        recovered = row.status == OUTBOX_STATUS_PUBLISHING
         row.status = OUTBOX_STATUS_PUBLISHING
         row.publish_claim_id = uuid4()
         row.locked_by = worker_id
@@ -182,7 +209,7 @@ async def claim_due_outbox_tasks(
         row.lock_expires_at = locked_until
         row.attempt_count += 1
         row.updated_at = now
-        values.append(_task_value(row))
+        values.append(_task_value(row, recovered_from_lease=recovered))
     await db.flush()
     return tuple(values)
 
@@ -222,26 +249,124 @@ async def mark_outbox_task_publish_failed(
     error_code: str,
     error_message: str,
     retry_delay_seconds: float,
-    max_attempts: int,
+    terminal: bool,
 ) -> bool:
+    """Record a publish failure under the claim guard.
+
+    ``terminal`` decides the outcome rather than an attempt ceiling: supported
+    correctness-sensitive tasks retry indefinitely (``terminal=False``) with a
+    caller-computed capped backoff delay, while an unsupported task name is
+    parked terminally (``terminal=True``). ``error_code`` and ``error_message``
+    are already bounded and secret-safe at the call site; they are additionally
+    truncated here as defense in depth.
+    """
+
     record = await _load_for_update(db, outbox_id)
     if record is None:
         return False
     if record.publish_claim_id != publish_claim_id:
         return False
     now = utcnow()
-    exhausted = record.attempt_count >= max_attempts
-    record.status = OUTBOX_STATUS_FAILED if exhausted else OUTBOX_STATUS_PENDING
+    record.status = OUTBOX_STATUS_FAILED if terminal else OUTBOX_STATUS_PENDING
     record.publish_claim_id = None
-    record.available_at = now + timedelta(seconds=retry_delay_seconds)
+    if not terminal:
+        record.available_at = now + timedelta(seconds=retry_delay_seconds)
     record.locked_by = None
     record.locked_at = None
     record.lock_expires_at = None
     record.last_error_code = error_code[:128]
-    record.last_error_message = error_message
+    record.last_error_message = error_message[:512]
     record.updated_at = now
     await db.flush()
     return True
+
+
+@dataclass(frozen=True)
+class OutboxBacklogSnapshot:
+    """Low-cardinality gauges for background-plane health telemetry."""
+
+    due_pending_count: int
+    publishing_count: int
+    expired_publishing_count: int
+    failed_count: int
+    oldest_due_pending_age_seconds: float
+    # Pending-row counts keyed by supported task family. Cardinality is bounded
+    # by the caller's supported-task allowlist: only recognized families appear,
+    # so this never widens to an unbounded set of arbitrary task names.
+    supported_pending_by_family: dict[str, int] = field(default_factory=dict)
+
+
+async def get_outbox_backlog_snapshot(
+    db: AsyncSession,
+    *,
+    supported_task_names: Collection[str] = (),
+) -> OutboxBacklogSnapshot:
+    """Return backlog gauges for the relay to emit as safe metrics.
+
+    All values are process-independent aggregates over the whole table so any
+    relay tick observes the same picture. ``oldest_due_pending_age_seconds`` is
+    the SLO signal alarmed on in hosted infrastructure.
+
+    ``supported_task_names`` bounds the per-family pending breakdown: every name
+    in the allowlist is reported (zero when absent) and no other name is ever
+    projected, so the emitted metric stays low-cardinality and secret-safe.
+    """
+
+    now = utcnow()
+    oldest_due = await db.scalar(
+        select(func.min(BackgroundOutboxTask.available_at)).where(
+            BackgroundOutboxTask.status == OUTBOX_STATUS_PENDING,
+            BackgroundOutboxTask.available_at <= now,
+        )
+    )
+    due_pending = await db.scalar(
+        select(func.count())
+        .select_from(BackgroundOutboxTask)
+        .where(
+            BackgroundOutboxTask.status == OUTBOX_STATUS_PENDING,
+            BackgroundOutboxTask.available_at <= now,
+        )
+    )
+    publishing = await db.scalar(
+        select(func.count())
+        .select_from(BackgroundOutboxTask)
+        .where(BackgroundOutboxTask.status == OUTBOX_STATUS_PUBLISHING)
+    )
+    expired_publishing = await db.scalar(
+        select(func.count())
+        .select_from(BackgroundOutboxTask)
+        .where(
+            BackgroundOutboxTask.status == OUTBOX_STATUS_PUBLISHING,
+            BackgroundOutboxTask.lock_expires_at.is_not(None),
+            BackgroundOutboxTask.lock_expires_at <= now,
+        )
+    )
+    failed = await db.scalar(
+        select(func.count())
+        .select_from(BackgroundOutboxTask)
+        .where(BackgroundOutboxTask.status == OUTBOX_STATUS_FAILED)
+    )
+    supported_pending_by_family: dict[str, int] = {name: 0 for name in supported_task_names}
+    if supported_pending_by_family:
+        family_rows = await db.execute(
+            select(BackgroundOutboxTask.task_name, func.count())
+            .where(
+                BackgroundOutboxTask.status == OUTBOX_STATUS_PENDING,
+                BackgroundOutboxTask.task_name.in_(list(supported_pending_by_family)),
+            )
+            .group_by(BackgroundOutboxTask.task_name)
+        )
+        for task_name, count in family_rows.all():
+            supported_pending_by_family[task_name] = int(count or 0)
+    oldest_age = 0.0 if oldest_due is None else max(0.0, (now - oldest_due).total_seconds())
+    return OutboxBacklogSnapshot(
+        due_pending_count=int(due_pending or 0),
+        publishing_count=int(publishing or 0),
+        expired_publishing_count=int(expired_publishing or 0),
+        failed_count=int(failed or 0),
+        oldest_due_pending_age_seconds=oldest_age,
+        supported_pending_by_family=supported_pending_by_family,
+    )
 
 
 async def _load_for_update(

--- a/server/tests/integration/background/__init__.py
+++ b/server/tests/integration/background/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the background runtime relay task."""

--- a/server/tests/integration/background/test_relay_task.py
+++ b/server/tests/integration/background/test_relay_task.py
@@ -1,0 +1,91 @@
+"""End-to-end wiring test for the Beat-fired ``background.relay`` task.
+
+The thin task builds its own engine from ``settings.database_url`` and drives one
+``relay_once`` batch. Here that URL is pointed at the migrated test database and
+the broker publish is stubbed, so the test exercises the real session-factory
+construction, claim, publish, mark-published, and metrics emission path without
+a live RabbitMQ.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.background import relay as relay_module
+from proliferate.background.config import HEALTH_NOOP_TASK, PERIODIC_DEFAULT_QUEUE
+from proliferate.background.tasks.relay import relay
+from proliferate.config import settings
+from proliferate.db.store.background_outbox import (
+    OUTBOX_STATUS_PUBLISHED,
+    enqueue_outbox_task,
+    load_outbox_task,
+)
+from tests.postgres import TEST_DATABASE_URL
+
+
+@pytest.mark.asyncio
+async def test_relay_task_publishes_committed_health_noop(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    published: list[str] = []
+    monkeypatch.setattr(settings, "database_url", TEST_DATABASE_URL)
+    monkeypatch.setattr(
+        relay_module.CeleryTaskPublisher,
+        "publish",
+        lambda self, message: published.append(message.celery_task_id),
+    )
+
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    await db_session.commit()
+
+    # The task calls ``asyncio.run`` internally, so run it off the test's loop.
+    metrics = await asyncio.to_thread(relay)
+
+    assert published == [str(task.id)]
+    assert metrics["claimed"] == 1
+    assert metrics["published"] == 1
+    assert metrics["failed"] == 0
+    assert "oldest_due_pending_age_seconds" in metrics
+    # Scheduler-store/relay liveness heartbeat and the bounded per-family
+    # backlog gauge are emitted every tick for the hosted metric plane.
+    assert metrics["relay_heartbeat"] == 1
+    assert metrics["supported_pending_by_family"] == {"background_health_noop": 0}
+
+    db_session.expire_all()
+    row = await load_outbox_task(db_session, task.id)
+    assert row is not None
+    assert row.status == OUTBOX_STATUS_PUBLISHED
+
+
+@pytest.mark.asyncio
+async def test_enqueue_health_module_commits_row(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The candidate-plane deploy proof enqueues a deterministic health no-op via
+    # `python -m proliferate.background.enqueue_health`. Exercise its store path
+    # against the migrated test DB: a committed pending health-noop row appears
+    # under the deterministic idempotency key, and a replay returns the same row.
+    from proliferate.background import enqueue_health
+
+    monkeypatch.setattr(settings, "database_url", TEST_DATABASE_URL)
+
+    outbox_id = await enqueue_health._enqueue("deploy-proof-key")
+    replay_id = await enqueue_health._enqueue("deploy-proof-key")
+    assert outbox_id == replay_id
+
+    db_session.expire_all()
+    from uuid import UUID
+
+    row = await load_outbox_task(db_session, UUID(outbox_id))
+    assert row is not None
+    assert row.task_name == HEALTH_NOOP_TASK
+    assert row.status.value == "pending"

--- a/server/tests/unit/test_background_celery.py
+++ b/server/tests/unit/test_background_celery.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from celery import Celery
 from kombu import Queue
 
 from proliferate.background.config import (
+    BACKGROUND_RELAY_TASK,
     CUSTOMERIO_ENGAGEMENT_SYNC_TASK,
     DEFAULT_QUEUE,
     HEALTH_NOOP_TASK,
@@ -13,7 +16,7 @@ from proliferate.background.config import (
     build_celery_config,
     enabled_worker_queues,
 )
-from proliferate.background.beat_schedule import build_beat_schedule
+from proliferate.background.beat_schedule import RELAY_SCHEDULE_ENTRY, build_beat_schedule
 from proliferate.config import Settings
 
 
@@ -33,6 +36,7 @@ def test_celery_app_import_registers_noop_task_without_broker_connection() -> No
 
     assert isinstance(celery_app, Celery)
     assert HEALTH_NOOP_TASK in celery_app.tasks
+    assert BACKGROUND_RELAY_TASK in celery_app.tasks
     assert NOTIFICATIONS_SEND_SLACK_TASK in celery_app.tasks
     assert celery_app.tasks[HEALTH_NOOP_TASK].run() == "ok"
 
@@ -48,6 +52,7 @@ def test_celery_routes_and_queues_match_ratified_names() -> None:
     }
     assert celery_app.conf.task_routes == {
         HEALTH_NOOP_TASK: {"queue": PERIODIC_DEFAULT_QUEUE},
+        BACKGROUND_RELAY_TASK: {"queue": PERIODIC_DEFAULT_QUEUE},
         NOTIFICATIONS_SEND_SLACK_TASK: {"queue": NOTIFICATIONS_QUEUE},
         CUSTOMERIO_ENGAGEMENT_SYNC_TASK: {"queue": PERIODIC_DEFAULT_QUEUE},
     }
@@ -59,8 +64,27 @@ def test_celery_routes_and_queues_match_ratified_names() -> None:
     assert celery_app.conf.result_backend is None
 
 
-def test_beat_schedule_empty_by_default() -> None:
-    assert build_beat_schedule(_test_settings()) == {}
+def test_beat_schedule_has_exactly_one_relay_entry_by_default() -> None:
+    schedule = build_beat_schedule(_test_settings())
+
+    assert set(schedule) == {RELAY_SCHEDULE_ENTRY}
+    relay_entries = [
+        name for name, entry in schedule.items() if entry["task"] == BACKGROUND_RELAY_TASK
+    ]
+    assert relay_entries == [RELAY_SCHEDULE_ENTRY]
+    assert schedule[RELAY_SCHEDULE_ENTRY]["schedule"] == 1.0
+
+
+def test_beat_schedule_keeps_single_relay_entry_with_customerio_enabled() -> None:
+    schedule = build_beat_schedule(
+        _test_settings(customerio_site_id="site", customerio_api_key="key")
+    )
+
+    relay_entries = [
+        name for name, entry in schedule.items() if entry["task"] == BACKGROUND_RELAY_TASK
+    ]
+    assert relay_entries == [RELAY_SCHEDULE_ENTRY]
+    assert "customerio-engagement-sync" in schedule
 
 
 def test_celery_config_reads_settings_without_result_backend() -> None:
@@ -84,6 +108,36 @@ def test_celery_config_reads_settings_without_result_backend() -> None:
     assert {queue.name for queue in queues} == {"default", "notifications"}
 
 
+def test_celery_config_enables_publisher_confirms_with_bounded_timeout() -> None:
+    # Regression for BG4-PUBLISH-CONFIRM-01: without publisher confirms a bare
+    # socket write looks like durable broker acceptance and the outbox row is
+    # marked published even if RabbitMQ never accepted the message. The broker
+    # transport options MUST enable confirm mode with a positive, bounded confirm
+    # timeout so a nack/timeout/ambiguity raises instead of silently returning.
+    options = build_celery_config(_test_settings())["broker_transport_options"]
+    assert isinstance(options, dict)
+    assert options["confirm_publish"] is True
+    confirm_timeout = options["confirm_timeout"]
+    assert isinstance(confirm_timeout, (int, float))
+    assert 0 < confirm_timeout < float("inf")
+
+
+def test_celery_config_confirm_timeout_is_settings_configurable() -> None:
+    options = build_celery_config(_test_settings(celery_broker_confirm_timeout_seconds=3.5))[
+        "broker_transport_options"
+    ]
+    assert options["confirm_timeout"] == 3.5
+
+
+def test_celery_config_rejects_nonpositive_confirm_timeout() -> None:
+    try:
+        build_celery_config(_test_settings(celery_broker_confirm_timeout_seconds=0))
+    except ValueError as exc:
+        assert "confirm_timeout" in str(exc)
+    else:
+        raise AssertionError("expected a nonpositive confirm timeout to be rejected")
+
+
 def test_celery_config_rejects_redis_broker() -> None:
     config = _test_settings(celery_broker_url="redis://127.0.0.1:6379/0")
 
@@ -95,6 +149,22 @@ def test_celery_config_rejects_redis_broker() -> None:
         raise AssertionError("expected Redis broker URL to be rejected")
 
 
+def test_background_package_imports_no_workflow_domain() -> None:
+    # This infrastructure slice must not couple to the Workflow domain: no
+    # Workflow task names or business modules may be imported from the background
+    # package. Guards against accidental scope creep the frozen spec forbids.
+    background_dir = Path(__file__).resolve().parents[2] / "proliferate" / "background"
+    offenders: list[str] = []
+    for source in background_dir.rglob("*.py"):
+        for line in source.read_text().splitlines():
+            stripped = line.strip()
+            if not (stripped.startswith("import ") or stripped.startswith("from ")):
+                continue
+            if "workflow" in stripped.lower():
+                offenders.append(f"{source.name}: {stripped}")
+    assert offenders == []
+
+
 def test_celery_queue_selector_rejects_unknown_queue() -> None:
     config = _test_settings(celery_worker_queues="default,unknown")
 
@@ -104,3 +174,44 @@ def test_celery_queue_selector_rejects_unknown_queue() -> None:
         assert "unknown" in str(exc)
     else:
         raise AssertionError("expected unknown queue to be rejected")
+
+
+def test_task_metric_payload_is_safe_and_low_cardinality() -> None:
+    # The worker-side outcome telemetry must carry only a safe task name and
+    # error code (exception class name), never the raw exception text or payload.
+    from proliferate.background.task_metrics import build_task_metric
+
+    success = build_task_metric("success", task_name=HEALTH_NOOP_TASK)["background_task"]
+    assert success == {
+        "outcome": "success",
+        "task_name": HEALTH_NOOP_TASK,
+        "error_code": "none",
+        "count": 1,
+    }
+
+    # The safe error code is the exception class name; the raw message (which may
+    # carry a broker URL, credentials, or payload) never appears.
+    boom = RuntimeError("amqps://user:secret@broker:5671 refused")
+    failure = build_task_metric(
+        "failure", task_name=HEALTH_NOOP_TASK, error_code=type(boom).__name__
+    )["background_task"]
+    assert failure["error_code"] == "RuntimeError"
+    serialized = str(failure)
+    assert "secret" not in serialized
+    assert "amqps://" not in serialized
+
+
+def test_task_metrics_handlers_are_connected() -> None:
+    # Importing celery_app must connect the success/retry/failure signal
+    # handlers so the worker emits outcome telemetry in production.
+    import proliferate.background.celery_app  # noqa: F401
+    from celery.signals import task_failure, task_retry, task_success
+
+    class _Sender:
+        name = HEALTH_NOOP_TASK
+
+    # A connected receiver returns a (receiver, response) pair when the signal
+    # fires; an unconnected signal returns an empty list.
+    assert task_success.send(sender=_Sender())
+    assert task_retry.send(sender=_Sender(), reason=RuntimeError("x"))
+    assert task_failure.send(sender=_Sender(), exception=RuntimeError("x"))

--- a/server/tests/unit/test_background_deploy_definitions.py
+++ b/server/tests/unit/test_background_deploy_definitions.py
@@ -1,0 +1,488 @@
+"""Merge-gated checks on the background-plane deployment definitions.
+
+These parse the local Compose file and the reusable server deploy workflow as
+data. They assert the invariants the frozen spec requires — every background
+process is defined locally, worker/Beat ride the exact same image as the API,
+and the hosted rollout order deploys worker+Beat before the API so a new API
+can never enqueue a task name no running worker imports.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_PATH = REPO_ROOT / "server" / "docker-compose.yml"
+DEPLOY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "_deploy-server.yml"
+
+_requires_jq = pytest.mark.skipif(
+    shutil.which("jq") is None, reason="jq is required for the deploy render-logic tests"
+)
+
+
+def _compose() -> dict[str, object]:
+    return yaml.safe_load(COMPOSE_PATH.read_text())
+
+
+def _deploy_steps() -> dict[str, dict[str, object]]:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    return {step.get("name", ""): step for step in workflow["jobs"]["deploy"]["steps"]}
+
+
+def test_compose_defines_all_background_processes() -> None:
+    services = _compose()["services"]
+    for required in ("db", "rabbitmq", "redis", "migrate", "api", "worker", "beat"):
+        assert required in services, f"compose is missing the {required} service"
+
+
+def test_compose_worker_and_beat_use_same_image_build_as_api() -> None:
+    services = _compose()["services"]
+    api_build = services["api"]["build"]
+    assert services["worker"]["build"] == api_build
+    assert services["beat"]["build"] == api_build
+    worker_command = " ".join(services["worker"]["command"])
+    beat_command = " ".join(services["beat"]["command"])
+    assert "proliferate.background.celery_app:celery_app" in worker_command
+    assert " worker" in f" {worker_command}"
+    assert "proliferate.background.celery_app:celery_app" in beat_command
+    assert " beat" in f" {beat_command}"
+
+
+def test_compose_host_ports_are_profile_overridable() -> None:
+    # Multi-worktree isolation: every published host port must be overridable
+    # via environment so two stacks never fight over a default port.
+    services = _compose()["services"]
+    for name in ("db", "rabbitmq", "redis", "api"):
+        for mapping in services[name].get("ports", []):
+            host_side = str(mapping).rsplit(":", 1)[0]
+            assert host_side.startswith("${"), (
+                f"{name} publishes fixed host port {mapping}; use an env override"
+            )
+
+
+def test_deploy_workflow_orders_worker_and_beat_before_api() -> None:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    steps = workflow["jobs"]["deploy"]["steps"]
+    names = [step.get("name", "") for step in steps]
+
+    migrations = names.index("Run Alembic migrations")
+    verify_broker = names.index("Verify broker and scheduler store")
+    deploy_background = names.index("Deploy worker and Beat from candidate image")
+    verify_background = names.index("Verify worker and Beat health")
+    candidate_proof = names.index("Prove candidate plane executes enqueued work")
+    roll_api = names.index("Roll ECS service")
+
+    # The candidate-plane EXECUTION proof runs after the worker/Beat are healthy
+    # but strictly BEFORE the API roll: a green runningCount is not enough, the
+    # plane must be proven to execute newly enqueued work before an API that can
+    # enqueue it is deployed.
+    assert (
+        migrations
+        < verify_broker
+        < deploy_background
+        < verify_background
+        < candidate_proof
+        < roll_api
+    )
+
+
+def test_candidate_proof_step_gates_on_both_services() -> None:
+    step = _deploy_steps()["Prove candidate plane executes enqueued work"]
+    condition = str(step.get("if", ""))
+    assert "ECS_WORKER_SERVICE != ''" in condition
+    assert "ECS_BEAT_SERVICE != ''" in condition
+
+
+def test_candidate_proof_covers_both_signals_and_is_resource_id_free() -> None:
+    # The proof must observe BOTH a relay heartbeat (Beat + scheduler store) and
+    # an EXACT-ID execution receipt for the row THIS deploy enqueued (worker
+    # consumed + ran that specific row), correlated by the outbox id the relay
+    # uses as the celery task id. The heartbeat rides the plane's own custom
+    # metric namespace and the exact-ID receipt is a structured log line, so the
+    # gate works identically on the managed-IDs and external-endpoint paths (no
+    # broker/store resource ID referenced).
+    run = str(_deploy_steps()["Prove candidate plane executes enqueued work"]["run"])
+    assert "RelayHeartbeat" in run
+    # Correlation is on the exact enqueued outbox id via a safe log receipt, not
+    # an aggregate success metric that a concurrent no-op could satisfy.
+    assert "background_health_receipt" in run
+    assert "recover_outbox_id" in run
+    assert "receipt_count_for_id" in run
+    assert "outbox_id" in run
+    assert "proliferate.background.enqueue_health" in run
+    # The proof key incorporates the run ATTEMPT so a rerun enqueues a FRESH row
+    # instead of colliding by idempotency key with a prior attempt's published one.
+    assert "GITHUB_RUN_ATTEMPT" in run
+    assert "FAILED CLOSED" in run
+    # The exact-ID correlation must NOT rely on the aggregate success-count
+    # metric (a different deploy's/operator's no-op could advance it).
+    assert "TaskSuccessCount" not in run
+    # No hosted broker/store resource identifiers leak into the proof: it measures
+    # the app reaching whatever endpoints are configured, not a managed resource.
+    # The server log group is derived from the environment name, not a resource ID.
+    assert "BACKGROUND_MQ_BROKER_ID" not in run
+    assert "BACKGROUND_STORE_NAME" not in run
+    assert "describe-broker" not in run
+    assert "describe-serverless-caches" not in run
+
+
+def test_deploy_workflow_uses_one_image_for_api_worker_and_beat() -> None:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    steps = {step.get("name", ""): step for step in workflow["jobs"]["deploy"]["steps"]}
+
+    background_run = steps["Deploy worker and Beat from candidate image"]["run"]
+    api_render_run = steps["Render ECS task definition"]["run"]
+    # Both the API render and the worker/Beat roll consume the single resolved
+    # IMMUTABLE digest reference; nothing re-derives a second tag.
+    assert "steps.digest.outputs.image_ref" in background_run
+    assert "steps.digest.outputs.image_ref" in api_render_run
+
+    summary_run = steps["Summarize server deploy"]["run"]
+    assert "steps.build.outputs.digest" in summary_run
+
+
+def test_deploy_pins_api_worker_and_beat_to_immutable_digest() -> None:
+    # BG4-IMAGE-01: the mutable `repo:shortsha` tag can be re-pointed after this
+    # deploy resolves it, so every task definition (API + worker + Beat) must be
+    # pinned to the immutable `repo@sha256:` digest and registration must fail
+    # closed on a mutable tag.
+    steps = _deploy_steps()
+
+    # A dedicated step resolves the immutable digest reference and rejects a
+    # non-sha256 build output.
+    digest_run = str(steps["Resolve immutable image digest"]["run"])
+    assert "steps.build.outputs.digest" in digest_run
+    assert "@${digest}" in digest_run
+    assert "sha256:*" in digest_run
+    assert "image_ref=" in digest_run
+
+    # The API render pins the server container to the digest ref and asserts the
+    # registered image is a @sha256: reference before register-task-definition.
+    api_render_run = str(steps["Render ECS task definition"]["run"])
+    assert "steps.digest.outputs.image_ref" in api_render_run
+    assert "*@sha256:*)" in api_render_run
+    assert "not an immutable @sha256: digest reference" in api_render_run
+
+    # The worker/Beat re-image step pins the candidate to the digest ref and
+    # rejects a mutable tag before rolling.
+    background_run = str(steps["Deploy worker and Beat from candidate image"]["run"])
+    assert "steps.digest.outputs.image_ref" in background_run
+    assert "*@sha256:*)" in background_run
+    assert "refusing to roll a mutable tag" in background_run
+
+    # The pre-API health check compares the live service image to the digest ref.
+    health_run = str(steps["Verify worker and Beat health"]["run"])
+    assert "steps.digest.outputs.image_ref" in health_run
+
+
+def test_background_steps_gate_on_both_worker_and_beat() -> None:
+    # Every background step (broker/store verify, worker+Beat roll, health) must
+    # gate on BOTH service names being nonempty. A step gated on only one would
+    # let a partial config skip part of the rollout while still rolling the API.
+    steps = _deploy_steps()
+    for name in (
+        "Verify broker and scheduler store",
+        "Deploy worker and Beat from candidate image",
+        "Verify worker and Beat health",
+    ):
+        condition = str(steps[name].get("if", ""))
+        assert "ECS_WORKER_SERVICE != ''" in condition, f"{name} must gate on worker service"
+        assert "ECS_BEAT_SERVICE != ''" in condition, f"{name} must gate on Beat service"
+
+
+def _run_validate_config(tmp_path: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run the deploy 'Validate server deploy config' bash body under bash.
+
+    Only the background-plane fail-closed branch is exercised; the required base
+    vars are supplied so the earlier `:?` guards pass, isolating the partial
+    background-config check.
+    """
+
+    body = str(_deploy_steps()["Validate server deploy config"]["run"])
+    script = tmp_path / "validate.sh"
+    script.write_text(body)
+    base_env = {
+        "AWS_DEPLOY_ROLE_ARN": "role",
+        "ECS_CLUSTER": "cluster",
+        "ECS_SERVER_SERVICE": "server",
+        "API_URL": "https://api",
+        "API_BASE_URL": "https://api/base",
+        "WEB_URL": "https://web",
+        "E2B_TEMPLATE_REF": "tpl",
+        "SUPPORT_FEED_SECRET_ARN": "arn:secret",
+        "SUPPORT_TRACKER_ENABLED": "false",
+        # Container names default to nonempty literals in the workflow env; the
+        # bash body reads them straight from the environment, so supply them.
+        "ECS_WORKER_CONTAINER_NAME": "worker",
+        "ECS_BEAT_CONTAINER_NAME": "beat",
+        "ECS_WORKER_SERVICE": "",
+        "ECS_BEAT_SERVICE": "",
+    }
+    base_env.update(env)
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=base_env,
+    )
+
+
+def test_validate_config_rejects_partial_background_plane(tmp_path: Path) -> None:
+    # Worker set, Beat missing: must fail closed rather than skip the rollout.
+    worker_only = _run_validate_config(tmp_path, {"ECS_WORKER_SERVICE": "worker-svc"})
+    assert worker_only.returncode != 0
+    assert "Partial background-plane configuration" in worker_only.stderr
+
+    # Beat set, worker missing: symmetric failure.
+    beat_only = _run_validate_config(tmp_path, {"ECS_BEAT_SERVICE": "beat-svc"})
+    assert beat_only.returncode != 0
+    assert "Partial background-plane configuration" in beat_only.stderr
+
+
+def test_validate_config_allows_complete_and_absent_background_plane(tmp_path: Path) -> None:
+    # Neither set: API-only deploy, background plane skipped cleanly.
+    neither = _run_validate_config(tmp_path, {})
+    assert neither.returncode == 0, neither.stderr
+
+    # Both set: complete config passes validation.
+    both = _run_validate_config(
+        tmp_path,
+        {"ECS_WORKER_SERVICE": "worker-svc", "ECS_BEAT_SERVICE": "beat-svc"},
+    )
+    assert both.returncode == 0, both.stderr
+
+
+def _container_match_count(tmp_path: Path, task_def: dict, container: str) -> int:
+    """Run the exact match-count jq the roll_service function uses."""
+
+    raw = tmp_path / "td.json"
+    raw.write_text(json.dumps(task_def))
+    proc = subprocess.run(
+        [
+            "jq",
+            "--arg",
+            "container",
+            container,
+            "[.containerDefinitions[] | select(.name == $container)] | length",
+            str(raw),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return int(proc.stdout.strip())
+
+
+@_requires_jq
+def test_roll_service_container_match_count(tmp_path: Path) -> None:
+    # The roll_service function fails closed unless exactly one container matches
+    # the configured name. Prove the match-count expression distinguishes the
+    # matched, missing, and duplicate cases so a wrong name can never register
+    # and roll the old image while reporting success.
+    task_def = {
+        "containerDefinitions": [
+            {"name": "worker", "image": "old:tag"},
+            {"name": "sidecar", "image": "other:tag"},
+        ]
+    }
+    assert _container_match_count(tmp_path, task_def, "worker") == 1
+    assert _container_match_count(tmp_path, task_def, "nonexistent") == 0
+
+    dup = {"containerDefinitions": [{"name": "worker"}, {"name": "worker"}]}
+    assert _container_match_count(tmp_path, dup, "worker") == 2
+
+
+def _write_fake_aws(bin_dir: Path, *, heartbeat: str, receipt_attempt: str) -> None:
+    """Write a fake `aws` CLI that stubs every call the proof step makes.
+
+    ECS calls return canned success (a running service with a network config, a
+    stopped task with exit code 0). `cloudwatch get-metric-statistics` returns the
+    requested RelayHeartbeat Sum. `logs filter-log-events` serves the two
+    correlation queries the proof makes, keyed to the RUN ATTEMPT so a rerun is
+    modeled faithfully:
+
+    * the enqueue-receipt recovery derives the committed outbox id from
+      ``GITHUB_RUN_ATTEMPT`` (each attempt enqueues a FRESH row, because the real
+      proof_key now includes the attempt), and emits
+      ``enqueued_health_noop outbox_id=<id> idempotency_key=<proof_key>``;
+    * the exact-ID execution-receipt count returns 1 ONLY when the queried task_id
+      equals the id for ``RECEIPT_ATTEMPT`` (the attempt whose row actually
+      executed). When ``RECEIPT_ATTEMPT`` differs from the current attempt (a
+      leftover receipt from a PRIOR attempt, or an unrelated concurrent no-op) or
+      is empty, the count is 0, so the gate must fail closed. No real AWS is
+      contacted.
+    """
+
+    script = f"""#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+attempt="${{GITHUB_RUN_ATTEMPT:-1}}"
+current_id="deadbeef-0000-4000-8000-0000000000${{attempt}}"
+receipt_attempt="${{RECEIPT_ATTEMPT:-}}"
+receipt_id=""
+if [ -n "$receipt_attempt" ]; then
+  receipt_id="deadbeef-0000-4000-8000-0000000000${{receipt_attempt}}"
+fi
+case "$args" in
+  *"ecs describe-services"*)
+    # Minimal service JSON: a network config for run-task and a task def arn.
+    cat <<'JSON'
+{{"services":[{{"taskDefinition":"arn:aws:ecs:us-east-1:1:task-definition/worker:1","runningCount":1,"networkConfiguration":{{"awsvpcConfiguration":{{"subnets":["subnet-1"],"securityGroups":["sg-1"],"assignPublicIp":"ENABLED"}}}}}}]}}
+JSON
+    ;;
+  *"ecs run-task"*)
+    echo "arn:aws:ecs:us-east-1:1:task/abc123"
+    ;;
+  *"ecs wait tasks-stopped"*)
+    exit 0
+    ;;
+  *"ecs describe-tasks"*)
+    # exitCode query -> 0 (enqueue succeeded)
+    echo 0
+    ;;
+  *"cloudwatch get-metric-statistics"*)
+    if [[ "$args" == *"RelayHeartbeat"* ]]; then
+      echo "{heartbeat}"
+    else
+      echo None
+    fi
+    ;;
+  *"logs filter-log-events"*)
+    receipt_needle="background_health_receipt.task_id = \\"${{receipt_id}}\\""
+    if [[ "$args" == *"enqueued_health_noop"* ]]; then
+      # This attempt's committed row id (fresh per attempt).
+      echo "enqueued_health_noop outbox_id=${{current_id}} idempotency_key=key"
+    elif [ -n "$receipt_id" ] && [[ "$args" == *"$receipt_needle"* ]]; then
+      # A fresh exact-ID execution receipt exists for the receipt_attempt row.
+      echo 1
+    else
+      # No receipt for the queried id.
+      echo 0
+    fi
+    ;;
+  *)
+    echo None
+    ;;
+esac
+"""
+    aws_path = bin_dir / "aws"
+    aws_path.write_text(script)
+    aws_path.chmod(0o755)
+
+
+def _run_candidate_proof(
+    tmp_path: Path,
+    *,
+    heartbeat: str,
+    receipt_attempt: str = "",
+    run_attempt: str = "1",
+    timeout_seconds: str = "2",
+) -> subprocess.CompletedProcess[str]:
+    """Execute the real 'Prove candidate plane executes enqueued work' bash body.
+
+    Runs against a fake `aws` on PATH with a short timeout and poll so the loop
+    completes quickly. This exercises the ACTUAL shell that runs in CI, not a
+    paraphrase, so the fail-closed behavior is proven on the shipped logic.
+    """
+
+    body = str(_deploy_steps()["Prove candidate plane executes enqueued work"]["run"])
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_aws(bin_dir, heartbeat=heartbeat, receipt_attempt=receipt_attempt)
+    script = tmp_path / "proof.sh"
+    script.write_text(body)
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        "DEPLOY_ENVIRONMENT": "staging",
+        "GIT_SHA": "deadbeefcafe",
+        "GITHUB_RUN_ID": "42",
+        "GITHUB_RUN_ATTEMPT": run_attempt,
+        "RECEIPT_ATTEMPT": receipt_attempt,
+        "ECS_CLUSTER": "cluster",
+        "ECS_WORKER_SERVICE": "worker-svc",
+        "ECS_BEAT_SERVICE": "beat-svc",
+        "ECS_WORKER_CONTAINER_NAME": "worker",
+        "CANDIDATE_PROOF_LOG_GROUP": "test-log-group",
+        "CANDIDATE_PROOF_TIMEOUT_SECONDS": timeout_seconds,
+        "CANDIDATE_PROOF_POLL_SECONDS": "1",
+    }
+    return subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env)
+
+
+@_requires_jq
+def test_candidate_proof_fails_closed_when_plane_does_not_execute(tmp_path: Path) -> None:
+    # No fresh datapoints for either signal: no heartbeat and no exact-ID receipt
+    # for the enqueued row. The candidate worker/Beat plane never executed the
+    # enqueued work, so the proof must FAIL CLOSED on timeout and the API roll
+    # (the next step) never runs. No receipt attempt -> no receipt exists.
+    result = _run_candidate_proof(tmp_path, heartbeat="None", receipt_attempt="")
+    assert result.returncode != 0
+    assert "FAILED CLOSED" in result.stderr
+
+
+@_requires_jq
+def test_candidate_proof_fails_closed_when_only_heartbeat_advances(tmp_path: Path) -> None:
+    # Beat/store alive (heartbeat advances) but the enqueued health no-op never
+    # executes (no matching exact-ID receipt): a broken worker consume/route path.
+    # The proof requires BOTH signals, so this still fails closed.
+    result = _run_candidate_proof(tmp_path, heartbeat="3", receipt_attempt="")
+    assert result.returncode != 0
+    assert "FAILED CLOSED" in result.stderr
+
+
+@_requires_jq
+def test_candidate_proof_fails_closed_on_unrelated_health_noop(tmp_path: Path) -> None:
+    # NEGATIVE PROOF (concurrent/unrelated): the heartbeat advances AND a FRESH
+    # exact-ID receipt exists, but only for an UNRELATED health no-op (a concurrent
+    # deploy, operator smoke, or retry) whose id differs from the row THIS run
+    # enqueued. The gate correlates on the enqueued outbox id, so the mismatch must
+    # still FAIL CLOSED — an aggregate "any success" metric would have wrongly
+    # passed here. Current attempt 1, receipt only for a different id (attempt 9).
+    result = _run_candidate_proof(tmp_path, heartbeat="2", run_attempt="1", receipt_attempt="9")
+    assert result.returncode != 0
+    assert "FAILED CLOSED" in result.stderr
+
+
+@_requires_jq
+def test_candidate_proof_fails_closed_on_rerun_with_prior_attempt_receipt(tmp_path: Path) -> None:
+    # NEGATIVE PROOF (rerun replay): a workflow RERUN. Because the proof_key now
+    # includes GITHUB_RUN_ATTEMPT, attempt 2 enqueues a FRESH row (id for attempt
+    # 2). Only the PRIOR attempt's row (attempt 1) has an execution receipt in the
+    # logs. An attempt-agnostic key would have replayed the already-published
+    # attempt-1 row and false-passed on its stale receipt; with the attempt in the
+    # key, this attempt's fresh row has no receipt, so the gate FAILS CLOSED.
+    result = _run_candidate_proof(tmp_path, heartbeat="2", run_attempt="2", receipt_attempt="1")
+    assert result.returncode != 0
+    assert "FAILED CLOSED" in result.stderr
+
+
+@_requires_jq
+def test_candidate_proof_passes_when_exact_id_receipt_and_heartbeat(tmp_path: Path) -> None:
+    # Relay heartbeat advanced AND a fresh exact-ID execution receipt exists for
+    # the EXACT row THIS attempt enqueued (receipt attempt == current attempt): the
+    # plane is proven to execute this newly enqueued work, so the proof passes and
+    # the API may roll.
+    result = _run_candidate_proof(tmp_path, heartbeat="2", run_attempt="2", receipt_attempt="2")
+    assert result.returncode == 0, result.stderr
+    assert "Candidate plane proven" in result.stdout
+
+
+def test_roll_service_asserts_registered_candidate_image() -> None:
+    # The deploy step must verify the REGISTERED task def (not just the local
+    # file) carries the candidate image on the named container before rolling,
+    # and the pre-API health step must re-check the live service image.
+    steps = _deploy_steps()
+    roll_run = str(steps["Deploy worker and Beat from candidate image"]["run"])
+    assert "found ${match_count}" in roll_run
+    assert "Registered ${service} task def" in roll_run
+
+    health_run = str(steps["Verify worker and Beat health"]["run"])
+    assert "before the API roll" in health_run
+    assert "candidate_image" in health_run

--- a/server/tests/unit/test_background_outbox.py
+++ b/server/tests/unit/test_background_outbox.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select, update
@@ -12,7 +13,11 @@ from proliferate.background.config import (
     HEALTH_NOOP_TASK,
     PERIODIC_DEFAULT_QUEUE,
 )
-from proliferate.background.relay import RelayMessage, relay_once
+from proliferate.background.relay import (
+    PUBLISH_FAILED_ERROR_MESSAGE,
+    RelayMessage,
+    relay_once,
+)
 from proliferate.db.models.background import BackgroundOutboxTask
 from proliferate.db.store.background_outbox import (
     OUTBOX_STATUS_FAILED,
@@ -20,6 +25,7 @@ from proliferate.db.store.background_outbox import (
     OUTBOX_STATUS_PUBLISHED,
     claim_due_outbox_tasks,
     enqueue_outbox_task,
+    get_outbox_backlog_snapshot,
     load_outbox_task,
     mark_outbox_task_published,
 )
@@ -193,6 +199,9 @@ async def test_relay_recovers_crash_before_publish(
 
     assert result.claimed == 1
     assert result.published == 1
+    # The claim reclaimed an expired publishing lease, so it is counted as a
+    # recovery for lease-expiry telemetry.
+    assert result.recovered == 1
     assert [message.celery_task_id for message in publisher.messages] == [str(task.id)]
     published = await _load_fresh_outbox_task(db_session, task.id)
     assert published is not None
@@ -265,8 +274,7 @@ async def test_relay_records_publish_failure_for_retry(
     result = await relay_once(
         session_factory=_session_factory(test_engine),
         publisher=FailingPublisher(),
-        retry_delay_seconds=60,
-        max_attempts=5,
+        retry_jitter_seconds=0.0,
     )
 
     failed = await _load_fresh_outbox_task(db_session, task.id)
@@ -274,14 +282,105 @@ async def test_relay_records_publish_failure_for_retry(
     assert result.published == 0
     assert result.failed == 1
     assert failed is not None
+    # Supported task -> retryable, never terminal, due time pushed into the future.
     assert failed.status == OUTBOX_STATUS_PENDING
+    assert failed.available_at > utcnow()
     db_session.expire_all()
     row = await db_session.scalar(
         select(BackgroundOutboxTask).where(BackgroundOutboxTask.id == task.id)
     )
     assert row is not None
-    assert row.last_error_code == "RuntimeError"
-    assert row.last_error_message == "broker unavailable"
+    # Stable safe code carries the exception class; the stored message is a fixed
+    # generic phrase and never the raw broker error string.
+    assert row.last_error_code == "publish_failed:RuntimeError"
+    assert row.last_error_message == PUBLISH_FAILED_ERROR_MESSAGE
+    assert "broker unavailable" not in (row.last_error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_relay_publish_error_is_secret_safe(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+) -> None:
+    secret_url = "amqp://user:sup3rsecret@broker.internal:5672/vhost"
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    await db_session.commit()
+
+    result = await relay_once(
+        session_factory=_session_factory(test_engine),
+        publisher=FailingPublisher(message=f"connection refused for {secret_url}"),
+        retry_jitter_seconds=0.0,
+    )
+
+    assert result.failed == 1
+    db_session.expire_all()
+    row = await db_session.scalar(
+        select(BackgroundOutboxTask).where(BackgroundOutboxTask.id == task.id)
+    )
+    assert row is not None
+    stored = f"{row.last_error_code} {row.last_error_message}"
+    assert secret_url not in stored
+    assert "sup3rsecret" not in stored
+    assert "amqp://" not in stored
+
+
+@pytest.mark.asyncio
+async def test_relay_supported_task_retries_beyond_five_attempts(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+) -> None:
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    await db_session.commit()
+    factory = _session_factory(test_engine)
+
+    # Drive far past the old five-attempt ceiling; a supported task must never
+    # go terminal on broker failure.
+    for _ in range(8):
+        await relay_once(
+            session_factory=factory,
+            publisher=FailingPublisher(),
+            retry_jitter_seconds=0.0,
+        )
+        # Force the row due again so the next tick reclaims it.
+        await db_session.execute(
+            update(BackgroundOutboxTask)
+            .where(BackgroundOutboxTask.id == task.id)
+            .values(available_at=utcnow() - timedelta(seconds=1))
+        )
+        await db_session.commit()
+
+    row = await db_session.scalar(
+        select(BackgroundOutboxTask).where(BackgroundOutboxTask.id == task.id)
+    )
+    assert row is not None
+    assert row.attempt_count >= 8
+    assert row.status == OUTBOX_STATUS_PENDING
+
+
+@pytest.mark.asyncio
+async def test_relay_backoff_is_capped_and_deterministic() -> None:
+    from proliferate.background.relay import compute_retry_delay_seconds
+
+    # Deterministic exponential with zero jitter: base * 2**(attempt-1).
+    no_jitter = {"jitter_seconds": 0.0, "base_seconds": 2.0, "cap_seconds": 300.0}
+    assert compute_retry_delay_seconds(1, **no_jitter) == 2.0
+    assert compute_retry_delay_seconds(2, **no_jitter) == 4.0
+    assert compute_retry_delay_seconds(4, **no_jitter) == 16.0
+    # Saturates at the cap and never overflows for huge attempt counts.
+    assert compute_retry_delay_seconds(100, **no_jitter) == 300.0
+    # Bounded jitter stays within [delay, delay + jitter).
+    delay = compute_retry_delay_seconds(
+        1, base_seconds=2.0, cap_seconds=300.0, jitter_seconds=5.0, rng=lambda: 0.5
+    )
+    assert delay == 2.0 + 5.0 * 0.5
 
 
 @pytest.mark.asyncio
@@ -310,3 +409,150 @@ async def test_relay_rejects_unknown_task_without_publishing(
     assert publisher.messages == []
     assert rejected is not None
     assert rejected.status == OUTBOX_STATUS_FAILED
+    db_session.expire_all()
+    row = await db_session.scalar(
+        select(BackgroundOutboxTask).where(BackgroundOutboxTask.id == task.id)
+    )
+    assert row is not None
+    assert row.last_error_code == "unsupported_task"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_defaults_available_at_to_now(db_session: AsyncSession) -> None:
+    before = utcnow()
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    after = utcnow()
+
+    assert task.available_at.tzinfo is not None
+    assert before <= task.available_at <= after
+
+
+@pytest.mark.asyncio
+async def test_enqueue_persists_future_available_at_unchanged(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+) -> None:
+    future = utcnow() + timedelta(hours=2)
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        available_at=future,
+    )
+    await db_session.commit()
+
+    assert task.available_at == future
+
+    # A future row is not yet due, so a relay tick claims nothing.
+    publisher = RecordingPublisher()
+    result = await relay_once(
+        session_factory=_session_factory(test_engine),
+        publisher=publisher,
+    )
+    assert result.claimed == 0
+    assert publisher.messages == []
+    still_pending = await _load_fresh_outbox_task(db_session, task.id)
+    assert still_pending is not None
+    assert still_pending.status == OUTBOX_STATUS_PENDING
+
+
+@pytest.mark.asyncio
+async def test_enqueue_normalizes_naive_available_at_to_utc(
+    db_session: AsyncSession,
+) -> None:
+    naive = datetime(2030, 1, 1, 12, 0, 0)
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        available_at=naive,
+    )
+
+    assert task.available_at == naive.replace(tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_idempotency_replay_does_not_move_due_time(
+    db_session: AsyncSession,
+) -> None:
+    original_due = utcnow() + timedelta(hours=1)
+    first = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        idempotency_key="due:once",
+        available_at=original_due,
+    )
+    # A replay with a different (earlier) due time must return the original row
+    # and leave its scheduled due time untouched.
+    second = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        idempotency_key="due:once",
+        available_at=utcnow(),
+    )
+
+    assert second.id == first.id
+    assert second.available_at == original_due
+
+
+@pytest.mark.asyncio
+async def test_concurrent_relays_skip_locked_claim_each_row_once(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+) -> None:
+    for index in range(6):
+        await enqueue_outbox_task(
+            db_session,
+            task_name=HEALTH_NOOP_TASK,
+            queue=PERIODIC_DEFAULT_QUEUE,
+            idempotency_key=f"concurrent:{index}",
+        )
+    await db_session.commit()
+    factory = _session_factory(test_engine)
+
+    async def _claim() -> tuple[str, ...]:
+        async with factory() as db, db.begin():
+            claimed = await claim_due_outbox_tasks(
+                db,
+                worker_id="concurrent",
+                limit=6,
+                lease_seconds=60,
+            )
+            return tuple(str(task.id) for task in claimed)
+
+    # Two relays racing on the same due set must partition the rows: SKIP LOCKED
+    # means no id is claimed twice and every id is claimed exactly once.
+    first, second = await asyncio.gather(_claim(), _claim())
+    claimed_ids = list(first) + list(second)
+    assert sorted(claimed_ids) == sorted(set(claimed_ids))
+    assert len(claimed_ids) == 6
+
+
+@pytest.mark.asyncio
+async def test_backlog_snapshot_reports_oldest_due_age(
+    db_session: AsyncSession,
+) -> None:
+    stale = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        available_at=utcnow() - timedelta(seconds=120),
+    )
+    await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        available_at=utcnow() + timedelta(hours=1),
+    )
+    await db_session.commit()
+
+    snapshot = await get_outbox_backlog_snapshot(db_session)
+    assert snapshot.due_pending_count == 1
+    assert snapshot.oldest_due_pending_age_seconds >= 100
+    assert stale.available_at < utcnow()

--- a/server/tests/unit/test_background_relay_surface.py
+++ b/server/tests/unit/test_background_relay_surface.py
@@ -1,0 +1,324 @@
+"""Relay-surface ownership and telemetry tests.
+
+These cover the single store-touching relay surface (``run_relay_tick``), the
+bounded per-family backlog gauge, and the server store law that the thin Beat
+task wrapper never imports a store. Split from ``test_background_outbox.py``
+solely to satisfy the repo-shape 600-line source cap (``check_max_lines.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from proliferate.background.config import (
+    DEFAULT_QUEUE,
+    HEALTH_NOOP_TASK,
+    PERIODIC_DEFAULT_QUEUE,
+)
+from proliferate.background.relay import (
+    SUPPORTED_OUTBOX_TASKS,
+    RelayMessage,
+    relay_once,
+    run_relay_tick,
+)
+from proliferate.db.store.background_outbox import (
+    OUTBOX_STATUS_PENDING,
+    OUTBOX_STATUS_PUBLISHED,
+    OUTBOX_STATUS_PUBLISHING,
+    enqueue_outbox_task,
+    get_outbox_backlog_snapshot,
+    load_outbox_task,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _session_factory(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(test_engine, expire_on_commit=False)
+
+
+@pytest.mark.asyncio
+async def test_backlog_snapshot_reports_supported_pending_by_family(
+    db_session: AsyncSession,
+) -> None:
+    # Two pending health-noop rows plus one committed unsupported name. The
+    # per-family breakdown reports only allowlisted families and never widens to
+    # the unsupported task name, keeping the emitted metric low-cardinality.
+    for index in range(2):
+        await enqueue_outbox_task(
+            db_session,
+            task_name=HEALTH_NOOP_TASK,
+            queue=PERIODIC_DEFAULT_QUEUE,
+            idempotency_key=f"family:noop:{index}",
+        )
+    await enqueue_outbox_task(
+        db_session,
+        task_name="background.not.enabled",
+        queue=DEFAULT_QUEUE,
+        idempotency_key="family:unsupported",
+    )
+    await db_session.commit()
+
+    snapshot = await get_outbox_backlog_snapshot(
+        db_session,
+        supported_task_names=SUPPORTED_OUTBOX_TASKS,
+    )
+    assert snapshot.supported_pending_by_family == {HEALTH_NOOP_TASK: 2}
+    assert "background.not.enabled" not in snapshot.supported_pending_by_family
+
+
+@pytest.mark.asyncio
+async def test_run_relay_tick_publishes_and_snapshots(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # run_relay_tick is the single relay-owned surface the thin task calls: it
+    # drains a batch and reads the backlog, returning already-safe fields. The
+    # publisher is stubbed here (no broker) but the store path is real.
+    from proliferate.background import relay as relay_module
+
+    published: list[str] = []
+    monkeypatch.setattr(
+        relay_module.CeleryTaskPublisher,
+        "publish",
+        lambda self, message: published.append(message.celery_task_id),
+    )
+
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    await db_session.commit()
+
+    tick = await run_relay_tick(session_factory=_session_factory(test_engine))
+
+    assert published == [str(task.id)]
+    assert tick.claimed == 1
+    assert tick.published == 1
+    assert tick.failed == 0
+    assert tick.supported_pending_by_family == {HEALTH_NOOP_TASK: 0}
+
+
+def test_task_wrapper_never_imports_store() -> None:
+    # Server store law: background/relay.py is the only background module that
+    # touches a store; the thin task wrapper must not import db.store at all.
+    source = (
+        REPO_ROOT / "server" / "proliferate" / "background" / "tasks" / "relay.py"
+    ).read_text()
+    assert "db.store" not in source
+    assert "background_outbox" not in source
+
+
+def test_relay_publisher_stamps_broker_publish_timestamp() -> None:
+    # OBS-01(c): the relay stamps the broker-publish wall-clock time as a Celery
+    # header so the worker can emit a broker-residence age (the achievable
+    # "Celery queue oldest task age" signal). Confirm the header is sent and
+    # parses back to a finite epoch value.
+    from proliferate.background import relay as relay_module
+    from proliferate.background.config import BACKGROUND_PUBLISH_TS_HEADER
+    from proliferate.background.task_metrics import parse_publish_timestamp
+
+    captured: dict[str, object] = {}
+
+    class _App:
+        def send_task(self, name: str, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    publisher = relay_module.CeleryTaskPublisher(app=_App())
+    message = relay_module.RelayMessage(
+        outbox_id=__import__("uuid").uuid4(),
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+        celery_task_id="cid",
+        args=(),
+        kwargs={},
+        publish_claim_id=__import__("uuid").uuid4(),
+    )
+    publisher.publish(message)
+
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    stamped = parse_publish_timestamp(headers[BACKGROUND_PUBLISH_TS_HEADER])
+    assert stamped is not None and stamped > 0
+
+
+def test_build_queue_age_metric_is_safe_and_bounded() -> None:
+    from proliferate.background.task_metrics import (
+        build_queue_age_metric,
+        parse_publish_timestamp,
+    )
+
+    payload = build_queue_age_metric(HEALTH_NOOP_TASK, 12.3456)
+    assert payload == {
+        "background_queue_age": {
+            "task_name": HEALTH_NOOP_TASK,
+            "age_seconds": 12.346,
+        }
+    }
+    # Negative clock skew clamps to zero rather than emitting a bogus negative age.
+    assert (
+        build_queue_age_metric(HEALTH_NOOP_TASK, -5.0)["background_queue_age"]["age_seconds"]
+        == 0.0
+    )
+    # Malformed/absent stamps are ignored, never raise or emit a bogus age.
+    assert parse_publish_timestamp(None) is None
+    assert parse_publish_timestamp("not-a-float") is None
+    assert parse_publish_timestamp("inf") is None
+    assert parse_publish_timestamp("123.5") == 123.5
+
+
+def test_task_prerun_emits_queue_age_from_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The worker task_prerun handler reads the stamped header off task.request and
+    # emits a broker-residence age line. A task with no stamp emits nothing.
+    import time as _time
+
+    from proliferate.background import task_metrics
+    from proliferate.background.config import BACKGROUND_PUBLISH_TS_HEADER
+
+    emitted: list[str] = []
+    monkeypatch.setattr(task_metrics._metrics_logger, "info", emitted.append)
+    monkeypatch.setattr(_time, "time", lambda: 1000.0)
+
+    class _Request:
+        def __init__(self, headers: dict[str, str]) -> None:
+            self._headers = headers
+
+        def get(self, key: str) -> object:
+            return self._headers.get(key)
+
+    class _Task:
+        name = HEALTH_NOOP_TASK
+
+        def __init__(self, headers: dict[str, str]) -> None:
+            self.request = _Request(headers)
+
+    task_metrics._on_task_prerun(task=_Task({BACKGROUND_PUBLISH_TS_HEADER: "990.0"}))
+    assert len(emitted) == 1
+    payload = __import__("json").loads(emitted[0])
+    assert payload["background_queue_age"]["task_name"] == HEALTH_NOOP_TASK
+    assert payload["background_queue_age"]["age_seconds"] == 10.0
+
+    emitted.clear()
+    task_metrics._on_task_prerun(task=_Task({}))
+    assert emitted == []
+
+
+def test_celery_publisher_passes_bounded_confirm_timeout_to_send_task() -> None:
+    # BG4-PUBLISH-CONFIRM-01: the publisher must publish under confirm semantics.
+    # It threads the app's configured bounded confirm_timeout to send_task so an
+    # unconfirmed publish (nack/timeout/ambiguity) raises instead of returning as
+    # if durably accepted.
+    from proliferate.background import relay as relay_module
+
+    captured: dict[str, object] = {}
+
+    class _Conf:
+        broker_transport_options = {"confirm_publish": True, "confirm_timeout": 7.5}
+
+    class _App:
+        conf = _Conf()
+
+        def send_task(self, name: str, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    publisher = relay_module.CeleryTaskPublisher(app=_App())
+    publisher.publish(
+        RelayMessage(
+            outbox_id=__import__("uuid").uuid4(),
+            task_name=HEALTH_NOOP_TASK,
+            queue=PERIODIC_DEFAULT_QUEUE,
+            celery_task_id="cid",
+            args=(),
+            kwargs={},
+            publish_claim_id=__import__("uuid").uuid4(),
+        )
+    )
+    assert captured["confirm_timeout"] == 7.5
+
+
+@pytest.mark.asyncio
+async def test_relay_confirm_nack_drives_row_to_retry_not_published(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+) -> None:
+    # BG4-PUBLISH-CONFIRM-01: a broker NACK / confirm-timeout surfaces from the
+    # publisher as the confirm-ambiguity exception. The relay must route it to the
+    # retry path (row back to pending, due in the future) and NEVER mark it
+    # published on an unconfirmed publish.
+    from amqp.exceptions import MessageNacked
+
+    class _NackingPublisher:
+        def publish(self, message: RelayMessage) -> None:
+            raise MessageNacked("broker refused to durably accept the publish")
+
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    await db_session.commit()
+
+    result = await relay_once(
+        session_factory=_session_factory(test_engine),
+        publisher=_NackingPublisher(),
+        retry_jitter_seconds=0.0,
+    )
+
+    assert result.published == 0
+    assert result.failed == 1
+    db_session.expire_all()
+    row = await load_outbox_task(db_session, task.id)
+    assert row is not None
+    # Retryable, not published: an unconfirmed publish must stay claimable.
+    assert row.status == OUTBOX_STATUS_PENDING
+
+
+@pytest.mark.asyncio
+async def test_relay_confirmed_publish_with_failed_db_mark_stays_claimable(
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # BG4-PUBLISH-CONFIRM-01 at-least-once contract: if the broker CONFIRMS the
+    # publish but the subsequent DB mark_published write fails, the row must NOT
+    # be lost — it stays in `publishing` with its lease, so a later tick reclaims
+    # and re-publishes it (a duplicate is expected and acceptable).
+    from proliferate.background import relay as relay_module
+
+    published: list[str] = []
+
+    class _ConfirmingPublisher:
+        def publish(self, message: RelayMessage) -> None:
+            published.append(message.celery_task_id)
+
+    async def _boom(*_args: object, **_kwargs: object) -> bool:
+        raise RuntimeError("db write failed after confirmed publish")
+
+    monkeypatch.setattr(relay_module, "mark_outbox_task_published", _boom)
+
+    task = await enqueue_outbox_task(
+        db_session,
+        task_name=HEALTH_NOOP_TASK,
+        queue=PERIODIC_DEFAULT_QUEUE,
+    )
+    await db_session.commit()
+
+    with pytest.raises(RuntimeError, match="db write failed"):
+        await relay_once(
+            session_factory=_session_factory(test_engine),
+            publisher=_ConfirmingPublisher(),
+        )
+
+    # The publish was confirmed once; the row stays claimable (publishing lease),
+    # so it is neither lost nor marked published on a failed DB write.
+    assert published == [str(task.id)]
+    db_session.expire_all()
+    row = await load_outbox_task(db_session, task.id)
+    assert row is not None
+    assert row.status == OUTBOX_STATUS_PUBLISHING
+    assert row.status != OUTBOX_STATUS_PUBLISHED

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -49,6 +49,77 @@ fails if enabled before a canonical worker service and command exist.
 
 See the [Hosted procedure](../../../../developing/deploying/hosted.md).
 
+### Background plane topology
+
+`_deploy-server.yml` builds one exact-SHA server image that the API, the Celery
+worker, and the Celery Beat scheduler all run. Its rollout order is migrations →
+broker/scheduler-store verify → worker + Beat → worker/Beat health (which also
+asserts the running task definitions carry the candidate image) → candidate-plane
+execution proof → API roll. This ordering guarantees a newly rolled API never
+enqueues a task name that no running worker can import.
+
+Resource health is not sufficient on its own — a `runningCount` of 1 does not
+prove the plane can execute work (broker credentials, task routing, worker
+task-registry import, RedBeat state, or relay publish/consume could all be
+broken while the container is up). Before the API rolls, the workflow enqueues
+one committed health no-op — keyed to this exact run and run-attempt, so a rerun
+enqueues a fresh row rather than replaying a prior attempt's already-published
+one — via a one-off task on the candidate worker task definition, then observes
+BOTH a fresh relay-heartbeat advance (Beat dispatched `background.relay` and a
+worker ran it, so the scheduler store and broker are reachable) AND an
+**exact-id** execution receipt for that specific enqueued row. The receipt is a
+structured log line the health task emits on success carrying its own task id
+(which the relay sets equal to the enqueued outbox id); the gate matches on that
+id, so an aggregate success count advanced by a concurrent deploy, an operator
+smoke, or a retry does **not** satisfy it — only execution of the row this
+attempt enqueued does. It **fails closed** on timeout. The heartbeat rides the
+plane's own CloudWatch metric namespace (`Proliferate/Background/<env>`) and the
+receipt is read from the server log group (derived from the environment name), so
+the proof references no broker/store resource ID and the identical gate covers
+both the managed-AWS-IDs path and the external-endpoint rebind path.
+
+The worker/Beat rollout is **conditional and fails closed as a set**. It runs
+only when both the worker and Beat service names are configured on the
+environment; a partial configuration (one set, the other empty) aborts the whole
+deploy rather than silently skipping the background plane and rolling the API
+alone. When neither is configured, the workflow deploys the API exactly as
+before. The re-image step also asserts that exactly one container matches each
+configured name and that the registered task definition carries the candidate
+image, so a mistyped container name fails closed instead of rolling the old
+image.
+
+`server/infra/background.tf` (Amazon MQ RabbitMQ broker, ElastiCache Serverless
+Valkey scheduler store, and the worker/Beat ECS services, task definitions,
+metric filters, and alarms) is a set of **checked-in definitions only**. Both
+Terraform stages gate on `count` flags that default to disabled, and the deploy
+workflow's background steps are inert until the service names are set. These
+definitions are **not a description of current live operating infrastructure**:
+no hosted background broker, scheduler store, or worker/Beat service is asserted
+to exist from their presence in the tree. Enabling the Terraform stages
+(provisioning the plane or rebinding to existing managed endpoints), setting the
+deploy environment's worker/Beat variables, and running the staging outbox smoke
+are **separate, individually gated actions** outside the merge of these
+definitions. `background_services_enabled = true` fails at Terraform plan time
+(a variable validation proven by `server/infra/tests/background_plane.tftest.hcl`
+under a mocked provider) unless either the managed broker/store stage is enabled
+or both external endpoint secret ARNs are supplied, so the services can never be
+created without a reachable broker/store.
+
+The plane's telemetry distinguishes two age/latency signals:
+`OutboxOldestDuePendingAgeSeconds` measures a row's pre-publish wait in Postgres
+(the SLO signal, a truthful current-oldest gauge), while
+`TaskBrokerResidenceLatencySeconds` measures how long a task waited in RabbitMQ
+between relay publish and worker consume. The latter is a **lagging** per-task
+latency observed only on consume: it goes silent exactly when consumption stalls,
+so it is **not** a truthful "current oldest queued-task age". Amazon MQ exposes no
+native oldest-message-age metric, so current-oldest-queued-age is not available
+from this substrate; broker backlog is instead covered by the `AWS/AmazonMQ`
+`MessageCount` depth alarm, which does not go silent when workers stop consuming.
+Desired-vs-running worker/Beat
+alarms query `RunningTaskCount` in `ECS/ContainerInsights` (Container Insights is
+enabled on the cluster), and the task-outcome metric filters carry `task_name`
+(and, for retries/failures, safe `error_code`) dimensions.
+
 ### Release coordinators
 
 The scheduled or manually dispatched nightly train detects changes since the
@@ -103,7 +174,7 @@ gate.
 | `_deploy-e2b.yml` | Reusable only | Build and/or promote one immutable E2B template into a rolling environment tag; the smoke proves the three runtime binaries report the canonical version and carry the stamped source SHA before the rolling tag moves. |
 | `_deploy-litellm.yml` | Reusable only | Build and roll the LiteLLM ECS service when its environment switch is enabled. |
 | `_deploy-mobile.yml` | Reusable only | Run the selected EAS build and optional submit lane when enabled. |
-| `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, roll ECS, and verify health. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, and preserves the support-feed secret, all asserted before registration. |
+| `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, conditionally roll the Celery worker and Beat before the API, roll the API, and verify health. API, worker, and Beat are all pinned to the one candidate image by its **immutable `repo@sha256:` digest** (resolved from the build/push output), never a mutable tag, so all three planes run the byte-identical image and a later tag move cannot change what a rolled service runs. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, and preserves the support-feed secret, all asserted before registration. |
 | `_deploy-web.yml` | Reusable only | Deploy and verify the selected Vercel web surface. |
 | `_deploy-workers.yml` | Reusable only | Report the disabled Worker lane, or fail if enabled before a canonical deploy exists. |
 

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -87,6 +87,12 @@
   description: Soft Celery task execution limit in seconds
   tags: [local-dev, self-hosted, production]
 
+- name: CELERY_BROKER_CONFIRM_TIMEOUT_SECONDS
+  secret: false
+  default: "10.0"
+  description: Bounded wait (seconds) for RabbitMQ publisher confirms; the relay publishes under confirm mode so a nack, confirm timeout, or connection ambiguity raises and the outbox row stays retryable instead of being marked published on an unconfirmed write
+  tags: [local-dev, self-hosted, production]
+
 - name: REDBEAT_REDIS_URL
   secret: true
   default: "redis://127.0.0.1:6379/0"
@@ -98,6 +104,48 @@
   default: "redbeat:proliferate:"
   description: Redis key prefix for redbeat scheduler metadata
   tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_INTERVAL_SECONDS
+  secret: false
+  default: "1.0"
+  description: Beat interval for the background.relay outbox-drain task
+  tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_BATCH_SIZE
+  secret: false
+  default: "50"
+  description: Maximum outbox rows claimed per relay tick
+  tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_LEASE_SECONDS
+  secret: false
+  default: "60.0"
+  description: Publishing lease duration for a claimed outbox row before another relay may reclaim it
+  tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_RETRY_BASE_SECONDS
+  secret: false
+  default: "2.0"
+  description: Base delay for capped exponential backoff on supported-task broker publish failures
+  tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_RETRY_CAP_SECONDS
+  secret: false
+  default: "300.0"
+  description: Maximum backoff delay between relay republication attempts
+  tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_RETRY_JITTER_SECONDS
+  secret: false
+  default: "5.0"
+  description: Upper bound of additive random jitter on relay retry delay
+  tags: [local-dev, self-hosted, production]
+
+- name: BACKGROUND_RELAY_OLDEST_DUE_SLO_SECONDS
+  secret: false
+  default: "300.0"
+  description: Alarm threshold for the oldest due-but-unpublished outbox row age (background-plane SLO)
+  tags: [self-hosted, production]
 
 - name: CORS_ALLOW_ORIGINS
   secret: false


### PR DESCRIPTION
## Exact-head merge handoff — supersedes stale SHA/status statements below

- Reviewed base: `d12295d7ec9a01d4beed3494baed05efe8690cd9`; current `main` composition through `6c017c47353b16b12107608de3d46a4f22920ffe` was independently reviewed as non-conflicting.
- Exact stable head: `9e3a1880be3242958be422efba7eb403cb216ba8`.
- Mapped Workflow CONTROL: `CONTROL_CLEAN` at that exact head, review 4715831742; no open blocker/material IDs.
- `BG4-OBS-02` disposition (b) is founder-approved in comment 4993833279: consumed-task residence latency plus Amazon MQ queue depth, with no native oldest-message-age claim.
- Exact-head CI, Server CI, Intent Tests, CodeQL, Self-Host Smoke, Terraform, repository-shape, and documentation proofs are green; path-inapplicable jobs skipped.
- Hosted infrastructure remains definitions-only and disabled by default. Post-merge staging execution/provisioning is still the separately gated operational acceptance step; no production enablement or deployment is authorized by this merge.

## Frozen spec

`specs` custody: **4 - Durable Background Runtime Foundation** (FROZEN RC1.0, founder full-delivery grant 2026-07-15). Independent infrastructure slice; NOT part of the 2b/slice-3 stack.

Base SHA: `1b757494f118dc4d7c1706cee6ab9328d141b8d4` (current `main` tip, includes merged 5a #1245; rebased per BG4-CUSTODY-02)
Head SHA: `7c1fb89b1c96b7a3c95e5fc3feb96012e29c6a56` (single scoped commit; `git diff --check` clean)

## What this delivers

A committed supported outbox row is eventually published to the broker and executed by an independently deployed Celery worker, surviving process restart, lease expiry, broker outage, and publish/ack loss. Proof task is the existing health no-op; no Workflow business behavior is added.

- **Delayed enqueue** — `enqueue_outbox_task(available_at=...)`: omission = now, supplied time persisted after UTC normalization, idempotency-key replay never reschedules.
- **Indefinite capped-backoff retry** for supported committed tasks (no attempt ceiling); unsupported task names go terminal (`failed`/`unsupported_task`) and never publish. Secret-safe bounded error codes/messages (no broker URLs, credentials, payloads, or raw exception strings persisted).
- **Beat relay task** — thin `background.relay` drives one bounded `relay_once` batch per tick and exits; exactly one Beat relay schedule entry; no in-process infinite loop.
- **Separate API / worker / Beat** on the same immutable image digest; deploy workflow orders migrations → broker/store verify → worker+Beat → health → **candidate-plane execution proof** → API roll, and records image digest + task-def revisions in its summary.
- **Metrics + alarms** — low-cardinality relay metrics, CloudWatch metric filters/alarms, **5-minute reviewable default SLO** on oldest due-but-unpublished outbox age.

## Round 3 fixes (authoritative CONTROL rollup, this revision)

- **BG4-PUBLISH-CONFIRM-01** — Broker publish now uses **publisher confirms**: `broker_transport_options={"confirm_publish": True, "confirm_timeout": <celery_broker_confirm_timeout_seconds>}` (new setting, default 10.0, rejects ≤0). py-amqp's `basic_publish_confirm` raises `MessageNacked` on nack/timeout, which lands in the relay's existing publish-exception path → `_mark_failed(terminal=False)` → capped-backoff retry. A broker that accepts the publish but whose DB mark fails keeps the row claimable (at-least-once duplicate preserved). 9 targeted tests incl. nack→retry and confirmed-publish-with-failed-mark-stays-claimable.
- **BG4-DEPLOY-PROOF-CORRELATION-01** — The candidate-plane proof no longer accepts aggregate health-task success. The relay uses the **outbox row id as the Celery task id**; the health no-op is `bind=True` and logs an exact-ID JSON receipt (`{"background_health_receipt": {"task_id": "<uuid>", "status": "ok"}}`); the deploy step captures the enqueued `outbox_id` and gates on a fresh RelayHeartbeat AND a CloudWatch Logs receipt for **that exact id** (task_id kept OUT of metric dimensions — no per-run cardinality). The proof/idempotency key includes **`GITHUB_RUN_ATTEMPT`** (`deploy-${GIT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`), so a workflow rerun enqueues a fresh row instead of false-passing on a prior attempt's already-executed row. Bash executed under a run-attempt-aware fake `aws`: rerun-with-stale-receipt FAILS CLOSED; unrelated-concurrent-noop FAILS CLOSED; exact-ID receipt + heartbeat passes.
- **BG4-IMAGE-01** — A "Resolve immutable image digest" step converts the build/push `sha256:` digest into `repo@sha256:...` (rejects non-sha256 build output); the API task-def render, the worker/Beat re-image, and the pre-API health verify all pin to that digest ref instead of the mutable short-SHA tag, with fail-closed `@sha256:` guards before both the API render and the worker/Beat roll.
- **BG4-OBS-02** — **Truthfulness fix (disposition b: reframe, not fabricate).** Amazon MQ (RabbitMQ) exposes no native oldest-message-age metric, so the `task_prerun` surface is a **lagging per-task consume-time latency** that goes silent when consumption stalls — it is NOT a current oldest-queued-age. Renamed `QueueBrokerResidenceAgeSeconds` → **`TaskBrokerResidenceLatencySeconds`** and reframed every code comment/docstring + the delivery README to say exactly that; current backlog is attributed to the existing `AWS/AmazonMQ MessageCount` depth alarm (which does not go silent). ⚠️ **Founder-ratification flag:** the frozen spec listed a "Celery queue oldest task age" signal; the substrate cannot truthfully provide it. This PR reframes to the lagging latency + depth alarm rather than inventing a spec amendment — needs founder sign-off at review.
- **BG4-LOCAL-02** — The Makefile's independent inline `sed` DATABASE_URL rewrite is gone; `make run BACKGROUND=1` now routes through a shared `node scripts/dev.mjs background-db-url` subcommand backed by the same helper the launcher test exercises. A bounded, Docker-free test slices the REAL `background_mode` branch out of the `run:` recipe and executes it (compose-up line neutralized): positive profile-DB rewrite, fail-closed on DATABASE_URL override, fail-closed on unallocated profile broker port.
- **BG4-CUSTODY-02** — Rebased onto current main (`1b757494f`, post-5a). Clean rebase; single scoped commit preserved.
- **BG4-HANDOFF-02** — Delivery README's candidate-proof paragraph now states the exact-ID execution receipt gate (aggregate success does not satisfy it) and the truthful telemetry framing; `_deploy-server.yml` row documents digest pinning.

## Round 2 CONTROL fixes (retained)

- **BG4-DEPLOY-01** — bounded candidate-plane execution proof before the API roll (fails closed on timeout; covers managed-AWS-IDs and external-endpoint rebind paths identically).
- **BG4-OBS-01(a)** — worker/Beat desired-vs-running alarms query `RunningTaskCount` in `ECS/ContainerInsights`.
- **BG4-OBS-01(b)** — task-outcome metric filters declare dimensions (`task_name`, `error_code`).
- **BG4-OBS-01(c)** — broker-residence telemetry via publish-timestamp header + `task_prerun` handler (now truthfully named/framed per OBS-02 above).
- **BG4-IAC-02** — plan-time variable validation: enabling background services requires the managed stage OR both external endpoint secret ARNs; `terraform test` proves both valid and both invalid-partial combos.
- **BG4-LOCAL-01** — worker/Beat point at the actual selected profile DB; profile-scoped broker/store host ports.

## Definitions only — NO live provisioning

`server/infra/background.tf` (Amazon MQ RabbitMQ + ElastiCache Serverless Valkey) and the `server/docker-compose.yml` / `Makefile` compose profiles are **DEFINITIONS ONLY**. No `terraform apply`, no AWS calls, no live infra was created from this PR. Both Terraform stages gate behind `count` flags defaulting to `false`, and the deploy workflow's background steps are inert until the worker/Beat service names are set. Founder may rebind to existing managed endpoints via the `*_secret_arn` overrides. TLS-only (AMQPS 5671 / rediss), per-environment isolation.

## Verification (all green at head `7c1fb89b1`)

- **Background tests: 67 passed** (real Postgres) — `tests/unit/test_background_{celery,outbox,relay_surface,deploy_definitions}.py`, `tests/integration/background/`, plus `tests/integration/test_support_feed_deploy_render.py` (9) proving the shared deploy-render surface is untouched. Covers publisher confirms (nack→retry, confirm-then-mark-fail stays claimable), the run-attempt-aware exact-ID candidate proof (rerun fail-closed, unrelated-noop fail-closed, exact-receipt pass), digest pinning across all three planes, delayed/immediate `availableAt`, idempotency replay, SKIP LOCKED concurrency, lease expiry, stale claim ID, capped backoff, unsupported→terminal, secret-safe errors, one relay Beat entry, and deploy ordering.
- **Launcher-config proof:** `node --test scripts/dev-background-launch.test.mjs` — **3 passed** (shared dev.mjs rewrite — no inline sed; real recipe-line execution positive + two fail-closed negatives).
- **Terraform:** `terraform 1.9.8` `fmt -check` clean, `validate` success, **`terraform test` 4/4 pass**. CI runs all four.
- **`ruff check proliferate/ tests/`** clean; **`ruff format --check`** clean on every edited Python file.
- **YAML:** `_deploy-server.yml` + `ci.yml` parse clean; `node --check scripts/dev.mjs` clean.
- **Repo-shape checkers all green:** `check_server_boundaries`, `check_max_lines`, `check_frontend_boundaries`, `report_frontend_structure --strict`, `check_anyharness_boundaries`, `check_migration_heads`.

## Deferred / assumptions

- **Staging smoke deferred** to the post-merge deploy gate (a draft PR cannot deploy). The same-image local Compose smoke from round 2 is the merge-gated substitute.
- **BG4-OBS-02 disposition (b)** is a contract-language reconciliation requiring founder ratification (flagged above); no spec amendment was invented.
- **BG4-IMAGE-01** derives the digest as `${registry}/${ECR_SERVER_REPOSITORY}@${steps.build.outputs.digest}` — assumes the docker build-push-action `digest` output is the repository image digest (standard for that action).
- The OBS-02 metric rename changes CloudWatch metric/filter names; grep confirms no in-repo dashboard/alarm references the old name.
- No schema migration was needed — the `available_at` column already exists on the outbox table.
- Founder decisions (substrate provider approval / rebind to existing managed endpoints, one Beat + scalable workers, indefinite retry, SLO threshold) are reversible at review and flagged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

