### PR TITLE
feat(server): independent GitHub repository access and managed-Cloud capabilities (v2)

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4480,10 +4480,13 @@ export interface components {
          *     and clone repositories without advertising Cloud workspaces.
          */
         GitHubRepositoryAccessCapability: {
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "disabled" | "operator_configuration_required" | "ready";
             /** Provider */
-            provider: string | null;
+            provider: "github_app" | null;
             /** Displayname */
             displayName: string | null;
         };
@@ -4706,10 +4709,13 @@ export interface components {
          *     involved in the managed-Cloud path.
          */
         ManagedCloudCapability: {
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "disabled" | "operator_configuration_required" | "ready";
             /** Repositoryauthority */
-            repositoryAuthority: string | null;
+            repositoryAuthority: "github_app" | null;
         };
         /** ManagedCloudWorkflowTarget */
         ManagedCloudWorkflowTarget: {

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4462,11 +4462,30 @@ export interface components {
              * Status
              * @enum {string}
              */
-            status: "ready" | "missing_user_authorization" | "expired_user_authorization" | "missing_installation" | "repo_not_covered" | "missing_user_repo_access" | "error";
+            status: "ready" | "missing_user_authorization" | "expired_user_authorization" | "missing_installation" | "repo_not_covered" | "missing_user_repo_access" | "operator_configuration_required" | "error";
             /** Action */
             action?: ("authorize_user" | "reauthorize_user" | "install_app" | "grant_repo_access") | null;
             /** Message */
             message?: string | null;
+        };
+        /**
+         * GitHubRepositoryAccessCapability
+         * @description Operator readiness of GitHub repository discovery/authority.
+         *
+         *     ``disabled`` means the operator intentionally configured no GitHub App;
+         *     ``operator_configuration_required`` means a partial App config that only
+         *     the operator can repair (clients must not offer user authorization);
+         *     ``ready`` means the App runtime config is complete. Independent of
+         *     managed-Cloud execution: an App-ready/E2B-disabled deployment can browse
+         *     and clone repositories without advertising Cloud workspaces.
+         */
+        GitHubRepositoryAccessCapability: {
+            /** Status */
+            status: string;
+            /** Provider */
+            provider: string | null;
+            /** Displayname */
+            displayName: string | null;
         };
         /**
          * GitProvider
@@ -4676,6 +4695,21 @@ export interface components {
             usedUsd: number;
             /** Remainingusd */
             remainingUsd: number;
+        };
+        /**
+         * ManagedCloudCapability
+         * @description Operator readiness of managed-Cloud workspace execution.
+         *
+         *     Requires both E2B provisioning and ready GitHub repository authority,
+         *     because workspace mutations enforce GitHub App authority server-side.
+         *     ``repositoryAuthority`` names the authority provider when one is
+         *     involved in the managed-Cloud path.
+         */
+        ManagedCloudCapability: {
+            /** Status */
+            status: string;
+            /** Repositoryauthority */
+            repositoryAuthority: string | null;
         };
         /** ManagedCloudWorkflowTarget */
         ManagedCloudWorkflowTarget: {
@@ -5508,7 +5542,8 @@ export interface components {
          *
          *     Defaults are disabled: a capability is true only when the operator
          *     configured the underlying feature. The desktop treats an absent contract
-         *     (older servers) as all-off + self-managed.
+         *     (older servers) as all-off + self-managed. ``cloudWorkspaces`` is a v1
+         *     compatibility projection of ``managedCloud.status == "ready"``.
          */
         ServerCapabilities: {
             /** Contractversion */
@@ -5525,6 +5560,8 @@ export interface components {
             webApp: components["schemas"]["WebAppCapability"];
             support: components["schemas"]["SupportCapability"];
             pricing: components["schemas"]["PricingCapability"];
+            githubRepositoryAccess: components["schemas"]["GitHubRepositoryAccessCapability"];
+            managedCloud: components["schemas"]["ManagedCloudCapability"];
         };
         /** SetIntegrationEnabledRequest */
         SetIntegrationEnabledRequest: {

--- a/server/deploy/preflight.sh
+++ b/server/deploy/preflight.sh
@@ -121,7 +121,7 @@ E2B_TEMPLATE_NAME="$(get E2B_TEMPLATE_NAME)"
 if [[ -n "$E2B_API_KEY" && -z "$E2B_TEMPLATE_NAME" ]]; then
   err "E2B_API_KEY is set but E2B_TEMPLATE_NAME is empty. The API validates this pair at startup and will refuse to boot (restart-looping the whole control plane). Set E2B_TEMPLATE_NAME (e.g. your-team/proliferate-runtime-cloud:production) or clear E2B_API_KEY to run without cloud workspaces."
 elif [[ -z "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" ]]; then
-  warn "E2B_TEMPLATE_NAME is set but E2B_API_KEY is empty. Cloud workspaces stay disabled until both are set."
+  warn "E2B_TEMPLATE_NAME is set but E2B_API_KEY is empty. The server reports operator_configuration_required and cloud workspaces stay unavailable until both are set."
 elif [[ -n "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" ]]; then
   ok "E2B provisioning config is a complete pair. GitHub-backed cloud workspaces additionally require a complete GitHub App config (checked in section 7)."
 fi
@@ -241,10 +241,11 @@ fi
 # reports as operator_configuration_required.
 
 # Mirrors Settings.github_app_configured / github_app_partially_configured:
-# five requirement groups (app id, client id, client secret, webhook secret,
-# private key in exactly one form). Any set without all set is a partial
-# config the /meta contract reports as operator_configuration_required.
+# six requirement groups (app id, app slug, client id, client secret, webhook
+# secret, private key in exactly one form). Any set without all set is a
+# partial config the /meta contract reports as operator_configuration_required.
 GITHUB_APP_ID_VAL="$(get GITHUB_APP_ID)"
+GITHUB_APP_SLUG_VAL="$(get GITHUB_APP_SLUG)"
 GITHUB_APP_CLIENT_ID_VAL="$(get GITHUB_APP_CLIENT_ID)"
 GITHUB_APP_CLIENT_SECRET_VAL="$(get GITHUB_APP_CLIENT_SECRET)"
 GITHUB_APP_WEBHOOK_SECRET_VAL="$(get GITHUB_APP_WEBHOOK_SECRET)"
@@ -254,19 +255,19 @@ GITHUB_APP_KEY_PRESENT=""
 [[ -n "$GITHUB_APP_KEY_INLINE" || -n "$GITHUB_APP_KEY_PATH" ]] && GITHUB_APP_KEY_PRESENT=1
 
 GITHUB_APP_PRESENT_COUNT=0
-for v in "$GITHUB_APP_ID_VAL" "$GITHUB_APP_CLIENT_ID_VAL" "$GITHUB_APP_CLIENT_SECRET_VAL" "$GITHUB_APP_WEBHOOK_SECRET_VAL" "$GITHUB_APP_KEY_PRESENT"; do
+for v in "$GITHUB_APP_ID_VAL" "$GITHUB_APP_SLUG_VAL" "$GITHUB_APP_CLIENT_ID_VAL" "$GITHUB_APP_CLIENT_SECRET_VAL" "$GITHUB_APP_WEBHOOK_SECRET_VAL" "$GITHUB_APP_KEY_PRESENT"; do
   [[ -n "$v" ]] && GITHUB_APP_PRESENT_COUNT=$((GITHUB_APP_PRESENT_COUNT + 1))
 done
 
-if [[ "$GITHUB_APP_PRESENT_COUNT" -gt 0 && "$GITHUB_APP_PRESENT_COUNT" -lt 5 ]]; then
-  warn "GitHub App config is partial: set GITHUB_APP_ID, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET, GITHUB_APP_WEBHOOK_SECRET, and one of GITHUB_APP_PRIVATE_KEY / GITHUB_APP_PRIVATE_KEY_PATH together. Until then the server reports operator_configuration_required and GitHub-backed cloud workspaces stay unavailable."
-elif [[ "$GITHUB_APP_PRESENT_COUNT" -eq 5 ]]; then
+if [[ "$GITHUB_APP_PRESENT_COUNT" -gt 0 && "$GITHUB_APP_PRESENT_COUNT" -lt 6 ]]; then
+  warn "GitHub App config is partial: set GITHUB_APP_ID, GITHUB_APP_SLUG, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET, GITHUB_APP_WEBHOOK_SECRET, and one of GITHUB_APP_PRIVATE_KEY / GITHUB_APP_PRIVATE_KEY_PATH together. Until then the server reports operator_configuration_required and GitHub-backed cloud workspaces stay unavailable."
+elif [[ "$GITHUB_APP_PRESENT_COUNT" -eq 6 ]]; then
   ok "GitHub App config is complete."
 fi
 if [[ -n "$GITHUB_APP_KEY_INLINE" && -n "$GITHUB_APP_KEY_PATH" ]]; then
   warn "Both GITHUB_APP_PRIVATE_KEY and GITHUB_APP_PRIVATE_KEY_PATH are set; only one form is needed (inline takes precedence)."
 fi
-if [[ -n "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" && "$GITHUB_APP_PRESENT_COUNT" -lt 5 ]]; then
+if [[ -n "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" && "$GITHUB_APP_PRESENT_COUNT" -lt 6 ]]; then
   warn "E2B is fully configured but the GitHub App is not. Cloud workspace creation enforces GitHub App repo authority, so cloud workspaces stay unavailable (operator_configuration_required) until the App config is complete."
 fi
 

--- a/server/deploy/preflight.sh
+++ b/server/deploy/preflight.sh
@@ -123,7 +123,7 @@ if [[ -n "$E2B_API_KEY" && -z "$E2B_TEMPLATE_NAME" ]]; then
 elif [[ -z "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" ]]; then
   warn "E2B_TEMPLATE_NAME is set but E2B_API_KEY is empty. Cloud workspaces stay disabled until both are set."
 elif [[ -n "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" ]]; then
-  ok "E2B cloud-workspace config is a complete pair."
+  ok "E2B provisioning config is a complete pair. GitHub-backed cloud workspaces additionally require a complete GitHub App config (checked in section 7)."
 fi
 
 # --- 3. Agent gateway pairing ------------------------------------------------
@@ -234,25 +234,40 @@ fi
 # --- 7. GitHub App (cloud repo access) partial config -------------------------
 #
 # Distinct credential set from GitHub OAuth sign-in above. Not required for
-# the base install or for cloud workspaces themselves (E2B is what gates
-# workspace creation); flagged here only so a half-entered App config does not
-# silently fail to authorize repos later.
+# the base install, but REQUIRED for GitHub-backed managed-cloud workspaces:
+# workspace creation and repo-environment saves enforce GitHub App repo
+# authority server-side, so E2B alone does not enable cloud workspaces. A
+# half-entered App config is an operator error the capability contract
+# reports as operator_configuration_required.
 
+# Mirrors Settings.github_app_configured / github_app_partially_configured:
+# five requirement groups (app id, client id, client secret, webhook secret,
+# private key in exactly one form). Any set without all set is a partial
+# config the /meta contract reports as operator_configuration_required.
 GITHUB_APP_ID_VAL="$(get GITHUB_APP_ID)"
-if [[ -n "$GITHUB_APP_ID_VAL" ]]; then
-  GITHUB_APP_CLIENT_ID_VAL="$(get GITHUB_APP_CLIENT_ID)"
-  GITHUB_APP_CLIENT_SECRET_VAL="$(get GITHUB_APP_CLIENT_SECRET)"
-  GITHUB_APP_WEBHOOK_SECRET_VAL="$(get GITHUB_APP_WEBHOOK_SECRET)"
-  GITHUB_APP_KEY_INLINE="$(get GITHUB_APP_PRIVATE_KEY)"
-  GITHUB_APP_KEY_PATH="$(get GITHUB_APP_PRIVATE_KEY_PATH)"
-  if [[ -z "$GITHUB_APP_CLIENT_ID_VAL" || -z "$GITHUB_APP_CLIENT_SECRET_VAL" || -z "$GITHUB_APP_WEBHOOK_SECRET_VAL" ]]; then
-    warn "GITHUB_APP_ID is set but one of GITHUB_APP_CLIENT_ID / GITHUB_APP_CLIENT_SECRET / GITHUB_APP_WEBHOOK_SECRET is empty. Set all of them together to use the GitHub App."
-  fi
-  if [[ -z "$GITHUB_APP_KEY_INLINE" && -z "$GITHUB_APP_KEY_PATH" ]]; then
-    warn "GITHUB_APP_ID is set but neither GITHUB_APP_PRIVATE_KEY nor GITHUB_APP_PRIVATE_KEY_PATH is set. The App needs its private key to authenticate."
-  elif [[ -n "$GITHUB_APP_KEY_INLINE" && -n "$GITHUB_APP_KEY_PATH" ]]; then
-    warn "Both GITHUB_APP_PRIVATE_KEY and GITHUB_APP_PRIVATE_KEY_PATH are set; only one form is needed (inline takes precedence)."
-  fi
+GITHUB_APP_CLIENT_ID_VAL="$(get GITHUB_APP_CLIENT_ID)"
+GITHUB_APP_CLIENT_SECRET_VAL="$(get GITHUB_APP_CLIENT_SECRET)"
+GITHUB_APP_WEBHOOK_SECRET_VAL="$(get GITHUB_APP_WEBHOOK_SECRET)"
+GITHUB_APP_KEY_INLINE="$(get GITHUB_APP_PRIVATE_KEY)"
+GITHUB_APP_KEY_PATH="$(get GITHUB_APP_PRIVATE_KEY_PATH)"
+GITHUB_APP_KEY_PRESENT=""
+[[ -n "$GITHUB_APP_KEY_INLINE" || -n "$GITHUB_APP_KEY_PATH" ]] && GITHUB_APP_KEY_PRESENT=1
+
+GITHUB_APP_PRESENT_COUNT=0
+for v in "$GITHUB_APP_ID_VAL" "$GITHUB_APP_CLIENT_ID_VAL" "$GITHUB_APP_CLIENT_SECRET_VAL" "$GITHUB_APP_WEBHOOK_SECRET_VAL" "$GITHUB_APP_KEY_PRESENT"; do
+  [[ -n "$v" ]] && GITHUB_APP_PRESENT_COUNT=$((GITHUB_APP_PRESENT_COUNT + 1))
+done
+
+if [[ "$GITHUB_APP_PRESENT_COUNT" -gt 0 && "$GITHUB_APP_PRESENT_COUNT" -lt 5 ]]; then
+  warn "GitHub App config is partial: set GITHUB_APP_ID, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET, GITHUB_APP_WEBHOOK_SECRET, and one of GITHUB_APP_PRIVATE_KEY / GITHUB_APP_PRIVATE_KEY_PATH together. Until then the server reports operator_configuration_required and GitHub-backed cloud workspaces stay unavailable."
+elif [[ "$GITHUB_APP_PRESENT_COUNT" -eq 5 ]]; then
+  ok "GitHub App config is complete."
+fi
+if [[ -n "$GITHUB_APP_KEY_INLINE" && -n "$GITHUB_APP_KEY_PATH" ]]; then
+  warn "Both GITHUB_APP_PRIVATE_KEY and GITHUB_APP_PRIVATE_KEY_PATH are set; only one form is needed (inline takes precedence)."
+fi
+if [[ -n "$E2B_API_KEY" && -n "$E2B_TEMPLATE_NAME" && "$GITHUB_APP_PRESENT_COUNT" -lt 5 ]]; then
+  warn "E2B is fully configured but the GitHub App is not. Cloud workspace creation enforces GitHub App repo authority, so cloud workspaces stay unavailable (operator_configuration_required) until the App config is complete."
 fi
 
 # --- 8. Runtime binaries for cloud workspaces --------------------------------

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -518,6 +518,55 @@ class Settings(BaseSettings):
         return None
 
     @property
+    def github_app_runtime_fields_present(self) -> tuple[bool, ...]:
+        """Presence of each GitHub App runtime requirement, order-stable.
+
+        One entry per field group the App runtime path needs: App id (JWT
+        signing subject), OAuth client id + secret (user authorization and
+        token exchange), webhook secret (webhook validation), and a private
+        key in exactly one of its two forms (App JWT signing). Internal
+        helper for the aggregate predicates below; never expose per-field
+        presence publicly.
+        """
+        return (
+            bool(self.github_app_id.strip()),
+            bool(self.github_app_client_id.strip()),
+            bool(self.github_app_client_secret.strip()),
+            bool(self.github_app_webhook_secret.strip()),
+            bool(self.github_app_private_key.strip() or self.github_app_private_key_path.strip()),
+        )
+
+    @property
+    def github_app_configured(self) -> bool:
+        """True when every GitHub App runtime requirement is configured.
+
+        This is the single completeness predicate shared by the ``/meta``
+        capability contract, startup/preflight expectations, and tests. It
+        gates whether GitHub repository authority (user authorization,
+        installation, repo coverage) can work at runtime.
+        """
+        return all(self.github_app_runtime_fields_present)
+
+    @property
+    def github_app_partially_configured(self) -> bool:
+        """True when some but not all GitHub App runtime fields are set.
+
+        A partial App config is an operator error: repo authorization will
+        fail at runtime even though the deployment looks intentional. The
+        capability contract reports it as operator configuration required
+        rather than disabled.
+        """
+        present = self.github_app_runtime_fields_present
+        return any(present) and not all(present)
+
+    @property
+    def cloud_provisioning_partially_configured(self) -> bool:
+        """True when E2B config is started but incomplete (non-debug only)."""
+        if self.debug:
+            return False
+        return bool(self.e2b_api_key.strip()) and not bool(self.e2b_template_name.strip())
+
+    @property
     def single_org_mode(self) -> bool:
         if self.single_org_mode_override is not None:
             return self.single_org_mode_override

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -522,14 +522,15 @@ class Settings(BaseSettings):
         """Presence of each GitHub App runtime requirement, order-stable.
 
         One entry per field group the App runtime path needs: App id (JWT
-        signing subject), OAuth client id + secret (user authorization and
-        token exchange), webhook secret (webhook validation), and a private
-        key in exactly one of its two forms (App JWT signing). Internal
-        helper for the aggregate predicates below; never expose per-field
-        presence publicly.
+        signing subject), App slug (installation URL construction), OAuth
+        client id + secret (user authorization and token exchange), webhook
+        secret (webhook validation), and a private key in exactly one of its
+        two forms (App JWT signing). Internal helper for the aggregate
+        predicates below; never expose per-field presence publicly.
         """
         return (
             bool(self.github_app_id.strip()),
+            bool(self.github_app_slug.strip()),
             bool(self.github_app_client_id.strip()),
             bool(self.github_app_client_secret.strip()),
             bool(self.github_app_webhook_secret.strip()),
@@ -561,10 +562,17 @@ class Settings(BaseSettings):
 
     @property
     def cloud_provisioning_partially_configured(self) -> bool:
-        """True when E2B config is started but incomplete (non-debug only)."""
+        """True when E2B config is started but incomplete (non-debug only).
+
+        Either half alone (API key without template, or template without API
+        key) is an operator error the capability contract reports as
+        operator configuration required rather than disabled.
+        """
         if self.debug:
             return False
-        return bool(self.e2b_api_key.strip()) and not bool(self.e2b_template_name.strip())
+        key_present = bool(self.e2b_api_key.strip())
+        template_present = bool(self.e2b_template_name.strip())
+        return key_present != template_present
 
     @property
     def single_org_mode(self) -> bool:

--- a/server/proliferate/constants/deployment.py
+++ b/server/proliferate/constants/deployment.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 # Bump when the ``capabilities`` wire shape on ``/meta`` changes. The desktop
 # treats an absent contract (older servers) conservatively and may branch on
 # this version to stay forward-compatible with newer contracts.
-SELF_HOST_CAPABILITY_CONTRACT_VERSION = 1
+SELF_HOST_CAPABILITY_CONTRACT_VERSION = 2
 
 # Deployment modes mirror the desktop telemetry runtime modes so the contract
 # and telemetry routing speak the same vocabulary.

--- a/server/proliferate/server/cloud/github_app/models.py
+++ b/server/proliferate/server/cloud/github_app/models.py
@@ -50,6 +50,7 @@ RepoAuthorityStatus = Literal[
     "missing_installation",
     "repo_not_covered",
     "missing_user_repo_access",
+    "operator_configuration_required",
     "error",
 ]
 

--- a/server/proliferate/server/cloud/github_app/repo_authority.py
+++ b/server/proliferate/server/cloud/github_app/repo_authority.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.config import settings
 from proliferate.db.store import github_app as github_app_store
 from proliferate.integrations.github import (
     GitHubAppInstallationInfo,
@@ -147,6 +148,23 @@ async def _refresh_github_app_authorization(
     )
 
 
+def require_github_app_runtime_configured() -> None:
+    """Fail closed when the operator's GitHub App config is incomplete.
+
+    Checked before any user-state lookup so an unconfigured or partially
+    configured deployment reports an operator problem instead of sending the
+    user to an authorization flow that cannot work — even when a cached user
+    authorization exists from before the config regressed.
+    """
+    if not settings.github_app_configured:
+        raise CloudApiError(
+            "github_app_not_configured",
+            "The GitHub App is not fully configured for this deployment. "
+            "An operator must complete the GitHub App configuration.",
+            status_code=503,
+        )
+
+
 async def require_github_cloud_repo_authority(
     db: AsyncSession,
     *,
@@ -154,6 +172,7 @@ async def require_github_cloud_repo_authority(
     git_owner: str,
     git_repo_name: str,
 ) -> GitHubCloudRepoAuthority:
+    require_github_app_runtime_configured()
     authorization = await ensure_fresh_github_app_authorization(db, user_id=user_id)
     installations = await github_app_store.list_active_github_app_installations_for_owner(
         db,

--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -583,7 +583,13 @@ def _repo_authority_status_for_error(
     if code == "github_app_repo_not_covered":
         return "repo_not_covered", "grant_repo_access"
     if code == "github_repo_access_required":
-        return "missing_user_repo_access", "authorize_user"
+        # The user's own GitHub account lacks access to the repository.
+        # Reauthorizing the App cannot repair that, so no action is offered.
+        return "missing_user_repo_access", None
+    if code == "github_app_not_configured":
+        # Deployment-level App misconfiguration; only the operator can
+        # repair it, so no user action is offered.
+        return "operator_configuration_required", None
     return "error", None
 
 

--- a/server/proliferate/server/meta.py
+++ b/server/proliferate/server/meta.py
@@ -102,12 +102,42 @@ class PricingCapability(BaseModel):
     url: str | None
 
 
+class GitHubRepositoryAccessCapability(BaseModel):
+    """Operator readiness of GitHub repository discovery/authority.
+
+    ``disabled`` means the operator intentionally configured no GitHub App;
+    ``operator_configuration_required`` means a partial App config that only
+    the operator can repair (clients must not offer user authorization);
+    ``ready`` means the App runtime config is complete. Independent of
+    managed-Cloud execution: an App-ready/E2B-disabled deployment can browse
+    and clone repositories without advertising Cloud workspaces.
+    """
+
+    status: str
+    provider: str | None
+    displayName: str | None
+
+
+class ManagedCloudCapability(BaseModel):
+    """Operator readiness of managed-Cloud workspace execution.
+
+    Requires both E2B provisioning and ready GitHub repository authority,
+    because workspace mutations enforce GitHub App authority server-side.
+    ``repositoryAuthority`` names the authority provider when one is
+    involved in the managed-Cloud path.
+    """
+
+    status: str
+    repositoryAuthority: str | None
+
+
 class ServerCapabilities(BaseModel):
     """Versioned, conservative declaration of what this deployment offers.
 
     Defaults are disabled: a capability is true only when the operator
     configured the underlying feature. The desktop treats an absent contract
-    (older servers) as all-off + self-managed.
+    (older servers) as all-off + self-managed. ``cloudWorkspaces`` is a v1
+    compatibility projection of ``managedCloud.status == "ready"``.
     """
 
     contractVersion: int
@@ -119,6 +149,57 @@ class ServerCapabilities(BaseModel):
     webApp: WebAppCapability
     support: SupportCapability
     pricing: PricingCapability
+    githubRepositoryAccess: GitHubRepositoryAccessCapability
+    managedCloud: ManagedCloudCapability
+
+
+CAPABILITY_DISABLED = "disabled"
+CAPABILITY_OPERATOR_CONFIGURATION_REQUIRED = "operator_configuration_required"
+CAPABILITY_READY = "ready"
+
+
+def _github_repository_access(config: Settings) -> GitHubRepositoryAccessCapability:
+    """Derive GitHub repository access readiness from the shared predicate.
+
+    Exposes only the aggregate status and a safe display name (App slug or
+    operator instance name) — never which specific field is missing.
+    """
+    if config.github_app_configured:
+        status = CAPABILITY_READY
+    elif config.github_app_partially_configured:
+        status = CAPABILITY_OPERATOR_CONFIGURATION_REQUIRED
+    else:
+        status = CAPABILITY_DISABLED
+    if status == CAPABILITY_DISABLED:
+        return GitHubRepositoryAccessCapability(status=status, provider=None, displayName=None)
+    display_name = config.github_app_slug.strip() or config.instance_name.strip() or None
+    return GitHubRepositoryAccessCapability(
+        status=status,
+        provider="github_app",
+        displayName=display_name,
+    )
+
+
+def _managed_cloud(
+    config: Settings, repository_access: GitHubRepositoryAccessCapability
+) -> ManagedCloudCapability:
+    """Derive managed-Cloud readiness from E2B plus repository authority.
+
+    E2B absent -> disabled. E2B partial, or E2B ready with incomplete GitHub
+    App authority -> operator configuration required (workspace mutations
+    would fail on ``require_github_cloud_repo_authority``). Ready only when
+    the whole path is operable.
+    """
+    e2b_ready = config.cloud_provisioning_configured
+    e2b_partial = config.cloud_provisioning_partially_configured
+    if not e2b_ready and not e2b_partial:
+        return ManagedCloudCapability(status=CAPABILITY_DISABLED, repositoryAuthority=None)
+    if e2b_partial or repository_access.status != CAPABILITY_READY:
+        return ManagedCloudCapability(
+            status=CAPABILITY_OPERATOR_CONFIGURATION_REQUIRED,
+            repositoryAuthority="github_app",
+        )
+    return ManagedCloudCapability(status=CAPABILITY_READY, repositoryAuthority="github_app")
 
 
 def build_server_capabilities(config: Settings) -> ServerCapabilities:
@@ -137,10 +218,13 @@ def build_server_capabilities(config: Settings) -> ServerCapabilities:
         BILLING_MODE_OBSERVE,
         BILLING_MODE_ENFORCE,
     }
-    # Shared with the actual provisioning gate (Settings.cloud_provisioning_configured)
-    # so the advertised capability never diverges from what the server will actually
-    # provision (e.g. a debug box with only E2B_API_KEY set).
-    cloud_workspaces = config.cloud_provisioning_configured
+    # Repository authority and managed Cloud are independent operator
+    # capabilities; `cloudWorkspaces` stays as the v1 compatibility
+    # projection so older clients fail closed unless the whole managed-Cloud
+    # path (E2B + GitHub App) is operable.
+    github_repository_access = _github_repository_access(config)
+    managed_cloud = _managed_cloud(config, github_repository_access)
+    cloud_workspaces = managed_cloud.status == CAPABILITY_READY
     agent_gateway = config.agent_gateway_enabled
 
     web_base = config.frontend_base_url.strip()
@@ -181,6 +265,8 @@ def build_server_capabilities(config: Settings) -> ServerCapabilities:
         webApp=web_app,
         support=support,
         pricing=pricing,
+        githubRepositoryAccess=github_repository_access,
+        managedCloud=managed_cloud,
     )
 
 

--- a/server/proliferate/server/meta.py
+++ b/server/proliferate/server/meta.py
@@ -22,6 +22,8 @@ booleans and safe, user-facing destinations (support email, pricing/web URL).
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -102,6 +104,14 @@ class PricingCapability(BaseModel):
     url: str | None
 
 
+CapabilityStatus = Literal["disabled", "operator_configuration_required", "ready"]
+RepositoryAuthorityProvider = Literal["github_app"]
+
+CAPABILITY_DISABLED: CapabilityStatus = "disabled"
+CAPABILITY_OPERATOR_CONFIGURATION_REQUIRED: CapabilityStatus = "operator_configuration_required"
+CAPABILITY_READY: CapabilityStatus = "ready"
+
+
 class GitHubRepositoryAccessCapability(BaseModel):
     """Operator readiness of GitHub repository discovery/authority.
 
@@ -113,8 +123,8 @@ class GitHubRepositoryAccessCapability(BaseModel):
     and clone repositories without advertising Cloud workspaces.
     """
 
-    status: str
-    provider: str | None
+    status: CapabilityStatus
+    provider: RepositoryAuthorityProvider | None
     displayName: str | None
 
 
@@ -127,8 +137,8 @@ class ManagedCloudCapability(BaseModel):
     involved in the managed-Cloud path.
     """
 
-    status: str
-    repositoryAuthority: str | None
+    status: CapabilityStatus
+    repositoryAuthority: RepositoryAuthorityProvider | None
 
 
 class ServerCapabilities(BaseModel):
@@ -151,11 +161,6 @@ class ServerCapabilities(BaseModel):
     pricing: PricingCapability
     githubRepositoryAccess: GitHubRepositoryAccessCapability
     managedCloud: ManagedCloudCapability
-
-
-CAPABILITY_DISABLED = "disabled"
-CAPABILITY_OPERATOR_CONFIGURATION_REQUIRED = "operator_configuration_required"
-CAPABILITY_READY = "ready"
 
 
 def _github_repository_access(config: Settings) -> GitHubRepositoryAccessCapability:

--- a/server/tests/integration/cloud_api_helpers.py
+++ b/server/tests/integration/cloud_api_helpers.py
@@ -102,6 +102,19 @@ async def seed_github_app_repo_authority(
     user_id: str,
     git_owner: str = "proliferate-ai",
 ) -> None:
+    # Repo-backed Cloud mutations fail closed unless the operator's GitHub App
+    # runtime config is complete (require_github_app_runtime_configured), so
+    # seeding user authority also configures the App for the test deployment.
+    for field, value in {
+        "github_app_id": "12345",
+        "github_app_slug": "proliferate-test",
+        "github_app_client_id": "Iv1.integration-test",
+        "github_app_client_secret": "integration-test-client-secret",
+        "github_app_webhook_secret": "integration-test-webhook-secret",
+        "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
+        "github_app_private_key_path": "",
+    }.items():
+        monkeypatch.setattr(repo_authority.settings, field, value)
     await github_app_store.upsert_github_app_authorization(
         db_session,
         user_id=uuid.UUID(user_id),

--- a/server/tests/unit/test_github_app_service.py
+++ b/server/tests/unit/test_github_app_service.py
@@ -454,3 +454,53 @@ async def test_create_github_app_installation_url_allows_desktop_environment_ret
     assert response.installation_url.startswith(
         "https://github.com/apps/proliferate-dev/installations/new?state="
     )
+
+
+# --- Repo authority error-to-status/action mapping (frozen PR 1 contract) -----
+#
+# The authority endpoint may only recommend an action that can actually repair
+# the state: operator misconfiguration and missing human repository access
+# have no user-side repair, so their action must be null.
+
+
+def test_repo_authority_mapping_offers_only_repairable_actions() -> None:
+    mapping = service._repo_authority_status_for_error
+
+    assert mapping("github_app_authorization_required") == (
+        "missing_user_authorization",
+        "authorize_user",
+    )
+    assert mapping("github_app_authorization_expired") == (
+        "expired_user_authorization",
+        "reauthorize_user",
+    )
+    assert mapping("github_app_installation_required") == (
+        "missing_installation",
+        "install_app",
+    )
+    assert mapping("github_app_repo_not_covered") == (
+        "repo_not_covered",
+        "grant_repo_access",
+    )
+
+
+def test_repo_authority_human_repo_access_has_no_user_repair_action() -> None:
+    # Reauthorizing the App cannot grant a GitHub account access to a
+    # repository it cannot see; offering authorize_user here was the bug.
+    assert service._repo_authority_status_for_error("github_repo_access_required") == (
+        "missing_user_repo_access",
+        None,
+    )
+
+
+def test_repo_authority_app_not_configured_is_operator_state() -> None:
+    # Deployment-level App misconfiguration is repaired by the operator, not
+    # by any user action.
+    assert service._repo_authority_status_for_error("github_app_not_configured") == (
+        "operator_configuration_required",
+        None,
+    )
+
+
+def test_repo_authority_unknown_code_stays_error() -> None:
+    assert service._repo_authority_status_for_error("something_else") == ("error", None)

--- a/server/tests/unit/test_github_repo_authority_gate.py
+++ b/server/tests/unit/test_github_repo_authority_gate.py
@@ -1,0 +1,188 @@
+"""The configuration-completeness gate on GitHub cloud repo authority.
+
+PR1-B1 (frozen PR 1 contract): every repository-backed Cloud mutation runs
+through ``require_github_cloud_repo_authority``, so the operator-configuration
+check lives there — an unconfigured or partially configured deployment must
+report ``operator_configuration_required`` with no user action, never send the
+user into an authorization flow that cannot work. This must hold even when a
+cached user authorization exists from before the App config regressed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.github_app import repo_authority
+from proliferate.server.cloud.github_app.api import router as github_app_router
+
+_APP_FIELDS = {
+    "github_app_id": "12345",
+    "github_app_slug": "acme-cloud",
+    "github_app_client_id": "Iv1.app-client",
+    "github_app_client_secret": "app-secret",
+    "github_app_webhook_secret": "hook-secret",
+    "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
+    "github_app_private_key_path": "",
+}
+
+
+def _set_app_config(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    values = {**_APP_FIELDS, **overrides}
+    for field, value in values.items():
+        monkeypatch.setattr(repo_authority.settings, field, value)
+
+
+@dataclass(frozen=True)
+class _User:
+    id: uuid.UUID
+
+
+def test_gate_passes_when_app_fully_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_config(monkeypatch)
+    repo_authority.require_github_app_runtime_configured()
+
+
+def test_gate_rejects_fully_unconfigured_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_config(monkeypatch, **dict.fromkeys(_APP_FIELDS, ""))
+    with pytest.raises(CloudApiError) as excinfo:
+        repo_authority.require_github_app_runtime_configured()
+    assert excinfo.value.code == "github_app_not_configured"
+    assert excinfo.value.status_code == 503
+
+
+_REQUIRED_FIELDS = sorted(set(_APP_FIELDS) - {"github_app_private_key_path"})
+
+
+@pytest.mark.parametrize("missing_field", _REQUIRED_FIELDS)
+def test_gate_rejects_each_partially_configured_deployment(
+    monkeypatch: pytest.MonkeyPatch, missing_field: str
+) -> None:
+    _set_app_config(monkeypatch, **{missing_field: ""})
+    with pytest.raises(CloudApiError) as excinfo:
+        repo_authority.require_github_app_runtime_configured()
+    assert excinfo.value.code == "github_app_not_configured"
+
+
+def test_gate_accepts_private_key_path_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_config(
+        monkeypatch,
+        github_app_private_key="",
+        github_app_private_key_path="/etc/proliferate/app.pem",
+    )
+    repo_authority.require_github_app_runtime_configured()
+
+
+@pytest.mark.asyncio
+async def test_authority_check_reports_operator_state_despite_cached_user_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The regression that motivated the gate: a user authorized while the App
+    # was complete, then the operator config regressed. The cached ready
+    # authorization must NOT surface missing_user_authorization/authorize_user.
+    _set_app_config(monkeypatch, github_app_webhook_secret="")
+
+    async def fail_if_reached(*args: object, **kwargs: object) -> object:
+        raise AssertionError("user authorization must not be consulted when App is unconfigured")
+
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "get_github_app_authorization_for_user",
+        fail_if_reached,
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await repo_authority.require_github_cloud_repo_authority(
+            object(),  # type: ignore[arg-type]  # never touches the db before the gate
+            user_id=uuid.uuid4(),
+            git_owner="acme",
+            git_repo_name="widgets",
+        )
+    assert excinfo.value.code == "github_app_not_configured"
+
+
+def _authority_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(github_app_router)
+
+    async def _fake_session() -> object:
+        return object()
+
+    app.dependency_overrides[get_async_session] = _fake_session
+    app.dependency_overrides[current_product_user] = lambda: _User(id=uuid.uuid4())
+    return TestClient(app)
+
+
+def test_authority_endpoint_reports_operator_configuration_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Endpoint-level proof: GET .../authority on an unconfigured deployment
+    # returns the operator status with a null action over the wire.
+    _set_app_config(monkeypatch, **dict.fromkeys(_APP_FIELDS, ""))
+
+    response = _authority_client().get("/github-app/repos/acme/widgets/authority")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authorized"] is False
+    assert body["status"] == "operator_configuration_required"
+    assert body["action"] is None
+
+
+def test_authority_endpoint_reports_user_flow_only_when_app_is_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With a complete App config and no user authorization, the user-side
+    # repair (authorize_user) is correct and must be preserved.
+    _set_app_config(monkeypatch)
+
+    async def no_authorization(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "get_github_app_authorization_for_user",
+        no_authorization,
+    )
+
+    response = _authority_client().get("/github-app/repos/acme/widgets/authority")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authorized"] is False
+    assert body["status"] == "missing_user_authorization"
+    assert body["action"] == "authorize_user"
+
+
+@pytest.mark.asyncio
+async def test_gate_runs_before_authorization_freshness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Even a fresh, ready cached authorization does not bypass the operator
+    # gate: the gate is ordered first inside require_github_cloud_repo_authority.
+    _set_app_config(monkeypatch, github_app_id="")
+
+    async def cached_authorization(*args: object, **kwargs: object) -> object:
+        raise AssertionError("gate must run before any authorization lookup")
+
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "get_github_app_authorization_for_user",
+        cached_authorization,
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await repo_authority.require_github_cloud_repo_authority(
+            object(),  # type: ignore[arg-type]
+            user_id=uuid.uuid4(),
+            git_owner="acme",
+            git_repo_name="widgets",
+        )
+    assert excinfo.value.code == "github_app_not_configured"

--- a/server/tests/unit/test_meta_endpoint.py
+++ b/server/tests/unit/test_meta_endpoint.py
@@ -176,9 +176,11 @@ def _cfg(**overrides):  # type: ignore[no-untyped-def]
 
 
 # Complete GitHub App runtime config: one entry per requirement group the
-# Settings.github_app_configured predicate checks.
+# Settings.github_app_configured predicate checks (the slug is required
+# because installation URL construction needs it at runtime).
 _APP_COMPLETE = {
     "github_app_id": "12345",
+    "github_app_slug": "acme-cloud",
     "github_app_client_id": "Iv1.app-client",
     "github_app_client_secret": "app-secret",
     "github_app_webhook_secret": "hook-secret",
@@ -350,11 +352,18 @@ def test_capabilities_app_partial_is_operator_configuration_required() -> None:
 
 
 def test_capabilities_e2b_partial_is_operator_configuration_required() -> None:
-    caps = build_server_capabilities(_cfg(e2b_api_key="e2b-key", **_APP_COMPLETE))
+    # Either half of the E2B pair alone is an operator error, not "disabled":
+    # key-without-template used to crash-loop the API at startup, and
+    # template-without-key silently looks intentional while provisioning fails.
+    key_only = build_server_capabilities(_cfg(e2b_api_key="e2b-key", **_APP_COMPLETE))
+    template_only = build_server_capabilities(
+        _cfg(e2b_template_name="company-runtime", **_APP_COMPLETE)
+    )
 
-    assert caps.githubRepositoryAccess.status == "ready"
-    assert caps.managedCloud.status == "operator_configuration_required"
-    assert caps.cloudWorkspaces is False
+    for caps in (key_only, template_only):
+        assert caps.githubRepositoryAccess.status == "ready"
+        assert caps.managedCloud.status == "operator_configuration_required"
+        assert caps.cloudWorkspaces is False
 
 
 def test_capabilities_e2b_ready_app_incomplete_is_operator_state_not_ready() -> None:
@@ -404,13 +413,20 @@ def test_capabilities_agent_gateway_independent_of_github_app() -> None:
 
 
 def test_capabilities_display_name_prefers_app_slug_then_instance() -> None:
-    slugged = build_server_capabilities(_cfg(github_app_slug="acme-cloud", **_APP_COMPLETE))
-    assert slugged.githubRepositoryAccess.displayName == "acme-cloud"
+    # A ready App always has a slug (it is a readiness requirement), so the
+    # instance-name and None fallbacks only apply to partial configs, which
+    # still surface a display name alongside operator_configuration_required.
+    ready = build_server_capabilities(_cfg(**_APP_COMPLETE))
+    assert ready.githubRepositoryAccess.displayName == "acme-cloud"
 
-    named = build_server_capabilities(_cfg(instance_name="Acme Internal", **_APP_COMPLETE))
+    slugless = dict(_APP_COMPLETE)
+    slugless.pop("github_app_slug")
+    named = build_server_capabilities(_cfg(instance_name="Acme Internal", **slugless))
+    assert named.githubRepositoryAccess.status == "operator_configuration_required"
     assert named.githubRepositoryAccess.displayName == "Acme Internal"
 
-    bare = build_server_capabilities(_cfg(**_APP_COMPLETE))
+    bare = build_server_capabilities(_cfg(**slugless))
+    assert bare.githubRepositoryAccess.status == "operator_configuration_required"
     assert bare.githubRepositoryAccess.displayName is None
 
 

--- a/server/tests/unit/test_meta_endpoint.py
+++ b/server/tests/unit/test_meta_endpoint.py
@@ -139,6 +139,8 @@ _CAPABILITY_FIELDS = {
     "webApp": ("available", "baseUrl"),
     "support": ("kind", "email", "url"),
     "pricing": ("available", "url"),
+    "githubRepositoryAccess": ("status", "provider", "displayName"),
+    "managedCloud": ("status", "repositoryAuthority"),
 }
 
 
@@ -159,6 +161,13 @@ def _cfg(**overrides):  # type: ignore[no-untyped-def]
         "instance_logo_url": "",
         "instance_support_email": "",
         "instance_support_url": "",
+        "github_app_id": "",
+        "github_app_slug": "",
+        "github_app_client_id": "",
+        "github_app_client_secret": "",
+        "github_app_webhook_secret": "",
+        "github_app_private_key": "",
+        "github_app_private_key_path": "",
     }
     base.update(overrides)
     for key, value in base.items():
@@ -166,10 +175,21 @@ def _cfg(**overrides):  # type: ignore[no-untyped-def]
     return cfg
 
 
+# Complete GitHub App runtime config: one entry per requirement group the
+# Settings.github_app_configured predicate checks.
+_APP_COMPLETE = {
+    "github_app_id": "12345",
+    "github_app_client_id": "Iv1.app-client",
+    "github_app_client_secret": "app-secret",
+    "github_app_webhook_secret": "hook-secret",
+    "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
+}
+
+
 def test_capabilities_shape_and_version() -> None:
     caps = build_server_capabilities(_cfg())
 
-    assert caps.contractVersion == 1
+    assert caps.contractVersion == 2
     dumped = caps.model_dump()
     assert set(dumped) == {
         "contractVersion",
@@ -181,6 +201,8 @@ def test_capabilities_shape_and_version() -> None:
         "webApp",
         "support",
         "pricing",
+        "githubRepositoryAccess",
+        "managedCloud",
     }
     for field, subfields in _CAPABILITY_FIELDS.items():
         if subfields is not None:
@@ -196,6 +218,7 @@ def test_capabilities_hosted_product() -> None:
             e2b_api_key="e2b-key",
             e2b_template_name="proliferate-runtime-cloud",
             frontend_base_url="https://web.proliferate.com",
+            **_APP_COMPLETE,
         )
     )
 
@@ -204,6 +227,10 @@ def test_capabilities_hosted_product() -> None:
     assert caps.billing is True
     assert caps.usageMetering is True
     assert caps.cloudWorkspaces is True
+    assert caps.githubRepositoryAccess.status == "ready"
+    assert caps.githubRepositoryAccess.provider == "github_app"
+    assert caps.managedCloud.status == "ready"
+    assert caps.managedCloud.repositoryAuthority == "github_app"
     assert caps.agentGateway is True
     assert caps.webApp.available is True
     assert caps.webApp.baseUrl == "https://web.proliferate.com"
@@ -223,6 +250,11 @@ def test_capabilities_self_managed_base_is_all_off() -> None:
     assert caps.billing is False
     assert caps.usageMetering is False
     assert caps.cloudWorkspaces is False
+    assert caps.githubRepositoryAccess.status == "disabled"
+    assert caps.githubRepositoryAccess.provider is None
+    assert caps.githubRepositoryAccess.displayName is None
+    assert caps.managedCloud.status == "disabled"
+    assert caps.managedCloud.repositoryAuthority is None
     assert caps.agentGateway is False
     assert caps.webApp.available is False
     assert caps.webApp.baseUrl is None
@@ -241,6 +273,7 @@ def test_capabilities_self_managed_with_addons() -> None:
             e2b_api_key="e2b-key",
             e2b_template_name="company-runtime",
             instance_name="Acme Internal",
+            **_APP_COMPLETE,
             instance_logo_url="https://acme.example.com/logo.svg",
             instance_support_email="it-help@acme.example.com",
         )
@@ -277,13 +310,122 @@ def test_capabilities_cloud_workspaces_matches_provisioning_predicate_in_debug()
     # Same predicate as actual provisioning (Settings.cloud_provisioning_configured):
     # in debug mode a blank template name is fine as long as an API key is set, so
     # the advertised capability never diverges from what the server will provision.
-    key_only_debug = _cfg(debug=True, e2b_api_key="e2b-key")
-    no_key_debug = _cfg(debug=True, e2b_template_name="company-runtime")
+    key_only_debug = _cfg(debug=True, e2b_api_key="e2b-key", **_APP_COMPLETE)
+    no_key_debug = _cfg(debug=True, e2b_template_name="company-runtime", **_APP_COMPLETE)
 
     assert build_server_capabilities(key_only_debug).cloudWorkspaces is True
     assert key_only_debug.cloud_provisioning_configured is True
     assert build_server_capabilities(no_key_debug).cloudWorkspaces is False
     assert no_key_debug.cloud_provisioning_configured is False
+
+
+# --- Independent GitHub repository access and managed Cloud (contract v2) ----
+#
+# The two operator capabilities must stay independent: repository authority
+# (GitHub App completeness) and managed-Cloud execution (E2B + authority).
+# Matrix over disabled/partial/ready on each axis, per the frozen PR 1
+# contract (specs/codebase/platforms/product/deployment-capabilities.md).
+
+
+def test_capabilities_app_ready_e2b_absent_is_repo_access_without_cloud() -> None:
+    caps = build_server_capabilities(_cfg(**_APP_COMPLETE))
+
+    assert caps.githubRepositoryAccess.status == "ready"
+    assert caps.githubRepositoryAccess.provider == "github_app"
+    assert caps.managedCloud.status == "disabled"
+    assert caps.managedCloud.repositoryAuthority is None
+    assert caps.cloudWorkspaces is False
+
+
+def test_capabilities_app_partial_is_operator_configuration_required() -> None:
+    partial = dict(_APP_COMPLETE)
+    partial.pop("github_app_webhook_secret")
+    caps = build_server_capabilities(_cfg(**partial))
+
+    assert caps.githubRepositoryAccess.status == "operator_configuration_required"
+    assert caps.githubRepositoryAccess.provider == "github_app"
+    # No E2B config at all: managed Cloud stays disabled independently.
+    assert caps.managedCloud.status == "disabled"
+    assert caps.cloudWorkspaces is False
+
+
+def test_capabilities_e2b_partial_is_operator_configuration_required() -> None:
+    caps = build_server_capabilities(_cfg(e2b_api_key="e2b-key", **_APP_COMPLETE))
+
+    assert caps.githubRepositoryAccess.status == "ready"
+    assert caps.managedCloud.status == "operator_configuration_required"
+    assert caps.cloudWorkspaces is False
+
+
+def test_capabilities_e2b_ready_app_incomplete_is_operator_state_not_ready() -> None:
+    # The exact deployment shape that used to lie: E2B fully configured but
+    # the GitHub App absent or partial. Workspace mutations enforce App
+    # authority, so this must be operator_configuration_required, and the
+    # compatibility boolean must fail closed for old clients.
+    e2b = {"e2b_api_key": "e2b-key", "e2b_template_name": "company-runtime"}
+
+    app_absent = build_server_capabilities(_cfg(**e2b))
+    assert app_absent.githubRepositoryAccess.status == "disabled"
+    assert app_absent.managedCloud.status == "operator_configuration_required"
+    assert app_absent.cloudWorkspaces is False
+
+    partial = dict(_APP_COMPLETE)
+    partial.pop("github_app_private_key")
+    app_partial = build_server_capabilities(_cfg(**e2b, **partial))
+    assert app_partial.githubRepositoryAccess.status == "operator_configuration_required"
+    assert app_partial.managedCloud.status == "operator_configuration_required"
+    assert app_partial.cloudWorkspaces is False
+
+
+def test_capabilities_private_key_path_counts_as_key_form() -> None:
+    keyless = dict(_APP_COMPLETE)
+    keyless.pop("github_app_private_key")
+    caps = build_server_capabilities(
+        _cfg(github_app_private_key_path="/etc/proliferate/app.pem", **keyless)
+    )
+
+    assert caps.githubRepositoryAccess.status == "ready"
+
+
+def test_capabilities_both_disabled_independently() -> None:
+    caps = build_server_capabilities(_cfg())
+
+    assert caps.githubRepositoryAccess.status == "disabled"
+    assert caps.managedCloud.status == "disabled"
+    assert caps.cloudWorkspaces is False
+
+
+def test_capabilities_agent_gateway_independent_of_github_app() -> None:
+    caps = build_server_capabilities(_cfg(agent_gateway_enabled=True))
+
+    assert caps.agentGateway is True
+    assert caps.githubRepositoryAccess.status == "disabled"
+    assert caps.managedCloud.status == "disabled"
+
+
+def test_capabilities_display_name_prefers_app_slug_then_instance() -> None:
+    slugged = build_server_capabilities(_cfg(github_app_slug="acme-cloud", **_APP_COMPLETE))
+    assert slugged.githubRepositoryAccess.displayName == "acme-cloud"
+
+    named = build_server_capabilities(_cfg(instance_name="Acme Internal", **_APP_COMPLETE))
+    assert named.githubRepositoryAccess.displayName == "Acme Internal"
+
+    bare = build_server_capabilities(_cfg(**_APP_COMPLETE))
+    assert bare.githubRepositoryAccess.displayName is None
+
+
+def test_capabilities_expose_no_secret_or_field_presence() -> None:
+    # The wire response may reveal only aggregate statuses and a safe display
+    # name — never secret values or which specific App/E2B field is missing.
+    partial = dict(_APP_COMPLETE)
+    partial.pop("github_app_client_secret")
+    caps = build_server_capabilities(_cfg(e2b_api_key="e2b-key", **partial))
+
+    dumped = caps.model_dump_json()
+    for secret in ("e2b-key", "app-secret", "hook-secret", "PRIVATE KEY", "Iv1.app-client"):
+        assert secret not in dumped
+    assert "github_app_client_secret" not in dumped
+    assert "e2b_api_key" not in dumped
 
 
 def test_capabilities_local_dev_is_self_managed_posture() -> None:

--- a/tests/intent/specs/capability-contract.spec.ts
+++ b/tests/intent/specs/capability-contract.spec.ts
@@ -28,6 +28,8 @@
 import { expect, test } from "@playwright/test";
 import { bootStack, type BootedStack } from "../stack/boot.ts";
 
+type CapabilityStatus = "disabled" | "operator_configuration_required" | "ready";
+
 interface MetaResponse {
   serverVersion: string;
   capabilities: {
@@ -39,6 +41,15 @@ interface MetaResponse {
     webApp: { available: boolean; baseUrl: string | null };
     support: { kind: string; email: string | null; url: string | null };
     pricing: { available: boolean; url: string | null };
+    githubRepositoryAccess: {
+      status: CapabilityStatus;
+      provider: string | null;
+      displayName: string | null;
+    };
+    managedCloud: {
+      status: CapabilityStatus;
+      repositoryAuthority: string | null;
+    };
   };
 }
 
@@ -67,6 +78,13 @@ test.describe("T2-SH-5: /meta capability contract — self-managed, every add-on
         INSTANCE_LOGO_URL: "",
         INSTANCE_SUPPORT_EMAIL: "",
         INSTANCE_SUPPORT_URL: "",
+        GITHUB_APP_ID: "",
+        GITHUB_APP_SLUG: "",
+        GITHUB_APP_CLIENT_ID: "",
+        GITHUB_APP_CLIENT_SECRET: "",
+        GITHUB_APP_WEBHOOK_SECRET: "",
+        GITHUB_APP_PRIVATE_KEY: "",
+        GITHUB_APP_PRIVATE_KEY_PATH: "",
       },
     });
   });
@@ -91,6 +109,12 @@ test.describe("T2-SH-5: /meta capability contract — self-managed, every add-on
     expect(meta.capabilities.support.kind).toBe("none");
     expect(meta.capabilities.support.email).toBeNull();
     expect(meta.capabilities.pricing.available).toBe(false);
+    // Contract v2: the two operator capabilities are independent and both
+    // intentionally off on a bare self-managed deployment.
+    expect(meta.capabilities.githubRepositoryAccess.status).toBe("disabled");
+    expect(meta.capabilities.githubRepositoryAccess.provider).toBeNull();
+    expect(meta.capabilities.managedCloud.status).toBe("disabled");
+    expect(meta.capabilities.managedCloud.repositoryAuthority).toBeNull();
   });
 });
 
@@ -109,6 +133,15 @@ test.describe("T2-SH-5: /meta capability contract — hosted mode advertises ful
         E2B_API_KEY: "e2b_capability_contract_test_placeholder",
         E2B_TEMPLATE_NAME: "proliferate-runtime-cloud",
         FRONTEND_BASE_URL: "https://web.proliferate.example.test",
+        // Contract v2: managedCloud (and the cloudWorkspaces projection) is
+        // ready only when GitHub App repository authority is also complete,
+        // because workspace mutations enforce it server-side.
+        GITHUB_APP_ID: "12345",
+        GITHUB_APP_SLUG: "proliferate-cloud-test",
+        GITHUB_APP_CLIENT_ID: "Iv1.capability-contract-test",
+        GITHUB_APP_CLIENT_SECRET: "capability_contract_test_client_secret",
+        GITHUB_APP_WEBHOOK_SECRET: "capability_contract_test_webhook_secret",
+        GITHUB_APP_PRIVATE_KEY: "-----BEGIN RSA PRIVATE KEY-----\\ntest\\n-----END RSA PRIVATE KEY-----",
       },
     });
   });
