### PR TITLE
fix(product-client): keep audio + xterm CSS off the eager login shell (phase-6 budget)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,40 @@ jobs:
       - name: Build web
         run: pnpm web:build
 
+  # Fail-closed phase-6 /login first-load budget gate (WDU-1247-B1). Builds the
+  # Web host against a fixed anonymous API fixture, loads /login in headless
+  # Chromium with that fixture intercepted, waits for the durable login-ready
+  # marker + settled network, and enforces the founder-approved gzip-9 ceilings
+  # (JS 485000 B, CSS 66000 B; zero eager fonts/images/audio) FAIL-CLOSED. No
+  # continue-on-error: a regression fails CI on PRs and main, which also gates
+  # the Deploy Staging workflow_run spine.
+  login-budget:
+    name: Login first-load budget (phase-6)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build shared packages
+        run: pnpm shared:build
+
+      - name: Enforce /login runtime budget
+        run: node scripts/measure-login-runtime-budget.mjs
+
   shared-frontend-packages:
     name: Shared frontend packages
     runs-on: ubuntu-latest

--- a/apps/packages/product-client/src/components/auth/AuthScreenLayout.tsx
+++ b/apps/packages/product-client/src/components/auth/AuthScreenLayout.tsx
@@ -100,6 +100,14 @@ export function AuthScreenLayout({
     <AuthAppearanceBoundary
       className="flex min-h-screen flex-col items-center justify-center bg-background p-8"
       data-tauri-drag-region="true"
+      // Durable readiness marker for the phase-6 /login budget collector
+      // (scripts/measure-login-runtime-budget.mjs). "auth" only once the shell
+      // has resolved to the signed-out sign-in surface; "loading" while the
+      // session bootstrap is still in flight. The collector waits for
+      // [data-auth-screen="auth"] specifically — an error/retry/loading screen
+      // never satisfies it, so a passing ledger always reflects the real
+      // login-ready point rather than any stray button/input on the page.
+      data-auth-screen={mode}
     >
       <div className="w-full max-w-md space-y-8">
         <div className="space-y-5">

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-turn-end-sound.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-turn-end-sound.ts
@@ -10,9 +10,6 @@ export function useTurnEndSound(): void {
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
-    const audio = new Audio(dingSrc);
-    audio.preload = "auto";
-    audioRef.current = audio;
     return () => {
       audioRef.current = null;
     };
@@ -23,11 +20,18 @@ export function useTurnEndSound(): void {
       const { turnEndSoundEnabled } = useUserPreferencesStore.getState();
       if (!turnEndSoundEnabled) return;
 
-      const audio = audioRef.current;
-      if (audio) {
-        audio.currentTime = 0;
-        audio.play().catch(() => {});
+      // Construct (and thereby fetch) the clip lazily on the first turn-end that
+      // actually needs it. This hook mounts in the shared lifecycle root above
+      // the auth gate, so eager `new Audio(...)` with `preload="auto"` would
+      // fetch the audio on the public login shell before the user signs in.
+      let audio = audioRef.current;
+      if (!audio) {
+        audio = new Audio(dingSrc);
+        audio.preload = "auto";
+        audioRef.current = audio;
       }
+      audio.currentTime = 0;
+      audio.play().catch(() => {});
     };
 
     onUserFacingTurnEnd(handler);

--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.ts
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.ts
@@ -1,4 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+// The xterm terminal stylesheet is co-located with the terminal surface (not
+// the eager product CSS entry) so it rides the lazy authenticated terminal
+// chunk alongside the dynamically imported xterm runtime below. The phase-6
+// cutover contract forbids the login/callback shell from eagerly loading
+// xterm/terminal CSS; this hook is only reachable through the lazy
+// AuthenticatedProductClient boundary.
+import "@xterm/xterm/css/xterm.css";
 import { getTerminalTheme, onThemeChange } from "#product/config/theme";
 import { resolveReadableCodeFontScale } from "#product/lib/domain/preferences/appearance";
 import { TERMINAL_FONT_FAMILY } from "#product/lib/domain/terminals/terminal-grid";

--- a/apps/packages/product-client/src/index.css
+++ b/apps/packages/product-client/src/index.css
@@ -1,2 +1,7 @@
-@import "@xterm/xterm/css/xterm.css";
+/* Shared product theme (tokens, base, component CSS, Tailwind utilities). The
+ * xterm terminal stylesheet is intentionally NOT imported here: the phase-6
+ * cutover contract forbids the login/callback shell from eagerly loading
+ * xterm/terminal CSS, and this file is pulled by the eager ProductClient
+ * entry. xterm.css is imported inside `use-xterm-surface.ts` instead, so it
+ * rides the lazy authenticated terminal chunk with the xterm runtime. */
 @import "@proliferate/design/product.css";

--- a/scripts/measure-login-runtime-budget.mjs
+++ b/scripts/measure-login-runtime-budget.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// Retained runtime /login budget collector + fail-closed gate (phase-6 cutover).
+//
+// WHY A RUNTIME COLLECTOR (not the static manifest walker). The binding legacy
+// baseline was produced by `scripts/collect-web-bundle-baseline.mjs`, which
+// walks the Vite manifest's STATIC import closure. For the replacement browser
+// host that tool is not a faithful gate: the manifest still associates
+// side-effect assets (e.g. `ding-*.mp3`) with `index.html`, so it would count
+// bytes the browser never requests on `/login`. The phase-6 contract requires
+// the gate to measure what the browser actually REQUESTS before readiness:
+// fresh cache, a durable ProductClient readiness marker, `document.fonts.ready`,
+// and a bounded network-idle settle. This script is that gate, kept in-tree so
+// it is reproducible and rerunnable against exact merged main.
+//
+// WHAT IT DOES.
+//   1. Builds `apps/web` (skip with --no-build to measure an existing dist).
+//   2. Serves apps/web/dist over loopback.
+//   3. Loads /login in headless Chromium with a fresh context (fresh cache),
+//      records unique same-origin GET responses until readiness, then computes
+//      gzip-9 byte totals per kind (js/css/font/image/audio) from the on-disk
+//      dist files (same compression metric as the baseline collector).
+//   4. Enforces the founder-approved gzip-9 ceilings FAIL-CLOSED (see CAPS):
+//      exits non-zero if requested JS or CSS exceeds its cap, or if any font /
+//      image / audio byte is requested on /login (baseline is 0).
+//   5. Emits a machine-readable ledger bound to the tested commit SHA and
+//      prints the exact rerun command.
+//
+// FOUNDER DECISION WDU-1247-D1 (approved 2026-07-15): exact gzip-9 /login
+// ceilings — JS 485000 bytes, CSS 66000 bytes. This chose shared-shell
+// simplicity / full shared-package Tailwind scanning over a separate
+// auth-shell CSS build boundary. These caps are the enforceable gate; the
+// legacy baseline (471,212 B JS / 24,226 B CSS) remains recorded context.
+//
+// USAGE.
+//   node scripts/measure-login-runtime-budget.mjs [--no-build] [--out <path>]
+//   (build first if using --no-build: pnpm shared:build && pnpm web:build)
+//
+// Exit codes: 0 = within all ceilings; 1 = over a ceiling / unexpected asset;
+// 2 = measurement could not be performed (build/serve/browser error).
+
+import { execFileSync } from "node:child_process";
+import { createServer } from "node:http";
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, extname, join, normalize } from "node:path";
+import { gzipSync } from "node:zlib";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DIST = join(REPO_ROOT, "apps", "web", "dist");
+
+// Founder-approved gzip-9 /login ceilings (WDU-1247-D1). Exact integer bytes.
+const CAPS = { js: 485000, css: 66000 };
+// Baseline requests zero of these on /login; any byte is a fail-closed
+// regression (login/callback must not eagerly load fonts/images/audio).
+const ZERO_KINDS = ["font", "image", "audio"];
+
+const RERUN_COMMAND =
+  "pnpm shared:build && pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build";
+
+const args = process.argv.slice(2);
+const noBuild = args.includes("--no-build");
+const outIdx = args.indexOf("--out");
+const outPath = outIdx >= 0 ? args[outIdx + 1] : null;
+
+function fail(code, message) {
+  console.error(`\n[login-budget] ${message}`);
+  process.exit(code);
+}
+
+function gitSha() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const MIME = {
+  ".html": "text/html", ".js": "application/javascript", ".css": "text/css",
+  ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png",
+  ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp",
+  ".gif": "image/gif", ".woff2": "font/woff2", ".woff": "font/woff",
+  ".mp3": "audio/mpeg", ".ico": "image/x-icon",
+};
+
+function kindOf(p) {
+  const e = extname(p);
+  if (e === ".js") return "js";
+  if (e === ".css") return "css";
+  if (e === ".woff2" || e === ".woff" || e === ".ttf" || e === ".otf") return "font";
+  if ([".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg", ".ico"].includes(e)) return "image";
+  if (e === ".mp3" || e === ".wav" || e === ".ogg") return "audio";
+  return "other";
+}
+
+// Compression metric: gzip level 9 for text assets (js/css/svg/other); emitted
+// (raw) bytes for already-compressed binary assets (fonts/images/audio) — same
+// rule as the baseline collector.
+function measuredBytes(kind, absFile) {
+  const raw = readFileSync(absFile);
+  const isText = kind === "js" || kind === "css" || kind === "other" || extname(absFile) === ".svg";
+  return isText ? gzipSync(raw, { level: 9 }).length : raw.length;
+}
+
+function serveDist() {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, "http://x");
+    const p = normalize(url.pathname).replace(/^\/+/, "");
+    let f = join(DIST, p);
+    if (!f.startsWith(DIST) || !existsSync(f) || !statSync(f).isFile()) {
+      f = join(DIST, "index.html"); // SPA fallback
+    }
+    res.statusCode = 200;
+    res.setHeader("content-type", MIME[extname(f)] ?? "application/octet-stream");
+    // Force a fresh fetch every time; the browser context is also fresh.
+    res.setHeader("cache-control", "no-store");
+    createReadStream(f).pipe(res);
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: server.address().port }),
+    );
+  });
+}
+
+// ---- 1. build ----
+if (!noBuild) {
+  console.error("[login-budget] building apps/web (pnpm web:build)…");
+  try {
+    execFileSync("pnpm", ["run", "web:build"], { cwd: REPO_ROOT, stdio: "inherit" });
+  } catch {
+    fail(2, "web:build failed; run `pnpm shared:build` first if package dist is stale.");
+  }
+}
+if (!existsSync(join(DIST, "index.html"))) {
+  fail(2, `no build at ${DIST}; run without --no-build, or build apps/web first.`);
+}
+
+// ---- 2. serve + 3. measure ----
+let chromium;
+try {
+  ({ chromium } = await import("playwright"));
+} catch {
+  fail(2, "playwright is not available; cannot run the runtime collector.");
+}
+
+const { server, port } = await serveDist();
+const base = `http://127.0.0.1:${port}`;
+const requested = new Map(); // pathname -> kind
+
+let browser;
+try {
+  browser = await chromium.launch();
+  const context = await browser.newContext(); // fresh profile = fresh cache
+  const page = await context.newPage();
+
+  page.on("response", (resp) => {
+    const u = new URL(resp.url());
+    if (u.origin !== base) return;
+    if (resp.request().method() !== "GET") return;
+    const path = u.pathname;
+    if (path === "/" || path === "/login" || path.endsWith(".html")) return; // document
+    requested.set(path, kindOf(path));
+  });
+
+  await page.goto(`${base}/login`, { waitUntil: "load" });
+  // Readiness: the login shell rendered (ProductClient auth gate output present).
+  await page.waitForSelector("button, input, [data-auth-screen], form", { timeout: 30_000 });
+  await page.evaluate(() => document.fonts.ready);
+  // Bounded network-idle settle, then a fixed drain window for late requests.
+  await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(2_000);
+} catch (err) {
+  await browser?.close().catch(() => {});
+  server.close();
+  fail(2, `runtime measurement failed: ${err?.message ?? err}`);
+} finally {
+  await browser?.close().catch(() => {});
+  server.close();
+}
+
+// ---- tally ----
+const perKind = {};
+const files = [];
+for (const [path, kind] of [...requested.entries()].sort()) {
+  const abs = join(DIST, path.replace(/^\/+/, ""));
+  if (!existsSync(abs)) continue;
+  const bytes = measuredBytes(kind, abs);
+  perKind[kind] = (perKind[kind] ?? 0) + bytes;
+  files.push({ path, kind, bytes });
+}
+const total = Object.values(perKind).reduce((a, b) => a + b, 0);
+const jsBytes = perKind.js ?? 0;
+const cssBytes = perKind.css ?? 0;
+
+// ---- 4. fail-closed gate ----
+const violations = [];
+if (jsBytes > CAPS.js) violations.push(`JS ${jsBytes} B > cap ${CAPS.js} B`);
+if (cssBytes > CAPS.css) violations.push(`CSS ${cssBytes} B > cap ${CAPS.css} B`);
+for (const k of ZERO_KINDS) {
+  if ((perKind[k] ?? 0) > 0) {
+    violations.push(`${k} ${perKind[k]} B requested on /login (baseline 0; must not eagerly load)`);
+  }
+}
+const pass = violations.length === 0;
+
+// ---- 5. ledger bound to tested SHA ----
+const ledger = {
+  schema: "login-runtime-budget/v1",
+  measuredAt: "runtime headless chromium, fresh cache, ProductClient readiness marker, document.fonts.ready, bounded network-idle + 2s settle",
+  testedSha: gitSha(),
+  base: "/login",
+  compressionMetric: "gzip (Node zlib, level 9) for js/css/svg/other; emitted bytes for fonts/images/audio",
+  caps: { ...CAPS, source: "founder decision WDU-1247-D1 (2026-07-15), gzip-9 bytes" },
+  legacyBaseline: {
+    source: "specs/codebase/systems/product/clients/web-desktop-unification/migration/web-bundle-baseline-c6e094b41.json",
+    jsGzipBytes: 471212,
+    cssGzipBytes: 24226,
+    note: "recorded context; the enforceable gate is the founder caps above",
+  },
+  perKind,
+  total,
+  jsBytes,
+  cssBytes,
+  headroom: { js: CAPS.js - jsBytes, css: CAPS.css - cssBytes },
+  pass,
+  violations,
+  files,
+  rerunCommand: RERUN_COMMAND,
+};
+
+const json = JSON.stringify(ledger, null, 2);
+if (outPath) {
+  const abs = join(REPO_ROOT, outPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, json + "\n");
+  console.error(`[login-budget] ledger written to ${outPath}`);
+}
+console.log(json);
+
+console.error(
+  `\n[login-budget] JS ${jsBytes}/${CAPS.js} B  CSS ${cssBytes}/${CAPS.css} B  ` +
+    `fonts/images/audio ${ZERO_KINDS.map((k) => `${k}=${perKind[k] ?? 0}`).join(" ")}`,
+);
+console.error(`[login-budget] rerun: ${RERUN_COMMAND}`);
+if (!pass) {
+  fail(1, `budget gate FAILED: ${violations.join("; ")}`);
+}
+console.error("[login-budget] budget gate PASSED (within all ceilings).");

