### PR TITLE
feat(cloud): cloud workspace identity for repository and scratch (slice 5a)

### DIFF
--- a/apps/mobile/src/components/chat/MobileChatScreen.tsx
+++ b/apps/mobile/src/components/chat/MobileChatScreen.tsx
@@ -239,7 +239,7 @@ export function MobileChatScreen({
   const subtitle = workspace?.repo
     ? `${workspace.repo.owner}/${workspace.repo.name}`
     : chat.repoLabel;
-  const branchLabel = workspace?.repo.branch ?? workspace?.repo.baseBranch ?? chat.branchLabel;
+  const branchLabel = workspace?.repo?.branch ?? workspace?.repo?.baseBranch ?? chat.branchLabel;
   const commandMessage =
     pendingPromptStatus ??
     (!session && !canStartNewSession ? workspaceHarnessAvailability.message : null) ??

--- a/apps/mobile/src/components/sessions/MobileSessionsScreen.tsx
+++ b/apps/mobile/src/components/sessions/MobileSessionsScreen.tsx
@@ -112,12 +112,12 @@ function cloudChatForSession(
     "sessionId" | "targetId" | "workspaceId" | "title" | "status"
   >,
 ): MobileCloudChat {
-  const workspaceName = workspace.displayName ?? workspace.repo.name;
+  const workspaceName = workspace.displayName ?? workspace.repo?.name ?? "Workspace";
   return {
     workspaceId: workspace.id,
     workspaceName,
-    repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
-    branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+    repoLabel: workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "",
+    branchLabel: workspace.repo?.branch ?? workspace.repo?.baseBranch ?? "main",
     targetId: session.targetId ?? workspace.targetId ?? null,
     workspaceRuntimeId: session.workspaceId ?? null,
     sessionId: session.sessionId,
@@ -141,7 +141,7 @@ function sessionProjectionFromSummary(
     sessionId: session.sessionId,
     targetId: session.targetId,
     workspaceId: session.workspaceId ?? workspace.anyharnessWorkspaceId ?? workspace.id,
-    title: session.title ?? workspace.displayName ?? workspace.repo.name,
+    title: session.title ?? workspace.displayName ?? workspace.repo?.name ?? "Workspace",
     status: session.status,
     lastEventSeq: 0,
     lastEventAt: session.lastEventAt ?? null,

--- a/apps/mobile/src/hooks/home/workflows/use-mobile-home-launch-actions.ts
+++ b/apps/mobile/src/hooks/home/workflows/use-mobile-home-launch-actions.ts
@@ -71,13 +71,13 @@ export function useMobileHomeLaunchActions(input: {
       input.onSubmitted?.();
       input.onOpenChat({
         workspaceId: workspace.id,
-        workspaceName: workspace.displayName ?? workspace.repo.name,
-        repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
-        branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+        workspaceName: workspace.displayName ?? workspace.repo?.name ?? "Workspace",
+        repoLabel: workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "",
+        branchLabel: workspace.repo?.branch ?? workspace.repo?.baseBranch ?? "main",
         targetId: workspace.targetId ?? null,
         workspaceRuntimeId: workspace.anyharnessWorkspaceId ?? null,
         sessionId: null,
-        title: workspace.displayName ?? workspace.repo.name,
+        title: workspace.displayName ?? workspace.repo?.name ?? "Workspace",
         status: workspace.workspaceStatus ?? workspace.status,
         visibility: workspace.visibility,
         initialPendingPrompt: pendingPrompt,

--- a/apps/mobile/src/hooks/work/derived/use-mobile-work-inventory.ts
+++ b/apps/mobile/src/hooks/work/derived/use-mobile-work-inventory.ts
@@ -74,13 +74,13 @@ export function mobileCloudChatForWorkspace(
   const session = workspace.lastSessionSummary;
   return {
     workspaceId: workspace.id,
-    workspaceName: workspace.displayName ?? session?.title ?? workspace.repo.name,
-    repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
-    branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+    workspaceName: workspace.displayName ?? session?.title ?? workspace.repo?.name ?? "Workspace",
+    repoLabel: workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "",
+    branchLabel: workspace.repo?.branch ?? workspace.repo?.baseBranch ?? "main",
     targetId: session?.targetId ?? workspace.targetId ?? null,
     workspaceRuntimeId: session?.workspaceId ?? cloudWorkspaceRuntimeId(workspace),
     sessionId: item?.defaultSessionId ?? session?.sessionId ?? null,
-    title: session?.title ?? item?.title ?? workspace.displayName ?? workspace.repo.name,
+    title: session?.title ?? item?.title ?? workspace.displayName ?? workspace.repo?.name ?? "Workspace",
     status: session?.status ?? workspace.workspaceStatus ?? workspace.status,
     visibility: workspace.visibility,
   };

--- a/apps/mobile/src/lib/domain/shell/mobile-shell-navigation.ts
+++ b/apps/mobile/src/lib/domain/shell/mobile-shell-navigation.ts
@@ -107,13 +107,13 @@ export function mobileLinkedChatForWorkspace(
     : sortedSessions[0] ?? null;
   return {
     workspaceId: workspace.id,
-    workspaceName: workspace.displayName ?? workspace.repo.name,
-    repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
-    branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+    workspaceName: workspace.displayName ?? workspace.repo?.name ?? "Workspace",
+    repoLabel: workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "",
+    branchLabel: workspace.repo?.branch ?? workspace.repo?.baseBranch ?? "main",
     targetId: session?.targetId ?? workspace.targetId ?? null,
     workspaceRuntimeId: session?.workspaceId ?? workspace.anyharnessWorkspaceId ?? null,
     sessionId: session?.sessionId ?? null,
-    title: session?.title ?? workspace.displayName ?? workspace.repo.name,
+    title: session?.title ?? workspace.displayName ?? workspace.repo?.name ?? "Workspace",
     status: session?.status ?? workspace.workspaceStatus ?? workspace.status,
     visibility: workspace.visibility,
   };

--- a/apps/packages/product-client/src/hooks/automations/derived/use-automation-target-selection.ts
+++ b/apps/packages/product-client/src/hooks/automations/derived/use-automation-target-selection.ts
@@ -54,10 +54,19 @@ export function useAutomationTargetSelection({
   );
   const scopedCloudWorkspaces = isOrganization ? EMPTY_CLOUD_WORKSPACES : cloudWorkspaces;
   const effectiveRepoConfigs = isOrganization ? EMPTY_REPO_CONFIGS : repoConfigs;
+  // Automation targets are repository-only: scratch workspaces (repo = null)
+  // are never target candidates.
+  const repositoryCloudWorkspaces = useMemo(
+    () => scopedCloudWorkspaces.filter(
+      (workspace): workspace is typeof workspace & { repo: NonNullable<typeof workspace.repo> } =>
+        workspace.repo != null,
+    ),
+    [scopedCloudWorkspaces],
+  );
 
   const targetState = useMemo(() => buildAutomationTargetState({
     repoConfigs: effectiveRepoConfigs,
-    cloudWorkspaces: scopedCloudWorkspaces,
+    cloudWorkspaces: repositoryCloudWorkspaces,
     sshTargets: computeTargets.sshTargetOptions,
     repositories,
     selectedTarget,
@@ -85,7 +94,7 @@ export function useAutomationTargetSelection({
     organizationId,
     effectiveRepoConfigs,
     repositories,
-    scopedCloudWorkspaces,
+    repositoryCloudWorkspaces,
     computeTargets.sshTargetOptions,
     selectedTarget,
   ]);

--- a/apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
+++ b/apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
@@ -206,7 +206,9 @@ export function useCreateCloudWorkspace() {
         telemetry.track("cloud_workspace_created", {
           workspace_kind: "cloud",
           status: workspaceStatus,
-          git_provider: workspace.repo.provider,
+          // Workspace creation is repository-only; scratch workspaces never
+          // come from this flow, but the payload type is placement-neutral.
+          git_provider: workspace.repo?.provider ?? "github",
           attempt_count: attemptCount,
           retry_count: retryCount,
         });
@@ -228,7 +230,7 @@ export function useCreateCloudWorkspace() {
           ...nextEntry,
           stage: workspaceStatus === "ready" ? "submitting" : "awaiting-cloud-ready",
           workspaceId,
-          baseBranchName: workspace.repo.baseBranch,
+          baseBranchName: workspace.repo?.baseBranch ?? null,
           request: { kind: "select-existing", workspaceId },
         };
         setPendingWorkspaceEntry(updatedEntry);

--- a/apps/packages/product-client/src/hooks/support/derived/use-sidebar-support-context.ts
+++ b/apps/packages/product-client/src/hooks/support/derived/use-sidebar-support-context.ts
@@ -32,9 +32,9 @@ export function useSidebarSupportContext() {
         intent: "general" as const,
         pathname,
         workspaceId: selectedWorkspaceId,
-        workspaceName: workspace?.repo.branch
+        workspaceName: workspace?.repo?.branch
           ? humanizeBranchName(workspace.repo.branch)
-          : workspace?.repo.name,
+          : workspace?.repo?.name,
         workspaceLocation: "cloud" as const,
       };
     }

--- a/apps/packages/product-client/src/hooks/support/derived/use-support-report-snapshot.ts
+++ b/apps/packages/product-client/src/hooks/support/derived/use-support-report-snapshot.ts
@@ -136,7 +136,7 @@ function sessionRecencyMs(
 function cloudWorkspaceOption(
   workspace: CloudWorkspaceSummary,
 ): SupportReportWorkspaceOption {
-  const branch = workspace.repo.branch || workspace.repo.baseBranch || null;
+  const branch = workspace.repo?.branch || workspace.repo?.baseBranch || null;
   const materialization = workspace.primaryMaterialization;
   const targetId = workspace.targetId
     ?? workspace.executionTarget?.targetId
@@ -146,9 +146,9 @@ function cloudWorkspaceOption(
   return {
     id: cloudWorkspaceSyntheticId(workspace.id),
     label: workspace.displayName?.trim()
-      || (branch ? humanizeBranchName(branch) : workspace.repo.name),
+      || (branch ? humanizeBranchName(branch) : workspace.repo?.name ?? "Workspace"),
     location: "cloud",
-    path: `${workspace.repo.owner}/${workspace.repo.name}`,
+    path: workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "",
     branch,
     status: workspace.status,
     updatedAt: workspace.updatedAt ?? workspace.readyAt ?? workspace.createdAt ?? null,

--- a/apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/use-workspace-collections-mutation-cache.ts
@@ -109,7 +109,7 @@ export function useWorkspaceCollectionsMutationCache(runtimeUrl: string) {
             displayName: workspace.displayName,
             repo: {
               ...candidate.repo,
-              branch: workspace.repo.branch,
+              branch: workspace.repo?.branch ?? candidate.repo.branch,
             },
             updatedAt: workspace.updatedAt,
           }

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-git-statuses.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-git-statuses.ts
@@ -35,7 +35,7 @@ function logicalWorkspaceBranch(workspace: LogicalWorkspace): string | null {
   if (localBranch) {
     return localBranch;
   }
-  const cloudBranch = workspace.cloudWorkspace?.repo.branch?.trim();
+  const cloudBranch = workspace.cloudWorkspace?.repo?.branch?.trim();
   return cloudBranch && cloudBranch.length > 0 ? cloudBranch : null;
 }
 

--- a/apps/packages/product-client/src/hooks/workspaces/facade/use-worktree-settings-targets.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/facade/use-worktree-settings-targets.ts
@@ -91,7 +91,8 @@ export function useWorktreeSettingsTargets() {
         key,
         label: environmentId
           ? `Cloud runtime ${environmentId.slice(0, 8)}`
-          : workspace.displayName ?? `${workspace.repo.owner}/${workspace.repo.name}`,
+          : workspace.displayName
+            ?? (workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "Workspace"),
         location: "cloud",
         runtimeUrl: connection.runtimeUrl,
         runtimeGeneration: generation,

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
@@ -151,12 +151,13 @@ export function collectKnownCloudBranchNames(args: {
 }): Set<string> {
   return new Set(
     args.cloudWorkspaces
+      // Repository-only: scratch workspaces have no repo and never collide.
       .filter((workspace) =>
-        workspace.repo.provider === "github"
+        workspace.repo?.provider === "github"
         && workspace.repo.owner === args.target.gitOwner
         && workspace.repo.name === args.target.gitRepoName
       )
-      .map((workspace) => workspace.repo.branch.trim())
+      .map((workspace) => workspace.repo?.branch.trim() ?? "")
       .filter(Boolean),
   );
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
@@ -138,8 +138,11 @@ export interface CloudWorkspaceCloudAccessSummary {
 export interface CloudWorkspaceSummary {
   id: string;
   targetId?: string | null;
+  // Placement-neutral backing kind; absent (older servers) means
+  // repositoryWorktree. Scratch workspaces have repo = null, never fabricated.
+  workspaceKind?: "repositoryWorktree" | "scratch";
   displayName: string | null;
-  repo: CloudWorkspaceRepoRef;
+  repo: CloudWorkspaceRepoRef | null;
   status: CloudWorkspaceStatus;
   workspaceStatus: CloudWorkspaceStatus;
   productLifecycle?: CloudWorkspaceProductLifecycle;

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status-presentation.ts
@@ -119,8 +119,10 @@ export function descriptionForStartBlockReason(
 export function buildCloudWorkspaceStatusScreenModel(
   workspace: CloudWorkspaceSummary,
 ): CloudWorkspaceStatusScreenModel {
-  const repoLabel = `${workspace.repo.owner}/${workspace.repo.name}`;
-  const branchLabel = `${workspace.repo.baseBranch} -> ${workspace.repo.branch}`;
+  const repoLabel = workspace.repo ? `${workspace.repo.owner}/${workspace.repo.name}` : "";
+  const branchLabel = workspace.repo
+    ? `${workspace.repo.baseBranch} -> ${workspace.repo.branch}`
+    : "";
   const status = resolveCloudWorkspaceStatus(workspace) ?? "error";
 
   if (workspace.actionBlockKind) {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/collections.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/collections.ts
@@ -11,8 +11,14 @@ function sortWorkspacesByUpdatedAtDesc<T extends Pick<Workspace, "updatedAt">>(w
 }
 
 export function cloudWorkspaceGroupKey(
-  workspace: { repo: Pick<CloudWorkspaceSummary["repo"], "provider" | "owner" | "name"> },
+  workspace: {
+    repo: Pick<NonNullable<CloudWorkspaceSummary["repo"]>, "provider" | "owner" | "name"> | null;
+  },
 ): string {
+  // Scratch workspaces have no repository backing; group them together.
+  if (!workspace.repo) {
+    return "scratch";
+  }
   return `${workspace.repo.provider}:${workspace.repo.owner}:${workspace.repo.name}`;
 }
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
@@ -13,7 +13,12 @@ export function normalizeLogicalWorkspaceBranchKey(
   return trimmed && trimmed.length > 0 ? trimmed : "HEAD";
 }
 
-export type LogicalWorkspaceIdKind = "remote" | "repo-root" | "path" | "local-slot";
+export type LogicalWorkspaceIdKind =
+  | "remote"
+  | "repo-root"
+  | "path"
+  | "local-slot"
+  | "cloud-workspace";
 
 export interface ParsedLogicalWorkspaceId {
   kind: LogicalWorkspaceIdKind;
@@ -64,6 +69,17 @@ export function buildLocalSlotLogicalWorkspaceId(workspaceId: string): string {
   ].join(":");
 }
 
+// Stable identity for a repository-less (scratch) cloud workspace, keyed by its
+// real ``CloudWorkspace.id``. Scratch workspaces carry no remote coordinates, so
+// they must never be folded onto a fabricated ``remote::::HEAD`` slot; each row
+// gets its own logical workspace and navigates independently.
+export function buildCloudWorkspaceLogicalWorkspaceId(cloudWorkspaceId: string): string {
+  return [
+    "cloud-workspace",
+    encodeLogicalSegment(cloudWorkspaceId),
+  ].join(":");
+}
+
 export function parseLogicalWorkspaceId(
   logicalWorkspaceId: string | null | undefined,
 ): ParsedLogicalWorkspaceId | null {
@@ -72,7 +88,13 @@ export function parseLogicalWorkspaceId(
   }
 
   const [kind, ...encodedSegments] = logicalWorkspaceId.split(":");
-  if (kind !== "remote" && kind !== "repo-root" && kind !== "path" && kind !== "local-slot") {
+  if (
+    kind !== "remote"
+    && kind !== "repo-root"
+    && kind !== "path"
+    && kind !== "local-slot"
+    && kind !== "cloud-workspace"
+  ) {
     return null;
   }
 
@@ -90,7 +112,7 @@ export function parseLogicalWorkspaceId(
     return null;
   }
 
-  if (kind === "local-slot") {
+  if (kind === "local-slot" || kind === "cloud-workspace") {
     if (segments.length !== 1) {
       return null;
     }
@@ -123,9 +145,9 @@ export function replaceLogicalWorkspaceBranch(
   }
 
   const nextBranchKey = normalizeLogicalWorkspaceBranchKey(branchKey);
-  if (parsed.kind === "local-slot") {
-    // A local-slot ID is keyed by workspace id; branch identity is read from
-    // the materialized workspace row.
+  if (parsed.kind === "local-slot" || parsed.kind === "cloud-workspace") {
+    // These IDs are keyed by workspace id; branch identity is read from the
+    // materialized workspace row, so the logical id has no branch to replace.
     return logicalWorkspaceId ?? null;
   }
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-slot.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-slot.ts
@@ -71,9 +71,9 @@ export function cloudDefaultDisplayName(workspace: CloudWorkspaceSummary): strin
     return override;
   }
 
-  return workspace.repo.branch?.trim()
+  return workspace.repo?.branch?.trim()
     ? humanizeBranchName(workspace.repo.branch)
-    : workspace.repo.name;
+    : workspace.repo?.name ?? "Workspace";
 }
 
 export function mobilityDefaultDisplayName(

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-source.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-source.ts
@@ -4,6 +4,7 @@ import {
   workspaceCurrentBranchName,
 } from "#product/lib/domain/workspaces/creation/branch-naming";
 import {
+  buildCloudWorkspaceLogicalWorkspaceId,
   buildPathLogicalWorkspaceId,
   buildRemoteLogicalWorkspaceId,
   buildRepoRootLogicalWorkspaceId,
@@ -20,7 +21,7 @@ export function workspaceBranchKey(workspace: Workspace): string {
 }
 
 export function cloudBranchKey(workspace: CloudWorkspaceSummary): string {
-  return normalizeLogicalWorkspaceBranchKey(workspace.repo.branch);
+  return normalizeLogicalWorkspaceBranchKey(workspace.repo?.branch);
 }
 
 export function remoteRepoKey(
@@ -87,6 +88,13 @@ export function compareLocalWorkspaceCanonicalOrder(
 export function buildLogicalWorkspaceIdForCloudWorkspace(
   workspace: CloudWorkspaceSummary,
 ): string {
+  // Repository-less (scratch) cloud workspaces have no remote coordinates. They
+  // must be keyed by their real id so two scratch rows are two distinct logical
+  // workspaces instead of folding onto a fabricated ``remote::::HEAD`` slot.
+  if (workspace.workspaceKind === "scratch" || !workspace.repo) {
+    return buildCloudWorkspaceLogicalWorkspaceId(workspace.id);
+  }
+
   return buildRemoteLogicalWorkspaceId(
     workspace.repo.provider,
     workspace.repo.owner,

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces-scratch.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces-scratch.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import { buildLogicalWorkspaces } from "#product/lib/domain/workspaces/cloud/logical-workspaces";
+import { buildLogicalWorkspaceIdForCloudWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+import {
+  buildCloudWorkspaceLogicalWorkspaceId,
+  parseLogicalWorkspaceId,
+} from "#product/lib/domain/workspaces/cloud/logical-workspace-id";
+import { findLogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-lookup";
+import { makeCloudWorkspace } from "#product/lib/domain/workspaces/sidebar/sidebar-test-fixtures";
+
+function makeScratchWorkspace(args: {
+  id: string;
+  displayName: string;
+  updatedAt?: string;
+}): CloudWorkspaceSummary {
+  // A scratch (managed Workflow run) workspace: no repository backing, so its
+  // repo/repoEnvironmentId are null and it uses the placement-neutral kind.
+  return {
+    ...makeCloudWorkspace({ id: args.id, updatedAt: args.updatedAt }),
+    workspaceKind: "scratch",
+    repo: null,
+    displayName: args.displayName,
+  };
+}
+
+describe("logical workspaces — scratch identity (MC5A-CLIENT-01)", () => {
+  it("keeps two scratch workspaces as two distinct logical workspaces (no folding)", () => {
+    const scratchA = makeScratchWorkspace({
+      id: "50000000-0000-4000-8000-00000000000a",
+      displayName: "Workflow run a",
+      updatedAt: "2026-07-15T10:00:00.000Z",
+    });
+    const scratchB = makeScratchWorkspace({
+      id: "50000000-0000-4000-8000-00000000000b",
+      displayName: "Workflow run b",
+      updatedAt: "2026-07-15T11:00:00.000Z",
+    });
+
+    const logicalWorkspaces = buildLogicalWorkspaces({
+      localWorkspaces: [],
+      repoRoots: [],
+      cloudWorkspaces: [scratchA, scratchB],
+      currentSelectionId: null,
+    });
+
+    // Two rows -> two logical workspaces (the old bug folded both into one).
+    expect(logicalWorkspaces).toHaveLength(2);
+
+    const idA = buildLogicalWorkspaceIdForCloudWorkspace(scratchA);
+    const idB = buildLogicalWorkspaceIdForCloudWorkspace(scratchB);
+
+    // Distinct selection/navigation IDs, each keyed by the real CloudWorkspace.id.
+    expect(idA).toBe(buildCloudWorkspaceLogicalWorkspaceId(scratchA.id));
+    expect(idB).toBe(buildCloudWorkspaceLogicalWorkspaceId(scratchB.id));
+    expect(idA).not.toBe(idB);
+
+    const parsedA = parseLogicalWorkspaceId(idA);
+    expect(parsedA?.kind).toBe("cloud-workspace");
+    expect(parsedA?.segments).toEqual([scratchA.id]);
+
+    const foundA = findLogicalWorkspace(logicalWorkspaces, idA);
+    const foundB = findLogicalWorkspace(logicalWorkspaces, idB);
+    expect(foundA?.cloudWorkspace?.id).toBe(scratchA.id);
+    expect(foundB?.cloudWorkspace?.id).toBe(scratchB.id);
+    expect(foundA?.id).not.toBe(foundB?.id);
+
+    // Cloud synthetic materialization id is per-row too (independent navigation).
+    expect(foundA?.preferredMaterializationId).toBe(cloudWorkspaceSyntheticId(scratchA.id));
+    expect(foundB?.preferredMaterializationId).toBe(cloudWorkspaceSyntheticId(scratchB.id));
+
+    // Null repo metadata is never fabricated for scratch placement.
+    for (const found of [foundA, foundB]) {
+      expect(found?.cloudWorkspace?.repo).toBeNull();
+      expect(found?.provider).toBeNull();
+      expect(found?.owner).toBeNull();
+      expect(found?.repoName).toBeNull();
+    }
+  });
+
+  it("still keys repository worktrees by their remote identity", () => {
+    const repository = makeCloudWorkspace({ id: "cloud-repo-1", branch: "feature-x" });
+    const logicalId = buildLogicalWorkspaceIdForCloudWorkspace(repository);
+    // Repository workspaces keep the remote identity, not the cloud-workspace kind.
+    expect(parseLogicalWorkspaceId(logicalId)?.kind).toBe("remote");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -309,9 +309,9 @@ export function buildLogicalWorkspaces(args: {
         : entry.cloudWorkspace
           ? repoRootsByRemoteKey.get(
             remoteRepoKey(
-              entry.cloudWorkspace.repo.provider,
-              entry.cloudWorkspace.repo.owner,
-              entry.cloudWorkspace.repo.name,
+              entry.cloudWorkspace.repo?.provider,
+              entry.cloudWorkspace.repo?.owner,
+              entry.cloudWorkspace.repo?.name,
             )!,
           ) ?? null
           : entry.mobilityWorkspace
@@ -351,17 +351,17 @@ export function buildLogicalWorkspaces(args: {
         repoRoot,
         provider:
           repoRoot?.remoteProvider
-          ?? entry.cloudWorkspace?.repo.provider
+          ?? entry.cloudWorkspace?.repo?.provider
           ?? entry.mobilityWorkspace?.repo.provider
           ?? null,
         owner:
           repoRoot?.remoteOwner
-          ?? entry.cloudWorkspace?.repo.owner
+          ?? entry.cloudWorkspace?.repo?.owner
           ?? entry.mobilityWorkspace?.repo.owner
           ?? null,
         repoName:
           repoRoot?.remoteRepoName
-          ?? entry.cloudWorkspace?.repo.name
+          ?? entry.cloudWorkspace?.repo?.name
           ?? entry.mobilityWorkspace?.repo.name
           ?? null,
         branchKey: entry.localWorkspace

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/selected-repo-target.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/selected-repo-target.ts
@@ -44,7 +44,9 @@ export function getCloudRepoTargetForSelectedWorkspace(
   const cloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
   if (cloudWorkspaceId) {
     const cloudWorkspace = cloudWorkspaces.find((workspace) => workspace.id === cloudWorkspaceId);
-    if (cloudWorkspace?.repo.provider !== "github") {
+    // Repository-only action: scratch workspaces (repo = null) never resolve a
+    // repo target.
+    if (cloudWorkspace?.repo?.provider !== "github") {
       return null;
     }
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-entries.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-entries.ts
@@ -79,9 +79,13 @@ export function sidebarEntryDisplayName(entry: SidebarWorkspaceEntry): string {
 export function cloudSidebarEntryDefaultDisplayName(
   entry: CloudSidebarWorkspaceEntry,
 ): string {
-  return entry.workspace.repo.branch?.trim()
-    ? humanizeBranchName(entry.workspace.repo.branch)
-    : entry.workspace.repo.name;
+  const repo = entry.workspace.repo;
+  if (!repo) {
+    return entry.workspace.displayName?.trim() || "Workspace";
+  }
+  return repo.branch?.trim()
+    ? humanizeBranchName(repo.branch)
+    : repo.name;
 }
 
 export function sidebarEntryUpdatedAt(entry: SidebarWorkspaceEntry): string {
@@ -96,11 +100,12 @@ export function sidebarEntryGitMetadata(
   entry: SidebarWorkspaceEntry,
 ): SidebarEntryGitMetadata {
   if (entry.source === "cloud") {
+    const repo = entry.workspace.repo;
     return {
-      provider: entry.workspace.repo.provider,
-      owner: entry.workspace.repo.owner,
-      repoName: entry.workspace.repo.name,
-      branchName: entry.workspace.repo.branch,
+      provider: repo?.provider ?? null,
+      owner: repo?.owner ?? null,
+      repoName: repo?.name ?? null,
+      branchName: repo?.branch ?? null,
     };
   }
 
@@ -124,7 +129,9 @@ export function sidebarEntryIsCloud(
 
 function sidebarEntryGroupName(entry: SidebarWorkspaceEntry): string {
   if (entry.source === "cloud") {
-    return entry.workspace.repo.name;
+    return entry.workspace.repo?.name
+      ?? entry.workspace.displayName?.trim()
+      ?? "Workspace";
   }
 
   return entry.workspace.path.split("/").filter(Boolean).pop()

--- a/apps/packages/product-client/src/lib/domain/workspaces/workspace-copy-metadata.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/workspace-copy-metadata.ts
@@ -44,7 +44,7 @@ export function workspaceCopyMetadataForLogicalWorkspace(
       : null;
   const branchName = firstTrimmed([
     localWorkspace ? workspaceCurrentBranchName(localWorkspace) : null,
-    workspace?.cloudWorkspace?.repo.branch,
+    workspace?.cloudWorkspace?.repo?.branch,
     workspace?.mobilityWorkspace?.repo.branch,
     workspace?.branchKey,
   ]);

--- a/apps/packages/product-domain/package.json
+++ b/apps/packages/product-domain/package.json
@@ -243,6 +243,10 @@
       "types": "./dist/workspaces/model.d.ts",
       "import": "./dist/workspaces/model.js"
     },
+    "./workspaces/backing-kind": {
+      "types": "./dist/workspaces/backing-kind.d.ts",
+      "import": "./dist/workspaces/backing-kind.js"
+    },
     "./workspaces/cloud-work-inventory": {
       "types": "./dist/workspaces/cloud-work-inventory.d.ts",
       "import": "./dist/workspaces/cloud-work-inventory.js"

--- a/apps/packages/product-domain/src/workspaces/backing-kind.test.ts
+++ b/apps/packages/product-domain/src/workspaces/backing-kind.test.ts
@@ -1,0 +1,97 @@
+import type { CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRecentWorkItems,
+} from "./recent-work-items";
+import { cloudWorkItemForWorkspace } from "./cloud-work-items";
+import {
+  isRepositoryWorktree,
+  isScratchWorkspace,
+  workspaceBackingKind,
+  workspaceBranchLabel,
+  workspaceDisplayTitle,
+  workspaceRepoLabel,
+  workspaceRepoRef,
+} from "./backing-kind";
+
+function workspace(overrides: Partial<CloudWorkspaceSummary> = {}): CloudWorkspaceSummary {
+  return {
+    id: "workspace",
+    displayName: "Workspace",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "feature-x",
+      baseBranch: "main",
+    },
+    status: "ready",
+    workspaceStatus: "ready",
+    statusDetail: null,
+    lastError: null,
+    templateVersion: null,
+    updatedAt: "2026-07-15T11:30:00Z",
+    createdAt: "2026-07-15T10:00:00Z",
+    readyAt: "2026-07-15T10:00:00Z",
+    postReadyPhase: "complete",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+    visibility: "private",
+    allowedAgentKinds: [],
+    readyAgentKinds: [],
+    ...overrides,
+  } as CloudWorkspaceSummary;
+}
+
+const scratch = () =>
+  workspace({
+    id: "run-1",
+    workspaceKind: "scratch",
+    displayName: "Workflow run run-1",
+    repo: null,
+    repoEnvironmentId: null,
+  });
+
+describe("workspace backing-kind derivation", () => {
+  it("treats absent workspaceKind as a repository worktree", () => {
+    const ws = workspace();
+    expect(ws.workspaceKind).toBeUndefined();
+    expect(workspaceBackingKind(ws)).toBe("repositoryWorktree");
+    expect(isRepositoryWorktree(ws)).toBe(true);
+    expect(isScratchWorkspace(ws)).toBe(false);
+    expect(workspaceRepoRef(ws)).toEqual(ws.repo);
+    expect(workspaceRepoLabel(ws)).toBe("proliferate-ai/proliferate");
+    expect(workspaceBranchLabel(ws)).toBe("feature-x");
+  });
+
+  it("never fabricates repository data for scratch workspaces", () => {
+    const ws = scratch();
+    expect(workspaceBackingKind(ws)).toBe("scratch");
+    expect(isScratchWorkspace(ws)).toBe(true);
+    expect(workspaceRepoRef(ws)).toBeNull();
+    expect(workspaceRepoLabel(ws)).toBeNull();
+    // Scratch workspaces default to the main branch, no repo dereference.
+    expect(workspaceBranchLabel(ws)).toBe("main");
+    expect(workspaceDisplayTitle(ws)).toBe("Workflow run run-1");
+  });
+
+  it("produces cloud work items for scratch workspaces without throwing", () => {
+    const item = cloudWorkItemForWorkspace(scratch(), { nowMs: Date.parse("2026-07-15T12:00:00Z") });
+    expect(item.repoLabel).toBe("");
+    expect(item.branchLabel).toBe("main");
+    expect(item.title).toBe("Workflow run run-1");
+  });
+
+  it("produces recent work items for scratch workspaces without throwing", () => {
+    const rows = buildRecentWorkItems([scratch()], {
+      nowMs: Date.parse("2026-07-15T12:00:00Z"),
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.title).toBe("Workflow run run-1");
+    expect(rows[0]?.repoLabel).toBe("");
+    expect(rows[0]?.branchLabel).toBe("main");
+  });
+});

--- a/apps/packages/product-domain/src/workspaces/backing-kind.ts
+++ b/apps/packages/product-domain/src/workspaces/backing-kind.ts
@@ -1,0 +1,78 @@
+import type {
+  CloudWorkspaceBackingKind as CloudSdkWorkspaceBackingKind,
+  CloudWorkspaceSummary,
+  RepoRef,
+} from "@proliferate/cloud-sdk";
+
+export type CloudWorkspaceBackingKind = CloudSdkWorkspaceBackingKind;
+
+/**
+ * Central placement/display derivation for the placement-neutral cloud
+ * workspace identity. A repository worktree carries real repository metadata; a
+ * scratch workspace (managed Workflow run) has no repository backing, so its
+ * `repo` is `null` and repo-only actions must not be offered for it.
+ *
+ * Consumers must route every repository-only read through `workspaceRepoRef`
+ * (or an explicit `isRepositoryWorktree` guard) rather than dereferencing
+ * `workspace.repo` directly, so scratch placement never fabricates repository
+ * data.
+ */
+
+type WorkspaceKindInput = Pick<CloudWorkspaceSummary, "workspaceKind">;
+type WorkspaceRepoInput = Pick<CloudWorkspaceSummary, "workspaceKind" | "repo">;
+
+/**
+ * The backing kind of a workspace. Absent (older servers that predate the
+ * migration) is treated as `repositoryWorktree`; only an explicit `scratch`
+ * value is scratch.
+ */
+export function workspaceBackingKind(workspace: WorkspaceKindInput): CloudWorkspaceBackingKind {
+  return workspace.workspaceKind === "scratch" ? "scratch" : "repositoryWorktree";
+}
+
+/** True only for repository worktrees — the sole placement with repo metadata. */
+export function isRepositoryWorktree(workspace: WorkspaceKindInput): boolean {
+  return workspaceBackingKind(workspace) === "repositoryWorktree";
+}
+
+/** True for scratch (repository-less) workspaces. */
+export function isScratchWorkspace(workspace: WorkspaceKindInput): boolean {
+  return workspaceBackingKind(workspace) === "scratch";
+}
+
+/**
+ * The repository reference for a workspace, or `null` when it has no repository
+ * backing. This is the one guard repo-only consumers must use before reading
+ * owner/name/branch.
+ */
+export function workspaceRepoRef(workspace: WorkspaceRepoInput): RepoRef | null {
+  return isRepositoryWorktree(workspace) ? (workspace.repo ?? null) : null;
+}
+
+/** `owner/name` label, or `null` for scratch workspaces. */
+export function workspaceRepoLabel(workspace: WorkspaceRepoInput): string | null {
+  const repo = workspaceRepoRef(workspace);
+  return repo ? `${repo.owner}/${repo.name}` : null;
+}
+
+/** Branch label, defaulting to `main` (scratch workspaces are always `main`). */
+export function workspaceBranchLabel(workspace: WorkspaceRepoInput): string {
+  const repo = workspaceRepoRef(workspace);
+  return nonEmpty(repo?.branch) ?? nonEmpty(repo?.baseBranch) ?? "main";
+}
+
+/** Best display title, never dereferencing repo data for scratch placement. */
+export function workspaceDisplayTitle(
+  workspace: WorkspaceRepoInput & Pick<CloudWorkspaceSummary, "displayName">,
+): string {
+  return (
+    nonEmpty(workspace.displayName) ??
+    nonEmpty(workspaceRepoRef(workspace)?.name) ??
+    workspaceBranchLabel(workspace)
+  );
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/apps/packages/product-domain/src/workspaces/cloud-work-inventory.ts
+++ b/apps/packages/product-domain/src/workspaces/cloud-work-inventory.ts
@@ -27,6 +27,16 @@ export type {
   RecentWorkStatusIndicatorTone,
   RecentWorkStatusIndicatorView,
 } from "./cloud-work-inventory-types";
+export type { CloudWorkspaceBackingKind } from "./backing-kind";
+export {
+  isRepositoryWorktree,
+  isScratchWorkspace,
+  workspaceBackingKind,
+  workspaceBranchLabel,
+  workspaceDisplayTitle,
+  workspaceRepoLabel,
+  workspaceRepoRef,
+} from "./backing-kind";
 export { buildCloudWorkRecencyInventory } from "./cloud-work-filters";
 export { recentWorkSourceForWorkspace } from "./cloud-work-items";
 export {

--- a/apps/packages/product-domain/src/workspaces/cloud-work-items.ts
+++ b/apps/packages/product-domain/src/workspaces/cloud-work-items.ts
@@ -1,5 +1,10 @@
 import type { CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
 
+import {
+  workspaceBranchLabel,
+  workspaceRepoLabel,
+  workspaceRepoRef,
+} from "./backing-kind";
 import type { CloudWorkItemView, CloudWorkSource, RecentWorkSourceKind } from "./cloud-work-inventory-types";
 import {
   SOURCE_LABELS,
@@ -31,9 +36,13 @@ export function cloudWorkItemForWorkspace(
   workspace: CloudWorkspaceSummary,
   options: { nowMs?: number } = {},
 ): CloudWorkItemView {
-  const repoLabel = `${workspace.repo.owner}/${workspace.repo.name}`;
-  const branchLabel = workspace.repo.branch ?? workspace.repo.baseBranch ?? "main";
-  const title = workspace.displayName ?? workspace.lastSessionSummary?.title ?? workspace.repo.name;
+  const repoLabel = workspaceRepoLabel(workspace) ?? "";
+  const branchLabel = workspaceBranchLabel(workspace);
+  const title =
+    workspace.displayName ??
+    workspace.lastSessionSummary?.title ??
+    workspaceRepoRef(workspace)?.name ??
+    branchLabel;
   const sessionTitle = workspace.lastSessionSummary?.title ?? null;
   const sourceAgentKind = cloudWorkSourceAgentKind(workspace);
   const source = cloudWorkSourceForWorkspace(workspace);

--- a/apps/packages/product-domain/src/workspaces/inventory-cloud.ts
+++ b/apps/packages/product-domain/src/workspaces/inventory-cloud.ts
@@ -1,5 +1,6 @@
 import type { CloudWorkspaceSummary } from "@proliferate/cloud-sdk";
 
+import { workspaceRepoRef } from "./backing-kind";
 import {
   recentWorkCloudAccessLabel,
   recentWorkCommandabilityLabel,
@@ -288,23 +289,20 @@ function workspaceExposureLabel(
 }
 
 function repoLabel(workspace: CloudWorkspaceSummary): string {
-  return `${workspace.repo.owner}/${workspace.repo.name}`;
+  const repo = workspaceRepoRef(workspace);
+  return repo ? `${repo.owner}/${repo.name}` : "";
 }
 
 function workspaceBranchLabel(workspace: CloudWorkspaceSummary): string {
-  return (
-    nonEmptyText(workspace.repo.branch) ??
-    nonEmptyText(workspace.repo.baseBranch) ??
-    "main"
-  );
+  const repo = workspaceRepoRef(workspace);
+  return nonEmptyText(repo?.branch) ?? nonEmptyText(repo?.baseBranch) ?? "main";
 }
 
 function workspaceDisplayLabel(workspace: CloudWorkspaceSummary): string {
   return (
     nonEmptyText(workspace.displayName) ??
-    nonEmptyText(workspace.repo.name) ??
-    workspaceBranchLabel(workspace) ??
-    repoLabel(workspace)
+    nonEmptyText(workspaceRepoRef(workspace)?.name) ??
+    workspaceBranchLabel(workspace)
   );
 }
 

--- a/apps/packages/product-domain/src/workspaces/recent-work-items.ts
+++ b/apps/packages/product-domain/src/workspaces/recent-work-items.ts
@@ -9,6 +9,12 @@ import type {
   RecentWorkItemView,
   RecentWorkRowKind,
 } from "./cloud-work-inventory-types";
+import {
+  workspaceBranchLabel,
+  workspaceDisplayTitle,
+  workspaceRepoLabel,
+  workspaceRepoRef,
+} from "./backing-kind";
 import { cloudWorkActivityPreview, recentWorkSourceForWorkspace } from "./cloud-work-items";
 import {
   recentWorkCommandabilityLabel,
@@ -93,13 +99,17 @@ function recentWorkItemForWorkspace(
     workspaceId: workspace.id,
     sessionId: null,
     openTarget: { kind: "workspace", workspaceId: workspace.id },
-    title: workspace.displayName ?? workspace.repo.name,
+    title: workspaceDisplayTitle(workspace),
     subtitle: "Workspace",
     state,
     stateLabel: recentWorkStateLabel(state),
     statusIndicator: recentWorkStatusIndicatorForWorkspace(workspace),
     activityPreview: cloudWorkActivityPreview(workspace),
-    searchText: recentSearchText(base, [workspace.displayName, workspace.repo.name, "workspace"]),
+    searchText: recentSearchText(base, [
+      workspace.displayName,
+      workspaceRepoRef(workspace)?.name,
+      "workspace",
+    ]),
   };
 }
 
@@ -118,13 +128,13 @@ function recentWorkItemForSessionSummary(
     workspaceId: workspace.id,
     sessionId: summary.sessionId,
     openTarget: { kind: "session", workspaceId: workspace.id, sessionId: summary.sessionId },
-    title: summary.title ?? summary.preview ?? workspace.displayName ?? workspace.repo.name,
-    subtitle: `${workspace.displayName ?? workspace.repo.name} session`,
+    title: summary.title ?? summary.preview ?? workspaceDisplayTitle(workspace),
+    subtitle: `${workspaceDisplayTitle(workspace)} session`,
     state,
     stateLabel: recentWorkStateLabel(state),
     statusIndicator: recentWorkStatusIndicatorForSession(workspace, summary.status, summary),
     activityPreview,
-    searchText: recentSearchText(base, [summary.title, activityPreview, workspace.displayName, workspace.repo.name, "session"]),
+    searchText: recentSearchText(base, [summary.title, activityPreview, workspace.displayName, workspaceRepoRef(workspace)?.name, "session"]),
   };
 }
 
@@ -142,13 +152,13 @@ function recentWorkItemForSessionProjection(
     workspaceId: workspace.id,
     sessionId: session.sessionId,
     openTarget: { kind: "session", workspaceId: workspace.id, sessionId: session.sessionId },
-    title: session.title ?? workspace.displayName ?? workspace.repo.name,
-    subtitle: `${workspace.displayName ?? workspace.repo.name} session`,
+    title: session.title ?? workspaceDisplayTitle(workspace),
+    subtitle: `${workspaceDisplayTitle(workspace)} session`,
     state,
     stateLabel: recentWorkStateLabel(state),
     statusIndicator: recentWorkStatusIndicatorForSession(workspace, session.status, session),
     activityPreview: null,
-    searchText: recentSearchText(base, [session.title, session.sourceAgentKind, workspace.displayName, workspace.repo.name, "session"]),
+    searchText: recentSearchText(base, [session.title, session.sourceAgentKind, workspace.displayName, workspaceRepoRef(workspace)?.name, "session"]),
   };
 }
 
@@ -178,8 +188,8 @@ function recentWorkBase(
   const ownership = recentWorkOwnership(workspace);
   const lastActivityMs = parseTime(options.rowActivityAt);
   return {
-    repoLabel: `${workspace.repo.owner}/${workspace.repo.name}`,
-    branchLabel: workspace.repo.branch ?? workspace.repo.baseBranch ?? "main",
+    repoLabel: workspaceRepoLabel(workspace) ?? "",
+    branchLabel: workspaceBranchLabel(workspace),
     sourceKind,
     sourceLabel: recentWorkSourceLabel(sourceKind),
     runtimeLocation,

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -1740,6 +1740,71 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/cloud/worker/download/{target}/{version}/{asset}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Worker Artifact Versioned Download Endpoint
+         * @description 302 to the worker binary at an EXACT version (R9R-001).
+         *
+         *     The version-specific path a supervisor-owned Worker resolves for an update
+         *     request: the server resolves the requested version or fails closed (404) —
+         *     it never falls back to the rolling ``stable`` path, so a B-pinned sandbox is
+         *     never handed an A-labelled artifact.
+         */
+        get: operations["worker_artifact_versioned_download_endpoint_v1_cloud_worker_download__target___version___asset__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/runtime/download/{target}/{version}/{asset}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Runtime Artifact Versioned Download Endpoint
+         * @description 302 to the AnyHarness binary at an EXACT version (R9R-001).
+         *
+         *     The runtime parallel of the versioned worker download: exact-version
+         *     resolution, fail closed on an unpublished version, no rolling fallback.
+         */
+        get: operations["runtime_artifact_versioned_download_endpoint_v1_cloud_runtime_download__target___version___asset__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/cloud/workers/admin/sandboxes/{cloud_sandbox_id}/desired-versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Set Sandbox Desired Versions Endpoint */
+        put: operations["set_sandbox_desired_versions_endpoint_v1_cloud_workers_admin_sandboxes__cloud_sandbox_id__desired_versions_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/cloud/integration-gateway/mcp": {
         parameters: {
             query?: never;
@@ -5466,6 +5531,28 @@ export interface components {
             /** Enabled */
             enabled: boolean;
         };
+        /**
+         * SetSandboxDesiredVersionsRequest
+         * @description Admin setter body for a sandbox's target-scoped desired versions.
+         *
+         *     ``None`` (the default, and the JSON explicit ``null``) clears the
+         *     override so the target inherits the global pin again.
+         */
+        SetSandboxDesiredVersionsRequest: {
+            /** Desiredanyharnessversion */
+            desiredAnyharnessVersion?: string | null;
+            /** Desiredworkerversion */
+            desiredWorkerVersion?: string | null;
+        };
+        /** SetSandboxDesiredVersionsResponse */
+        SetSandboxDesiredVersionsResponse: {
+            /** Cloudsandboxid */
+            cloudSandboxId: string;
+            /** Desiredanyharnessversion */
+            desiredAnyharnessVersion: string | null;
+            /** Desiredworkerversion */
+            desiredWorkerVersion: string | null;
+        };
         /** SsoDiscoveryResponse */
         SsoDiscoveryResponse: {
             /** Enabled */
@@ -6247,6 +6334,36 @@ export interface components {
             /** Heartbeatintervalseconds */
             heartbeatIntervalSeconds: number;
             desiredVersions: components["schemas"]["WorkerDesiredVersions"];
+            /** Desiredtopology */
+            desiredTopology?: string | null;
+            supervisorBridge?: components["schemas"]["WorkerSupervisorBridge"] | null;
+        };
+        /**
+         * WorkerSupervisorBridge
+         * @description Server-materialized D5 bridge inputs for an already-provisioned legacy
+         *     target (R9R-002).
+         *
+         *     A legacy Worker's persisted config carries none of the supervisor-owned
+         *     fields, so without these it could never bridge. The server delivers the
+         *     Supervisor config TOML + a supervisor-owned Worker config TOML and the paths
+         *     to write them through the live heartbeat channel; the legacy Worker
+         *     materializes both, starts the Supervisor, and hands the box off. Absent for
+         *     Supervisor-first provisions (their on-disk config already carries the inputs)
+         *     and for every non-flag-enabled target.
+         */
+        WorkerSupervisorBridge: {
+            /** Supervisorbinarypath */
+            supervisorBinaryPath: string;
+            /** Supervisorconfigpath */
+            supervisorConfigPath: string;
+            /** Supervisorconfigtoml */
+            supervisorConfigToml: string;
+            /** Workerconfigpath */
+            workerConfigPath: string;
+            /** Workerconfigtoml */
+            workerConfigToml: string;
+            /** Markerdir */
+            markerDir: string;
         };
         /** WorkflowDefinitionCreateRequest */
         WorkflowDefinitionCreateRequest: {
@@ -6498,11 +6615,16 @@ export interface components {
             id: string;
             /** Targetid */
             targetId?: string | null;
+            /**
+             * Workspacekind
+             * @enum {string}
+             */
+            workspaceKind: "repositoryWorktree" | "scratch";
             /** Repoenvironmentid */
-            repoEnvironmentId: string;
+            repoEnvironmentId: string | null;
             /** Displayname */
             displayName: string;
-            repo: components["schemas"]["RepoRef"];
+            repo: components["schemas"]["RepoRef"] | null;
             /**
              * Status
              * @enum {string}
@@ -6653,11 +6775,16 @@ export interface components {
             id: string;
             /** Targetid */
             targetId?: string | null;
+            /**
+             * Workspacekind
+             * @enum {string}
+             */
+            workspaceKind: "repositoryWorktree" | "scratch";
             /** Repoenvironmentid */
-            repoEnvironmentId: string;
+            repoEnvironmentId: string | null;
             /** Displayname */
             displayName: string;
-            repo: components["schemas"]["RepoRef"];
+            repo: components["schemas"]["RepoRef"] | null;
             /**
              * Status
              * @enum {string}
@@ -10338,6 +10465,107 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    worker_artifact_versioned_download_endpoint_v1_cloud_worker_download__target___version___asset__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target: string;
+                version: string;
+                asset: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    runtime_artifact_versioned_download_endpoint_v1_cloud_runtime_download__target___version___asset__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                target: string;
+                version: string;
+                asset: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_sandbox_desired_versions_endpoint_v1_cloud_workers_admin_sandboxes__cloud_sandbox_id__desired_versions_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cloud_sandbox_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetSandboxDesiredVersionsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetSandboxDesiredVersionsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -31,6 +31,13 @@ export type CloudWorkspaceSandboxType =
   | "managed_shared"
   | "self_hosted";
 
+// Placement-neutral backing kind for a lightweight cloud workspace. A
+// repository worktree carries real repository metadata; a scratch workspace has
+// no repository backing (managed Workflow runs) and serializes repo/
+// repoEnvironmentId as null. Absent (older servers) is treated as
+// repositoryWorktree by the product-domain derivation.
+export type CloudWorkspaceBackingKind = "repositoryWorktree" | "scratch";
+
 export type CloudWorkspaceProductLifecycle = "active" | "archived" | "deleted";
 export type CloudWorkspaceExecutionTargetKind =
   | "local_desktop"
@@ -204,9 +211,10 @@ export interface CurrentTeamCheckoutResponse {
 export interface CloudWorkspaceSummary {
   id: string;
   targetId?: string | null;
+  workspaceKind?: CloudWorkspaceBackingKind;
   repoEnvironmentId?: string | null;
   displayName: string | null;
-  repo: RepoRef;
+  repo: RepoRef | null;
   status: CloudWorkspaceStatus;
   workspaceStatus: CloudWorkspaceStatus;
   productLifecycle?: CloudWorkspaceProductLifecycle;

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -29,7 +29,7 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1107 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
-cloud/sdk/src/types/generated.ts 776 existing generated cloud SDK type surface (+git numstat line-count fields)
+cloud/sdk/src/types/generated.ts 784 existing generated cloud SDK type surface (+workspaceKind identity migration (5a))
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file

--- a/server/alembic/versions/c3a7b8d9e0f1_cloud_workspace_backing_kind.py
+++ b/server/alembic/versions/c3a7b8d9e0f1_cloud_workspace_backing_kind.py
@@ -1,0 +1,90 @@
+"""cloud workspace backing kind (repository_worktree | scratch)
+
+Revision ID: c3a7b8d9e0f1
+Revises: 6f545e279264
+Create Date: 2026-07-15 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c3a7b8d9e0f1"
+down_revision = "6f545e279264"
+branch_labels = None
+depends_on = None
+
+_BRANCH_INDEX = "ux_cloud_workspace_active_repo_environment_branch"
+
+
+def upgrade() -> None:
+    # Generalize the lightweight cloud workspace row with a placement-neutral
+    # backing kind. Every existing row is a repository worktree; the NOT NULL
+    # server default backfills them.
+    op.add_column(
+        "cloud_workspace",
+        sa.Column(
+            "workspace_kind",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'repository_worktree'"),
+        ),
+    )
+
+    # Scratch workspaces have no repository backing.
+    op.alter_column(
+        "cloud_workspace",
+        "repo_environment_id",
+        existing_type=sa.Uuid(),
+        nullable=True,
+    )
+
+    op.create_check_constraint(
+        "ck_cloud_workspace_kind",
+        "cloud_workspace",
+        "workspace_kind IN ('repository_worktree', 'scratch')",
+    )
+    op.create_check_constraint(
+        "ck_cloud_workspace_kind_repo_environment",
+        "cloud_workspace",
+        "(workspace_kind = 'repository_worktree' AND repo_environment_id IS NOT NULL) "
+        "OR (workspace_kind = 'scratch' AND repo_environment_id IS NULL)",
+    )
+
+    # Repository branch uniqueness applies only to repository worktrees.
+    op.drop_index(_BRANCH_INDEX, table_name="cloud_workspace")
+    op.create_index(
+        _BRANCH_INDEX,
+        "cloud_workspace",
+        ["owner_user_id", "repo_environment_id", "git_branch"],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL AND workspace_kind = 'repository_worktree'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_BRANCH_INDEX, table_name="cloud_workspace")
+    op.create_index(
+        _BRANCH_INDEX,
+        "cloud_workspace",
+        ["owner_user_id", "repo_environment_id", "git_branch"],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL"),
+    )
+
+    op.drop_constraint(
+        "ck_cloud_workspace_kind_repo_environment",
+        "cloud_workspace",
+        type_="check",
+    )
+    op.drop_constraint("ck_cloud_workspace_kind", "cloud_workspace", type_="check")
+
+    op.alter_column(
+        "cloud_workspace",
+        "repo_environment_id",
+        existing_type=sa.Uuid(),
+        nullable=False,
+    )
+    op.drop_column("cloud_workspace", "workspace_kind")

--- a/server/proliferate/db/models/cloud/workspaces.py
+++ b/server/proliferate/db/models/cloud/workspaces.py
@@ -3,15 +3,33 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from proliferate.db.models.base import Base, utcnow
+
+# Placement-neutral backing kind for a lightweight cloud workspace row. A
+# ``repository_worktree`` is bound to a real cloud repo environment and keeps the
+# existing repository/branch behavior; a ``scratch`` workspace has no repository
+# backing (managed Workflow runs), so it forbids a ``repo_environment_id``.
+CLOUD_WORKSPACE_REPOSITORY_WORKTREE = "repository_worktree"
+CLOUD_WORKSPACE_SCRATCH = "scratch"
 
 
 class CloudWorkspace(Base):
     __tablename__ = "cloud_workspace"
     __table_args__ = (
+        CheckConstraint(
+            "workspace_kind IN ('repository_worktree', 'scratch')",
+            name="ck_cloud_workspace_kind",
+        ),
+        # Repository worktrees require a real repo environment; scratch
+        # workspaces forbid one (their API repo/repoEnvironmentId are null).
+        CheckConstraint(
+            "(workspace_kind = 'repository_worktree' AND repo_environment_id IS NOT NULL) "
+            "OR (workspace_kind = 'scratch' AND repo_environment_id IS NULL)",
+            name="ck_cloud_workspace_kind_repo_environment",
+        ),
         Index(
             "ux_cloud_workspace_anyharness_workspace",
             "owner_user_id",
@@ -23,13 +41,16 @@ class CloudWorkspace(Base):
             "ix_cloud_workspace_repo_environment_id",
             "repo_environment_id",
         ),
+        # Repository branch uniqueness applies only to repository worktrees.
         Index(
             "ux_cloud_workspace_active_repo_environment_branch",
             "owner_user_id",
             "repo_environment_id",
             "git_branch",
             unique=True,
-            postgresql_where=text("archived_at IS NULL"),
+            postgresql_where=text(
+                "archived_at IS NULL AND workspace_kind = 'repository_worktree'"
+            ),
         ),
     )
 
@@ -38,8 +59,14 @@ class CloudWorkspace(Base):
         ForeignKey("user.id", ondelete="CASCADE"),
         index=True,
     )
-    repo_environment_id: Mapped[uuid.UUID] = mapped_column(
+    workspace_kind: Mapped[str] = mapped_column(
+        String(32),
+        server_default=text("'repository_worktree'"),
+        default=CLOUD_WORKSPACE_REPOSITORY_WORKTREE,
+    )
+    repo_environment_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("repo_environment.id", ondelete="RESTRICT"),
+        nullable=True,
     )
     display_name: Mapped[str] = mapped_column(String(255))
     git_branch: Mapped[str] = mapped_column(String(255))

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -11,17 +11,29 @@ from sqlalchemy import Select, exists, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db.models.cloud.workspaces import CloudWorkspace
+from proliferate.db.models.cloud.workspaces import (
+    CLOUD_WORKSPACE_REPOSITORY_WORKTREE,
+    CLOUD_WORKSPACE_SCRATCH,
+    CloudWorkspace,
+)
 from proliferate.utils.time import utcnow
 
 CloudWorkspaceLifecycle = Literal["active", "archived", "all"]
+CloudWorkspaceKind = Literal["repository_worktree", "scratch"]
+
+# Scratch workspaces (managed Workflow runs) have no repository backing: their
+# branch is always ``main``. Display naming is a product derivation owned by the
+# workspace domain (``server/cloud/workspaces/domain/naming.py``); the store only
+# inserts the already-decided value.
+SCRATCH_WORKSPACE_GIT_BRANCH = "main"
 
 
 @dataclass(frozen=True)
 class CloudWorkspaceValue:
     id: UUID
     owner_user_id: UUID
-    repo_environment_id: UUID
+    workspace_kind: CloudWorkspaceKind
+    repo_environment_id: UUID | None
     display_name: str
     git_branch: str
     git_base_branch: str | None
@@ -35,6 +47,7 @@ def cloud_workspace_value(row: CloudWorkspace) -> CloudWorkspaceValue:
     return CloudWorkspaceValue(
         id=row.id,
         owner_user_id=row.owner_user_id,
+        workspace_kind=_normalize_kind(row.workspace_kind),
         repo_environment_id=row.repo_environment_id,
         display_name=row.display_name,
         git_branch=row.git_branch,
@@ -43,6 +56,14 @@ def cloud_workspace_value(row: CloudWorkspace) -> CloudWorkspaceValue:
         created_at=row.created_at,
         updated_at=row.updated_at,
         archived_at=row.archived_at,
+    )
+
+
+def _normalize_kind(value: str | None) -> CloudWorkspaceKind:
+    return (
+        CLOUD_WORKSPACE_SCRATCH
+        if value == CLOUD_WORKSPACE_SCRATCH
+        else (CLOUD_WORKSPACE_REPOSITORY_WORKTREE)
     )
 
 
@@ -136,10 +157,14 @@ async def create_cloud_workspace(
     git_base_branch: str | None,
     anyharness_workspace_id: str | None = None,
 ) -> CloudWorkspaceValue | None:
-    """Create a workspace row; returns None when the active branch is taken."""
+    """Create a repository-worktree workspace row.
+
+    Returns None when the active repository branch is already taken.
+    """
     now = utcnow()
     workspace = CloudWorkspace(
         owner_user_id=user_id,
+        workspace_kind=CLOUD_WORKSPACE_REPOSITORY_WORKTREE,
         repo_environment_id=repo_environment_id,
         display_name=display_name,
         git_branch=git_branch,
@@ -154,6 +179,36 @@ async def create_cloud_workspace(
             await db.flush()
     except IntegrityError:
         return None
+    return cloud_workspace_value(workspace)
+
+
+async def create_scratch_cloud_workspace(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    display_name: str,
+    anyharness_workspace_id: str | None = None,
+) -> CloudWorkspaceValue:
+    """Create a scratch (repository-less) workspace row for a managed run.
+
+    Scratch workspaces forbid a ``repo_environment_id`` and always use the
+    ``main`` branch with no base branch; repository branch uniqueness does not
+    apply to them.
+    """
+    now = utcnow()
+    workspace = CloudWorkspace(
+        owner_user_id=user_id,
+        workspace_kind=CLOUD_WORKSPACE_SCRATCH,
+        repo_environment_id=None,
+        display_name=display_name,
+        git_branch=SCRATCH_WORKSPACE_GIT_BRANCH,
+        git_base_branch=None,
+        anyharness_workspace_id=anyharness_workspace_id,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(workspace)
+    await db.flush()
     return cloud_workspace_value(workspace)
 
 

--- a/server/proliferate/server/cloud/workspaces/domain/naming.py
+++ b/server/proliferate/server/cloud/workspaces/domain/naming.py
@@ -1,0 +1,17 @@
+"""Product naming derivations for cloud workspaces.
+
+Display names are product presentation, not persistence, so their derivation
+lives in the workspace domain rather than the SQL store. The store only inserts
+already-decided values. This is the one ownership-correct place for the exact
+``Workflow run <invocationId>`` scratch naming rule that managed execution (5b)
+will reuse.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+def scratch_workspace_display_name(invocation_id: UUID | str) -> str:
+    """Display name for a scratch (managed Workflow run) workspace."""
+    return f"Workflow run {invocation_id}"

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -10,6 +10,11 @@ from pydantic import BaseModel, Field
 CloudWorkspaceStatus = Literal["pending", "materializing", "ready", "archived", "error"]
 CloudRuntimeStatus = Literal["pending", "running", "paused", "error", "disabled"]
 
+# Placement-neutral backing kind. A repository worktree carries frozen real
+# repository metadata; a scratch workspace has no repository backing and
+# serializes ``repo``/``repoEnvironmentId`` as null (never fabricated).
+CloudWorkspaceBackingKind = Literal["repositoryWorktree", "scratch"]
+
 
 class CreateCloudWorkspaceRequest(BaseModel):
     git_provider: Literal["github"] = Field(default="github", alias="gitProvider")
@@ -74,9 +79,15 @@ class WorkspaceCloudAccessSummary(BaseModel):
 class WorkspaceSummary(BaseModel):
     id: str
     target_id: str | None = Field(default=None, serialization_alias="targetId")
-    repo_environment_id: str = Field(serialization_alias="repoEnvironmentId")
+    # The frozen response requires current servers to ALWAYS emit these three:
+    # ``workspaceKind`` non-null, and ``repo``/``repoEnvironmentId`` required but
+    # nullable for scratch (never omittable). They carry no default so the
+    # OpenAPI schema keeps them in the required set; older-server compatibility
+    # is expressed in the deliberately optional public projection type, not here.
+    workspace_kind: CloudWorkspaceBackingKind = Field(serialization_alias="workspaceKind")
+    repo_environment_id: str | None = Field(serialization_alias="repoEnvironmentId")
     display_name: str = Field(serialization_alias="displayName")
-    repo: RepoRef
+    repo: RepoRef | None
     status: CloudWorkspaceStatus
     workspace_status: CloudWorkspaceStatus = Field(serialization_alias="workspaceStatus")
     product_lifecycle: Literal["active", "archived"] = Field(

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -40,6 +40,7 @@ from proliferate.server.cloud.repos.service import get_repo_branches_for_credent
 from proliferate.server.cloud.workspaces.domain.origin import resolve_workspace_origin_entrypoint
 from proliferate.server.cloud.workspaces.models import (
     CloudRuntimeStatus,
+    CloudWorkspaceBackingKind,
     CloudWorkspaceRuntimeStatusResponse,
     CloudWorkspaceStatus,
     CreateCloudWorkspaceRequest,
@@ -342,6 +343,17 @@ async def restore_cloud_workspace_for_user(
     workspace_id: UUID,
 ) -> WorkspaceDetail:
     workspace = await _load_user_workspace(db, user_id=user_id, workspace_id=workspace_id)
+    # Scratch workspaces carry no repository backing and are exempt from
+    # repository branch uniqueness.
+    if workspace.repo_environment_id is None:
+        restored = await cloud_workspace_store.restore_cloud_workspace(db, workspace)
+        if restored is None:
+            raise CloudApiError(
+                "cloud_workspace_restore_failed",
+                "Cloud workspace could not be restored.",
+                status_code=409,
+            )
+        return await _workspace_payload(db, restored, detail=True)
     active_branches = (
         await cloud_workspace_store.list_active_workspace_branches_for_repo_environment(
             db,
@@ -526,8 +538,14 @@ async def _load_user_workspace(
 
 async def _load_repo_environment(
     db: AsyncSession,
-    repo_environment_id: UUID,
+    repo_environment_id: UUID | None,
 ) -> RepoEnvironmentValue:
+    if repo_environment_id is None:
+        raise CloudApiError(
+            "cloud_repo_environment_not_found",
+            "Cloud repo environment not found.",
+            status_code=404,
+        )
     repo_environment = await repositories_store.get_repo_environment_by_id(
         db,
         repo_environment_id,
@@ -553,7 +571,6 @@ async def _workspace_payload(
     *,
     detail: bool = False,
 ) -> WorkspaceSummary:
-    repo_environment = await _load_repo_environment(db, workspace.repo_environment_id)
     sandbox = await cloud_sandbox_store.load_personal_cloud_sandbox(
         db,
         workspace.owner_user_id,
@@ -562,25 +579,42 @@ async def _workspace_payload(
     status = _workspace_status(workspace)
     stalled = _materialization_is_stalled(workspace)
     runtime_status = _runtime_status(sandbox)
-    return payload_type(
-        id=str(workspace.id),
-        target_id=None,
-        repo_environment_id=str(workspace.repo_environment_id),
-        display_name=workspace.display_name,
-        repo=RepoRef(
+
+    # Scratch workspaces have no repository backing: repo and repoEnvironmentId
+    # are null (never fabricated) and no repo environment is loaded onto the
+    # runtime.
+    if workspace.workspace_kind == "scratch":
+        repo_environment_id = None
+        repo = None
+        runtime_environment_id = None
+        workspace_kind: CloudWorkspaceBackingKind = "scratch"
+    else:
+        repo_environment = await _load_repo_environment(db, workspace.repo_environment_id)
+        repo_environment_id = str(repo_environment.id)
+        repo = RepoRef(
             provider=repo_environment.git_provider,
             owner=repo_environment.git_owner,
             name=repo_environment.git_repo_name,
             branch=workspace.git_branch,
             base_branch=workspace.git_base_branch or repo_environment.default_branch or "main",
-        ),
+        )
+        runtime_environment_id = str(repo_environment.id)
+        workspace_kind = "repositoryWorktree"
+
+    return payload_type(
+        id=str(workspace.id),
+        target_id=None,
+        workspace_kind=workspace_kind,
+        repo_environment_id=repo_environment_id,
+        display_name=workspace.display_name,
+        repo=repo,
         status=status,
         workspace_status=status,
         status_detail=_STALLED_STATUS_DETAIL if stalled else None,
         last_error=_STALLED_LAST_ERROR if stalled else None,
         product_lifecycle="archived" if workspace.archived_at is not None else "active",
         runtime=WorkspaceRuntimeSummary(
-            environment_id=str(repo_environment.id),
+            environment_id=runtime_environment_id,
             status=runtime_status,
             generation=sandbox.runtime_generation if sandbox is not None else 0,
         ),

--- a/server/tests/integration/test_cloud_workspace_backing_kind.py
+++ b/server/tests/integration/test_cloud_workspace_backing_kind.py
@@ -1,0 +1,181 @@
+"""Real-Postgres proof for placement-neutral cloud workspace identity (5a).
+
+Covers the DB-layer invariants of the ``workspace_kind`` migration:
+
+- backfill/server default makes an unspecified row a ``repository_worktree``;
+- repository worktrees require a real ``repo_environment_id``;
+- scratch workspaces forbid a ``repo_environment_id``;
+- repository branch uniqueness is scoped to repository worktrees, so multiple
+  scratch rows can share the ``main`` branch for one owner.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import GitProvider, RepoEnvironmentKind
+from proliferate.db.models.auth import User
+from proliferate.db.models.cloud.repositories import RepoConfig, RepoEnvironment
+from proliferate.db.models.cloud.workspaces import CloudWorkspace
+from proliferate.db.store import cloud_workspaces as store
+from proliferate.server.cloud.workspaces.domain.naming import scratch_workspace_display_name
+
+
+async def _seed_user(db: AsyncSession) -> uuid.UUID:
+    user = User(
+        email=f"identity-{uuid.uuid4()}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user.id
+
+
+async def _seed_cloud_repo_environment(db: AsyncSession, user_id: uuid.UUID) -> uuid.UUID:
+    repo_config = RepoConfig(
+        user_id=user_id,
+        git_provider=GitProvider.github,
+        git_owner="proliferate-ai",
+        git_repo_name=f"repo-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(repo_config)
+    await db.flush()
+    repo_environment = RepoEnvironment(
+        repo_config_id=repo_config.id,
+        environment_kind=RepoEnvironmentKind.cloud,
+        default_branch="main",
+        setup_script="",
+        run_command="",
+    )
+    db.add(repo_environment)
+    await db.flush()
+    return repo_environment.id
+
+
+@pytest.mark.asyncio
+async def test_backfill_defaults_unspecified_row_to_repository_worktree(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _seed_user(db_session)
+    repo_environment_id = await _seed_cloud_repo_environment(db_session, user_id)
+    workspace_id = uuid.uuid4()
+
+    # Insert without workspace_kind — the migration's NOT NULL server default is
+    # exactly the backfill applied to every pre-existing row.
+    await db_session.execute(
+        text(
+            "INSERT INTO cloud_workspace "
+            "(id, owner_user_id, repo_environment_id, display_name, git_branch, "
+            " created_at, updated_at) "
+            "VALUES (:id, :owner, :repo_env, :name, :branch, now(), now())"
+        ),
+        {
+            "id": workspace_id,
+            "owner": user_id,
+            "repo_env": repo_environment_id,
+            "name": "feature",
+            "branch": "feature",
+        },
+    )
+    await db_session.flush()
+
+    loaded = await store.get_cloud_workspace_by_id(db_session, workspace_id)
+    assert loaded is not None
+    assert loaded.workspace_kind == "repository_worktree"
+
+
+@pytest.mark.asyncio
+async def test_repository_worktree_requires_repo_environment(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _seed_user(db_session)
+    db_session.add(
+        CloudWorkspace(
+            owner_user_id=user_id,
+            workspace_kind="repository_worktree",
+            repo_environment_id=None,
+            display_name="orphan",
+            git_branch="feature",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_scratch_forbids_repo_environment(db_session: AsyncSession) -> None:
+    user_id = await _seed_user(db_session)
+    repo_environment_id = await _seed_cloud_repo_environment(db_session, user_id)
+    db_session.add(
+        CloudWorkspace(
+            owner_user_id=user_id,
+            workspace_kind="scratch",
+            repo_environment_id=repo_environment_id,
+            display_name="Workflow run x",
+            git_branch="main",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_create_scratch_cloud_workspace_shape(db_session: AsyncSession) -> None:
+    user_id = await _seed_user(db_session)
+    invocation_id = uuid.uuid4()
+    workspace = await store.create_scratch_cloud_workspace(
+        db_session,
+        user_id=user_id,
+        display_name=scratch_workspace_display_name(invocation_id),
+    )
+    assert workspace.workspace_kind == "scratch"
+    assert workspace.repo_environment_id is None
+    assert workspace.git_branch == "main"
+    assert workspace.git_base_branch is None
+    assert workspace.display_name == f"Workflow run {invocation_id}"
+
+
+@pytest.mark.asyncio
+async def test_branch_uniqueness_scoped_to_repository_worktrees(
+    db_session: AsyncSession,
+) -> None:
+    user_id = await _seed_user(db_session)
+    repo_environment_id = await _seed_cloud_repo_environment(db_session, user_id)
+
+    first = await store.create_cloud_workspace(
+        db_session,
+        user_id=user_id,
+        repo_environment_id=repo_environment_id,
+        display_name="feature",
+        git_branch="feature",
+        git_base_branch="main",
+    )
+    assert first is not None
+    # Same owner + repo environment + branch collides for repository worktrees.
+    duplicate = await store.create_cloud_workspace(
+        db_session,
+        user_id=user_id,
+        repo_environment_id=repo_environment_id,
+        display_name="feature",
+        git_branch="feature",
+        git_base_branch="main",
+    )
+    assert duplicate is None
+
+    # Scratch rows all share git_branch="main" and are exempt from that index.
+    scratch_a = await store.create_scratch_cloud_workspace(
+        db_session, user_id=user_id, display_name="Workflow run a"
+    )
+    scratch_b = await store.create_scratch_cloud_workspace(
+        db_session, user_id=user_id, display_name="Workflow run b"
+    )
+    assert scratch_a.id != scratch_b.id
+    assert scratch_a.git_branch == scratch_b.git_branch == "main"

--- a/server/tests/integration/test_cloud_workspace_backing_kind_migration.py
+++ b/server/tests/integration/test_cloud_workspace_backing_kind_migration.py
@@ -1,0 +1,286 @@
+"""Real-Postgres upgrade proof for the cloud workspace backing-kind migration.
+
+MC5A-MIGRATION-PROOF-01. Unlike the server-default test, this starts a
+disposable database at the PRIOR migration head, inserts representative
+pre-existing legacy repository rows (active + archived) into the old schema
+(where ``repo_environment_id`` is NOT NULL and no ``workspace_kind`` column
+exists), then upgrades through ``c3a7b8d9e0f1`` and verifies:
+
+- every legacy row is backfilled to ``repository_worktree``;
+- ``repo_environment_id`` becomes nullable but preserves the existing value;
+- the kind/repo-environment check constraints are enforced;
+- a scratch row (no repo environment) is now insertable;
+- the branch-uniqueness partial index carries the exact
+  ``archived_at IS NULL AND workspace_kind = 'repository_worktree'`` predicate,
+  collides on duplicate active repository branches, and exempts scratch rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from alembic import command
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from proliferate.db.migrations import build_alembic_config
+from tests.postgres import run_migrations_async, temporary_database
+
+_REVISION = "c3a7b8d9e0f1"
+_DOWN_REVISION = "6f545e279264"
+_BRANCH_INDEX = "ux_cloud_workspace_active_repo_environment_branch"
+
+
+async def _seed_repo_environment(conn, *, owner_email: str) -> tuple[uuid.UUID, uuid.UUID]:
+    """Insert a user + cloud repo environment via raw SQL (schema-version-agnostic)."""
+    user_id = uuid.uuid4()
+    repo_config_id = uuid.uuid4()
+    repo_environment_id = uuid.uuid4()
+    await conn.execute(
+        text(
+            'INSERT INTO "user" (id, email, hashed_password, is_active, is_superuser, '
+            "is_verified, created_at) "
+            "VALUES (:id, :email, 'x', true, false, true, now())"
+        ),
+        {"id": user_id, "email": owner_email},
+    )
+    await conn.execute(
+        text(
+            "INSERT INTO repo_config (id, user_id, git_provider, git_owner, git_repo_name, "
+            "commit_instructions, created_at, updated_at) "
+            "VALUES (:id, :user_id, 'github', 'proliferate-ai', :repo, '', now(), now())"
+        ),
+        {"id": repo_config_id, "user_id": user_id, "repo": f"repo-{uuid.uuid4().hex[:8]}"},
+    )
+    await conn.execute(
+        text(
+            "INSERT INTO repo_environment (id, repo_config_id, environment_kind, default_branch, "
+            "setup_script, run_command, created_at, updated_at) "
+            "VALUES (:id, :cfg, 'cloud', 'main', '', '', now(), now())"
+        ),
+        {"id": repo_environment_id, "cfg": repo_config_id},
+    )
+    return user_id, repo_environment_id
+
+
+async def _insert_legacy_repository_row(
+    conn,
+    *,
+    user_id: uuid.UUID,
+    repo_environment_id: uuid.UUID,
+    branch: str,
+    archived: bool,
+) -> uuid.UUID:
+    """Insert into the OLD (pre-migration) cloud_workspace schema.
+
+    The prior schema has no ``workspace_kind`` column and a NOT NULL
+    ``repo_environment_id``; this models a real pre-existing repository row.
+    """
+    workspace_id = uuid.uuid4()
+    await conn.execute(
+        text(
+            "INSERT INTO cloud_workspace "
+            "(id, owner_user_id, repo_environment_id, display_name, git_branch, "
+            " git_base_branch, created_at, updated_at, archived_at) "
+            "VALUES (:id, :owner, :repo_env, :name, :branch, 'main', now(), now(), "
+            ":archived_at)"
+        ),
+        {
+            "id": workspace_id,
+            "owner": user_id,
+            "repo_env": repo_environment_id,
+            "name": branch,
+            "branch": branch,
+            "archived_at": datetime.now(UTC) if archived else None,
+        },
+    )
+    return workspace_id
+
+
+async def _column_is_nullable(conn, table: str, column: str) -> bool:
+    return await conn.run_sync(
+        lambda sync_conn: next(
+            c["nullable"] for c in inspect(sync_conn).get_columns(table) if c["name"] == column
+        )
+    )
+
+
+async def _branch_index_predicate(conn) -> str | None:
+    row = await conn.execute(
+        text(
+            "SELECT pg_get_indexdef(indexrelid) FROM pg_index i "
+            "JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = :name"
+        ),
+        {"name": _BRANCH_INDEX},
+    )
+    return row.scalar_one_or_none()
+
+
+@pytest.mark.asyncio
+async def test_legacy_repository_rows_upgrade_to_repository_worktree() -> None:
+    async with temporary_database("mc5a_backfill") as (_name, database_url):
+        config = build_alembic_config(database_url)
+
+        # 1. Start at the PRIOR migration head (no workspace_kind column yet).
+        await asyncio.to_thread(command.upgrade, config, _DOWN_REVISION)
+
+        engine = create_async_engine(database_url, echo=False)
+        try:
+            # 2. Insert representative legacy repository rows (active + archived).
+            async with engine.begin() as conn:
+                user_id, repo_environment_id = await _seed_repo_environment(
+                    conn, owner_email=f"legacy-{uuid.uuid4()}@example.com"
+                )
+                active_id = await _insert_legacy_repository_row(
+                    conn,
+                    user_id=user_id,
+                    repo_environment_id=repo_environment_id,
+                    branch="feature-active",
+                    archived=False,
+                )
+                archived_id = await _insert_legacy_repository_row(
+                    conn,
+                    user_id=user_id,
+                    repo_environment_id=repo_environment_id,
+                    branch="feature-archived",
+                    archived=True,
+                )
+                # The old schema has no workspace_kind column.
+                cols_before = await conn.run_sync(
+                    lambda c: {col["name"] for col in inspect(c).get_columns("cloud_workspace")}
+                )
+                assert "workspace_kind" not in cols_before
+                assert (
+                    await _column_is_nullable(conn, "cloud_workspace", "repo_environment_id")
+                    is False
+                )
+
+            # 3. Upgrade through the target revision.
+            await asyncio.to_thread(command.upgrade, config, _REVISION)
+
+            async with engine.begin() as conn:
+                # Backfill: every pre-existing row is a repository_worktree with
+                # its repo metadata preserved.
+                rows = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT id, workspace_kind, repo_environment_id, git_branch, "
+                                "archived_at FROM cloud_workspace ORDER BY git_branch"
+                            )
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                by_id = {r["id"]: r for r in rows}
+                assert by_id[active_id]["workspace_kind"] == "repository_worktree"
+                assert by_id[archived_id]["workspace_kind"] == "repository_worktree"
+                assert by_id[active_id]["repo_environment_id"] == repo_environment_id
+                assert by_id[archived_id]["repo_environment_id"] == repo_environment_id
+                assert by_id[archived_id]["archived_at"] is not None
+
+                # repo_environment_id is now nullable at the schema level.
+                assert (
+                    await _column_is_nullable(conn, "cloud_workspace", "repo_environment_id")
+                    is True
+                )
+
+                # Partial index predicate is exactly repository-worktree + active.
+                # Postgres renders the stored predicate with explicit ::text casts,
+                # so normalize casts/parens away before asserting the exact terms.
+                predicate = await _branch_index_predicate(conn)
+                assert predicate is not None
+                normalized = predicate.replace("(", "").replace(")", "").replace("::text", "")
+                assert "archived_at IS NULL" in normalized
+                assert "workspace_kind = 'repository_worktree'" in normalized
+                # Both conditions are AND-combined (scratch + archived are excluded).
+                assert " AND " in predicate
+
+            # 4. Constraint behavior on the upgraded schema.
+            engine2 = create_async_engine(database_url, echo=False)
+            try:
+                # A scratch row (no repo environment) is now insertable.
+                async with engine2.begin() as conn:
+                    scratch_id = uuid.uuid4()
+                    await conn.execute(
+                        text(
+                            "INSERT INTO cloud_workspace "
+                            "(id, owner_user_id, workspace_kind, repo_environment_id, "
+                            " display_name, git_branch, created_at, updated_at) "
+                            "VALUES (:id, :owner, 'scratch', NULL, 'Workflow run x', 'main', "
+                            "now(), now())"
+                        ),
+                        {"id": scratch_id, "owner": user_id},
+                    )
+                    # A second scratch row on the same main branch does NOT collide.
+                    await conn.execute(
+                        text(
+                            "INSERT INTO cloud_workspace "
+                            "(id, owner_user_id, workspace_kind, repo_environment_id, "
+                            " display_name, git_branch, created_at, updated_at) "
+                            "VALUES (:id, :owner, 'scratch', NULL, 'Workflow run y', 'main', "
+                            "now(), now())"
+                        ),
+                        {"id": uuid.uuid4(), "owner": user_id},
+                    )
+
+                # A scratch row WITH a repo environment violates the kind constraint.
+                with pytest.raises(IntegrityError):
+                    async with engine2.begin() as conn:
+                        await conn.execute(
+                            text(
+                                "INSERT INTO cloud_workspace "
+                                "(id, owner_user_id, workspace_kind, repo_environment_id, "
+                                " display_name, git_branch, created_at, updated_at) "
+                                "VALUES (:id, :owner, 'scratch', :repo_env, 'bad', 'main', "
+                                "now(), now())"
+                            ),
+                            {
+                                "id": uuid.uuid4(),
+                                "owner": user_id,
+                                "repo_env": repo_environment_id,
+                            },
+                        )
+
+                # A duplicate ACTIVE repository branch collides on the partial index.
+                with pytest.raises(IntegrityError):
+                    async with engine2.begin() as conn:
+                        await conn.execute(
+                            text(
+                                "INSERT INTO cloud_workspace "
+                                "(id, owner_user_id, workspace_kind, repo_environment_id, "
+                                " display_name, git_branch, created_at, updated_at) "
+                                "VALUES (:id, :owner, 'repository_worktree', :repo_env, 'dup', "
+                                "'feature-active', now(), now())"
+                            ),
+                            {
+                                "id": uuid.uuid4(),
+                                "owner": user_id,
+                                "repo_env": repo_environment_id,
+                            },
+                        )
+            finally:
+                await engine2.dispose()
+        finally:
+            await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_migration_round_trips_to_head() -> None:
+    """Sanity: upgrading straight to head from a fresh DB includes this revision."""
+    async with temporary_database("mc5a_head") as (_name, database_url):
+        await run_migrations_async(database_url)
+        engine = create_async_engine(database_url, echo=False)
+        try:
+            async with engine.begin() as conn:
+                cols = await conn.run_sync(
+                    lambda c: {col["name"] for col in inspect(c).get_columns("cloud_workspace")}
+                )
+                assert "workspace_kind" in cols
+        finally:
+            await engine.dispose()

--- a/server/tests/integration/test_cloud_workspace_identity_payload.py
+++ b/server/tests/integration/test_cloud_workspace_identity_payload.py
@@ -1,0 +1,155 @@
+"""Serialization proof for placement-neutral cloud workspace identity (5a).
+
+Pins the repository payload byte-stable (only additive ``workspaceKind``) and
+proves scratch rows serialize ``repo``/``repoEnvironmentId``/``runtime`` without
+fabricated repository data.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, UTC
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from proliferate.db.store.cloud_workspaces import CloudWorkspaceValue
+from proliferate.server.cloud.workspaces import service as workspaces_service
+from proliferate.server.cloud.workspaces.domain.naming import scratch_workspace_display_name
+
+_CREATED = datetime(2026, 7, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _repository_value(repo_environment_id: uuid.UUID) -> CloudWorkspaceValue:
+    return CloudWorkspaceValue(
+        id=uuid.UUID("50000000-0000-4000-8000-000000000001"),
+        owner_user_id=uuid.uuid4(),
+        workspace_kind="repository_worktree",
+        repo_environment_id=repo_environment_id,
+        display_name="feature-x",
+        git_branch="feature-x",
+        git_base_branch="main",
+        anyharness_workspace_id="workspace-123",
+        created_at=_CREATED,
+        updated_at=_CREATED,
+        archived_at=None,
+    )
+
+
+def _scratch_value(invocation_id: uuid.UUID) -> CloudWorkspaceValue:
+    return CloudWorkspaceValue(
+        id=invocation_id,
+        owner_user_id=uuid.uuid4(),
+        workspace_kind="scratch",
+        repo_environment_id=None,
+        display_name=scratch_workspace_display_name(invocation_id),
+        git_branch="main",
+        git_base_branch=None,
+        anyharness_workspace_id="workspace-scratch-1",
+        created_at=_CREATED,
+        updated_at=_CREATED,
+        archived_at=None,
+    )
+
+
+def _patch_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repo_environment_id: uuid.UUID,
+) -> None:
+    repo_environment = SimpleNamespace(
+        id=repo_environment_id,
+        environment_kind="cloud",
+        git_provider="github",
+        git_owner="proliferate-ai",
+        git_repo_name="proliferate",
+        default_branch="main",
+    )
+
+    async def _get_repo_environment(*_a: Any, **_k: Any) -> Any:
+        return repo_environment
+
+    async def _load_sandbox(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(status="ready", runtime_generation=3)
+
+    monkeypatch.setattr(
+        workspaces_service.repositories_store,
+        "get_repo_environment_by_id",
+        _get_repo_environment,
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandbox_store,
+        "load_personal_cloud_sandbox",
+        _load_sandbox,
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_payload_is_byte_stable_plus_workspace_kind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_environment_id = uuid.uuid4()
+    _patch_loaders(monkeypatch, repo_environment_id=repo_environment_id)
+
+    payload = await workspaces_service._workspace_payload(
+        db=SimpleNamespace(),  # type: ignore[arg-type]
+        workspace=_repository_value(repo_environment_id),
+        detail=True,
+    )
+    dumped = payload.model_dump(by_alias=True)
+
+    # New additive field.
+    assert dumped["workspaceKind"] == "repositoryWorktree"
+    # Pre-existing repository fields are unchanged (populated, never nulled).
+    assert dumped["repoEnvironmentId"] == str(repo_environment_id)
+    assert dumped["repo"] == {
+        "provider": "github",
+        "owner": "proliferate-ai",
+        "name": "proliferate",
+        "branch": "feature-x",
+        "baseBranch": "main",
+    }
+    assert dumped["runtime"]["environmentId"] == str(repo_environment_id)
+    assert dumped["status"] == "ready"
+    assert dumped["displayName"] == "feature-x"
+    assert dumped["anyharnessWorkspaceId"] == "workspace-123"
+
+
+@pytest.mark.asyncio
+async def test_scratch_payload_has_no_fabricated_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invocation_id = uuid.UUID("60000000-0000-4000-8000-000000000009")
+
+    # Loaders present but must NOT be consulted for scratch — patch to explode.
+    async def _explode(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("scratch payload must not load a repo environment")
+
+    async def _load_sandbox(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(status="ready", runtime_generation=3)
+
+    monkeypatch.setattr(
+        workspaces_service.repositories_store,
+        "get_repo_environment_by_id",
+        _explode,
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandbox_store,
+        "load_personal_cloud_sandbox",
+        _load_sandbox,
+    )
+
+    payload = await workspaces_service._workspace_payload(
+        db=SimpleNamespace(),  # type: ignore[arg-type]
+        workspace=_scratch_value(invocation_id),
+        detail=True,
+    )
+    dumped = payload.model_dump(by_alias=True)
+
+    assert dumped["workspaceKind"] == "scratch"
+    assert dumped["repo"] is None
+    assert dumped["repoEnvironmentId"] is None
+    assert dumped["runtime"]["environmentId"] is None
+    assert dumped["displayName"] == f"Workflow run {invocation_id}"
+    assert dumped["anyharnessWorkspaceId"] == "workspace-scratch-1"

--- a/server/tests/integration/test_cloud_workspace_identity_payload.py
+++ b/server/tests/integration/test_cloud_workspace_identity_payload.py
@@ -153,3 +153,49 @@ async def test_scratch_payload_has_no_fabricated_repo(
     assert dumped["runtime"]["environmentId"] is None
     assert dumped["displayName"] == f"Workflow run {invocation_id}"
     assert dumped["anyharnessWorkspaceId"] == "workspace-scratch-1"
+
+
+def _permits_null(prop_schema: dict[str, Any]) -> bool:
+    """True when the OpenAPI property schema allows an explicit ``null``.
+
+    Pydantic emits ``str | None`` and ``RepoRef | None`` as an ``anyOf`` that
+    includes a ``{"type": "null"}`` branch. A non-null default (the regression)
+    would collapse this to a single-type schema with no null branch.
+    """
+    return any(branch.get("type") == "null" for branch in prop_schema.get("anyOf", []))
+
+
+@pytest.mark.parametrize("schema_name", ["WorkspaceSummary", "WorkspaceDetail"])
+def test_identity_fields_are_required_in_openapi_contract(schema_name: str) -> None:
+    """Regression pin for the Pydantic-default identity regression (MC5A-SDK-01).
+
+    The frozen response requires current servers to ALWAYS emit ``workspaceKind``
+    (non-null enum) and ``repo``/``repoEnvironmentId`` (required but nullable).
+    Reintroducing a Pydantic default on any of these would silently drop it from
+    the OpenAPI ``required`` set (and, for the nullable fields, drop the null
+    branch), which is exactly what this contract asserts against.
+    """
+    # Import locally so the module-level serialization proofs above do not depend
+    # on constructing the whole app.
+    from proliferate.main import create_app
+
+    schemas = create_app().openapi()["components"]["schemas"]
+    schema = schemas[schema_name]
+    required = schema.get("required", [])
+    props = schema["properties"]
+
+    # All three identity fields are in the required set (never omittable).
+    assert "workspaceKind" in required
+    assert "repoEnvironmentId" in required
+    assert "repo" in required
+
+    # ``workspaceKind`` is a non-null enum with exactly the two allowed values.
+    workspace_kind = props["workspaceKind"]
+    assert workspace_kind.get("type") == "string"
+    assert not _permits_null(workspace_kind)
+    assert set(workspace_kind["enum"]) == {"repositoryWorktree", "scratch"}
+
+    # ``repoEnvironmentId`` and ``repo`` are required but permit an explicit null
+    # (scratch serializes null; repository worktrees populate them).
+    assert _permits_null(props["repoEnvironmentId"])
+    assert _permits_null(props["repo"])

--- a/specs/codebase/platforms/product/workspace-provisioning.md
+++ b/specs/codebase/platforms/product/workspace-provisioning.md
@@ -48,7 +48,8 @@ repository preparation failure.
 defines `cloud_workspace`. It owns:
 
 - the product workspace id and owner;
-- `repo_environment_id`;
+- a placement-neutral `workspace_kind` (`repository_worktree | scratch`);
+- a nullable `repo_environment_id`;
 - display name, Git branch, and optional base branch;
 - the optional `anyharness_workspace_id`; and
 - archive timestamps.
@@ -56,6 +57,40 @@ defines `cloud_workspace`. It owns:
 It does not own a sandbox id, runtime session state, runtime path, or runtime
 events. An AnyHarness workspace id is a reference to runtime truth, not a copy
 of that truth in Cloud.
+
+### Placement-neutral identity
+
+The row is placement-neutral so it can back either a repository worktree or a
+repository-less scratch workspace, without inventing repository metadata for
+scratch:
+
+- `repository_worktree` (the backfilled default for every pre-existing row)
+  requires a real `repo_environment_id` and preserves the existing
+  repository/branch behavior; its API response carries `workspaceKind =
+  repositoryWorktree` with a populated `repo` and `repoEnvironmentId`.
+- `scratch` (managed Workflow runs) forbids a `repo_environment_id`, uses the
+  `main` branch with no base branch, and serializes `repo`/`repoEnvironmentId`
+  and `runtime.environmentId` as `null` — never fabricated. Repository branch
+  uniqueness (the active partial index) applies only to repository worktrees, so
+  scratch rows freely share `main`.
+
+Two check constraints enforce this: `workspace_kind` is restricted to the two
+values, and a repo-environment presence constraint ties a non-null
+`repo_environment_id` to `repository_worktree` and forbids one for `scratch`.
+The migration is `c3a7b8d9e0f1_cloud_workspace_backing_kind`.
+
+Current servers always emit `workspaceKind`, `repo`, and `repoEnvironmentId`
+(the latter two nullable for scratch, never omitted); the shared client type
+keeps them optional only so responses from older servers that predate the
+migration are read as `repositoryWorktree`.
+
+Scope note: the mounted human `POST /workspaces` flow below remains
+repository-only — it always creates a `repository_worktree` bound to a resolved
+cloud repo environment. There is no current mounted route that creates a
+`scratch` workspace; managed scratch creation and execution are downstream in
+Managed Cloud Execution (5b), not current behavior. This slice (5a) delivers
+only the placement-neutral identity, its migration, the serialized fields, and
+the shared display derivation.
 
 ## Mounted API
 
@@ -199,6 +234,9 @@ Use these focused tests as the code-level proof:
 - `server/tests/unit/test_sandbox_materialization.py`
 - `server/tests/unit/test_cloud_workspace_status.py`
 - `server/tests/unit/test_cloud_sandbox_gateway_access.py`
+- `server/tests/integration/test_cloud_workspace_backing_kind.py`
+- `server/tests/integration/test_cloud_workspace_backing_kind_migration.py`
+- `server/tests/integration/test_cloud_workspace_identity_payload.py`
 
 For incident diagnosis, use
 [`cloud-provisioning-failure.md`](../../../developing/operating/cloud-provisioning-failure.md).


### PR DESCRIPTION
## Frozen spec

Delivers **part 5a "Cloud Workspace Identity for Repository and Scratch"** of the frozen spec `5 - Managed Cloud Execution` (RC1.0). The 5a/5b split was **pre-approved** in the spec itself (founder decision 12): the shared workspace-identity migration spans server + cloud-sdk + product-domain + three client apps, which would make one combined diff materially unreviewable. This PR is the migration slice only. **5b "Managed Cloud Execution"** (managed delivery / observation / cancellation / stale-window) is a separate downstream slice and is intentionally NOT implemented here.

## What's implemented

- **Server model/migration**: `workspace_kind` column on `cloud_workspace` (`repository_worktree | scratch`) with a NOT NULL server-default backfill to `repository_worktree`; `repo_environment_id` made nullable; CHECK constraints binding scratch rows to a null repo environment and repository worktrees to a real one; active-branch uniqueness index scoped to `workspace_kind = 'repository_worktree'`. Alembic migration `c3a7b8d9e0f1` (revises `6f545e279264`).
- **Server store/service**: `create_scratch_cloud_workspace` + scratch display-name helper (`Workflow run <invocationId>`, branch `main`, no base branch); `_workspace_payload` serializes scratch `repo` / `repoEnvironmentId` / `runtime.environmentId` as `null` (never fabricated) and never loads a repo environment for scratch, while the repository payload stays byte-stable plus the additive `workspaceKind`.
- **Cloud SDK regen**: `CloudWorkspaceBackingKind = "repositoryWorktree" | "scratch"`; additive `workspaceKind` and nullable `repo` / `repoEnvironmentId` on `CloudWorkspaceSummary` / detail schemas.
- **product-domain**: central placement/display derivation `backing-kind.ts` (`workspaceBackingKind`, `isRepositoryWorktree`, `isScratchWorkspace`, `workspaceRepoRef`, `workspaceRepoLabel`, `workspaceBranchLabel`, `workspaceDisplayTitle`) — absent `workspaceKind` (older servers) is treated as `repositoryWorktree`.
- **Compile-safe consumers**: product-client, web, and mobile workspace consumers route repository reads through the derivation guard so scratch placement never dereferences fabricated repo data. Minimum compile-safe guards only; the visible Recents/navigation/action behavior remains owned by the Managed Workflow Product Experience slice.
- **max_lines allowlist**: generated cloud SDK type surface bumped to 784 (+`workspaceKind`).

## Base / head

- Base: current `main` at `24c0a9ef9956f5942f88a50a4a33cb4dfb464ee3` (custody clean; no rebase required for this delta round).
- Head: `df6ef4374cd03d09bf7e94c45bfe991d311cddab`.

## Verification (repaired evidence)

- **Server tests (real PostgreSQL)** — mirrors `server-ci.yml`: `test_cloud_workspace_identity_payload.py` (4) + `test_cloud_workspace_backing_kind.py` (5) + `test_cloud_workspace_backing_kind_migration.py` (2) + `test_cloud_workspace_status.py` (6) = **17 passed**. The migration file includes a genuine PostgreSQL migration-upgrade proof (real `alembic upgrade` against Postgres, backfill + CHECK-constraint + scoped-uniqueness assertions), not an offline `--sql` render.
- **New OpenAPI required-list pin** (MC5A-SDK-01): `test_identity_fields_are_required_in_openapi_contract` asserts `create_app().openapi()` keeps `workspaceKind` / `repoEnvironmentId` / `repo` in the `required` set of both `WorkspaceSummary` and `WorkspaceDetail`, that `workspaceKind` is a non-null enum of exactly `{repositoryWorktree, scratch}`, and that `repoEnvironmentId` / `repo` permit an explicit `null`. Mutation-verified: giving any of the three a Pydantic default makes the test fail.
- **product-domain vitest** (incl. `backing-kind.test.ts`): **552 passed** (59 files).
- **product-client vitest**: **3036 passed** (524 files).
- **TS typecheck clean**: product-client, web, mobile, product-domain (`tsc --noEmit`, exit 0).
- **`ruff check proliferate/ tests/`**: clean.
- **Cloud SDK regen is byte-reproducible**: re-running `make cloud-client-generate` (`Makefile:1107-1123`) regenerates `server/openapi.json` and the **generated OpenAPI artifact `cloud/sdk/src/generated/openapi.ts`** byte-for-byte against the checked-in file. `cloud/sdk/src/types/generated.ts` is a **separate, deliberately hand-maintained older-server compatibility projection** — the generator does not write it and it is not expected to be byte-reproducible; its optionality was already accepted. The **complete** generated OpenAPI drift is included in the committed artifact (the 5a `workspaceKind` / nullable `repo` / `repoEnvironmentId` delta plus the pre-existing worker/runtime versioned-download and desired-versions endpoints that had been stale in the checked-in file).
- All five repo-shape checkers pass: `check_max_lines.py`, `check_frontend_boundaries.py`, `report_frontend_structure.py --strict`, `check_server_boundaries.py`, `check_anyharness_boundaries.py`.

## Disclosed assumptions / judgment calls

- The original worktree edits touched three legacy web files (`build-web-cloud-chat-surface-props.ts`, `create-workspace-with-transient-recovery.ts`, `cloud-sidebar-model.ts`) that main's PR #1229 deleted (legacy Web replaced by shared ProductClient). Accepted the deletions during the earlier rebase — the compile-safe guards now live in product-client, which those web surfaces consume.

## Not in this PR

5b Managed Cloud Execution (managed-execution table, delivery/observe/cancel APIs and tasks, target-plan freezing, monotonic projection, freshness/stale window, `/meta` capability). Feature gate remains off; no production enablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