@@ -128,5 +161,12 @@ test.describe("T2-SH-5: /meta capability contract — hosted mode advertises ful
     expect(meta.capabilities.webApp.baseUrl).toBe("https://web.proliferate.example.test");
     expect(meta.capabilities.support.kind).toBe("vendor");
     expect(meta.capabilities.pricing.available).toBe(true);
+    // Contract v2: both independent capabilities ready; cloudWorkspaces above
+    // is their compatibility projection, not a standalone flag.
+    expect(meta.capabilities.githubRepositoryAccess.status).toBe("ready");
+    expect(meta.capabilities.githubRepositoryAccess.provider).toBe("github_app");
+    expect(meta.capabilities.githubRepositoryAccess.displayName).toBe("proliferate-cloud-test");
+    expect(meta.capabilities.managedCloud.status).toBe("ready");
+    expect(meta.capabilities.managedCloud.repositoryAuthority).toBe("github_app");
   });
 });


### PR DESCRIPTION
## Summary

Implements the frozen **Managed Cloud Capability And GitHub Authority — PR 1** contract (promoted in #1255, which this PR is stacked on and must land first).

- **Capability contract v2**: `/meta` now reports independent `githubRepositoryAccess` and `managedCloud` operator capabilities (`disabled` / `operator_configuration_required` / `ready`). `cloudWorkspaces` remains as a compatibility projection, true only when the whole managed-Cloud path is operable — old clients fail closed on E2B-ready/App-incomplete deployments instead of being invited into flows that fail on `require_github_cloud_repo_authority`.
- **Shared completeness predicate**: `Settings.github_app_configured` / `github_app_partially_configured` cover the five App runtime requirement groups (App id, OAuth client id/secret, webhook secret, private key in one form). Public responses expose only aggregate status + safe display name; a leak-guard test asserts no secret or field-level presence appears on the wire.
- **Repairable authority statuses**: `github_repo_access_required` → `missing_user_repo_access` with **no** action (reauthorizing the App cannot grant a GitHub account repository access); `github_app_not_configured` → new `operator_configuration_required` status with no user action.
- **preflight.sh truth**: removes the false claim that E2B alone gates Cloud workspaces; mirrors the Python predicate and warns explicitly on E2B-ready/App-incomplete.
- **Generated artifacts**: `server/openapi.json` and `cloud/sdk/src/generated/openapi.ts` regenerated via `make cloud-client-generate`; no hand edits.

No UI, no database schema, no version-aware client branching (PR 2 owns those).

## Verification

- `DEBUG=true uv run pytest -q tests/unit/test_meta_endpoint.py tests/unit/test_github_app_service.py tests/unit/test_github_app_callback_return.py` — 43 passed (full E2B × App matrix incl. App-ready/E2B-disabled, both partials, display-name fallback, secret-leak guard, all authority mappings).
- `make cloud-client-generate` — clean regeneration.
- `pnpm run typecheck` in `cloud/sdk` and `cloud/sdk-react` — pass.
- `ruff check` + `ruff format --check` on touched files — clean.
- `python3 scripts/check_docs.py` — pass.

## Review sequencing

Stacked on #1255 (docs promotion). Per the frozen handoff: the docs PR lands first, and any review changes to the promoted contract are reconciled here before this merges. PR 2 (client UX) is intentionally not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)