### PR TITLE
fix(cloud): destroy provider sandboxes on destroy + reap orphaned E2B sandboxes

### DIFF
--- a/server/proliferate/integrations/sandbox/e2b.py
+++ b/server/proliferate/integrations/sandbox/e2b.py
@@ -32,6 +32,9 @@ from proliferate.utils.time import utcnow
 logger = logging.getLogger("proliferate.cloud.e2b")
 
 _E2B_API_BASE_URL = "https://api.e2b.app"
+# Bound the list pagination so a paging bug cannot loop forever; large enough to
+# cover any realistic account (100/page x 50 = 5000 sandboxes).
+_LIST_SANDBOXES_MAX_PAGES = 50
 
 
 class E2BRuntimeError(RuntimeError):
@@ -113,7 +116,14 @@ def _normalize_state(value: object) -> str:
 
 
 def _state_from_payload(payload: dict[str, Any]) -> ProviderSandboxState | None:
-    sandbox_id = payload.get("sandboxId") or payload.get("sandbox_id") or payload.get("id")
+    # v2 /sandboxes returns `sandboxID` (capital ID); older payloads used
+    # `sandboxId`/`sandbox_id`/`id`. Accept all so this parser is endpoint-agnostic.
+    sandbox_id = (
+        payload.get("sandboxID")
+        or payload.get("sandboxId")
+        or payload.get("sandbox_id")
+        or payload.get("id")
+    )
     if not sandbox_id:
         return None
     return ProviderSandboxState(
@@ -182,25 +192,47 @@ class E2BSandboxProvider:
         return await asyncio.to_thread(self._get_sandbox_state, sandbox_id)
 
     async def list_sandbox_states(self) -> list[ProviderSandboxState]:
-        async with httpx.AsyncClient(base_url=_E2B_API_BASE_URL, timeout=30.0) as client:
-            response = await client.get(
-                "/sandboxes",
-                headers={"X-API-Key": self._require_api_key()},
-            )
-            response.raise_for_status()
-        payload = response.json()
-        if isinstance(payload, dict):
-            raw_items = payload.get("sandboxes") or payload.get("data") or []
-        else:
-            raw_items = payload
-        if not isinstance(raw_items, list):
-            return []
+        # Mirror the E2B SDK's list: GET /v2/sandboxes with an explicit
+        # `state` filter (comma-joined values, as the SDK serializes it) and
+        # header-based pagination via `x-next-token`. RUNNING alone would miss
+        # PAUSED sandboxes — the PRIMARY orphan shape, since E2B pauses on
+        # timeout — so both states are requested. Pagination is bounded to avoid
+        # an unbounded loop against a paging bug; the bound is logged, never
+        # silently truncated.
         states: list[ProviderSandboxState] = []
-        for item in raw_items:
-            if isinstance(item, dict):
-                state = _state_from_payload(item)
-                if state is not None:
-                    states.append(state)
+        next_token: str | None = None
+        async with httpx.AsyncClient(base_url=_E2B_API_BASE_URL, timeout=30.0) as client:
+            for _page in range(_LIST_SANDBOXES_MAX_PAGES):
+                params: list[tuple[str, str]] = [
+                    ("state", "running,paused"),
+                    ("limit", "100"),
+                ]
+                if next_token:
+                    params.append(("nextToken", next_token))
+                response = await client.get(
+                    "/v2/sandboxes",
+                    params=params,
+                    headers={"X-API-KEY": self._require_api_key()},
+                )
+                response.raise_for_status()
+                payload = response.json()
+                if isinstance(payload, dict):
+                    raw_items = payload.get("sandboxes") or payload.get("data") or []
+                else:
+                    raw_items = payload
+                if isinstance(raw_items, list):
+                    for item in raw_items:
+                        if isinstance(item, dict):
+                            state = _state_from_payload(item)
+                            if state is not None:
+                                states.append(state)
+                next_token = response.headers.get("x-next-token")
+                if not next_token:
+                    return states
+            logger.warning(
+                "e2b list_sandbox_states hit the %s-page bound; results may be truncated",
+                _LIST_SANDBOXES_MAX_PAGES,
+            )
         return states
 
     async def resolve_runtime_endpoint(self, sandbox: Any) -> RuntimeEndpoint:

--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -8,6 +8,7 @@ ORM stack.
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol
 from uuid import UUID
 
@@ -18,11 +19,15 @@ from proliferate.db.store import billing_subjects
 from proliferate.db.store import cloud_sandboxes as sandbox_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
+from proliferate.integrations.sandbox import get_sandbox_provider
 from proliferate.server.billing.authorization import (
     assert_cloud_sandbox_resume_allowed_for_owner,
 )
+from proliferate.server.cloud.cloud_sandboxes.transactions import run_after_commit
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.utils.crypto import decrypt_text
+
+logger = logging.getLogger("proliferate.cloud.cloud_sandboxes")
 
 
 class _UserWithId(Protocol):
@@ -107,7 +112,39 @@ async def destroy_cloud_sandbox(
     # Retire the sandbox's worker + gateway token so a destroyed sandbox can
     # never keep authenticating back to Cloud.
     await runtime_workers_store.revoke_active_workers_for_identity(db, cloud_sandbox_id=sandbox.id)
-    return await sandbox_store.mark_cloud_sandbox_destroyed(db, sandbox.id)
+    destroyed = await sandbox_store.mark_cloud_sandbox_destroyed(db, sandbox.id)
+    # Kill the provider VM so a destroyed row does not leave an E2B sandbox
+    # running forever (it is created with on_timeout=pause + auto_resume, so it
+    # never dies on its own). This MUST happen only after the DB destroy durably
+    # commits: if we killed inline and the caller's transaction then rolled back,
+    # the row would stay alive pointing at a dead provider id and the next
+    # connect would resume the dead id instead of recreating — a wedged sandbox.
+    # run_after_commit defers to the root-commit event and discards on rollback.
+    # The captured ids are plain locals (no ORM access inside the callback, which
+    # runs after the session may be closed). Loss on process restart before the
+    # callback fires is accepted at-most-once behavior; a periodic reaper backstop
+    # for that loss (and for pre-existing orphans) is tracked as a follow-up in
+    # #1280 — there is no shipped reaper yet.
+    if sandbox.e2b_sandbox_id:
+        provider_sandbox_id = sandbox.e2b_sandbox_id
+        template_ref = sandbox.e2b_template_ref
+        sandbox_id_for_log = str(sandbox.id)
+
+        async def _destroy_provider_sandbox() -> None:
+            try:
+                provider = get_sandbox_provider(template_ref)
+                await provider.destroy_sandbox(provider_sandbox_id)
+            except Exception:
+                logger.exception(
+                    "failed to destroy provider sandbox on cloud sandbox destroy",
+                    extra={
+                        "cloud_sandbox_id": sandbox_id_for_log,
+                        "e2b_sandbox_id": provider_sandbox_id,
+                    },
+                )
+
+        await run_after_commit(db, _destroy_provider_sandbox)
+    return destroyed
 
 
 async def load_cloud_sandbox_runtime_access(

--- a/server/proliferate/server/cloud/cloud_sandboxes/transactions.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/transactions.py
@@ -24,5 +24,12 @@ def defer_after_commit(
     session_ops.defer_after_commit(db, callback)
 
 
+async def run_after_commit(
+    db: AsyncSession,
+    callback: Callable[[], Awaitable[None]],
+) -> None:
+    await session_ops.run_after_commit(db, callback)
+
+
 async def commit_cloud_sandbox_session(db: AsyncSession) -> None:
     await session_ops.commit_session(db)

--- a/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import secrets
 import shlex
 from uuid import UUID
@@ -50,6 +51,8 @@ from proliferate.server.cloud.runtime.sandbox_exec import (
 )
 from proliferate.server.cloud.runtime_workers.service import worker_cloud_base_url
 from proliferate.utils.crypto import decrypt_text, encrypt_text
+
+logger = logging.getLogger("proliferate.cloud.materialization.connect")
 
 
 def _runtime_token(sandbox: CloudSandboxValue) -> str | None:
@@ -116,8 +119,32 @@ async def connect_ready_sandbox(
             e2b_sandbox_id=provider_sandbox_id,
             e2b_template_ref=provider.template_version,
         )
-        if refreshed is not None:
-            sandbox = refreshed
+        if refreshed is None:
+            # The row was destroyed (or vanished) mid-create. record_* returns
+            # None from its row-gone/destroyed guard BEFORE writing anything, so
+            # the provider id we just minted was never persisted to any row —
+            # unlike destroy_cloud_sandbox (P2-001), there is no DB state that a
+            # rollback could leave disagreeing with a killed VM. We are about to
+            # raise and roll this transaction back, and the VM is unrecorded
+            # either way, so an immediate inline best-effort destroy is correct
+            # here (no after-commit hook needed). This runs in the materializer's
+            # own transaction, not a request-held FOR UPDATE critical path, so it
+            # does not wedge a locked row. If this best-effort destroy fails the
+            # VM orphans; a periodic reaper backstop is tracked in #1280.
+            try:
+                await provider.destroy_sandbox(provider_sandbox_id)
+            except Exception:
+                logger.exception(
+                    "failed to destroy provider sandbox after lost record",
+                    extra={
+                        "cloud_sandbox_id": str(sandbox.id),
+                        "e2b_sandbox_id": provider_sandbox_id,
+                    },
+                )
+            raise CloudMaterializationCommandError(
+                "Cloud sandbox was destroyed while provisioning."
+            )
+        sandbox = refreshed
         await db.commit()
 
     provider_sandbox = await provider.resume_sandbox(provider_sandbox_id)

--- a/server/tests/unit/test_cloud_connect_race.py
+++ b/server/tests/unit/test_cloud_connect_race.py
@@ -1,0 +1,70 @@
+"""Part B: a lost record mid-create destroys the freshly created VM and raises."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from proliferate.server.cloud.materialization.sandbox_io import connect
+from proliferate.server.cloud.materialization.sandbox_io.target import (
+    CloudMaterializationCommandError,
+)
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.commits = 0
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+class _FakeProvider:
+    template_version = "e2b"
+
+    def __init__(self) -> None:
+        self.destroyed: list[str] = []
+
+    async def create_sandbox(self, *, metadata: dict[str, str] | None = None) -> Any:
+        return SimpleNamespace(sandbox_id="sbx-new")
+
+    async def destroy_sandbox(self, sandbox_id: str) -> None:
+        self.destroyed.append(sandbox_id)
+
+
+@pytest.mark.asyncio
+async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _FakeProvider()
+    sandbox = SimpleNamespace(
+        id=uuid.uuid4(),
+        destroyed_at=None,
+        status="creating",
+        e2b_sandbox_id=None,
+        e2b_template_ref="e2b",
+        owner_user_id=uuid.uuid4(),
+    )
+
+    async def _resume_allowed(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _record_none(*_a: Any, **_k: Any) -> None:
+        return None  # row destroyed mid-create
+
+    monkeypatch.setattr(connect, "assert_cloud_sandbox_resume_allowed", _resume_allowed)
+    monkeypatch.setattr(connect, "get_sandbox_provider", lambda _ref: provider)
+    monkeypatch.setattr(
+        connect.cloud_sandboxes_store,
+        "record_cloud_sandbox_provider_sandbox",
+        _record_none,
+    )
+
+    db = _FakeDb()
+    with pytest.raises(CloudMaterializationCommandError):
+        await connect.connect_ready_sandbox(db, sandbox=sandbox)
+
+    assert provider.destroyed == ["sbx-new"]
+    # Never committed the lost record and never proceeded to resume/launch.
+    assert db.commits == 0

--- a/server/tests/unit/test_cloud_sandbox_destroy_provider.py
+++ b/server/tests/unit/test_cloud_sandbox_destroy_provider.py
@@ -1,0 +1,148 @@
+"""Part A / P2-001: destroy_cloud_sandbox kills the provider VM only AFTER the
+DB destroy durably commits, via the canonical run_after_commit hook."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.server.cloud.cloud_sandboxes import service
+
+
+class _FakeProvider:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.destroyed: list[str] = []
+        self._fail = fail
+
+    async def destroy_sandbox(self, sandbox_id: str) -> None:
+        self.destroyed.append(sandbox_id)
+        if self._fail:
+            raise RuntimeError("provider destroy exploded")
+
+
+def _sandbox(e2b_sandbox_id: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        e2b_sandbox_id=e2b_sandbox_id,
+        e2b_template_ref="e2b",
+    )
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, sandbox: Any, provider: _FakeProvider) -> None:
+    async def _load(*_a: Any, **_k: Any) -> Any:
+        return sandbox
+
+    async def _revoke(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _mark(*_a: Any, **_k: Any) -> Any:
+        return sandbox
+
+    monkeypatch.setattr(service.sandbox_store, "load_personal_cloud_sandbox", _load)
+    monkeypatch.setattr(
+        service.runtime_workers_store, "revoke_active_workers_for_identity", _revoke
+    )
+    monkeypatch.setattr(service.sandbox_store, "mark_cloud_sandbox_destroyed", _mark)
+    monkeypatch.setattr(service, "get_sandbox_provider", lambda _ref: provider)
+
+
+async def _pump() -> None:
+    # The after-commit listener schedules the callback via loop.create_task;
+    # yield a few times so the deferred coroutine actually runs.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_provider_killed_only_after_commit(
+    monkeypatch: pytest.MonkeyPatch, db_session: AsyncSession
+) -> None:
+    provider = _FakeProvider()
+    _patch(monkeypatch, _sandbox("sbx-1"), provider)
+
+    # Real root transaction so run_after_commit defers through db/engine's actual
+    # after_commit listener rather than firing inline.
+    await db_session.begin()
+    result = await service.destroy_cloud_sandbox(db_session, SimpleNamespace(id=uuid.uuid4()))
+    assert result is not None
+    # Not killed yet — the destroy is deferred until the commit is durable.
+    assert provider.destroyed == []
+
+    await db_session.commit()
+    await _pump()
+    # Exactly one kill after the commit lands.
+    assert provider.destroyed == ["sbx-1"]
+
+
+@pytest.mark.asyncio
+async def test_provider_not_killed_on_rollback(
+    monkeypatch: pytest.MonkeyPatch, db_session: AsyncSession
+) -> None:
+    provider = _FakeProvider()
+    _patch(monkeypatch, _sandbox("sbx-2"), provider)
+
+    await db_session.begin()
+    await service.destroy_cloud_sandbox(db_session, SimpleNamespace(id=uuid.uuid4()))
+    assert provider.destroyed == []
+
+    # A rollback after destroy returns must discard the deferred kill entirely,
+    # otherwise a killed VM would be left with a still-alive row (the wedge bug).
+    await db_session.rollback()
+    await _pump()
+    assert provider.destroyed == []
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_after_commit_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch, db_session: AsyncSession
+) -> None:
+    provider = _FakeProvider(fail=True)
+    _patch(monkeypatch, _sandbox("sbx-3"), provider)
+
+    await db_session.begin()
+    result = await service.destroy_cloud_sandbox(db_session, SimpleNamespace(id=uuid.uuid4()))
+    assert result is not None
+    # A provider failure inside the deferred callback is swallowed (logged);
+    # committing the destroy never fails (a periodic reaper backstop for the
+    # leaked VM is tracked in #1280).
+    await db_session.commit()
+    await _pump()
+    assert provider.destroyed == ["sbx-3"]
+
+
+@pytest.mark.asyncio
+async def test_no_provider_call_when_no_e2b_id(
+    monkeypatch: pytest.MonkeyPatch, db_session: AsyncSession
+) -> None:
+    provider = _FakeProvider()
+    resolved: list[bool] = []
+    _patch(monkeypatch, _sandbox(None), provider)
+    monkeypatch.setattr(
+        service, "get_sandbox_provider", lambda _ref: resolved.append(True) or provider
+    )
+
+    await db_session.begin()
+    await service.destroy_cloud_sandbox(db_session, SimpleNamespace(id=uuid.uuid4()))
+    await db_session.commit()
+    await _pump()
+
+    assert provider.destroyed == []
+    assert resolved == []
+
+
+@pytest.mark.asyncio
+async def test_no_sandbox_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _load(*_a: Any, **_k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(service.sandbox_store, "load_personal_cloud_sandbox", _load)
+
+    result = await service.destroy_cloud_sandbox(
+        SimpleNamespace(), SimpleNamespace(id=uuid.uuid4())
+    )
+    assert result is None

--- a/server/tests/unit/test_e2b_runtime.py
+++ b/server/tests/unit/test_e2b_runtime.py
@@ -1,3 +1,6 @@
+import httpx
+import pytest
+
 from proliferate.integrations.sandbox import e2b as e2b_runtime
 
 
@@ -272,6 +275,100 @@ def test_run_command_passes_background_envs_and_cwd(monkeypatch) -> None:
         "background": True,
         "timeout": 15,
     }
+
+
+def _mount_list_transport(
+    monkeypatch, pages: list[tuple[list[dict], str | None]]
+) -> list[httpx.Request]:
+    """Serve `pages` (items, next_token) from a mocked httpx transport.
+
+    Returns the captured requests so tests can assert the query params sent.
+    """
+    monkeypatch.setattr(e2b_runtime.settings, "e2b_api_key", "e2b_test_key")
+    requests: list[httpx.Request] = []
+    calls = {"n": 0}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        items, next_token = pages[calls["n"]]
+        calls["n"] += 1
+        headers = {"x-next-token": next_token} if next_token else {}
+        return httpx.Response(200, json=items, headers=headers)
+
+    real_client = httpx.AsyncClient
+
+    def _fake_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(_handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(e2b_runtime.httpx, "AsyncClient", _fake_client)
+    return requests
+
+
+@pytest.mark.asyncio
+async def test_list_sandbox_states_filters_state_and_parses_v2_keys(monkeypatch) -> None:
+    # v2 payload uses camelCase `sandboxID`/`startedAt`/`endAt`.
+    item = {
+        "sandboxID": "sbx-1",
+        "state": "paused",
+        "startedAt": "2026-07-15T00:00:00Z",
+        "endAt": "2026-07-15T01:00:00Z",
+        "metadata": {"proliferate_cloud_sandbox_id": "abc"},
+    }
+    requests = _mount_list_transport(monkeypatch, [([item], None)])
+
+    states = await e2b_runtime.E2BSandboxProvider().list_sandbox_states()
+
+    assert len(states) == 1
+    assert states[0].external_sandbox_id == "sbx-1"
+    assert states[0].state == "paused"
+    assert states[0].started_at is not None
+    assert states[0].metadata == {"proliferate_cloud_sandbox_id": "abc"}
+    # Hits the v2 endpoint with the running+paused state filter.
+    assert requests[0].url.path == "/v2/sandboxes"
+    assert requests[0].url.params.get("state") == "running,paused"
+    assert requests[0].headers["X-API-KEY"] == "e2b_test_key"
+
+
+@pytest.mark.asyncio
+async def test_list_sandbox_states_paginates_via_next_token_header(monkeypatch) -> None:
+    pages = [
+        ([{"sandboxID": "sbx-1", "state": "running"}], "token-2"),
+        ([{"sandboxID": "sbx-2", "state": "paused"}], None),
+    ]
+    requests = _mount_list_transport(monkeypatch, pages)
+
+    states = await e2b_runtime.E2BSandboxProvider().list_sandbox_states()
+
+    assert [s.external_sandbox_id for s in states] == ["sbx-1", "sbx-2"]
+    # First page carries no token; second page passes it back as nextToken.
+    assert "nextToken" not in requests[0].url.params
+    assert requests[1].url.params.get("nextToken") == "token-2"
+
+
+@pytest.mark.asyncio
+async def test_list_sandbox_states_bounds_pagination(monkeypatch) -> None:
+    # Every page returns a token, so the loop must stop at the page bound.
+    infinite = [([{"sandboxID": f"sbx-{i}", "state": "running"}], f"token-{i}") for i in range(60)]
+    requests = _mount_list_transport(monkeypatch, infinite)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        e2b_runtime.logger, "warning", lambda msg, *a, **k: warnings.append(msg % a if a else msg)
+    )
+
+    states = await e2b_runtime.E2BSandboxProvider().list_sandbox_states()
+
+    assert len(requests) == e2b_runtime._LIST_SANDBOXES_MAX_PAGES
+    assert len(states) == e2b_runtime._LIST_SANDBOXES_MAX_PAGES
+    assert warnings and "page bound" in warnings[0]
+
+
+def test_state_from_payload_accepts_legacy_and_v2_id_keys() -> None:
+    assert e2b_runtime._state_from_payload({"sandboxID": "v2"}).external_sandbox_id == "v2"
+    assert e2b_runtime._state_from_payload({"sandboxId": "legacy"}).external_sandbox_id == "legacy"
+    assert e2b_runtime._state_from_payload({"sandbox_id": "snake"}).external_sandbox_id == "snake"
+    assert e2b_runtime._state_from_payload({"id": "bare"}).external_sandbox_id == "bare"
+    assert e2b_runtime._state_from_payload({"state": "running"}) is None
 
 
 def test_resolve_runtime_context_uses_static_e2b_paths() -> None:


### PR DESCRIPTION
## Problem

Confirmed live during PR 2 (#1239) qualification: E2B provider sandboxes can outlive their `cloud_sandbox` row and run forever. They are created with `lifecycle={on_timeout: pause, auto_resume: True}`, so nothing kills them on their own — a cost and cleanup risk in prod.

Two orphan-**creation** mechanisms this PR fixes:

1. **DB destroy never reached the provider.** `destroy_cloud_sandbox` marked the row destroyed and revoked worker tokens but never called the provider; `provider.destroy_sandbox` had **zero call sites** in the entire server.
2. **Create/destroy race dropped the link.** `connect_ready_sandbox` creates the provider VM, then `record_cloud_sandbox_provider_sandbox` silently returns `None` if the row was destroyed mid-create — the fresh VM id was never persisted and the code proceeded anyway.

## Scope (Parts A + B — orphan-creation sources)

**A — after-commit provider destroy** (`cloud_sandboxes/service.py`): `destroy_cloud_sandbox` marks the row destroyed, then defers the best-effort provider kill through the canonical `run_after_commit(db, ...)` hook so the VM is killed **only after the DB destroy durably commits** (the hook discards the callback on rollback). This prevents the wedge where a killed VM would be left behind a still-alive row pointing at the dead id. Captured ids are plain locals (no ORM access inside the callback); a provider failure is logged, never fails the request; no `db.commit()` in the service layer. Callback loss on process restart is accepted at-most-once behavior.

**B — race closed at the source** (`materialization/sandbox_io/connect.py`): when the provider-id write is dropped because the row was destroyed mid-create, the just-created VM is destroyed inline and the materialization raises `"Cloud sandbox was destroyed while provisioning."` instead of silently continuing with an unrecorded VM. Inline is correct here (not after-commit): `record_*` returns `None` from its row-gone guard **before** writing anything, so no DB state ever references this VM and the imminent rollback cannot disagree with the kill; this path is the materializer's own transaction, not a request-held `FOR UPDATE` critical path.

Also included (independent, genuine fix): the E2B `list_sandbox_states` now uses `GET /v2/sandboxes` with a `state=running,paused` filter and `x-next-token` header pagination (bounded, warns at the bound), and `_state_from_payload` accepts the v2 `sandboxID` key. This method is shared by the **billing reconciler** (`billing/reconciler.py`), which previously would have missed paused sandboxes; kept because it improves an existing, actively-called method. SDK-verified against `e2b/sandbox_sync/paginator.py`, `api/client/api/sandboxes/get_v2_sandboxes.py`, `models/listed_sandbox.py`.

## Deferred — Part C (periodic reaper): tracked in #1280

The periodic orphan-reaper backstop was **removed from this PR** per founder ruling (merge-first directive, 2026-07-16): no current deployment path runs a Celery worker or Beat scheduler (production compose has no RabbitMQ/worker/beat — see `background/tasks/notifications.py`), so a registered Beat task would be dormant scaffolding that cannot execute and must not be claimed as incident closure. The CONTROL-audited implementation (reaper pass + advisory lock + Beat task + conservative tag-plus-local-row attribution) is preserved on branch **`backup/orphan-reaper-with-beat-task`** and tracked in **#1280** to resurrect once a real executor exists.

**This PR does not close the incident.** It fixes the orphan-**creation** sources going forward. Pre-existing orphans in the E2B account and the at-most-once restart-loss of the after-commit destroy remain until the follow-up (#1280) ships an executor.

## Tests

- `test_cloud_sandbox_destroy_provider.py` — after-commit ordering on a real Postgres session through db/engine's actual listener: commit → exactly one kill; rollback → zero kills; deferred provider failure never raises; no-e2b-id → no call.
- `test_cloud_connect_race.py` — dropped-record → inline destroy + raise.
- `test_e2b_runtime.py` — v2 list: state filter, next-token pagination, page bound, id-key fallbacks.

Focused battery (these + `test_sandbox_materialization.py`, `test_background_celery.py`, `test_background_workers_flag.py`, `test_customerio_sync.py`): **35 passed**. `ruff check`/`format` clean; `scripts/check_server_boundaries.py` passes; mypy clean on changed logic.

## CONTROL history

- **P2-001 (blocker) — CLOSED.** Provider destruction moved to `run_after_commit` (kill only after durable commit; no provider I/O held across the `FOR UPDATE` lock). Transaction-level regressions prove commit/rollback behavior.
- **P2-002 (blocker) — RESOLVED by deferral (founder ruling).** No deployed worker/Beat can execute a scheduled task, so the reaper is removed from this PR and tracked as a separate product PR (#1280); preserved on `backup/orphan-reaper-with-beat-task`. A registered task no deployed worker can run is not incident closure.
- **P2-003 (material/custody) — post-merge acceptance debt.** Live destructive E2B qualification against a real account is deferred to founder-approved post-merge acceptance; no E2B calls were made. This head remains unit-proven; the Vault ledger distinction stays truthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
