### PR TITLE
fix(product): bound telemetry payload scrubbing

### DIFF
--- a/apps/desktop/src/lib/integrations/telemetry/scrub.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/scrub.ts
@@ -14,11 +14,11 @@ export function scrubTelemetryData<T>(value: T): T {
 export function scrubSentryBreadcrumb(
   breadcrumb: Breadcrumb,
 ): Breadcrumb | null {
-  return {
-    ...breadcrumb,
-    message: breadcrumb.message ? scrubTelemetryText(breadcrumb.message) : breadcrumb.message,
-    data: scrubTelemetryData(breadcrumb.data),
-  };
+  const scrubbed = scrubTelemetryData(breadcrumb);
+  scrubbed.message = typeof scrubbed.message === "string"
+    ? scrubTelemetryText(scrubbed.message)
+    : scrubbed.message;
+  return scrubbed;
 }
 
 type SentryStackFrame = {
@@ -156,11 +156,5 @@ export function scrubPostHogPayload(
   event: CaptureResult | null,
 ): CaptureResult | null {
   if (!event) return event;
-
-  return {
-    ...event,
-    properties: scrubPostHogProperties(event.properties),
-    $set: scrubPostHogProperties(event.$set),
-    $set_once: scrubPostHogProperties(event.$set_once),
-  };
+  return scrubPostHogProperties(event);
 }

--- a/apps/desktop/src/lib/integrations/telemetry/sentry.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/sentry.test.ts
@@ -111,4 +111,51 @@ describe("desktop sentry transport", () => {
     expect(scrubbed.environment).toBe("production");
     expect((scrubbed.tags as Record<string, unknown>).environment).toBe("[redacted]");
   });
+
+  it("bounds cyclic and deep payloads at the Sentry scrubber entrypoints", async () => {
+    const sentry = await loadSentryModule();
+
+    sentry.initializeDesktopSentry({
+      environment: "production",
+      release: "proliferate-desktop@test",
+      sentry: {
+        enabled: true,
+        dsn: "https://sentry.example/123",
+        tracesSampleRate: 1,
+        enableLogs: true,
+        replaysOnErrorSampleRate: 1,
+      },
+      apiBaseUrl: "https://app.proliferate.com/api",
+      telemetryMode: "hosted_product",
+    });
+
+    const initArgs = mocks.initMock.mock.calls[0][0] as {
+      beforeSend: (event: Record<string, unknown>) => Record<string, unknown>;
+      beforeBreadcrumb: (breadcrumb: Record<string, unknown>) => Record<string, unknown>;
+      beforeSendSpan: (span: Record<string, unknown>) => Record<string, unknown>;
+    };
+    const cyclicEvent: Record<string, unknown> = { environment: "production" };
+    cyclicEvent.self = cyclicEvent;
+    const cyclicSpan: Record<string, unknown> = { description: "safe" };
+    cyclicSpan.self = cyclicSpan;
+    const deepData: Record<string, unknown> = {};
+    let cursor = deepData;
+    for (let index = 0; index < 20_000; index += 1) {
+      const next: Record<string, unknown> = {};
+      cursor.next = next;
+      cursor = next;
+    }
+    const cyclicBreadcrumb: Record<string, unknown> = { data: deepData };
+    cyclicBreadcrumb.self = cyclicBreadcrumb;
+
+    const event = initArgs.beforeSend(cyclicEvent);
+    const breadcrumb = initArgs.beforeBreadcrumb(cyclicBreadcrumb);
+    const span = initArgs.beforeSendSpan(cyclicSpan);
+
+    expect(event).toEqual({ environment: "production", self: "[circular]" });
+    expect(breadcrumb.self).toBe("[circular]");
+    expect(span).toEqual({ description: "safe", self: "[circular]" });
+    expect(JSON.stringify(breadcrumb)).toContain("[truncated]");
+    expect(() => JSON.stringify([event, breadcrumb, span])).not.toThrow();
+  });
 });

