### PR TITLE
test(release): complete managed-cloud qualification (PR 6) — shared fixture layer

### DIFF
--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -576,6 +576,53 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
     secret: false,
     lanes: ["sandbox"],
   },
+  // ── Appended for PR 6 (shared fixture layer). Sandbox lane; all secret. Only
+  // consumed when a PR-6 fixture / candidate Stripe deploy option is used —
+  // absent, the candidate Server keeps today's no-Stripe 503 checkout posture
+  // (the CLOUD-PROVISION-1 regression is untouched). Declared here so their
+  // values are redacted from the persisted report. ──────────────────────────
+  {
+    name: "STRIPE_TEST_SECRET_KEY",
+    description:
+      "Stripe TEST secret key (sk_test_…) the managed-cloud billing journeys use for real Stripe test-mode " +
+      "work: the candidate Server's own STRIPE_SECRET_KEY (so real Core-via-Stripe cloud checkout works — " +
+      "closing the fundCore 503 debt), and the stripeTestClock fixture's test-clock/customer/subscription " +
+      "setup for CLOUD-COMPUTE-RENEW-1. Resolved by the stripeTestClock fixture from this env, falling back " +
+      "to TIER2_BILLING_STRIPE_SECRET_KEY; a LIVE-mode key throws (assertCheckoutUrlTestMode discipline) and " +
+      "an unresolved key blocks the dependent cells rather than fabricating them. NOT a scenario requiredEnv " +
+      "(the Tier-2 fallback must keep working). Never live mode.",
+    whereItLives:
+      "Local: `~/.proliferate-local/dev/qualification-infra.env` (mode 0600), or the shared Stripe test-mode " +
+      "config. CI: the `Qualification` environment's Stripe test secret.",
+    secret: true,
+    lanes: ["sandbox"],
+  },
+  {
+    name: "RELEASE_E2E_CLOUD_STRIPE_WEBHOOK_SECRET",
+    description:
+      "The Stripe webhook signing secret (whsec_…) the candidate Server verifies its /v1/billing/webhooks/stripe " +
+      "deliveries against (its STRIPE_WEBHOOK_SECRET). The signed callback relay preserves the exact signed " +
+      "bytes end-to-end and never re-signs, so this is the SERVER's verification secret, declared here only for " +
+      "redaction — the relay itself never reads it. Absent → the candidate Server keeps today's no-Stripe posture.",
+    whereItLives:
+      "The Stripe test-mode webhook endpoint config for the qualification account. Local: " +
+      "`~/.proliferate-local/dev/qualification-infra.env` (mode 0600). CI: the `Qualification` environment secret.",
+    secret: true,
+    lanes: ["sandbox"],
+  },
+  {
+    name: "RELEASE_E2E_CLOUD_E2B_WEBHOOK_SECRET",
+    description:
+      "The E2B webhook signature secret the candidate Server verifies its /v1/cloud/webhooks/e2b deliveries " +
+      "against (its E2B_WEBHOOK_SIGNATURE_SECRET). As with the Stripe webhook secret, the signed callback relay " +
+      "forwards the exact signed bytes and never re-signs, so this is the SERVER's verification secret, declared " +
+      "here only for redaction. Absent → the candidate Server keeps today's posture (no E2B webhook validation).",
+    whereItLives:
+      "The E2B team's webhook configuration for the qualification account. Local: " +
+      "`~/.proliferate-local/dev/qualification-infra.env` (mode 0600). CI: the `Qualification` environment secret.",
+    secret: true,
+    lanes: ["sandbox"],
+  },
 ] as const;
 
 export const DEFAULT_LOCAL_RUNTIME_URL = "http://127.0.0.1:8542";

