### PR TITLE
fix(product): settle replayed and queued chat work

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SessionEventEnvelope } from "@anyharness/sdk";
+import { resolveSessionViewState } from "@proliferate/product-domain/sessions/activity";
+import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
+import {
+  applyHistoryStateToStores,
+} from "#product/hooks/sessions/lifecycle/session-history-hydration-helpers";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+describe("applyHistoryStateToStores", () => {
+  beforeEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  afterEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  it.each([
+    {
+      name: "turn completion",
+      envelope: turnEnded(2),
+      expectedStatus: "idle" as const,
+      expectedPhase: "idle" as const,
+      expectedViewState: "idle" as const,
+    },
+    {
+      name: "turn interruption",
+      envelope: turnEnded(2, "turn-1", "cancelled"),
+      expectedStatus: "idle" as const,
+      expectedPhase: "idle" as const,
+      expectedViewState: "idle" as const,
+    },
+    {
+      name: "turn error",
+      envelope: errorEvent(2),
+      expectedStatus: "errored" as const,
+      expectedPhase: "errored" as const,
+      expectedViewState: "errored" as const,
+    },
+  ])("applies an authoritative $name from a history tail", ({
+    envelope,
+    expectedStatus,
+    expectedPhase,
+    expectedViewState,
+  }) => {
+    const currentState = replaySessionHistory("session-1", [turnStarted(1)]);
+    const currentRecord = {
+      ...createEmptySessionRecord("session-1", "codex", {
+        workspaceId: "workspace-1",
+      }),
+      events: currentState.events,
+      transcript: currentState.transcript,
+      status: "running" as const,
+      executionSummary: {
+        phase: "running" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-04-04T00:00:01Z",
+      },
+      streamConnectionState: "disconnected" as const,
+      transcriptHydrated: true,
+    };
+    putSessionRecord(currentRecord);
+    const nextState = replaySessionHistory("session-1", [turnStarted(1), envelope]);
+
+    applyHistoryStateToStores("session-1", currentRecord, {
+      events: nextState.events,
+      transcript: nextState.transcript,
+      reconcileEnvelopes: [envelope],
+    });
+
+    const updated = getSessionRecord("session-1")!;
+    expect(updated.transcript.isStreaming).toBe(false);
+    expect(updated.status).toBe(expectedStatus);
+    expect(updated.executionSummary?.phase).toBe(expectedPhase);
+    expect(resolveSessionViewState(updated)).toBe(expectedViewState);
+  });
+
+  it("does not let prepended older history overwrite newer running activity", () => {
+    const events = [turnStarted(1, "turn-1"), turnEnded(2, "turn-1"), turnStarted(3, "turn-2")];
+    const currentState = replaySessionHistory("session-1", events);
+    const currentRecord = {
+      ...createEmptySessionRecord("session-1", "codex", {
+        workspaceId: "workspace-1",
+      }),
+      events: currentState.events,
+      transcript: currentState.transcript,
+      status: "running" as const,
+      executionSummary: {
+        phase: "running" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-04-04T00:00:03Z",
+      },
+      streamConnectionState: "open" as const,
+      transcriptHydrated: true,
+    };
+    putSessionRecord(currentRecord);
+
+    applyHistoryStateToStores("session-1", currentRecord, {
+      events: currentState.events,
+      transcript: currentState.transcript,
+      reconcileEnvelopes: [events[1]!],
+    });
+
+    const updated = getSessionRecord("session-1")!;
+    expect(updated.status).toBe("running");
+    expect(updated.executionSummary?.phase).toBe("running");
+    expect(resolveSessionViewState(updated)).toBe("working");
+  });
+});
+
+function turnStarted(seq: number, turnId = "turn-1"): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:0${seq}Z`,
+    turnId,
+    event: { type: "turn_started" },
+  };
+}
+
+function turnEnded(
+  seq: number,
+  turnId = "turn-1",
+  stopReason: "end_turn" | "cancelled" = "end_turn",
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:0${seq}Z`,
+    turnId,
+    event: { type: "turn_ended", stopReason },
+  };
+}
+
+function errorEvent(seq: number): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:0${seq}Z`,
+    turnId: "turn-1",
+    itemId: "error-1",
+    event: {
+      type: "error",
+      message: "failed",
+    },
+  };
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts
@@ -16,6 +16,7 @@ import type {
 import { scheduleAfterNextPaint } from "#product/lib/infra/scheduling/schedule-after-next-paint";
 import { batchSessionStoreWrites } from "#product/lib/infra/scheduling/react-batching";
 import { activityFromTranscript } from "#product/lib/domain/sessions/directory/directory-activity";
+import { buildSessionStreamBatchPatch } from "#product/lib/domain/sessions/stream-patch";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
@@ -90,8 +91,19 @@ export function applyHistoryStateToStores(
     reconcileEnvelopes: readonly SessionEventEnvelope[];
   },
 ): void {
-  const status = resolveSessionStatus(currentRecord.status, {
-    executionSummary: currentRecord.executionSummary,
+  const appendedEnvelopes = nextState.events
+    .filter((envelope) => envelope.seq > currentRecord.transcript.lastSeq)
+    .sort((left, right) => left.seq - right.seq);
+  const historyTransitionPatch = buildSessionStreamBatchPatch({
+    slot: currentRecord,
+    nextTranscript: nextState.transcript,
+    envelopes: appendedEnvelopes,
+  });
+  const executionSummary = historyTransitionPatch.executionSummary !== undefined
+    ? historyTransitionPatch.executionSummary
+    : currentRecord.executionSummary;
+  const status = historyTransitionPatch.status ?? resolveSessionStatus(currentRecord.status, {
+    executionSummary,
     streamConnectionState: currentRecord.streamConnectionState,
     transcript: nextState.transcript,
   });
@@ -107,10 +119,11 @@ export function applyHistoryStateToStores(
     );
     useSessionDirectoryStore.getState().patchEntry(sessionId, {
       status,
+      executionSummary,
       modeId: nextState.transcript.currentModeId ?? currentRecord.modeId,
       activity: activityFromTranscript(nextState.transcript, {
         status,
-        executionSummary: currentRecord.executionSummary,
+        executionSummary,
       }),
     });
   });

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionIntentDispatcher } from "#product/hooks/sessions/lifecycle/use-session-intent-dispatcher";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const mocks = vi.hoisted(() => ({
+  dispatchPromptIntent: vi.fn(),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    cloud: { client: null },
+    desktop: null,
+  }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useDeletePendingPromptMutation: () => ({}),
+  useEditPendingPromptMutation: () => ({}),
+  usePromptSessionMutation: () => ({}),
+  useResolveSessionInteractionMutation: () => ({}),
+  useSetSessionConfigOptionMutation: () => ({}),
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/use-session-history-hydration", () => ({
+  useSessionHistoryHydration: () => ({ rehydrateSessionSlotFromHistory: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-summary-actions", () => ({
+  useSessionSummaryActions: () => ({ applySessionSummary: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-title-actions", () => ({
+  useSessionTitleActions: () => ({ maybeGenerateSessionTitle: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-name-actions", () => ({
+  useWorkspaceNameActions: () => ({ maybeGenerateWorkspaceName: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-surface-lookup", () => ({
+  useWorkspaceSurfaceLookup: () => ({ getWorkspaceSurface: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/access/anyharness/sessions/use-workspace-session-cache", () => ({
+  useWorkspaceSessionCache: () => ({ upsertWorkspaceSessionRecord: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/session-intent-config-dispatch", () => ({
+  dispatchConfigIntent: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/session-intent-interaction-dispatch", () => ({
+  dispatchDeletePendingPromptIntent: vi.fn(),
+  dispatchEditPendingPromptIntent: vi.fn(),
+  dispatchInteractionIntent: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/session-intent-prompt-dispatch", () => ({
+  dispatchPromptIntent: mocks.dispatchPromptIntent,
+}));
+
+describe("useSessionIntentDispatcher", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    useSessionIntentStore.getState().clear();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    putSessionRecord(createEmptySessionRecord("session-1", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-session-1",
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("dispatches the next same-session prompt after canceling one in preparation", async () => {
+    const firstDispatch = deferred<void>();
+    mocks.dispatchPromptIntent
+      .mockImplementationOnce(() => firstDispatch.promise)
+      .mockImplementationOnce((intent) => {
+        useSessionIntentStore.getState().patchIntent(intent.intentId, {
+          status: "accepted",
+          deliveryState: "accepted_running",
+        });
+        return Promise.resolve();
+      });
+
+    renderHook(() => useSessionIntentDispatcher());
+
+    act(() => {
+      enqueuePrompt("prompt-1", "first");
+    });
+    await waitFor(() => {
+      expect(mocks.dispatchPromptIntent).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      useSessionIntentStore.getState().patchIntent("prompt-1", {
+        status: "preparing",
+        deliveryState: "preparing",
+      });
+      enqueuePrompt("prompt-2", "second");
+    });
+    expect(mocks.dispatchPromptIntent).toHaveBeenCalledTimes(1);
+
+    // cancelBeforeDispatch removes a preparing prompt. This store update runs
+    // while the session is serialized behind prompt-1, so prompt-2 must be
+    // reconsidered when prompt-1's preparation finally returns.
+    act(() => {
+      useSessionIntentStore.getState().removeIntent("prompt-1");
+    });
+    expect(mocks.dispatchPromptIntent).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstDispatch.resolve();
+      await firstDispatch.promise;
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mocks.dispatchPromptIntent).toHaveBeenCalledTimes(2);
+    });
+    expect(mocks.dispatchPromptIntent.mock.calls[1]?.[0]).toMatchObject({
+      clientPromptId: "prompt-2",
+      deliveryState: "waiting_for_session",
+    });
+  });
+});
+
+function enqueuePrompt(clientPromptId: string, text: string): void {
+  useSessionIntentStore.getState().enqueuePrompt({
+    clientPromptId,
+    clientSessionId: "session-1",
+    materializedSessionId: "runtime-session-1",
+    workspaceId: "workspace-1",
+    text,
+    blocks: [{ type: "text", text }],
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import {
   useDeletePendingPromptMutation,
@@ -54,6 +54,10 @@ export function useSessionIntentDispatcher(): void {
   const deletePendingPromptMutation = useDeletePendingPromptMutation();
   const inFlightSessionIdsRef = useRef(new Set<string>());
   const dispatcherOwnerRef = useRef<symbol | null>(null);
+  const [dispatchSettlementVersion, notifyDispatchSettled] = useReducer(
+    (version: number) => version + 1,
+    0,
+  );
 
   useEffect(() => {
     if (activeDispatcherOwner) {
@@ -151,9 +155,12 @@ export function useSessionIntentDispatcher(): void {
       inFlightSessionIdsRef.current.add(clientSessionId);
       void dispatchIntent(intent).finally(() => {
         inFlightSessionIdsRef.current.delete(clientSessionId);
+        if (isActiveDispatcherOwner(dispatcherOwnerRef.current)) {
+          notifyDispatchSettled();
+        }
       });
     }
-  }, [dispatchIntent, dispatchVersion]);
+  }, [dispatchIntent, dispatchSettlementVersion, dispatchVersion]);
 }
 
 function isActiveDispatcherOwner(owner: symbol | null): boolean {


### PR DESCRIPTION
## Summary

- apply authoritative terminal, cancellation, error, and resumed-running transitions during session-history catch-up
- recheck queued same-session intents after an in-flight dispatch settles
- prevent stale `running` summaries and lost wakeups from leaving chat permanently stuck

## Impact

Reconnect/replay and prompt-cancellation races now settle the session consistently instead of leaving the UI in a perpetual streaming state.

## Verification

- Product Client focused tests: 35 passed
- Product-domain tests: 34 passed
- SDK tests: 40 passed
- Product Client typecheck passed
- rebased onto current `origin/main`; `git diff --check` passed