### PR TITLE
fix(server): persist GitHub App reauthorization

### DIFF
--- a/server/proliferate/integrations/github/app_user_tokens.py
+++ b/server/proliferate/integrations/github/app_user_tokens.py
@@ -60,7 +60,7 @@ async def _post_token(data: dict[str, str]) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise GitHubIntegrationError("GitHub App authorization response was invalid.")
     error = payload.get("error")
-    if error == "invalid_grant":
+    if error in {"invalid_grant", "bad_refresh_token"}:
         raise GitHubAppInvalidGrant("GitHub App authorization expired.")
     if response.status_code >= 300 or error:
         raise GitHubIntegrationError("Could not exchange GitHub App authorization.")

--- a/server/proliferate/server/cloud/errors.py
+++ b/server/proliferate/server/cloud/errors.py
@@ -34,4 +34,4 @@ def raise_cloud_error(error: CloudApiError) -> NoReturn:
         status_code=error.status_code,
         detail={"code": error.code, "message": error.message, **error.extra_detail},
         headers=error.headers or None,
-    )
+    ) from error

--- a/server/proliferate/server/cloud/github_app/api.py
+++ b/server/proliferate/server/cloud/github_app/api.py
@@ -28,6 +28,9 @@ from proliferate.server.cloud.github_app.service import (
     get_github_repo_authority_status,
     list_github_app_accessible_repositories,
 )