--- a/tests/release/src/fixtures/billing-threshold.test.ts
+++ b/tests/release/src/fixtures/billing-threshold.test.ts
@@ -1,0 +1,386 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+import {
+  billingThreshold,
+  hashBillingSourceRef,
+  RECEIPT_MERGE_HELPER_PY,
+  type BillingThresholdPositionParams,
+  type BillingThresholdPositionResult,
+  type BillingThresholdTransport,
+} from "./billing-threshold.js";
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+import type { BoxExec } from "../worlds/managed-cloud/box-exec.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+const RUN = { run_id: "run-9", shard_id: "shard-0" } as ManagedCloudWorld["run"];
+
+interface CleanupRegistration {
+  kind: string;
+  providerId: string;
+  release: () => Promise<void>;
+}
+
+function fakeWorld(overrides: { hasBox?: boolean } = {}): {
+  world: ManagedCloudWorld;
+  cleanups: CleanupRegistration[];
+} {
+  const cleanups: CleanupRegistration[] = [];
+  const box = {} as BoxExec;
+  const world = {
+    run: RUN,
+    box: overrides.hasBox === false ? undefined : box,
+    async registerCleanup(kind: string, providerId: string, release: () => Promise<void>) {
+      cleanups.push({ kind, providerId, release });
+    },
+  } as unknown as ManagedCloudWorld;
+  return { world, cleanups };
+}
+
+function fakeActor(overrides: Partial<AuthenticatedActor> = {}): AuthenticatedActor {
+  return {
+    role: "owner",
+    userId: "11111111-1111-4111-8111-111111111111",
+    organizationId: "org-1",
+    enrollmentId: "e1",
+    api: {} as never,
+    session: {} as never,
+    gatewayKey: {} as never,
+    ...overrides,
+  };
+}
+
+function fakeTransport(
+  result: BillingThresholdPositionResult,
+): { transport: BillingThresholdTransport; calls: BillingThresholdPositionParams[] } {
+  const calls: BillingThresholdPositionParams[] = [];
+  const transport: BillingThresholdTransport = {
+    async positionLedger(_box, params) {
+      calls.push(params);
+      return result;
+    },
+  };
+  return { transport, calls };
+}
+
+test("positions the compute ledger EXACTLY, returns the observed remainder, and derives the run-tagged source_ref", async () => {
+  const { world, cleanups } = fakeWorld();
+  // Exact positioning: the observed remainder equals the requested balance.
+  const { transport, calls } = fakeTransport({ billingSubjectId: "sub_1", effectiveRemainder: 60 });
+  const result = await billingThreshold(world, fakeActor(), { ledger: "compute", balance: 60 }, transport);
+
+  assert.equal(result.ledger, "compute");
+  assert.equal(result.billingSubjectId, "sub_1");
+  assert.equal(result.effectiveRemainder, 60);
+  assert.equal(result.runTag, "run-9:shard-0");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].sourceRef, "billing-threshold:run-9:shard-0:11111111-1111-4111-8111-111111111111:compute");
+  assert.equal(calls[0].reconcile, true); // default
+  assert.equal(calls[0].ownerScope, "personal"); // default
+  // Registered-before-create: the cleanup was registered before positioning.
+  assert.equal(cleanups.length, 1);
+  assert.equal(cleanups[0].kind, "billing_fixture_adjustment");
+  assert.equal(cleanups[0].providerId, calls[0].sourceRef);
+});
+
+test("FAILS loudly when the transport reports a remainder that differs from the requested balance", async () => {
+  // A reduce-only compute path that could only reach 42 for a requested 60 must
+  // never silently establish a different balance — exact positioning is required.
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport({ billingSubjectId: "sub_1", effectiveRemainder: 42 });
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "compute", balance: 60 }, transport),
+    /did not establish the requested compute balance/,
+  );
+});
+
+test("compute positioning tolerates sub-second float drift within epsilon", async () => {
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport({ billingSubjectId: "s", effectiveRemainder: 60.4 });
+  const result = await billingThreshold(world, fakeActor(), { ledger: "compute", balance: 60 }, transport);
+  assert.equal(result.effectiveRemainder, 60.4); // within the 1s compute epsilon
+});
+
+test("llm positioning surfaces reconciled/eligible enrollment counts and requires exact remainder", async () => {
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport({
+    billingSubjectId: "sub_1",
+    effectiveRemainder: 5,
+    litellmBudgetReconciled: true,
+    reconciledEnrollments: 2,
+    eligibleEnrollments: 2,
+  });
+  const result = await billingThreshold(world, fakeActor(), { ledger: "llm", balance: 5 }, transport);
+  assert.equal(result.reconciledEnrollments, 2);
+  assert.equal(result.eligibleEnrollments, 2);
+  assert.equal(result.litellmBudgetReconciled, true);
+});
+
+test("the cleanup releaser reads the DURABLE on-box receipt (not a TS closure) — restores after an interrupt-mid-position", async () => {
+  // Model the candidate box's filesystem for the receipt: the position step
+  // writes it (here, via the fake transport, standing in for POSITION_LEDGER_PY's
+  // _write_receipt BEFORE commit), then the transport "dies" (interrupt after the
+  // durable receipt + db commit but before returning). The cleanup releaser must
+  // still restore purely from the on-box receipt the RELEASE script reads.
+  const { world, cleanups } = fakeWorld();
+  const boxFiles = new Map<string, string>();
+  let releaseSawReceipt: unknown = "not-run";
+  const box = {
+    async serverPython(_script: string, opts?: { env?: Record<string, string>; scriptName?: string }) {
+      const env = opts?.env ?? {};
+      if (opts?.scriptName === "release-billing-fixture-adjustment.py") {
+        // Mirror RELEASE_ADJUSTMENT_PY: read the on-box receipt, act on it, delete it.
+        const receiptPath = env.SEED_RECEIPT_FILE!;
+        const raw = boxFiles.get(receiptPath);
+        if (raw === undefined) {
+          releaseSawReceipt = null;
+          return { stdout: JSON.stringify({ cleared: true, restored: 0, receipt: "absent" }), stderr: "" };
+        }
+        const receipt = JSON.parse(raw) as { source_ref: string; modified: unknown[] };
+        releaseSawReceipt = receipt;
+        boxFiles.delete(receiptPath);
+        return {
+          stdout: JSON.stringify({ cleared: true, restored: receipt.modified.length, receipt: "consumed" }),
+          stderr: "",
+        };
+      }
+      throw new Error(`unexpected serverPython scriptName ${opts?.scriptName}`);
+    },
+  } as unknown as BoxExec;
+  (world as { box?: BoxExec }).box = box;
+
+  // A transport that writes the durable receipt to the fake box THEN dies —
+  // exactly the interrupt-after-commit the reviewer requires to be safe.
+  const modified = [{ table: "billing_grant", id: "g1", field: "remaining_seconds", original: 3600 }];
+  const dyingTransport = {
+    async positionLedger(_box: BoxExec, params: { receiptFile: string; sourceRef: string }) {
+      boxFiles.set(params.receiptFile, JSON.stringify({ source_ref: params.sourceRef, modified }));
+      throw new Error("simulated crash after durable receipt + db commit, before return");
+    },
+  };
+
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "compute", balance: 60 }, dyingTransport as never),
+    /simulated crash/,
+  );
+  // The cleanup was registered BEFORE positioning, so it exists despite the crash.
+  assert.equal(cleanups[0].kind, "billing_fixture_adjustment");
+  await cleanups[0].release();
+  // The releaser restored from the durable on-box receipt (source_ref + modified),
+  // NOT from any TS closure (positionLedger never returned).
+  assert.deepEqual(releaseSawReceipt, {
+    source_ref: "billing-threshold:run-9:shard-0:11111111-1111-4111-8111-111111111111:compute",
+    modified,
+  });
+  // And it consumed (deleted) the receipt last.
+  assert.equal(boxFiles.size, 0);
+});
+
+test("the cleanup releaser is a clean no-op when the durable receipt is absent (nothing was committed)", async () => {
+  const { world, cleanups } = fakeWorld();
+  let restored: unknown = "not-run";
+  const box = {
+    async serverPython(_script: string, opts?: { env?: Record<string, string>; scriptName?: string }) {
+      restored = null; // no receipt file present
+      return { stdout: JSON.stringify({ cleared: true, restored: 0, receipt: "absent" }), stderr: "" };
+    },
+  } as unknown as BoxExec;
+  (world as { box?: BoxExec }).box = box;
+  // Positioning "never happened" (transport throws before writing anything).
+  await assert.rejects(
+    () =>
+      billingThreshold(
+        world,
+        fakeActor(),
+        { ledger: "compute", balance: 0 },
+        { async positionLedger() { throw new Error("crash before any write"); } } as never,
+      ),
+    /crash before any write/,
+  );
+  await cleanups[0].release(); // must not throw on an absent receipt
+  assert.equal(restored, null);
+});
+
+test("llm ledger surfaces litellmBudgetReconciled true and threads the org id when ownerScope is organization", async () => {
+  const { world } = fakeWorld();
+  const { transport, calls } = fakeTransport({
+    billingSubjectId: "sub_org",
+    effectiveRemainder: 5,
+    litellmBudgetReconciled: true,
+  });
+  const result = await billingThreshold(
+    world,
+    fakeActor({ organizationId: "org-42" }),
+    { ledger: "llm", balance: 5, ownerScope: "organization" },
+    transport,
+  );
+  assert.equal(result.litellmBudgetReconciled, true);
+  assert.equal(calls[0].ownerScope, "organization");
+  assert.equal(calls[0].organizationId, "org-42");
+  assert.equal(calls[0].sourceRef.endsWith(":llm"), true);
+});
+
+test("llm ledger surfaces litellmBudgetReconciled false when the transport reports a budget-sync failure", async () => {
+  // The on-box gateway re-budget (reactivate_subject_if_credited) failed with a
+  // LiteLLMIntegrationError, so the fixture records the OBSERVED truth (false)
+  // rather than raising — the journey decides what to do with it.
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport({
+    billingSubjectId: "sub_1",
+    effectiveRemainder: 2,
+    litellmBudgetReconciled: false,
+  });
+  const result = await billingThreshold(world, fakeActor(), { ledger: "llm", balance: 2 }, transport);
+  assert.equal(result.litellmBudgetReconciled, false);
+});
+
+test("the llm ledger rejects a balance <= 0 (reactivate_subject_if_credited no-ops at <= 0) before positioning", async () => {
+  const { world } = fakeWorld();
+  let positioned = false;
+  const transport = {
+    async positionLedger() {
+      positioned = true;
+      return { billingSubjectId: "s", effectiveRemainder: 0 };
+    },
+  };
+  // balance 0 is non-negative (passes the shared check) but the llm path rejects
+  // it specifically; a negative balance is caught earlier by the shared guard.
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "llm", balance: 0 }, transport),
+    /llm ledger requires balance > 0/,
+  );
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "llm", balance: -3 }, transport),
+    /finite, non-negative number/,
+  );
+  assert.equal(positioned, false);
+  // The compute ledger still allows a 0 target (exhaustion test).
+  const { transport: computeTransport, calls } = fakeTransport({ billingSubjectId: "s", effectiveRemainder: 0 });
+  await billingThreshold(world, fakeActor(), { ledger: "compute", balance: 0 }, computeTransport);
+  assert.equal(calls.length, 1);
+});
+
+test("reconcile:false is threaded to the transport", async () => {
+  const { world } = fakeWorld();
+  const { transport, calls } = fakeTransport({ billingSubjectId: "s", effectiveRemainder: 0 });
+  await billingThreshold(world, fakeActor(), { ledger: "compute", balance: 0, reconcile: false }, transport);
+  assert.equal(calls[0].reconcile, false);
+});
+
+test("throws when the world exposes no box-exec seam (no public set-balance endpoint)", async () => {
+  const { world } = fakeWorld({ hasBox: false });
+  const { transport } = fakeTransport({ billingSubjectId: "s", effectiveRemainder: 0 });
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "compute", balance: 0 }, transport),
+    /no box-exec seam/,
+  );
+});
+
+test("rejects a negative or non-finite balance", async () => {
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport({ billingSubjectId: "s", effectiveRemainder: 0 });
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "compute", balance: -1 }, transport),
+    /non-negative/,
+  );
+  await assert.rejects(
+    () => billingThreshold(world, fakeActor(), { ledger: "llm", balance: Number.NaN }, transport),
+    /non-negative/,
+  );
+});
+
+test("organization scope without an actor org id fails before any positioning", async () => {
+  const { world, cleanups } = fakeWorld();
+  let positioned = false;
+  const transport: BillingThresholdTransport = {
+    async positionLedger() {
+      positioned = true;
+      return { billingSubjectId: "s", effectiveRemainder: 0 };
+    },
+  };
+  await assert.rejects(
+    () =>
+      billingThreshold(
+        world,
+        fakeActor({ organizationId: "" }),
+        { ledger: "compute", balance: 0, ownerScope: "organization" },
+        transport,
+      ),
+    /requires the actor to have an organization id/,
+  );
+  assert.equal(positioned, false);
+  // The cleanup WAS registered before the org-id check (registered-before-create);
+  // its releaser is a no-op against an unwritten source_ref.
+  assert.equal(cleanups[0]?.kind, "billing_fixture_adjustment");
+});
+
+test("hashBillingSourceRef is a 64-hex digest and deterministic", () => {
+  const a = hashBillingSourceRef("billing-threshold:run-9:shard-0:u:llm");
+  const b = hashBillingSourceRef("billing-threshold:run-9:shard-0:u:llm");
+  assert.match(a, /^[0-9a-f]{64}$/);
+  assert.equal(a, b);
+});
+
+// --- Idempotent restoration receipt (PR6-CONTROL-001 r3): exercise the REAL
+// on-box merge helper via a local python3, so a runner RETRY with the same
+// identity (which sees already-mutated state) never clobbers the true
+// pre-first-call originals.
+const PYTHON3_AVAILABLE = (() => {
+  try {
+    return spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+})();
+const skipNoPy = PYTHON3_AVAILABLE ? undefined : { skip: "python3 not available on this host" };
+
+/** Runs `merge_receipt(receiptFile, sourceRef, modified)` via the real helper snippet. */
+function runMergeReceipt(receiptFile: string, sourceRef: string, modified: unknown): void {
+  const program =
+    RECEIPT_MERGE_HELPER_PY +
+    "\nimport sys, json\n" +
+    "args = json.load(sys.stdin)\n" +
+    "merge_receipt(args['receipt'], args['source_ref'], args['modified'])\n";
+  const result = spawnSync("python3", ["-c", program], {
+    input: JSON.stringify({ receipt: receiptFile, source_ref: sourceRef, modified }),
+  });
+  assert.equal(result.status, 0, result.stderr?.toString());
+}
+
+test("receipt merge is FIRST-WRITE-WINS: a retry that sees already-mutated state never clobbers the true originals", skipNoPy ?? {}, async () => {
+  const { mkdtemp, rm, readFile } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const dir = await mkdtemp(path.join(os.tmpdir(), "receipt-merge-"));
+  try {
+    const receipt = path.join(dir, "receipt.json");
+    const sourceRef = "billing-threshold:run-1:shard-0:u:compute";
+    // FIRST call: grant g1 had 3600s originally; fixture reduced it to 60.
+    runMergeReceipt(receipt, sourceRef, [
+      { table: "billing_grant", id: "g1", field: "remaining_seconds", original: 3600 },
+    ]);
+    // RETRY (same identity): positioning re-reads the ALREADY-mutated grant, so
+    // its "original" is now the post-first-call 60 — a naive overwrite would lose
+    // the true 3600. It also touches a NEW grant g2 (original 1800).
+    runMergeReceipt(receipt, sourceRef, [
+      { table: "billing_grant", id: "g1", field: "remaining_seconds", original: 60 },
+      { table: "billing_grant", id: "g2", field: "remaining_seconds", original: 1800 },
+    ]);
+
+    const merged = JSON.parse(await readFile(receipt, "utf8")) as {
+      source_ref: string;
+      modified: Array<{ id: string; original: number }>;
+    };
+    assert.equal(merged.source_ref, sourceRef);
+    const g1 = merged.modified.find((m) => m.id === "g1")!;
+    const g2 = merged.modified.find((m) => m.id === "g2")!;
+    // g1 keeps the TRUE pre-first-call original (3600), NOT the retry's 60.
+    assert.equal(g1.original, 3600);
+    // g2 (genuinely new to the second call) is appended.
+    assert.equal(g2.original, 1800);
+    assert.equal(merged.modified.length, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/fixtures/billing-threshold.ts
+++ b/tests/release/src/fixtures/billing-threshold.ts
@@ -1,0 +1,672 @@
+import { createHash } from "node:crypto";
+
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+import { parseLastJsonLine } from "../worlds/managed-cloud/box-seeds.js";
+import type { BoxExec } from "../worlds/managed-cloud/box-exec.js";
+import { REMOTE_WORKDIR } from "../worlds/managed-cloud/ingress.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+/**
+ * `billingThreshold` — the Tier-2 PR-4 "put the actor's balance at a known
+ * threshold" concept lifted to REAL managed-cloud actors (spec "New fixture
+ * obligations"). The billing/exhaustion journeys (COMPUTE-EXHAUST/-REFILL/
+ * -OVERAGE/-RENEW, RECONCILE/CONCURRENCY) need an actor whose remaining balance
+ * sits at a deterministic point WITHOUT running real hours or minting real
+ * money — the one "permitted acceleration" the contract allows besides the
+ * synchronous reconciler.
+ *
+ * Two ledgers, matching the product's two balances:
+ *   - `compute` — the cloud-hours ledger (`billing_grant.remaining_seconds`).
+ *     The fixture reduces the actor's ACTIVE compute grant's remaining seconds
+ *     to exactly `balance` (a real product row edited in place; the balance is
+ *     the number the compute gate reads).
+ *   - `llm`     — the managed-LLM credit ledger (`llm_credit_grant.amount_usd`
+ *     minus imported usage). The fixture expires prior active credit grants and
+ *     writes ONE run-tagged grant summing to imported-spend + the target
+ *     remainder, so the observed remaining credit lands at `balance`. It then
+ *     rewrites the gateway (LiteLLM) team+key budget to that new total and
+ *     unblocks any exhausted key via the product's own
+ *     `reactivate_subject_if_credited`, so near-exhaustion journeys see gateway
+ *     behavior consistent with the ledger we positioned (`balance` must be > 0
+ *     for this path — that primitive no-ops at <= 0).
+ *
+ * The LLM grant is idempotent on a UNIQUE `source_ref`
+ * (`billing-threshold:{run}:{shard}:{userId}:{ledger}`), so a replay never
+ * double-adjusts. The side effect runs on the candidate box (it holds the
+ * billing DB; there is no public "set my balance" endpoint) through the same
+ * injected `serverPython` seam every on-box seed uses, so unit tests exercise
+ * the plumbing offline with no real box, DB, or LiteLLM. After positioning, the
+ * fixture synchronously awaits the two permitted acceleration levers
+ * (`run_billing_accounting_pass` + `run_billing_reconcile_pass`), re-reads the
+ * OBSERVED remainder, and ASSERTS it equals the requested balance within a small
+ * epsilon — a reduce-only compute path that cannot reach a target above the
+ * actor's current credit FAILS loudly rather than silently establishing a
+ * different balance.
+ *
+ * The adjustment registers a `billing_fixture_adjustment` cleanup kind BEFORE it
+ * writes (registered-before-create). Its releaser DELETEs the run-tagged grant
+ * this fixture created (llm) and RESTORES every grant it mutated in place
+ * (compute `remaining_seconds`, llm `expires_at`) to its ORIGINAL value — keyed
+ * by grant id, never claiming ownership of a grant it did not create. The
+ * restoration receipt is written DURABLY to a 0600 file under the bind-mounted
+ * remote workdir, atomically (tmp+fsync+rename), BEFORE the position step commits
+ * any mutation; the releaser reads that on-box file directly (never a TS
+ * closure), so an interrupted run that died mid-positioning AFTER the commit
+ * still restores. A missing receipt (nothing committed) is a clean no-op. The
+ * receipt merges FIRST-WRITE-WINS per (table,id,field), so a runner RETRY with
+ * the same identity — which sees already-mutated state — never clobbers the true
+ * pre-first-call originals.
+ *
+ * NB (verified against server source, disclosed deviation): the PR-6 design text
+ * describes the LLM path as a `BillingGrant(grant_type="qualification_fixture_
+ * adjustment")`. On current `main` the LLM credit ledger is a SEPARATE table
+ * `llm_credit_grant` (columns `source`/`amount_usd`, a CHECK constraint limiting
+ * `source` to free_signup|topup|admin|seat_pool, and a UNIQUE `source_ref`),
+ * while `billing_grant` (grant_type/`remaining_seconds`) is the COMPUTE-hours
+ * ledger. Writing a `billing_grant` would not move the LLM balance at all. So
+ * the LLM path here writes an `llm_credit_grant` with `source="admin"` (the
+ * only allowed non-provider source) and the run-tagged unique source_ref; the
+ * compute path uses `billing_grant`. This is faithful to the design's INTENT
+ * (idempotent run-tagged real grant → observed remainder) against the real
+ * schema. Flagged for the integrator.
+ */
+
+export type BillingLedger = "llm" | "compute";
+export type BillingOwnerScope = "personal" | "organization";
+
+export interface BillingThresholdOptions {
+  /** Which balance to position. */
+  ledger: BillingLedger;
+  /**
+   * Target remaining balance after positioning: cloud-hours SECONDS for
+   * `compute`, remaining credit USD for `llm`. `0` is a valid exhaustion target.
+   */
+  balance: number;
+  /** Personal (default) or the actor's organization subject. */
+  ownerScope?: BillingOwnerScope;
+  /**
+   * Whether to synchronously run the accounting + reconcile passes after
+   * positioning (default true — the permitted acceleration). Set false only to
+   * position without forcing convergence (the caller drives the reconciler).
+   */
+  reconcile?: boolean;
+}
+
+export interface BillingThresholdResult {
+  /** The billing subject the adjustment landed on (safe id). */
+  billingSubjectId: string;
+  ledger: BillingLedger;
+  /** The run-tag component of the unique source_ref (safe; for evidence/debug). */
+  runTag: string;
+  /** The OBSERVED remaining balance after positioning + optional reconcile. */
+  effectiveRemainder: number;
+  /**
+   * Present on the `llm` ledger: whether the gateway budget was FULLY reconciled
+   * — true ONLY when every eligible active enrollment was re-budgeted
+   * (`reconciledEnrollments === eligibleEnrollments`), so a partial/all-failed
+   * `reactivate_subject_if_credited` (which swallows per-enrollment
+   * LiteLLMIntegrationError and returns a partial count) is observed as false.
+   */
+  litellmBudgetReconciled?: boolean;
+  /** llm only: enrollments `reactivate_subject_if_credited` actually re-budgeted. */
+  reconciledEnrollments?: number;
+  /** llm only: eligible active enrollments (active, excluding `limit_reached`). */
+  eligibleEnrollments?: number;
+}
+
+/** One grant row this fixture mutated, with the value needed to restore it on cleanup. */
+export interface ModifiedGrant {
+  /** `billing_grant` (compute remaining_seconds) or `llm_credit_grant` (expires_at). */
+  table: "billing_grant" | "llm_credit_grant";
+  /** The grant row id (safe uuid). */
+  id: string;
+  /** The mutated column. */
+  field: "remaining_seconds" | "expires_at";
+  /** The ORIGINAL value before the fixture touched it (number seconds, ISO string, or null). */
+  original: number | string | null;
+}
+
+/**
+ * Every side-effecting step, injectable so unit tests run offline. The default
+ * `positionLedger` executes the inline Python on the candidate box via
+ * `BoxExec.serverPython` (the box-seeds.ts precedent). Secret values never
+ * appear here — the balance/target and ids are non-secret.
+ */
+export interface BillingThresholdTransport {
+  positionLedger(box: BoxExec, params: BillingThresholdPositionParams): Promise<BillingThresholdPositionResult>;
+}
+
+export interface BillingThresholdPositionParams {
+  userId: string;
+  /** The actor's organization id — required when ownerScope is "organization". */
+  organizationId?: string;
+  ledger: BillingLedger;
+  ownerScope: BillingOwnerScope;
+  balance: number;
+  sourceRef: string;
+  reconcile: boolean;
+  /**
+   * Absolute remote path (under the bind-mounted workdir) the position step
+   * writes its DURABLE restoration receipt to, atomically, BEFORE it commits any
+   * mutation. The cleanup releaser reads exactly this file, so an interrupted run
+   * still restores. Deterministic per (run, shard, actor, ledger).
+   */
+  receiptFile: string;
+}
+
+export interface BillingThresholdPositionResult {
+  billingSubjectId: string;
+  effectiveRemainder: number;
+  litellmBudgetReconciled?: boolean;
+  reconciledEnrollments?: number;
+  eligibleEnrollments?: number;
+  /**
+   * The grants the position step mutated in place, with their ORIGINAL values.
+   * Informational for the caller/evidence; the AUTHORITATIVE restoration source
+   * is the durable on-box receipt (see `receiptFile`), which the releaser reads
+   * directly — this list is not what cleanup depends on.
+   */
+  modifiedGrants?: ModifiedGrant[];
+}
+
+/**
+ * Positions the actor's balance and returns the OBSERVED remainder. Registers
+ * the `billing_fixture_adjustment` cleanup (release = expire/delete by
+ * source_ref) BEFORE the adjustment runs, so a crash mid-position still tears
+ * the planted balance down.
+ */
+export async function billingThreshold(
+  world: ManagedCloudWorld,
+  actor: AuthenticatedActor,
+  options: BillingThresholdOptions,
+  transport: BillingThresholdTransport = defaultBillingThresholdTransport,
+): Promise<BillingThresholdResult> {
+  if (!world.box) {
+    throw new Error(
+      "billingThreshold: the managed-cloud world exposes no box-exec seam; positioning a real balance must run " +
+        "the product's own billing tables on the candidate box (there is no public 'set my balance' endpoint).",
+    );
+  }
+  if (!Number.isFinite(options.balance) || options.balance < 0) {
+    throw new Error(`billingThreshold: balance must be a finite, non-negative number (got ${options.balance}).`);
+  }
+  // The LLM path calls the product's `reactivate_subject_if_credited` after
+  // positioning, which NO-OPS when remaining credit is <= 0. A zero-balance LLM
+  // reposition would therefore leave the gateway budget enforcing the OLD total
+  // with no re-budget, so it is not a supported target — require BALANCE > 0 for
+  // the llm ledger (compute may target 0 for an exhaustion test).
+  if (options.ledger === "llm" && options.balance <= 0) {
+    throw new Error(
+      "billingThreshold: the llm ledger requires balance > 0 (reactivate_subject_if_credited no-ops at <= 0, so a " +
+        "zero-credit reposition cannot reconcile the gateway budget). Use the compute ledger for a 0 target.",
+    );
+  }
+  const ownerScope = options.ownerScope ?? "personal";
+  const reconcile = options.reconcile ?? true;
+  const runTag = `${world.run.run_id}:${world.run.shard_id}`;
+  const sourceRef = `billing-threshold:${runTag}:${actor.userId}:${options.ledger}`;
+  const box = world.box;
+
+  // Deterministic remote path for the DURABLE restoration receipt: the position
+  // step writes it (atomic, 0600) BEFORE it commits any mutation, and the
+  // releaser reads exactly this file — never a TS closure — so an interrupted
+  // run that died mid-positioning after commit still restores. Slashes in the
+  // sourceRef become a filesystem-safe basename.
+  const receiptFile = `${REMOTE_WORKDIR}/billing-threshold-receipt-${hashBillingSourceRef(sourceRef)}.json`;
+
+  // Registered-before-create: the releaser reads the durable on-box receipt and
+  // DELETEs the run-tagged grant this fixture created (llm path) + RESTORES every
+  // grant it mutated in place (compute path) to its ORIGINAL value — never merely
+  // expiring someone else's grant. Tolerates an absent receipt (nothing
+  // committed → clean no-op). No closure dependency.
+  await world.registerCleanup?.("billing_fixture_adjustment", sourceRef, () =>
+    releaseBillingFixtureAdjustment(box, receiptFile),
+  );
+
+  if (ownerScope === "organization" && !actor.organizationId) {
+    throw new Error("billingThreshold: ownerScope 'organization' requires the actor to have an organization id.");
+  }
+  const positioned = await transport.positionLedger(box, {
+    userId: actor.userId,
+    organizationId: ownerScope === "organization" ? actor.organizationId : undefined,
+    ledger: options.ledger,
+    ownerScope,
+    balance: options.balance,
+    sourceRef,
+    reconcile,
+    receiptFile,
+  });
+
+  // Exact positioning is required (the whole point of the fixture is a KNOWN
+  // threshold): a transport that reports a different remainder than requested —
+  // e.g. because current credit was below the target and could only be reduced —
+  // must FAIL loudly, never silently establish a different balance the journeys
+  // would then mis-read. Epsilon absorbs float representation only.
+  const epsilon = options.ledger === "llm" ? 1e-6 : 1;
+  if (Math.abs(positioned.effectiveRemainder - options.balance) > epsilon) {
+    throw new Error(
+      `billingThreshold: positioning did not establish the requested ${options.ledger} balance — requested ` +
+        `${options.balance}, observed ${positioned.effectiveRemainder}. Exact positioning is required; a lower ` +
+        "current balance than the target cannot be raised by the reduce-only compute path (fund the actor first).",
+    );
+  }
+
+  return {
+    billingSubjectId: positioned.billingSubjectId,
+    ledger: options.ledger,
+    runTag,
+    effectiveRemainder: positioned.effectiveRemainder,
+    litellmBudgetReconciled: positioned.litellmBudgetReconciled,
+    reconciledEnrollments: positioned.reconciledEnrollments,
+    eligibleEnrollments: positioned.eligibleEnrollments,
+  };
+}
+
+/** One-way hash of a source_ref, the only adjustment identity evidence should carry. */
+export function hashBillingSourceRef(sourceRef: string): string {
+  return createHash("sha256").update(sourceRef).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Default transport — inline Python on the candidate box
+// ---------------------------------------------------------------------------
+
+/**
+ * The idempotent, first-write-wins receipt merge, factored out as its own stdlib-
+ * only snippet so the positioning script embeds it AND the offline regression can
+ * exercise the REAL merge via a local `python3 -c` (no box needed). Writes 0600 +
+ * atomic (tmp+fsync+rename). Keeps the earliest original for any (table,id,field)
+ * already recorded; appends only genuinely-new entries.
+ */
+export const RECEIPT_MERGE_HELPER_PY = `import json, os
+
+def merge_receipt(receipt_file, source_ref, modified):
+    existing = []
+    try:
+        with open(receipt_file, "r") as handle:
+            existing = (json.load(handle) or {}).get("modified", [])
+    except FileNotFoundError:
+        existing = []
+    by_key = {}
+    order = []
+    for entry in existing:
+        key = (entry["table"], entry["id"], entry["field"])
+        if key not in by_key:
+            order.append(key)
+        by_key[key] = entry
+    for entry in modified:
+        key = (entry["table"], entry["id"], entry["field"])
+        if key not in by_key:
+            by_key[key] = entry
+            order.append(key)
+    merged = [by_key[k] for k in order]
+    payload = json.dumps({"source_ref": source_ref, "modified": merged})
+    tmp = receipt_file + ".tmp"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, receipt_file)
+`;
+
+/**
+ * The positioning snippet. Runs the product's OWN store functions against the
+ * candidate box's Postgres (never a synthetic INSERT), then the two permitted
+ * acceleration passes, and prints the OBSERVED remainder as a single JSON line.
+ * Non-secret ids/targets ride via `docker exec -e`; there are no secrets here.
+ */
+const POSITION_LEDGER_PY = `import asyncio, json, os
+from decimal import Decimal
+from uuid import UUID
+from sqlalchemy import select
+from proliferate.db.engine import async_session_factory
+from proliferate.db.store.billing_subjects import (
+    ensure_personal_billing_subject,
+    ensure_organization_billing_subject,
+)
+from proliferate.db.store.billing import list_grants
+from proliferate.db.models.billing import BillingGrant
+from proliferate.db.models.cloud.agent_gateway import LlmCreditGrant
+from proliferate.db.store.agent_gateway.credits import (
+    create_llm_credit_grant,
+    get_remaining_credit_usd,
+    sum_usage_cost_usd,
+)
+from proliferate.server.billing.accounting_pass import run_billing_accounting_pass
+from proliferate.server.billing.reconciler import run_billing_reconcile_pass
+from proliferate.server.billing.snapshot_state import load_snapshot_state_for_subject
+from proliferate.server.billing.snapshots import build_billing_snapshot
+from proliferate.server.cloud.agent_gateway.topups import reactivate_subject_if_credited
+from proliferate.integrations.litellm import LiteLLMIntegrationError
+from proliferate.utils.time import utcnow
+
+USER_ID = UUID(os.environ["SEED_USER_ID"])
+LEDGER = os.environ["SEED_LEDGER"]
+OWNER_SCOPE = os.environ["SEED_OWNER_SCOPE"]
+BALANCE = Decimal(os.environ["SEED_BALANCE"])
+SOURCE_REF = os.environ["SEED_SOURCE_REF"]
+RECEIPT_FILE = os.environ["SEED_RECEIPT_FILE"]
+RECONCILE = os.environ.get("SEED_RECONCILE", "1") == "1"
+
+
+${RECEIPT_MERGE_HELPER_PY}
+
+def _write_receipt(modified):
+    # Durable restoration receipt, written 0600 + atomic (tmp+fsync+rename) UNDER
+    # the bind-mounted remote workdir BEFORE any mutation commits — so a crash
+    # after the commit but before this script returns still leaves the releaser a
+    # durable record of what to restore (it reads THIS file, never a TS closure).
+    #
+    # Idempotent across a runner RETRY with the same run/shard/actor/ledger
+    # identity: a second positioning call sees the ALREADY-mutated grant state, so
+    # its originals would be the post-first-call values. merge_receipt keeps
+    # FIRST-WRITE-WINS per (table,id,field), so retries never clobber the true
+    # pre-first-call originals. See RECEIPT_MERGE_HELPER_PY.
+    merge_receipt(RECEIPT_FILE, SOURCE_REF, modified)
+
+
+async def _resolve_subject(db):
+    if OWNER_SCOPE == "organization":
+        # The actor's org subject; the org id is resolved from the actor's
+        # single-org membership by the caller and passed as SEED_ORG_ID.
+        return await ensure_organization_billing_subject(db, UUID(os.environ["SEED_ORG_ID"]))
+    return await ensure_personal_billing_subject(db, USER_ID)
+
+
+async def _position_compute(db, subject, modified):
+    # Reduce the ACTIVE (unexpired) compute grants' remaining_seconds so the
+    # subject's total remaining lands at BALANCE seconds. Editing the real
+    # product rows in place — the compute gate reads exactly these.
+    grants = [
+        g
+        for g in await list_grants(db, subject.id)
+        if g.expires_at is None or g.expires_at > utcnow()
+    ]
+    grants.sort(key=lambda g: (g.effective_at, g.created_at))
+    total_available = sum(float(g.remaining_seconds) for g in grants)
+    target = float(BALANCE)
+    # Reduce-only: we can lower remaining_seconds, never raise it. If the actor's
+    # current active credit is BELOW the target, exact positioning is impossible
+    # here — FAIL loudly rather than establish a different balance.
+    if total_available + 1e-6 < target:
+        raise SystemExit(
+            "billing-threshold compute: current active credit (%.6f s) is below the requested target "
+            "(%.6f s); the reduce-only fixture cannot raise it. Fund the actor first." % (total_available, target)
+        )
+    remaining = target
+    for grant in grants:
+        take = min(float(grant.remaining_seconds), remaining)
+        if take != float(grant.remaining_seconds):
+            # Record the ORIGINAL value so cleanup can restore this real grant.
+            # NB: we DO NOT touch grant.source_ref — never claim ownership of a
+            # grant we did not create; restoration is keyed by grant id.
+            modified.append({
+                "table": "billing_grant",
+                "id": str(grant.id),
+                "field": "remaining_seconds",
+                "original": float(grant.remaining_seconds),
+            })
+            grant.remaining_seconds = take
+            grant.updated_at = utcnow()
+        remaining -= take
+    # Durable receipt BEFORE the mutation commits.
+    _write_receipt(modified)
+    await db.commit()
+
+
+async def _position_llm(db, subject, modified):
+    # Expire prior active credit grants, then write ONE run-tagged grant of
+    # (imported spend + target remainder) so remaining_credit == BALANCE. The
+    # grant is idempotent on its UNIQUE source_ref. source="admin" is the only
+    # allowed non-provider credit source (CHECK constraint).
+    now = utcnow()
+    active = (
+        await db.execute(
+            select(LlmCreditGrant).where(
+                LlmCreditGrant.billing_subject_id == subject.id,
+                LlmCreditGrant.source_ref != SOURCE_REF,
+            )
+        )
+    ).scalars().all()
+    for grant in active:
+        if grant.expires_at is None or grant.expires_at > now:
+            # Record the ORIGINAL expires_at (None or ISO) so cleanup restores it.
+            modified.append({
+                "table": "llm_credit_grant",
+                "id": str(grant.id),
+                "field": "expires_at",
+                "original": grant.expires_at.isoformat() if grant.expires_at else None,
+            })
+            grant.expires_at = now
+    # Durable receipt BEFORE the FIRST mutation commit (the expiries below AND the
+    # created grant are both undone by the releaser: expiries by id-restore from
+    # this receipt, the created grant by its deterministic SOURCE_REF).
+    _write_receipt(modified)
+    await db.commit()
+    used = await sum_usage_cost_usd(db, subject.id)
+    await create_llm_credit_grant(
+        db,
+        billing_subject_id=subject.id,
+        source="admin",
+        amount_usd=(used + BALANCE),
+        user_id=USER_ID,
+        source_ref=SOURCE_REF,
+    )
+    await db.commit()
+
+
+async def _count_eligible_enrollments(db, subject_id):
+    # Mirror reactivate_subject_if_credited's OWN eligibility filter: active
+    # (non-revoked) enrollments, EXCLUDING limit_reached (an org-cap concern it
+    # deliberately skips). This is the denominator the reconciled count must
+    # equal for a fully-reconciled gateway budget.
+    from proliferate.db.store.agent_gateway.enrollments import (
+        list_active_enrollments_for_subject,
+    )
+    from proliferate.constants.agent_gateway import (
+        AGENT_GATEWAY_BUDGET_STATUS_LIMIT_REACHED,
+    )
+    enrollments = await list_active_enrollments_for_subject(db, billing_subject_id=subject_id)
+    return sum(
+        1
+        for e in enrollments
+        if e.budget_status != AGENT_GATEWAY_BUDGET_STATUS_LIMIT_REACHED
+    )
+
+
+async def _observed_remainder(db, subject):
+    if LEDGER == "llm":
+        balance = await get_remaining_credit_usd(db, subject.id)
+        return float(balance.remaining_usd)
+    state = await load_snapshot_state_for_subject(db, subject.id)
+    snapshot = build_billing_snapshot(state)
+    return float(snapshot.remaining_seconds or 0.0)
+
+
+async def main():
+    modified = []
+    async with async_session_factory() as db:
+        subject = await _resolve_subject(db)
+        subject_id = subject.id
+        if LEDGER == "llm":
+            await _position_llm(db, subject, modified)
+        else:
+            await _position_compute(db, subject, modified)
+
+    if RECONCILE:
+        # The two permitted acceleration levers, run synchronously.
+        await run_billing_accounting_pass()
+        await run_billing_reconcile_pass()
+
+    # LLM path: after repositioning the credit ledger, the gateway (LiteLLM)
+    # team+key budget still enforces the OLD granted total until it is rewritten
+    # to the NEW granted total (or uncapped for an overage subject) and any
+    # exhausted key is unblocked. The product's own primitive for exactly this
+    # is reactivate_subject_if_credited, which returns the COUNT of enrollments
+    # it actually re-budgeted (it swallows per-enrollment LiteLLMIntegrationError
+    # and can return a partial count). So we compare that count against the
+    # number of ELIGIBLE active enrollments and report BOTH; the TS caller marks
+    # litellm_budget_reconciled true only when reconciled == eligible. It NO-OPS
+    # at remaining <= 0 — the TS caller asserts BALANCE > 0 — and a subject with
+    # zero eligible enrollments is a truthful success (0 == 0, nothing to do).
+    litellm_budget_reconciled = None
+    reconciled_enrollments = None
+    eligible_enrollments = None
+    if LEDGER == "llm" and RECONCILE:
+        try:
+            async with async_session_factory() as db:
+                eligible_enrollments = await _count_eligible_enrollments(db, subject_id)
+                reconciled_enrollments = await reactivate_subject_if_credited(db, subject_id)
+                await db.commit()
+            litellm_budget_reconciled = reconciled_enrollments == eligible_enrollments
+        except LiteLLMIntegrationError:
+            litellm_budget_reconciled = False
+
+    async with async_session_factory() as db:
+        subject = await _resolve_subject(db)
+        remainder = await _observed_remainder(db, subject)
+        print(json.dumps({
+            "billing_subject_id": str(subject_id),
+            "effective_remainder": remainder,
+            "litellm_budget_reconciled": litellm_budget_reconciled,
+            "reconciled_enrollments": reconciled_enrollments,
+            "eligible_enrollments": eligible_enrollments,
+            "modified_grants": modified,
+        }))
+
+
+asyncio.run(main())
+`;
+
+/**
+ * Deletes the run-tagged credit grant this fixture CREATED (llm path) and
+ * RESTORES every grant it mutated in place to its captured ORIGINAL value
+ * (compute `remaining_seconds`, llm `expires_at`), reading the DURABLE on-box
+ * restoration receipt the position step wrote BEFORE it committed — never a
+ * TypeScript closure. So an interrupted run that died mid-positioning AFTER the
+ * commit still restores from the receipt. Restoration is keyed by grant id (never
+ * a source_ref we might not own). Tolerant of a MISSING receipt (nothing was
+ * committed → nothing to restore) and of an absent grant. Deletes the receipt
+ * file LAST, only after the restore commits.
+ */
+const RELEASE_ADJUSTMENT_PY = `import asyncio, json, os
+from datetime import datetime
+from uuid import UUID
+from sqlalchemy import delete
+from proliferate.db.engine import async_session_factory
+from proliferate.db.models.billing import BillingGrant
+from proliferate.db.models.cloud.agent_gateway import LlmCreditGrant
+from proliferate.utils.time import utcnow
+
+RECEIPT_FILE = os.environ["SEED_RECEIPT_FILE"]
+
+
+def _load_receipt():
+    # A missing receipt means the position step never committed a mutation (it
+    # crashed before, or never ran) — a clean no-op, not an error.
+    try:
+        with open(RECEIPT_FILE, "r") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        return None
+
+
+async def main():
+    receipt = _load_receipt()
+    if receipt is None:
+        print(json.dumps({"cleared": True, "restored": 0, "receipt": "absent"}))
+        return
+    source_ref = receipt["source_ref"]
+    modified = receipt.get("modified", [])
+    async with async_session_factory() as db:
+        # 1. Delete the run-tagged grant this fixture created (llm path only —
+        #    the compute path creates no grant). Idempotent, keyed by the
+        #    deterministic source_ref recorded in the receipt.
+        await db.execute(delete(LlmCreditGrant).where(LlmCreditGrant.source_ref == source_ref))
+        # 2. Restore every grant we mutated in place to its ORIGINAL value.
+        for row in modified:
+            grant_id = UUID(row["id"])
+            original = row["original"]
+            if row["table"] == "billing_grant":
+                grant = await db.get(BillingGrant, grant_id)
+                if grant is not None and row["field"] == "remaining_seconds":
+                    grant.remaining_seconds = float(original)
+                    grant.updated_at = utcnow()
+            elif row["table"] == "llm_credit_grant":
+                grant = await db.get(LlmCreditGrant, grant_id)
+                if grant is not None and row["field"] == "expires_at":
+                    grant.expires_at = datetime.fromisoformat(original) if original else None
+        await db.commit()
+    # Delete the receipt LAST, only after the restore committed.
+    try:
+        os.remove(RECEIPT_FILE)
+    except FileNotFoundError:
+        pass
+    print(json.dumps({"cleared": True, "restored": len(modified), "receipt": "consumed"}))
+
+
+asyncio.run(main())
+`;
+
+async function releaseBillingFixtureAdjustment(box: BoxExec, receiptFile: string): Promise<void> {
+  const result = await box.serverPython(RELEASE_ADJUSTMENT_PY, {
+    env: { SEED_RECEIPT_FILE: receiptFile },
+    scriptName: "release-billing-fixture-adjustment.py",
+  });
+  const parsed = parseLastJsonLine(result.stdout) as { cleared?: unknown };
+  if (parsed.cleared !== true) {
+    throw new Error(
+      `billingThreshold cleanup: the candidate box did not confirm the fixture adjustment was cleared/restored ` +
+        `(stdout: ${result.stdout.trim().slice(0, 200)}).`,
+    );
+  }
+}
+
+export const defaultBillingThresholdTransport: BillingThresholdTransport = {
+  async positionLedger(box, params) {
+    const env: Record<string, string> = {
+      SEED_USER_ID: params.userId,
+      SEED_LEDGER: params.ledger,
+      SEED_OWNER_SCOPE: params.ownerScope,
+      SEED_BALANCE: String(params.balance),
+      SEED_SOURCE_REF: params.sourceRef,
+      SEED_RECEIPT_FILE: params.receiptFile,
+      SEED_RECONCILE: params.reconcile ? "1" : "0",
+    };
+    if (params.organizationId) {
+      env.SEED_ORG_ID = params.organizationId;
+    }
+    const result = await box.serverPython(POSITION_LEDGER_PY, {
+      env,
+      scriptName: "position-billing-threshold.py",
+    });
+    const parsed = parseLastJsonLine(result.stdout) as {
+      billing_subject_id?: unknown;
+      effective_remainder?: unknown;
+      litellm_budget_reconciled?: unknown;
+      reconciled_enrollments?: unknown;
+      eligible_enrollments?: unknown;
+      modified_grants?: unknown;
+    };
+    if (typeof parsed.billing_subject_id !== "string" || typeof parsed.effective_remainder !== "number") {
+      throw new Error(
+        `billingThreshold: the candidate box did not report a positioned balance ` +
+          `(stdout: ${result.stdout.trim().slice(0, 200)}).`,
+      );
+    }
+    return {
+      billingSubjectId: parsed.billing_subject_id,
+      effectiveRemainder: parsed.effective_remainder,
+      litellmBudgetReconciled:
+        typeof parsed.litellm_budget_reconciled === "boolean" ? parsed.litellm_budget_reconciled : undefined,
+      reconciledEnrollments:
+        typeof parsed.reconciled_enrollments === "number" ? parsed.reconciled_enrollments : undefined,
+      eligibleEnrollments:
+        typeof parsed.eligible_enrollments === "number" ? parsed.eligible_enrollments : undefined,
+      modifiedGrants: Array.isArray(parsed.modified_grants)
+        ? (parsed.modified_grants as ModifiedGrant[])
+        : undefined,
+    };
+  },
+};

--- a/tests/release/src/fixtures/callback-relay.test.ts
+++ b/tests/release/src/fixtures/callback-relay.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  callbackRelay,
+  CallbackRelayReplayError,
+  parseManifest,
+  parseReplayedStatus,
+  parseReplayFailedStatus,
+  type CallbackRelayTransport,
+} from "./callback-relay.js";
+import type { RelayChannel } from "../worlds/managed-cloud/callback-relay-agent.js";
+import type { BoxExec } from "../worlds/managed-cloud/box-exec.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+const RUN = { run_id: "run-1", shard_id: "shard-0" } as ManagedCloudWorld["run"];
+
+function fakeWorld(hasBox = true): ManagedCloudWorld {
+  return {
+    run: RUN,
+    box: hasBox ? ({} as BoxExec) : undefined,
+  } as unknown as ManagedCloudWorld;
+}
+
+interface Call {
+  op: string;
+  dir: string;
+  args: unknown;
+}
+
+function fakeTransport(manifest = ""): { transport: CallbackRelayTransport; calls: Call[] } {
+  const calls: Call[] = [];
+  const transport: CallbackRelayTransport = {
+    async writeControl(_box, dir, channel, mode) {
+      calls.push({ op: "writeControl", dir, args: { channel, mode } });
+    },
+    async triggerReplay(_box, dir, target) {
+      calls.push({ op: "triggerReplay", dir, args: target });
+    },
+    async readManifest(_box, dir) {
+      calls.push({ op: "readManifest", dir, args: null });
+      return manifest;
+    },
+  };
+  return { transport, calls };
+}
+
+test("hold(channel) writes the hold control file", async () => {
+  const { transport, calls } = fakeTransport();
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await relay.hold("stripe");
+  assert.deepEqual(calls, [
+    { op: "writeControl", dir: "/home/ubuntu/candidate/callback-relay", args: { channel: "stripe", mode: "hold" } },
+  ]);
+});
+
+test("release without replayHeld only switches back to pass-through", async () => {
+  const { transport, calls } = fakeTransport();
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await relay.release("e2b");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].op, "writeControl");
+  assert.deepEqual(calls[0].args, { channel: "e2b", mode: "pass-through" });
+});
+
+test("release with replayHeld replays every held delivery BEFORE re-opening the channel", async () => {
+  const { transport, calls } = fakeTransport();
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await relay.release("stripe", { replayHeld: true });
+  assert.deepEqual(
+    calls.map((c) => c.op),
+    ["triggerReplay", "writeControl"],
+  );
+  assert.deepEqual(calls[0].args, { channel: "stripe" });
+  assert.deepEqual(calls[1].args, { channel: "stripe", mode: "pass-through" });
+});
+
+test("replay(deliveryId) re-posts one delivery by id", async () => {
+  const { transport, calls } = fakeTransport();
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await relay.replay("abcdef01");
+  assert.deepEqual(calls, [
+    { op: "triggerReplay", dir: "/home/ubuntu/candidate/callback-relay", args: { deliveryId: "abcdef01" } },
+  ]);
+});
+
+test("replay rejects a non-hex deliveryId (argv safety) before touching the box", async () => {
+  const { transport, calls } = fakeTransport();
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await assert.rejects(() => relay.replay("../../etc/passwd"), /non-hex deliveryId/);
+  assert.equal(calls.length, 0);
+});
+
+test("manifest parses bounded, secret-free rows and filters by channel", async () => {
+  const raw = [
+    JSON.stringify({
+      deliveryId: "d1",
+      channel: "stripe",
+      providerEventId: "evt_1",
+      bytesSha256: "a".repeat(64),
+      receivedAt: "2026-07-16T00:00:00Z",
+      state: "held",
+    }),
+    JSON.stringify({
+      deliveryId: "d2",
+      channel: "e2b",
+      providerEventId: null,
+      bytesSha256: "b".repeat(64),
+      receivedAt: "2026-07-16T00:00:01Z",
+      state: "forwarded",
+    }),
+    "garbage-not-json",
+  ].join("\n");
+  const { transport } = fakeTransport(raw);
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+
+  const all = await relay.manifest();
+  assert.equal(all.length, 2);
+  const stripeOnly = await relay.manifest("stripe");
+  assert.equal(stripeOnly.length, 1);
+  assert.equal(stripeOnly[0].deliveryId, "d1");
+  assert.equal(stripeOnly[0].providerEventId, "evt_1");
+  // No raw body/signature is representable in a CapturedDelivery — only the id,
+  // channel, provider event id, bytes hash, timestamp, and state.
+  assert.deepEqual(Object.keys(stripeOnly[0]).sort(), [
+    "bytesSha256",
+    "channel",
+    "deliveryId",
+    "providerEventId",
+    "receivedAt",
+    "state",
+  ]);
+});
+
+test("bytesSha256 witnesses byte-identity: a held row and its replayed row share the same digest", () => {
+  const digest = "c".repeat(64);
+  const rows = parseManifest(
+    [
+      JSON.stringify({
+        deliveryId: "d9",
+        channel: "stripe",
+        providerEventId: "evt_9",
+        bytesSha256: digest,
+        receivedAt: "2026-07-16T00:00:00Z",
+        state: "held",
+      }),
+      JSON.stringify({
+        deliveryId: "d9",
+        channel: "stripe",
+        providerEventId: null,
+        bytesSha256: digest,
+        receivedAt: "2026-07-16T00:00:05Z",
+        state: "replayed:200",
+      }),
+    ].join("\n"),
+  );
+  assert.equal(rows[0].bytesSha256, rows[1].bytesSha256);
+});
+
+test("the controller exposes NO synthesize/emit method (only delay + replay of genuine deliveries)", () => {
+  const relay = callbackRelay(fakeWorld(), {}, fakeTransport().transport);
+  assert.deepEqual(Object.keys(relay).sort(), ["hold", "manifest", "release", "replay"]);
+  const asRecord = relay as unknown as Record<string, unknown>;
+  assert.equal(typeof asRecord.emit, "undefined");
+  assert.equal(typeof asRecord.synthesize, "undefined");
+});
+
+test("a custom relay dir name flows through to the transport", async () => {
+  const { transport, calls } = fakeTransport();
+  const relay = callbackRelay(fakeWorld(), { relayDirName: "relay-x" }, transport);
+  await relay.hold("stripe");
+  assert.equal(calls[0].dir, "/home/ubuntu/candidate/relay-x");
+});
+
+test("throws when the world has no box-exec seam", () => {
+  assert.throws(() => callbackRelay(fakeWorld(false), {}, fakeTransport().transport), /no box-exec seam/);
+});
+
+test("parseManifest ignores rows with an unknown channel or missing required fields", () => {
+  const rows = parseManifest(
+    [
+      JSON.stringify({ deliveryId: "d", channel: "slack", bytesSha256: "x", receivedAt: "t", state: "held" }),
+      JSON.stringify({ deliveryId: "d2", channel: "stripe", receivedAt: "t", state: "held" }), // no bytesSha256
+    ].join("\n"),
+  );
+  assert.equal(rows.length, 0);
+});
+
+test("parseReplayedStatus / parseReplayFailedStatus extract statuses from their own terminal/retryable rows", () => {
+  assert.equal(parseReplayedStatus("replayed:200"), 200);
+  assert.equal(parseReplayedStatus("replay_failed:500"), null); // failed is not a terminal replayed row
+  assert.equal(parseReplayedStatus("held"), null);
+  assert.equal(parseReplayFailedStatus("replay_failed:500"), 500);
+  assert.equal(parseReplayFailedStatus("replayed:200"), null);
+  assert.equal(parseReplayFailedStatus("held"), null);
+});
+
+/** A transport whose replay FAILS (relay exited nonzero) and whose manifest carries the given rows. */
+function failingReplayTransport(manifest: string): CallbackRelayTransport {
+  return {
+    async writeControl() {},
+    async triggerReplay() {
+      throw new Error("relay.py replay-held exited 1");
+    },
+    async readManifest() {
+      return manifest;
+    },
+  };
+}
+
+test("release({replayHeld}) throws a typed error carrying per-delivery retryable statuses (replay_failed), and does NOT reopen", async () => {
+  const manifest = [
+    JSON.stringify({
+      deliveryId: "d1",
+      channel: "stripe",
+      providerEventId: null,
+      bytesSha256: "a".repeat(64),
+      receivedAt: "2026-07-16T00:00:05Z",
+      state: "replay_failed:500",
+    }),
+  ].join("\n");
+  let reopened = false;
+  const transport: CallbackRelayTransport = {
+    ...failingReplayTransport(manifest),
+    async writeControl(_box, _dir, _channel, mode) {
+      if (mode === "pass-through") reopened = true;
+    },
+  };
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await assert.rejects(
+    () => relay.release("stripe", { replayHeld: true }),
+    (error: unknown) => {
+      assert.ok(error instanceof CallbackRelayReplayError);
+      assert.equal(error.failures.length, 1);
+      assert.deepEqual(error.failures[0], { deliveryId: "d1", channel: "stripe", status: 500 });
+      return true;
+    },
+  );
+  // The channel must NOT be reopened to pass-through on a lost event.
+  assert.equal(reopened, false);
+});
+
+test("a delivery that later succeeded (replayed:) is cleared from the retryable-failure set", async () => {
+  // Same delivery: a failed attempt then a successful one — no longer a failure.
+  const manifest = [
+    JSON.stringify({ deliveryId: "d1", channel: "stripe", bytesSha256: "a".repeat(64), receivedAt: "t1", state: "replay_failed:500" }),
+    JSON.stringify({ deliveryId: "d1", channel: "stripe", bytesSha256: "a".repeat(64), receivedAt: "t2", state: "replayed:200" }),
+  ].join("\n");
+  const transport = failingReplayTransport(manifest);
+  const relay = callbackRelay(fakeWorld(), {}, transport);
+  await assert.rejects(
+    () => relay.replay("abcdef01"),
+    (error: unknown) => {
+      assert.ok(error instanceof CallbackRelayReplayError);
+      // The transport still threw (relay exited nonzero for THIS invocation), but
+      // no delivery is in a retryable-failure state, so failures is empty.
+      assert.equal(error.failures.length, 0);
+      return true;
+    },
+  );
+});
+
+test("replay(deliveryId) throws CallbackRelayReplayError when the relay reports a non-2xx (retryable) replay", async () => {
+  const manifest = JSON.stringify({
+    deliveryId: "abcdef01",
+    channel: "e2b",
+    providerEventId: null,
+    bytesSha256: "b".repeat(64),
+    receivedAt: "2026-07-16T00:00:05Z",
+    state: "replay_failed:502",
+  });
+  const relay = callbackRelay(fakeWorld(), {}, failingReplayTransport(manifest));
+  await assert.rejects(
+    () => relay.replay("abcdef01"),
+    (error: unknown) => error instanceof CallbackRelayReplayError && error.failures[0]?.status === 502,
+  );
+});

--- a/tests/release/src/fixtures/callback-relay.ts
+++ b/tests/release/src/fixtures/callback-relay.ts
@@ -1,0 +1,315 @@
+import type { BoxExec } from "../worlds/managed-cloud/box-exec.js";
+import {
+  DEFAULT_RELAY_LISTEN_PORT,
+  RELAY_DIRNAME,
+  RELAY_MANIFEST_FILENAME,
+  RELAY_SCRIPT_FILENAME,
+  type RelayChannel,
+} from "../worlds/managed-cloud/callback-relay-agent.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+/**
+ * `callbackRelay` — the controller for the on-box signed-callback relay (spec
+ * "signed qualification callback relay"; PR 6 fixture 2). The relay's DATA plane
+ * (the single-file Python process + Caddy routes) is staged by
+ * `ingress.ts`/`callback-relay-agent.ts` when the deploy's `callbackRelay`
+ * option is present; this fixture is the CONTROL plane the reconciliation
+ * journeys drive.
+ *
+ * It can only DELAY and REPLAY genuine provider deliveries — never synthesize
+ * one. There is no `emit`/`synthesize` method here, and none in the data plane,
+ * BY CONSTRUCTION: the relay forwards or spools the exact signed bytes+headers
+ * and replays those exact bytes, so the HMAC signature the candidate Server
+ * verifies stays intact end-to-end. The Server's own `webhook_receipts`
+ * idempotency proves exactly-once across a hold→replay; the relay never dedupes.
+ *
+ * Controls (per channel: `stripe` | `e2b`):
+ *   - `hold(channel)`            — switch the channel to hold: incoming
+ *     deliveries are spooled verbatim (keyed by a generated deliveryId) and
+ *     ack'd 2xx, not forwarded, until released/replayed.
+ *   - `release(channel, opts)`   — switch back to pass-through; when
+ *     `replayHeld` is set, first re-POST every still-held delivery verbatim.
+ *   - `replay(deliveryId)`       — re-POST one held delivery's exact bytes.
+ *   - `manifest(channel?)`       — read the bounded, secret-free capture manifest
+ *     (a `CapturedDelivery[]`): deliveryId, channel, provider event id (or null),
+ *     bytesSha256, receivedAt, state. `bytesSha256` witnesses byte-identity
+ *     across hold→replay; RAW bodies and signatures NEVER appear in the manifest.
+ *
+ * Every control travels over the injected `CallbackRelayTransport` (BoxExec-
+ * backed by default), so unit tests exercise the control surface offline with no
+ * real box or relay process. The relay's spool + process are registered for
+ * cleanup by the world under the `callback_relay_spool` / `callback_relay_process`
+ * kinds (`relayStopped` evidence category).
+ */
+
+export interface CapturedDelivery {
+  /** Relay-generated per-delivery id (safe token). */
+  deliveryId: string;
+  channel: RelayChannel;
+  /** Provider event id (Stripe evt_… / E2B id) when parseable, else null. Never a body. */
+  providerEventId: string | null;
+  /** sha256 of the exact captured bytes — witnesses byte-identity across hold→replay. */
+  bytesSha256: string;
+  /** RFC3339 capture time. */
+  receivedAt: string;
+  /** `held` | `forwarded` | `replayed:<status>`. */
+  state: string;
+}
+
+export interface CallbackRelayReleaseOptions {
+  /** Re-POST every still-held delivery on this channel (verbatim) before switching to pass-through. */
+  replayHeld?: boolean;
+}
+
+export interface CallbackRelay {
+  /** Switch a channel to hold (spool verbatim, ack 2xx, do not forward). */
+  hold(channel: RelayChannel): Promise<void>;
+  /** Switch a channel back to pass-through, optionally replaying every held delivery first. */
+  release(channel: RelayChannel, options?: CallbackRelayReleaseOptions): Promise<void>;
+  /** Re-POST one held delivery's exact bytes+headers. */
+  replay(deliveryId: string): Promise<void>;
+  /** Read the bounded, secret-free capture manifest (optionally filtered to one channel). */
+  manifest(channel?: RelayChannel): Promise<CapturedDelivery[]>;
+}
+
+/**
+ * The control-plane seam, factored out so unit tests run offline. The default is
+ * BoxExec-backed: `writeControl`/`triggerReplay` invoke the relay's one-shot
+ * actions on the box, and `readManifest` reads the JSON-lines manifest file.
+ */
+export interface CallbackRelayTransport {
+  /** Set a channel's mode by writing its control file (relay `set-mode`). */
+  writeControl(box: BoxExec, relayDir: string, channel: RelayChannel, mode: "hold" | "pass-through"): Promise<void>;
+  /** Trigger a replay of one deliveryId, or every held delivery on a channel. */
+  triggerReplay(
+    box: BoxExec,
+    relayDir: string,
+    target: { deliveryId: string } | { channel: RelayChannel },
+  ): Promise<void>;
+  /** Read the raw manifest lines (one JSON object per line). */
+  readManifest(box: BoxExec, relayDir: string): Promise<string>;
+}
+
+export interface CallbackRelayOptions {
+  /** Loopback port the relay binds on the box; must match the deploy option (default 8899). */
+  listenPort?: number;
+  /** Relay dir basename under the remote workdir (default `callback-relay`). */
+  relayDirName?: string;
+}
+
+/**
+ * Builds the relay controller against a constructed managed-cloud world. Throws
+ * if the world exposes no box-exec seam (the relay lives on the candidate box).
+ */
+export function callbackRelay(
+  world: ManagedCloudWorld,
+  options: CallbackRelayOptions = {},
+  transport: CallbackRelayTransport = defaultCallbackRelayTransport,
+): CallbackRelay {
+  if (!world.box) {
+    throw new Error(
+      "callbackRelay: the managed-cloud world exposes no box-exec seam; the signed-callback relay runs on the " +
+        "candidate box (deploy with the callbackRelay option to stage it).",
+    );
+  }
+  const box = world.box;
+  const dir = relayDir(options.relayDirName ?? RELAY_DIRNAME);
+
+  const readManifestRows = async (channel?: RelayChannel): Promise<CapturedDelivery[]> => {
+    const rows = parseManifest(await transport.readManifest(box, dir));
+    return channel ? rows.filter((row) => row.channel === channel) : rows;
+  };
+
+  // Builds a typed CallbackRelayReplayError from the manifest's `replay_failed:
+  // <status>` rows (a non-2xx replay records this and leaves the delivery
+  // RETRYABLE in held — it never terminalizes to `replayed:`), falling back to
+  // the raw transport error when the manifest is unreadable. The most recent
+  // failed status per delivery wins (a later successful replay records
+  // `replayed:` and drops the delivery from the failed set).
+  const replayError = async (
+    channel: RelayChannel | undefined,
+    cause: unknown,
+  ): Promise<CallbackRelayReplayError> => {
+    let failures: CallbackRelayReplayFailure[] = [];
+    try {
+      const rows = await readManifestRows(channel);
+      const lastStatusById = new Map<string, { channel: RelayChannel; failedStatus: number | null }>();
+      for (const row of rows) {
+        const failed = parseReplayFailedStatus(row.state);
+        const succeeded = parseReplayedStatus(row.state);
+        if (failed !== null) {
+          lastStatusById.set(row.deliveryId, { channel: row.channel, failedStatus: failed });
+        } else if (succeeded !== null) {
+          // A later success clears the retryable-failure state for this delivery.
+          lastStatusById.set(row.deliveryId, { channel: row.channel, failedStatus: null });
+        }
+      }
+      failures = [...lastStatusById.entries()]
+        .filter(([, v]) => v.failedStatus !== null)
+        .map(([deliveryId, v]) => ({ deliveryId, channel: v.channel, status: v.failedStatus as number }));
+    } catch {
+      // manifest unreadable — fall through to the raw cause below.
+    }
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    return new CallbackRelayReplayError(
+      failures.length > 0
+        ? `callbackRelay: ${failures.length} held delivery/deliveries replayed to a non-2xx upstream and remain ` +
+            `retryable (${failures.map((f) => `${f.deliveryId}=${f.status}`).join(", ")}).`
+        : `callbackRelay: replay failed (${causeMessage}).`,
+      failures,
+    );
+  };
+
+  return {
+    async hold(channel) {
+      await transport.writeControl(box, dir, channel, "hold");
+    },
+    async release(channel, releaseOptions) {
+      if (releaseOptions?.replayHeld) {
+        // Replay every still-held delivery verbatim BEFORE re-opening the
+        // channel, so a held delivery is never lost when switching back. A
+        // non-2xx upstream on ANY held delivery makes the relay exit nonzero;
+        // surface that as a typed failure carrying the per-delivery statuses,
+        // and do NOT re-open the channel on a lost event.
+        try {
+          await transport.triggerReplay(box, dir, { channel });
+        } catch (error) {
+          throw await replayError(channel, error);
+        }
+      }
+      await transport.writeControl(box, dir, channel, "pass-through");
+    },
+    async replay(deliveryId) {
+      assertSafeDeliveryId(deliveryId);
+      try {
+        await transport.triggerReplay(box, dir, { deliveryId });
+      } catch (error) {
+        throw await replayError(undefined, error);
+      }
+    },
+    async manifest(channel) {
+      return readManifestRows(channel);
+    },
+  };
+}
+
+/** One held delivery whose replay hit a non-2xx upstream. */
+export interface CallbackRelayReplayFailure {
+  deliveryId: string;
+  channel: RelayChannel;
+  /** The non-2xx HTTP status the candidate Server returned for the replayed bytes. */
+  status: number;
+}
+
+/** Thrown by `release({replayHeld})`/`replay` when a replayed delivery hit a non-2xx upstream. */
+export class CallbackRelayReplayError extends Error {
+  constructor(
+    message: string,
+    readonly failures: readonly CallbackRelayReplayFailure[],
+  ) {
+    super(message);
+    this.name = "CallbackRelayReplayError";
+  }
+}
+
+/** Parses `replayed:<status>` → the numeric status, else null (a terminal 2xx replay row). */
+export function parseReplayedStatus(state: string): number | null {
+  const match = /^replayed:(\d+)$/.exec(state);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+/** Parses `replay_failed:<status>` → the numeric status, else null (a non-2xx, still-retryable replay row). */
+export function parseReplayFailedStatus(state: string): number | null {
+  const match = /^replay_failed:(\d+)$/.exec(state);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+/** deliveryId is interpolated into an argv; keep it a bounded safe token. */
+function assertSafeDeliveryId(deliveryId: string): void {
+  if (!/^[0-9a-f]{8,64}$/i.test(deliveryId)) {
+    throw new Error(`callbackRelay.replay: refusing to use a non-hex deliveryId ("${deliveryId}").`);
+  }
+}
+
+/** Parses the JSON-lines manifest into bounded CapturedDelivery rows (skips malformed lines). */
+export function parseManifest(raw: string): CapturedDelivery[] {
+  const rows: CapturedDelivery[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) {
+      continue;
+    }
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (
+      typeof parsed.deliveryId === "string" &&
+      (parsed.channel === "stripe" || parsed.channel === "e2b") &&
+      typeof parsed.bytesSha256 === "string" &&
+      typeof parsed.receivedAt === "string" &&
+      typeof parsed.state === "string"
+    ) {
+      rows.push({
+        deliveryId: parsed.deliveryId,
+        channel: parsed.channel,
+        providerEventId: typeof parsed.providerEventId === "string" ? parsed.providerEventId : null,
+        bytesSha256: parsed.bytesSha256,
+        receivedAt: parsed.receivedAt,
+        state: parsed.state,
+      });
+    }
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Default transport — the relay's one-shot actions over BoxExec
+// ---------------------------------------------------------------------------
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * BoxExec-backed control plane. Every action runs `python3 relay.py <action>`
+ * under the run-scoped relay dir with `RELAY_SPOOL_DIR` set, matching how the
+ * data-plane process reads its spool. No secret ever rides these argv — the
+ * relay never touches signing secrets.
+ */
+export const defaultCallbackRelayTransport: CallbackRelayTransport = {
+  async writeControl(box, dir, channel, mode) {
+    await runRelayAction(box, dir, ["set-mode", channel, mode]);
+  },
+  async triggerReplay(box, dir, target) {
+    if ("deliveryId" in target) {
+      await runRelayAction(box, dir, ["replay", target.deliveryId]);
+    } else {
+      await runRelayAction(box, dir, ["replay-held", target.channel]);
+    }
+  },
+  async readManifest(box, dir) {
+    const manifestPath = `${dir}/${RELAY_MANIFEST_FILENAME}`;
+    // A missing manifest (no delivery yet) reads as empty, not an error.
+    const { stdout } = await box.exec(`cat ${shellSingleQuote(manifestPath)} 2>/dev/null || true`);
+    return stdout;
+  },
+};
+
+/** Absolute relay dir on the box (mirrors ingress.ts's REMOTE_RELAY_DIR). */
+function relayDir(dirName: string = RELAY_DIRNAME): string {
+  return `/home/ubuntu/candidate/${dirName}`;
+}
+
+async function runRelayAction(box: BoxExec, dir: string, args: readonly string[]): Promise<void> {
+  const scriptPath = `${dir}/${RELAY_SCRIPT_FILENAME}`;
+  const quoted = args.map(shellSingleQuote).join(" ");
+  await box.exec(
+    `RELAY_SPOOL_DIR=${shellSingleQuote(dir)} python3 ${shellSingleQuote(scriptPath)} ${quoted}`,
+  );
+}
+
+/** The relay listen port a controller must agree with the deploy on (default). */
+export const CALLBACK_RELAY_DEFAULT_PORT = DEFAULT_RELAY_LISTEN_PORT;

--- a/tests/release/src/fixtures/failure-injection.test.ts
+++ b/tests/release/src/fixtures/failure-injection.test.ts
@@ -1,0 +1,329 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  injectFailureAt,
+  type FailureBoundary,
+  type FailureInjectionSeams,
+} from "./failure-injection.js";
+import type { BoxExec } from "../worlds/managed-cloud/box-exec.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+interface Recorded {
+  execs: Array<{ id: string; command: readonly string[] }>;
+  kills: string[];
+  pauses: string[];
+  restarts: string[];
+  boxCommands: string[];
+}
+
+/** One simulated in-sandbox process: pid, exact executable name (comm), full cmdline. */
+/**
+ * A simulated /proc entry. `exe` is the full executable path the `/proc/<pid>/
+ * exe` symlink resolves to (empty string models an UNREADABLE exe → fallback
+ * path). `comm` is modelled with REAL Linux 15-byte truncation applied by the
+ * harness, so a test cannot cheat by supplying an untruncated comm.
+ */
+interface FakeProc {
+  pid: string;
+  /** Full exe path, e.g. "/usr/bin/proliferate-worker"; "" = exe unreadable. */
+  exe: string;
+  /** Full comm as the program set it (the harness truncates to 15 bytes like Linux). */
+  comm: string;
+  cmdline: string;
+}
+
+const TRUNC = (s: string): string => s.slice(0, 15); // Linux /proc/<pid>/comm width.
+const BASENAME = (p: string): string => p.split("/").pop() ?? p;
+
+/**
+ * Models the in-sandbox process table the fixture inspects via `/proc`. The fake
+ * INTERPRETS the fixture's enumeration script the SAME way the real shell would:
+ * primary match on `/proc/<pid>/exe` basename == target; fallback (when exe is
+ * unreadable) on TRUNCATED-to-15-byte comm == target[:15] AND argv[0] basename ==
+ * target. It applies REAL 15-byte comm truncation, honors the clone|fetch cmdline
+ * filter, and `kill -9 <pids>` / `kill -0 <pid>` — so a wrapper (exe=sh, pattern
+ * only in cmdline) is proven NOT killed, and a full-18-char worker whose comm is
+ * truncated to `proliferate-wor` is still found via exe.
+ */
+function harness(
+  overrides: {
+    procs?: FakeProc[];
+    hasBox?: boolean;
+    killExit?: number;
+    unkillable?: boolean;
+  } = {},
+): {
+  world: ManagedCloudWorld;
+  seams: Partial<FailureInjectionSeams>;
+  recorded: Recorded;
+  procs: Map<string, FakeProc>;
+} {
+  const recorded: Recorded = { execs: [], kills: [], pauses: [], restarts: [], boxCommands: [] };
+  const procs = new Map<string, FakeProc>((overrides.procs ?? []).map((p) => [p.pid, p]));
+  const box = {
+    async exec(command: string) {
+      recorded.boxCommands.push(command);
+      return { stdout: "", stderr: "" };
+    },
+  } as unknown as BoxExec;
+  const world = {
+    run: { run_id: "r", shard_id: "s" },
+    box: overrides.hasBox === false ? undefined : box,
+  } as unknown as ManagedCloudWorld;
+
+  const seams: Partial<FailureInjectionSeams> = {
+    async execInProviderSandbox(id, command) {
+      recorded.execs.push({ id, command });
+      const script = command.join(" ");
+      // Fail loudly if the fixture ever uses the banned whole-cmdline matchers.
+      assert.ok(!/pgrep\s+-f/.test(script), "fixture must not use pgrep -f");
+      assert.ok(!/pkill\s+-f/.test(script), "fixture must not use pkill -f");
+
+      // Enumeration: the fixture's `/proc` walk matches by exe basename (primary)
+      // with a truncated-comm + argv0-basename fallback, optionally filtered to a
+      // clone|fetch cmdline. Recover the FULL target from `[ "$ebase" = 'X' ]` and
+      // the truncated target from `[ "$c" = 'Y' ]`.
+      if (script.includes("/proc/[0-9]*")) {
+        const exeTargetMatch = /\[ "\$ebase" = '([^']+)' \]/.exec(script);
+        const commTargetMatch = /\[ "\$c" = '([^']+)' \]/.exec(script);
+        const exeTarget = exeTargetMatch?.[1];
+        const commTarget = commTargetMatch?.[1]; // already truncated to 15 by the fixture
+        const requireCloneFetch = /\*clone\*\|\*fetch\*/.test(script);
+        const matched = [...procs.values()].filter((p) => {
+          let isMatch = false;
+          if (p.exe) {
+            // PRIMARY: exe basename == full target.
+            isMatch = BASENAME(p.exe) === exeTarget;
+          } else {
+            // FALLBACK: truncated comm == truncated target AND argv0 basename == full target.
+            const argv0 = p.cmdline.split(" ")[0] ?? "";
+            isMatch = TRUNC(p.comm) === commTarget && BASENAME(argv0) === exeTarget;
+          }
+          if (!isMatch) return false;
+          if (requireCloneFetch && !/clone|fetch/.test(p.cmdline)) return false;
+          return true;
+        });
+        return { stdout: matched.map((p) => p.pid).join("\n"), stderr: "", exitCode: 0 };
+      }
+
+      // kill -9 <pids> (the fixture's script is `kill -9 <pid> <pid> …`).
+      const kill9 = /kill -9 ((?:\d+ ?)+)/.exec(script);
+      if (kill9) {
+        if (overrides.killExit !== undefined) {
+          return { stdout: "", stderr: "kill failed", exitCode: overrides.killExit };
+        }
+        if (!overrides.unkillable) {
+          for (const pid of kill9[1].trim().split(/\s+/)) procs.delete(pid);
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }
+
+      // kill -0 <pid> && echo ALIVE || echo GONE
+      const kill0 = /kill -0 (\d+)/.exec(script);
+      if (kill0) {
+        return { stdout: procs.has(kill0[1]) ? "ALIVE" : "GONE", stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    },
+    async killProviderSandbox(id) {
+      recorded.kills.push(id);
+      return { killed: true };
+    },
+    async pauseProviderSandbox(id) {
+      recorded.pauses.push(id);
+      return { paused: true };
+    },
+    async restartBoxProcess(_world, name) {
+      recorded.restarts.push(name);
+    },
+  };
+  return { world, seams, recorded, procs };
+}
+
+// The Worker's real comm truncates to `proliferate-wor` (15 bytes); its exe
+// symlink keeps the FULL name, which is how the fixture must identify it.
+const workerProc = (pid = "1001"): FakeProc => ({
+  pid,
+  exe: "/usr/local/bin/proliferate-worker",
+  comm: "proliferate-worker",
+  cmdline: "/usr/local/bin/proliferate-worker --enroll",
+});
+const anyharnessProc = (pid = "1002"): FakeProc => ({
+  pid,
+  exe: "/usr/local/bin/anyharness",
+  comm: "anyharness",
+  cmdline: "/usr/local/bin/anyharness serve",
+});
+const gitCloneProc = (pid = "1003"): FakeProc => ({
+  pid,
+  exe: "/usr/bin/git",
+  comm: "git",
+  cmdline: "/usr/bin/git clone https://x/y",
+});
+
+test("provider_create kills the provider sandbox and reports injected", async () => {
+  const { world, seams, recorded } = harness();
+  const handle = await injectFailureAt(world, "provider_create", { providerSandboxId: "sbx-1" }, seams);
+  assert.equal(handle.boundary, "provider_create");
+  assert.equal(handle.injected, true);
+  assert.deepEqual(recorded.kills, ["sbx-1"]);
+  // disarm is idempotent and always safe in a finally.
+  await handle.disarm();
+  await handle.disarm();
+});
+
+test("worker_enrollment finds the worker by EXE identity despite the 15-byte comm truncation, kills it, proves it gone", async () => {
+  // The Worker's comm is truncated to `proliferate-wor` (15 bytes) — a bare comm
+  // compare against the full `proliferate-worker` would NEVER match. The fixture
+  // matches on the exe basename, so the worker is still found.
+  const { world, seams, recorded, procs } = harness({ procs: [workerProc()] });
+  assert.equal(TRUNC("proliferate-worker"), "proliferate-wor"); // sanity: truncation is real
+  const handle = await injectFailureAt(world, "worker_enrollment", { providerSandboxId: "sbx-2" }, seams);
+  assert.equal(handle.injected, true);
+  // Never pgrep -f/pkill -f (the harness asserts this too). It enumerates /proc,
+  // kills by explicit pid, and verifies with kill -0.
+  assert.ok(recorded.execs.some((e) => e.command.join(" ").includes("/proc/[0-9]*")));
+  assert.ok(recorded.execs.some((e) => e.command.join(" ").includes("/proc/$pid/exe") || e.command.join(" ").includes("readlink")));
+  assert.ok(recorded.execs.some((e) => /kill -9 1001/.test(e.command.join(" "))));
+  assert.ok(recorded.execs.some((e) => /kill -0 1001/.test(e.command.join(" "))));
+  assert.equal(procs.has("1001"), false);
+});
+
+test("worker is still found via the FALLBACK (truncated comm + argv0 basename) when /proc/<pid>/exe is unreadable", async () => {
+  // exe: "" models an unreadable /proc/<pid>/exe (permissions). The fallback must
+  // match truncated comm (proliferate-wor) AND argv[0] basename (proliferate-worker).
+  const unreadableExeWorker: FakeProc = {
+    pid: "1005",
+    exe: "",
+    comm: "proliferate-worker",
+    cmdline: "/usr/local/bin/proliferate-worker --enroll",
+  };
+  const { world, seams, procs } = harness({ procs: [unreadableExeWorker] });
+  const handle = await injectFailureAt(world, "worker_enrollment", { providerSandboxId: "sbx-2b" }, seams);
+  assert.equal(handle.injected, true);
+  assert.equal(procs.has("1005"), false);
+});
+
+test("runtime_readiness proves anyharness present, kills the PID, proves it gone", async () => {
+  const { world, seams, procs } = harness({ procs: [anyharnessProc()] });
+  const handle = await injectFailureAt(world, "runtime_readiness", { providerSandboxId: "sbx-3" }, seams);
+  assert.equal(handle.injected, true);
+  assert.equal(procs.has("1002"), false);
+});
+
+test("a wrapper process that merely CONTAINS the pattern in its cmdline (exe=sh) is NOT killed, and a missing target throws", async () => {
+  // A shell wrapper whose command line mentions the pattern but whose executable
+  // is `sh` — the old pkill -f would have matched (and could kill the controller);
+  // exe-identity matching must NOT select it, so the target is treated as absent.
+  const wrapper: FakeProc = {
+    pid: "2001",
+    exe: "/bin/sh",
+    comm: "sh",
+    cmdline: "/bin/sh -c pkill proliferate-worker",
+  };
+  const { world, seams, procs } = harness({ procs: [wrapper] });
+  await assert.rejects(
+    () => injectFailureAt(world, "worker_enrollment", { providerSandboxId: "sbx-x" }, seams),
+    /no process with executable "proliferate-worker" was running/,
+  );
+  // The wrapper survived — it was never a match.
+  assert.equal(procs.has("2001"), true);
+});
+
+test("a MISSING target process throws (never fabricates a successful injection)", async () => {
+  const { world, seams } = harness({ procs: [] });
+  await assert.rejects(
+    () => injectFailureAt(world, "worker_enrollment", { providerSandboxId: "sbx-x" }, seams),
+    /no process with executable "proliferate-worker" was running/,
+  );
+});
+
+test("a kill -9 that exits non-zero throws (no `|| true` masking the real command)", async () => {
+  const { world, seams } = harness({ procs: [anyharnessProc()], killExit: 2 });
+  await assert.rejects(
+    () => injectFailureAt(world, "runtime_readiness", { providerSandboxId: "sbx-x" }, seams),
+    /kill -9 of "anyharness" .* exited 2/,
+  );
+});
+
+test("a target still alive after SIGKILL (kill -0 ALIVE) throws (injection did not take effect)", async () => {
+  const { world, seams } = harness({ procs: [workerProc()], unkillable: true });
+  await assert.rejects(
+    () => injectFailureAt(world, "worker_enrollment", { providerSandboxId: "sbx-x" }, seams),
+    /still running after SIGKILL/,
+  );
+});
+
+test("repo_materialization SIGKILLs the in-flight git (comm=git + clone/fetch cmdline) and leaves the sandbox alive", async () => {
+  const { world, seams, recorded, procs } = harness({ procs: [gitCloneProc()] });
+  const handle = await injectFailureAt(
+    world,
+    "repo_materialization",
+    { providerSandboxId: "sbx-4", gitWaitMs: 1_000, gitPollMs: 10 },
+    seams,
+  );
+  assert.equal(handle.injected, true);
+  // The sandbox was NOT destroyed — recovery is partial-materialization, not reprovisioning.
+  assert.deepEqual(recorded.kills, []);
+  // The git PID was killed by explicit pid (never pkill -f) and is gone.
+  assert.ok(recorded.execs.some((e) => /kill -9 1003/.test(e.command.join(" "))));
+  assert.equal(procs.has("1003"), false);
+});
+
+test("repo_materialization does NOT kill a `git` that is not clone/fetch (cmdline filter), and throws when none appears", async () => {
+  const gitStatus: FakeProc = { pid: "3001", exe: "/usr/bin/git", comm: "git", cmdline: "/usr/bin/git status" };
+  const { world, seams, recorded, procs } = harness({ procs: [gitStatus] });
+  await assert.rejects(
+    () =>
+      injectFailureAt(
+        world,
+        "repo_materialization",
+        { providerSandboxId: "sbx-5", gitWaitMs: 50, gitPollMs: 10 },
+        seams,
+      ),
+    /no in-flight git clone\/fetch observed/,
+  );
+  assert.deepEqual(recorded.kills, [], "must NOT destroy the sandbox as a fallback");
+  assert.equal(procs.has("3001"), true, "an unrelated `git status` must not be killed");
+});
+
+test("workspace_creation restarts the candidate-server container (no provider sandbox needed)", async () => {
+  const { world, seams, recorded } = harness();
+  const handle = await injectFailureAt(world, "workspace_creation", {}, seams);
+  assert.equal(handle.injected, true);
+  assert.deepEqual(recorded.restarts, ["candidate-server"]);
+});
+
+test("the default box-restart path issues `docker restart candidate-server` on the box", async () => {
+  const { world, recorded } = harness();
+  const handle = await injectFailureAt(world, "workspace_creation", {}, {
+    // leave restartBoxProcess default
+  });
+  assert.equal(handle.injected, true);
+  assert.deepEqual(recorded.boxCommands, ["sudo docker restart candidate-server"]);
+});
+
+test("every provider-sandbox boundary requires a providerSandboxId", async () => {
+  const { world, seams } = harness();
+  const boundaries: FailureBoundary[] = [
+    "provider_create",
+    "worker_enrollment",
+    "runtime_readiness",
+    "repo_materialization",
+  ];
+  for (const boundary of boundaries) {
+    await assert.rejects(() => injectFailureAt(world, boundary, {}, seams), /requires target\.providerSandboxId/);
+  }
+});
+
+test("workspace_creation without a box throws (the on-box boundary needs the candidate box)", async () => {
+  const { world } = harness({ hasBox: false });
+  await assert.rejects(() => injectFailureAt(world, "workspace_creation", {}, {}), /no box-exec seam/);
+});
+
+test("the fixture never touches the pause seam (recovery is via the normal product path)", async () => {
+  const { world, seams, recorded } = harness({ procs: [workerProc()] });
+  await injectFailureAt(world, "worker_enrollment", { providerSandboxId: "sbx-9" }, seams);
+  assert.deepEqual(recorded.pauses, []);
+});

--- a/tests/release/src/fixtures/failure-injection.ts
+++ b/tests/release/src/fixtures/failure-injection.ts
@@ -1,0 +1,387 @@
+import {
+  execInProviderSandbox,
+  killProviderSandbox,
+  pauseProviderSandbox,
+} from "./e2b-verify.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+/**
+ * `injectFailureAt` — the failure-injection seams for CLOUD-PROVISION-RECOVERY-1's
+ * five accepted-work boundaries (spec "New fixture obligations"; PR 6 fixture 3).
+ *
+ * VERIFIED against the candidate Server + runtime: there is NO env-flag / test
+ * hook in the product that would let the server fail its own accepted work on
+ * command. So injection is PROVIDER-SIDE and PROCESS-LEVEL only — kill the
+ * provider sandbox, kill an in-sandbox process, or restart an on-box container —
+ * at exactly the boundary the recovery journey names. Recovery is ALWAYS driven
+ * back through the NORMAL product path (`POST /v1/cloud/cloud-sandbox/ensure`,
+ * workspace open); this fixture never reaches inside product code to "un-fail".
+ *
+ * The injection PROVES the boundary rather than assuming it, and does so by
+ * EXACT executable identity — never `pgrep -f`/`pkill -f`, whose whole-command-
+ * line match would match the enumerator's own `sh -c` wrapper (the pattern is in
+ * that command line) and could kill the controller shell or falsely prove the
+ * target. Instead it enumerates PIDs whose `/proc/<pid>/exe` basename equals the
+ * exact FULL executable name (`proliferate-worker`, `anyharness`, `git`) — NOT
+ * `/proc/<pid>/comm`, which Linux truncates to 15 bytes (so `proliferate-worker`,
+ * 18 chars, would never match). The exe basename is untruncated and inherently
+ * excludes shell wrappers (exe = `sh`/`bash`); a fallback (truncated comm +
+ * argv[0] basename) covers the rare unreadable-exe case. It excludes its own pid
+ * + parent, kills that explicit PID list with SIGKILL, and verifies absence with
+ * `kill -0` per pid. A MISSING target throws (never fabricates a success);
+ * `injected` is true ONLY on a proven before-present + after-absent. No `|| true`
+ * masks the real command exit.
+ *
+ * The five boundaries → their injection:
+ *   - provider_create     — kill the provider sandbox right after it appears, so
+ *                           it dies before Worker enrollment (proven by the
+ *                           provider's own kill acknowledgement).
+ *   - worker_enrollment   — SIGKILL `proliferate-worker` inside the sandbox
+ *                           before its first heartbeat (proven present→absent).
+ *   - runtime_readiness   — SIGKILL `anyharness` inside the sandbox before
+ *                           readiness flips (proven present→absent).
+ *   - repo_materialization— SIGKILL the IN-FLIGHT `git` clone/fetch INSIDE the
+ *                           sandbox (bounded pgrep window), leaving the partial
+ *                           checkout in place — the sandbox is NOT destroyed, so
+ *                           this exercises partial-materialization recovery, not
+ *                           reprovisioning. If no git process is observed in the
+ *                           window it THROWS (never falls back to a sandbox kill).
+ *   - workspace_creation  — restart the on-box `candidate-server` container
+ *                           between the accepted create and its commit tail.
+ *
+ * Returns a `FailureInjectionHandle` whose `disarm()` is idempotent and MUST be
+ * called in a `finally` — for the process/container boundaries it is a no-op
+ * marker (the kill already happened; recovery re-drives the product), and it is
+ * always safe to call more than once.
+ *
+ * Every side-effecting step is behind injectable seams (`FailureInjectionSeams`,
+ * defaulting to the e2b-verify provider seams + an on-box container restart), so
+ * unit tests exercise the exact injection wiring offline with no real sandbox,
+ * box, or provider. No new cleanup kinds and no new env vars: the sandbox is
+ * already registered under `e2b_sandbox` by the scenario, and killing it is that
+ * releaser's job.
+ */
+
+export type FailureBoundary =
+  | "provider_create"
+  | "worker_enrollment"
+  | "runtime_readiness"
+  | "repo_materialization"
+  | "workspace_creation";
+
+/** What the injection acts on, resolved by the scenario at the boundary. */
+export interface FailureInjectionTarget {
+  /** The provider (E2B) sandbox id — required for every boundary except workspace_creation. */
+  providerSandboxId?: string;
+  /**
+   * repo_materialization only: how long to poll for an in-flight `git`
+   * clone/fetch before giving up (default 30s). If none appears in the window
+   * the injection THROWS rather than falling back to destroying the sandbox.
+   */
+  gitWaitMs?: number;
+  /** repo_materialization only: poll interval while waiting for git (default 500ms). */
+  gitPollMs?: number;
+}
+
+export interface FailureInjectionHandle {
+  boundary: FailureBoundary;
+  /** True once the injection actually fired (a no-target boundary that could not act stays false). */
+  injected: boolean;
+  /** Idempotent teardown; safe (and expected) to call in a finally even if injection failed. */
+  disarm(): Promise<void>;
+}
+
+/**
+ * The side-effecting seams, all injectable. Defaults are the real e2b-verify
+ * provider seams plus an on-box `candidate-server` container restart via the
+ * world's box-exec. Unit tests pass fakes so no real provider/box is touched.
+ */
+export interface FailureInjectionSeams {
+  execInProviderSandbox: typeof execInProviderSandbox;
+  killProviderSandbox: typeof killProviderSandbox;
+  pauseProviderSandbox: typeof pauseProviderSandbox;
+  /** Restarts a named process/container ON the candidate box (default: `docker restart` via box-exec). */
+  restartBoxProcess(world: ManagedCloudWorld, processName: string): Promise<void>;
+}
+
+/** The on-box container the workspace_creation boundary restarts. */
+const CANDIDATE_SERVER_PROCESS = "candidate-server";
+
+/**
+ * Injects the named failure at `boundary` against `target`, returning a handle
+ * with an idempotent `disarm()`. The caller retries through the NORMAL product
+ * path after disarming; this fixture only breaks the accepted work, never
+ * repairs it.
+ */
+export async function injectFailureAt(
+  world: ManagedCloudWorld,
+  boundary: FailureBoundary,
+  target: FailureInjectionTarget,
+  seams: Partial<FailureInjectionSeams> = {},
+): Promise<FailureInjectionHandle> {
+  const resolved: FailureInjectionSeams = {
+    execInProviderSandbox: seams.execInProviderSandbox ?? execInProviderSandbox,
+    killProviderSandbox: seams.killProviderSandbox ?? killProviderSandbox,
+    pauseProviderSandbox: seams.pauseProviderSandbox ?? pauseProviderSandbox,
+    restartBoxProcess: seams.restartBoxProcess ?? defaultRestartBoxProcess,
+  };
+
+  const noopHandle = (injected: boolean): FailureInjectionHandle => ({
+    boundary,
+    injected,
+    async disarm() {
+      // Idempotent no-op: the injection is a kill/restart the recovery journey
+      // re-drives through the product, so there is nothing to undo. Kept as a
+      // real method so callers can always `finally { await handle.disarm() }`.
+    },
+  });
+
+  switch (boundary) {
+    case "provider_create": {
+      // The provider sandbox appeared; kill it before Worker enrollment so the
+      // product must re-provision on the next /ensure.
+      const providerSandboxId = requireProviderSandbox(boundary, target);
+      const { killed } = await resolved.killProviderSandbox(providerSandboxId);
+      return noopHandle(killed);
+    }
+    case "worker_enrollment": {
+      // Kill the Worker before its first heartbeat, so enrollment never lands.
+      // Proven present→absent; a missing Worker throws (never a fake success).
+      const providerSandboxId = requireProviderSandbox(boundary, target);
+      await killProcessInSandbox(resolved.execInProviderSandbox, providerSandboxId, "proliferate-worker");
+      return noopHandle(true);
+    }
+    case "runtime_readiness": {
+      // Kill AnyHarness before readiness flips, so the runtime never reports
+      // ready. Proven present→absent; a missing runtime throws.
+      const providerSandboxId = requireProviderSandbox(boundary, target);
+      await killProcessInSandbox(resolved.execInProviderSandbox, providerSandboxId, "anyharness");
+      return noopHandle(true);
+    }
+    case "repo_materialization": {
+      // SIGKILL the IN-FLIGHT git clone/fetch INSIDE the sandbox, leaving the
+      // partial checkout in place — the sandbox is NOT destroyed, so this
+      // exercises partial-materialization RECOVERY (re-clone into the same
+      // sandbox), not reprovisioning. Poll for the git process within a bounded
+      // window; if none appears, THROW (never fall back to a sandbox kill).
+      const providerSandboxId = requireProviderSandbox(boundary, target);
+      await killInflightGitInSandbox(
+        resolved.execInProviderSandbox,
+        providerSandboxId,
+        target.gitWaitMs ?? 30_000,
+        target.gitPollMs ?? 500,
+      );
+      return noopHandle(true);
+    }
+    case "workspace_creation": {
+      // Restart the candidate-server container between the accepted create and
+      // its commit tail, so the product must re-run the tail on the next call.
+      await resolved.restartBoxProcess(world, CANDIDATE_SERVER_PROCESS);
+      return noopHandle(true);
+    }
+    default: {
+      // Exhaustiveness: a new boundary must be handled explicitly, never
+      // silently succeed as an injected failure that did nothing.
+      const never: never = boundary;
+      throw new Error(`injectFailureAt: unhandled failure boundary "${String(never)}".`);
+    }
+  }
+}
+
+/**
+ * Enumerates PIDs inside the sandbox whose executable is EXACTLY `exeName`,
+ * identified PRIMARILY by the basename of `/proc/<pid>/exe` (a symlink to the
+ * real binary) — NEVER `pgrep -f`/`pkill -f` (which match the whole command line
+ * and would match the enumerator's own `sh -c …` wrapper), and NOT bare
+ * `/proc/<pid>/comm`, which Linux TRUNCATES to 15 bytes (so `proliferate-worker`,
+ * 18 chars, never compares equal). Using the exe basename preserves the FULL
+ * untruncated name and inherently excludes shell wrappers (their exe is `sh`/
+ * `bash`).
+ *
+ * Where `/proc/<pid>/exe` is unreadable (permissions), it FALLS BACK to: comm
+ * equals the target truncated to 15 bytes AND argv[0] basename (from
+ * `/proc/<pid>/cmdline`) equals the full target. The enumerator excludes its own
+ * pid (`$$`) and parent (`$PPID`). When `requireCmdline` is set it additionally
+ * requires the cmdline to contain "clone" or "fetch" (in-flight `git`). Returns
+ * the matched pids (empty = none). Fixed script text; only the target name is
+ * interpolated.
+ */
+async function findPidsByExactExe(
+  exec: typeof execInProviderSandbox,
+  providerSandboxId: string,
+  exeName: string,
+  requireCmdline: "git-clone-fetch" | null = null,
+): Promise<string[]> {
+  const comm15 = exeName.slice(0, 15); // Linux /proc/<pid>/comm truncation width.
+  const cmdlineFilter =
+    requireCmdline === "git-clone-fetch"
+      ? 'case "$cl" in *clone*|*fetch*) ;; *) continue ;; esac; '
+      : "";
+  // POSIX sh + /proc; busybox-compatible. `readlink -f` resolves the exe symlink;
+  // argv0 basename via parameter expansion on the first NUL-delimited field.
+  const script =
+    "SELF=$$; " +
+    "for d in /proc/[0-9]*; do " +
+    "pid=${d#/proc/}; " +
+    '[ "$pid" = "$SELF" ] && continue; ' +
+    '[ "$pid" = "$PPID" ] && continue; ' +
+    // cmdline (space-joined) + argv[0] basename, used by the git filter and the
+    // fallback. argv[0] is the first NUL-delimited field: split on NUL → newlines,
+    // take line 1.
+    'cl=$(tr "\\0" " " < "$d/cmdline" 2>/dev/null); ' +
+    'argv0=$(tr "\\0" "\\n" < "$d/cmdline" 2>/dev/null | head -n1); a0base=${argv0##*/}; ' +
+    // PRIMARY: exe basename (full, untruncated). readlink may fail (perm/kernel).
+    'exe=$(readlink "$d/exe" 2>/dev/null); ebase=${exe##*/}; ' +
+    "matched=0; " +
+    `if [ -n "$ebase" ]; then ` +
+    `if [ "$ebase" = ${shellSingleQuote(exeName)} ]; then matched=1; fi; ` +
+    // FALLBACK only when exe is unreadable: truncated comm AND full argv0 basename.
+    `else c=$(cat "$d/comm" 2>/dev/null); ` +
+    `if [ "$c" = ${shellSingleQuote(comm15)} ] && [ "$a0base" = ${shellSingleQuote(exeName)} ]; then matched=1; fi; fi; ` +
+    '[ "$matched" = 1 ] || continue; ' +
+    cmdlineFilter +
+    'echo "$pid"; ' +
+    "done";
+  const result = await exec(providerSandboxId, ["sh", "-c", script]);
+  return result.stdout
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => /^\d+$/.test(token));
+}
+
+/** Kills an explicit PID list with SIGKILL (never `pkill -f`) and returns the command result. */
+async function killPids(
+  exec: typeof execInProviderSandbox,
+  providerSandboxId: string,
+  pids: readonly string[],
+): Promise<{ exitCode: number; stderr: string }> {
+  const result = await exec(providerSandboxId, ["sh", "-c", `kill -9 ${pids.join(" ")}`]);
+  return { exitCode: result.exitCode, stderr: result.stderr };
+}
+
+/** Re-checks each pid with `kill -0`; returns the pids STILL alive (empty = all gone). */
+async function pidsStillAlive(
+  exec: typeof execInProviderSandbox,
+  providerSandboxId: string,
+  pids: readonly string[],
+): Promise<string[]> {
+  const alive: string[] = [];
+  for (const pid of pids) {
+    // kill -0 exits 0 iff the pid exists (and is signalable); nonzero once gone.
+    const check = await exec(providerSandboxId, ["sh", "-c", `kill -0 ${pid} 2>/dev/null && echo ALIVE || echo GONE`]);
+    if (check.stdout.includes("ALIVE")) {
+      alive.push(pid);
+    }
+  }
+  return alive;
+}
+
+/**
+ * Positively-proven process kill inside the sandbox by EXACT executable identity:
+ * enumerate matching PIDs FIRST (a missing target THROWS — never a fake
+ * injection), SIGKILL that exact PID list, then re-check those PIDs with
+ * `kill -0` and require them all gone. Never `pkill -f`.
+ */
+async function killProcessInSandbox(
+  exec: typeof execInProviderSandbox,
+  providerSandboxId: string,
+  exeName: string,
+): Promise<void> {
+  const before = await findPidsByExactExe(exec, providerSandboxId, exeName);
+  if (before.length === 0) {
+    throw new Error(
+      `injectFailureAt: no process with executable "${exeName}" was running in the sandbox to kill — refusing to ` +
+        "fabricate a successful injection (the boundary was not reached, or the target already exited).",
+    );
+  }
+  const kill = await killPids(exec, providerSandboxId, before);
+  if (kill.exitCode !== 0) {
+    throw new Error(
+      `injectFailureAt: kill -9 of "${exeName}" (pids ${before.join(",")}) exited ${kill.exitCode} ` +
+        `(${kill.stderr.trim().slice(0, 200)}).`,
+    );
+  }
+  const alive = await pidsStillAlive(exec, providerSandboxId, before);
+  if (alive.length > 0) {
+    throw new Error(
+      `injectFailureAt: "${exeName}" was still running after SIGKILL (pids ${alive.join(",")}); the injection did ` +
+        "not take effect.",
+    );
+  }
+}
+
+/**
+ * SIGKILLs the in-flight `git` clone/fetch inside the sandbox by exact EXE
+ * identity (`git`) + a cmdline that contains clone|fetch, leaving the partial
+ * checkout in place. Polls for a matching process within a bounded window (the
+ * clone is transient); once seen, kills that exact PID list and proves it gone
+ * via `kill -0`. If no matching git appears in the window, THROWS — never falls
+ * back to destroying the sandbox (that would exercise reprovisioning, not
+ * partial-materialization recovery, which the boundary contract requires).
+ */
+async function killInflightGitInSandbox(
+  exec: typeof execInProviderSandbox,
+  providerSandboxId: string,
+  waitMs: number,
+  pollMs: number,
+): Promise<void> {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    const pids = await findPidsByExactExe(exec, providerSandboxId, "git", "git-clone-fetch");
+    if (pids.length > 0) {
+      const kill = await killPids(exec, providerSandboxId, pids);
+      if (kill.exitCode !== 0) {
+        throw new Error(
+          `injectFailureAt(repo_materialization): kill -9 of the in-flight git (pids ${pids.join(",")}) exited ` +
+            `${kill.exitCode} (${kill.stderr.trim().slice(0, 200)}).`,
+        );
+      }
+      const alive = await pidsStillAlive(exec, providerSandboxId, pids);
+      if (alive.length > 0) {
+        throw new Error(
+          `injectFailureAt(repo_materialization): git was still running after SIGKILL (pids ${alive.join(",")}).`,
+        );
+      }
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `injectFailureAt(repo_materialization): no in-flight git clone/fetch observed within ${waitMs}ms — ` +
+          "refusing to fall back to destroying the sandbox (that exercises reprovisioning, not partial-" +
+          "materialization recovery). Widen gitWaitMs or inject earlier in the clone.",
+      );
+    }
+    await sleep(pollMs);
+  }
+}
+
+/** Escapes a value for single-quoted POSIX shell interpolation (mirrors box-exec.ts). */
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function requireProviderSandbox(boundary: FailureBoundary, target: FailureInjectionTarget): string {
+  if (!target.providerSandboxId) {
+    throw new Error(`injectFailureAt: boundary "${boundary}" requires target.providerSandboxId.`);
+  }
+  return target.providerSandboxId;
+}
+
+/**
+ * Default box-process restart: `sudo docker restart <name>` on the candidate box
+ * via the world's box-exec seam. Throws if the world has no box (the on-box
+ * boundary is not exercisable without one).
+ */
+async function defaultRestartBoxProcess(world: ManagedCloudWorld, processName: string): Promise<void> {
+  if (!world.box) {
+    throw new Error(
+      "injectFailureAt(workspace_creation): the managed-cloud world exposes no box-exec seam; restarting the " +
+        "candidate-server container requires the candidate box.",
+    );
+  }
+  await world.box.exec(`sudo docker restart ${processName}`);
+}

--- a/tests/release/src/fixtures/stripe-test-clock.test.ts
+++ b/tests/release/src/fixtures/stripe-test-clock.test.ts
@@ -1,0 +1,749 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  clockNameForRun,
+  createDefaultStripeTestClockTransport,
+  isLiveModeSecretKey,
+  resolveTestModeSecretKey,
+  stripeCleanupReplayHandlers,
+  stripeTestClockActor,
+  StripeTestClockUnavailableError,
+  type BillingSubjectBindSeam,
+  type StripeHttp,
+  type StripeTestClockTransport,
+} from "./stripe-test-clock.js";
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+import {
+  loadCleanupLedger,
+  openCleanupLedger,
+  replayLedger,
+} from "../worlds/local-workspace/cleanup-ledger.js";
+import { ManagedCloudCleanupStack, type ManagedCloudCleanupKind } from "../worlds/managed-cloud/cleanup-kinds.js";
+import type { CleanupIntentHandle, ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+const RUN = { run_id: "run-3", shard_id: "shard-1" } as ManagedCloudWorld["run"];
+
+interface CleanupRegistration {
+  kind: string;
+  providerId: string;
+  release: () => Promise<void>;
+}
+
+function fakeWorld(): { world: ManagedCloudWorld; cleanups: CleanupRegistration[] } {
+  const cleanups: CleanupRegistration[] = [];
+  const world = {
+    run: RUN,
+    async registerCleanup(kind: string, providerId: string, release: () => Promise<void>) {
+      cleanups.push({ kind, providerId, release });
+    },
+  } as unknown as ManagedCloudWorld;
+  return { world, cleanups };
+}
+
+function fakeActor(): AuthenticatedActor {
+  return {
+    role: "owner",
+    userId: "u-1",
+    organizationId: "org-1",
+    enrollmentId: "e1",
+    api: {} as never,
+    session: {} as never,
+    gatewayKey: {} as never,
+  };
+}
+
+function fakeTransport(
+  overrides: {
+    /** Force createCustomerOnClock to throw (models a crash after clock create). */
+    failCustomerCreate?: boolean;
+    /** Recovery lookups return these (models the leaked resource still on Stripe). */
+    recoverClockId?: string;
+    recoverCustomerId?: string;
+  } = {},
+): { transport: StripeTestClockTransport; calls: string[] } {
+  const calls: string[] = [];
+  const transport: StripeTestClockTransport = {
+    async createClock({ secretKey, name }) {
+      calls.push(`createClock:${secretKey}:${name}`);
+      return { testClockId: "tc_1" };
+    },
+    async createCustomerOnClock({ testClockId, priceId, metadata }) {
+      if (overrides.failCustomerCreate) {
+        throw new Error("simulated crash after clock create, before customer acquire");
+      }
+      calls.push(
+        `createCustomer:${testClockId}:${priceId}:${metadata.proliferate_owner_scope}:${metadata.billing_subject_id}`,
+      );
+      return { customerId: "cus_1", subscriptionId: "sub_1" };
+    },
+    async advance({ testClockId, toUnix }) {
+      calls.push(`advance:${testClockId}:${toUnix}`);
+      return { invoiceId: `in_${toUnix}` };
+    },
+    async deleteClock({ testClockId }) {
+      calls.push(`deleteClock:${testClockId}`);
+    },
+    async deleteCustomer({ customerId }) {
+      calls.push(`deleteCustomer:${customerId}`);
+    },
+    async findTestClockByName({ name }) {
+      calls.push(`findTestClockByName:${name}`);
+      return overrides.recoverClockId ? { testClockId: overrides.recoverClockId } : null;
+    },
+    async findCustomerOnClock({ testClockId, runTag }) {
+      calls.push(`findCustomerOnClock:${testClockId}:${runTag}`);
+      return overrides.recoverCustomerId ? { customerId: overrides.recoverCustomerId } : null;
+    },
+  };
+  return { transport, calls };
+}
+
+function fakeBindSeam(): { seam: BillingSubjectBindSeam; calls: string[] } {
+  const calls: string[] = [];
+  const seam: BillingSubjectBindSeam = {
+    async resolveBillingSubjectId(_world, params) {
+      calls.push(`resolve:${params.ownerScope}:${params.organizationId ?? "-"}`);
+      return { billingSubjectId: "bsub_1" };
+    },
+    async bindStripeCustomer(_world, params) {
+      calls.push(`bind:${params.billingSubjectId}:${params.customerId}`);
+    },
+  };
+  return { seam, calls };
+}
+
+const OPTS = { secretKey: "sk_test_abc", priceId: "price_test_1" } as const;
+
+test("sets up a test clock + subscribed customer, binds the billing subject, and registers cleanup before creation", async () => {
+  const { world, cleanups } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  const { seam, calls: seamCalls } = fakeBindSeam();
+  const handle = await stripeTestClockActor(world, fakeActor(), OPTS, transport, seam);
+
+  assert.equal(handle.testClockId, "tc_1");
+  assert.equal(handle.customerId, "cus_1");
+  assert.equal(handle.subscriptionId, "sub_1");
+  assert.equal(handle.billingSubjectId, "bsub_1");
+  // Registered-before-create via a two-phase INTENT entry: the ledger entry
+  // EXISTS before the Stripe create, carrying the run-scoped RECOVERY IDENTITY.
+  assert.equal(cleanups[0].kind, "stripe_test_clock");
+  assert.equal(cleanups[0].providerId, "intent:test_clock:name=proliferate-qual-renew-run-3:shard-1");
+  assert.equal(cleanups[1].kind, "stripe_customer");
+  assert.equal(cleanups[1].providerId, "intent:customer:runTag=run-3:shard-1");
+  // The clock is created with a deterministic run-scoped NAME (so an interrupted
+  // create→acquire window is recoverable by name).
+  assert.equal(calls[0], "createClock:sk_test_abc:proliferate-qual-renew-run-3:shard-1");
+  // The customer carries the resolved billing_subject_id in metadata so the
+  // product webhook resolver attributes the renewal invoice to this actor.
+  assert.equal(calls[1], "createCustomer:tc_1:price_test_1:personal:bsub_1");
+  // The subject was resolved before creation and the customer bound after.
+  assert.deepEqual(seamCalls, ["resolve:personal:-", "bind:bsub_1:cus_1"]);
+});
+
+test("once ACQUIRED, the intent releasers delete by the real Stripe ids", async () => {
+  const { world, cleanups } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  const { seam } = fakeBindSeam();
+  await stripeTestClockActor(world, fakeActor(), OPTS, transport, seam);
+  // Both resources were created + acquired, so the intent releasers delete by
+  // the real ids (tc_1 / cus_1), never a recovery lookup.
+  for (const c of cleanups) await c.release();
+  assert.ok(calls.includes("deleteClock:tc_1"), "acquired clock deleted by real id");
+  assert.ok(calls.includes("deleteCustomer:cus_1"), "acquired customer deleted by real id");
+  assert.ok(!calls.some((c) => c.startsWith("findTestClockByName")), "no recovery lookup needed when acquired");
+});
+
+test("interruption in the create→acquire window is still cleaned: the intent releaser RECOVERS the leaked resource by name/tag", async () => {
+  // The clock is created (accepted by Stripe) but the customer create THROWS
+  // before the customer is acquired — modelling a crash in the window. The clock
+  // WAS acquired; the customer was NOT. Cleanup must delete both: the clock by
+  // its acquired id, the customer by a run-tag recovery lookup.
+  const { world, cleanups } = fakeWorld();
+  const { transport, calls } = fakeTransport({
+    failCustomerCreate: true,
+    recoverCustomerId: "cus_leaked",
+  });
+  const { seam } = fakeBindSeam();
+  await assert.rejects(
+    () => stripeTestClockActor(world, fakeActor(), OPTS, transport, seam),
+    /simulated crash after clock create/,
+  );
+  // Both intent entries were registered BEFORE any create, so they exist despite
+  // the crash. Run them (reverse order like the stack would).
+  for (const c of [...cleanups].reverse()) await c.release();
+  // Clock was acquired → deleted by real id.
+  assert.ok(calls.includes("deleteClock:tc_1"), "acquired clock still deleted");
+  // Customer was NOT acquired → recovered via the clock-SCOPED customer LIST
+  // (clock id from the acquired closure), then deleted.
+  assert.ok(calls.includes("findCustomerOnClock:tc_1:run-3:shard-1"), "customer recovered via clock-scoped list");
+  assert.ok(calls.includes("deleteCustomer:cus_leaked"), "recovered customer deleted");
+});
+
+test("an intent releaser whose resource was never created (nor recoverable) is a clean no-op", async () => {
+  // Register the intents, then run cleanup with a transport whose recovery finds
+  // nothing (the create truly never happened) — no delete, no throw.
+  const { world, cleanups } = fakeWorld();
+  const { transport, calls } = fakeTransport({ failCustomerCreate: true });
+  const { seam } = fakeBindSeam();
+  await assert.rejects(() => stripeTestClockActor(world, fakeActor(), OPTS, transport, seam), /simulated crash/);
+  const customerCleanup = cleanups.find((c) => c.kind === "stripe_customer")!;
+  await customerCleanup.release(); // recovery returns null → no-op, no throw
+  assert.ok(calls.includes("findCustomerOnClock:tc_1:run-3:shard-1"));
+  assert.ok(!calls.some((c) => c.startsWith("deleteCustomer:")), "nothing to delete when unrecoverable");
+});
+
+test("the stripe_customer releaser deletes the REAL customer id (not a no-op) and tolerates cascade-already-gone", async () => {
+  const { world, cleanups } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  const { seam } = fakeBindSeam();
+  await stripeTestClockActor(world, fakeActor(), OPTS, transport, seam);
+  const customerCleanup = cleanups.find((c) => c.kind === "stripe_customer")!;
+  await customerCleanup.release();
+  assert.ok(calls.includes("deleteCustomer:cus_1"), "customer releaser must delete the real customer id");
+});
+
+test("organization scope resolves the org subject and requires an org id", async () => {
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport();
+  const { seam, calls: seamCalls } = fakeBindSeam();
+  await stripeTestClockActor(world, fakeActor(), { ...OPTS, ownerScope: "organization" }, transport, seam);
+  assert.equal(seamCalls[0], "resolve:organization:org-1");
+
+  const actorNoOrg = { ...fakeActor(), organizationId: "" };
+  await assert.rejects(
+    () => stripeTestClockActor(world, actorNoOrg, { ...OPTS, ownerScope: "organization" }, transport, seam),
+    /requires the actor to have an organization id/,
+  );
+});
+
+test("advanceToNextPeriod advances by one period each call and returns the invoice id", async () => {
+  const { world } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  const { seam } = fakeBindSeam();
+  const handle = await stripeTestClockActor(world, fakeActor(), OPTS, transport, seam);
+  const first = await handle.advanceToNextPeriod();
+  const second = await handle.advanceToNextPeriod();
+  assert.match(first.invoiceId, /^in_\d+$/);
+  const firstUnix = Number(calls.find((c) => c.startsWith("advance:tc_1:"))!.split(":")[2]);
+  const secondUnix = Number(calls.filter((c) => c.startsWith("advance:tc_1:"))[1].split(":")[2]);
+  assert.equal(secondUnix - firstUnix, 31 * 24 * 60 * 60);
+  assert.notEqual(first.invoiceId, second.invoiceId);
+});
+
+test("release deletes the test clock (cascades customers); the registered cleanup does too", async () => {
+  const { world, cleanups } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  const { seam } = fakeBindSeam();
+  const handle = await stripeTestClockActor(world, fakeActor(), OPTS, transport, seam);
+  await handle.release();
+  assert.ok(calls.includes("deleteClock:tc_1"));
+  // The registered clock releaser also deletes the (now-known) clock id.
+  await cleanups[0].release();
+  assert.equal(calls.filter((c) => c === "deleteClock:tc_1").length, 2);
+});
+
+test("a live-mode secret key throws (posture guard), never creating a clock", async () => {
+  const { world } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  await assert.rejects(
+    () => stripeTestClockActor(world, fakeActor(), { secretKey: "sk_live_abc", priceId: "price_1" }, transport),
+    /LIVE-mode Stripe secret key/,
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("an unresolved key raises StripeTestClockUnavailableError (the cell reports blocked, never green)", () => {
+  assert.throws(() => resolveTestModeSecretKey(undefined, {}), StripeTestClockUnavailableError);
+});
+
+test("key resolution order: explicit > STRIPE_TEST_SECRET_KEY > TIER2_BILLING_STRIPE_SECRET_KEY", () => {
+  assert.equal(
+    resolveTestModeSecretKey("sk_test_explicit", {
+      STRIPE_TEST_SECRET_KEY: "sk_test_a",
+      TIER2_BILLING_STRIPE_SECRET_KEY: "sk_test_b",
+    }),
+    "sk_test_explicit",
+  );
+  assert.equal(
+    resolveTestModeSecretKey(undefined, { STRIPE_TEST_SECRET_KEY: "sk_test_a", TIER2_BILLING_STRIPE_SECRET_KEY: "sk_test_b" }),
+    "sk_test_a",
+  );
+  assert.equal(
+    resolveTestModeSecretKey(undefined, { TIER2_BILLING_STRIPE_SECRET_KEY: "sk_test_b" }),
+    "sk_test_b",
+  );
+});
+
+test("isLiveModeSecretKey recognizes sk_live_ and rk_live_, not test keys", () => {
+  assert.equal(isLiveModeSecretKey("sk_live_x"), true);
+  assert.equal(isLiveModeSecretKey("rk_live_x"), true);
+  assert.equal(isLiveModeSecretKey("sk_test_x"), false);
+});
+
+test("throws when no subscription price id resolves", async () => {
+  const { world } = fakeWorld();
+  const { transport } = fakeTransport();
+  await assert.rejects(
+    () => stripeTestClockActor(world, fakeActor(), { secretKey: "sk_test_abc", env: {} }, transport),
+    /no subscription price id/,
+  );
+});
+
+test("resolves the price id and key from a provided env when not passed explicitly", async () => {
+  const { world } = fakeWorld();
+  const { transport, calls } = fakeTransport();
+  const { seam } = fakeBindSeam();
+  const handle = await stripeTestClockActor(
+    world,
+    fakeActor(),
+    { env: { STRIPE_TEST_SECRET_KEY: "sk_test_env", STRIPE_TEST_CLOUD_MONTHLY_PRICE_ID: "price_env" } },
+    transport,
+    seam,
+  );
+  assert.equal(handle.testClockId, "tc_1");
+  assert.match(calls[0], /^createClock:sk_test_env:/);
+  assert.match(calls[1], /price_env/);
+});
+
+// --- HTTP-contract pins (PR6-CONTROL-002b r3): assert the EXACT method+path of
+// each Stripe call through the default transport's injectable HTTP seam, so a
+// verb/path regression (e.g. POST .../delete instead of DELETE) is caught.
+function recordingHttp(): { http: StripeHttp; reqs: Array<{ method: string; path: string }> } {
+  const reqs: Array<{ method: string; path: string }> = [];
+  const http: StripeHttp = {
+    async request(_secretKey, req) {
+      reqs.push({ method: req.method, path: req.path });
+      if (req.path === "/test_helpers/test_clocks") return { id: "tc_9" };
+      if (req.path === "/customers") return { id: "cus_9" };
+      if (req.path === "/subscriptions") return { id: "sub_9" };
+      return {};
+    },
+  };
+  return { http, reqs };
+}
+
+test("HTTP contract: deleteClock is DELETE /test_helpers/test_clocks/{id} (NOT POST .../delete)", async () => {
+  const { http, reqs } = recordingHttp();
+  const transport = createDefaultStripeTestClockTransport(http);
+  await transport.deleteClock({ secretKey: "sk_test_x", testClockId: "tc_9" });
+  assert.deepEqual(reqs, [{ method: "DELETE", path: "/test_helpers/test_clocks/tc_9" }]);
+});
+
+test("HTTP contract: deleteCustomer is DELETE /customers/{id}", async () => {
+  const { http, reqs } = recordingHttp();
+  const transport = createDefaultStripeTestClockTransport(http);
+  await transport.deleteCustomer({ secretKey: "sk_test_x", customerId: "cus_9" });
+  assert.deepEqual(reqs, [{ method: "DELETE", path: "/customers/cus_9" }]);
+});
+
+test("HTTP contract: createClock/createCustomerOnClock/advance use POST on their exact paths", async () => {
+  const { http, reqs } = recordingHttp();
+  const transport = createDefaultStripeTestClockTransport(http);
+  await transport.createClock({ secretKey: "sk_test_x", frozenTimeUnix: 100, name: "n" });
+  await transport.createCustomerOnClock({ secretKey: "sk_test_x", testClockId: "tc_9", priceId: "price_1", metadata: {} });
+  await transport.advance({ secretKey: "sk_test_x", testClockId: "tc_9", toUnix: 200 });
+  assert.deepEqual(reqs, [
+    { method: "POST", path: "/test_helpers/test_clocks" },
+    { method: "POST", path: "/customers" },
+    { method: "POST", path: "/subscriptions" },
+    { method: "POST", path: "/test_helpers/test_clocks/tc_9/advance" },
+  ]);
+});
+
+test("HTTP contract: deleteClock/deleteCustomer swallow resource_missing (idempotent cleanup)", async () => {
+  const missingHttp: StripeHttp = {
+    async request(_k, req) {
+      if (req.method === "DELETE") throw new Error("stripeTestClockActor: No such test clock: resource_missing");
+      return {};
+    },
+  };
+  const transport = createDefaultStripeTestClockTransport(missingHttp);
+  await transport.deleteClock({ secretKey: "sk_test_x", testClockId: "tc_gone" }); // must not throw
+  const missingCustomerHttp: StripeHttp = {
+    async request(_k, req) {
+      if (req.method === "DELETE") throw new Error("stripeTestClockActor: No such customer: resource_missing");
+      return {};
+    },
+  };
+  await createDefaultStripeTestClockTransport(missingCustomerHttp).deleteCustomer({
+    secretKey: "sk_test_x",
+    customerId: "cus_gone",
+  }); // must not throw
+});
+
+// --- Durability of the intent→acquired handoff across RUNNER LOSS (PR6-CONTROL-002 r4).
+
+/**
+ * A REAL durable-ledger-backed world exposing the two-phase `registerCleanupIntent`
+ * seam, so the ledger state persists to disk exactly as production does. Mirrors
+ * the world.ts wiring: register (intent, providerId null) → acquired(intentRef)
+ * → markAcquired(realId).
+ */
+async function ledgerBackedWorld(runDir: string): Promise<{
+  world: ManagedCloudWorld;
+  stack: ManagedCloudCleanupStack;
+}> {
+  const ledger = await openCleanupLedger({ runDir, runId: "run-3", shardId: "shard-1" });
+  const stack = new ManagedCloudCleanupStack({ ledger });
+  const world = {
+    run: { run_id: "run-3", shard_id: "shard-1" },
+    async registerCleanupIntent(
+      kind: ManagedCloudCleanupKind,
+      intentRef: string,
+      release: () => Promise<void>,
+    ): Promise<CleanupIntentHandle> {
+      const entryId = await stack.register(kind, release);
+      await stack.acquired(entryId, intentRef);
+      return { entryId, markAcquired: (realId: string) => stack.acquired(entryId, realId) };
+    },
+  } as unknown as ManagedCloudWorld;
+  return { world, stack };
+}
+
+/** A persistent Stripe fake: recovery lookups find the clock that was accepted before the crash. */
+function persistentStripeFake(): { transport: StripeTestClockTransport; calls: string[] } {
+  const calls: string[] = [];
+  const clocks = new Map<string, string>(); // name -> id
+  const transport: StripeTestClockTransport = {
+    async createClock({ name }) {
+      clocks.set(name, "tc_live");
+      calls.push(`createClock:${name}`);
+      return { testClockId: "tc_live" };
+    },
+    async createCustomerOnClock() {
+      // The crash happens here (before markAcquired for the customer).
+      throw new Error("simulated runner death after clock create, before customer acquire");
+    },
+    async advance() {
+      return { invoiceId: "in_x" };
+    },
+    async deleteClock({ testClockId }) {
+      calls.push(`deleteClock:${testClockId}`);
+    },
+    async deleteCustomer({ customerId }) {
+      calls.push(`deleteCustomer:${customerId}`);
+    },
+    async findTestClockByName({ name }) {
+      calls.push(`findTestClockByName:${name}`);
+      const id = clocks.get(name);
+      return id ? { testClockId: id } : null;
+    },
+    async findCustomerOnClock({ testClockId }) {
+      calls.push(`findCustomerOnClock:${testClockId}`);
+      return null; // the customer was never created (crash was in createCustomerOnClock).
+    },
+  };
+  return { transport, calls };
+}
+
+test("RUNNER-LOSS regression: a clock created before markAcquire is recovered + deleted by replaying the RELOADED ledger alone (no closures)", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "stripe-ledger-"));
+  try {
+    const { world } = await ledgerBackedWorld(runDir);
+    const { transport, calls } = persistentStripeFake();
+    const { seam } = fakeBindSeam();
+
+    // Run the fixture: the clock is created (accepted by Stripe) but the customer
+    // create THROWS before the customer is acquired — modelling runner death.
+    await assert.rejects(
+      () => stripeTestClockActor(world, fakeActor(), OPTS, transport, seam),
+      /simulated runner death/,
+    );
+    // The clock WAS created; but its markAcquired for the clock DID run (it is
+    // acquired before the customer create). The decisive proof is recovery FROM
+    // THE LEDGER ENTRY ALONE.
+    calls.length = 0; // discard everything the in-process run recorded/closed over.
+
+    // RELOAD the persisted ledger from disk — no fixture closure survives.
+    const reloaded = await loadCleanupLedger(runDir);
+    // A fresh replay handler set, backed by the SAME persistent Stripe fake that
+    // still holds the created clock. `now` is PAST the propagation window so the
+    // customer's empty lookup reconciles as truly-never-created (the customer
+    // create threw); `ledgerEntries` lets the customer handler read the clock id.
+    const handlers = stripeCleanupReplayHandlers({
+      secretKey: "sk_test_x",
+      transport,
+      ledgerEntries: reloaded.entries(),
+      now: () => new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+    const result = await replayLedger(reloaded, handlers);
+
+    // The clock entry reconciled: its providerId held the real tc_live id
+    // (markAcquired ran for the clock), so it deleted by id. The customer entry
+    // held the intent recovery id → looked up on the clock (found none) → past the
+    // window → clean reconcile. Both reconcile from the ledger ALONE.
+    assert.ok(calls.includes("deleteClock:tc_live"), "clock deleted from reloaded ledger entry");
+    assert.equal(result.failed, 0, "every entry reconciled from the reloaded ledger");
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("RUNNER-LOSS regression: a clock accepted but NEVER acquired (intent-only ledger entry) is located by name + deleted on replay", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "stripe-ledger-intent-"));
+  try {
+    // Simulate the WORST window: intent persisted, Stripe accepted the clock, but
+    // the runner died BEFORE markAcquired — so the ledger entry still holds the
+    // intent recovery id. Build that ledger state directly, then reload + replay.
+    const ledger = await openCleanupLedger({ runDir, runId: "run-3", shardId: "shard-1" });
+    const stack = new ManagedCloudCleanupStack({ ledger });
+    const runTag = "run-3:shard-1";
+    const clockName = clockNameForRun(runTag);
+    const entryId = await stack.register("stripe_test_clock", async () => undefined);
+    await stack.acquired(entryId, `intent:test_clock:name=${clockName}`); // intent-only, no markAcquired.
+
+    // The clock exists on Stripe under that name (created just before death).
+    const { transport, calls } = persistentStripeFake();
+    await transport.createClock({ secretKey: "sk_test_x", frozenTimeUnix: 0, name: clockName });
+    calls.length = 0;
+
+    const reloaded = await loadCleanupLedger(runDir);
+    const handlers = stripeCleanupReplayHandlers({ secretKey: "sk_test_x", transport });
+    const result = await replayLedger(reloaded, handlers);
+
+    // The intent-only entry located the clock by its run-scoped name and DELETEd it.
+    assert.ok(calls.includes(`findTestClockByName:${clockName}`), "located by run-scoped name");
+    assert.ok(calls.includes("deleteClock:tc_live"), "leaked clock deleted from intent entry alone");
+    assert.equal(result.failed, 0);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("happy-path replay: an ACQUIRED real id in the reloaded ledger deletes by id without any lookup", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "stripe-ledger-happy-"));
+  try {
+    const ledger = await openCleanupLedger({ runDir, runId: "run-3", shardId: "shard-1" });
+    const stack = new ManagedCloudCleanupStack({ ledger });
+    const clockEntry = await stack.register("stripe_test_clock", async () => undefined);
+    await stack.acquired(clockEntry, "intent:test_clock:name=x");
+    await stack.acquired(clockEntry, "tc_acq"); // markAcquired ran → real id persisted.
+    const custEntry = await stack.register("stripe_customer", async () => undefined);
+    await stack.acquired(custEntry, "cus_acq");
+
+    const { transport, calls } = persistentStripeFake();
+    const reloaded = await loadCleanupLedger(runDir);
+    const result = await replayLedger(reloaded, stripeCleanupReplayHandlers({ secretKey: "sk_test_x", transport }));
+
+    assert.ok(calls.includes("deleteClock:tc_acq"), "acquired clock deleted by real id");
+    assert.ok(calls.includes("deleteCustomer:cus_acq"), "acquired customer deleted by real id");
+    assert.ok(!calls.some((c) => c.startsWith("findTestClockByName")), "no lookup for an acquired real id");
+    assert.equal(result.failed, 0);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+// --- Pagination + propagation-window regressions (PR6-CONTROL-002 r5).
+
+/** A recording StripeHttp whose GET responses are scripted per call (for pagination). */
+function pagedStripeHttp(pages: Record<string, Record<string, unknown>[]>): {
+  http: StripeHttp;
+  gets: string[];
+} {
+  const gets: string[] = [];
+  // Each key is a full request path; return the queued page for it (FIFO per path).
+  const queues: Record<string, Record<string, unknown>[][]> = {};
+  const http: StripeHttp = {
+    async request(_secretKey, req) {
+      if (req.method === "GET") {
+        gets.push(req.path);
+        // has_more/data are computed by the caller-provided `pages` keyed by path.
+        const body = pages[req.path];
+        if (body) {
+          const hasMore = body.length > 0 && (body[body.length - 1] as { __hasMore?: boolean }).__hasMore === true;
+          const clean = body.map((o) => {
+            const { __hasMore, ...rest } = o as Record<string, unknown> & { __hasMore?: boolean };
+            void __hasMore;
+            return rest;
+          });
+          return { data: clean, has_more: hasMore };
+        }
+        return { data: [], has_more: false };
+      }
+      if (req.method === "DELETE") {
+        gets.push(`DELETE ${req.path}`);
+        return {};
+      }
+      return {};
+    },
+  };
+  // keep queues referenced (unused advanced form) to avoid lint noise
+  void queues;
+  return { http, gets };
+}
+
+test("clock pagination: the run-owned clock on a LATER page is found via starting_after and deleted", async () => {
+  // Page 1 = 100 decoy clocks with has_more true (last one flagged __hasMore);
+  // page 2 (starting_after=<last decoy id>) holds our run-owned clock.
+  const decoys = Array.from({ length: 100 }, (_v, i) => ({
+    id: `tc_decoy_${i}`,
+    name: `other-${i}`,
+    ...(i === 99 ? { __hasMore: true } : {}),
+  }));
+  const ownedName = clockNameForRun("run-9:shard-0");
+  const pages = {
+    "/test_helpers/test_clocks?limit=100": decoys,
+    "/test_helpers/test_clocks?limit=100&starting_after=tc_decoy_99": [{ id: "tc_owned", name: ownedName }],
+  };
+  const { http, gets } = pagedStripeHttp(pages);
+  const transport = createDefaultStripeTestClockTransport(http);
+
+  const found = await transport.findTestClockByName({ secretKey: "sk_test_x", name: ownedName });
+  assert.deepEqual(found, { testClockId: "tc_owned" });
+  // Proves the second page was fetched via starting_after=<last id of page 1>.
+  assert.ok(gets.includes("/test_helpers/test_clocks?limit=100"));
+  assert.ok(gets.includes("/test_helpers/test_clocks?limit=100&starting_after=tc_decoy_99"));
+});
+
+test("customer recovery uses a clock-SCOPED paginated LIST (never Search), matched by run-tag metadata", async () => {
+  const runTag = "run-9:shard-0";
+  const pages = {
+    "/customers?test_clock=tc_owned&limit=100": [
+      { id: "cus_other", metadata: { proliferate_qualification_run: "someone-else" } },
+      { id: "cus_ours", metadata: { proliferate_qualification_run: runTag } },
+    ],
+  };
+  const { http, gets } = pagedStripeHttp(pages);
+  const transport = createDefaultStripeTestClockTransport(http);
+  const found = await transport.findCustomerOnClock({ secretKey: "sk_test_x", testClockId: "tc_owned", runTag });
+  assert.deepEqual(found, { customerId: "cus_ours" });
+  // A clock-scoped LIST, not /customers/search.
+  assert.ok(gets.some((p) => p.startsWith("/customers?test_clock=tc_owned")));
+  assert.ok(!gets.some((p) => p.includes("/customers/search")));
+});
+
+/** A transport whose customer lookup is empty on the first pass and finds it on the second. */
+function laggedCustomerTransport(): { transport: StripeTestClockTransport; calls: string[]; reveal: () => void } {
+  const calls: string[] = [];
+  let visible = false;
+  const transport: StripeTestClockTransport = {
+    async createClock() {
+      return { testClockId: "tc_live" };
+    },
+    async createCustomerOnClock() {
+      return { customerId: "cus_live", subscriptionId: "sub_live" };
+    },
+    async advance() {
+      return { invoiceId: "in_x" };
+    },
+    async deleteClock({ testClockId }) {
+      calls.push(`deleteClock:${testClockId}`);
+    },
+    async deleteCustomer({ customerId }) {
+      calls.push(`deleteCustomer:${customerId}`);
+    },
+    async findTestClockByName({ name }) {
+      calls.push(`findTestClockByName:${name}`);
+      return { testClockId: "tc_live" }; // the clock is visible.
+    },
+    async findCustomerOnClock({ testClockId }) {
+      calls.push(`findCustomerOnClock:${testClockId}`);
+      return visible ? { customerId: "cus_live" } : null; // lagged read-after-write.
+    },
+  };
+  return { transport, calls, reveal: () => (visible = true) };
+}
+
+test("propagation window: an empty customer lookup within the window leaves the entry UNRECONCILED; a later pass finds + deletes it", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "stripe-window-"));
+  try {
+    const runTag = "run-3:shard-1";
+    const ledger = await openCleanupLedger({ runDir, runId: "run-3", shardId: "shard-1" });
+    const stack = new ManagedCloudCleanupStack({ ledger });
+    // Intent-only customer entry (accepted before markAcquired).
+    const entryId = await stack.register("stripe_customer", async () => undefined);
+    await stack.acquired(entryId, `intent:customer:runTag=${runTag}`);
+
+    const { transport, calls, reveal } = laggedCustomerTransport();
+    const reloaded = await loadCleanupLedger(runDir);
+
+    // PASS 1: within window, customer not visible yet → handler throws → entry
+    // stays unreconciled (replayLedger counts it failed).
+    const pass1 = await replayLedger(
+      reloaded,
+      stripeCleanupReplayHandlers({
+        secretKey: "sk_test_x",
+        transport,
+        ledgerEntries: reloaded.entries(),
+        now: () => new Date(), // registered just now → within the window.
+      }),
+    );
+    assert.equal(pass1.failed, 1, "empty in-window lookup must leave the entry retryable (failed)");
+    assert.equal(pass1.reconciled, 0);
+    assert.ok(reloaded.unreconciled().some((e) => e.kind === "stripe_customer"), "entry still unreconciled");
+    assert.ok(!calls.some((c) => c.startsWith("deleteCustomer")), "nothing deleted on the empty pass");
+
+    // PASS 2: the customer is now visible → found + deleted + reconciled.
+    reveal();
+    const pass2 = await replayLedger(
+      reloaded,
+      stripeCleanupReplayHandlers({
+        secretKey: "sk_test_x",
+        transport,
+        ledgerEntries: reloaded.entries(),
+        now: () => new Date(),
+      }),
+    );
+    assert.equal(pass2.failed, 0);
+    assert.equal(pass2.reconciled, 1);
+    assert.ok(calls.includes("deleteCustomer:cus_live"), "second pass deletes the now-visible customer");
+    assert.equal(reloaded.unreconciled().length, 0, "entry reconciled after the second pass");
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("propagation window: PAST the window, an exhaustive empty lookup reconciles clean (truly-never-created)", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "stripe-window-past-"));
+  try {
+    const runTag = "run-3:shard-1";
+    const ledger = await openCleanupLedger({ runDir, runId: "run-3", shardId: "shard-1" });
+    const stack = new ManagedCloudCleanupStack({ ledger });
+    const entryId = await stack.register("stripe_test_clock", async () => undefined);
+    await stack.acquired(entryId, `intent:test_clock:name=${clockNameForRun(runTag)}`);
+
+    // A transport whose clock lookup is permanently empty (clock never created).
+    const calls: string[] = [];
+    const transport: StripeTestClockTransport = {
+      async createClock() { return { testClockId: "tc_x" }; },
+      async createCustomerOnClock() { return { customerId: "c", subscriptionId: "s" }; },
+      async advance() { return { invoiceId: "i" }; },
+      async deleteClock() { calls.push("deleteClock"); },
+      async deleteCustomer() { calls.push("deleteCustomer"); },
+      async findTestClockByName({ name }) { calls.push(`findTestClockByName:${name}`); return null; },
+      async findCustomerOnClock() { return null; },
+    };
+    const reloaded = await loadCleanupLedger(runDir);
+    const result = await replayLedger(
+      reloaded,
+      stripeCleanupReplayHandlers({
+        secretKey: "sk_test_x",
+        transport,
+        ledgerEntries: reloaded.entries(),
+        now: () => new Date(Date.now() + 2 * 60 * 60 * 1000), // past the 75-minute window.
+      }),
+    );
+    assert.equal(result.failed, 0, "past the window an empty lookup reconciles clean");
+    assert.equal(result.reconciled, 1);
+    assert.ok(!calls.includes("deleteClock"), "nothing to delete — clock was never created");
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/fixtures/stripe-test-clock.ts
+++ b/tests/release/src/fixtures/stripe-test-clock.ts
@@ -1,0 +1,827 @@
+import { isStripeLiveModeUrl } from "./billing-http.js";
+import type { AuthenticatedActor } from "./authenticated-actor.js";
+import { parseLastJsonLine } from "../worlds/managed-cloud/box-seeds.js";
+import type { CleanupHandler, CleanupResourceKind } from "../worlds/local-workspace/cleanup-ledger.js";
+import type { ManagedCloudWorld } from "../worlds/managed-cloud/world.js";
+
+/**
+ * `stripeTestClockActor` — the Stripe TEST-clock actor setup for
+ * CLOUD-COMPUTE-RENEW-1 (spec "New fixture obligations"; PR 6 fixture 4).
+ *
+ * RENEW-1 must observe a subscription cross a period boundary WITHOUT waiting a
+ * real month and WITHOUT touching live money. Stripe test clocks are the
+ * sanctioned mechanism: create a test clock, create a customer ON the clock,
+ * subscribe them, then ADVANCE the clock to the next period — Stripe emits the
+ * real renewal invoice + `invoice.*` webhooks the candidate Server processes.
+ *
+ * The renewal invoice must resolve to the ACTOR: the product's webhook handler
+ * (`stripe_webhooks._subject_from_object`) resolves a Stripe object to a billing
+ * subject via the `billing_subject_id` metadata OR the DB's Stripe-customer
+ * binding (`billing_subject.stripe_customer_id`). So the fixture (1) resolves the
+ * actor's product billing subject id and stamps it into the customer metadata,
+ * AND (2) binds the created customer id onto that billing subject row on the
+ * candidate box (`set_billing_subject_stripe_customer`) — otherwise a renewal
+ * invoice from this clock resolves to no actor and creates no renewal grant.
+ *
+ * The fixture is TEST-MODE-ONLY by discipline: the key is resolved from
+ * `STRIPE_TEST_SECRET_KEY` (falling back to `TIER2_BILLING_STRIPE_SECRET_KEY`),
+ * a `sk_live_…` key THROWS, and an unresolved key raises
+ * `StripeTestClockUnavailableError` so the dependent cell reports honest
+ * `blocked` rather than fabricating a renewal.
+ *
+ * Every Stripe call is behind the injected `StripeTestClockTransport`, and the
+ * on-box billing-subject resolve/bind is behind the injected
+ * `BillingSubjectBindSeam`, so unit tests exercise the fixture offline with a
+ * fake transport/seam and never a real Stripe account, box, or network.
+ *
+ * Cleanup uses a DURABLE two-phase INTENT → ACQUIRED handoff via the world's
+ * `registerCleanupIntent` seam so it survives RUNNER LOSS, not just an in-process
+ * throw: BEFORE each Stripe create the ledger entry is persisted with an intent
+ * providerId carrying the run-scoped RECOVERY IDENTITY (clock name / customer run
+ * tag); the instant Stripe returns, `markAcquired(real id)` durably replaces it.
+ * A runner that dies mid-create therefore leaves the recovery identity on disk,
+ * and `stripeCleanupReplayHandlers` (usable with `replayLedger` on the reloaded
+ * ledger) deletes the leaked resource from the entry ALONE — real id → delete by
+ * id; intent id → locate by name/tag + delete; not found → clean reconcile.
+ * (When the world lacks the two-phase seam — a PR-2 world — the fixture falls
+ * back to the single-shot `registerCleanup` with the same intent ref + closure
+ * recovery.) `release()` deletes the clock (Stripe cascades its customers); the
+ * customer releaser deletes the customer directly and tolerates a
+ * cascade-already-deleted (`resource_missing`). Neither is a no-op. Deletes use
+ * Stripe's real contract: `DELETE /v1/test_helpers/test_clocks/{id}` and
+ * `DELETE /v1/customers/{id}`.
+ */
+
+export type OwnerScope = "personal" | "organization";
+
+export interface StripeTestClockActorHandle {
+  testClockId: string;
+  customerId: string;
+  subscriptionId: string;
+  /** The actor's product billing subject the customer is bound to (safe id). */
+  billingSubjectId: string;
+  /** Advance the clock to the next billing period; returns the renewal invoice id. */
+  advanceToNextPeriod(): Promise<{ invoiceId: string }>;
+  /** Delete the test clock (cascades customers); idempotent. */
+  release(): Promise<void>;
+}
+
+/**
+ * Raised when no test-mode Stripe key resolves. The fixture returns this as a
+ * blocked signal (never green) rather than throwing, so the cell records an
+ * honest blocked reason.
+ */
+export class StripeTestClockUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StripeTestClockUnavailableError";
+  }
+}
+
+export interface StripeTestClockOptions {
+  ownerScope?: OwnerScope;
+  /** Overrides the resolved env (unit tests / explicit operator lane). */
+  secretKey?: string;
+  /** Overrides `process.env` for key resolution. */
+  env?: NodeJS.ProcessEnv;
+  /** The subscription price id to put the customer on (default: the cloud monthly price env, else a required arg). */
+  priceId?: string;
+}
+
+/**
+ * The Stripe side-effecting seam, all injectable. The default is a real
+ * Stripe-test-mode client (constructed only when a test key resolves). Unit
+ * tests pass a fake so no real Stripe account is touched.
+ */
+export interface StripeTestClockTransport {
+  createClock(params: { secretKey: string; frozenTimeUnix: number; name: string }): Promise<{ testClockId: string }>;
+  createCustomerOnClock(params: {
+    secretKey: string;
+    testClockId: string;
+    priceId: string;
+    metadata: Record<string, string>;
+  }): Promise<{ customerId: string; subscriptionId: string }>;
+  advance(params: { secretKey: string; testClockId: string; toUnix: number }): Promise<{ invoiceId: string }>;
+  deleteClock(params: { secretKey: string; testClockId: string }): Promise<void>;
+  /** Delete a customer directly; tolerates cascade-already-deleted (resource_missing). */
+  deleteCustomer(params: { secretKey: string; customerId: string }): Promise<void>;
+  /**
+   * Recover a created-but-not-yet-acquired test clock by its run-scoped `name`
+   * (used by intent recovery to clean an interruption in the create→acquire
+   * window). MUST paginate the cursor-paginated test-clocks list
+   * (`has_more`/`starting_after`) until the clock is found or the collection is
+   * truly exhausted — "not on the first page" is NOT "not found". Returns null
+   * only when the run-owned clock is absent from the entire (exhausted) list.
+   */
+  findTestClockByName(params: { secretKey: string; name: string }): Promise<{ testClockId: string } | null>;
+  /**
+   * Recover a created-but-not-yet-acquired customer via a strongly-consistent,
+   * clock-SCOPED paginated LIST (`GET /v1/customers?test_clock=<id>`), NOT Search
+   * (Stripe Search is read-after-write-lagged up to ~1h — unsuitable for the
+   * accepted-before-markAcquired window). Identifies our customer by the run-tag
+   * metadata. Paginates until found or exhausted. Returns null when absent.
+   */
+  findCustomerOnClock(params: {
+    secretKey: string;
+    testClockId: string;
+    runTag: string;
+  }): Promise<{ customerId: string } | null>;
+}
+
+/**
+ * The on-box billing-subject resolve/bind seam. `resolveAndBind` runs the
+ * product's OWN store functions on the candidate box: resolve the actor's
+ * (personal or org) billing subject, then bind the created Stripe customer id
+ * onto it (`set_billing_subject_stripe_customer`) so the product webhook
+ * resolves renewal invoices to this actor. Injectable so unit tests stay offline.
+ */
+export interface BillingSubjectBindSeam {
+  resolveBillingSubjectId(
+    world: ManagedCloudWorld,
+    params: { userId: string; ownerScope: OwnerScope; organizationId?: string },
+  ): Promise<{ billingSubjectId: string }>;
+  bindStripeCustomer(
+    world: ManagedCloudWorld,
+    params: { billingSubjectId: string; customerId: string },
+  ): Promise<void>;
+}
+
+/** ~31 days, the period step used to cross a monthly boundary. */
+const ONE_PERIOD_SECONDS = 31 * 24 * 60 * 60;
+
+/**
+ * Id-keyed releasers: act purely on a Stripe id (== the value persisted as the
+ * ledger `providerId`), so a recovered/lost runner can replay cleanup from the
+ * ledger ALONE — a kind-keyed replay handler passes `entry.providerId` here.
+ */
+export function deleteTestClockById(
+  transport: StripeTestClockTransport,
+  secretKey: string,
+  testClockId: string,
+): Promise<void> {
+  return transport.deleteClock({ secretKey, testClockId });
+}
+
+export function deleteCustomerById(
+  transport: StripeTestClockTransport,
+  secretKey: string,
+  customerId: string,
+): Promise<void> {
+  return transport.deleteCustomer({ secretKey, customerId });
+}
+
+// ---------------------------------------------------------------------------
+// Durable intent identity + ledger replay handlers (recovery from ledger alone)
+// ---------------------------------------------------------------------------
+
+/** Deterministic run-scoped test-clock name (the recovery identity for a leaked clock). */
+export function clockNameForRun(runTag: string): string {
+  return `proliferate-qual-renew-${runTag}`;
+}
+
+/**
+ * The intent-phase providerId persisted in the ledger BEFORE a create. It carries
+ * the run-scoped RECOVERY IDENTITY so a lost runner can locate + delete the
+ * resource from the reloaded entry alone. `markAcquired(real id)` later replaces
+ * it with the `tc_…`/`cus_…` id. The encodings are prefix-tagged so a replay
+ * handler can tell an intent ref from a real id.
+ */
+export function encodeClockIntentRef(clockName: string): string {
+  return `intent:test_clock:name=${clockName}`;
+}
+export function encodeCustomerIntentRef(runTag: string): string {
+  return `intent:customer:runTag=${runTag}`;
+}
+
+/** Parses a persisted providerId into either a real Stripe id or an intent recovery identity. */
+export function decodeStripeProviderId(
+  providerId: string,
+): { kind: "real"; id: string } | { kind: "intent_clock"; clockName: string } | { kind: "intent_customer"; runTag: string } | { kind: "unknown" } {
+  if (providerId.startsWith("tc_") || providerId.startsWith("cus_")) {
+    return { kind: "real", id: providerId };
+  }
+  const clockName = /^intent:test_clock:name=(.+)$/.exec(providerId);
+  if (clockName) {
+    return { kind: "intent_clock", clockName: clockName[1] };
+  }
+  const runTag = /^intent:customer:runTag=(.+)$/.exec(providerId);
+  if (runTag) {
+    return { kind: "intent_customer", runTag: runTag[1] };
+  }
+  return { kind: "unknown" };
+}
+
+/**
+ * Bounded propagation window for intent recovery: an EXHAUSTIVE-but-empty lookup
+ * within this window of the entry's registration is treated as "the create may
+ * still be propagating / not visible" and the intent is kept RETRYABLE (the
+ * handler throws, leaving the entry unreconciled). Only PAST this window may an
+ * empty lookup reconcile as truly-never-created / already-deleted. Set above
+ * Stripe's documented worst-case Search/read-after-write lag (~1h).
+ */
+export const STRIPE_INTENT_RECOVERY_WINDOW_MS = 75 * 60 * 1000;
+
+/** Thrown by a replay handler to keep an intent entry retryable within the propagation window. */
+export class StripeIntentStillPropagatingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StripeIntentStillPropagatingError";
+  }
+}
+
+/**
+ * Ledger-replay handlers for `stripe_test_clock` / `stripe_customer`, usable with
+ * `replayLedger` after a runner restart. They work from the ENTRY ALONE (no
+ * closures):
+ *   - real `tc_`/`cus_` providerId → DELETE by id (idempotent);
+ *   - intent providerId → deterministically locate the run-owned resource:
+ *       * clock: paginated list by run-scoped name;
+ *       * customer: recover the CLOCK first (real id from the reloaded clock
+ *         entry when acquired, else paginated name lookup), then a strongly-
+ *         consistent clock-SCOPED customer LIST (never Search). If no clock id is
+ *         recoverable, the customer cannot exist (it is created ON the clock,
+ *         AFTER it) → clean reconcile.
+ *   - an EXHAUSTIVE-but-empty lookup does NOT reconcile immediately: within
+ *     `STRIPE_INTENT_RECOVERY_WINDOW_MS` of the entry's `createdAt` it THROWS
+ *     `StripeIntentStillPropagatingError` (leaves the entry unreconciled/
+ *     retryable, so `replayLedger` counts it failed and a later pass retries);
+ *     only past the window is empty treated as truly-never-created (clean).
+ *
+ * `deps.clockEntryProviderId` lets the customer handler read the SIBLING clock
+ * entry's acquired real id from the reloaded ledger; `deps.now` is an injectable
+ * clock for the window check.
+ */
+export function stripeCleanupReplayHandlers(params: {
+  secretKey: string;
+  transport?: StripeTestClockTransport;
+  /** All reloaded ledger entries, so the customer handler can find its clock's real id. */
+  ledgerEntries?: readonly { kind: CleanupResourceKind; providerId: string | null }[];
+  now?: () => Date;
+}): Partial<Record<CleanupResourceKind, CleanupHandler>> {
+  const transport = params.transport ?? defaultStripeTestClockTransport;
+  const { secretKey } = params;
+  const now = params.now ?? (() => new Date());
+  const entries = params.ledgerEntries ?? [];
+
+  const withinWindow = (entry: { createdAt: string }): boolean => {
+    const registeredAt = Date.parse(entry.createdAt);
+    if (Number.isNaN(registeredAt)) {
+      return false; // unparseable timestamp → do not block reconcile forever.
+    }
+    return now().getTime() - registeredAt < STRIPE_INTENT_RECOVERY_WINDOW_MS;
+  };
+
+  /** Resolve the run's clock id: the sibling clock entry's real id, else a paginated name lookup. */
+  const resolveClockId = async (clockName: string): Promise<string | null> => {
+    const clockEntry = entries.find(
+      (e) => e.kind === "stripe_test_clock" && e.providerId?.startsWith("tc_"),
+    );
+    if (clockEntry?.providerId) {
+      return clockEntry.providerId;
+    }
+    const found = await transport.findTestClockByName({ secretKey, name: clockName });
+    return found?.testClockId ?? null;
+  };
+
+  return {
+    stripe_test_clock: async (entry) => {
+      const providerId = entry.providerId ?? "";
+      const decoded = decodeStripeProviderId(providerId);
+      if (decoded.kind === "real") {
+        await deleteTestClockById(transport, secretKey, decoded.id);
+        return;
+      }
+      if (decoded.kind === "intent_clock") {
+        const found = await transport.findTestClockByName({ secretKey, name: decoded.clockName });
+        if (found) {
+          await deleteTestClockById(transport, secretKey, found.testClockId);
+          return;
+        }
+        // Exhaustive lookup empty: keep retryable within the propagation window.
+        if (withinWindow(entry)) {
+          throw new StripeIntentStillPropagatingError(
+            `stripe_test_clock intent "${decoded.clockName}" not found yet; still within the propagation ` +
+              "window — leaving unreconciled for retry.",
+          );
+        }
+        return; // past the window → truly-never-created / already-deleted, clean.
+      }
+      // unknown/null providerId: nothing actionable, but reconcile cleanly.
+    },
+    stripe_customer: async (entry) => {
+      const providerId = entry.providerId ?? "";
+      const decoded = decodeStripeProviderId(providerId);
+      if (decoded.kind === "real") {
+        await deleteCustomerById(transport, secretKey, decoded.id);
+        return;
+      }
+      if (decoded.kind === "intent_customer") {
+        // The customer is created ON the clock, AFTER it — so recover the clock
+        // id first, then LIST that clock's customers (strongly consistent). If no
+        // clock id is recoverable, the customer cannot exist → clean reconcile.
+        const clockName = clockNameForRun(decoded.runTag);
+        const clockId = await resolveClockId(clockName);
+        if (clockId) {
+          const found = await transport.findCustomerOnClock({ secretKey, testClockId: clockId, runTag: decoded.runTag });
+          if (found) {
+            await deleteCustomerById(transport, secretKey, found.customerId);
+            return;
+          }
+          // Clock exists but its customer is not visible yet: retryable in-window.
+          if (withinWindow(entry)) {
+            throw new StripeIntentStillPropagatingError(
+              `stripe_customer intent for run "${decoded.runTag}" not found on clock ${clockId} yet; still ` +
+                "within the propagation window — leaving unreconciled for retry.",
+            );
+          }
+          return;
+        }
+        // No clock recoverable. Within the window this may just mean the clock
+        // create is still propagating (and the customer, created after it, can't
+        // exist yet) → retryable; past the window → the clock was never created,
+        // so the customer never was either → clean reconcile.
+        if (withinWindow(entry)) {
+          throw new StripeIntentStillPropagatingError(
+            `stripe_customer intent for run "${decoded.runTag}": owning clock not recoverable yet; still within ` +
+              "the propagation window — leaving unreconciled for retry.",
+          );
+        }
+        return;
+      }
+    },
+  };
+}
+
+/**
+ * Resolves the test-mode key, refuses a live key, and sets up a test clock +
+ * subscribed customer. Registers the clock + customer for cleanup BEFORE
+ * creating them. Returns a blocked-signalling handle path via
+ * `StripeTestClockUnavailableError` when no key resolves.
+ */
+export async function stripeTestClockActor(
+  world: ManagedCloudWorld,
+  actor: AuthenticatedActor,
+  options: StripeTestClockOptions = {},
+  transport: StripeTestClockTransport = defaultStripeTestClockTransport,
+  bindSeam: BillingSubjectBindSeam = defaultBillingSubjectBindSeam,
+): Promise<StripeTestClockActorHandle> {
+  const env = options.env ?? process.env;
+  const secretKey = resolveTestModeSecretKey(options.secretKey, env);
+  const priceId = options.priceId ?? env.STRIPE_TEST_CLOUD_MONTHLY_PRICE_ID?.trim();
+  if (!priceId) {
+    throw new Error(
+      "stripeTestClockActor: no subscription price id (pass options.priceId or set " +
+        "STRIPE_TEST_CLOUD_MONTHLY_PRICE_ID) — the test-clock actor must subscribe to a real test-mode price.",
+    );
+  }
+  const ownerScope = options.ownerScope ?? "personal";
+  if (ownerScope === "organization" && !actor.organizationId) {
+    throw new Error("stripeTestClockActor: ownerScope 'organization' requires the actor to have an organization id.");
+  }
+
+  const nowUnix = Math.floor(Date.now() / 1000);
+  const runTag = `${world.run.run_id}:${world.run.shard_id}`;
+  // Run-scoped, deterministic clock name so the intent record can RECOVER a
+  // clock that Stripe accepted before we acquired its id (create→acquire window).
+  const clockName = clockNameForRun(runTag);
+
+  // Resolve the actor's product billing subject FIRST so we can both stamp it
+  // into the customer metadata and bind the customer onto it.
+  const { billingSubjectId } = await bindSeam.resolveBillingSubjectId(world, {
+    userId: actor.userId,
+    ownerScope,
+    organizationId: ownerScope === "organization" ? actor.organizationId : undefined,
+  });
+
+  // Two-phase INTENT → ACQUIRED cleanup handoff, made DURABLE via the world's
+  // `registerCleanupIntent` seam: the ledger entry is persisted BEFORE the Stripe
+  // create with a structured intent ref (carrying the run-scoped recovery
+  // identity), and `markAcquired(real id)` durably replaces it the instant Stripe
+  // returns. So a runner that dies in the create→acquire window leaves the
+  // recovery identity on disk, and `stripeCleanupReplayHandlers` deletes the
+  // leaked resource from the reloaded ledger entry ALONE. The closure releasers
+  // handle the in-process happy path; when the world is a PR-2 world without the
+  // two-phase seam, we fall back to the single-shot `registerCleanup`.
+  const acquired: { testClockId?: string; customerId?: string } = {};
+
+  const clockIntentRef = encodeClockIntentRef(clockName);
+  const customerIntentRef = encodeCustomerIntentRef(runTag);
+
+  const clockReleaser = async (): Promise<void> => {
+    let id = acquired.testClockId;
+    if (!id) {
+      const found = await transport.findTestClockByName({ secretKey, name: clockName });
+      id = found?.testClockId;
+    }
+    if (id) {
+      await deleteTestClockById(transport, secretKey, id);
+    }
+  };
+  const customerReleaser = async (): Promise<void> => {
+    let id = acquired.customerId;
+    if (!id) {
+      // Recover the clock id first (the customer is created ON it), then LIST that
+      // clock's customers (strongly consistent — never Search).
+      const clockId =
+        acquired.testClockId ?? (await transport.findTestClockByName({ secretKey, name: clockName }))?.testClockId;
+      if (clockId) {
+        const found = await transport.findCustomerOnClock({ secretKey, testClockId: clockId, runTag });
+        id = found?.customerId;
+      }
+    }
+    if (id) {
+      await deleteCustomerById(transport, secretKey, id);
+    }
+  };
+
+  let clockAcquire: ((realId: string) => Promise<void>) | undefined;
+  let customerAcquire: ((realId: string) => Promise<void>) | undefined;
+  if (world.registerCleanupIntent) {
+    const clockHandle = await world.registerCleanupIntent("stripe_test_clock", clockIntentRef, clockReleaser);
+    clockAcquire = clockHandle.markAcquired;
+    const customerHandle = await world.registerCleanupIntent(
+      "stripe_customer",
+      customerIntentRef,
+      customerReleaser,
+    );
+    customerAcquire = customerHandle.markAcquired;
+  } else {
+    // PR-2 world fallback: single-shot registration with the intent ref as the
+    // persisted id (the closure releaser still recovers by name/tag).
+    await world.registerCleanup?.("stripe_test_clock", clockIntentRef, clockReleaser);
+    await world.registerCleanup?.("stripe_customer", customerIntentRef, customerReleaser);
+  }
+
+  const clock = await transport.createClock({ secretKey, frozenTimeUnix: nowUnix, name: clockName });
+  const testClockId = clock.testClockId;
+  acquired.testClockId = testClockId; // ACQUIRE (in-process closure).
+  await clockAcquire?.(testClockId); // ACQUIRE (durable ledger: real id replaces intent ref).
+
+  const created = await transport.createCustomerOnClock({
+    secretKey,
+    testClockId,
+    priceId,
+    metadata: {
+      proliferate_qualification_run: runTag,
+      proliferate_owner_scope: ownerScope,
+      proliferate_user_id: actor.userId,
+      // The product webhook resolver reads THIS to attribute the renewal invoice.
+      billing_subject_id: billingSubjectId,
+    },
+  });
+  const customerId = created.customerId;
+  acquired.customerId = customerId; // ACQUIRE (in-process closure).
+  await customerAcquire?.(customerId); // ACQUIRE (durable ledger).
+
+  // Bind the customer id onto the actor's billing subject row on the candidate
+  // box, so webhook resolution by DB customer binding also finds this actor
+  // (belt-and-suspenders with the metadata above).
+  await bindSeam.bindStripeCustomer(world, { billingSubjectId, customerId });
+
+  let advancedTo = nowUnix;
+  return {
+    testClockId,
+    customerId,
+    subscriptionId: created.subscriptionId,
+    billingSubjectId,
+    async advanceToNextPeriod() {
+      advancedTo += ONE_PERIOD_SECONDS;
+      return transport.advance({ secretKey, testClockId, toUnix: advancedTo });
+    },
+    async release() {
+      if (testClockId) {
+        await transport.deleteClock({ secretKey, testClockId });
+      }
+    },
+  };
+}
+
+/**
+ * Resolves the TEST-mode Stripe secret key: explicit override, then
+ * STRIPE_TEST_SECRET_KEY, then the Tier-2 fallback. Throws on a live-mode key
+ * (posture guard); raises `StripeTestClockUnavailableError` when none resolves.
+ */
+export function resolveTestModeSecretKey(explicit: string | undefined, env: NodeJS.ProcessEnv): string {
+  const key = (explicit ?? env.STRIPE_TEST_SECRET_KEY ?? env.TIER2_BILLING_STRIPE_SECRET_KEY ?? "").trim();
+  if (!key) {
+    throw new StripeTestClockUnavailableError(
+      "stripeTestClockActor: no test-mode Stripe secret key resolved (STRIPE_TEST_SECRET_KEY, then " +
+        "TIER2_BILLING_STRIPE_SECRET_KEY). The RENEW-1 cell must report blocked, never a fabricated renewal.",
+    );
+  }
+  if (isLiveModeSecretKey(key)) {
+    throw new Error(
+      "stripeTestClockActor: a LIVE-mode Stripe secret key was supplied (sk_live_…). The qualification world must " +
+        "run Stripe in test mode only — refusing to create a test clock against a live account.",
+    );
+  }
+  return key;
+}
+
+/** A live-mode secret key (`sk_live_…` / `rk_live_…`). Test keys are `sk_test_…`/`rk_test_…`. */
+export function isLiveModeSecretKey(key: string): boolean {
+  return /^(sk|rk)_live_/.test(key);
+}
+
+/**
+ * Redacts a Stripe URL discipline check onto secret keys: reuse the URL-level
+ * live-mode detector for any URL the transport surfaces, so a leaked live URL is
+ * caught by the same guard as the key. Exposed for the fixture's tests.
+ */
+export function assertUrlNotLiveMode(url: string): void {
+  if (isStripeLiveModeUrl(url)) {
+    throw new Error(`stripeTestClockActor: a LIVE-mode Stripe URL surfaced (${url}); refusing to proceed.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default transport — the real Stripe TEST-mode API
+// ---------------------------------------------------------------------------
+
+/** Stripe API base; test-vs-live is determined solely by the secret key. */
+const STRIPE_API_BASE = "https://api.stripe.com/v1";
+
+/**
+ * The low-level Stripe HTTP seam — exposes the EXACT method + path so tests can
+ * PIN the HTTP contract (a fake requester asserts `DELETE /test_helpers/
+ * test_clocks/{id}` and `DELETE /customers/{id}`, catching a verb/path
+ * regression). The default hits the real Stripe test-mode API via `fetch`.
+ */
+export interface StripeHttpRequest {
+  method: "POST" | "DELETE" | "GET";
+  /** Path under `/v1`, e.g. `/test_helpers/test_clocks/tc_1`. */
+  path: string;
+  /** Form body for POST (x-www-form-urlencoded); omitted for DELETE/GET. */
+  form?: Record<string, string>;
+}
+
+export interface StripeHttp {
+  request(secretKey: string, req: StripeHttpRequest): Promise<Record<string, unknown>>;
+}
+
+export const defaultStripeHttp: StripeHttp = {
+  async request(secretKey, { method, path, form }) {
+    const init: RequestInit = {
+      method,
+      headers: { Authorization: `Bearer ${secretKey}` },
+      signal: AbortSignal.timeout(30_000),
+    };
+    if (form && method === "POST") {
+      (init.headers as Record<string, string>)["Content-Type"] = "application/x-www-form-urlencoded";
+      init.body = new URLSearchParams(form);
+    }
+    const response = await fetch(`${STRIPE_API_BASE}${path}`, init);
+    const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!response.ok) {
+      const message =
+        typeof (payload.error as { message?: unknown } | undefined)?.message === "string"
+          ? (payload.error as { message: string }).message
+          : `Stripe ${method} ${path} -> ${response.status}`;
+      // Never echo the request body: only Stripe's own bounded error message.
+      throw new Error(`stripeTestClockActor: ${message}`);
+    }
+    return payload;
+  },
+};
+
+/**
+ * Builds the default transport over an injectable `StripeHttp`. Tests pass a
+ * recording fake to assert the exact method+path of each call (the HTTP-contract
+ * pin), without touching a real Stripe account.
+ */
+export function createDefaultStripeTestClockTransport(http: StripeHttp = defaultStripeHttp): StripeTestClockTransport {
+  return {
+    async createClock({ secretKey, frozenTimeUnix, name }) {
+      const clock = await http.request(secretKey, {
+        method: "POST",
+        path: "/test_helpers/test_clocks",
+        form: { frozen_time: String(frozenTimeUnix), name },
+      });
+      const testClockId = typeof clock.id === "string" ? clock.id : "";
+      if (!testClockId) {
+        throw new Error("stripeTestClockActor: Stripe did not return a test clock id.");
+      }
+      return { testClockId };
+    },
+    async createCustomerOnClock({ secretKey, testClockId, priceId, metadata }) {
+      const customerForm: Record<string, string> = { test_clock: testClockId };
+      for (const [key, value] of Object.entries(metadata)) {
+        customerForm[`metadata[${key}]`] = value;
+      }
+      const customer = await http.request(secretKey, { method: "POST", path: "/customers", form: customerForm });
+      const customerId = typeof customer.id === "string" ? customer.id : "";
+      if (!customerId) {
+        throw new Error("stripeTestClockActor: Stripe did not return a customer id.");
+      }
+      const subscription = await http.request(secretKey, {
+        method: "POST",
+        path: "/subscriptions",
+        form: { customer: customerId, "items[0][price]": priceId },
+      });
+      const subscriptionId = typeof subscription.id === "string" ? subscription.id : "";
+      if (!subscriptionId) {
+        throw new Error("stripeTestClockActor: Stripe did not return a subscription id.");
+      }
+      return { customerId, subscriptionId };
+    },
+    async advance({ secretKey, testClockId, toUnix }) {
+      await http.request(secretKey, {
+        method: "POST",
+        path: `/test_helpers/test_clocks/${testClockId}/advance`,
+        form: { frozen_time: String(toUnix) },
+      });
+      // The renewal invoice is created by the advance; the caller correlates it
+      // from the server's processed webhook. Stripe's advance response does not
+      // inline the invoice id, so we surface a best-effort marker the scenario
+      // reconciles against the candidate Server's invoice record.
+      return { invoiceId: `advance:${testClockId}:${toUnix}` };
+    },
+    async deleteClock({ secretKey, testClockId }) {
+      // Stripe's real contract is DELETE /v1/test_helpers/test_clocks/{id}
+      // (NOT a POST .../delete). Deleting the clock cascades its customers/
+      // subscriptions. Idempotent: a missing clock is a clean release.
+      try {
+        await http.request(secretKey, { method: "DELETE", path: `/test_helpers/test_clocks/${testClockId}` });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!/No such test clock|resource_missing/i.test(message)) {
+          throw error;
+        }
+      }
+    },
+    async deleteCustomer({ secretKey, customerId }) {
+      // DELETE /v1/customers/{id}. Idempotent: if the clock delete already
+      // cascaded this customer away, Stripe answers resource_missing.
+      try {
+        await http.request(secretKey, { method: "DELETE", path: `/customers/${customerId}` });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!/No such customer|resource_missing/i.test(message)) {
+          throw error;
+        }
+      }
+    },
+    async findTestClockByName({ secretKey, name }) {
+      // Cursor-paginated list (GET /v1/test_helpers/test_clocks): follow
+      // has_more/starting_after until the run-owned clock is found or the
+      // collection is exhausted. "Not on the first page" is NOT "not found".
+      let startingAfter: string | undefined;
+      for (;;) {
+        const q = startingAfter ? `&starting_after=${startingAfter}` : "";
+        const page = await http.request(secretKey, {
+          method: "GET",
+          path: `/test_helpers/test_clocks?limit=100${q}`,
+        });
+        const data = Array.isArray(page.data) ? (page.data as Array<Record<string, unknown>>) : [];
+        const match = data.find((c) => c.name === name && typeof c.id === "string");
+        if (match) {
+          return { testClockId: match.id as string };
+        }
+        if (page.has_more === true && data.length > 0) {
+          const last = data[data.length - 1];
+          startingAfter = typeof last.id === "string" ? last.id : undefined;
+          if (startingAfter) {
+            continue;
+          }
+        }
+        return null; // exhausted without a match.
+      }
+    },
+    async findCustomerOnClock({ secretKey, testClockId, runTag }) {
+      // Strongly-consistent, clock-SCOPED cursor-paginated LIST
+      // (GET /v1/customers?test_clock=<id>) — never Search (read-after-write
+      // lagged). Filter the run-owned customer by the run-tag metadata.
+      let startingAfter: string | undefined;
+      for (;;) {
+        const q = startingAfter ? `&starting_after=${startingAfter}` : "";
+        const page = await http.request(secretKey, {
+          method: "GET",
+          path: `/customers?test_clock=${testClockId}&limit=100${q}`,
+        });
+        const data = Array.isArray(page.data) ? (page.data as Array<Record<string, unknown>>) : [];
+        const match = data.find(
+          (c) =>
+            typeof c.id === "string" &&
+            typeof c.metadata === "object" &&
+            c.metadata !== null &&
+            (c.metadata as Record<string, unknown>).proliferate_qualification_run === runTag,
+        );
+        if (match) {
+          return { customerId: match.id as string };
+        }
+        if (page.has_more === true && data.length > 0) {
+          const last = data[data.length - 1];
+          startingAfter = typeof last.id === "string" ? last.id : undefined;
+          if (startingAfter) {
+            continue;
+          }
+        }
+        return null;
+      }
+    },
+  };
+}
+
+export const defaultStripeTestClockTransport: StripeTestClockTransport = createDefaultStripeTestClockTransport();
+
+// ---------------------------------------------------------------------------
+// Default billing-subject bind seam — on-box product store functions
+// ---------------------------------------------------------------------------
+
+const RESOLVE_BILLING_SUBJECT_PY = `import asyncio, json, os
+from uuid import UUID
+from proliferate.db.engine import async_session_factory
+from proliferate.db.store.billing_subjects import (
+    ensure_personal_billing_subject,
+    ensure_organization_billing_subject,
+)
+
+OWNER_SCOPE = os.environ["SEED_OWNER_SCOPE"]
+
+
+async def main():
+    async with async_session_factory() as db:
+        if OWNER_SCOPE == "organization":
+            subject = await ensure_organization_billing_subject(db, UUID(os.environ["SEED_ORG_ID"]))
+        else:
+            subject = await ensure_personal_billing_subject(db, UUID(os.environ["SEED_USER_ID"]))
+        await db.commit()
+        print(json.dumps({"billing_subject_id": str(subject.id)}))
+
+
+asyncio.run(main())
+`;
+
+const BIND_STRIPE_CUSTOMER_PY = `import asyncio, json, os
+from uuid import UUID
+from proliferate.db.engine import async_session_factory
+from proliferate.db.store.billing_subjects import set_billing_subject_stripe_customer
+
+
+async def main():
+    async with async_session_factory() as db:
+        await set_billing_subject_stripe_customer(
+            db,
+            billing_subject_id=UUID(os.environ["SEED_BILLING_SUBJECT_ID"]),
+            stripe_customer_id=os.environ["SEED_CUSTOMER_ID"],
+        )
+        await db.commit()
+    print(json.dumps({"bound": True}))
+
+
+asyncio.run(main())
+`;
+
+/**
+ * Default bind seam: runs the product's own billing-subject store functions on
+ * the candidate box. Throws if the world exposes no box-exec seam (the binding
+ * is a DB write there is no public endpoint for).
+ */
+export const defaultBillingSubjectBindSeam: BillingSubjectBindSeam = {
+  async resolveBillingSubjectId(world, params) {
+    if (!world.box) {
+      throw new Error(
+        "stripeTestClockActor: the managed-cloud world exposes no box-exec seam; resolving the actor's billing " +
+          "subject must run the product's own store functions on the candidate box.",
+      );
+    }
+    const env: Record<string, string> = {
+      SEED_OWNER_SCOPE: params.ownerScope,
+      SEED_USER_ID: params.userId,
+    };
+    if (params.organizationId) {
+      env.SEED_ORG_ID = params.organizationId;
+    }
+    const result = await world.box.serverPython(RESOLVE_BILLING_SUBJECT_PY, {
+      env,
+      scriptName: "resolve-billing-subject.py",
+    });
+    const parsed = parseLastJsonLine(result.stdout) as { billing_subject_id?: unknown };
+    if (typeof parsed.billing_subject_id !== "string" || !parsed.billing_subject_id) {
+      throw new Error(
+        `stripeTestClockActor: the candidate box did not report a billing subject id ` +
+          `(stdout: ${result.stdout.trim().slice(0, 200)}).`,
+      );
+    }
+    return { billingSubjectId: parsed.billing_subject_id };
+  },
+  async bindStripeCustomer(world, params) {
+    if (!world.box) {
+      throw new Error(
+        "stripeTestClockActor: the managed-cloud world exposes no box-exec seam; binding the Stripe customer must " +
+          "run the product's own store function on the candidate box.",
+      );
+    }
+    const result = await world.box.serverPython(BIND_STRIPE_CUSTOMER_PY, {
+      env: { SEED_BILLING_SUBJECT_ID: params.billingSubjectId, SEED_CUSTOMER_ID: params.customerId },
+      scriptName: "bind-stripe-customer.py",
+    });
+    const parsed = parseLastJsonLine(result.stdout) as { bound?: unknown };
+    if (parsed.bound !== true) {
+      throw new Error(
+        `stripeTestClockActor: the candidate box did not confirm the Stripe customer binding ` +
+          `(stdout: ${result.stdout.trim().slice(0, 200)}).`,
+      );
+    }
+  },
+};

--- a/tests/release/src/worlds/local-workspace/cleanup-ledger.ts
+++ b/tests/release/src/worlds/local-workspace/cleanup-ledger.ts
@@ -55,7 +55,26 @@ export type CleanupResourceKind =
   // reverse-order-reconcile; see worlds/managed-cloud/cleanup-kinds.ts for the
   // cloud evidence-category mapping and cleanup stack. ──────────────────────
   | "e2b_template"
-  | "e2b_sandbox";
+  | "e2b_sandbox"
+  // ── Appended for PR 6 (managed-cloud shared fixture layer). Registered-
+  // before-create, reverse-order-reconcile; released by the same cloud cleanup
+  // stack (worlds/managed-cloud/cleanup-kinds.ts). None of these fire unless a
+  // PR-6 fixture (billingThreshold / callback relay / Stripe test clock) or the
+  // append-only relay/Stripe deploy options are actually used, so a run that
+  // touches none of them registers none of them and stays byte-identical. ────
+  //   - billing_fixture_adjustment: the run-tagged BillingGrant/LlmCreditGrant
+  //     the billingThreshold fixture writes on the candidate box; released by
+  //     expiring/deleting it by its UNIQUE source_ref.
+  //   - callback_relay_spool / callback_relay_process: the on-box signed-
+  //     callback relay's spool directory and its single-file http process;
+  //     released by clearing the spool and stopping the process.
+  //   - stripe_test_clock / stripe_customer: the Stripe TEST-mode test clock and
+  //     the customer created on it (deleting the clock cascades its customers).
+  | "billing_fixture_adjustment"
+  | "callback_relay_spool"
+  | "callback_relay_process"
+  | "stripe_test_clock"
+  | "stripe_customer";
 
 export type CleanupPhase = "intent" | "acquired" | "reconciled";
 

--- a/tests/release/src/worlds/managed-cloud/callback-relay-agent.test.ts
+++ b/tests/release/src/worlds/managed-cloud/callback-relay-agent.test.ts
@@ -1,0 +1,390 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createServer, request, type IncomingMessage, type Server } from "node:http";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { CALLBACK_RELAY_SCRIPT } from "./callback-relay-agent.js";
+
+/**
+ * Focused EXECUTION tests for the on-box signed-callback relay: they run the
+ * ACTUAL relay Python script locally against a tiny stub upstream http server on
+ * loopback (offline; no box, no network egress). They cover the correctness
+ * properties the TypeScript transport fakes cannot exercise: hold-buffering,
+ * byte-identical forward (sha256), atomic mode change, one-shot replay, terminal
+ * state, and non-2xx propagation.
+ *
+ * Skipped cleanly (with a visible reason) only when python3 is absent.
+ */
+
+const PYTHON3_AVAILABLE = (() => {
+  try {
+    return spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+})();
+
+const skip = PYTHON3_AVAILABLE ? undefined : { skip: "python3 not available on this host" };
+
+/** A stub upstream that records every received request (path, headers, exact body) and answers a scripted status. */
+interface StubUpstream {
+  server: Server;
+  port: number;
+  received: Array<{ path: string; headers: IncomingMessage["headers"]; body: Buffer }>;
+  setStatus(status: number): void;
+  close(): Promise<void>;
+}
+
+async function startStubUpstream(): Promise<StubUpstream> {
+  const received: StubUpstream["received"] = [];
+  let status = 200;
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      received.push({ path: req.url ?? "", headers: req.headers, body: Buffer.concat(chunks) });
+      res.writeHead(status);
+      res.end("ok");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    server,
+    port,
+    received,
+    setStatus(next) {
+      status = next;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+async function writeRelayScript(dir: string): Promise<string> {
+  const scriptPath = path.join(dir, "relay.py");
+  await writeFile(scriptPath, CALLBACK_RELAY_SCRIPT, { mode: 0o755 });
+  return scriptPath;
+}
+
+function relayEnv(spoolDir: string, upstreamPort: number, servePort?: number): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    RELAY_SPOOL_DIR: spoolDir,
+    RELAY_UPSTREAM: `http://127.0.0.1:${upstreamPort}`,
+    ...(servePort ? { RELAY_PORT: String(servePort) } : {}),
+  };
+}
+
+/**
+ * Runs a one-shot relay action (set-mode/replay/replay-held); returns exit code
+ * + stderr. Uses async `spawn` (NOT spawnSync) so the in-process stub upstream's
+ * event loop keeps running while a replay action connects to it — spawnSync
+ * would block Node's loop and the replay's forward would hang.
+ */
+function runRelayAction(
+  scriptPath: string,
+  spoolDir: string,
+  upstreamPort: number,
+  args: string[],
+): Promise<{ status: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("python3", [scriptPath, ...args], { env: relayEnv(spoolDir, upstreamPort) });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+    child.on("error", reject);
+    child.on("exit", (status) => resolve({ status, stderr }));
+  });
+}
+
+async function pollRelayHealth(port: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const ok = await new Promise<boolean>((resolve) => {
+      const req = request(
+        { host: "127.0.0.1", port, path: "/__relay/health", method: "GET", timeout: 500 },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode === 200);
+        },
+      );
+      req.on("error", () => resolve(false));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.end();
+    });
+    if (ok) return;
+    if (Date.now() >= deadline) throw new Error("relay never became healthy");
+    await delay(100);
+  }
+}
+
+/** POST bytes to the running relay on `path`; resolves with the relay's status + body. */
+function postToRelay(
+  port: number,
+  urlPath: string,
+  body: Buffer,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: urlPath,
+        method: "POST",
+        headers: { "Content-Length": String(body.length), ...headers },
+        timeout: 5_000,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }));
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy(new Error("relay POST timeout"));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+async function startServe(
+  scriptPath: string,
+  spoolDir: string,
+  upstreamPort: number,
+): Promise<{ child: ChildProcess; port: number }> {
+  // Bind a fixed ephemeral port chosen by asking the OS via a throwaway server.
+  const probe = createServer();
+  const port: number = await new Promise((resolve) =>
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      const p = typeof address === "object" && address ? address.port : 0;
+      probe.close(() => resolve(p));
+    }),
+  );
+  const child = spawn("python3", [scriptPath, "serve"], {
+    env: relayEnv(spoolDir, upstreamPort, port),
+    stdio: "ignore",
+  });
+  await pollRelayHealth(port);
+  return { child, port };
+}
+
+async function withSpool<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "relay-exec-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("relay: /__relay/health answers 200 and is never forwarded upstream", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    const { child, port } = await startServe(scriptPath, dir, upstream.port);
+    try {
+      await pollRelayHealth(port);
+      assert.equal(upstream.received.length, 0, "health probe must not reach upstream");
+    } finally {
+      child.kill();
+      await upstream.close();
+    }
+  });
+});
+
+test("relay: pass-through forwards byte-identically (sha256 of the exact bytes matches upstream)", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    const { child, port } = await startServe(scriptPath, dir, upstream.port);
+    try {
+      const body = Buffer.from(JSON.stringify({ id: "evt_1", nested: { x: [1, 2, 3] } }));
+      const sig = "t=123,v1=deadbeef";
+      const res = await postToRelay(port, "/v1/billing/webhooks/stripe", body, { "Stripe-Signature": sig });
+      assert.equal(res.status, 200);
+      assert.equal(upstream.received.length, 1);
+      const forwarded = upstream.received[0];
+      // Byte-identical body.
+      assert.equal(
+        createHash("sha256").update(forwarded.body).digest("hex"),
+        createHash("sha256").update(body).digest("hex"),
+      );
+      // The signed header rode untouched.
+      assert.equal(forwarded.headers["stripe-signature"], sig);
+    } finally {
+      child.kill();
+      await upstream.close();
+    }
+  });
+});
+
+test("relay: hold buffers (2xx ack, NOT forwarded); one-shot replay forwards exactly once, byte-identical", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    const { child, port } = await startServe(scriptPath, dir, upstream.port);
+    try {
+      // Atomic mode change to hold.
+      const setMode = await runRelayAction(scriptPath, dir, upstream.port, ["set-mode", "stripe", "hold"]);
+      assert.equal(setMode.status, 0);
+
+      const body = Buffer.from(JSON.stringify({ id: "evt_hold" }));
+      const held = await postToRelay(port, "/v1/billing/webhooks/stripe", body, { "Stripe-Signature": "sig-h" });
+      assert.equal(held.status, 200); // ack
+      assert.equal(upstream.received.length, 0, "a held delivery must NOT be forwarded");
+
+      // The manifest records the held delivery; recover its id.
+      const manifest = await readFile(path.join(dir, "manifest.jsonl"), "utf8");
+      const heldRow = manifest
+        .trim()
+        .split("\n")
+        .map((l) => JSON.parse(l))
+        .find((r) => r.state === "held");
+      assert.ok(heldRow, "a held row must be recorded");
+
+      // replay-held forwards it once, byte-identically with the signed header.
+      const replay = await runRelayAction(scriptPath, dir, upstream.port, ["replay-held", "stripe"]);
+      assert.equal(replay.status, 0, replay.stderr);
+      assert.equal(upstream.received.length, 1);
+      assert.equal(upstream.received[0].headers["stripe-signature"], "sig-h");
+      assert.equal(
+        createHash("sha256").update(upstream.received[0].body).digest("hex"),
+        createHash("sha256").update(body).digest("hex"),
+      );
+
+      // Terminal state: a SECOND replay-held must NOT re-forward it.
+      const replayAgain = await runRelayAction(scriptPath, dir, upstream.port, ["replay-held", "stripe"]);
+      assert.equal(replayAgain.status, 0, replayAgain.stderr);
+      assert.equal(upstream.received.length, 1, "replay-held must be one-shot (terminal state)");
+    } finally {
+      child.kill();
+      await upstream.close();
+    }
+  });
+});
+
+test("relay: a corrupt control file fails CLOSED (treated as hold, delivery buffered not forwarded)", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    const { child, port } = await startServe(scriptPath, dir, upstream.port);
+    try {
+      // A present-but-corrupt control file: unknown state during a possible hold.
+      await writeFile(path.join(dir, "control-stripe.json"), "{ this is not json");
+      const body = Buffer.from(JSON.stringify({ id: "evt_corrupt" }));
+      const res = await postToRelay(port, "/v1/billing/webhooks/stripe", body);
+      assert.equal(res.status, 200); // ack (buffered)
+      assert.equal(upstream.received.length, 0, "a corrupt control file must fail closed (buffer, never forward)");
+    } finally {
+      child.kill();
+      await upstream.close();
+    }
+  });
+});
+
+test("relay: a non-2xx replay stays RETRYABLE (held), exits nonzero; a later replay after recovery succeeds and terminalizes", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    const { child, port } = await startServe(scriptPath, dir, upstream.port);
+    try {
+      await runRelayAction(scriptPath, dir, upstream.port, ["set-mode", "e2b", "hold"]);
+      const body = Buffer.from(JSON.stringify({ id: "evt_500" }));
+      await postToRelay(port, "/v1/cloud/webhooks/e2b", body);
+      assert.equal(upstream.received.length, 0);
+
+      // First replay: upstream 500 → nonzero exit, delivery LEFT in held (the
+      // provider was already ack'd and will not resend, so it must remain
+      // retryable — not terminalized).
+      upstream.setStatus(500);
+      const failed = await runRelayAction(scriptPath, dir, upstream.port, ["replay-held", "e2b"]);
+      assert.notEqual(failed.status, 0, "a non-2xx replay must propagate a nonzero exit");
+      assert.equal(upstream.received.length, 1);
+      const manifestAfterFail = await readFile(path.join(dir, "manifest.jsonl"), "utf8");
+      assert.match(manifestAfterFail, /"state": "replay_failed:500"/);
+      assert.doesNotMatch(manifestAfterFail, /"state": "replayed:/, "must NOT terminalize on a non-2xx");
+      // Still in held (retryable), with a last_status sidecar recorded.
+      const { readdir } = await import("node:fs/promises");
+      const heldFiles = await readdir(path.join(dir, "held"));
+      assert.ok(heldFiles.some((n) => n.endsWith(".meta.json")), "delivery must remain held/retryable");
+      assert.ok(heldFiles.some((n) => n.endsWith(".last_status.json")), "last_status sidecar recorded");
+
+      // Upstream recovers: a subsequent replay-held succeeds and THEN terminalizes.
+      upstream.setStatus(200);
+      const ok = await runRelayAction(scriptPath, dir, upstream.port, ["replay-held", "e2b"]);
+      assert.equal(ok.status, 0, ok.stderr);
+      assert.equal(upstream.received.length, 2, "the recovered replay re-forwarded the retryable delivery");
+      const manifestAfterOk = await readFile(path.join(dir, "manifest.jsonl"), "utf8");
+      assert.match(manifestAfterOk, /"state": "replayed:200"/);
+      // Terminal now: a further replay-held is a no-op.
+      const noop = await runRelayAction(scriptPath, dir, upstream.port, ["replay-held", "e2b"]);
+      assert.equal(noop.status, 0);
+      assert.equal(upstream.received.length, 2, "a terminalized delivery is never re-selected");
+    } finally {
+      child.kill();
+      await upstream.close();
+    }
+  });
+});
+
+test("relay: set-mode writes are atomic (no leftover tmp file, control file parses)", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    try {
+      const r = await runRelayAction(scriptPath, dir, upstream.port, ["set-mode", "stripe", "hold"]);
+      assert.equal(r.status, 0);
+      const control = JSON.parse(await readFile(path.join(dir, "control-stripe.json"), "utf8"));
+      assert.equal(control.mode, "hold");
+      const { readdir } = await import("node:fs/promises");
+      const leftover = (await readdir(dir)).filter((n) => n.includes(".tmp-"));
+      assert.deepEqual(leftover, [], "no tmp file should linger after an atomic rename");
+    } finally {
+      await upstream.close();
+    }
+  });
+});
+
+test("relay: spool dirs are 0700 and every delivery/control/manifest file is 0600 (signature material is owner-only)", skip ?? {}, async () => {
+  await withSpool(async (dir) => {
+    const upstream = await startStubUpstream();
+    const scriptPath = await writeRelayScript(dir);
+    const { child, port } = await startServe(scriptPath, dir, upstream.port);
+    try {
+      await runRelayAction(scriptPath, dir, upstream.port, ["set-mode", "stripe", "hold"]);
+      const body = Buffer.from(JSON.stringify({ id: "evt_perm" }));
+      await postToRelay(port, "/v1/billing/webhooks/stripe", body, { "Stripe-Signature": "sig-perm" });
+
+      const { stat, readdir } = await import("node:fs/promises");
+      const mode = (p: string) => stat(p).then((s) => s.mode & 0o777);
+
+      // Dirs 0700.
+      assert.equal(await mode(path.join(dir, "held")), 0o700);
+      assert.equal(await mode(path.join(dir, "replayed")), 0o700);
+      // Control + manifest 0600.
+      assert.equal(await mode(path.join(dir, "control-stripe.json")), 0o600);
+      assert.equal(await mode(path.join(dir, "manifest.jsonl")), 0o600);
+      // Every held delivery file (bin/headers/meta — the signed material) is 0600.
+      const heldDir = path.join(dir, "held");
+      for (const name of await readdir(heldDir)) {
+        assert.equal(await mode(path.join(heldDir, name)), 0o600, `held/${name} must be 0600`);
+      }
+    } finally {
+      child.kill();
+      await upstream.close();
+    }
+  });
+});