--- a/apps/mobile/src/lib/integrations/telemetry/sentry.ts
+++ b/apps/mobile/src/lib/integrations/telemetry/sentry.ts
@@ -56,11 +56,11 @@ type MutableSentryEvent = {
 };
 
 function scrubSentryBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb | null {
-  return {
-    ...breadcrumb,
-    message: breadcrumb.message ? scrubTelemetryText(breadcrumb.message) : breadcrumb.message,
-    data: scrubTelemetryData(breadcrumb.data),
-  };
+  const scrubbed = scrubTelemetryData(breadcrumb);
+  scrubbed.message = typeof scrubbed.message === "string"
+    ? scrubTelemetryText(scrubbed.message)
+    : scrubbed.message;
+  return scrubbed;
 }
 
 function scrubSentryFrame(frame: SentryStackFrame): void {

--- a/apps/packages/product-domain/src/telemetry/scrub.test.ts
+++ b/apps/packages/product-domain/src/telemetry/scrub.test.ts
@@ -26,6 +26,114 @@ describe("scrubTelemetryData", () => {
     });
   });
 
+  it("replaces cyclic object and array edges with a fixed marker", () => {
+    const cyclicObject: Record<string, unknown> = { token: "secret" };
+    cyclicObject.self = cyclicObject;
+    const cyclicArray: unknown[] = [];
+    cyclicArray.push(cyclicArray);
+
+    expect(scrubTelemetryData(cyclicObject)).toEqual({
+      token: "[redacted]",
+      self: "[circular]",
+    });
+    expect(scrubTelemetryData(cyclicArray)).toEqual(["[circular]"]);
+  });
+
+  it("reuses a completed scrubbed value for repeated shared references", () => {
+    const shared = {
+      path: "/Users/pablo/private/file.ts",
+      message: "Bearer secret-token",
+    };
+    const scrubbed = scrubTelemetryData({ first: shared, second: shared });
+
+    expect(scrubbed).toEqual({
+      first: { path: "[redacted]", message: "[redacted-token]" },
+      second: { path: "[redacted]", message: "[redacted-token]" },
+    });
+    expect(scrubbed.first).toBe(scrubbed.second);
+    expect(() => JSON.stringify(scrubbed)).not.toThrow();
+  });
+
+  it("truncates adversarially deep containers before recursion can overflow", () => {
+    const payload: Record<string, unknown> = {};
+    let cursor = payload;
+    for (let index = 0; index < 20_000; index += 1) {
+      const next: Record<string, unknown> = {};
+      cursor.next = next;
+      cursor = next;
+    }
+
+    const scrubbed = scrubTelemetryData(payload);
+    let nested: unknown = scrubbed;
+    let scrubbedDepth = 0;
+    while (nested !== null && typeof nested === "object") {
+      nested = (nested as Record<string, unknown>).next;
+      scrubbedDepth += 1;
+    }
+
+    expect(nested).toBe("[truncated]");
+    expect(scrubbedDepth).toBeLessThan(20);
+    expect(() => JSON.stringify(scrubbed)).not.toThrow();
+  });
+
+  it("bounds huge sparse arrays without retaining the source length", () => {
+    const sparse: unknown[] = [];
+    sparse.length = 1_000_000;
+    sparse[0] = { token: "secret", message: "useful" };
+    sparse[999_999] = "Bearer omitted-secret";
+
+    const scrubbed = scrubTelemetryData(sparse);
+    const serialized = JSON.stringify(scrubbed);
+
+    expect(scrubbed.length).toBeLessThan(200);
+    expect(scrubbed[0]).toEqual({ token: "[redacted]", message: "useful" });
+    expect(scrubbed.at(-1)).toBe("[truncated]");
+    expect(serialized.length).toBeLessThan(2_000);
+    expect(serialized).not.toContain("omitted-secret");
+  });
+
+  it("bounds wide objects and does not evaluate omitted accessors", () => {
+    let getterCalls = 0;
+    const wide: Record<string, unknown> = {};
+    for (let index = 0; index < 1_000; index += 1) {
+      wide[`field_${index}`] = `value-${index}`;
+    }
+    Object.defineProperty(wide, "omitted", {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1;
+        return "Bearer should-not-be-read";
+      },
+    });
+
+    const scrubbed = scrubTelemetryData(wide);
+
+    expect(Object.keys(scrubbed).length).toBeLessThan(200);
+    expect(scrubbed.field_0).toBe("value-0");
+    expect(scrubbed["[truncated]"]).toBe("[truncated]");
+    expect(scrubbed.omitted).toBeUndefined();
+    expect(getterCalls).toBe(0);
+    expect(JSON.stringify(scrubbed)).not.toContain("should-not-be-read");
+  });
+
+  it("does not evaluate enumerable getters while inspecting telemetry", () => {
+    let getterCalls = 0;
+    const payload = { safe: "value" } as Record<string, unknown>;
+    Object.defineProperty(payload, "constructor", {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1;
+        return "Bearer should-not-be-read";
+      },
+    });
+
+    expect(scrubTelemetryData(payload)).toEqual({
+      safe: "value",
+      constructor: "[redacted]",
+    });
+    expect(getterCalls).toBe(0);
+  });
+
   it("scrubs bearer tokens, jwt values, and absolute paths from strings", () => {
     expect(
       scrubTelemetryText(

--- a/apps/packages/product-domain/src/telemetry/scrub.ts
+++ b/apps/packages/product-domain/src/telemetry/scrub.ts
@@ -15,6 +15,15 @@ const QUERY_SECRET_PATTERN =
 // (CodeQL js/polynomial-redos) on adversarial `scheme://"""...` inputs.
 const ABSOLUTE_URL_PARTS_PATTERN =
   /^([a-z][a-z0-9+.-]*:\/\/[^/?#]+)(\/[^?#]*)?(?:[?#].*)?$/i;
+const CIRCULAR_REFERENCE_MARKER = "[circular]";
+const TRUNCATION_MARKER = "[truncated]";
+const OBJECT_TRUNCATION_KEY = "[truncated]";
+const UNINSPECTABLE_VALUE_MARKER = "[redacted]";
+// Normal Sentry and PostHog envelopes stay well below this while stack frames
+// and nested contexts retain enough headroom for useful diagnostics.
+const MAX_SCRUB_DEPTH = 10;
+const MAX_SCRUB_ARRAY_ITEMS = 100;
+const MAX_SCRUB_OBJECT_PROPERTIES = 100;
 
 export type Scrubbable =
   | string
@@ -27,6 +36,12 @@ export type Scrubbable =
 
 export interface ScrubTelemetryOptions {
   preservePostHogInternalKeys?: boolean;
+}
+
+interface ScrubContext {
+  activeObjects: WeakSet<object>;
+  scrubbedObjects: WeakMap<object, Scrubbable>;
+  options: ScrubTelemetryOptions;
 }
 
 export function scrubTelemetryUrl(value: string): string {
@@ -70,14 +85,141 @@ function shouldScrubKey(key: string, options: ScrubTelemetryOptions): boolean {
   return SENSITIVE_KEY_PATTERN.test(key);
 }
 
+function readOwnDataProperty(value: unknown, key: string): unknown {
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && "value" in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readArrayShape(
+  value: object,
+): { isArray: false } | { isArray: true; length: number } | null {
+  try {
+    if (!Array.isArray(value)) {
+      return { isArray: false };
+    }
+
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    if (
+      !lengthDescriptor
+      || !("value" in lengthDescriptor)
+      || typeof lengthDescriptor.value !== "number"
+      || !Number.isInteger(lengthDescriptor.value)
+      || lengthDescriptor.value < 0
+    ) {
+      return null;
+    }
+    return { isArray: true, length: lengthDescriptor.value };
+  } catch {
+    return null;
+  }
+}
+
+function defineScrubbedProperty(target: object, key: string, value: Scrubbable): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function scrubDescriptorValue(
+  descriptor: PropertyDescriptor,
+  key: string | undefined,
+  depth: number,
+  context: ScrubContext,
+): Scrubbable {
+  if (!("value" in descriptor)) {
+    return UNINSPECTABLE_VALUE_MARKER;
+  }
+  return scrubValue(descriptor.value as Scrubbable, key, depth, context);
+}
+
+function scrubArrayItems(
+  value: object,
+  scrubbed: Scrubbable[],
+  sourceLength: number,
+  depth: number,
+  context: ScrubContext,
+): void {
+  const retainedLength = Math.min(sourceLength, MAX_SCRUB_ARRAY_ITEMS);
+  scrubbed.length = retainedLength;
+  let truncated = sourceLength > retainedLength;
+
+  try {
+    for (let index = 0; index < retainedLength; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (!descriptor?.enumerable) {
+        continue;
+      }
+      defineScrubbedProperty(
+        scrubbed,
+        String(index),
+        scrubDescriptorValue(descriptor, undefined, depth + 1, context),
+      );
+    }
+  } catch {
+    truncated = true;
+  }
+
+  if (truncated) {
+    defineScrubbedProperty(scrubbed, String(retainedLength), TRUNCATION_MARKER);
+  }
+}
+
+function scrubObjectProperties(
+  value: object,
+  scrubbed: Record<string, Scrubbable>,
+  depth: number,
+  context: ScrubContext,
+): void {
+  let inspectedProperties = 0;
+  let truncated = false;
+
+  try {
+    for (const entryKey in value) {
+      if (inspectedProperties >= MAX_SCRUB_OBJECT_PROPERTIES) {
+        truncated = true;
+        break;
+      }
+      inspectedProperties += 1;
+
+      const descriptor = Object.getOwnPropertyDescriptor(value, entryKey);
+      if (!descriptor?.enumerable) {
+        continue;
+      }
+      defineScrubbedProperty(
+        scrubbed,
+        entryKey,
+        scrubDescriptorValue(descriptor, entryKey, depth + 1, context),
+      );
+    }
+  } catch {
+    truncated = true;
+  }
+
+  if (truncated) {
+    defineScrubbedProperty(scrubbed, OBJECT_TRUNCATION_KEY, TRUNCATION_MARKER);
+  }
+}
+
 function scrubValue(
   value: Scrubbable,
   key: string | undefined,
-  options: ScrubTelemetryOptions,
+  depth: number,
+  context: ScrubContext,
 ): Scrubbable {
   if (value == null) return value;
 
-  if (key && shouldScrubKey(key, options)) {
+  if (key && shouldScrubKey(key, context.options)) {
     return "[redacted]";
   }
 
@@ -85,15 +227,46 @@ function scrubValue(
     return scrubTelemetryText(value);
   }
 
-  if (Array.isArray(value)) {
-    return value.map((entry) => scrubValue(entry, undefined, options));
-  }
-
   if (typeof value === "object") {
-    const scrubbed: Record<string, Scrubbable> = {};
-    for (const [entryKey, entryValue] of Object.entries(value)) {
-      scrubbed[entryKey] = scrubValue(entryValue as Scrubbable, entryKey, options);
+    if (depth >= MAX_SCRUB_DEPTH) {
+      return TRUNCATION_MARKER;
     }
+
+    if (context.activeObjects.has(value)) {
+      return CIRCULAR_REFERENCE_MARKER;
+    }
+
+    const cached = context.scrubbedObjects.get(value);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const shape = readArrayShape(value);
+    if (!shape) {
+      return UNINSPECTABLE_VALUE_MARKER;
+    }
+
+    const scrubbed: Record<string, Scrubbable> | Scrubbable[] = shape.isArray
+      ? []
+      : {};
+    context.scrubbedObjects.set(value, scrubbed);
+    context.activeObjects.add(value);
+
+    try {
+      if (shape.isArray) {
+        scrubArrayItems(value, scrubbed as Scrubbable[], shape.length, depth, context);
+      } else {
+        scrubObjectProperties(
+          value,
+          scrubbed as Record<string, Scrubbable>,
+          depth,
+          context,
+        );
+      }
+    } finally {
+      context.activeObjects.delete(value);
+    }
+
     return scrubbed;
   }
 
@@ -101,7 +274,11 @@ function scrubValue(
 }
 
 export function scrubTelemetryData<T>(value: T, options: ScrubTelemetryOptions = {}): T {
-  return scrubValue(value as Scrubbable, undefined, options) as T;
+  return scrubValue(value as Scrubbable, undefined, 0, {
+    activeObjects: new WeakSet(),
+    scrubbedObjects: new WeakMap(),
+    options,
+  }) as T;
 }
 
 /**
@@ -116,10 +293,14 @@ export function scrubTelemetryData<T>(value: T, options: ScrubTelemetryOptions =
  * maps, and every other sensitive key stay redacted.
  */
 export function scrubTelemetryEvent<T>(value: T, options: ScrubTelemetryOptions = {}): T {
-  const originalEnvironment = (value as { environment?: unknown } | null | undefined)?.environment;
+  const originalEnvironment = readOwnDataProperty(value, "environment");
   const scrubbed = scrubTelemetryData(value, options);
-  if (typeof originalEnvironment === "string") {
-    (scrubbed as { environment?: unknown }).environment = scrubTelemetryText(originalEnvironment);
+  if (
+    typeof originalEnvironment === "string"
+    && scrubbed !== null
+    && typeof scrubbed === "object"
+  ) {
+    defineScrubbedProperty(scrubbed, "environment", scrubTelemetryText(originalEnvironment));
   }
   return scrubbed;
 }

--- a/apps/web/src/browser/telemetry/install-web-telemetry.ts
+++ b/apps/web/src/browser/telemetry/install-web-telemetry.ts
@@ -165,11 +165,11 @@ function buildTracePropagationTargets(apiBaseUrl: string): Array<string | RegExp
 }
 
 function scrubSentryBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb | null {
-  return {
-    ...breadcrumb,
-    message: breadcrumb.message ? scrubTelemetryText(breadcrumb.message) : breadcrumb.message,
-    data: scrubTelemetryData(breadcrumb.data),
-  };
+  const scrubbed = scrubTelemetryData(breadcrumb);
+  scrubbed.message = typeof scrubbed.message === "string"
+    ? scrubTelemetryText(scrubbed.message)
+    : scrubbed.message;
+  return scrubbed;
 }
 
 function scrubSentryFrame(frame: SentryStackFrame): void {

--- a/specs/codebase/structures/frontend/guides/telemetry.md
+++ b/specs/codebase/structures/frontend/guides/telemetry.md
@@ -83,6 +83,12 @@ session replay, and telemetry-related provider and hook ownership.
 ## Replay and Privacy
 
 - Session replay is opt-in and should default to disabled.
+- Shared client payload scrubbing bounds container traversal by depth, array
+  positions, and object properties. It replaces cyclic back-edges with
+  `[circular]` and structural overflow with `[truncated]`, reuses a completed
+  scrubbed value for repeated references, and redacts enumerable accessors
+  without evaluating them. These are structural bounds; strings retain their
+  existing redaction behavior and are not truncated by length.
 - When replay is enabled, workspace and settings surfaces should be blocked by
   default.
 - Continue using explicit masking for input areas that may contain sensitive


### PR DESCRIPTION
## Summary

- bound telemetry container traversal by depth, array positions, and object properties
- replace cycles and structural overflow with fixed markers
- avoid evaluating enumerable accessors or allocating from adversarial source array lengths
- apply the shared guard at Desktop, Web, Mobile, Sentry, and PostHog entrypoints

## Impact

Cyclic, deeply nested, sparse, or very wide telemetry payloads are scrubbed into serializable bounded structures without reading omitted values. Existing string-redaction behavior is unchanged; strings are not length-truncated by this PR.

## Verification

- Product-domain scrubber tests: 14 passed
- Desktop Sentry entrypoint tests: 3 passed
- Product-domain, Desktop, Web, and Mobile typechecks passed
- documentation integrity and `git diff --check` passed
- rebased over the merged query-telemetry documentation update