### PR TITLE
fix(product): filter expected query control states

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/cache/use-repo-pr-statuses.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/use-repo-pr-statuses.test.tsx
@@ -133,19 +133,24 @@ describe("useRepoPrStatuses", () => {
     });
   });
 
-  it("maps hosting error codes to typed availabilities", async () => {
+  it.each([
+    ["HOSTING_GH_NOT_INSTALLED", "gh_not_installed"],
+    ["HOSTING_GH_AUTH_REQUIRED", "gh_auth_required"],
+    ["HOSTING_REMOTE_UNSUPPORTED", "remote_unsupported"],
+  ] as const)("maps %s to typed %s availability", async (code, availability) => {
     mocks.listForRepoRoot.mockRejectedValue(new AnyHarnessError({
       type: "about:blank",
-      title: "gh auth required",
-      status: 409,
-      code: "HOSTING_GH_AUTH_REQUIRED",
+      title: "Hosting unavailable",
+      status: 400,
+      code,
     }));
     const queryClient = makeQueryClient();
 
     const { result } = renderRepoPrStatuses(queryClient, ["root-a"]);
 
     await waitFor(() => {
-      expect(result.current.availabilityByRepoRootId["root-a"]).toBe("gh_auth_required");
+      expect(result.current.availabilityByRepoRootId["root-a"]).toBe(availability);
     });
+    expect(result.current.entriesByRepoRootId["root-a"]).toEqual([]);
   });
 });