--- a/scripts/measure-login-runtime-budget.mjs
+++ b/scripts/measure-login-runtime-budget.mjs
@@ -8,20 +8,39 @@
 // side-effect assets (e.g. `ding-*.mp3`) with `index.html`, so it would count
 // bytes the browser never requests on `/login`. The phase-6 contract requires
 // the gate to measure what the browser actually REQUESTS before readiness:
-// fresh cache, a durable ProductClient readiness marker, `document.fonts.ready`,
-// and a bounded network-idle settle. This script is that gate, kept in-tree so
+// fresh cache, a fixed anonymous auth fixture, a durable ProductClient
+// login-ready marker, `document.fonts.ready`, and a bounded network-idle settle
+// that FAILS when it is not reached. This script is that gate, kept in-tree so
 // it is reproducible and rerunnable against exact merged main.
 //
+// DETERMINISM (WDU-1247-B1 repair). The Web host boots by POSTing a real
+// session bootstrap and probing the deployment for its sign-in methods. Left
+// live those requests make the "readiness" ambiguous — a slow/erroring backend
+// could render a retry screen that still contains a `button`/`input`, and an
+// unsettled request stream could be silently ignored. This collector removes
+// that ambiguity: it intercepts EVERY request, serves the built dist from the
+// loopback origin, and answers the cross-origin API with a FIXED anonymous
+// fixture (bootstrap 401 -> signed-out; deterministic method/health probes).
+// Any request to an unexpected cross-origin endpoint fails the gate closed. It
+// then waits for the durable `[data-auth-screen="auth"]` login-ready marker
+// (set only once the shell resolves to the signed-out sign-in surface — an
+// error/loading screen never satisfies it), and treats a network-idle that is
+// never reached as a measurement failure rather than a pass.
+//
 // WHAT IT DOES.
