### PR TITLE
fix(ci): drop stale frontend-structure allowlist entry

### DIFF
--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -39,4 +39,3 @@ apps/packages/product-client/src/lib/domain/preferences/appearance.ts 437 appear
 apps/packages/product-client/src/components/playground/GitReviewV2Playground.tsx 445 git review playground fixtures pending scenario-module split
 apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx 410 composer input growth from workspace-status card wiring (#1210 debt repair, #1256 resources/advanced threading)
 apps/packages/product-client/src/hooks/plans/workflows/use-proposed-plan-actions.ts 405 plan decision + carry-out workflow growth (#1250); split deferred
-apps/packages/product-client/src/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl.tsx 463 workspace-status composer control pending section split (#1210 debt repair)


### PR DESCRIPTION
## What

Removes the stale `WorkspaceStatusComposerControl.tsx` entry from `frontend_structure_allowlist.txt`.

## Why

That file shrank to **341 lines** (≤ the 400 soft threshold) but was still allowlisted at **463**. `report_frontend_structure.py --strict` treats a shrunk-below-threshold file as a **stale entry** and fails until it's removed — so `Repo shape checks` stayed **red on main** even after #1258 caught the *grown* files up. This is the last piece to restore the gate to green.

The allowlist is a shrinking ratchet: entries must be deleted once a file drops back under the soft threshold. Config-only, no code change.

## Proof

`report_frontend_structure.py --strict` → TOTAL 0; `check_max_lines.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)