--- a/tests/release/src/worlds/managed-cloud/callback-relay-agent.ts
+++ b/tests/release/src/worlds/managed-cloud/callback-relay-agent.ts
@@ -1,0 +1,418 @@
+/**
+ * The on-box signed-callback relay's data plane (PR 6 fixture 2). Fronting the
+ * candidate Server's two signed webhook endpoints —
+ * `/v1/billing/webhooks/stripe` (HMAC over the exact raw bytes, Stripe-Signature
+ * header) and `/v1/cloud/webhooks/e2b` (E2B signature over the raw bytes) — is a
+ * single-file Python http process that must forward BYTE-IDENTICALLY: it never
+ * re-encodes, re-orders headers, or re-signs, because any mutation of the body
+ * or the signed headers breaks the signature the Server verifies. It has NO
+ * emit/synthesize capability by construction (there is no code path that
+ * fabricates a delivery); it can only spool a genuine delivery and re-POST those
+ * exact bytes, so the fixture cannot manufacture a webhook the provider never
+ * sent. The Server's own `webhook_receipts` idempotency proves exactly-once
+ * across a hold→replay, so the relay never dedupes.
+ *
+ * Two per-channel modes, switched via a control file the controller writes over
+ * SSH:
+ *   - `pass-through` (default): forward the delivery to the upstream Server
+ *     verbatim and return the upstream response — behaviourally invisible.
+ *   - `hold`: spool the verbatim bytes+headers keyed by a generated deliveryId,
+ *     ack the provider 2xx immediately, and forward only on an explicit replay.
+ *
+ * The long-running process is `relay.py serve`; the controller drives one-shot
+ * actions (`set-mode`, `replay`, `replay-held`) as separate short invocations
+ * over the same box, so no in-process control socket or watcher thread is
+ * needed. Every manifest row is bounded and secret-free (a deliveryId, the
+ * channel, an optional provider event id, the sha256 of the exact bytes, a
+ * timestamp, and the state) — never a raw body or signature; `bytesSha256`
+ * proves byte-identity across hold→replay.
+ *
+ * This module is data-plane only: it exports the script text, the fixed webhook
+ * paths/channel map, and the on-box filename conventions. `ingress.ts` stages
+ * and starts the process and wires the Caddy routes; `fixtures/callback-relay.ts`
+ * is the controller. Neither the script nor this module ever reads a webhook
+ * signing secret — the relay forwards the signed bytes untouched, so the Server
+ * (which holds the secret) is the only verifier.
+ *
+ * Correctness properties enforced by the script (see the focused execution tests
+ * in callback-relay-agent.test.ts):
+ *   - a loopback `GET /__relay/health` (never forwarded) so ingress can prove the
+ *     relay is live BEFORE Caddy routes signed callbacks through it;
+ *   - ATOMIC control-file writes (tmp+rename) and FAIL-CLOSED reads: a control
+ *     file that exists but is unreadable/corrupt is treated as `hold` (buffer,
+ *     never forward), so a callback during hold activation can never bypass it;
+ *   - TERMINAL delivery state: replay renames the spool files out of the held dir
+ *     (atomic), and replay-held enumerates the held dir (not the append-only
+ *     manifest), so a delivery is replayed exactly once and never re-selected;
+ *   - NON-2xx PROPAGATION: a replay whose upstream returns non-2xx exits nonzero
+ *     (and replay-held aggregates failures), so the controller surfaces the loss
+ *     instead of silently reopening pass-through.
+ */
+
+/** The signed webhook channels the relay fronts. */
+export type RelayChannel = "stripe" | "e2b";
+
+/** Per-channel relay mode (pass-through is the default, behaviourally invisible). */
+export type RelayMode = "pass-through" | "hold";
+
+/**
+ * The candidate Server's two signed webhook request paths, in the order Caddy
+ * matches them. These are prefix-relative to the deployment origin (the
+ * candidate Server mounts its routers at `/v1/...` with no api prefix, matching
+ * `deployCandidateApi`'s local-prefix posture).
+ */
+export const RELAY_CHANNEL_PATHS: Readonly<Record<RelayChannel, string>> = {
+  stripe: "/v1/billing/webhooks/stripe",
+  e2b: "/v1/cloud/webhooks/e2b",
+};
+
+/** The two webhook paths Caddy routes through the relay (only when the option is present). */
+export const RELAY_WEBHOOK_PATHS: readonly string[] = [
+  RELAY_CHANNEL_PATHS.stripe,
+  RELAY_CHANNEL_PATHS.e2b,
+];
+
+/** The relay's on-box filename conventions (all relative to the run-scoped spool dir). */
+export const RELAY_SCRIPT_FILENAME = "relay.py";
+/** JSON-lines manifest the controller reads (one bounded, secret-free row per delivery). */
+export const RELAY_MANIFEST_FILENAME = "manifest.jsonl";
+/** Per-channel control file: `{"mode":"hold"|"pass-through"}`. */
+export function relayControlFilename(channel: RelayChannel): string {
+  return `control-${channel}.json`;
+}
+
+/** Default loopback port the relay http process binds on the box. */
+export const DEFAULT_RELAY_LISTEN_PORT = 8899;
+/** Default relay dir basename under the candidate box's remote workdir. */
+export const RELAY_DIRNAME = "callback-relay";
+/** Loopback readiness endpoint (never forwarded upstream); ingress polls it for 200 before routing Caddy. */
+export const RELAY_HEALTH_PATH = "/__relay/health";
+
+/**
+ * The single-file relay process (stdlib only; no third-party deps on the box).
+ *
+ * `serve`             — run the forwarding http server on RELAY_PORT.
+ * `set-mode C M`      — write channel C's control file to mode M.
+ * `replay ID`         — re-POST the spooled bytes for deliveryId ID, verbatim.
+ * `replay-held C`     — re-POST every still-held delivery for channel C, verbatim.
+ *
+ * Byte-identity guarantees, enforced structurally by this script:
+ *   - the request body is read as exact bytes (Content-Length) and forwarded /
+ *     spooled unchanged; replay reads the spooled bytes back and POSTs them as-is;
+ *   - every request header except `Host` (which the http client sets per
+ *     connection) is copied verbatim, so the provider signature header rides
+ *     untouched;
+ *   - there is NO method that constructs a body or a signature — only forward
+ *     and replay of captured bytes exist.
+ */
+export const CALLBACK_RELAY_SCRIPT = `#!/usr/bin/env python3
+"""On-box signed-callback relay (qualification fixture; forwards byte-identically)."""
+import hashlib
+import json
+import os
+import sys
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib import request as urlrequest
+from urllib.error import HTTPError, URLError
+
+# Signed callback bodies + header sidecars are replay-capable credential
+# material, so nothing this process writes may be group/other-readable. Set a
+# restrictive umask at startup (belt); every dir is created 0700 and every file
+# opened 0600 (suspenders).
+os.umask(0o077)
+
+SPOOL_DIR = os.environ["RELAY_SPOOL_DIR"]
+UPSTREAM = os.environ.get("RELAY_UPSTREAM", "http://127.0.0.1:8000")
+PORT = int(os.environ.get("RELAY_PORT", "8899"))
+HELD_DIR = os.path.join(SPOOL_DIR, "held")
+REPLAYED_DIR = os.path.join(SPOOL_DIR, "replayed")
+MANIFEST = os.path.join(SPOOL_DIR, "manifest.jsonl")
+HEALTH_PATH = "/__relay/health"
+
+CHANNEL_PATHS = {
+    "stripe": "/v1/billing/webhooks/stripe",
+    "e2b": "/v1/cloud/webhooks/e2b",
+}
+PATH_CHANNELS = {path: channel for channel, path in CHANNEL_PATHS.items()}
+
+# The relay NEVER re-signs and NEVER synthesizes: only forward and replay of
+# captured bytes exist. The Host header is the sole header the http client owns
+# per connection; every other header (including the provider signature) is
+# copied verbatim so the signed bytes+headers reach the Server unchanged.
+_SKIP_FORWARD_HEADERS = {"host"}
+
+
+def _ensure_dirs():
+    # Owner-only spool dirs (0700), enforced with an explicit chmod (makedirs mode
+    # is masked by umask, and an existing dir keeps its mode without one).
+    for d in (SPOOL_DIR, HELD_DIR, REPLAYED_DIR):
+        os.makedirs(d, mode=0o700, exist_ok=True)
+        os.chmod(d, 0o700)
+
+
+def _write_bytes_0600(path, data):
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+
+
+def _write_text_0600(path, text):
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(text)
+
+
+def _control_path(channel):
+    return os.path.join(SPOOL_DIR, "control-%s.json" % channel)
+
+
+def _mode_for(channel):
+    # FAIL-CLOSED during hold: a control file that does NOT exist means the
+    # channel was never put into hold (default pass-through). But a control file
+    # that DOES exist yet is unreadable/unparseable is an UNKNOWN state that may
+    # be an in-flight hold — buffer it, never forward. We cannot silently
+    # pass-through an unknown state or a callback could bypass a configured hold.
+    path = _control_path(channel)
+    if not os.path.exists(path):
+        return "pass-through"
+    try:
+        with open(path, "r") as handle:
+            data = json.load(handle)
+        mode = (data or {}).get("mode", "pass-through")
+        return mode if mode in ("hold", "pass-through") else "hold"
+    except (OSError, ValueError):
+        # Control file present but unreadable/corrupt → fail closed (hold).
+        return "hold"
+
+
+def _atomic_write_json(path, obj):
+    # tmp + rename (0600) so a reader never sees a half-written control file (the
+    # race a non-atomic overwrite would open during hold activation).
+    tmp = path + ".tmp-" + uuid.uuid4().hex
+    _write_text_0600(tmp, json.dumps(obj))
+    os.replace(tmp, path)
+
+
+def _provider_event_id(channel, body):
+    # Best-effort: the provider event id is a bounded, non-secret identifier
+    # (Stripe evt_…, E2B event id). Only the id is ever extracted; the raw body
+    # is never recorded in the manifest.
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    candidate = parsed.get("id") or parsed.get("event_id")
+    return candidate if isinstance(candidate, str) else None
+
+
+def _append_manifest(row):
+    # Open 0600 (only affects a first create; subsequent appends keep the mode).
+    fd = os.open(MANIFEST, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    with os.fdopen(fd, "a") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\\n")
+
+
+def _forward(method, path, headers, body):
+    fwd = urlrequest.Request(UPSTREAM + path, data=body, method=method)
+    for name, value in headers:
+        if name.lower() in _SKIP_FORWARD_HEADERS:
+            continue
+        fwd.add_header(name, value)
+    try:
+        with urlrequest.urlopen(fwd, timeout=30) as resp:
+            return resp.status, resp.read()
+    except HTTPError as err:
+        return err.code, err.read()
+    except URLError as err:
+        return 502, ("relay upstream error: %s" % err).encode("utf-8")
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args):
+        pass
+
+    def _respond(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        # Loopback readiness probe (ingress waits for 200 before routing Caddy
+        # through the relay). Never forwarded upstream.
+        if self.path == HEALTH_PATH:
+            self._respond(200, b'{"relay":"ok"}')
+            return
+        self._respond(404, b'{"relay":"not-found"}')
+
+    def do_POST(self):
+        channel = PATH_CHANNELS.get(self.path)
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length) if length else b""
+        if channel is None:
+            # Unmatched path: forward verbatim so the relay is transparent to
+            # anything Caddy routed here by mistake.
+            status, resp = _forward("POST", self.path, self.headers.items(), body)
+            self._respond(status, resp)
+            return
+        delivery_id = uuid.uuid4().hex
+        digest = hashlib.sha256(body).hexdigest()
+        provider_event_id = _provider_event_id(channel, body)
+        mode = _mode_for(channel)
+        if mode == "hold":
+            # Spool the verbatim bytes + headers under a per-delivery pair, then
+            # record the channel/path in a sidecar so replay never has to scan
+            # the manifest to recover them (which the terminal-state rename could
+            # otherwise race). All three land BEFORE the 2xx ack.
+            _write_bytes_0600(os.path.join(HELD_DIR, delivery_id + ".bin"), body)
+            _write_text_0600(
+                os.path.join(HELD_DIR, delivery_id + ".headers.json"),
+                json.dumps([[k, v] for k, v in self.headers.items()]),
+            )
+            _write_text_0600(
+                os.path.join(HELD_DIR, delivery_id + ".meta.json"),
+                json.dumps({"channel": channel, "path": self.path}),
+            )
+            _append_manifest({
+                "deliveryId": delivery_id,
+                "channel": channel,
+                "providerEventId": provider_event_id,
+                "bytesSha256": digest,
+                "receivedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "state": "held",
+            })
+            # Ack the provider 2xx so it does not retry while the delivery is held.
+            self._respond(200, b'{"relay":"held"}')
+            return
+        status, resp = _forward("POST", self.path, self.headers.items(), body)
+        _append_manifest({
+            "deliveryId": delivery_id,
+            "channel": channel,
+            "providerEventId": provider_event_id,
+            "bytesSha256": digest,
+            "receivedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "state": "forwarded",
+        })
+        self._respond(status, resp)
+
+
+def _read_held(delivery_id):
+    with open(os.path.join(HELD_DIR, delivery_id + ".bin"), "rb") as handle:
+        body = handle.read()
+    with open(os.path.join(HELD_DIR, delivery_id + ".headers.json"), "r") as handle:
+        headers = json.load(handle)
+    with open(os.path.join(HELD_DIR, delivery_id + ".meta.json"), "r") as handle:
+        meta = json.load(handle)
+    return body, headers, meta
+
+
+def _mark_replayed(delivery_id):
+    # TERMINAL state via atomic rename: move the spool files out of HELD_DIR so a
+    # subsequent replay-held never re-selects an already-replayed delivery. Once
+    # the .meta.json is moved the delivery is no longer "held" by construction
+    # (_held_delivery_ids enumerates .meta.json). Also sweep the retryable
+    # last_status sidecar a prior failed attempt may have left behind.
+    for suffix in (".bin", ".headers.json", ".meta.json"):
+        src = os.path.join(HELD_DIR, delivery_id + suffix)
+        if os.path.exists(src):
+            os.replace(src, os.path.join(REPLAYED_DIR, delivery_id + suffix))
+    stale = os.path.join(HELD_DIR, delivery_id + ".last_status.json")
+    if os.path.exists(stale):
+        os.replace(stale, os.path.join(REPLAYED_DIR, delivery_id + ".last_status.json"))
+
+
+def _replay(delivery_id):
+    body, headers, meta = _read_held(delivery_id)
+    path = meta.get("path") or CHANNEL_PATHS.get(meta.get("channel"))
+    channel = meta.get("channel")
+    if path is None:
+        raise SystemExit("relay replay: unknown channel/path for delivery %s" % delivery_id)
+    status, _resp = _forward("POST", path, headers, body)
+    if 200 <= status < 300:
+        # ONLY terminalize on a 2xx: the delivery is now durably accepted, so move
+        # it out of held (atomic rename) — replay-held will never re-select it.
+        _mark_replayed(delivery_id)
+        _append_manifest({
+            "deliveryId": delivery_id,
+            "channel": channel,
+            "providerEventId": None,
+            "bytesSha256": hashlib.sha256(body).hexdigest(),
+            "receivedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "state": "replayed:%d" % status,
+        })
+        return
+    # NON-2xx: the provider was already ack'd 2xx and will not resend, so the
+    # delivery must remain RETRYABLE — leave it in HELD (do NOT terminalize),
+    # record the last status in a sidecar for diagnostics, and exit nonzero so
+    # the controller surfaces the failure (and does not reopen pass-through). A
+    # later replay after the upstream recovers will then succeed and terminalize.
+    _write_text_0600(
+        os.path.join(HELD_DIR, delivery_id + ".last_status.json"),
+        json.dumps({"last_status": status, "at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())}),
+    )
+    _append_manifest({
+        "deliveryId": delivery_id,
+        "channel": channel,
+        "providerEventId": None,
+        "bytesSha256": hashlib.sha256(body).hexdigest(),
+        "receivedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "state": "replay_failed:%d" % status,
+    })
+    raise SystemExit("relay replay: delivery %s upstream returned %d (left retryable in held)" % (delivery_id, status))
+
+
+def _held_delivery_ids(channel):
+    # Source of truth is the HELD_DIR contents (terminal rename removes replayed
+    # ones), NOT the append-only manifest — so replay-held is one-shot.
+    ids = []
+    try:
+        names = sorted(os.listdir(HELD_DIR))
+    except OSError:
+        return []
+    for name in names:
+        if not name.endswith(".meta.json"):
+            continue
+        delivery_id = name[: -len(".meta.json")]
+        try:
+            with open(os.path.join(HELD_DIR, name), "r") as handle:
+                meta = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        if meta.get("channel") == channel:
+            ids.append(delivery_id)
+    return ids
+
+
+def main():
+    _ensure_dirs()
+    if len(sys.argv) < 2 or sys.argv[1] == "serve":
+        ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+        return
+    action = sys.argv[1]
+    if action == "set-mode":
+        channel, mode = sys.argv[2], sys.argv[3]
+        _atomic_write_json(_control_path(channel), {"mode": mode})
+    elif action == "replay":
+        _replay(sys.argv[2])
+    elif action == "replay-held":
+        failures = []
+        for delivery_id in _held_delivery_ids(sys.argv[2]):
+            try:
+                _replay(delivery_id)
+            except SystemExit as exc:
+                failures.append(str(exc))
+        if failures:
+            raise SystemExit("relay replay-held: %d failure(s): %s" % (len(failures), "; ".join(failures)))
+    else:
+        raise SystemExit("relay: unknown action %r" % action)
+
+
+if __name__ == "__main__":
+    main()
+`;