-//   1. Builds `apps/web` (skip with --no-build to measure an existing dist).
+//   1. Builds `apps/web` against the fixed fixture origin (skip with --no-build
+//      to measure an existing dist).
 //   2. Serves apps/web/dist over loopback.
-//   3. Loads /login in headless Chromium with a fresh context (fresh cache),
-//      records unique same-origin GET responses until readiness, then computes
-//      gzip-9 byte totals per kind (js/css/font/image/audio) from the on-disk
-//      dist files (same compression metric as the baseline collector).
+//   3. Loads /login in headless Chromium with a fresh context (fresh cache) and
+//      the fixed anonymous API fixture, records unique same-origin GET
+//      responses until the durable login-ready marker + fonts + settled
+//      network, then computes gzip-9 byte totals per kind
+//      (js/css/font/image/audio) from the on-disk dist files (same compression
+//      metric as the baseline collector).
 //   4. Enforces the founder-approved gzip-9 ceilings FAIL-CLOSED (see CAPS):
-//      exits non-zero if requested JS or CSS exceeds its cap, or if any font /
-//      image / audio byte is requested on /login (baseline is 0).
+//      exits non-zero if requested JS or CSS exceeds its cap, if any font /
+//      image / audio byte is requested on /login (baseline is 0), or if an
+//      unexpected cross-origin endpoint is requested.
 //   5. Emits a machine-readable ledger bound to the tested commit SHA and
 //      prints the exact rerun command.
 //
@@ -33,10 +52,14 @@
 //
 // USAGE.
 //   node scripts/measure-login-runtime-budget.mjs [--no-build] [--out <path>]
-//   (build first if using --no-build: pnpm shared:build && pnpm web:build)
+//   (build first if using --no-build so the dist is built against the fixed
+//    fixture origin: pnpm shared:build && VITE_PROLIFERATE_API_BASE_URL=<fixture>
+//    pnpm web:build — the default rerun command below does this for you.)
 //
-// Exit codes: 0 = within all ceilings; 1 = over a ceiling / unexpected asset;
-// 2 = measurement could not be performed (build/serve/browser error).
+// Exit codes: 0 = within all ceilings; 1 = over a ceiling / unexpected asset /
+// unexpected cross-origin request; 2 = measurement could not be performed
+// (build/serve/browser error, or the login-ready marker / network settle was
+// never reached).
 
 import { execFileSync } from "node:child_process";
 import { createServer } from "node:http";
@@ -61,8 +84,20 @@ const CAPS = { js: 485000, css: 66000 };
 // regression (login/callback must not eagerly load fonts/images/audio).
 const ZERO_KINDS = ["font", "image", "audio"];
 
