### PR TITLE
fix(anyharness): normalize problem detail errors

### DIFF
--- a/anyharness/sdk/src/client/core.test.ts
+++ b/anyharness/sdk/src/client/core.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AnyHarnessError, AnyHarnessTransport } from "./core.js";
+
+describe("AnyHarnessTransport problem details", () => {
+  it("preserves valid RFC 7807 fields", async () => {
+    const error = await requestError(problemResponse({
+      type: "https://runtime.test/problems/model-gated",
+      title: "Model access required",
+      status: 403,
+      detail: "Connect a supported provider",
+      code: "SESSION_MODEL_GATED",
+      instance: "/v1/sessions/session-1",
+      requiredContexts: ["anthropic"],
+    }, 502));
+
+    expect(error.message).toBe("Connect a supported provider");
+    expect(error.problem).toEqual({
+      type: "https://runtime.test/problems/model-gated",
+      title: "Model access required",
+      status: 403,
+      detail: "Connect a supported provider",
+      code: "SESSION_MODEL_GATED",
+      instance: "/v1/sessions/session-1",
+      requiredContexts: ["anthropic"],
+    });
+  });
+
+  it("drops structured detail and uses the valid title", async () => {
+    const error = await requestError(problemResponse({
+      type: "about:blank",
+      title: "Gateway request failed",
+      status: "502",
+      detail: {
+        provider: "upstream-provider",
+        payload: { secret: "must-not-leak" },
+      },
+      code: ["INVALID_CODE"],
+    }, 502));
+
+    expect(error.message).toBe("Gateway request failed");
+    expect(error.message).not.toContain("[object Object]");
+    expect(error.message).not.toContain("upstream-provider");
+    expect(error.message).not.toContain("must-not-leak");
+    expect(error.problem).toEqual({
+      type: "about:blank",
+      title: "Gateway request failed",
+      status: 502,
+    });
+  });
+
+  it.each([
+    ["array", [{ detail: "raw array payload" }]],
+    ["string", "raw string payload"],
+    ["number", 503],
+    ["boolean", true],
+  ])("uses a generic fallback for a non-object %s body", async (_kind, body) => {
+    const error = await requestError(problemResponse(body, 503, "Service Unavailable"));
+
+    expect(error.message).toBe("Service Unavailable");
+    expect(error.problem).toEqual({
+      type: "about:blank",
+      title: "Service Unavailable",
+      status: 503,
+    });
+  });
+
+  it("normalizes null fields without coercing them into the message", async () => {
+    const error = await requestError(problemResponse({
+      type: null,
+      title: null,
+      status: null,
+      detail: null,
+      code: null,
+      instance: null,
+      requiredContexts: null,
+    }, 429));
+
+    expect(error.message).toBe("Request failed");
+    expect(error.message).not.toContain("[object Object]");
+    expect(error.problem).toEqual({
+      type: "about:blank",
+      title: "Request failed",
+      status: 429,
+      detail: null,
+      code: null,
+      instance: null,
+      requiredContexts: null,
+    });
+  });
+
+  it("uses a generic fallback for invalid JSON", async () => {
+    const error = await requestError(new Response("<html>provider failure</html>", {
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: { "content-type": "text/html" },
+    }));
+
+    expect(error.message).toBe("Bad Gateway");
+    expect(error.message).not.toContain("provider failure");
+    expect(error.problem).toEqual({
+      type: "about:blank",
+      title: "Bad Gateway",
+      status: 502,
+    });
+  });
+
+  it("normalizes directly constructed errors", () => {
+    const error = new AnyHarnessError({
+      type: null,
+      title: { provider: "must-not-leak" },
+      status: "500",
+      detail: ["must-not-leak"],
+    } as unknown as ConstructorParameters<typeof AnyHarnessError>[0]);
+
+    expect(error.message).toBe("Request failed");
+    expect(error.problem).toEqual({
+      type: "about:blank",
+      title: "Request failed",
+      status: 500,
+    });
+  });
+});
+
+async function requestError(response: Response): Promise<AnyHarnessError> {
+  const transport = new AnyHarnessTransport({
+    baseUrl: "http://runtime.test",
+    fetch: vi.fn(async () => response) as typeof globalThis.fetch,
+  });
+
+  try {
+    await transport.get("/failure");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AnyHarnessError);
+    return error as AnyHarnessError;
+  }
+
+  throw new Error("Expected request to fail");
+}
+
+function problemResponse(
+  body: unknown,
+  status: number,
+  statusText = "",
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText,
+    headers: { "content-type": "application/problem+json" },
+  });
+}

