### PR TITLE
fix(cloud): pin the runtime home in the E2B template agent bake

### DIFF
--- a/scripts/build-template.mjs
+++ b/scripts/build-template.mjs
@@ -351,12 +351,25 @@ function prepareTemplateContext(bundlePaths) {
   return contextDir;
 }
 
+// The AnyHarness runtime home the serving runtime resolves at launch time:
+// the launch script exports HOME=/home/user (SandboxRuntimeContext.base_env,
+// integrations/sandbox/e2b.py) and `serve` receives no --runtime-home, so it
+// resolves default_runtime_home() = $HOME/.proliferate/anyharness. The bake
+// must install agents into this exact home — a Docker/E2B build-stage
+// `USER user` does NOT update $HOME, so an unpinned bake-time install-agents
+// can resolve a different default home, leaving agents where the serving
+// runtime never looks (readiness reports InstallRequired and
+// GET /v1/agents/launch-options returns zero launchable agents → empty
+// composer picker in fresh cloud sandboxes).
+const ANYHARNESS_RUNTIME_HOME = "/home/user/.proliferate/anyharness";
+
 function buildAgentInstallCommand(agentKinds) {
   const agentArgs = agentKinds.map((agentKind) => `--agent ${agentKind}`).join(" ");
   return [
     "set -eu",
     `echo "Preinstalling agents: ${agentKinds.join(", ")}"`,
-    `/home/user/anyharness install-agents ${agentArgs}`,
+    "export HOME=/home/user",
+    `/home/user/anyharness install-agents --runtime-home ${ANYHARNESS_RUNTIME_HOME} ${agentArgs}`,
   ].join(" && ");
 }
 


### PR DESCRIPTION
## Summary

The production E2B template bake (`scripts/build-template.mjs`) ran `install-agents` with an unpinned `$HOME` and no `--runtime-home`. The serving runtime resolves its home as `$HOME/.proliferate/anyharness` with `HOME=/home/user` exported by the launch script (`SandboxRuntimeContext.base_env`, `integrations/sandbox/e2b.py`) — but a Docker/E2B build-stage `USER user` does **not** update `$HOME`, so the bake-time install can resolve a different default home.

When that happens, agents are installed where the serving runtime never looks: readiness reports `InstallRequired`, `GET /v1/agents/launch-options` returns zero launchable agents, and fresh cloud sandboxes show an **empty composer model picker**.

## Fix

Pin both sides in the bake command, exactly as the qualification world bake does (proven live in PR #1239's runs — the empty-picker root cause disappeared once pinned):

- `export HOME=/home/user`
- `install-agents --runtime-home /home/user/.proliferate/anyharness`

This is the `filed` finding from the PR 2 qualification findings ledger ("Prod E2B template bake installs agents into an unpinned $HOME").

## Risk

One-line behavior pin in a build script; if prod's base image was already setting `HOME=/home/user` (escaping by luck), this is a no-op. The next template build via `release-cloud-template.yml` / `_deploy-e2b.yml` picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)