+// Fixed anonymous auth fixture. The web build bakes in
+// VITE_PROLIFERATE_API_BASE_URL, so we build against this sentinel origin and
+// intercept it in the browser with canned signed-out responses. This makes the
+// measurement hermetic and deterministic: no live backend, no
+// slow/erroring-network ambiguity, and a login-ready state that is always the
+// real signed-out sign-in surface.
+const FIXTURE_API_ORIGIN = "https://login-budget-fixture.invalid";
+// The durable ProductClient login-ready marker (AuthScreenLayout renders
+// data-auth-screen="auth" only once resolved to the signed-out sign-in surface).
+const LOGIN_READY_SELECTOR = '[data-auth-screen="auth"]';
+
 const RERUN_COMMAND =
-  "pnpm shared:build && pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build";
+  `pnpm shared:build && VITE_PROLIFERATE_API_BASE_URL=${FIXTURE_API_ORIGIN} pnpm web:build ` +
+  "&& node scripts/measure-login-runtime-budget.mjs --no-build";
 
 const args = process.argv.slice(2);
 const noBuild = args.includes("--no-build");
@@ -136,9 +171,17 @@ function serveDist() {
 
 // ---- 1. build ----
 if (!noBuild) {
-  console.error("[login-budget] building apps/web (pnpm web:build)…");
+  console.error(
+    `[login-budget] building apps/web against fixture origin ${FIXTURE_API_ORIGIN}…`,
+  );
   try {
-    execFileSync("pnpm", ["run", "web:build"], { cwd: REPO_ROOT, stdio: "inherit" });
+    execFileSync("pnpm", ["run", "web:build"], {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+      // Bake the fixed fixture origin into the bundle so the login shell's
+      // bootstrap/probe requests target an origin we deterministically stub.
+      env: { ...process.env, VITE_PROLIFERATE_API_BASE_URL: FIXTURE_API_ORIGIN },
+    });
   } catch {
     fail(2, "web:build failed; run `pnpm shared:build` first if package dist is stale.");
   }
@@ -158,12 +201,76 @@ try {
 const { server, port } = await serveDist();
 const base = `http://127.0.0.1:${port}`;
 const requested = new Map(); // pathname -> kind
+// Cross-origin endpoints the fixed anonymous fixture answers. Anything else the
+// login shell tries to reach cross-origin is an unexpected producer and fails
+// the gate closed.
+const unexpectedCrossOrigin = [];
+
+// The fixed anonymous auth fixture: canned signed-out responses for exactly the
+// endpoints the public login shell touches at boot (session bootstrap, health,
+// sign-in method/availability probes). Bootstrap 401 -> the shell resolves to
+// the signed-out sign-in surface; probes report a deterministic method set.
+function fixtureResponseFor(pathname) {
+  const json = (status, body) => ({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+  // Anonymous: no refresh cookie -> bootstrap/refresh are unauthorized.
+  if (pathname === "/auth/web/session/bootstrap" || pathname === "/auth/web/session/refresh") {
+    return json(401, { detail: "unauthenticated" });
+  }
+  if (pathname === "/health") return json(200, { status: "ok" });
+  if (pathname === "/auth/desktop/methods") {
+    return json(200, { password_login: false, github: true });
+  }
+  if (pathname === "/auth/desktop/github/availability") {
+    return json(200, { enabled: true, client_id: "login-budget-fixture" });
+  }
+  if (pathname === "/auth/sso/discover") return json(200, { enabled: false });
+  // The anonymous login shell also probes the connected deployment's public
+  // capability contract and the launch catalog before auth. Answer both with
+  // benign, deterministic bodies so the shell settles without a live backend.
+  if (pathname === "/meta") return json(200, { capabilities: {} });
+  if (pathname === "/v1/catalogs/agents") {
+    return json(200, { schemaVersion: 2, agents: [] });
+  }
+  return null;
+}
 
 let browser;
+let readyMarkerReached = false;
+let networkSettled = false;
 try {
   browser = await chromium.launch();
   const context = await browser.newContext(); // fresh profile = fresh cache
   const page = await context.newPage();
+
+  // Intercept EVERY request. Loopback dist requests pass through to the local
+  // server; the fixture origin gets canned anonymous answers; any other
+  // cross-origin request is recorded as unexpected and aborted (fail-closed).
+  await context.route("**/*", (route) => {
+    const u = new URL(route.request().url());
+    if (u.origin === base) {
+      route.continue();
+      return;
+    }
+    if (u.origin === FIXTURE_API_ORIGIN) {
+      const fixture = fixtureResponseFor(u.pathname);
+      if (fixture) {
+        route.fulfill(fixture);
+        return;
+      }
+      // A fixture-origin path we did not anticipate: record and 404 it so the
+      // shell resolves deterministically but the gate still flags the gap.
+      unexpectedCrossOrigin.push(`${u.origin}${u.pathname}`);
+      route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+      return;
+    }
+    // Truly unexpected cross-origin producer on the public login shell.
+    unexpectedCrossOrigin.push(`${u.origin}${u.pathname}`);
+    route.abort();
+  });
 
   page.on("response", (resp) => {
     const u = new URL(resp.url());
@@ -175,11 +282,30 @@ try {
   });
 
   await page.goto(`${base}/login`, { waitUntil: "load" });
-  // Readiness: the login shell rendered (ProductClient auth gate output present).
-  await page.waitForSelector("button, input, [data-auth-screen], form", { timeout: 30_000 });
+  // Readiness: the durable ProductClient login-ready marker, i.e. the shell
+  // resolved to the signed-out sign-in surface (not a loading/error screen).
+  try {
+    await page.waitForSelector(LOGIN_READY_SELECTOR, { timeout: 30_000 });
+    readyMarkerReached = true;
+  } catch {
+    throw new Error(
+      `login-ready marker ${LOGIN_READY_SELECTOR} never appeared; the signed-out ` +
+        "sign-in surface was not reached (the ledger must not pass without it).",
+    );
+  }
   await page.evaluate(() => document.fonts.ready);
-  // Bounded network-idle settle, then a fixed drain window for late requests.
-  await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+  // Bounded network-idle settle. A stream that never settles is a measurement
+  // failure — we do NOT swallow the timeout and pass anyway.
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 15_000 });
+    networkSettled = true;
+  } catch {
+    throw new Error(
+      "network never reached idle within 15s on /login; the request stream did " +
+        "not settle, so the measurement is not trustworthy (fail closed).",
+    );
+  }
+  // Short fixed drain for any late same-origin asset after idle.
   await page.waitForTimeout(2_000);
 } catch (err) {
   await browser?.close().catch(() => {});
@@ -188,6 +314,10 @@ try {
 } finally {
   await browser?.close().catch(() => {});
   server.close();
+}
+
+if (!readyMarkerReached || !networkSettled) {
+  fail(2, "readiness or network settle was not reached; refusing to emit a passing ledger.");
 }
 
 // ---- tally ----
@@ -213,12 +343,35 @@ for (const k of ZERO_KINDS) {
     violations.push(`${k} ${perKind[k]} B requested on /login (baseline 0; must not eagerly load)`);
   }
 }
+const unexpected = [...new Set(unexpectedCrossOrigin)].sort();
+if (unexpected.length > 0) {
+  violations.push(
+    `unexpected cross-origin request(s) on /login: ${unexpected.join(", ")} ` +
+      "(not in the fixed anonymous fixture)",
+  );
+}
 const pass = violations.length === 0;
 
 // ---- 5. ledger bound to tested SHA ----
 const ledger = {
   schema: "login-runtime-budget/v1",
-  measuredAt: "runtime headless chromium, fresh cache, ProductClient readiness marker, document.fonts.ready, bounded network-idle + 2s settle",
+  measuredAt:
+    "runtime headless chromium; fresh cache; fixed anonymous API fixture " +
+    `(${FIXTURE_API_ORIGIN}); durable login-ready marker ${LOGIN_READY_SELECTOR}; ` +
+    "document.fonts.ready; network-idle (fail-closed, not swallowed) + 2s drain",
+  readiness: {
+    loginReadySelector: LOGIN_READY_SELECTOR,
+    markerReached: readyMarkerReached,
+    networkSettled,
+    fixtureApiOrigin: FIXTURE_API_ORIGIN,
+    fixtureEndpoints: [
+      "POST /auth/web/session/bootstrap -> 401 (anonymous)",
+      "GET /health -> 200",
+      "GET /auth/desktop/methods -> 200",
+      "GET /auth/desktop/github/availability -> 200",
+      "GET /auth/sso/discover -> 200 { enabled: false }",
+    ],
+  },
   testedSha: gitSha(),
   base: "/login",
   compressionMetric: "gzip (Node zlib, level 9) for js/css/svg/other; emitted bytes for fonts/images/audio",
@@ -234,6 +387,7 @@ const ledger = {
   jsBytes,
   cssBytes,
   headroom: { js: CAPS.js - jsBytes, css: CAPS.css - cssBytes },
+  unexpectedCrossOrigin: unexpected,
   pass,
   violations,
   files,

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json
@@ -1,0 +1,44 @@
+{
+  "schema": "login-runtime-budget/v1",
+  "measuredAt": "runtime headless chromium, fresh cache, ProductClient readiness marker, document.fonts.ready, bounded network-idle + 2s settle",
+  "testedSha": "8f0482375b648a47a0e8d139fcaa593de745b012",
+  "base": "/login",
+  "compressionMetric": "gzip (Node zlib, level 9) for js/css/svg/other; emitted bytes for fonts/images/audio",
+  "caps": {
+    "js": 485000,
+    "css": 66000,
+    "source": "founder decision WDU-1247-D1 (2026-07-15), gzip-9 bytes"
+  },
+  "legacyBaseline": {
+    "source": "specs/codebase/systems/product/clients/web-desktop-unification/migration/web-bundle-baseline-c6e094b41.json",
+    "jsGzipBytes": 471212,
+    "cssGzipBytes": 24226,
+    "note": "recorded context; the enforceable gate is the founder caps above"
+  },
+  "perKind": {
+    "css": 65097,
+    "js": 482329
+  },
+  "total": 547426,
+  "jsBytes": 482329,
+  "cssBytes": 65097,
+  "headroom": {
+    "js": 2671,
+    "css": 903
+  },
+  "pass": true,
+  "violations": [],
+  "files": [
+    {
+      "path": "/assets/index-DO5cjKOq.css",
+      "kind": "css",
+      "bytes": 65097
+    },
+    {
+      "path": "/assets/index-F2qG_uA4.js",
+      "kind": "js",
+      "bytes": 482329
+    }
+  ],
+  "rerunCommand": "pnpm shared:build && pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build"
+}

--- a/specs/codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json
@@ -1,7 +1,20 @@
 {
   "schema": "login-runtime-budget/v1",
-  "measuredAt": "runtime headless chromium, fresh cache, ProductClient readiness marker, document.fonts.ready, bounded network-idle + 2s settle",
-  "testedSha": "8f0482375b648a47a0e8d139fcaa593de745b012",
+  "measuredAt": "runtime headless chromium; fresh cache; fixed anonymous API fixture (https://login-budget-fixture.invalid); durable login-ready marker [data-auth-screen=\"auth\"]; document.fonts.ready; network-idle (fail-closed, not swallowed) + 2s drain",
+  "readiness": {
+    "loginReadySelector": "[data-auth-screen=\"auth\"]",
+    "markerReached": true,
+    "networkSettled": true,
+    "fixtureApiOrigin": "https://login-budget-fixture.invalid",
+    "fixtureEndpoints": [
+      "POST /auth/web/session/bootstrap -> 401 (anonymous)",
+      "GET /health -> 200",
+      "GET /auth/desktop/methods -> 200",
+      "GET /auth/desktop/github/availability -> 200",
+      "GET /auth/sso/discover -> 200 { enabled: false }"
+    ]
+  },
+  "testedSha": "d3cd7c35fad04ab41b1e4ccbb043abe82853e75d",
   "base": "/login",
   "compressionMetric": "gzip (Node zlib, level 9) for js/css/svg/other; emitted bytes for fonts/images/audio",
   "caps": {
@@ -16,29 +29,30 @@
     "note": "recorded context; the enforceable gate is the founder caps above"
   },
   "perKind": {
-    "css": 65097,
-    "js": 482329
+    "css": 65351,
+    "js": 482026
   },
-  "total": 547426,
-  "jsBytes": 482329,
-  "cssBytes": 65097,
+  "total": 547377,
+  "jsBytes": 482026,
+  "cssBytes": 65351,
   "headroom": {
-    "js": 2671,
-    "css": 903
+    "js": 2974,
+    "css": 649
   },
+  "unexpectedCrossOrigin": [],
   "pass": true,
   "violations": [],
   "files": [
     {
-      "path": "/assets/index-DO5cjKOq.css",
+      "path": "/assets/index-BEZuXXCZ.css",
       "kind": "css",
-      "bytes": 65097
+      "bytes": 65351
     },
     {
-      "path": "/assets/index-F2qG_uA4.js",
+      "path": "/assets/index-BeNGt1Xk.js",
       "kind": "js",
-      "bytes": 482329
+      "bytes": 482026
     }
   ],
-  "rerunCommand": "pnpm shared:build && pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build"
+  "rerunCommand": "pnpm shared:build && VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build"
 }

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -58,25 +58,48 @@ replacement browser-host build against.
 ## Phase-6 first-load budget measurement (optimized candidate)
 
 The replacement browser host is measured against the founder-approved `/login`
-ceilings by a **retained, reproducible runtime collector**,
-[`scripts/measure-login-runtime-budget.mjs`](../../../scripts/measure-login-runtime-budget.mjs)
-(headless Chromium, fresh cache, ProductClient readiness marker,
-`document.fonts.ready`, bounded network-idle settle; gzip level 9 for JS/CSS,
-emitted bytes for pre-compressed assets — the contract's metric). It **fails
-closed** against the caps and emits a machine-readable candidate ledger bound to
-the tested commit SHA at
-[`migration/login-runtime-budget-candidate.json`](../../codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json).
+ceilings by a **retained, reproducible, deterministic runtime collector**,
+[`scripts/measure-login-runtime-budget.mjs`](../../../scripts/measure-login-runtime-budget.mjs),
+and enforced by a **required CI check** (`Login first-load budget (phase-6)` in
+[`ci.yml`](../../../.github/workflows/ci.yml), no `continue-on-error`). The
+collector:
+
+- builds the Web host against a **fixed anonymous API fixture origin** (baked in
+  via `VITE_PROLIFERATE_API_BASE_URL`), so the login shell's session-bootstrap
+  and sign-in-method probes target an origin the collector intercepts;
+- loads `/login` in headless Chromium with a **fresh cache** and answers that
+  fixture origin with canned **signed-out** responses (bootstrap `401`;
+  deterministic `/health`, `/auth/desktop/methods`,
+  `/auth/desktop/github/availability`, `/auth/sso/discover`). Any request to an
+  **unexpected cross-origin endpoint** fails the gate closed;
+- waits for the **durable ProductClient login-ready marker**
+  `[data-auth-screen="auth"]` — rendered by `AuthScreenLayout` only once the
+  shell resolves to the signed-out sign-in surface, so a loading/error/retry
+  screen never satisfies readiness — then `document.fonts.ready`;
+- requires the network to reach idle within a bounded window; a stream that
+  **never settles fails the measurement closed** (the timeout is not swallowed);
+- computes gzip level 9 for JS/CSS and emitted bytes for pre-compressed assets
+  (the contract's metric), **fails closed** against the caps, and emits a
+  machine-readable candidate ledger bound to the tested commit SHA at
+  [`migration/login-runtime-budget-candidate.json`](../../codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json).
+
 Rerun against exact merged main with:
 
 ```bash
-pnpm shared:build && pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build
+pnpm shared:build \
+  && VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build \
+  && node scripts/measure-login-runtime-budget.mjs --no-build
 ```
+
+(or simply `node scripts/measure-login-runtime-budget.mjs` after `pnpm
+shared:build`, which builds against the fixture origin for you.)
 
 A runtime collector is required (not the static-manifest walker
 `collect-web-bundle-baseline.mjs`): the Vite manifest associates side-effect
 assets such as `ding-*.mp3` with `index.html`, so a static closure cannot prove
 the runtime claim that `/login` requests zero audio bytes. The runtime collector
-measures what the browser actually requests before readiness (WDU-1247-B1).
+measures what the browser actually requests before the real login-ready point
+(WDU-1247-B1).
 
 Two eager-shell regressions were root-caused and fixed on
 `codex/wdu-login-budget`:
@@ -94,9 +117,13 @@ Two eager-shell regressions were root-caused and fixed on
 
 | Readiness point | Legacy baseline (gzip-9) | Approved cap (gzip-9) | Candidate (gzip-9) | Headroom | Result |
 | --- | ---: | ---: | ---: | ---: | --- |
-| `/login` requested JS | 471,212 B | **485,000 B** | 482,329 B | 2,671 B | **Pass** |
-| `/login` requested CSS | 24,226 B | **66,000 B** | 65,097 B | 903 B | **Pass** |
+| `/login` requested JS | 471,212 B | **485,000 B** | 482,026 B | 2,974 B | **Pass** |
+| `/login` requested CSS | 24,226 B | **66,000 B** | 65,351 B | 649 B | **Pass** |
 | `/login` fonts/images/audio | 0 B | 0 B | 0 B | 0 B | **Pass** |
+
+(Candidate measured against the fixed anonymous fixture at the durable
+login-ready marker; see the ledger `readiness` block for the marker, settle, and
+fixture-endpoint record.)
 
 The `/login` caps are the founder-approved gzip-9 ceilings (WDU-1247-D1):
 JS 485,000 B, CSS 66,000 B, and zero eagerly-requested fonts/images/audio. The
@@ -121,7 +148,7 @@ product (the full authenticated app is lazy-split into a separate
   duplicating tokens and risking cross-host visual drift.
 - **JS.** The eager entry is the shared shell (React, router, query, cloud SDK,
   product providers, login, telemetry). Login-only modules were verified absent
-  of authenticated-only editor/terminal/Monaco/Shiki code; the +2.4% is the
+  of authenticated-only editor/terminal/Monaco/Shiki code; the +2.3% is the
   richer shared shell, not stray authenticated chunks.
 
 **Founder budget decision — RESOLVED (WDU-1247-D1, approved 2026-07-15).** The

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -57,11 +57,28 @@ replacement browser-host build against.
 
 ## Phase-6 first-load budget measurement (optimized candidate)
 
-The replacement browser host was measured against the binding baseline with a
-runtime `/login` request collector (headless Chromium, fresh cache, ProductClient
-readiness marker, `document.fonts.ready`, bounded network-idle settle; gzip
-level 9 for JS/CSS, emitted bytes for pre-compressed assets — the contract's
-metric). Two eager-shell regressions were root-caused and fixed on
+The replacement browser host is measured against the founder-approved `/login`
+ceilings by a **retained, reproducible runtime collector**,
+[`scripts/measure-login-runtime-budget.mjs`](../../../scripts/measure-login-runtime-budget.mjs)
+(headless Chromium, fresh cache, ProductClient readiness marker,
+`document.fonts.ready`, bounded network-idle settle; gzip level 9 for JS/CSS,
+emitted bytes for pre-compressed assets — the contract's metric). It **fails
+closed** against the caps and emits a machine-readable candidate ledger bound to
+the tested commit SHA at
+[`migration/login-runtime-budget-candidate.json`](../../codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json).
+Rerun against exact merged main with:
+
+```bash
+pnpm shared:build && pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build
+```
+
+A runtime collector is required (not the static-manifest walker
+`collect-web-bundle-baseline.mjs`): the Vite manifest associates side-effect
+assets such as `ding-*.mp3` with `index.html`, so a static closure cannot prove
+the runtime claim that `/login` requests zero audio bytes. The runtime collector
+measures what the browser actually requests before readiness (WDU-1247-B1).
+
+Two eager-shell regressions were root-caused and fixed on
 `codex/wdu-login-budget`:
 
 - **Turn-end audio** (`use-turn-end-sound.ts`): eager `new Audio(ding)` above
@@ -75,12 +92,17 @@ metric). Two eager-shell regressions were root-caused and fixed on
   chunk. Verified against the built manifest: eager entry CSS has zero xterm
   rules.
 
-| Readiness point | Legacy baseline (gzip-9) | Optimized candidate (gzip-9) | Delta | Rule | Result |
-| --- | ---: | ---: | ---: | --- | --- |
-| `/login` requested JS | 471,212 B | 482,329 B | +11,117 B (+2.4%) | No regression | **Over** |
-| `/login` requested CSS | 24,226 B | 65,097 B | +40,871 B (+169%) | No regression | **Over** |
-| `/login` fonts/images/audio | 0 B | 0 B | 0 | No regression | Pass |
-| `/login` total | 495,438 B | 547,426 B | +51,988 B (+10.5%) | No regression | **Over** |
+| Readiness point | Legacy baseline (gzip-9) | Approved cap (gzip-9) | Candidate (gzip-9) | Headroom | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `/login` requested JS | 471,212 B | **485,000 B** | 482,329 B | 2,671 B | **Pass** |
+| `/login` requested CSS | 24,226 B | **66,000 B** | 65,097 B | 903 B | **Pass** |
+| `/login` fonts/images/audio | 0 B | 0 B | 0 B | 0 B | **Pass** |
+
+The `/login` caps are the founder-approved gzip-9 ceilings (WDU-1247-D1):
+JS 485,000 B, CSS 66,000 B, and zero eagerly-requested fonts/images/audio. The
+legacy baseline (471,212 B JS / 24,226 B CSS) is recorded context; the caps are
+the enforceable gate. The candidate passes with thin headroom, so any future
+eager-shell growth must re-run the collector before merge.
 
 **Why the residual gap is structural, not an unshipped optimization.** The
 legacy `/login` numbers are those of a small standalone app that did no code
@@ -102,17 +124,17 @@ product (the full authenticated app is lazy-split into a separate
   of authenticated-only editor/terminal/Monaco/Shiki code; the +2.4% is the
   richer shared shell, not stray authenticated chunks.
 
-**Founder budget decision required.** The pre-approved contract formula for
-`/login` is *no regression vs the legacy baseline*, and the contract forbids
-silently raising a ceiling. The smallest verified split still materially exceeds
-that ceiling for reasons intrinsic to unifying onto one shared design system and
-one shared app shell — the intended, already-accepted cost of the program, but a
-specific byte ceiling that was never explicitly waived. This is the single
-evidence-backed founder gate for phase 6: either accept a revised `/login`
-ceiling that reflects the shared shell (recommended: CSS ≤ ~66 KB gzip, JS
-≤ ~485 KB gzip, one-time and browser-cacheable) or direct further optimization
-before cutover. Qualification does not mutate any production producer until this
-gate is resolved.
+**Founder budget decision — RESOLVED (WDU-1247-D1, approved 2026-07-15).** The
+original contract formula was *no regression vs the legacy baseline*. The
+smallest verified split still exceeds that baseline for reasons intrinsic to
+unifying onto one shared design system and one shared app shell (the intended,
+already-accepted cost of the program). The founder explicitly chose shared-shell
+simplicity and full shared-package Tailwind scanning over adding a separate
+auth-shell CSS build boundary, and set exact enforceable gzip-9 `/login`
+ceilings: **JS 485,000 B, CSS 66,000 B**. These are encoded as fail-closed caps
+in `scripts/measure-login-runtime-budget.mjs` (`CAPS`), and the candidate ledger
+is bound to the tested SHA. This is a deliberate, recorded ceiling — not a silent
+increase.
 
 ## Hosted Web cutover gate
 

--- a/specs/developing/deploying/web-desktop-unification-rollout.md
+++ b/specs/developing/deploying/web-desktop-unification-rollout.md
@@ -55,6 +55,65 @@ product) and emits **no separate font/image assets** (`index.css` imports only
 `@proliferate/design/dom.css`). These are the numbers phase 6 compares the
 replacement browser-host build against.
 
+## Phase-6 first-load budget measurement (optimized candidate)
+
+The replacement browser host was measured against the binding baseline with a
+runtime `/login` request collector (headless Chromium, fresh cache, ProductClient
+readiness marker, `document.fonts.ready`, bounded network-idle settle; gzip
+level 9 for JS/CSS, emitted bytes for pre-compressed assets — the contract's
+metric). Two eager-shell regressions were root-caused and fixed on
+`codex/wdu-login-budget`:
+
+- **Turn-end audio** (`use-turn-end-sound.ts`): eager `new Audio(ding)` above
+  the auth gate fetched 58.8 KB on the public login shell. Fixed by
+  lazy-constructing the clip on first turn-end.
+- **xterm terminal CSS** (`product-client/src/index.css` → `use-xterm-surface.ts`):
+  the eager ProductClient entry pulled `@xterm/xterm/css/xterm.css` (~1.9 KB
+  gzip) into the login bundle — a named contract violation (login/callback must
+  not eagerly load xterm/terminal CSS). Fixed by co-locating the stylesheet with
+  the lazily imported xterm runtime so it rides the `AuthenticatedProductClient`
+  chunk. Verified against the built manifest: eager entry CSS has zero xterm
+  rules.
+
+| Readiness point | Legacy baseline (gzip-9) | Optimized candidate (gzip-9) | Delta | Rule | Result |
+| --- | ---: | ---: | ---: | --- | --- |
+| `/login` requested JS | 471,212 B | 482,329 B | +11,117 B (+2.4%) | No regression | **Over** |
+| `/login` requested CSS | 24,226 B | 65,097 B | +40,871 B (+169%) | No regression | **Over** |
+| `/login` fonts/images/audio | 0 B | 0 B | 0 | No regression | Pass |
+| `/login` total | 495,438 B | 547,426 B | +51,988 B (+10.5%) | No regression | **Over** |
+
+**Why the residual gap is structural, not an unshipped optimization.** The
+legacy `/login` numbers are those of a small standalone app that did no code
+splitting; the candidate `/login` numbers are the *shell* of the unified shared
+product (the full authenticated app is lazy-split into a separate
+`AuthenticatedProductClient` chunk, ~746 KB gzip, not requested on `/login`).
+
+- **CSS floor probe.** Tailwind v4 emits utilities from `@source` scanning all
+  four shared package trees (`ui`, `product-ui`, `product-surfaces`,
+  `product-client`) into one eager stylesheet. Re-scoping `@source` to only the
+  login/auth shell sources and rebuilding floors the eager CSS at **35.4 KB
+  gzip — still +46% over the 24.2 KB baseline.** The residual is the shared
+  design-system token + base + login-utility layer, which is inherently larger
+  than legacy Web's minimal standalone login stylesheet. Reaching no-regression
+  would require a second parallel Tailwind pipeline for the login surface,
+  duplicating tokens and risking cross-host visual drift.
+- **JS.** The eager entry is the shared shell (React, router, query, cloud SDK,
+  product providers, login, telemetry). Login-only modules were verified absent
+  of authenticated-only editor/terminal/Monaco/Shiki code; the +2.4% is the
+  richer shared shell, not stray authenticated chunks.
+
+**Founder budget decision required.** The pre-approved contract formula for
+`/login` is *no regression vs the legacy baseline*, and the contract forbids
+silently raising a ceiling. The smallest verified split still materially exceeds
+that ceiling for reasons intrinsic to unifying onto one shared design system and
+one shared app shell — the intended, already-accepted cost of the program, but a
+specific byte ceiling that was never explicitly waived. This is the single
+evidence-backed founder gate for phase 6: either accept a revised `/login`
+ceiling that reflects the shared shell (recommended: CSS ≤ ~66 KB gzip, JS
+≤ ~485 KB gzip, one-time and browser-cacheable) or direct further optimization
+before cutover. Qualification does not mutate any production producer until this
+gate is resolved.
+
 ## Hosted Web cutover gate
 
 Before hosted Web cutover, inventory every external producer of a hosted Web


### PR DESCRIPTION
## What

Phase-6 hosted-Web cutover work: shrink the eager `/login` shell so it stops loading authenticated-only assets, then **gate** the first-load budget with a deterministic, fail-closed, required CI check.

## Eager-shell regressions fixed

1. **Turn-end audio** — `use-turn-end-sound.ts` mounted in the shared lifecycle root *above* the auth gate and eagerly constructed `new Audio(ding)` with `preload="auto"`, fetching **58.8 KB** on the public login shell. Now lazy-constructs the clip on first turn-end.
2. **xterm terminal CSS** — the eager `ProductClient` entry imports `product-client/src/index.css`, which pulled `@xterm/xterm/css/xterm.css` (~1.9 KB gzip) into the login bundle — a **named contract violation** (login/callback must not eagerly load xterm/terminal CSS). Moved the `import "@xterm/xterm/css/xterm.css"` into `use-xterm-surface.ts`, reachable only through the lazy `AuthenticatedProductClient` boundary, so the CSS rides the lazy terminal chunk. Verified via the built manifest: eager entry CSS has zero xterm rules.

## The budget gate (WDU-1247-B1)

The `/login` budget is enforced by a retained, **deterministic** runtime collector [`scripts/measure-login-runtime-budget.mjs`](scripts/measure-login-runtime-budget.mjs), wired into a **required CI check** `Login first-load budget (phase-6)` (in `ci.yml`, no `continue-on-error`). It:

- builds the Web host against a **fixed anonymous API fixture origin** and intercepts every request — loopback dist passes through, the fixture origin gets canned **signed-out** responses (bootstrap `401`; `/health`, `/auth/desktop/methods`, `/auth/desktop/github/availability`, `/auth/sso/discover`, `/meta`, `/v1/catalogs/agents`), and **any unexpected cross-origin request fails the gate closed**;
- waits for a **durable ProductClient login-ready marker** `[data-auth-screen="auth"]` (rendered by `AuthScreenLayout` only once resolved to the signed-out sign-in surface — a loading/error/retry screen never satisfies readiness), then `document.fonts.ready`;
- **fails closed if the network never settles** (the network-idle timeout is no longer swallowed into a pass);
- computes gzip-9 for JS/CSS + emitted bytes for pre-compressed assets, and emits a machine-readable candidate ledger bound to the tested commit SHA at [`.../migration/login-runtime-budget-candidate.json`](specs/codebase/systems/product/clients/web-desktop-unification/migration/login-runtime-budget-candidate.json).

A runtime collector is required (not the static-manifest walker): the Vite manifest attributes `ding-*.mp3` to `index.html`, so a static closure cannot prove `/login` requests zero audio bytes.

## Founder budget decision — RESOLVED (WDU-1247-D1, approved 2026-07-15)

The frozen formula was *no regression* vs the legacy baseline (471,212 B JS / 24,226 B CSS gzip-9). The smallest verified split still exceeds that baseline for reasons intrinsic to unifying onto one shared design system and one shared app shell. The founder **explicitly chose shared-shell simplicity / full shared-package Tailwind scanning over a separate auth-shell CSS build boundary**, and set **exact enforceable gzip-9 ceilings: JS `485000` B, CSS `66000` B** (plus zero eager fonts/images/audio). These are encoded as fail-closed `CAPS` in the collector — no ambiguous decimal-KB language remains.

## Proof (head `f1e7c8192`)

- Collector run on exact head: **JS 482,026 B / CSS 65,351 B gzip-9**, fonts/images/audio **0 B**, **0 unexpected cross-origin requests**, login-ready marker + network settle reached → **pass** (headroom JS 2,974 B / CSS 649 B). Ledger `testedSha` = `d3cd7c35` (the deterministic-gate code commit); the ledger commit adds only the JSON on top.
- Fail-closed trip proofs: caps `{1,1}` → **exit 1** (`JS 482026 B > cap 1 B; CSS 65351 B > cap 1 B`); nonexistent readiness marker → **exit 2** (`login-ready marker … never appeared`); live run caught two un-stubbed anonymous-boot endpoints and **failed closed** before they were added to the fixture.
- Built-manifest check: eager entry CSS has **zero** xterm rules; `xterm.css` lands on the `AuthenticatedProductClient` lazy chunk.
- `@proliferate/product-client` auth suite green; `pnpm web:typecheck` clean; `check_frontend_boundaries.py`, `report_frontend_structure.py --strict` (TOTAL 0), `check_max_lines.py`, `check_docs.py` all pass.

| Readiness point | Legacy baseline | Approved cap (gzip-9) | Candidate (gzip-9) | Headroom | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| `/login` requested JS | 471,212 B | **485,000 B** | 482,026 B | 2,974 B | Pass |
| `/login` requested CSS | 24,226 B | **66,000 B** | 65,351 B | 649 B | Pass |
| `/login` fonts/images/audio | 0 B | 0 B | 0 B | 0 B | Pass |

Full measurement + reasoning: `specs/developing/deploying/web-desktop-unification-rollout.md`. **Production cutover is out of scope for this PR and requires explicit founder authorization.**

Session: `da66d22d-a4fc-41c8-8022-57dd71652468`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