--- a/anyharness/sdk/src/client/core.ts
+++ b/anyharness/sdk/src/client/core.ts
@@ -158,12 +158,19 @@ export function withTimingCategory(
 }
 
 export class AnyHarnessError extends Error {
+  public readonly problem: ProblemDetails;
+
   constructor(
-    public readonly problem: ProblemDetails,
+    problem: ProblemDetails,
     cause?: unknown,
   ) {
-    super(problem.detail ?? problem.title);
+    const normalizedProblem = normalizeProblemDetails(problem, {
+      title: "Request failed",
+      status: 500,
+    });
+    super(normalizedProblem.detail ?? normalizedProblem.title);
     this.name = "AnyHarnessError";
+    this.problem = normalizedProblem;
     if (cause !== undefined) {
       (this as Error & { cause?: unknown }).cause = cause;
     }
@@ -414,13 +421,61 @@ export class AnyHarnessClient {
 }
 
 async function toProblemDetails(res: Response): Promise<ProblemDetails> {
+  let body: unknown;
   try {
-    return (await res.json()) as ProblemDetails;
+    body = await res.json();
   } catch {
-    return {
-      type: "about:blank",
-      title: res.statusText || "Request failed",
-      status: res.status,
-    };
+    body = undefined;
   }
+
+  return normalizeProblemDetails(body, {
+    title: res.statusText || "Request failed",
+    status: res.status,
+  });
+}
+
+interface ProblemDetailsFallback {
+  title: string;
+  status: number;
+}
+
+function normalizeProblemDetails(
+  value: unknown,
+  fallback: ProblemDetailsFallback,
+): ProblemDetails {
+  const source = isJsonObject(value) ? value : {};
+  const problem: ProblemDetails = {
+    type: typeof source.type === "string" ? source.type : "about:blank",
+    title: typeof source.title === "string" ? source.title : fallback.title,
+    status: isHttpStatus(source.status) ? source.status : fallback.status,
+  };
+
+  if (typeof source.code === "string" || source.code === null) {
+    problem.code = source.code;
+  }
+  if (typeof source.detail === "string" || source.detail === null) {
+    problem.detail = source.detail;
+  }
+  if (typeof source.instance === "string" || source.instance === null) {
+    problem.instance = source.instance;
+  }
+  if (
+    source.requiredContexts === null
+    || (
+      Array.isArray(source.requiredContexts)
+      && source.requiredContexts.every((context) => typeof context === "string")
+    )
+  ) {
+    problem.requiredContexts = source.requiredContexts;
+  }
+
+  return problem;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isHttpStatus(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 100 && value <= 599;
 }


### PR DESCRIPTION
## Summary

- normalize RFC Problem Details fields before constructing `AnyHarnessError`
- keep structured `detail` payloads from coercing into `[object Object]`
- fall back safely for malformed, primitive, or non-JSON response bodies

## Impact

Client errors retain useful typed metadata and readable messages without changing the HTTP API contract.

## Verification

- `pnpm --filter @anyharness/sdk test` — 15 files, 94 tests
- `pnpm --filter @anyharness/sdk typecheck`
- `pnpm --filter @anyharness/sdk build`
- rebased onto current `origin/main`; `git diff --check` passed