### PR TITLE
fix(ci): bump size allowlists to match files #1249 grew

### DIFF
--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -30,12 +30,13 @@ apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceIte
 apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts 415 injected typed telemetry deps threaded from the calling hook; split deferred
 apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model
-apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts 406 product telemetry facade threading into session-creation workflows; split deferred
+apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts 423 product telemetry facade threading into session-creation workflows; split deferred (+missing-worktree handling, #1249)
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 apps/packages/product-client/src/hooks/access/tauri/use-updater.ts 410 WDU slice 04 (G1): updater hook grew from the injected telemetry/storage scheduler DI; behavior-preserving
 apps/packages/product-client/src/host/product-host.ts 420 WDU slice 04 (G2/G4): host contract grew from getAnonymousInstallId + getSandboxGatewayAccessToken and their doc contracts
 apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx 450 status-card playground fixtures pending scenario-module split (#1202 debt repair)
 apps/packages/product-client/src/lib/domain/preferences/appearance.ts 437 appearance preset model pending preset-catalog split (#1202 growth recorded in debt repair)
 apps/packages/product-client/src/components/playground/GitReviewV2Playground.tsx 445 git review playground fixtures pending scenario-module split
-apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx 401 composer input growth from workspace-status card wiring (#1210 debt repair)
+apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx 402 composer input growth from workspace-status card wiring (#1210 debt repair) + missing-worktree composer panel (#1249)
+apps/packages/product-client/src/hooks/plans/workflows/use-proposed-plan-actions.ts 405 proposed-plan action workflows grown by missing-worktree state handling (#1249); split deferred
 apps/packages/product-client/src/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl.tsx 463 workspace-status composer control pending section split (#1210 debt repair)

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -9,21 +9,21 @@
 
 anyharness/crates/anyharness-contract/src/v1/events.rs 1092 existing AnyHarness contract oversized file
 anyharness/crates/anyharness-contract/src/v1/sessions.rs 767 existing AnyHarness contract oversized file
-anyharness/crates/anyharness-lib/src/api/openapi.rs 655 existing AnyHarness oversized file (+hosting schema registration, +agent-auth state response, +gateway catalog endpoints) + enriched gateway-models schema fields (model-table §1) + workflow-runs paths/schemas
+anyharness/crates/anyharness-lib/src/api/openapi.rs 656 existing AnyHarness oversized file (+hosting schema registration, +agent-auth state response, +gateway catalog endpoints) + enriched gateway-models schema fields (model-table §1) + workflow-runs paths/schemas + missing-worktree state schema (#1249)
 anyharness/crates/anyharness-lib/src/api/router_tests.rs 1364 existing AnyHarness oversized test file (+hosting PR-status route tests, +catalog version + enrichment tests)
 anyharness/crates/anyharness-lib/src/domains/workflows/service.rs 664 workflow durable rules (+run-control cancel-intent use case and helpers); split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 1307 workflow-runs merge-gated domain suite (+run-control stateVersion progression, four-outcome cancel intent at every boundary, first-terminal-wins, interrupted fencing)
-anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 1814 workflow-runs HTTP + runtime/extension crossing suite (+run-control cancel matrix, wire pinning, dropped-cancel handoff, cancel/execution race, interrupted fencing, PROOF-01 battery: effort-window cancel, deterministic dispatch-vs-cancel orders, missing-actor recovery, post-commit read-failure intent)
+anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 1819 workflow-runs HTTP + runtime/extension crossing suite (+run-control cancel matrix, wire pinning, dropped-cancel handoff, cancel/execution race, interrupted fencing, PROOF-01 battery: effort-window cancel, deterministic dispatch-vs-cancel orders, missing-actor recovery, post-commit read-failure intent) + missing-worktree coverage (#1249)
 anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 605 defaultAgentKind must name a declared agent (was already at 598)
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection
-anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1895 existing AnyHarness oversized file
+anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1911 existing AnyHarness oversized file (+missing-worktree state, #1249)
 anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1520 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/plans/service.rs 628 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/domains/goals/service_tests.rs 682 goal service regression tests for pending_op idempotency
 anyharness/crates/anyharness-lib/src/domains/reviews/service/service_tests.rs 1510 existing AnyHarness oversized test file
-anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 680 existing AnyHarness oversized test file
+anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs 897 existing AnyHarness oversized test file (+missing-worktree state coverage, #1249)
 anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 653 runtime pressure worktree inventory joins and tests
 anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 existing AnyHarness oversized file
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
@@ -52,7 +52,7 @@ apps/packages/ui/src/icons/core.tsx 413 existing consolidated icon barrel pendin
 apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 908 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock + ProductHost test-host wiring
 apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
-apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 630 existing desktop oversized test file
+apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 648 existing desktop oversized test file (+missing-worktree indicator coverage, #1249)
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 anyharness/crates/anyharness-lib/src/api/router.rs 613 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs route, +workflow-run cancel route)
 anyharness/crates/anyharness-lib/src/app/mod.rs 625 AnyHarness app wiring (+goal/loop/activity/feed services, +two-phase workflow-run wiring calls into app/workflows.rs)


### PR DESCRIPTION
## What

PR #1249 (`4238761df`, typed missing-worktree state) grew **five already-allowlisted files** past their recorded counts **without bumping the size allowlists**. As a result `Repo shape checks` (max-lines + `report_frontend_structure.py --strict`) has been **red on main and every downstream PR** since #1249 merged.

This is a config-only ratchet — **no code changes** — bringing the recorded counts up to the observed sizes.

### max_lines_allowlist.txt
| file | was | now |
| --- | ---: | ---: |
| `api/openapi.rs` | 655 | 656 |
| `api/workflow_runs_tests.rs` | 1814 | 1819 |
| `domains/cowork/runtime.rs` | 1895 | 1911 |
| `domains/sessions/runtime/tests.rs` | 680 | 897 |
| `sidebar/sidebar-indicators.test.ts` | 630 | 648 |

### frontend_structure_allowlist.txt
| file | was | now |
| --- | ---: | ---: |
| `chat/input/ChatInput.tsx` | 401 | 402 |
| `hooks/sessions/workflows/use-session-creation-actions.ts` | 406 | 423 |
| `hooks/plans/workflows/use-proposed-plan-actions.ts` | (new) | 405 |

## Why

The size gates use **exact-match** semantics (a file over its recorded count fails; the allowlist is a shrinking ratchet). #1249 should have bumped these in the same PR. Restoring the gate to green unblocks the Deploy Staging spine and downstream WDU phase-6 qualification. The deferred splits remain tracked in the allowlist reasons.

## Proof

Full repo-shape suite green locally on this branch: `check_max_lines.py` OK, `report_frontend_structure.py --strict` TOTAL 0, boundaries/migrations/docs all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)