--- a/apps/packages/product-client/src/lib/domain/telemetry/failures.test.ts
+++ b/apps/packages/product-client/src/lib/domain/telemetry/failures.test.ts
@@ -1,0 +1,157 @@
+import { AnyHarnessError } from "@anyharness/sdk";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+import { describe, expect, it } from "vitest";
+import {
+  classifyTelemetryFailure,
+  isExpectedQueryTelemetryError,
+} from "#product/lib/domain/telemetry/failures";
+
+describe("query telemetry failure classification", () => {
+  it("classifies AbortError by type and treats it as an expected query state", () => {
+    const error = new DOMException("Aborted", "AbortError");
+
+    expect(classifyTelemetryFailure(error)).toBe("aborted");
+    expect(isExpectedQueryTelemetryError(error)).toBe(true);
+  });
+
+  it.each([401, 403])(
+    "treats status %i as an expected auth or permission gate",
+    (status) => {
+      const error = new ProliferateClientError("Authentication required", status);
+
+      expect(classifyTelemetryFailure(error)).toBe("permission_error");
+      expect(isExpectedQueryTelemetryError(error)).toBe(true);
+    },
+  );
+
+  it.each([400, 404, 409, 422])(
+    "keeps generic status %i reportable",
+    (status) => {
+      const error = new ProliferateClientError("Configuration unavailable", status);
+
+      expect(classifyTelemetryFailure(error)).toBe("configuration_error");
+      expect(isExpectedQueryTelemetryError(error)).toBe(false);
+    },
+  );
+
+  it("keeps a generic Not Found response reportable", () => {
+    const error = new ProliferateClientError("Not Found", 404);
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it.each([
+    "github_app_authorization_required",
+    "github_app_authorization_expired",
+    "github_app_installation_required",
+    "github_app_repo_not_covered",
+    "github_repo_access_required",
+  ])("treats explicit GitHub App code %s as expected state", (code) => {
+    const error = new ProliferateClientError("GitHub App action required", 409, code);
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(true);
+  });
+
+  it.each([
+    "HOSTING_GH_NOT_INSTALLED",
+    "HOSTING_GH_AUTH_REQUIRED",
+    "HOSTING_REMOTE_UNSUPPORTED",
+  ])("treats AnyHarness %s as typed expected availability", (code) => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Hosting unavailable",
+      status: 400,
+      code,
+    });
+
+    expect(classifyTelemetryFailure(error)).toBe("configuration_error");
+    expect(isExpectedQueryTelemetryError(error)).toBe(true);
+  });
+
+  it("does not let an availability code hide a 5xx request failure", () => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Request failed",
+      status: 503,
+      code: "HOSTING_GH_NOT_INSTALLED",
+    });
+
+    expect(classifyTelemetryFailure(error)).toBe("request_error");
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it("does not let a GitHub App state code hide a 5xx request failure", () => {
+    const error = new ProliferateClientError(
+      "GitHub App request failed",
+      503,
+      "github_app_installation_required",
+    );
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it("uses a typed availability code when no status is present", () => {
+    const error = Object.assign(new Error("Hosting unavailable"), {
+      problem: { code: "HOSTING_GH_NOT_INSTALLED" },
+    });
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(true);
+  });
+
+  it("uses an explicit GitHub App state code when no status is present", () => {
+    const error = Object.assign(new Error("Reconnect GitHub App"), {
+      code: "github_app_authorization_expired",
+    });
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(true);
+  });
+
+  it.each([
+    "HOSTING_PR_VIEW_FAILED",
+    "HOSTING_PR_CREATE_FAILED",
+  ])("keeps AnyHarness %s request errors reportable", (code) => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Hosting request failed",
+      status: 400,
+      code,
+    });
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it.each([
+    [new ProliferateClientError("Request failed", 503), "request_error"],
+    [new TypeError("Failed to fetch"), "network_error"],
+    [new Error("Invariant failed"), "unknown_error"],
+  ] as const)("keeps capture-worthy %s failures reportable", (error, kind) => {
+    expect(classifyTelemetryFailure(error)).toBe(kind);
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it("does not suppress an unknown coded error from configuration-like wording", () => {
+    const error = Object.assign(new Error("Missing configuration invariant"), {
+      code: "INTERNAL_STATE_INVALID",
+    });
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it("does not suppress an unrecognized 409 product code", () => {
+    const error = new ProliferateClientError(
+      "Workspace state conflict",
+      409,
+      "workspace_state_conflict",
+    );
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+
+  it("does not use configuration-like wording when a non-HTTP status exists", () => {
+    const error = Object.assign(new Error("Missing configuration invariant"), {
+      status: 0,
+    });
+
+    expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/telemetry/failures.ts
+++ b/apps/packages/product-client/src/lib/domain/telemetry/failures.ts
@@ -6,8 +6,22 @@ export type TelemetryFailureKind =
   | "request_error"
   | "unknown_error";
 
+const EXPECTED_ANYHARNESS_HOSTING_AVAILABILITY_CODES = new Set([
+  "HOSTING_GH_NOT_INSTALLED",
+  "HOSTING_GH_AUTH_REQUIRED",
+  "HOSTING_REMOTE_UNSUPPORTED",
+]);
+
+const EXPECTED_GITHUB_APP_STATE_CODES = new Set([
+  "github_app_authorization_required",
+  "github_app_authorization_expired",
+  "github_app_installation_required",
+  "github_app_repo_not_covered",
+  "github_repo_access_required",
+]);
+
 export function classifyTelemetryFailure(error: unknown): TelemetryFailureKind {
-  if (error instanceof Error && error.name === "AbortError") {
+  if (errorName(error) === "AbortError") {
     return "aborted";
   }
 
@@ -60,9 +74,72 @@ export function classifyTelemetryFailure(error: unknown): TelemetryFailureKind {
 }
 
 function errorStatus(error: unknown): number | null {
-  if (!(error instanceof Error)) {
+  if (typeof error !== "object" || error === null) {
     return null;
   }
+
   const status = (error as { status?: unknown }).status;
-  return typeof status === "number" ? status : null;
+  if (typeof status === "number") {
+    return status;
+  }
+
+  const problem = (error as { problem?: unknown }).problem;
+  if (typeof problem !== "object" || problem === null) {
+    return null;
+  }
+  const problemStatus = (problem as { status?: unknown }).status;
+  return typeof problemStatus === "number" ? problemStatus : null;
+}
+
+function errorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === "string") {
+    return code;
+  }
+
+  const problem = (error as { problem?: unknown }).problem;
+  if (typeof problem !== "object" || problem === null) {
+    return null;
+  }
+  const problemCode = (problem as { code?: unknown }).code;
+  return typeof problemCode === "string" ? problemCode : null;
+}
+
+function errorName(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  const name = (error as { name?: unknown }).name;
+  return typeof name === "string" ? name : null;
+}
+
+/**
+ * Returns true only for structurally represented query control states. The
+ * global query boundary deliberately does not use the classifier's message
+ * fallbacks: an unknown/programming error remains reportable even when its
+ * wording happens to contain terms such as "missing" or "configuration".
+ */
+export function isExpectedQueryTelemetryError(error: unknown): boolean {
+  if (errorName(error) === "AbortError") {
+    return true;
+  }
+
+  const status = errorStatus(error);
+  if (status !== null && status >= 500) {
+    return false;
+  }
+  if (status === 401 || status === 403) {
+    return true;
+  }
+
+  const code = errorCode(error);
+  return code !== null
+    && (
+      EXPECTED_ANYHARNESS_HOSTING_AVAILABILITY_CODES.has(code)
+      || EXPECTED_GITHUB_APP_STATE_CODES.has(code)
+    );
 }

--- a/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { hashAppQueryKey } from "#product/lib/infra/query/query-client";
+import { AnyHarnessError } from "@anyharness/sdk";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+import { CancelledError, type QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAppQueryClient,
+  hashAppQueryKey,
+  shouldCaptureAppQueryError,
+} from "#product/lib/infra/query/query-client";
 
 describe("hashAppQueryKey", () => {
   it("hashes plain query keys with sorted object fields", () => {
@@ -21,5 +28,154 @@ describe("hashAppQueryKey", () => {
     const event = new Event("click");
 
     expect(hashAppQueryKey(["event", event])).toBe('["event","[Event]"]');
+  });
+});
+
+async function runFailingQuery(
+  client: QueryClient,
+  queryKey: readonly unknown[],
+  error: Error,
+  meta?: { telemetryHandled: true },
+): Promise<void> {
+  await expect(client.fetchQuery({
+    queryKey,
+    queryFn: async () => {
+      throw error;
+    },
+    retry: false,
+    meta,
+  })).rejects.toBe(error);
+}
+
+describe("createAppQueryClient query telemetry", () => {
+  it.each([
+    ["AbortError", new DOMException("Aborted", "AbortError")],
+    ["401 auth gate", new ProliferateClientError("Signed out", 401)],
+    ["403 permission gate", new ProliferateClientError("Forbidden", 403)],
+    ["GitHub App reconnect state", new ProliferateClientError(
+      "Reconnect GitHub App",
+      409,
+      "github_app_authorization_expired",
+    )],
+    ["GitHub App installation state", new ProliferateClientError(
+      "Install GitHub App",
+      409,
+      "github_app_installation_required",
+    )],
+    ["AnyHarness hosting availability", new AnyHarnessError({
+      type: "about:blank",
+      title: "GitHub CLI is not installed",
+      status: 400,
+      code: "HOSTING_GH_NOT_INSTALLED",
+    })],
+  ])("does not capture %s while preserving query error state", async (_name, error) => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const queryKey = ["expected-state", _name];
+
+    await runFailingQuery(client, queryKey, error);
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(client.getQueryState(queryKey)).toMatchObject({
+      status: "error",
+      error,
+    });
+  });
+
+  it("does not capture TanStack cancellation", () => {
+    expect(shouldCaptureAppQueryError(new CancelledError())).toBe(false);
+  });
+
+  it.each([
+    ["generic 400", new ProliferateClientError("Bad Request", 400)],
+    ["generic Not Found", new ProliferateClientError("Not Found", 404)],
+    ["generic 409", new ProliferateClientError("Conflict", 409)],
+    ["generic 422", new ProliferateClientError("Unprocessable", 422)],
+    ["unrecognized coded 409", new ProliferateClientError(
+      "Workspace state conflict",
+      409,
+      "workspace_state_conflict",
+    )],
+    ["5xx request failure", new ProliferateClientError("Unavailable", 503)],
+    ["coded AnyHarness request failure", new AnyHarnessError({
+      type: "about:blank",
+      title: "Pull request lookup failed",
+      status: 400,
+      code: "HOSTING_PR_VIEW_FAILED",
+    })],
+    ["network failure", new TypeError("Failed to fetch")],
+    ["unknown programming failure", new Error("Invariant failed")],
+    [
+      "configuration-like unknown failure",
+      Object.assign(new Error("Missing configuration invariant"), {
+        code: "INTERNAL_STATE_INVALID",
+      }),
+    ],
+  ])("captures %s", async (_name, error) => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const queryKey = ["capture", _name];
+
+    await runFailingQuery(client, queryKey, error);
+
+    expect(captureException).toHaveBeenCalledExactlyOnceWith(error, {
+      tags: {
+        action: "query_error",
+        domain: "react_query",
+      },
+      extras: {
+        query_hash: hashAppQueryKey(queryKey),
+      },
+    });
+  });
+
+  it("preserves the explicit telemetryHandled query override", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+
+    await runFailingQuery(
+      client,
+      ["handled"],
+      new Error("Captured by the query owner"),
+      { telemetryHandled: true },
+    );
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing query retry and UI defaults", () => {
+    const client = createAppQueryClient({ captureException: vi.fn() });
+
+    expect(client.getDefaultOptions().queries).toMatchObject({
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    });
+  });
+
+  it("leaves mutation telemetry behavior unchanged", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const error = new ProliferateClientError("Forbidden", 403);
+    const mutationKey = ["mutation-permission-gate"];
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey,
+      mutationFn: async () => {
+        throw error;
+      },
+      retry: false,
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toBe(error);
+
+    expect(captureException).toHaveBeenCalledExactlyOnceWith(error, {
+      tags: {
+        action: "mutation_error",
+        domain: "react_query",
+      },
+      extras: {
+        mutation_key: hashAppQueryKey(mutationKey),
+      },
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/infra/query/query-client.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.ts
@@ -1,8 +1,10 @@
 import {
+  isCancelledError,
   MutationCache,
   QueryCache,
   QueryClient,
 } from "@tanstack/react-query";
+import { isExpectedQueryTelemetryError } from "#product/lib/domain/telemetry/failures";
 
 /**
  * The narrow exception-capture dependency the query cache reports through. The
@@ -92,13 +94,20 @@ export function hashAppQueryKey(queryKey: unknown): string {
   }
 }
 
+export function shouldCaptureAppQueryError(error: unknown): boolean {
+  return !isCancelledError(error) && !isExpectedQueryTelemetryError(error);
+}
+
 export function createAppQueryClient({
   captureException,
 }: AppQueryClientDeps): QueryClient {
   return new QueryClient({
     queryCache: new QueryCache({
       onError: (error, query) => {
-        if (query.meta?.telemetryHandled) {
+        if (
+          query.meta?.telemetryHandled
+          || !shouldCaptureAppQueryError(error)
+        ) {
           return;
         }
 

--- a/specs/codebase/structures/frontend/guides/telemetry.md
+++ b/specs/codebase/structures/frontend/guides/telemetry.md
@@ -68,6 +68,11 @@ session replay, and telemetry-related provider and hook ownership.
 - If a query or mutation hook captures its own exception, mark it with
   `meta.telemetryHandled = true` so the global React Query handlers do not
   report it again.
+- The global query handler leaves cancellation, unambiguous auth/permission
+  gates, and explicitly coded GitHub App or AnyHarness availability states in
+  React Query without sending them as exceptions. Generic 4xx responses remain
+  reportable, as do request, network, and unknown failures. The global mutation
+  handler does not apply this query disposition rule.
 - Sentry tags must stay low-cardinality. Prefer stable keys such as `domain`,
   `action`, `provider`, `workspace_kind`, and `route`.
 - Put high-cardinality or diagnostic values in scrubbed extras, not tags.


### PR DESCRIPTION
## Summary

- keep cancellation, explicit auth/permission gates, and exact GitHub App or AnyHarness availability states out of global query exception capture
- keep generic 400/404/409/422, unknown product codes, network failures, and all 5xx errors reportable
- preserve query error state, retries, owner-handled telemetry, and mutation telemetry

## Impact

Expected product control states no longer create noisy Sentry issues, while unknown client and server defects remain visible.

## Verification

- 51 focused query/classification tests
- 75 adjacent PR-status tests
- Product Client typecheck and direct `tsc --noEmit`
- documentation integrity and frontend boundary checks
- rebased onto current `origin/main`; `git diff --check` passed