--- a/tests/release/src/worlds/managed-cloud/cleanup-kinds-pr6.test.ts
+++ b/tests/release/src/worlds/managed-cloud/cleanup-kinds-pr6.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { openCleanupLedger } from "../local-workspace/cleanup-ledger.js";
+import { ManagedCloudCleanupStack } from "./cleanup-kinds.js";
+
+/**
+ * Append-only PR-6 coverage for the three new cleanup categories
+ * (billingFixtureCleared / relayStopped / stripeFixturesDeleted). Kept separate
+ * from cleanup-kinds.test.ts so the existing suite is untouched (extension
+ * contract). Proves: (a) a run that registers none of the PR-6 kinds reports all
+ * three vacuously clean (true) — byte-identical evidence to today for the
+ * regression; (b) each new category flips true only when its kinds reconcile.
+ */
+
+async function stackInTemp(): Promise<{ stack: ManagedCloudCleanupStack; runDir: string }> {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "mc-cleanup-pr6-"));
+  const ledger = await openCleanupLedger({ runDir, runId: "run-1", shardId: "shard-0" });
+  return { stack: new ManagedCloudCleanupStack({ ledger }), runDir };
+}
+
+test("a run using no PR-6 fixture reports every new category vacuously clean (true)", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    const id = await stack.register("ec2_instance", async () => undefined);
+    await stack.acquired(id, "i-1");
+    const evidence = await stack.runAll();
+    assert.equal(evidence.billingFixtureCleared, true);
+    assert.equal(evidence.relayStopped, true);
+    assert.equal(evidence.stripeFixturesDeleted, true);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("each PR-6 category flips true only when its registered kinds reconcile", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    for (const kind of [
+      "billing_fixture_adjustment",
+      "callback_relay_spool",
+      "callback_relay_process",
+      "stripe_test_clock",
+      "stripe_customer",
+    ] as const) {
+      const id = await stack.register(kind, async () => undefined);
+      await stack.acquired(id, `${kind}-id`);
+    }
+    const evidence = await stack.runAll();
+    assert.equal(evidence.failed, 0);
+    assert.equal(evidence.billingFixtureCleared, true);
+    assert.equal(evidence.relayStopped, true);
+    assert.equal(evidence.stripeFixturesDeleted, true);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("a failed relay releaser flips relayStopped false but leaves the other categories clean", async () => {
+  const { stack, runDir } = await stackInTemp();
+  try {
+    const okId = await stack.register("stripe_test_clock", async () => undefined);
+    await stack.acquired(okId, "tc-1");
+    const badId = await stack.register("callback_relay_process", async () => {
+      throw new Error("relay stop failed");
+    });
+    await stack.acquired(badId, "relay-pid");
+    const evidence = await stack.runAll();
+    assert.equal(evidence.failed, 1);
+    assert.equal(evidence.relayStopped, false);
+    assert.equal(evidence.stripeFixturesDeleted, true);
+    assert.equal(evidence.billingFixtureCleared, true); // untouched category is vacuously clean
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/worlds/managed-cloud/cleanup-kinds.ts
+++ b/tests/release/src/worlds/managed-cloud/cleanup-kinds.ts
@@ -43,6 +43,14 @@ export const MANAGED_CLOUD_CLEANUP_KINDS = [
   "secret_env_file",
   "run_directory",
   "port_registration",
+  // ── Appended for PR 6 (shared fixture layer). Only registered when a PR-6
+  // fixture / deploy option is actually used; absent otherwise (behavior with
+  // the fixtures unused is byte-identical). ────────────────────────────────
+  "billing_fixture_adjustment",
+  "callback_relay_spool",
+  "callback_relay_process",
+  "stripe_test_clock",
+  "stripe_customer",
 ] as const satisfies readonly CleanupResourceKind[];
 
 export type ManagedCloudCleanupKind = (typeof MANAGED_CLOUD_CLEANUP_KINDS)[number];
@@ -67,6 +75,20 @@ export interface ManagedCloudCleanupEvidence {
   virtualKeyDeleted: boolean;
   litellmSubjectsDeleted: boolean;
   localPathsRemoved: boolean;
+  // ── Appended for PR 6 (shared fixture layer). OPTIONAL so every existing
+  // constructor of this evidence shape (e.g. CLOUD-PROVISION-1's fake driver)
+  // stays valid unchanged — `runAll` always populates them, but a caller that
+  // fabricates a summary need not. Each category is vacuously clean (true) on a
+  // run that registers no entry of its kind(s), so a run that uses none of the
+  // PR-6 fixtures reports these `true` exactly as an untouched category always
+  // has (see `categoryClean`). CLOUD-PROVISION-1's evidence mapping ignores
+  // these fields, so the regression is unchanged. ────────────────────────────
+  /** The run-tagged billingThreshold grant adjustment was expired/deleted. */
+  billingFixtureCleared?: boolean;
+  /** The on-box signed-callback relay spool + process were cleared/stopped. */
+  relayStopped?: boolean;
+  /** The Stripe TEST-mode test clock + customer(s) were deleted. */
+  stripeFixturesDeleted?: boolean;
 }
 
 /**
@@ -85,6 +107,10 @@ export const MANAGED_CLOUD_EVIDENCE_CATEGORIES = {
   virtualKeyDeleted: ["litellm_virtual_key"],
   litellmSubjectsDeleted: ["litellm_user", "litellm_team"],
   localPathsRemoved: ["secret_env_file", "run_directory", "port_registration"],
+  // ── Appended for PR 6 (shared fixture layer). ──────────────────────────────
+  billingFixtureCleared: ["billing_fixture_adjustment"],
+  relayStopped: ["callback_relay_spool", "callback_relay_process"],
+  stripeFixturesDeleted: ["stripe_test_clock", "stripe_customer"],
 } satisfies Record<string, CleanupResourceKind[]>;
 
 /** One registered releaser plus the ledger entry that shadows it durably. */
@@ -184,6 +210,9 @@ export class ManagedCloudCleanupStack {
       virtualKeyDeleted: this.categoryClean("virtualKeyDeleted", succeeded),
       litellmSubjectsDeleted: this.categoryClean("litellmSubjectsDeleted", succeeded),
       localPathsRemoved: this.categoryClean("localPathsRemoved", succeeded),
+      billingFixtureCleared: this.categoryClean("billingFixtureCleared", succeeded),
+      relayStopped: this.categoryClean("relayStopped", succeeded),
+      stripeFixturesDeleted: this.categoryClean("stripeFixturesDeleted", succeeded),
     };
   }
 

--- a/tests/release/src/worlds/managed-cloud/ingress-pr6.test.ts
+++ b/tests/release/src/worlds/managed-cloud/ingress-pr6.test.ts
@@ -1,0 +1,358 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
+import { RELAY_CHANNEL_PATHS } from "./callback-relay-agent.js";
+import type { Ec2IngressBox, Route53Record } from "./ec2.js";
+import { deployCandidateApi, type SshExec } from "./ingress.js";
+
+/**
+ * Append-only PR-6 coverage for ingress.ts: the `stripe?` + `callbackRelay?`
+ * options. The existing ingress.test.ts proves the ABSENT-option path unchanged;
+ * this file proves (a) with both absent the Caddyfile is byte-identical to the
+ * single-proxy shape and no relay/Stripe files are staged, and (b) with them
+ * present the relay is staged + wired and the Stripe secret files ride as their
+ * own env files (never argv). Kept in a separate file so ingress.test.ts is
+ * untouched (extension contract).
+ */
+
+const SERVER_VERSION = "1.2.3";
+
+const BOX: Ec2IngressBox = {
+  instanceId: "i-0abcdef",
+  securityGroupId: "sg-abc",
+  keyName: "mcq-key",
+  keyPath: "/tmp/mcq-key.pem",
+  publicIp: "203.0.113.9",
+  sshDestination: "ubuntu@203.0.113.9",
+};
+
+const RECORD: Route53Record = {
+  recordName: "mcq-run-1-shard-0.qualification.proliferate.com",
+  hostedZoneId: "Z123",
+  address: "203.0.113.9",
+  ttl: 60,
+};
+
+interface FakeSsh {
+  ssh: SshExec;
+  runs: string[];
+  copies: Array<{ local: string; remote: string }>;
+}
+
+function fakeSsh(): FakeSsh {
+  const runs: string[] = [];
+  const copies: Array<{ local: string; remote: string }> = [];
+  const ssh: SshExec = {
+    async run(_dest, _key, command) {
+      runs.push(command);
+      if (command.includes("ingress-ready")) return { stdout: "Docker version 24.0\n", stderr: "" };
+      if (command.includes("docker load")) return { stdout: "Loaded image: candidate-server:candidate\n", stderr: "" };
+      if (command.includes("pg_isready")) return { stdout: "accepting connections\n", stderr: "" };
+      if (command.includes("test -s")) return { stdout: "present\n", stderr: "" };
+      if (command.includes("cat ") && command.includes("setup-token")) return { stdout: "TOKEN\n", stderr: "" };
+      // The relay readiness probe (`curl … /__relay/health`) answers 200 once
+      // the relay is up; the fake reports it immediately.
+      if (command.includes("__relay/health")) return { stdout: "200", stderr: "" };
+      // The relay-stop cleanup script: model "already absent" (no pidfile) as a
+      // clean stop in the offline test.
+      if (command.includes("RELAY_STOP_ABSENT")) return { stdout: "RELAY_STOP_ABSENT\n", stderr: "" };
+      return { stdout: "", stderr: "" };
+    },
+    async copyFile(_dest, _key, localPath, remotePath) {
+      copies.push({ local: localPath, remote: remotePath });
+    },
+  };
+  return { ssh, runs, copies };
+}
+
+async function harness() {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "ingress-pr6-"));
+  const secretsDir = path.join(runDir, "secrets");
+  const imagePath = path.join(runDir, "server-image.tar");
+  await writeFile(imagePath, "server-image-bytes");
+  const githubSecrets = path.join(runDir, "github.secrets.env");
+  await writeFile(githubSecrets, "GITHUB_APP_CLIENT_SECRET=cs\n", { mode: 0o600 });
+  const githubPrivateKey = path.join(runDir, "github-app-private-key.pem");
+  await writeFile(githubPrivateKey, "-----BEGIN RSA PRIVATE KEY-----\nPEM\n-----END RSA PRIVATE KEY-----\n", { mode: 0o600 });
+  const e2bSecrets = path.join(runDir, "e2b.secrets.env");
+  await writeFile(e2bSecrets, "E2B_API_KEY=e2b\n", { mode: 0o600 });
+  const stripeSecrets = path.join(runDir, "stripe.secrets.env");
+  await writeFile(stripeSecrets, "STRIPE_SECRET_KEY=sk_test_SECRET\n", { mode: 0o600 });
+  const stripeWebhookSecrets = path.join(runDir, "stripe-webhook.secrets.env");
+  await writeFile(
+    stripeWebhookSecrets,
+    "STRIPE_WEBHOOK_SECRET=whsec_SECRET\nE2B_WEBHOOK_SIGNATURE_SECRET=e2bwh_SECRET\n",
+    { mode: 0o600 },
+  );
+  const serverArtifact: MaterializedArtifact = {
+    artifact_id: "server/linux/amd64",
+    version: SERVER_VERSION,
+    sha256: "a".repeat(64),
+    path: imagePath,
+  };
+  return {
+    runDir,
+    secretsDir,
+    serverArtifact,
+    githubSecrets,
+    githubPrivateKey,
+    e2bSecrets,
+    stripeSecrets,
+    stripeWebhookSecrets,
+    setupTokenHostPath: path.join(runDir, "setup-token"),
+  };
+}
+
+function baseOptions(h: Awaited<ReturnType<typeof harness>>, ssh: SshExec) {
+  return {
+    box: BOX,
+    record: RECORD,
+    serverArtifact: h.serverArtifact,
+    litellm: { adminBaseUrl: "http://admin", publicBaseUrl: "http://public", masterKey: "sk-master" },
+    github: {
+      appSlug: "proliferate-cloud-staging",
+      appId: "1",
+      clientId: "Iv1.a",
+      installationId: "9",
+      secretsEnvFilePath: h.githubSecrets,
+      privateKeyPemPath: h.githubPrivateKey,
+    },
+    e2b: { teamId: "team", secretsEnvFilePath: h.e2bSecrets, templateName: "tmpl" },
+    publicOrigin: `https://${RECORD.recordName}`,
+    rendererOrigin: "http://127.0.0.1:41999",
+    secretsDir: h.secretsDir,
+    setupTokenHostPath: h.setupTokenHostPath,
+    ssh,
+    probeHealth: async () => ({ ok: true, version: SERVER_VERSION }),
+    timeoutMs: 10_000,
+  };
+}
+
+test("with stripe + callbackRelay ABSENT: byte-identical single-proxy Caddyfile, no relay/Stripe staged", async () => {
+  const h = await harness();
+  try {
+    const f = fakeSsh();
+    await deployCandidateApi(baseOptions(h, f.ssh));
+
+    const caddy = await readFile(path.join(h.secretsDir, "Caddyfile"), "utf8");
+    // Exactly the historical single reverse_proxy Caddyfile.
+    assert.equal(caddy, `${RECORD.recordName} {\n  reverse_proxy 127.0.0.1:8000\n}\n`);
+    // No relay process launched, no Stripe env files copied.
+    assert.ok(!f.runs.some((c) => c.includes("relay.py")));
+    assert.ok(!f.copies.some((c) => c.remote.includes("stripe")));
+    // The server env carries no Stripe checkout URLs.
+    const serverEnv = await readFile(path.join(h.secretsDir, "candidate-server.env"), "utf8");
+    assert.ok(!serverEnv.includes("STRIPE_CHECKOUT_SUCCESS_URL"));
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});
+
+test("with stripe present: Stripe secret files ride their own env files (never argv) + checkout URLs in server env", async () => {
+  const h = await harness();
+  try {
+    const f = fakeSsh();
+    await deployCandidateApi({
+      ...baseOptions(h, f.ssh),
+      stripe: {
+        secretsEnvFilePath: h.stripeSecrets,
+        webhookSecretEnvFilePath: h.stripeWebhookSecrets,
+        checkoutSuccessUrl: `https://${RECORD.recordName}/billing/success`,
+        checkoutCancelUrl: `https://${RECORD.recordName}/billing/cancel`,
+      },
+    });
+
+    // The two Stripe 0600 env files were copied up as-is.
+    assert.ok(f.copies.some((c) => c.local === h.stripeSecrets));
+    assert.ok(f.copies.some((c) => c.local === h.stripeWebhookSecrets));
+    // No secret value ever appears in a run() command (argv-equivalent).
+    for (const command of f.runs) {
+      assert.ok(!command.includes("sk_test_SECRET"), `stripe key leaked into: ${command}`);
+      assert.ok(!command.includes("whsec_SECRET"), `webhook secret leaked into: ${command}`);
+      assert.ok(!command.includes("e2bwh_SECRET"), `e2b webhook secret leaked into: ${command}`);
+    }
+    // The docker run/migration reference the Stripe env files.
+    assert.ok(f.runs.some((c) => c.includes("candidate-server") && c.includes("stripe.env") && c.includes("stripe-webhook.env")));
+    // Non-secret checkout URLs go in the server env file.
+    const serverEnv = await readFile(path.join(h.secretsDir, "candidate-server.env"), "utf8");
+    assert.match(serverEnv, /STRIPE_CHECKOUT_SUCCESS_URL=https:\/\/mcq-run-1-shard-0/);
+    assert.match(serverEnv, /STRIPE_CHECKOUT_CANCEL_URL=https:\/\/mcq-run-1-shard-0/);
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});
+
+test("with callbackRelay present: relay staged + started and the two signed webhook paths route through it", async () => {
+  const h = await harness();
+  try {
+    const f = fakeSsh();
+    await deployCandidateApi({ ...baseOptions(h, f.ssh), callbackRelay: { listenPort: 8899 } });
+
+    // The relay script was copied and the process started (pass-through default).
+    assert.ok(f.copies.some((c) => c.remote.endsWith("callback-relay/relay.py")));
+    assert.ok(f.runs.some((c) => c.includes("relay.py serve") && c.includes("RELAY_PORT=8899")));
+
+    const caddy = await readFile(path.join(h.secretsDir, "Caddyfile"), "utf8");
+    // Both signed webhook paths route to the relay port; a catch-all still
+    // proxies everything else to the Server.
+    assert.ok(caddy.includes(`handle ${RELAY_CHANNEL_PATHS.stripe} {`));
+    assert.ok(caddy.includes(`handle ${RELAY_CHANNEL_PATHS.e2b} {`));
+    assert.match(caddy, /reverse_proxy 127\.0\.0\.1:8899/);
+    assert.match(caddy, /handle \{\n\s+reverse_proxy 127\.0\.0\.1:8000/);
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});
+
+test("with callbackRelay present: PID is captured, readiness is probed, and both relay resources register cleanup BEFORE start", async () => {
+  const h = await harness();
+  try {
+    const f = fakeSsh();
+    const registered: Array<{ kind: string; providerId: string }> = [];
+    const releasers: Array<() => Promise<void>> = [];
+    await deployCandidateApi({
+      ...baseOptions(h, f.ssh),
+      callbackRelay: { listenPort: 8899 },
+      registerCleanup: async (kind, providerId, release) => {
+        registered.push({ kind, providerId });
+        releasers.push(release);
+      },
+    });
+
+    // Both relay resources registered (registered-before-create): spool + process.
+    const spoolReg = registered.find((r) => r.kind === "callback_relay_spool");
+    const procReg = registered.find((r) => r.kind === "callback_relay_process");
+    assert.ok(spoolReg);
+    assert.ok(procReg);
+    // Durable identity: the process providerId is `<box-ip>:<pidfile>` so a
+    // recovered runner can act from the ledger alone.
+    assert.match(procReg!.providerId, /^203\.0\.113\.9:.*relay\.pid$/);
+    // The spool dir is created owner-only (0700).
+    assert.ok(f.runs.some((c) => c.includes("install -d -m 700") || c.includes("chmod 700")));
+    // The registration happened BEFORE the serve command ran.
+    const serveIdx = f.runs.findIndex((c) => c.includes("relay.py serve"));
+    assert.ok(serveIdx >= 0);
+    // The start records the ownership discriminator (pid + starttime + script)
+    // into the JSON pidfile, and readiness was probed.
+    const startCmd = f.runs.find((c) => c.includes("relay.py serve"))!;
+    assert.match(startCmd, /RELAY_PID=\$!/);
+    assert.match(startCmd, /\/proc\/\$RELAY_PID\/stat/);
+    assert.match(startCmd, /"pid":%s,"starttime":"%s","script":"%s"/);
+    assert.ok(f.runs.some((c) => c.includes("__relay/health")));
+
+    // The process releaser runs the PID-reuse-safe stop script (validates
+    // starttime + cmdline before signalling, then kill + kill -0); the spool
+    // releaser rm -rf's the dir.
+    const before = f.runs.length;
+    for (const release of releasers) await release();
+    const cleanupCmds = f.runs.slice(before);
+    const stopCmd = cleanupCmds.find((c) => c.includes("kill -0") && c.includes("relay.pid"));
+    assert.ok(stopCmd, "process releaser runs the stop script");
+    assert.match(stopCmd!, /\/proc\/\$PID\/stat/); // re-checks starttime
+    assert.match(stopCmd!, /\/proc\/\$PID\/cmdline/); // re-checks cmdline
+    assert.match(stopCmd!, /RELAY_STOP_STALE_PID/); // has the reused-PID branch
+    assert.ok(cleanupCmds.some((c) => c.includes("rm -rf") && c.includes("callback-relay")));
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});
+
+test("the relay process releaser does NOT kill a REUSED PID (starttime/cmdline mismatch → stale, clean success)", async () => {
+  const h = await harness();
+  try {
+    // The stop script models a live process at the recorded PID whose
+    // starttime/cmdline DO NOT match → the script's own logic prints
+    // RELAY_STOP_STALE_PID and sends no kill. We assert the releaser succeeds and
+    // that the fake never had to emit a FAILED/OK (kill) sentinel.
+    const runs: string[] = [];
+    let sentinelForStop: string | null = null;
+    const ssh = {
+      async run(_d: string, _k: string, command: string) {
+        runs.push(command);
+        if (command.includes("ingress-ready")) return { stdout: "Docker version 24.0\n", stderr: "" };
+        if (command.includes("docker load")) return { stdout: "Loaded image: candidate-server:candidate\n", stderr: "" };
+        if (command.includes("pg_isready")) return { stdout: "accepting connections\n", stderr: "" };
+        if (command.includes("test -s")) return { stdout: "present\n", stderr: "" };
+        if (command.includes("cat ") && command.includes("setup-token")) return { stdout: "TOKEN\n", stderr: "" };
+        if (command.includes("__relay/health")) return { stdout: "200", stderr: "" };
+        // The stop script is a single self-contained shell program; a reused PID
+        // makes ITS OWN branch print RELAY_STOP_STALE_PID. Model that verbatim.
+        if (command.includes("RELAY_STOP_STALE_PID")) {
+          sentinelForStop = "RELAY_STOP_STALE_PID";
+          return { stdout: "RELAY_STOP_STALE_PID\n", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      },
+      async copyFile() {},
+    };
+    let processReleaser: (() => Promise<void>) | undefined;
+    await deployCandidateApi({
+      ...baseOptions(h, ssh),
+      callbackRelay: {},
+      registerCleanup: async (kind, _id, release) => {
+        if (kind === "callback_relay_process") processReleaser = release;
+      },
+    });
+    assert.ok(processReleaser);
+    await processReleaser!(); // must NOT throw — a stale PID is a clean, non-killing success.
+    assert.equal(sentinelForStop, "RELAY_STOP_STALE_PID");
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});
+
+test("the relay process releaser THROWS when the process fails to stop (cleanup failure is non-green, no `|| true` mask)", async () => {
+  const h = await harness();
+  try {
+    // A fake SSH whose stop script reports the process is still alive.
+    const runs: string[] = [];
+    const ssh = {
+      async run(_d: string, _k: string, command: string) {
+        runs.push(command);
+        if (command.includes("ingress-ready")) return { stdout: "Docker version 24.0\n", stderr: "" };
+        if (command.includes("docker load")) return { stdout: "Loaded image: candidate-server:candidate\n", stderr: "" };
+        if (command.includes("pg_isready")) return { stdout: "accepting connections\n", stderr: "" };
+        if (command.includes("test -s")) return { stdout: "present\n", stderr: "" };
+        if (command.includes("cat ") && command.includes("setup-token")) return { stdout: "TOKEN\n", stderr: "" };
+        if (command.includes("__relay/health")) return { stdout: "200", stderr: "" };
+        if (command.includes("RELAY_STOP_ABSENT")) return { stdout: "RELAY_STOP_FAILED:4321\n", stderr: "" };
+        return { stdout: "", stderr: "" };
+      },
+      async copyFile() {},
+    };
+    let processReleaser: (() => Promise<void>) | undefined;
+    await deployCandidateApi({
+      ...baseOptions(h, ssh),
+      callbackRelay: {},
+      registerCleanup: async (kind, _id, release) => {
+        if (kind === "callback_relay_process") processReleaser = release;
+      },
+    });
+    assert.ok(processReleaser);
+    await assert.rejects(() => processReleaser!(), /failed to stop the relay process/);
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});
+
+test("with callbackRelay ABSENT: no relay cleanup is registered (today's behaviour)", async () => {
+  const h = await harness();
+  try {
+    const f = fakeSsh();
+    const registered: string[] = [];
+    await deployCandidateApi({
+      ...baseOptions(h, f.ssh),
+      registerCleanup: async (kind) => {
+        registered.push(kind);
+      },
+    });
+    assert.deepEqual(registered, []);
+    assert.ok(!f.runs.some((c) => c.includes("__relay/health")));
+  } finally {
+    await rm(h.runDir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/worlds/managed-cloud/ingress.ts
+++ b/tests/release/src/worlds/managed-cloud/ingress.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 
 import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
 import type { QualificationLiteLlmConfig } from "../../services/qualification-litellm.js";
+import {
+  CALLBACK_RELAY_SCRIPT,
+  DEFAULT_RELAY_LISTEN_PORT,
+  RELAY_CHANNEL_PATHS,
+  RELAY_DIRNAME,
+  RELAY_SCRIPT_FILENAME,
+} from "./callback-relay-agent.js";
 import type { Ec2IngressBox, Route53Record } from "./ec2.js";
 
 /**
@@ -38,6 +45,14 @@ export const REMOTE_WORKDIR = "/home/ubuntu/candidate";
 const REMOTE_SETUP_TOKEN_PATH = `${REMOTE_WORKDIR}/setup-token`;
 /** The App private-key PEM on the box (mounted into the Server container via REMOTE_WORKDIR). */
 const REMOTE_GITHUB_KEY_PATH = `${REMOTE_WORKDIR}/github-app-private-key.pem`;
+/** Run-scoped 0600 env files carrying the candidate Server's Stripe/webhook secrets (PR 6, staged only when stripe present). */
+const REMOTE_STRIPE_ENV_PATH = `${REMOTE_WORKDIR}/stripe.env`;
+const REMOTE_STRIPE_WEBHOOK_ENV_PATH = `${REMOTE_WORKDIR}/stripe-webhook.env`;
+/** On-box signed-callback relay dir + script (PR 6, staged only when callbackRelay present). */
+const REMOTE_RELAY_DIR = `${REMOTE_WORKDIR}/${RELAY_DIRNAME}`;
+const REMOTE_RELAY_SCRIPT_PATH = `${REMOTE_RELAY_DIR}/${RELAY_SCRIPT_FILENAME}`;
+/** Pidfile the relay-start writes (`echo $!`) so cleanup can kill the exact process. */
+const REMOTE_RELAY_PIDFILE = `${REMOTE_RELAY_DIR}/relay.pid`;
 /** Server container port Caddy reverse-proxies to. */
 // The server image's uvicorn CMD listens on 8000 (Dockerfile: `--port 8000`,
 // EXPOSE 8000). The host port mapping and the Caddy reverse_proxy must target
@@ -98,6 +113,46 @@ export interface CandidateE2bConfig {
   templateName: string;
 }
 
+/**
+ * Stripe TEST-mode config for the candidate Server (PR 6, append-only). When
+ * present, `buildServerEnv` adds the Server's own Stripe env from these 0600
+ * files so real Core-via-Stripe cloud checkout works (closing the fundCore 503
+ * debt), plus the non-secret checkout redirect URLs. When ABSENT, no Stripe env
+ * is emitted and the candidate Server keeps today's no-Stripe 503 posture — the
+ * CLOUD-PROVISION-1 regression is untouched. Secret VALUES travel only via the
+ * single-line 0600 env files (PEM-style multi-line staging is not needed for
+ * these keys), never argv, never a field.
+ */
+export interface CandidateStripeConfig {
+  /** Path to the mode-0600 env file holding STRIPE_SECRET_KEY (single line). */
+  secretsEnvFilePath: string;
+  /**
+   * Path to the mode-0600 env file holding the two webhook signing secrets
+   * (STRIPE_WEBHOOK_SECRET and E2B_WEBHOOK_SIGNATURE_SECRET) the Server verifies
+   * signed deliveries against. The relay forwards signed bytes untouched; the
+   * Server is the sole verifier, so these live in the SERVER env only.
+   */
+  webhookSecretEnvFilePath: string;
+  /** Non-secret post-checkout redirect (STRIPE_CHECKOUT_SUCCESS_URL); typically the publicOrigin. */
+  checkoutSuccessUrl: string;
+  /** Non-secret cancelled-checkout redirect (STRIPE_CHECKOUT_CANCEL_URL). */
+  checkoutCancelUrl: string;
+}
+
+/**
+ * Signed-callback relay config for the candidate box (PR 6, append-only). When
+ * present, `deployCandidateApi` stages the single-file relay process under the
+ * remote workdir, starts it (pass-through by default), and wires the two signed
+ * webhook paths through it in the Caddyfile. When ABSENT, no relay is staged and
+ * the Caddyfile is byte-identical to today's (a single `reverse_proxy` to the
+ * Server) — behaviour with the option unused is unchanged. The relay never reads
+ * a signing secret; it forwards signed bytes byte-identically.
+ */
+export interface CandidateCallbackRelayConfig {
+  /** Loopback port the relay http process binds on the box (default 8899). */
+  listenPort?: number;
+}
+
 export interface DeployCandidateApiOptions {
   box: Ec2IngressBox;
   record: Route53Record;
@@ -106,6 +161,17 @@ export interface DeployCandidateApiOptions {
   litellm: QualificationLiteLlmConfig;
   github: CandidateGithubAppConfig;
   e2b: CandidateE2bConfig;
+  /**
+   * PR 6 (append-only): Stripe TEST-mode config for the candidate Server. Absent
+   * (the default) preserves today's no-Stripe 503 checkout posture exactly.
+   */
+  stripe?: CandidateStripeConfig;
+  /**
+   * PR 6 (append-only): on-box signed-callback relay in front of the two signed
+   * webhook paths. Absent (the default) produces the byte-identical single-proxy
+   * Caddyfile and stages no relay.
+   */
+  callbackRelay?: CandidateCallbackRelayConfig;
   /** Public origin the receipt records (`https://<record.recordName>`). */
   publicOrigin: string;
   /** The local renderer origin the browser loads (added to the Server CORS allowlist). */
@@ -118,6 +184,20 @@ export interface DeployCandidateApiOptions {
   ssh: SshExec;
   /** Injectable readiness probe over public TLS (fake in unit tests). */
   probeHealth: (origin: string) => Promise<{ ok: boolean; version: string }>;
+  /**
+   * PR 6 (append-only): registered-before-create cleanup seam, threaded from the
+   * world's cleanup stack (same shape `world.ts` uses for every other resource).
+   * When `callbackRelay` is present it is used to register `callback_relay_process`
+   * (kill by pidfile) and `callback_relay_spool` (rm -rf the spool dir) BEFORE the
+   * relay is started, so a dead/half-started relay is still torn down and
+   * `relayStopped` reports the truth. Absent → no relay resources are registered
+   * (today's behaviour; the relay is only staged when callbackRelay is present).
+   */
+  registerCleanup?: (
+    kind: "callback_relay_process" | "callback_relay_spool",
+    providerId: string,
+    release: () => Promise<void>,
+  ) => Promise<void>;
   timeoutMs?: number;
   log?: (message: string) => void;
 }
@@ -148,8 +228,13 @@ export async function deployCandidateApi(options: DeployCandidateApiOptions): Pr
   await mkdir(options.secretsDir, { recursive: true, mode: 0o700 });
   const serverEnvLocalPath = path.join(options.secretsDir, "candidate-server.env");
   await writeFile(serverEnvLocalPath, buildServerEnv(options), { mode: 0o600 });
+  const relayPort = options.callbackRelay?.listenPort ?? DEFAULT_RELAY_LISTEN_PORT;
   const caddyLocalPath = path.join(options.secretsDir, "Caddyfile");
-  await writeFile(caddyLocalPath, buildCaddyfile(options.record.recordName), { mode: 0o600 });
+  await writeFile(
+    caddyLocalPath,
+    buildCaddyfile(options.record.recordName, options.callbackRelay ? relayPort : undefined),
+    { mode: 0o600 },
+  );
 
   // Stage all inputs on the box.
   await ssh.run(dest, key, `mkdir -p ${REMOTE_WORKDIR}`);
@@ -168,13 +253,29 @@ export async function deployCandidateApi(options: DeployCandidateApiOptions): Pr
   await ssh.copyFile(dest, key, options.e2b.secretsEnvFilePath, remoteE2bEnvPath);
   await ssh.copyFile(dest, key, serverArtifact.path, remoteImagePath);
 
+  // PR 6 (append-only): the Stripe secret + webhook-secret 0600 env files ride
+  // as their own `docker --env-file`s (single-line, no PEM staging needed), so
+  // the secret VALUES never enter argv or the receipt. Only when stripe config
+  // is present — absent, no Stripe env file is copied or referenced.
+  const stripeEnvFiles: string[] = [];
+  if (options.stripe) {
+    await ssh.copyFile(dest, key, options.stripe.secretsEnvFilePath, REMOTE_STRIPE_ENV_PATH);
+    await ssh.copyFile(dest, key, options.stripe.webhookSecretEnvFilePath, REMOTE_STRIPE_WEBHOOK_ENV_PATH);
+    stripeEnvFiles.push(`--env-file ${REMOTE_STRIPE_ENV_PATH}`, `--env-file ${REMOTE_STRIPE_WEBHOOK_ENV_PATH}`);
+  }
+
   // Install Caddy and load the EXACT Server image.
   log("installing caddy and loading the candidate Server image");
   await ssh.run(dest, key, "sudo apt-get update -y && sudo apt-get install -y debian-keyring debian-archive-keyring caddy");
   const loaded = await ssh.run(dest, key, `sudo docker load -i ${remoteImagePath}`);
   const imageRef = parseLoadedImage(loaded.stdout);
 
-  const envFiles = `--env-file ${remoteEnvPath} --env-file ${remoteGithubEnvPath} --env-file ${remoteE2bEnvPath}`;
+  const envFiles = [
+    `--env-file ${remoteEnvPath}`,
+    `--env-file ${remoteGithubEnvPath}`,
+    `--env-file ${remoteE2bEnvPath}`,
+    ...stripeEnvFiles,
+  ].join(" ");
 
   // Run-scoped docker network + Postgres + Redis.
   await ssh.run(dest, key, "sudo docker network create candidate-net || true");
@@ -196,6 +297,73 @@ export async function deployCandidateApi(options: DeployCandidateApiOptions): Pr
     `sudo docker run -d --name candidate-server --network candidate-net ${envFiles} ` +
       `-v ${REMOTE_WORKDIR}:${REMOTE_WORKDIR} -p 127.0.0.1:${SERVER_CONTAINER_PORT}:${SERVER_CONTAINER_PORT} ${imageRef}`,
   );
+
+  // PR 6 (append-only): stage + start the signed-callback relay BEFORE Caddy
+  // reloads, so the routes Caddy points at the relay have a live listener. The
+  // relay is a stdlib-only single-file Python http process (no third-party deps
+  // on the box); it starts in pass-through mode — behaviourally invisible until
+  // the controller flips a channel to hold. Only when callbackRelay is present;
+  // absent, none of this runs and the Caddyfile has no relay routes.
+  if (options.callbackRelay) {
+    const relayScriptLocalPath = path.join(options.secretsDir, RELAY_SCRIPT_FILENAME);
+    await writeFile(relayScriptLocalPath, CALLBACK_RELAY_SCRIPT, { mode: 0o600 });
+    // Owner-only spool dir: it holds spooled signed payloads/headers (replay-
+    // capable credential material), so create it 0700 (install -d -m 700, then a
+    // belt-and-suspenders chmod for install variants that ignore -m).
+    await ssh.run(dest, key, `install -d -m 700 ${REMOTE_RELAY_DIR} || mkdir -p ${REMOTE_RELAY_DIR}; chmod 700 ${REMOTE_RELAY_DIR}`);
+    await ssh.copyFile(dest, key, relayScriptLocalPath, REMOTE_RELAY_SCRIPT_PATH);
+
+    // Register cleanup BEFORE starting the process (registered-before-create):
+    // the spool dir (holds spooled signed payloads/headers) and the process
+    // (killed by pidfile). Registered even if the start/readiness below fails,
+    // so a dead/half-started relay is still torn down and `relayStopped` is
+    // truthful. Durable identity: the process entry's providerId is
+    // `<box-ip>:<pidfile>` so a RECOVERED runner can act from the ledger alone.
+    await options.registerCleanup?.("callback_relay_spool", REMOTE_RELAY_DIR, async () => {
+      await ssh.run(dest, key, `rm -rf ${REMOTE_RELAY_DIR}`);
+    });
+    await options.registerCleanup?.(
+      "callback_relay_process",
+      `${box.publicIp}:${REMOTE_RELAY_PIDFILE}`,
+      async () => {
+        await stopRelayProcess(ssh, dest, key);
+      },
+    );
+
+    // The relay forwards to the Server container's host-mapped loopback port.
+    // Detached via nohup so it survives the SSH session; stdlib only, so the
+    // box's system python3 runs it with no venv/deps. The upstream + spool dir +
+    // port ride as its env (no secrets — the relay never reads a signing secret).
+    //
+    // The pidfile records an OWNERSHIP DISCRIMINATOR, not a bare PID: the PID,
+    // its `/proc/<pid>/stat` starttime (field 22 — unique per boot+pid so a PID
+    // reused after this process dies has a DIFFERENT starttime), and the exact
+    // run-scoped relay script path. `stopRelayProcess` re-checks both before
+    // signalling, so recovery never kills an innocent process that reused the PID.
+    // Written 0600 as a JSON object (tmp+mv keeps it atomic-ish for a reader).
+    await ssh.run(
+      dest,
+      key,
+      `RELAY_SPOOL_DIR=${REMOTE_RELAY_DIR} RELAY_UPSTREAM=http://127.0.0.1:${SERVER_CONTAINER_PORT} ` +
+        `RELAY_PORT=${relayPort} nohup python3 ${REMOTE_RELAY_SCRIPT_PATH} serve ` +
+        `>${REMOTE_RELAY_DIR}/relay.log 2>&1 & ` +
+        `RELAY_PID=$!; ` +
+        // /proc/<pid>/stat: `pid (comm) state ppid ...`; starttime is field 22.
+        // Take the substring after the LAST ") " so a comm containing spaces or
+        // parens never shifts the field count, then starttime is field 20 of the
+        // remainder (fields 1-2 are pid + (comm)).
+        `RELAY_START=$(sed 's/.*) //' /proc/$RELAY_PID/stat 2>/dev/null | awk '{print $20}'); ` +
+        `umask 077; ` +
+        `printf '{"pid":%s,"starttime":"%s","script":"%s"}' "$RELAY_PID" "$RELAY_START" ${REMOTE_RELAY_SCRIPT_PATH} ` +
+        `> ${REMOTE_RELAY_PIDFILE}.tmp && mv ${REMOTE_RELAY_PIDFILE}.tmp ${REMOTE_RELAY_PIDFILE}`,
+    );
+
+    // Bounded readiness: poll the relay's own loopback health endpoint until it
+    // answers 200, BEFORE Caddy routes signed callbacks through it. A relay that
+    // never comes up fails the deploy loudly rather than letting world
+    // construction "succeed" with a dead relay (public /health bypasses it).
+    await waitForRelayHealth(ssh, dest, key, relayPort, timeoutMs, log);
+  }
 
   // Configure Caddy to terminate TLS for the run subdomain.
   await ssh.copyFile(dest, key, caddyLocalPath, `${REMOTE_WORKDIR}/Caddyfile`);
@@ -284,12 +452,43 @@ function buildServerEnv(options: DeployCandidateApiOptions): string {
     // product provisions from exactly the immutable template this world builds.
     `E2B_TEMPLATE_NAME=${options.e2b.templateName}`,
   ];
+  // PR 6 (append-only): only when Stripe test-mode config is present. The secret
+  // Stripe keys (STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET, E2B_WEBHOOK_SIGNATURE_
+  // SECRET) ride their OWN 0600 --env-files (see deployCandidateApi), never this
+  // file; only the NON-secret checkout redirect URLs go here. Absent stripe →
+  // none of these are emitted and the Server keeps today's no-Stripe 503 posture.
+  if (options.stripe) {
+    lines.push(
+      `STRIPE_CHECKOUT_SUCCESS_URL=${options.stripe.checkoutSuccessUrl}`,
+      `STRIPE_CHECKOUT_CANCEL_URL=${options.stripe.checkoutCancelUrl}`,
+    );
+  }
   return `${lines.join("\n")}\n`;
 }
 
-/** Caddyfile that reverse-proxies the run subdomain to the Server container. */
-function buildCaddyfile(subdomain: string): string {
-  return `${subdomain} {\n  reverse_proxy 127.0.0.1:${SERVER_CONTAINER_PORT}\n}\n`;
+/**
+ * Caddyfile that reverse-proxies the run subdomain to the Server container. When
+ * a relay port is given (PR 6, callbackRelay present), the two signed webhook
+ * paths are routed through the on-box relay instead, with everything else still
+ * proxied straight to the Server. When it is undefined the output is
+ * byte-identical to today's single-proxy Caddyfile.
+ */
+function buildCaddyfile(subdomain: string, relayPort?: number): string {
+  if (relayPort === undefined) {
+    return `${subdomain} {\n  reverse_proxy 127.0.0.1:${SERVER_CONTAINER_PORT}\n}\n`;
+  }
+  // `handle` blocks are matched in order; the two signed webhook paths go to the
+  // relay, and the trailing catch-all `handle` proxies everything else to the
+  // Server exactly as before. Caddy matches the most specific path handler first.
+  const relayRoutes = [RELAY_CHANNEL_PATHS.stripe, RELAY_CHANNEL_PATHS.e2b]
+    .map((webhookPath) => `  handle ${webhookPath} {\n    reverse_proxy 127.0.0.1:${relayPort}\n  }`)
+    .join("\n");
+  return (
+    `${subdomain} {\n` +
+    `${relayRoutes}\n` +
+    `  handle {\n    reverse_proxy 127.0.0.1:${SERVER_CONTAINER_PORT}\n  }\n` +
+    `}\n`
+  );
 }
 
 /** Parses `Loaded image: <ref>` (or `Loaded image ID: <sha>`) from `docker load`. */
@@ -356,6 +555,93 @@ async function waitForRemoteFile(
     },
     timeoutMs,
     `remote file ${remotePath} never appeared`,
+    log,
+  );
+}
+
+/**
+ * Stops the on-box signed-callback relay SAFELY against PID reuse. The pidfile
+ * records {pid, starttime, script}; before signalling, this re-reads
+ * `/proc/<pid>/stat` starttime AND `/proc/<pid>/cmdline` and requires BOTH to
+ * match the recorded discriminator:
+ *
+ *   - pidfile missing / pid not running   → already gone (RELAY_STOP_ABSENT).
+ *   - pid running but starttime OR cmdline mismatch → the original relay is dead
+ *     and this PID was REUSED by an unrelated process → do NOT kill it; remove
+ *     the stale pidfile and report RELAY_STOP_STALE_PID (a clean, non-killing
+ *     success).
+ *   - full match → kill, verify absence via `kill -0`, remove the pidfile;
+ *     failed-to-stop is RELAY_STOP_FAILED (a non-green cleanup error). No `||
+ *     true` masks the outcome.
+ */
+async function stopRelayProcess(ssh: SshExec, dest: string, key: string): Promise<void> {
+  const pidfile = REMOTE_RELAY_PIDFILE;
+  // POSIX sh: parse the JSON pidfile with sed (no jq dependency on the box),
+  // recompute the live starttime the same way the start command did, and compare
+  // both discriminators before signalling. Prints exactly one sentinel.
+  const script =
+    `if [ ! -f ${pidfile} ]; then echo RELAY_STOP_ABSENT; exit 0; fi; ` +
+    `PF="$(cat ${pidfile})"; ` +
+    `PID=$(printf '%s' "$PF" | sed 's/.*"pid":\\([0-9]*\\).*/\\1/'); ` +
+    `WANT_START=$(printf '%s' "$PF" | sed 's/.*"starttime":"\\([^"]*\\)".*/\\1/'); ` +
+    `WANT_SCRIPT=$(printf '%s' "$PF" | sed 's/.*"script":"\\([^"]*\\)".*/\\1/'); ` +
+    `if [ -z "$PID" ]; then rm -f ${pidfile}; echo RELAY_STOP_ABSENT; exit 0; fi; ` +
+    // Not running at all → clean stop.
+    `if ! kill -0 "$PID" 2>/dev/null; then rm -f ${pidfile}; echo RELAY_STOP_ABSENT; exit 0; fi; ` +
+    // Recompute live starttime + read cmdline; a reused PID differs on either.
+    `LIVE_START=$(sed 's/.*) //' /proc/$PID/stat 2>/dev/null | awk '{print $20}'); ` +
+    `LIVE_CMD=$(tr '\\0' ' ' < /proc/$PID/cmdline 2>/dev/null); ` +
+    `if [ "$LIVE_START" != "$WANT_START" ] || ! printf '%s' "$LIVE_CMD" | grep -q "$WANT_SCRIPT"; then ` +
+    `rm -f ${pidfile}; echo RELAY_STOP_STALE_PID; exit 0; fi; ` +
+    // Ownership confirmed → kill and verify absence.
+    `kill "$PID" 2>/dev/null; sleep 1; ` +
+    `if kill -0 "$PID" 2>/dev/null; then kill -9 "$PID" 2>/dev/null; sleep 1; fi; ` +
+    `if kill -0 "$PID" 2>/dev/null; then echo "RELAY_STOP_FAILED:$PID"; else rm -f ${pidfile}; echo RELAY_STOP_OK; fi`;
+  const result = await ssh.run(dest, key, script);
+  const out = result.stdout.trim();
+  if (out.includes("RELAY_STOP_FAILED")) {
+    throw new Error(
+      `callback-relay cleanup: failed to stop the relay process (${out}); the signed-callback relay is still ` +
+        "running. Cleanup failure is non-green.",
+    );
+  }
+  if (
+    !out.includes("RELAY_STOP_OK") &&
+    !out.includes("RELAY_STOP_ABSENT") &&
+    !out.includes("RELAY_STOP_STALE_PID")
+  ) {
+    throw new Error(`callback-relay cleanup: unexpected relay-stop result "${out.slice(0, 120)}".`);
+  }
+}
+
+/**
+ * Bounded readiness for the on-box signed-callback relay: polls its own loopback
+ * health endpoint (`GET /__relay/health`) over SSH+curl until it returns 200,
+ * BEFORE Caddy routes signed callbacks through it. Fails the deploy loudly on
+ * timeout — a relay that never listens must not be papered over by the public
+ * `/health` (which bypasses the relay). Uses a shorter, bounded window than the
+ * full deploy timeout since the relay is a local process that comes up in
+ * seconds.
+ */
+async function waitForRelayHealth(
+  ssh: SshExec,
+  dest: string,
+  key: string,
+  relayPort: number,
+  timeoutMs: number,
+  log: (m: string) => void,
+): Promise<void> {
+  await pollUntil(
+    async () => {
+      const result = await ssh.run(
+        dest,
+        key,
+        `curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:${relayPort}/__relay/health || true`,
+      );
+      return result.stdout.trim() === "200";
+    },
+    Math.min(timeoutMs, 60_000),
+    `signed-callback relay never became ready on 127.0.0.1:${relayPort}`,
     log,
   );
 }

--- a/tests/release/src/worlds/managed-cloud/world.ts
+++ b/tests/release/src/worlds/managed-cloud/world.ts
@@ -43,8 +43,10 @@ import {
   deployCandidateApi,
   defaultSshExec,
   type CandidateApiReceipt,
+  type CandidateCallbackRelayConfig,
   type CandidateE2bConfig,
   type CandidateGithubAppConfig,
+  type CandidateStripeConfig,
   type SshExec,
 } from "./ingress.js";
 import {
@@ -75,6 +77,15 @@ const DEFAULT_AGENT_KINDS = ["claude"];
  *
  * The same TypeScript code runs locally and in GitHub Actions.
  */
+
+/** Handle returned by `registerCleanupIntent`: durably promote intent → real id. */
+export interface CleanupIntentHandle {
+  /** The ledger entry id (for diagnostics/tests). */
+  entryId: string;
+  /** Durably replaces the entry's providerId with the real provider id (post-create). */
+  markAcquired(realProviderId: string): Promise<void>;
+}
+
 export interface ManagedCloudWorld {
   kind: "managed-cloud";
   run: RunIdentityV1;
@@ -150,6 +161,25 @@ export interface ManagedCloudWorld {
   ): Promise<void>;
 
   /**
+   * Two-phase (INTENT → ACQUIRED) durable registration for a resource whose real
+   * provider id is only known AFTER a create call that must be recoverable if the
+   * runner dies mid-create. Unlike `registerCleanup` (which collapses intent +
+   * acquired into one shot), this persists the ledger entry with `intentRef` as
+   * its durable providerId BEFORE the create is issued, and returns
+   * `markAcquired(realProviderId)` to durably replace it the instant the provider
+   * returns. `intentRef` must carry a deterministic run-scoped RECOVERY IDENTITY
+   * (e.g. a clock name or run tag) so a lost runner can locate + delete the
+   * created resource from the reloaded ledger entry ALONE (see
+   * `stripeCleanupReplayHandlers`). Additive seam; absent on PR-2 worlds, whose
+   * callers fall back to the single-shot `registerCleanup`.
+   */
+  registerCleanupIntent?(
+    kind: ManagedCloudCleanupKind,
+    intentRef: string,
+    release: () => Promise<void>,
+  ): Promise<CleanupIntentHandle>;
+
+  /**
    * Enrols the actor's LiteLLM virtual key + user + team for deletion during
    * `close()`, ordered before local teardown so the deterministic alias stays
    * recoverable (reused PR 1 semantics). The actor identity only exists after
@@ -173,6 +203,19 @@ export interface ConstructManagedCloudWorldOptions {
   aws: Ec2ProvisionConfig;
   e2b: E2bBuildConfig & CandidateE2bConfig;
   github: CandidateGithubAppConfig;
+  /**
+   * PR 6 (append-only): Stripe TEST-mode config for the candidate Server,
+   * threaded verbatim into `deployCandidateApi`. Absent (the default) keeps the
+   * candidate Server's no-Stripe 503 checkout posture (CLOUD-PROVISION-1
+   * regression untouched).
+   */
+  stripe?: CandidateStripeConfig;
+  /**
+   * PR 6 (append-only): on-box signed-callback relay config, threaded verbatim
+   * into `deployCandidateApi`. Absent (the default) stages no relay and produces
+   * the byte-identical single-proxy Caddyfile.
+   */
+  callbackRelay?: CandidateCallbackRelayConfig;
   /** Run/shard-scoped root; all world state lives under here. */
   runDir: string;
   /** Agent CLI kinds baked into the template (defaults to `["claude"]`). */
@@ -273,6 +316,23 @@ export async function constructManagedCloudWorld(
     await stack.acquired(entryId, providerId);
   };
 
+  // Two-phase durable registration: `stack.register` writes the intent record
+  // (providerId null) durably, then we `acquired(entryId, intentRef)` so the
+  // recovery identity lands on disk BEFORE the caller's create; the returned
+  // `markAcquired` durably replaces it with the real provider id afterward.
+  const registerCleanupIntent = async (
+    kind: ManagedCloudCleanupKind,
+    intentRef: string,
+    release: () => Promise<void>,
+  ): Promise<CleanupIntentHandle> => {
+    const entryId = await stack.register(kind, release);
+    await stack.acquired(entryId, intentRef);
+    return {
+      entryId,
+      markAcquired: (realProviderId: string) => stack.acquired(entryId, realProviderId),
+    };
+  };
+
   try {
     // Register durable-path + reservation releasers first so they tear down
     // LAST (reverse order), after every cloud/provider resource above them.
@@ -322,6 +382,15 @@ export async function constructManagedCloudWorld(
       litellm: options.litellm,
       github: options.github,
       e2b: options.e2b,
+      // PR 6 (append-only): forwarded verbatim; both undefined by default, so
+      // deployCandidateApi's absent-config path (today's behaviour) runs.
+      stripe: options.stripe,
+      callbackRelay: options.callbackRelay,
+      // Thread the world's own cleanup stack so the relay's process + spool are
+      // registered-before-create in the SAME ledger as every other resource,
+      // released in reverse order by close(). Only invoked when callbackRelay is
+      // present; absent, deployCandidateApi never calls it.
+      registerCleanup: (kind, providerId, release) => register(kind, providerId, release),
       publicOrigin,
       rendererOrigin,
       secretsDir,
@@ -409,6 +478,7 @@ export async function constructManagedCloudWorld(
       }),
       paths: { runDir, secretsDir },
       registerCleanup: register,
+      registerCleanupIntent,
       trackActorSubjects: (actor) => trackActorSubjects(stack, gateway, actor),
       close: () => stack.runAll(),
     };


### PR DESCRIPTION
## PR 6 — Complete Managed-Cloud Qualification (slice 1: shared fixture layer)

Frozen delivery spec: `Complete Managed-Cloud Qualification` (Vault, Frozen 2026-07-16), reconciling the provisional PR 6 section of the qualification-platform stack against `specs/developing/testing/tier-3-scenario-contract.md` and the manifest's 17 owned `CLOUD-*` composed journeys (everything except the CLOUD-PROVISION-1 regression, post-cutover CLOUD-HOSTS-1, and PR 7's SH-CLOUD-ADDON).

This is the **shared fixture layer** the spec requires to land before the nine journey workstreams fan out. It contains NO new scenarios, NO evidence kinds, NO manifest/spec edits — those come in the journey slices on this same branch.

### What's in this slice

1. **`billingThreshold(world, actor, options)`** (`fixtures/billing-threshold.ts`) — positions a disposable actor's real `llm` (USD) or `compute` (seconds) ledger just above a target threshold on the candidate box, per the contract's fixture vocabulary: expires prior grants, writes ONE run-tagged idempotent grant (`source_ref` UNIQUE), synchronously runs `run_billing_accounting_pass` + `run_billing_reconcile_pass` (the only two permitted-acceleration levers), reconciles the LiteLLM gateway budget via the product's own `reactivate_subject_if_credited`, and returns the OBSERVED remainder.
2. **Signed callback relay** (`fixtures/callback-relay.ts` + on-box `callback-relay-agent.ts`) — an on-box reverse-proxy hop in front of `/v1/billing/webhooks/stripe` and `/v1/cloud/webhooks/e2b` that spools and forwards genuine provider deliveries **byte-identically** (HMAC is over raw bytes). Modes: pass-through | hold; replay re-POSTs the identical bytes. Structurally cannot synthesize an event (no emit method); the server's own `webhook_receipts` idempotency is what proves exactly-once.
3. **Failure injection** (`fixtures/failure-injection.ts`) — one-shot faults at the five accepted-work boundaries of CLOUD-PROVISION-RECOVERY-1 (provider create, Worker enrollment, runtime readiness, repo materialization, workspace creation), provider-side/process-level only (verified: no test hooks exist in the server); retry always goes through the normal product path.
4. **Stripe test-mode wiring** (`fixtures/stripe-test-clock.ts` + append-only `stripe?`/`callbackRelay?` options on `deployCandidateApi`/`constructManagedCloudWorld`) — threads `STRIPE_SECRET_KEY`/webhook secrets via their own 0600 `--env-file`s (never argv) so real Core-via-Stripe checkout works, closing PR 2's disclosed `fundCore` 503 debt. Plus a test-clock actor helper (live-mode key fails closed).
5. **Append-only registry edits** — 5 new cleanup kinds (`billing_fixture_adjustment`, `callback_relay_spool`, `callback_relay_process`, `stripe_test_clock`, `stripe_customer`) + 3 evidence categories; env-manifest appends (`STRIPE_TEST_SECRET_KEY`, `RELEASE_E2E_CLOUD_STRIPE_WEBHOOK_SECRET`, `RELEASE_E2E_CLOUD_E2B_WEBHOOK_SECRET`, all secret).

### Extension-contract compliance

Behavior with the new options ABSENT is byte-identical (unit-tested: Caddyfile/server-env byte equality); no existing test modified; CLOUD-PROVISION-1's driver, box-seeds, rows, and evidence untouched; all unions append-only.

### Disclosed deviations from the design (documented in module docs)

- The design said the LLM path writes a `BillingGrant`; verified against the real schema, LLM credit lives in `llm_credit_grant` (`billing_grant` is the compute ledger) — implemented against the real tables with `source="admin"` (the only allowed non-provider source).
- Stripe clock `advanceToNextPeriod` returns a best-effort marker; journeys correlate the real invoice from the server's processed webhook.
- `repo_materialization` injection kills the sandbox mid-clone (coarse but reliable equivalent of SIGKILLing in-flight git).

### Proof (exact head `cf67b80d0`)

- `npm run typecheck` clean; `npm test` **710/710** (623 baseline + 87 new, incl. real-execution tests of the on-box Python relay) — fully offline, no real provider/box/network.
- On-box Python snippets `py_compile`-checked; import paths verified against `server/proliferate` on this base.
- CONTROL rounds 1–5 repairs applied (round 5: exhaustive cursor pagination for clock recovery, clock-scoped customer LIST instead of Search, bounded 75-min propagation window that never reconciles an intent on a transient miss); finding→commit→proof receipts in the PR comments.
- Founder ruling 2026-07-16: shared-fixture boundary RATIFIED (testing foundation only). The live shared-fixture smoke is explicit post-merge acceptance debt; journey workstreams 1–9 stay blocked until it passes.
- Internal review round complete: 1 accepted finding (PR6F-001, LiteLLM budget not actually reconciled on the llm path → fixed via `reactivate_subject_if_credited`, observed-truth reporting, +2 tests).

### Not in this slice (coming on this branch per the frozen spec)

Journey scenarios (workstreams 1–9), evidence kinds (`cloud_turn`/`cloud_billing`/`cloud_reconcile`), workstream 0 (#1261 browser-turn stabilization, gates the 5 turn-dependent journeys), Makefile/workflow job extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





