### PR TITLE
docs(observability): how to instrument a new feature's anomalies

### DIFF
--- a/specs/codebase/systems/engineering/observability/sentry.md
+++ b/specs/codebase/systems/engineering/observability/sentry.md
@@ -155,3 +155,31 @@ following up with reporters. Observability does not own tracker state.
 Use the [Sentry operating procedure](../../../../developing/operating/analytics/sentry.md)
 to discover current provider state and verify delivery without exposing
 credentials.
+
+## Instrumenting a new feature
+
+Recommendation for surfacing "this should/shouldn't happen" signals so they land
+as tracked issues via [Issue Lifecycle](../issue-lifecycle/README.md). Choose by
+what actually happened, not by convenience — do not `raise` to flag a non-failure.
+
+| Situation | Use | Effect |
+| --- | --- | --- |
+| The operation genuinely failed | let the exception propagate | auto-captured as a `proliferate-server` issue |
+| An anomaly the user didn't feel — latency budget exceeded, invariant violated, unexpected-but-recovered branch | `capture_server_sentry_exception(..., level="warning", fingerprint=[...])` | tracked issue, request still succeeds |
+| A page-worthy "must never happen" invariant | `report_critical(...)` | fatal Sentry event **and** the `CRITICAL_FAILURE` log marker that drives the Grafana/CloudWatch alert path |
+
+Conventions that keep issues clean and countable:
+
+- **Set a stable `fingerprint`** for any recurring anomaly. It is the dedup key:
+  one issue accrues occurrences (with user/release/timing) instead of spawning
+  thousands. This — not a metric counter — is how you "count" an anomaly.
+- **Emit on threshold, not per call.** For latency, measure and emit only when a
+  budget is exceeded; the budget belongs in code, not in an alert rule.
+- **Tag consistently** so the tracker and rules can slice: `anomaly=<slug>`
+  (e.g. `latency_budget`, `invariant_violation`), `surface=<area>`. Put bounded
+  diagnostic scalars (elapsed_ms, budget_ms, ids) in `extras`.
+- Obey [Privacy and replay](#privacy-and-replay): tags/extras carry identifiers
+  and bounded scalars, never message/prompt/transcript content or secrets.
+
+Reserve `report_critical` for real paging conditions; a `warning` anomaly that
+fires constantly trains everyone to ignore the fatal ones.


### PR DESCRIPTION
## What

Adds an **Instrumenting a new feature** recommendation to the canonical observability doc (`specs/codebase/systems/engineering/observability/sentry.md`).

## Why

The doc already describes *what* the Sentry helpers do, but nothing told a feature-builder *which* to reach for when they want "make sure X happens and Y doesn't" — latency budgets, invariant violations, unexpected-but-recovered states. The common wrong instinct is to `raise` for a non-failure (which breaks an otherwise-fine request) or to emit per-call (which fragments dedup). This encodes the recommendation so those signals land cleanly as tracked, countable issues in the issue system.

## Contents (tight — recommendation, not tutorial)

- **Tier decision:** propagate exception (real failure) vs `capture_server_sentry_exception(level="warning", fingerprint=...)` (anomaly, request still succeeds) vs `report_critical(...)` (page-worthy; also drives the Grafana/CloudWatch alert path).
- **Conventions:** stable `fingerprint` as the dedup/count key (not a metric counter), emit-on-threshold not per-call, consistent `anomaly=`/`surface=` tags, bounded scalars in `extras`, privacy rules.
- Reiterates: reserve `report_critical` for real paging so warnings don't train people to ignore fatals.

All helpers referenced already exist in `server/proliferate/integrations/sentry.py`; no code change. `check_docs.py` / `check_max_lines.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)