+from proliferate.server.cloud.github_app.transactions import (
+    commit_github_app_reauthorization_on_error,
+)
 from proliferate.server.cloud.repos.models import (
     CloudGitRepositoriesResponse,
     cloud_git_repositories_payload,
@@ -37,6 +40,8 @@ from proliferate.server.cloud.repos.service import (
     DEFAULT_REPO_VISIBILITY,
 )
 from proliferate.utils.redirect_callback_pages import make_redirect_callback_response
+
+_REAUTH_TRANSACTION_DEPENDENCIES = [Depends(commit_github_app_reauthorization_on_error)]
 
 router = APIRouter(prefix="/github-app", tags=["github-app"])
 organization_router = APIRouter(
@@ -80,6 +85,7 @@ async def github_app_user_authorization_status_endpoint(
 @router.get(
     "/accessible-repos",
     response_model=CloudGitRepositoriesResponse,
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
 )
 async def list_github_app_accessible_repositories_endpoint(
     db: AsyncSession = Depends(get_async_session),
@@ -170,7 +176,10 @@ async def github_app_user_authorization_callback_endpoint(
     return RedirectResponse(redirect_url, status_code=302)
 
 
-@callback_router.get("/installation/callback")
+@callback_router.get(
+    "/installation/callback",
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
+)
 async def github_app_installation_callback_endpoint(
     installation_id: str | None = Query(default=None),
     setup_action: str | None = Query(default=None),
@@ -189,7 +198,10 @@ async def github_app_installation_callback_endpoint(
     return RedirectResponse(redirect_url, status_code=302)
 
 
-@setup_callback_router.get("/callback")
+@setup_callback_router.get(
+    "/callback",
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
+)
 async def github_app_setup_callback_endpoint(
     installation_id: str | None = Query(default=None),
     setup_action: str | None = Query(default=None),

--- a/server/proliferate/server/cloud/github_app/errors.py
+++ b/server/proliferate/server/cloud/github_app/errors.py
@@ -1,0 +1,21 @@
+"""GitHub App authorization domain errors."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from proliferate.server.cloud.errors import CloudApiError
+
+
+class GitHubAppReauthorizationRequired(CloudApiError):
+    """A permanent refresh failure whose staged state must commit with the error."""
+
+    def __init__(
+        self,
+        authorization_id: UUID,
+        *,
+        code: str = "github_app_authorization_expired",
+        message: str = ("Reconnect the Proliferate GitHub App before using GitHub Cloud repos."),
+    ) -> None:
+        super().__init__(code, message, status_code=409)
+        self.authorization_id = authorization_id

--- a/server/proliferate/server/cloud/github_app/repo_authority.py
+++ b/server/proliferate/server/cloud/github_app/repo_authority.py
@@ -19,6 +19,7 @@ from proliferate.integrations.github import (
     verify_github_app_user_repo_access,
 )
 from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.github_app.errors import GitHubAppReauthorizationRequired
 from proliferate.utils.time import utcnow
 
 
@@ -122,11 +123,7 @@ async def _refresh_github_app_authorization(
             db,
             authorization.id,
         )
-        raise CloudApiError(
-            "github_app_authorization_expired",
-            "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
-            status_code=409,
-        )
+        raise GitHubAppReauthorizationRequired(authorization.id)
     try:
         refreshed = await refresh_github_app_user_authorization(
             refresh_token=authorization.refresh_token,
@@ -136,11 +133,7 @@ async def _refresh_github_app_authorization(
             db,
             authorization.id,
         )
-        raise CloudApiError(
-            "github_app_authorization_expired",
-            "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
-            status_code=409,
-        ) from exc
+        raise GitHubAppReauthorizationRequired(authorization.id) from exc
     except GitHubIntegrationError as exc:
         raise CloudApiError(
             "github_app_refresh_failed",

--- a/server/proliferate/server/cloud/github_app/transactions.py
+++ b/server/proliferate/server/cloud/github_app/transactions.py
@@ -1,0 +1,42 @@
+"""Request transaction boundary for durable GitHub App reauthorization state."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db import session_ops
+from proliferate.db.engine import get_async_session
+from proliferate.server.cloud.github_app.errors import GitHubAppReauthorizationRequired
+
+
+def _reauthorization_error(error: BaseException) -> GitHubAppReauthorizationRequired | None:
+    current: BaseException | None = error
+    while current is not None:
+        if isinstance(current, GitHubAppReauthorizationRequired):
+            return current
+        current = current.__cause__
+    return None
+
+
+async def commit_github_app_reauthorization_on_error(
+    db: AsyncSession = Depends(get_async_session),
+) -> AsyncIterator[None]:
+    """Commit only the permanent auth transition before its structured response.
+
+    The GitHub authorization gate runs before request-owned mutations at every
+    HTTP entrypoint using this dependency. It holds the authorization row lock,
+    stages ``needs_reauth``, and raises ``GitHubAppReauthorizationRequired``.
+    Committing here preserves that transition without moving transaction
+    ownership into a service or store.
+    """
+
+    try:
+        yield
+    except Exception as error:
+        if _reauthorization_error(error) is None:
+            raise
+        await session_ops.commit_session(db)
+        raise

--- a/server/proliferate/server/cloud/materialization/runner.py
+++ b/server/proliferate/server/cloud/materialization/runner.py
@@ -13,6 +13,7 @@ from proliferate.db.engine import async_session_factory
 from proliferate.db.engine import run_after_commit as db_run_after_commit
 from proliferate.integrations.sentry import report_critical
 from proliferate.server.billing.authorization import CloudSandboxResumeBlockedError
+from proliferate.server.cloud.github_app.errors import GitHubAppReauthorizationRequired
 
 logger = logging.getLogger("proliferate.cloud.materialization")
 
@@ -78,6 +79,19 @@ async def _run_with_fresh_session(
         try:
             await fn(db, **kwargs)
             await db.commit()
+        except GitHubAppReauthorizationRequired as exc:
+            # The refresh gate holds the authorization row lock and has staged
+            # ``needs_reauth``. This fresh-session runner owns the background
+            # transaction, so it must commit that permanent transition instead
+            # of sending it through the generic rollback path.
+            await db.commit()
+            logger.info(
+                "github_app_reauthorization_required",
+                extra={
+                    "authorization_id": str(exc.authorization_id),
+                    "fn": getattr(fn, "__name__", repr(fn)),
+                },
+            )
         except CloudSandboxResumeBlockedError as exc:
             await db.rollback()
             _log_billing_block(exc, fn=getattr(fn, "__name__", repr(fn)))

--- a/server/proliferate/server/cloud/repos/api.py
+++ b/server/proliferate/server/cloud/repos/api.py
@@ -5,6 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.engine import get_async_session
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.github_app.transactions import (
+    commit_github_app_reauthorization_on_error,
+)
 from proliferate.server.cloud.repos.access import CloudRepoGitHubCredentialsDependency
 from proliferate.server.cloud.repos.models import (
     CloudGitRepositoriesResponse,
@@ -18,7 +21,7 @@ from proliferate.server.cloud.repos.service import (
     list_cloud_repositories,
 )
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(commit_github_app_reauthorization_on_error)])
 
 
 @router.get("/repos", response_model=CloudGitRepositoriesResponse)

--- a/server/proliferate/server/cloud/repositories/api.py
+++ b/server/proliferate/server/cloud/repositories/api.py
@@ -9,6 +9,9 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.github_app.transactions import (
+    commit_github_app_reauthorization_on_error,
+)
 from proliferate.server.cloud.repos.access import CloudRepoGitHubCredentialsDependency
 from proliferate.server.cloud.repos.models import (
     CloudGitRepositoriesResponse,
@@ -37,10 +40,16 @@ from proliferate.server.cloud.repositories.service import (
     update_repo_config,
 )
 
+_REAUTH_TRANSACTION_DEPENDENCIES = [Depends(commit_github_app_reauthorization_on_error)]
+
 router = APIRouter()
 
 
-@router.get("/repositories/catalog", response_model=CloudGitRepositoriesResponse)
+@router.get(
+    "/repositories/catalog",
+    response_model=CloudGitRepositoriesResponse,
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
+)
 async def list_repository_catalog_endpoint(
     credentials: CloudRepoGitHubCredentialsDependency,
     db: AsyncSession = Depends(get_async_session),
@@ -79,7 +88,9 @@ async def list_repositories_endpoint(
 
 
 @router.get(
-    "/repositories/{git_owner}/{git_repo_name}/branches", response_model=RepoBranchesResponse
+    "/repositories/{git_owner}/{git_repo_name}/branches",
+    response_model=RepoBranchesResponse,
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
 )
 async def get_repository_branches_endpoint(
     git_owner: str,
@@ -120,6 +131,7 @@ async def update_repo_config_endpoint(
 @router.put(
     "/repositories/{git_owner}/{git_repo_name}/environment",
     response_model=RepoEnvironmentResponse,
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
 )
 async def save_repo_environment_endpoint(
     git_owner: str,

--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -12,6 +12,9 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
+from proliferate.server.cloud.github_app.transactions import (
+    commit_github_app_reauthorization_on_error,
+)
 from proliferate.server.cloud.workspaces.models import (
     CloudWorkspaceRuntimeStatusResponse,
     CreateCloudWorkspaceRequest,
@@ -29,6 +32,8 @@ from proliferate.server.cloud.workspaces.service import (
     restore_cloud_workspace_for_user,
     sync_cloud_workspace_display_name,
 )
+
+_REAUTH_TRANSACTION_DEPENDENCIES = [Depends(commit_github_app_reauthorization_on_error)]
 
 router = APIRouter()
 
@@ -49,7 +54,11 @@ async def list_cloud_workspaces_endpoint(
         raise_cloud_error(error)
 
 
-@router.post("/workspaces", response_model=WorkspaceDetail)
+@router.post(
+    "/workspaces",
+    response_model=WorkspaceDetail,
+    dependencies=_REAUTH_TRANSACTION_DEPENDENCIES,
+)
 async def create_cloud_workspace_endpoint(
     body: CreateCloudWorkspaceRequest,
     user: User = Depends(current_product_user),

--- a/server/tests/integration/test_github_app_reauthorization.py
+++ b/server/tests/integration/test_github_app_reauthorization.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store import github_app as github_app_store
+from proliferate.integrations.github import GitHubAppInvalidGrant
+from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthorization
+from proliferate.server.cloud.github_app import repo_authority
+from proliferate.server.cloud.materialization import runner as materialization_runner
+from proliferate.server.cloud.materialization.materialize import github_credentials
+from tests.integration.cloud_api_helpers import register_and_login
+
+
+async def _seed_expired_authorization(
+    db_session: AsyncSession,
+    *,
+    user_id: UUID,
+    refresh_token: str | None = "expired-refresh-token",
+) -> None:
+    await github_app_store.upsert_github_app_authorization(
+        db_session,
+        user_id=user_id,
+        authorization=GitHubAppUserAuthorization(
+            access_token="expired-github-app-token",
+            refresh_token=refresh_token,
+            expires_at=datetime.now(UTC) - timedelta(minutes=1),
+            refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30),
+            github_user_id="12345",
+            github_login="cloud-tester",
+            permissions={},
+        ),
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_mode", ["bad_refresh_token", "missing_refresh_token"])
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/v1/cloud/repos",
+        "/v1/cloud/github-app/accessible-repos",
+    ],
+)
+async def test_permanent_refresh_failure_returns_409_and_persists_reauth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+    endpoint: str,
+) -> None:
+    session = await register_and_login(
+        client,
+        f"github-reauth-{failure_mode}-{uuid4().hex[:8]}@example.com",
+    )
+    user_id = UUID(session["user_id"])
+    await _seed_expired_authorization(
+        db_session,
+        user_id=user_id,
+        refresh_token=(
+            None if failure_mode == "missing_refresh_token" else "expired-refresh-token"
+        ),
+    )
+
+    refresh_attempts: list[str] = []
+
+    async def _refresh(*, refresh_token: str) -> None:
+        refresh_attempts.append(refresh_token)
+        raise GitHubAppInvalidGrant("GitHub App authorization expired.")
+
+    monkeypatch.setattr(repo_authority, "refresh_github_app_user_authorization", _refresh)
+    headers = {"Authorization": f"Bearer {session['access_token']}"}
+
+    first = await client.get(endpoint, headers=headers)
+
+    assert first.status_code == 409
+    assert first.json() == {
+        "detail": {
+            "code": "github_app_authorization_expired",
+            "message": ("Reconnect the Proliferate GitHub App before using GitHub Cloud repos."),
+        }
+    }
+    persisted = await github_app_store.get_github_app_authorization_for_user(
+        db_session,
+        user_id=user_id,
+    )
+    assert persisted is not None
+    assert persisted.status == "needs_reauth"
+
+    second = await client.get(endpoint, headers=headers)
+
+    assert second.status_code == 409
+    assert second.json()["detail"]["code"] == "github_app_authorization_expired"
+    assert refresh_attempts == (
+        [] if failure_mode == "missing_refresh_token" else ["expired-refresh-token"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_authority_endpoint_returns_actionable_response_and_persists_reauth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await register_and_login(
+        client,
+        f"github-authority-reauth-{uuid4().hex[:8]}@example.com",
+    )
+    user_id = UUID(session["user_id"])
+    await _seed_expired_authorization(db_session, user_id=user_id)
+    refresh_attempts: list[str] = []
+
+    async def _refresh(*, refresh_token: str) -> None:
+        refresh_attempts.append(refresh_token)
+        raise GitHubAppInvalidGrant("GitHub App authorization expired.")
+
+    monkeypatch.setattr(repo_authority, "refresh_github_app_user_authorization", _refresh)
+    headers = {"Authorization": f"Bearer {session['access_token']}"}
+    endpoint = "/v1/cloud/github-app/repos/acme/rocket/authority"
+
+    first = await client.get(endpoint, headers=headers)
+
+    assert first.status_code == 200
+    assert first.json() == {
+        "authorized": False,
+        "status": "expired_user_authorization",
+        "action": "reauthorize_user",
+        "message": "Reconnect the Proliferate GitHub App before using GitHub Cloud repos.",
+    }
+    db_session.expire_all()
+    persisted = await github_app_store.get_github_app_authorization_for_user(
+        db_session,
+        user_id=user_id,
+    )
+    assert persisted is not None
+    assert persisted.status == "needs_reauth"
+
+    second = await client.get(endpoint, headers=headers)
+
+    assert second.status_code == 200
+    assert second.json() == first.json()
+    assert refresh_attempts == ["expired-refresh-token"]
+
+
+@pytest.mark.asyncio
+async def test_background_materialization_runner_persists_reauth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = await register_and_login(
+        client,
+        f"github-background-reauth-{uuid4().hex[:8]}@example.com",
+    )
+    user_id = UUID(session["user_id"])
+    await _seed_expired_authorization(db_session, user_id=user_id)
+    refresh_attempts: list[str] = []
+
+    async def _refresh(*, refresh_token: str) -> None:
+        refresh_attempts.append(refresh_token)
+        raise GitHubAppInvalidGrant("GitHub App authorization expired.")
+
+    monkeypatch.setattr(repo_authority, "refresh_github_app_user_authorization", _refresh)
+    monkeypatch.setattr(
+        materialization_runner,
+        "async_session_factory",
+        async_sessionmaker(test_engine, expire_on_commit=False),
+    )
+    paged: list[Exception] = []
+    monkeypatch.setattr(
+        materialization_runner,
+        "report_critical",
+        lambda exc, **_kwargs: paged.append(exc),
+    )
+
+    async def _materialize(db: AsyncSession) -> None:
+        await github_credentials.materialize_github_credentials(
+            db,
+            target=object(),  # Refresh fails before the sandbox target is used.
+            operation_id=uuid4(),
+            user_id=user_id,
+        )
+
+    await materialization_runner._run_with_fresh_session(_materialize, {})
+
+    db_session.expire_all()
+    persisted = await github_app_store.get_github_app_authorization_for_user(
+        db_session,
+        user_id=user_id,
+    )
+    assert persisted is not None
+    assert persisted.status == "needs_reauth"
+    assert refresh_attempts == ["expired-refresh-token"]
+    assert paged == []

--- a/server/tests/unit/test_github_app_repo_authority.py
+++ b/server/tests/unit/test_github_app_repo_authority.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from proliferate.integrations.github import GitHubAppInvalidGrant, GitHubIntegrationError
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.github_app import repo_authority
+from proliferate.server.cloud.github_app.errors import GitHubAppReauthorizationRequired
+
+
+def _expired_authorization(*, refresh_token: str | None = "refresh-token") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=uuid4(),
+        access_token="expired-access-token",
+        refresh_token=refresh_token,
+        token_expires_at=datetime.now(UTC) - timedelta(minutes=1),
+        status="ready",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "integration_error",
+    [
+        GitHubIntegrationError("GitHub is unavailable."),
+        GitHubIntegrationError("GitHub App OAuth is not configured."),
+    ],
+)
+async def test_refresh_transient_or_config_failure_stays_502_without_reauth(
+    monkeypatch: pytest.MonkeyPatch,
+    integration_error: GitHubIntegrationError,
+) -> None:
+    authorization = _expired_authorization()
+    marked: list[object] = []
+
+    async def _get_authorization(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return authorization
+
+    async def _refresh(**_kwargs: object) -> None:
+        raise integration_error
+
+    async def _mark(*_args: object, **_kwargs: object) -> None:
+        marked.append(object())
+
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "get_github_app_authorization_for_user",
+        _get_authorization,
+    )
+    monkeypatch.setattr(repo_authority, "refresh_github_app_user_authorization", _refresh)
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "mark_github_app_authorization_needs_reauth",
+        _mark,
+    )
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await repo_authority._refresh_github_app_authorization(
+            object(),
+            user_id=authorization.user_id,
+        )
+
+    assert exc_info.value.code == "github_app_refresh_failed"
+    assert exc_info.value.status_code == 502
+    assert marked == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_invalid_grant_stages_reauth_for_request_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorization = _expired_authorization()
+    marked: list[object] = []
+
+    async def _get_authorization(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return authorization
+
+    async def _refresh(**_kwargs: object) -> None:
+        raise GitHubAppInvalidGrant("expired")
+
+    async def _mark(_db: object, authorization_id: object) -> None:
+        marked.append(authorization_id)
+
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "get_github_app_authorization_for_user",
+        _get_authorization,
+    )
+    monkeypatch.setattr(repo_authority, "refresh_github_app_user_authorization", _refresh)
+    monkeypatch.setattr(
+        repo_authority.github_app_store,
+        "mark_github_app_authorization_needs_reauth",
+        _mark,
+    )
+
+    with pytest.raises(GitHubAppReauthorizationRequired) as exc_info:
+        await repo_authority._refresh_github_app_authorization(
+            object(),
+            user_id=authorization.user_id,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert marked == [authorization.id]

--- a/server/tests/unit/test_github_app_user_tokens.py
+++ b/server/tests/unit/test_github_app_user_tokens.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from types import TracebackType
+
+import httpx
+import pytest
+
+from proliferate.integrations.github import app_user_tokens
+from proliferate.integrations.github.app_user_tokens import GitHubAppInvalidGrant
+from proliferate.integrations.github.repos import GitHubIntegrationError
+
+
+class _FakeTokenClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+
+    async def __aenter__(self) -> _FakeTokenClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def post(self, *_args: object, **_kwargs: object) -> httpx.Response:
+        return self.response
+
+
+def _token_response(status_code: int, payload: object) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload,
+        request=httpx.Request("POST", "https://github.com/login/oauth/access_token"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_maps_bad_refresh_token_to_permanent_invalid_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_detail = "provider detail must stay private"
+    client = _FakeTokenClient(
+        _token_response(
+            400,
+            {
+                "error": "bad_refresh_token",
+                "error_description": provider_detail,
+            },
+        )
+    )
+    monkeypatch.setattr(app_user_tokens.settings, "github_app_client_id", "client-id")
+    monkeypatch.setattr(app_user_tokens.settings, "github_app_client_secret", "client-secret")
+    monkeypatch.setattr(app_user_tokens.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    with pytest.raises(GitHubAppInvalidGrant) as exc_info:
+        await app_user_tokens.refresh_github_app_user_authorization(
+            refresh_token="expired-refresh-token"
+        )
+
+    assert provider_detail not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_transient_provider_failure_generic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_detail = "upstream body must stay private"
+    client = _FakeTokenClient(
+        _token_response(
+            502,
+            {
+                "error": "temporarily_unavailable",
+                "error_description": provider_detail,
+            },
+        )
+    )
+    monkeypatch.setattr(app_user_tokens.settings, "github_app_client_id", "client-id")
+    monkeypatch.setattr(app_user_tokens.settings, "github_app_client_secret", "client-secret")
+    monkeypatch.setattr(app_user_tokens.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    with pytest.raises(GitHubIntegrationError) as exc_info:
+        await app_user_tokens.refresh_github_app_user_authorization(
+            refresh_token="still-valid-refresh-token"
+        )
+
+    assert not isinstance(exc_info.value, GitHubAppInvalidGrant)
+    assert provider_detail not in str(exc_info.value)


### PR DESCRIPTION
## Summary

- classify GitHub's permanent `bad_refresh_token` response as expired authorization
- persist `needs_reauth` across request and background materialization transaction boundaries
- preserve the repository-authority endpoint's actionable 200 response contract
- keep transient provider failures reportable as 502 errors

## Root cause

Permanent refresh failures staged `needs_reauth`, then propagated through generic exception paths that rolled the transaction back. Every later request or background job retried the same invalid credential and reported another internal error.

## Impact

Expired GitHub App authorization becomes a durable reconnect state instead of a repeated Sentry failure. Operational endpoints still return the structured reauthorization error; the authority endpoint continues to return its product-actionable status payload.

## Verification

- 45 focused and adjacent tests passed
- request tests prove first and subsequent authority calls return the same actionable 200 response
- background credential materialization persists `needs_reauth` without critical paging
- Ruff, server boundary, max-lines, narrow mypy, and `git diff --check` passed
- rebased onto current `origin/main`