### PR TITLE
feat(mobile): cloud repository access parity (PR 7)

### DIFF
--- a/apps/mobile/src/components/home/MobileHomeScreen.tsx
+++ b/apps/mobile/src/components/home/MobileHomeScreen.tsx
@@ -10,6 +10,7 @@ import {
 
 import { useMobileHomeLaunchModel } from "../../hooks/home/derived/use-mobile-home-launch-model";
 import { useMobileHomeLaunchActions } from "../../hooks/home/workflows/use-mobile-home-launch-actions";
+import { useMobileCloudRepoReadiness } from "../../hooks/access/cloud/repositories/use-mobile-cloud-repo-readiness";
 import { useVisualViewportKeyboardInset } from "../../hooks/ui/keyboard/use-visual-viewport-keyboard-inset";
 import { useMobileWorkInventory } from "../../hooks/work/derived/use-mobile-work-inventory";
 import { summarizeMobileHomeLaunchConfig } from "../../lib/domain/home/mobile-home-config-summary";
@@ -43,6 +44,26 @@ export function MobileHomeScreen({
   const launchModel = useMobileHomeLaunchModel();
   const recentInventory = useMobileWorkInventory();
   const recentItems = recentInventory.recentItems.slice(0, 2);
+  // Gate workspace creation on the same managed-Cloud / GitHub App readiness
+  // the Add Repository modal uses, resolved for the selected repo.
+  const cloudRepoReadiness = useMobileCloudRepoReadiness({
+    enabled: Boolean(launchModel.selectedRepo),
+    repo: launchModel.selectedRepo
+      ? {
+          gitOwner: launchModel.selectedRepo.gitOwner,
+          gitRepoName: launchModel.selectedRepo.gitRepoName,
+        }
+      : null,
+  });
+  // Skip surfacing a blocked reason while readiness is still resolving —
+  // otherwise a fully-configured deployment briefly shows the operator
+  // "not configured" copy (the readiness gate fail-closes to "disabled"
+  // before /meta resolves).
+  const readinessBlockedReason = launchModel.selectedRepo
+      && !cloudRepoReadiness.checking
+      && cloudRepoReadiness.blocker
+    ? cloudRepoReadiness.blocker.description
+    : null;
   const launchActions = useMobileHomeLaunchActions({
     ownerUserId,
     catalog: launchModel.agentCatalog.data,
@@ -53,6 +74,7 @@ export function MobileHomeScreen({
     selection: launchModel.resolvedLaunchSelection,
     onOpenChat,
     onSubmitted: () => setDraft(""),
+    readinessBlockedReason,
   });
   const launchConfigSummary = summarizeMobileHomeLaunchConfig(
     launchModel.launchComposerControls,
@@ -63,6 +85,7 @@ export function MobileHomeScreen({
     && Boolean(launchModel.selectedRepo)
     && Boolean(launchModel.selectedRuntime)
     && canStartCloudHarness
+    && !readinessBlockedReason
     && !launchActions.submitting;
 
   function closeSheet() {
@@ -99,9 +122,9 @@ export function MobileHomeScreen({
 
       <View style={styles.spacer} />
 
-      {launchActions.status || launchActions.error || (!canStartCloudHarness && launchModel.harnessAvailability.message) ? (
+      {launchActions.status || launchActions.error || readinessBlockedReason || (!canStartCloudHarness && launchModel.harnessAvailability.message) ? (
         <Text style={[styles.launchNote, launchActions.error && styles.launchError]}>
-          {launchActions.error ?? launchActions.status ?? launchModel.harnessAvailability.message}
+          {launchActions.error ?? launchActions.status ?? readinessBlockedReason ?? launchModel.harnessAvailability.message}
         </Text>
       ) : null}
       <MobileHomeComposer

--- a/apps/mobile/src/components/settings/screen/MobileAddRepositoryModal.tsx
+++ b/apps/mobile/src/components/settings/screen/MobileAddRepositoryModal.tsx
@@ -14,6 +14,7 @@ import { useMobileRepositoryPicker } from "../../../hooks/settings/workflows/use
 import { useMobileSettingsSheetSlide } from "../../../hooks/settings/ui/use-mobile-settings-sheet-slide";
 import { colors, radius, spacing } from "../../../styles/tokens";
 import { MobileIcon } from "../../primitives/MobileIcon";
+import { MobileRepoReadinessBlocker } from "./MobileRepoReadinessBlocker";
 
 interface MobileAddRepositoryModalProps {
   visible: boolean;
@@ -43,7 +44,7 @@ export function MobileAddRepositoryModal({
         <Animated.View style={[styles.modalSheet, { transform: [{ translateY: slideUp }] }]}>
           <View style={styles.modalGrabber} />
           <View style={styles.modalHeader}>
-            <Text style={styles.modalTitle}>Add repository</Text>
+            <Text style={styles.modalTitle}>Set up in Cloud</Text>
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Close"
@@ -53,6 +54,22 @@ export function MobileAddRepositoryModal({
               <MobileIcon name="close" size={16} color={colors.fg} />
             </Pressable>
           </View>
+          {repositoryPicker.readiness.blocker ? (
+            <MobileRepoReadinessBlocker
+              blocker={repositoryPicker.readiness.blocker}
+              onAction={() => {
+                void repositoryPicker.readiness.runAction(
+                  repositoryPicker.readiness.blocker!.actionKind,
+                );
+              }}
+            />
+          ) : repositoryPicker.readiness.checking ? (
+            <View style={styles.modalEmpty}>
+              <ActivityIndicator color={colors.faint} />
+              <Text style={styles.modalEmptyText}>Checking Cloud access…</Text>
+            </View>
+          ) : (
+          <>
           <View style={styles.searchWrap}>
             <MobileIcon name="search" size={15} color={colors.faint} />
             <TextInput
@@ -120,6 +137,8 @@ export function MobileAddRepositoryModal({
             )}
             {repositoryPicker.error ? <Text style={styles.modalErrorText}>{repositoryPicker.error}</Text> : null}
           </ScrollView>
+          </>
+          )}
         </Animated.View>
       </View>
     </Modal>

--- a/apps/mobile/src/components/settings/screen/MobileRepoReadinessBlocker.tsx
+++ b/apps/mobile/src/components/settings/screen/MobileRepoReadinessBlocker.tsx
@@ -1,0 +1,111 @@
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
+
+import type { MobileRepoReadinessBlocker as MobileRepoReadinessBlockerView } from "../../../lib/domain/repos/mobile-repo-readiness-blocker";
+import { MobileIcon } from "../../primitives/MobileIcon";
+import { colors, radius, spacing } from "../../../styles/tokens";
+
+/**
+ * Native presentation of the shared repository-readiness blocker: an icon,
+ * title, description, and (when repairable here) a single CTA. Operator and
+ * human-access states render explanation with no button. No tokens or private
+ * keys are ever shown — only the server-issued browser handoff.
+ */
+export function MobileRepoReadinessBlocker({
+  blocker,
+  onAction,
+}: {
+  blocker: MobileRepoReadinessBlockerView;
+  onAction: () => void;
+}) {
+  const showCta = blocker.actionKind !== "none" && blocker.actionLabel !== null;
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.row}>
+        <View style={styles.iconTile}>
+          {blocker.pending ? (
+            <ActivityIndicator color={colors.faint} />
+          ) : (
+            <MobileIcon name="shield" size={16} color={colors.faint} />
+          )}
+        </View>
+        <View style={styles.textBlock}>
+          <Text style={styles.title}>{blocker.title}</Text>
+          <Text style={styles.description}>{blocker.description}</Text>
+        </View>
+      </View>
+      {showCta ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={blocker.actionLabel ?? undefined}
+          accessibilityState={{ disabled: blocker.pending }}
+          disabled={blocker.pending}
+          onPress={onAction}
+          style={({ pressed }) => [
+            styles.cta,
+            blocker.pending && styles.ctaDisabled,
+            pressed && styles.pressed,
+          ]}
+        >
+          <Text style={styles.ctaText}>{blocker.actionLabel}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing[3],
+  },
+  iconTile: {
+    width: 34,
+    height: 34,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radius.lg,
+    backgroundColor: colors.card,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  textBlock: {
+    flex: 1,
+    minWidth: 0,
+    gap: 4,
+  },
+  title: {
+    color: colors.fg,
+    fontSize: 14.5,
+    fontWeight: "600",
+  },
+  description: {
+    color: colors.faint,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  cta: {
+    minHeight: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    backgroundColor: colors.fg,
+    paddingHorizontal: spacing[4],
+  },
+  ctaDisabled: {
+    opacity: 0.62,
+  },
+  ctaText: {
+    color: colors.background,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+});

--- a/apps/mobile/src/components/shell/MobileShell.tsx
+++ b/apps/mobile/src/components/shell/MobileShell.tsx
@@ -1,16 +1,7 @@
 import { StatusBar } from "expo-status-bar";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  ActivityIndicator,
-  BackHandler,
-  Linking,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { useMemo } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-
-import { useCloudWorkspace } from "@proliferate/cloud-sdk-react";
 
 import { MobileAuthScreen } from "../auth/MobileAuthScreen";
 import { MobileConnectGitHubScreen } from "../auth/MobileConnectGitHubScreen";
@@ -24,20 +15,14 @@ import { MobileShellWithDrawer } from "./screen/MobileShellWithDrawer";
 import { MobileTopBar } from "../primitives/MobileTopBar";
 import { MobileWorkspacesScreen } from "../work/MobileAllWorkScreen";
 import { useMobileOnboardingStatus } from "../../hooks/shell/lifecycle/use-mobile-onboarding-status";
+import { useMobileShellNavigation } from "../../hooks/shell/lifecycle/use-mobile-shell-navigation";
 import { useMobileClientDailyActivity } from "../../hooks/telemetry/lifecycle/use-mobile-client-daily-activity";
 import { useMobileScreenTelemetry } from "../../hooks/telemetry/lifecycle/use-mobile-screen-telemetry";
 import {
-  clearMobileShellNavigation,
-  persistMobileShellNavigation,
-  restoreMobileShellNavigation,
-} from "../../lib/access/native/mobile-shell-navigation-storage";
-import {
   buildMobileShellAccountSummary,
-  mobileLinkedChatForWorkspace,
   mobileShellRouteSubtitle,
-  mobileWorkspaceLinkFromUrl,
 } from "../../lib/domain/shell/mobile-shell-navigation";
-import { routeTitle, type MobileCloudChat, type RouteId } from "../../navigation/navigation-model";
+import { routeTitle } from "../../navigation/navigation-model";
 import { useMobileAuth } from "../../providers/MobileAuthProvider";
 import { colors, spacing } from "../../styles/tokens";
 
@@ -53,24 +38,13 @@ export function MobileShell() {
     loadingAction,
     error,
   } = useMobileAuth();
-  const [route, setRoute] = useState<RouteId>("home");
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedChat, setSelectedChat] = useState<MobileCloudChat | null>(null);
-  const [linkedWorkspaceId, setLinkedWorkspaceId] = useState<string | null>(null);
-  const [linkedWorkspaceSessionId, setLinkedWorkspaceSessionId] = useState<string | null>(null);
-  const [initialLinkChecked, setInitialLinkChecked] = useState(false);
-  const [navigationRestored, setNavigationRestored] = useState(false);
-  const initialLinkAppliedRef = useRef(false);
-  const linkedWorkspace = useCloudWorkspace(
-    linkedWorkspaceId,
-    authState === "active" && linkedWorkspaceId !== null,
-  );
+  const ownerUserId = user?.id ?? null;
+  const nav = useMobileShellNavigation(authState, ownerUserId);
 
   const { completeOnboarding, onboardingStatus } = useMobileOnboardingStatus(authState);
-  const subtitle = useMemo(() => mobileShellRouteSubtitle(route), [route]);
+  const subtitle = useMemo(() => mobileShellRouteSubtitle(nav.route), [nav.route]);
   const account = useMemo(() => buildMobileShellAccountSummary(user), [user]);
-  const telemetryScreen = selectedChat ? "chat" : route;
-  const ownerUserId = user?.id ?? null;
+  const telemetryScreen = nav.selectedChat ? "chat" : nav.route;
 
   useMobileScreenTelemetry(authState, telemetryScreen);
   const canRecordAuthenticatedActivity = authState === "active" || authState === "needs_github";
@@ -78,153 +52,11 @@ export function MobileShell() {
     accessToken: canRecordAuthenticatedActivity ? accessToken : null,
     actorStorageKey: user?.id ?? null,
     routeOrScreen: authState === "needs_github" ? "connect_github" : telemetryScreen,
-    viewingChat: authState === "active" && selectedChat !== null,
+    viewingChat: authState === "active" && nav.selectedChat !== null,
   });
-  const applyWorkspaceLink = useCallback((url: string | null): boolean => {
-    const link = mobileWorkspaceLinkFromUrl(url);
-    if (!link) {
-      return false;
-    }
-    initialLinkAppliedRef.current = true;
-    setLinkedWorkspaceId(link.workspaceId);
-    setLinkedWorkspaceSessionId(link.sessionId);
-    setRoute("work");
-    setSelectedChat(null);
-    setDrawerOpen(false);
-    return true;
-  }, []);
-
-  useEffect(() => {
-    let active = true;
-    void Linking.getInitialURL()
-      .then((url) => {
-        if (active) {
-          applyWorkspaceLink(url);
-        }
-      })
-      .finally(() => {
-        if (active) {
-          setInitialLinkChecked(true);
-        }
-      });
-    const subscription = Linking.addEventListener("url", ({ url }) => {
-      applyWorkspaceLink(url);
-    });
-    return () => {
-      active = false;
-      subscription.remove();
-    };
-  }, [applyWorkspaceLink]);
-
-  useEffect(() => {
-    if (authState !== "active") {
-      setNavigationRestored(false);
-      return;
-    }
-    if (!initialLinkChecked) {
-      return;
-    }
-    if (initialLinkAppliedRef.current) {
-      setNavigationRestored(true);
-      return;
-    }
-    if (!ownerUserId) {
-      return;
-    }
-    let cancelled = false;
-    void restoreMobileShellNavigation(ownerUserId)
-      .then((stored) => {
-        if (cancelled) {
-          return;
-        }
-        if (stored.route) {
-          setRoute(stored.route);
-        }
-        if (stored.chat) {
-          setSelectedChat(stored.chat);
-        }
-      })
-      .catch(() => undefined)
-      .finally(() => {
-        if (!cancelled) {
-          setNavigationRestored(true);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [authState, initialLinkChecked, ownerUserId]);
-
-  useEffect(() => {
-    if (authState !== "active" || !navigationRestored || !ownerUserId) {
-      return;
-    }
-    void persistMobileShellNavigation(ownerUserId, route, selectedChat);
-  }, [authState, navigationRestored, ownerUserId, route, selectedChat]);
-
-  useEffect(() => {
-    if (!linkedWorkspaceId || !linkedWorkspace.data) {
-      return;
-    }
-    const chat = mobileLinkedChatForWorkspace(linkedWorkspace.data, [], linkedWorkspaceSessionId);
-    if (chat) {
-      setSelectedChat(chat);
-    } else {
-      setRoute("work");
-    }
-    setLinkedWorkspaceId(null);
-    setLinkedWorkspaceSessionId(null);
-  }, [linkedWorkspace.data, linkedWorkspaceId, linkedWorkspaceSessionId]);
-
-  useEffect(() => {
-    const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
-      if (drawerOpen) {
-        setDrawerOpen(false);
-        return true;
-      }
-      if (selectedChat) {
-        setSelectedChat(null);
-        return true;
-      }
-      if (route !== "home") {
-        setRoute("home");
-        return true;
-      }
-      return false;
-    });
-
-    return () => subscription.remove();
-  }, [drawerOpen, route, selectedChat]);
-
-  function navigate(nextRoute: RouteId) {
-    setRoute(nextRoute);
-    setSelectedChat(null);
-    setDrawerOpen(false);
-  }
-
-  function openChat(chat: MobileCloudChat) {
-    setSelectedChat(chat);
-    setDrawerOpen(false);
-  }
-
-  const markSelectedChatSession = useCallback((sessionId: string) => {
-    setSelectedChat((current) => current ? { ...current, sessionId } : current);
-  }, []);
-  const clearSelectedChatInitialPendingPrompt = useCallback(() => {
-    setSelectedChat((current) =>
-      current?.initialPendingPrompt ? { ...current, initialPendingPrompt: null } : current
-    );
-  }, []);
 
   async function handleSignOut() {
-    setRoute("home");
-    setDrawerOpen(false);
-    setSelectedChat(null);
-    setLinkedWorkspaceId(null);
-    setLinkedWorkspaceSessionId(null);
-    setNavigationRestored(false);
-    initialLinkAppliedRef.current = false;
-    await clearMobileShellNavigation(ownerUserId).catch(() => undefined);
+    await nav.resetForSignOut(ownerUserId);
     await signOut();
   }
 
@@ -282,58 +114,58 @@ export function MobileShell() {
       <StatusBar style="light" />
 
       <MobileShellWithDrawer
-        drawerOpen={drawerOpen}
-        setDrawerOpen={setDrawerOpen}
+        drawerOpen={nav.drawerOpen}
+        setDrawerOpen={nav.setDrawerOpen}
         drawer={
           <MobileDrawer
-            activeRoute={selectedChat ? null : route}
-            onNavigate={navigate}
-            onOpenChat={openChat}
-            onNewChat={() => navigate("home")}
-            onClose={() => setDrawerOpen(false)}
+            activeRoute={nav.selectedChat ? null : nav.route}
+            onNavigate={nav.navigate}
+            onOpenChat={nav.openChat}
+            onNewChat={() => nav.navigate("home")}
+            onClose={() => nav.setDrawerOpen(false)}
             account={account}
           />
         }
       >
-        {selectedChat ? (
+        {nav.selectedChat ? (
           <MobileChatScreen
-            chat={selectedChat}
+            chat={nav.selectedChat}
             ownerUserId={ownerUserId}
             productToken={accessToken}
-            onBack={() => setSelectedChat(null)}
-            onInitialPendingPromptConsumed={clearSelectedChatInitialPendingPrompt}
-            onSessionSelected={markSelectedChatSession}
+            onBack={nav.closeChat}
+            onInitialPendingPromptConsumed={nav.clearSelectedChatInitialPendingPrompt}
+            onSessionSelected={nav.markSelectedChatSession}
           />
-        ) : route === "home" ? (
+        ) : nav.route === "home" ? (
           <MobileHomeScreen
             ownerUserId={ownerUserId}
-            onOpenChat={openChat}
-            onOpenDrawer={() => setDrawerOpen(true)}
-            onConfigureRepos={() => navigate("settings")}
+            onOpenChat={nav.openChat}
+            onOpenDrawer={() => nav.setDrawerOpen(true)}
+            onConfigureRepos={() => nav.navigate("settings")}
           />
         ) : (
           <View style={styles.body}>
-            {route === "work" ? (
+            {nav.route === "work" ? (
               <MobileWorkspacesScreen
-                onOpenChat={openChat}
-                onOpenDrawer={() => setDrawerOpen(true)}
-                onNewChat={() => navigate("home")}
+                onOpenChat={nav.openChat}
+                onOpenDrawer={() => nav.setDrawerOpen(true)}
+                onNewChat={() => nav.navigate("home")}
               />
-            ) : route === "automations" ? (
+            ) : nav.route === "automations" ? (
               <>
                 <MobileTopBar
-                  title={routeTitle(route)}
+                  title={routeTitle(nav.route)}
                   subtitle={subtitle}
-                  leading={{ kind: "menu", onPress: () => setDrawerOpen(true) }}
+                  leading={{ kind: "menu", onPress: () => nav.setDrawerOpen(true) }}
                 />
                 <MobileAutomationsScreen />
               </>
             ) : (
               <>
                 <MobileTopBar
-                  title={routeTitle(route)}
+                  title={routeTitle(nav.route)}
                   subtitle={subtitle}
-                  leading={{ kind: "menu", onPress: () => setDrawerOpen(true) }}
+                  leading={{ kind: "menu", onPress: () => nav.setDrawerOpen(true) }}
                 />
                 <MobileSettingsScreen account={account} onSignOut={() => void handleSignOut()} />
               </>

--- a/apps/mobile/src/components/work/MobileAllWorkScreen.tsx
+++ b/apps/mobile/src/components/work/MobileAllWorkScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useMobileWorkInventory } from "../../hooks/work/derived/use-mobile-work-inventory";
 import { useMobileWorkFilters } from "../../hooks/work/ui/use-mobile-work-filters";
 import { useMobileWorkClaimActions } from "../../hooks/work/workflows/use-mobile-work-claim-actions";
+import { useMobileServerCapabilities } from "../../hooks/access/cloud/capabilities/use-mobile-server-capabilities";
 import {
   MOBILE_WORK_STATUS_OPTIONS,
   MOBILE_WORK_TYPE_OPTIONS,
@@ -44,6 +45,16 @@ export function MobileWorkspacesScreen({
   const filterState = useMobileWorkFilters(allInventory.items);
   const inventory = useMobileWorkInventory(filterState.filters);
   const claimActions = useMobileWorkClaimActions();
+  // Access-loss (PR 7): when managed-Cloud capability is no longer ready, keep
+  // existing Cloud workspace records visible but locked and explained. Only
+  // treat an explicit non-ready capability as loss — an in-flight/unknown read
+  // must not lock records (fail closed on gating, not on presentation).
+  const capabilities = useMobileServerCapabilities();
+  const cloudAccessLost = capabilities.data?.managedCloud === "disabled"
+    || capabilities.data?.managedCloud === "operator_configuration_required";
+  const accessLossReason = cloudAccessLost
+    ? "Cloud access is no longer available on this deployment. This workspace is read-only until access is restored."
+    : null;
 
   return (
     <MobileScreen
@@ -155,6 +166,7 @@ export function MobileWorkspacesScreen({
                     key={item.view.id}
                     item={item}
                     claiming={claimActions.claimingWorkspaceId === item.workspace.id}
+                    accessLossReason={accessLossReason}
                     onPress={() => onOpenChat(item.chat)}
                     onClaim={() => {
                       void claimActions.claimListWorkspace(item);

--- a/apps/mobile/src/components/work/MobileWorkspaceCard.tsx
+++ b/apps/mobile/src/components/work/MobileWorkspaceCard.tsx
@@ -13,6 +13,12 @@ interface MobileWorkspaceCardProps {
   item: MobileWorkItem;
   compact?: boolean;
   claiming?: boolean;
+  /**
+   * PR 7 access-loss state: when Cloud repository access is lost, the existing
+   * record stays visible but is marked locked and explained; commanding it is
+   * disabled. No local materialization / clone action is offered on mobile.
+   */
+  accessLossReason?: string | null;
   onPress: () => void;
   onClaim?: () => void;
 }
@@ -21,13 +27,15 @@ export function MobileWorkspaceCard({
   item,
   compact = false,
   claiming = false,
+  accessLossReason = null,
   onPress,
   onClaim,
 }: MobileWorkspaceCardProps) {
   const detailText = workspaceDetailText(item);
   const statusColor = colors[mobileColorKeyForWorkStatusTone(item.view.statusIndicator.tone)];
   const unclaimed = item.view.unclaimed;
-  const canClaim = Boolean(onClaim) && unclaimed;
+  const locked = Boolean(accessLossReason);
+  const canClaim = Boolean(onClaim) && unclaimed && !locked;
 
   return (
     <Pressable
@@ -79,6 +87,14 @@ export function MobileWorkspaceCard({
         <View style={styles.promptBlock}>
           <Text style={styles.promptText} numberOfLines={2}>
             {detailText}
+          </Text>
+        </View>
+      ) : null}
+      {locked ? (
+        <View style={styles.lockedBlock}>
+          <MobileIcon name="lock" size={13} color={colors.warning} />
+          <Text style={styles.lockedText} numberOfLines={compact ? 1 : 3}>
+            {accessLossReason}
           </Text>
         </View>
       ) : null}
@@ -213,6 +229,22 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[2],
+  },
+  lockedBlock: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing[2],
+    borderRadius: 14,
+    backgroundColor: colors.warningSubtle,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  lockedText: {
+    flex: 1,
+    minWidth: 0,
+    color: colors.warning,
+    fontSize: 12,
+    lineHeight: 16,
   },
   promptText: {
     color: colors.mutedForeground,

--- a/apps/mobile/src/hooks/access/cloud/capabilities/use-mobile-server-capabilities.ts
+++ b/apps/mobile/src/hooks/access/cloud/capabilities/use-mobile-server-capabilities.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import { useCloudClient } from "@proliferate/cloud-sdk-react";
+
+import {
+  DISABLED_MOBILE_CAPABILITIES,
+  parseMobileMetaCapabilities,
+  type MobileServerCapabilities,
+} from "../../../../lib/access/cloud/capabilities/mobile-server-capabilities";
+
+/**
+ * Read the connected control plane's v2 managed-Cloud / GitHub-access
+ * capability status from `GET /meta`.
+ *
+ * Fail-closed: any error or malformed body resolves to fully-disabled
+ * capabilities, so a gate never opens on unknown state. The query lives under
+ * the cloud client's base URL so it re-fetches when the deployment changes.
+ */
+export function useMobileServerCapabilities(enabled = true) {
+  const client = useCloudClient();
+  return useQuery<MobileServerCapabilities>({
+    queryKey: ["cloud", "meta-capabilities", client.baseUrl],
+    queryFn: async () => {
+      try {
+        const body = await client.requestJson<unknown>({
+          method: "GET",
+          path: "/meta",
+        });
+        return parseMobileMetaCapabilities(body);
+      } catch {
+        return DISABLED_MOBILE_CAPABILITIES;
+      }
+    },
+    enabled,
+  });
+}

--- a/apps/mobile/src/hooks/access/cloud/repositories/use-mobile-cloud-repo-readiness.ts
+++ b/apps/mobile/src/hooks/access/cloud/repositories/use-mobile-cloud-repo-readiness.ts
@@ -1,0 +1,246 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  githubAppRootKey,
+  repositoriesKey,
+  useCloudClient,
+  useGitHubAppInstallationStatus,
+  useGitHubAppUserAuthorizationStatus,
+  useGitHubRepoAuthority,
+  useOrganizations,
+} from "@proliferate/cloud-sdk-react";
+import {
+  resolveRepositoryReadiness,
+  type RepositoryReadiness,
+} from "@proliferate/product-domain/repos/repo-readiness";
+import * as Clipboard from "expo-clipboard";
+
+import {
+  openMobileGitHubAppInstallation,
+  openMobileGitHubAppUserAuthorization,
+  openMobileGitHubInstallationSettings,
+} from "../../../../lib/access/cloud/auth/mobile-auth-flow";
+import {
+  resolveMobileInstallationTarget,
+  synthesizeListAuthority,
+  type MobileInstallationState,
+  type MobileUserAuthorizationState,
+} from "../../../../lib/domain/repos/mobile-repo-access-inputs";
+import {
+  buildMobileCloudAdminRequestMessage,
+  resolveMobileRepoReadinessBlocker,
+  type MobileRepoReadinessActionKind,
+  type MobileRepoReadinessBlocker,
+} from "../../../../lib/domain/repos/mobile-repo-readiness-blocker";
+import { useMobileServerCapabilities } from "../capabilities/use-mobile-server-capabilities";
+
+export interface MobileCloudRepoReadiness {
+  /** The resolver result; `gate === 10` means every prerequisite is met. */
+  readiness: RepositoryReadiness;
+  /** The single blocker to render, or null when ready to list / save. */
+  blocker: MobileRepoReadinessBlocker | null;
+  /** True while any prerequisite query is still loading. */
+  checking: boolean;
+  /** Perform the blocker's CTA (opens browser / copies request / refetches). */
+  runAction: (kind: MobileRepoReadinessActionKind) => Promise<void>;
+  /** Invalidate all access queries and re-run the resolver (callback return). */
+  refetchOnReturn: () => void;
+}
+
+/**
+ * Shared readiness gate for the mobile Cloud repository surfaces — the Add
+ * Repository modal (list level) and workspace creation. Assembles the
+ * already-fetched GitHub App / capability / organization state into the shared
+ * `resolveRepositoryReadiness` resolver, so mobile uses the exact Desktop/Web
+ * gate ordering and vocabulary, and exposes the native browser actions plus the
+ * callback-return invalidation the spec requires.
+ *
+ * Pass a concrete `repo` to gate per-repository (authority query runs);
+ * omit it (or pass null) for the list-level gate before a repo is chosen —
+ * authority is then synthesized from account-level authorization/installation.
+ */
+export function useMobileCloudRepoReadiness(input: {
+  enabled: boolean;
+  repo?: { gitOwner: string; gitRepoName: string } | null;
+}): MobileCloudRepoReadiness {
+  const { enabled } = input;
+  const repo = input.repo ?? null;
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+  const [actionBusy, setActionBusy] = useState(false);
+
+  const capabilities = useMobileServerCapabilities(enabled);
+  const managedCloudStatus = capabilities.data?.managedCloud ?? "disabled";
+  const githubAccessStatus = capabilities.data?.githubRepositoryAccess ?? "disabled";
+  const githubAccessDisplayName =
+    capabilities.data?.githubRepositoryAccessDisplayName ?? null;
+
+  // Managed Cloud disabled/operator-incomplete short-circuits: never call the
+  // repository authority endpoint (spec failure behavior).
+  const capabilityReady = enabled && managedCloudStatus === "ready";
+
+  const organizations = useOrganizations(enabled);
+  const installationTarget = useMemo(
+    () =>
+      resolveMobileInstallationTarget(
+        (organizations.data?.organizations ?? []).map((org) => ({
+          id: org.id,
+          role: org.membership?.role ?? null,
+        })),
+      ),
+    [organizations.data?.organizations],
+  );
+
+  const userAuthorization = useGitHubAppUserAuthorizationStatus(capabilityReady);
+  const installation = useGitHubAppInstallationStatus(
+    installationTarget.organizationId,
+    capabilityReady && installationTarget.organizationId !== null,
+  );
+
+  // Per-repo authority: only when a concrete repo is targeted and capability is
+  // ready and the user is authorized (avoids a doomed call before auth).
+  const authorityEnabled =
+    capabilityReady
+    && repo !== null
+    && userAuthorization.data?.connected === true;
+  const authority = useGitHubRepoAuthority(
+    { gitOwner: repo?.gitOwner, gitRepoName: repo?.gitRepoName },
+    authorityEnabled,
+  );
+
+  const readiness = useMemo<RepositoryReadiness>(() => {
+    const userAuthState: MobileUserAuthorizationState = userAuthorization.isLoading
+      ? "unknown"
+      : userAuthorization.data?.connected === true
+        ? "connected"
+        : userAuthorization.data?.action === "reauthorize"
+          ? "needs_reauthorize"
+          : "needs_authorize";
+    const installationState: MobileInstallationState = installation.isLoading
+      ? "unknown"
+      : installation.data?.installed === true
+        ? "installed"
+        : "missing";
+
+    // For the per-repo gate use the authority endpoint result; for the
+    // list-level gate synthesize authority from account-level state.
+    const authoritySnapshot = repo
+      ? authority.data
+        ? { authorized: authority.data.authorized, status: authority.data.status }
+        : null
+      : synthesizeListAuthority({
+          userAuthorization: userAuthState,
+          installation: installationState,
+          requiresInstallation: installationTarget.organizationId !== null,
+        });
+
+    return resolveRepositoryReadiness({
+      requirement: "managed_cloud",
+      githubRepositoryAccess: githubAccessStatus,
+      managedCloud: managedCloudStatus,
+      // Mobile is only reachable when signed in.
+      signedIn: true,
+      // List level has no specific repo identity yet — treat as supported so
+      // the gate advances to authority; the per-repo gate always has identity.
+      hasSupportedRepoIdentity: true,
+      authorityLoading: repo
+        ? authorityEnabled && authority.isPending && !authority.data
+        : userAuthorization.isLoading || installation.isLoading,
+      authorityError: repo ? authority.isError : false,
+      authority: authoritySnapshot,
+      canManageInstallation: installationTarget.canManageInstallation,
+      // The list surface saves the environment on pick; treat as not-yet so the
+      // resolver reports gate 9 (ready-to-save) rather than gate 10.
+      cloudEnvironmentConfigured: false,
+    });
+  }, [
+    authority.data,
+    authority.isError,
+    authority.isPending,
+    authorityEnabled,
+    githubAccessStatus,
+    installation.data?.installed,
+    installation.isLoading,
+    installationTarget.canManageInstallation,
+    installationTarget.organizationId,
+    managedCloudStatus,
+    repo,
+    userAuthorization.data?.action,
+    userAuthorization.data?.connected,
+    userAuthorization.isLoading,
+  ]);
+
+  // While capabilities are still loading, `managedCloudStatus` above has
+  // fail-closed to "disabled" and the resolver reports gate 1 on placeholder
+  // input. Route that through the blocker's checking presentation instead of
+  // "Cloud is not configured on this deployment" so a fully-configured
+  // deployment does not flash the operator-blocker copy on cold open.
+  const checking =
+    capabilities.isLoading
+    || (capabilityReady
+      && (userAuthorization.isLoading || (installationTarget.organizationId !== null && installation.isLoading)));
+
+  const blocker = useMemo(
+    () =>
+      resolveMobileRepoReadinessBlocker({
+        readiness,
+        githubAccessDisplayName,
+        actionBusy,
+        checking: capabilities.isLoading,
+      }),
+    [actionBusy, capabilities.isLoading, githubAccessDisplayName, readiness],
+  );
+
+  const refetchOnReturn = useCallback(() => {
+    // Callback return: invalidate user authorization, installation, accessible
+    // repos, and per-repo authority (all under the GitHub App root), plus
+    // repositories, so the resolver re-runs with fresh state.
+    void queryClient.invalidateQueries({ queryKey: githubAppRootKey(client.baseUrl) });
+    void queryClient.invalidateQueries({ queryKey: repositoriesKey() });
+  }, [client.baseUrl, queryClient]);
+
+  const runAction = useCallback(
+    async (kind: MobileRepoReadinessActionKind) => {
+      if (actionBusy) {
+        return;
+      }
+      setActionBusy(true);
+      try {
+        switch (kind) {
+          case "retry":
+            refetchOnReturn();
+            break;
+          case "authorize_user":
+          case "reauthorize_user":
+            await openMobileGitHubAppUserAuthorization(client);
+            break;
+          case "install_app":
+            if (installationTarget.organizationId) {
+              await openMobileGitHubAppInstallation(
+                client,
+                installationTarget.organizationId,
+              );
+            }
+            break;
+          case "grant_repo_access":
+            await openMobileGitHubInstallationSettings();
+            break;
+          case "copy_admin_request":
+            await Clipboard.setStringAsync(
+              buildMobileCloudAdminRequestMessage(
+                repo ? `${repo.gitOwner}/${repo.gitRepoName}` : null,
+              ),
+            );
+            break;
+          case "none":
+            break;
+        }
+      } finally {
+        setActionBusy(false);
+      }
+    },
+    [actionBusy, client, installationTarget.organizationId, refetchOnReturn, repo],
+  );
+
+  return { readiness, blocker, checking, runAction, refetchOnReturn };
+}

--- a/apps/mobile/src/hooks/home/workflows/use-mobile-home-launch-actions.ts
+++ b/apps/mobile/src/hooks/home/workflows/use-mobile-home-launch-actions.ts
@@ -27,6 +27,12 @@ export function useMobileHomeLaunchActions(input: {
   selection: CloudLaunchComposerSelection;
   onOpenChat: (chat: MobileCloudChat) => void;
   onSubmitted?: () => void;
+  /**
+   * Readiness gate (PR 7): when the managed-Cloud / GitHub App prerequisites
+   * for the selected repo are not met, submit is blocked with this reason.
+   * Passed as a plain string so this workflow stays free of access hooks.
+   */
+  readinessBlockedReason?: string | null;
 }) {
   const submitInFlightRef = useRef(false);
   const [status, setStatus] = useState<string | null>(null);
@@ -40,6 +46,10 @@ export function useMobileHomeLaunchActions(input: {
     }
     if (!input.ownerUserId) {
       setError("Account is still loading. Try again in a moment.");
+      return;
+    }
+    if (input.readinessBlockedReason) {
+      setError(input.readinessBlockedReason);
       return;
     }
 

--- a/apps/mobile/src/hooks/settings/workflows/use-mobile-repository-picker.ts
+++ b/apps/mobile/src/hooks/settings/workflows/use-mobile-repository-picker.ts
@@ -2,6 +2,7 @@ import {
   useMobileGitRepositories,
   useSaveMobileRepoConfig,
 } from "../../access/cloud/repositories/use-mobile-repositories";
+import { useMobileCloudRepoReadiness } from "../../access/cloud/repositories/use-mobile-cloud-repo-readiness";
 import { useMobileRepositoryPickerOptions } from "../derived/use-mobile-repository-picker-options";
 import { useMobileRepositoryPickerState } from "../ui/use-mobile-repository-picker-state";
 
@@ -16,7 +17,13 @@ export function useMobileRepositoryPicker({
   onSaved: () => void;
   onClose: () => void;
 }) {
-  const repos = useMobileGitRepositories(visible);
+  // List-level readiness gate: resolve deployment -> sign-in -> user App auth
+  // -> installation -> coverage before the repository picker lists or saves.
+  const readiness = useMobileCloudRepoReadiness({ enabled: visible });
+  // Only list / list-save once every list-level gate is met.
+  const gatesReady = readiness.blocker === null && !readiness.checking;
+
+  const repos = useMobileGitRepositories(visible && gatesReady);
   const save = useSaveMobileRepoConfig();
   const pickerState = useMobileRepositoryPickerState(visible);
   const available = useMobileRepositoryPickerOptions({
@@ -30,6 +37,10 @@ export function useMobileRepositoryPicker({
     gitRepoName: string,
     defaultBranch: string | null,
   ): Promise<void> {
+    // Defense in depth: never save while a gate is unmet.
+    if (!gatesReady) {
+      return;
+    }
     const key = `${gitOwner}/${gitRepoName}`;
     pickerState.setBusyKey(key);
     pickerState.setError(null);
@@ -58,8 +69,10 @@ export function useMobileRepositoryPicker({
     available,
     busyKey: pickerState.busyKey,
     error: pickerState.error,
+    gatesReady,
     pickRepository,
     query: pickerState.query,
+    readiness,
     repos,
     setQuery: pickerState.setQuery,
   };

--- a/apps/mobile/src/hooks/shell/lifecycle/use-mobile-shell-navigation.ts
+++ b/apps/mobile/src/hooks/shell/lifecycle/use-mobile-shell-navigation.ts
@@ -1,0 +1,266 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { BackHandler, Linking } from "react-native";
+
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  githubAppRootKey,
+  repositoriesKey,
+  useCloudClient,
+  useCloudWorkspace,
+} from "@proliferate/cloud-sdk-react";
+
+import { isMobileGitHubAppCallbackUrl } from "../../../lib/access/cloud/auth/mobile-github-app-callback";
+import {
+  clearMobileShellNavigation,
+  persistMobileShellNavigation,
+  restoreMobileShellNavigation,
+} from "../../../lib/access/native/mobile-shell-navigation-storage";
+import {
+  mobileLinkedChatForWorkspace,
+  mobileWorkspaceLinkFromUrl,
+} from "../../../lib/domain/shell/mobile-shell-navigation";
+import type { MobileCloudChat, RouteId } from "../../../navigation/navigation-model";
+import type { MobileAuthState } from "../../../providers/MobileAuthProvider";
+
+export interface MobileShellNavigation {
+  route: RouteId;
+  drawerOpen: boolean;
+  setDrawerOpen: (open: boolean) => void;
+  selectedChat: MobileCloudChat | null;
+  /** Navigate to a top-level route, closing the drawer and any open chat. */
+  navigate: (nextRoute: RouteId) => void;
+  /** Open a chat, closing the drawer. */
+  openChat: (chat: MobileCloudChat) => void;
+  /** Return to the route view, discarding the open chat. */
+  closeChat: () => void;
+  markSelectedChatSession: (sessionId: string) => void;
+  clearSelectedChatInitialPendingPrompt: () => void;
+  /** Reset all navigation state to its signed-out defaults and clear storage. */
+  resetForSignOut: (ownerUserId: string | null) => Promise<void>;
+}
+
+/**
+ * Owns MobileShell's route/drawer/chat state plus its three side-effect
+ * concerns: GitHub App callback / deep-link recovery, cross-launch
+ * navigation persistence (restore on mount, persist on change), and the
+ * Android hardware back button. Extracted so MobileShell itself stays a
+ * thin render switch over auth/onboarding state.
+ */
+export function useMobileShellNavigation(
+  authState: MobileAuthState,
+  ownerUserId: string | null,
+): MobileShellNavigation {
+  const [route, setRoute] = useState<RouteId>("home");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedChat, setSelectedChat] = useState<MobileCloudChat | null>(null);
+  const [linkedWorkspaceId, setLinkedWorkspaceId] = useState<string | null>(null);
+  const [linkedWorkspaceSessionId, setLinkedWorkspaceSessionId] = useState<string | null>(null);
+  const [initialLinkChecked, setInitialLinkChecked] = useState(false);
+  const [navigationRestored, setNavigationRestored] = useState(false);
+  const initialLinkAppliedRef = useRef(false);
+  const linkedWorkspace = useCloudWorkspace(
+    linkedWorkspaceId,
+    authState === "active" && linkedWorkspaceId !== null,
+  );
+  const queryClient = useQueryClient();
+  const cloudClient = useCloudClient();
+
+  const applyGitHubAppCallback = useCallback((url: string | null): boolean => {
+    if (!isMobileGitHubAppCallbackUrl(url)) {
+      return false;
+    }
+    // Callback return: invalidate authorization, installation, accessible
+    // repos, per-repo authority, and repositories so the resolver re-runs. On a
+    // warm return the in-memory modal intent survives and self-heals; on a cold
+    // start we land in repository/access settings — no arbitrary command is
+    // persisted (PR 7 acceptance: callback recovery is native-safe).
+    void queryClient.invalidateQueries({ queryKey: githubAppRootKey(cloudClient.baseUrl) });
+    void queryClient.invalidateQueries({ queryKey: repositoriesKey() });
+    initialLinkAppliedRef.current = true;
+    setRoute("settings");
+    setSelectedChat(null);
+    setDrawerOpen(false);
+    return true;
+  }, [cloudClient.baseUrl, queryClient]);
+
+  const applyWorkspaceLink = useCallback((url: string | null): boolean => {
+    if (applyGitHubAppCallback(url)) {
+      return true;
+    }
+    const link = mobileWorkspaceLinkFromUrl(url);
+    if (!link) {
+      return false;
+    }
+    initialLinkAppliedRef.current = true;
+    setLinkedWorkspaceId(link.workspaceId);
+    setLinkedWorkspaceSessionId(link.sessionId);
+    setRoute("work");
+    setSelectedChat(null);
+    setDrawerOpen(false);
+    return true;
+  }, [applyGitHubAppCallback]);
+
+  useEffect(() => {
+    let active = true;
+    void Linking.getInitialURL()
+      .then((url) => {
+        if (active) {
+          applyWorkspaceLink(url);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setInitialLinkChecked(true);
+        }
+      });
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      applyWorkspaceLink(url);
+    });
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, [applyWorkspaceLink]);
+
+  useEffect(() => {
+    if (authState !== "active") {
+      setNavigationRestored(false);
+      return;
+    }
+    if (!initialLinkChecked) {
+      return;
+    }
+    if (initialLinkAppliedRef.current) {
+      setNavigationRestored(true);
+      return;
+    }
+    if (!ownerUserId) {
+      return;
+    }
+    let cancelled = false;
+    void restoreMobileShellNavigation(ownerUserId)
+      .then((stored) => {
+        if (cancelled) {
+          return;
+        }
+        if (stored.route) {
+          setRoute(stored.route);
+        }
+        if (stored.chat) {
+          setSelectedChat(stored.chat);
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) {
+          setNavigationRestored(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authState, initialLinkChecked, ownerUserId]);
+
+  useEffect(() => {
+    if (authState !== "active" || !navigationRestored || !ownerUserId) {
+      return;
+    }
+    void persistMobileShellNavigation(ownerUserId, route, selectedChat);
+  }, [authState, navigationRestored, ownerUserId, route, selectedChat]);
+
+  useEffect(() => {
+    if (!linkedWorkspaceId || !linkedWorkspace.data) {
+      return;
+    }
+    const chat = mobileLinkedChatForWorkspace(linkedWorkspace.data, [], linkedWorkspaceSessionId);
+    if (chat) {
+      setSelectedChat(chat);
+    } else {
+      setRoute("work");
+    }
+    setLinkedWorkspaceId(null);
+    setLinkedWorkspaceSessionId(null);
+  }, [linkedWorkspace.data, linkedWorkspaceId, linkedWorkspaceSessionId]);
+
+  useEffect(() => {
+    const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
+      if (drawerOpen) {
+        setDrawerOpen(false);
+        return true;
+      }
+      if (selectedChat) {
+        setSelectedChat(null);
+        return true;
+      }
+      if (route !== "home") {
+        setRoute("home");
+        return true;
+      }
+      return false;
+    });
+
+    return () => subscription.remove();
+  }, [drawerOpen, route, selectedChat]);
+
+  const navigate = useCallback((nextRoute: RouteId) => {
+    setRoute(nextRoute);
+    setSelectedChat(null);
+    setDrawerOpen(false);
+  }, []);
+
+  const openChat = useCallback((chat: MobileCloudChat) => {
+    setSelectedChat(chat);
+    setDrawerOpen(false);
+  }, []);
+
+  const closeChat = useCallback(() => {
+    setSelectedChat(null);
+  }, []);
+
+  const markSelectedChatSession = useCallback((sessionId: string) => {
+    setSelectedChat((current) => current ? { ...current, sessionId } : current);
+  }, []);
+
+  const clearSelectedChatInitialPendingPrompt = useCallback(() => {
+    setSelectedChat((current) =>
+      current?.initialPendingPrompt ? { ...current, initialPendingPrompt: null } : current
+    );
+  }, []);
+
+  const resetForSignOut = useCallback(async (ownerUserIdAtSignOut: string | null) => {
+    setRoute("home");
+    setDrawerOpen(false);
+    setSelectedChat(null);
+    setLinkedWorkspaceId(null);
+    setLinkedWorkspaceSessionId(null);
+    setNavigationRestored(false);
+    initialLinkAppliedRef.current = false;
+    await clearMobileShellNavigation(ownerUserIdAtSignOut).catch(() => undefined);
+  }, []);
+
+  return useMemo(
+    () => ({
+      route,
+      drawerOpen,
+      setDrawerOpen,
+      selectedChat,
+      navigate,
+      openChat,
+      closeChat,
+      markSelectedChatSession,
+      clearSelectedChatInitialPendingPrompt,
+      resetForSignOut,
+    }),
+    [
+      clearSelectedChatInitialPendingPrompt,
+      closeChat,
+      drawerOpen,
+      markSelectedChatSession,
+      navigate,
+      openChat,
+      resetForSignOut,
+      route,
+      selectedChat,
+    ],
+  );
+}

--- a/apps/mobile/src/lib/access/cloud/auth/mobile-auth-flow.ts
+++ b/apps/mobile/src/lib/access/cloud/auth/mobile-auth-flow.ts
@@ -5,14 +5,79 @@ import {
   completeAppleMobileAuth,
   exchangeMobileAuthCode,
   startAuthProvider,
+  startGitHubAppInstallation,
+  startGitHubAppUserAuthorization,
   type AuthProviderName,
   type AuthPurpose,
   type AuthSessionResponse,
+  type ProliferateCloudClient,
 } from "@proliferate/cloud-sdk";
 
 import { mobileEnv } from "../../../../config/env";
 import { createOAuthState, createPkcePair } from "../../../infra/auth/pkce";
+import { openNativeUrl } from "../../native/open-url";
 import { createMobileCloudClient } from "../client";
+
+/**
+ * Deep-link path GitHub returns the App authorization / installation flow to.
+ * Distinct from the OAuth `redirectUri` so the App-auth callback owner does not
+ * collide with the sign-in callback. Mobile combines this deep-link recovery
+ * with a refetch-on-foreground (the query client's focus manager), so the
+ * resolver re-runs whether the user is deep-linked back or reopens the app.
+ */
+export const MOBILE_GITHUB_APP_RETURN_URL = `${mobileEnv.redirectUri.replace(
+  "/auth/callback",
+  "",
+)}/settings/environments?source=github_app_callback`;
+
+/**
+ * Start the GitHub App user-authorization flow and open GitHub in the system
+ * browser. The user returns via the App-auth deep link or by reopening the
+ * app; the caller invalidates and re-runs the resolver on return. No token or
+ * private key is ever exposed to the UI — only the server-issued browser URL.
+ */
+export async function openMobileGitHubAppUserAuthorization(
+  client: ProliferateCloudClient,
+): Promise<void> {
+  const start = await startGitHubAppUserAuthorization(
+    { returnTo: MOBILE_GITHUB_APP_RETURN_URL },
+    client,
+  );
+  if (!start.authorizationUrl) {
+    throw new Error("GitHub did not return an authorization URL.");
+  }
+  await openNativeUrl(start.authorizationUrl);
+}
+
+/**
+ * Start the GitHub App organization installation flow and open GitHub.
+ */
+export async function openMobileGitHubAppInstallation(
+  client: ProliferateCloudClient,
+  organizationId: string,
+): Promise<void> {
+  const start = await startGitHubAppInstallation(
+    organizationId,
+    { returnTo: MOBILE_GITHUB_APP_RETURN_URL },
+    client,
+  );
+  if (!start.installationUrl) {
+    throw new Error("GitHub did not return an installation URL.");
+  }
+  await openNativeUrl(start.installationUrl);
+}
+
+/**
+ * GitHub's per-user installation settings page — where repository access for an
+ * existing installation is granted. Same target Desktop/Web open for
+ * "Grant repository access".
+ */
+export const MOBILE_GITHUB_INSTALLATION_SETTINGS_URL =
+  "https://github.com/settings/installations";
+
+export async function openMobileGitHubInstallationSettings(): Promise<void> {
+  await openNativeUrl(MOBILE_GITHUB_INSTALLATION_SETTINGS_URL);
+}
 
 const MOBILE_AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const MOBILE_WEB_AUTH_CALLBACK_PATH = "/auth/callback";

--- a/apps/mobile/src/lib/access/cloud/auth/mobile-github-app-callback.test.ts
+++ b/apps/mobile/src/lib/access/cloud/auth/mobile-github-app-callback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { isMobileGitHubAppCallbackUrl } from "./mobile-github-app-callback";
+
+describe("isMobileGitHubAppCallbackUrl", () => {
+  it("matches the custom-scheme App callback", () => {
+    expect(
+      isMobileGitHubAppCallbackUrl(
+        "proliferate://settings/environments?source=github_app_callback",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the staging-scheme App callback", () => {
+    expect(
+      isMobileGitHubAppCallbackUrl(
+        "proliferate-staging://settings/environments?source=github_app_callback",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches an https callback with the source param", () => {
+    expect(
+      isMobileGitHubAppCallbackUrl(
+        "https://app.proliferate.ai/settings/environments?source=github_app_callback",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match the OAuth sign-in callback", () => {
+    expect(isMobileGitHubAppCallbackUrl("proliferate://auth/callback?code=abc&state=xyz")).toBe(false);
+  });
+
+  it("does not match a workspace deep link", () => {
+    expect(
+      isMobileGitHubAppCallbackUrl("https://app.proliferate.ai/workspaces/ws_123"),
+    ).toBe(false);
+  });
+
+  it("does not match null", () => {
+    expect(isMobileGitHubAppCallbackUrl(null)).toBe(false);
+  });
+});

--- a/apps/mobile/src/lib/access/cloud/auth/mobile-github-app-callback.ts
+++ b/apps/mobile/src/lib/access/cloud/auth/mobile-github-app-callback.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure detector for the GitHub App authorization / installation callback deep
+ * link. Distinct from the OAuth sign-in callback and from workspace deep links.
+ *
+ * The App-auth flow returns to `proliferate://settings/environments?source=
+ * github_app_callback` (or the staging scheme). On a warm return the in-memory
+ * modal intent is still alive, so the resolver just re-runs after invalidation;
+ * on a cold start the app lands in repository/access settings with the relevant
+ * state. No arbitrary continuation command is ever persisted.
+ *
+ * No React, no platform APIs — unit-tested directly.
+ */
+
+const GITHUB_APP_CALLBACK_SOURCE = "github_app_callback";
+
+export function isMobileGitHubAppCallbackUrl(url: string | null): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.searchParams.get("source") === GITHUB_APP_CALLBACK_SOURCE) {
+      return true;
+    }
+    // Custom-scheme URLs (proliferate://settings/environments?...) put the
+    // first path segment in the hostname; also accept the raw query match.
+    return parsed.hash.includes(GITHUB_APP_CALLBACK_SOURCE);
+  } catch {
+    return url.includes(`source=${GITHUB_APP_CALLBACK_SOURCE}`);
+  }
+}

--- a/apps/mobile/src/lib/access/cloud/capabilities/mobile-server-capabilities.test.ts
+++ b/apps/mobile/src/lib/access/cloud/capabilities/mobile-server-capabilities.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DISABLED_MOBILE_CAPABILITIES,
+  parseMobileMetaCapabilities,
+  parseMobileServerCapabilities,
+} from "./mobile-server-capabilities";
+
+describe("parseMobileServerCapabilities", () => {
+  it("reads explicit v2 statuses and display name", () => {
+    const parsed = parseMobileServerCapabilities({
+      contractVersion: 2,
+      githubRepositoryAccess: {
+        status: "ready",
+        provider: "github_app",
+        displayName: "Acme Cloud",
+      },
+      managedCloud: { status: "ready", repositoryAuthority: "github_app" },
+    });
+    expect(parsed).toEqual({
+      githubRepositoryAccess: "ready",
+      managedCloud: "ready",
+      githubRepositoryAccessDisplayName: "Acme Cloud",
+    });
+  });
+
+  it("keeps managed-Cloud and GitHub access independent", () => {
+    const parsed = parseMobileServerCapabilities({
+      contractVersion: 2,
+      githubRepositoryAccess: { status: "ready", provider: "github_app", displayName: null },
+      managedCloud: { status: "disabled", repositoryAuthority: null },
+    });
+    expect(parsed.githubRepositoryAccess).toBe("ready");
+    expect(parsed.managedCloud).toBe("disabled");
+  });
+
+  it("fails closed for a malformed declared v2 status", () => {
+    const parsed = parseMobileServerCapabilities({
+      contractVersion: 2,
+      githubRepositoryAccess: { status: "totally-bogus" },
+      managedCloud: { status: 42 },
+    });
+    expect(parsed.githubRepositoryAccess).toBe("disabled");
+    expect(parsed.managedCloud).toBe("disabled");
+  });
+
+  it("fails closed when a v2 object is absent", () => {
+    const parsed = parseMobileServerCapabilities({ contractVersion: 2 });
+    expect(parsed.githubRepositoryAccess).toBe("disabled");
+    expect(parsed.managedCloud).toBe("disabled");
+  });
+
+  it("projects a v1 (pre-v2) cloudWorkspaces=true contract as ready", () => {
+    const parsed = parseMobileServerCapabilities({
+      contractVersion: 1,
+      cloudWorkspaces: true,
+    });
+    expect(parsed.githubRepositoryAccess).toBe("ready");
+    expect(parsed.managedCloud).toBe("ready");
+  });
+
+  it("projects a v1 cloudWorkspaces=false contract as disabled", () => {
+    const parsed = parseMobileServerCapabilities({
+      contractVersion: 1,
+      cloudWorkspaces: false,
+    });
+    expect(parsed).toEqual({
+      githubRepositoryAccess: "disabled",
+      managedCloud: "disabled",
+      githubRepositoryAccessDisplayName: null,
+    });
+  });
+
+  it("projects a legacy contract with no version from cloudWorkspaces", () => {
+    const parsed = parseMobileServerCapabilities({ cloudWorkspaces: true });
+    expect(parsed.managedCloud).toBe("ready");
+  });
+
+  it("returns fully-disabled for a non-object payload", () => {
+    expect(parseMobileServerCapabilities(null)).toEqual(DISABLED_MOBILE_CAPABILITIES);
+    expect(parseMobileServerCapabilities("nope")).toEqual(DISABLED_MOBILE_CAPABILITIES);
+  });
+});
+
+describe("parseMobileMetaCapabilities", () => {
+  it("extracts the capabilities block from a /meta body", () => {
+    const parsed = parseMobileMetaCapabilities({
+      serverVersion: "1.2.3",
+      capabilities: {
+        contractVersion: 2,
+        githubRepositoryAccess: { status: "operator_configuration_required" },
+        managedCloud: { status: "ready" },
+      },
+    });
+    expect(parsed.githubRepositoryAccess).toBe("operator_configuration_required");
+    expect(parsed.managedCloud).toBe("ready");
+  });
+
+  it("fails closed for a non-object body", () => {
+    expect(parseMobileMetaCapabilities(undefined)).toEqual(DISABLED_MOBILE_CAPABILITIES);
+  });
+});

--- a/apps/mobile/src/lib/access/cloud/capabilities/mobile-server-capabilities.ts
+++ b/apps/mobile/src/lib/access/cloud/capabilities/mobile-server-capabilities.ts
@@ -1,0 +1,117 @@
+/**
+ * Minimal, mobile-owned read of the `/meta` v2 capability contract.
+ *
+ * Mobile depends on `@proliferate/product-domain` (the readiness resolver) but
+ * NOT on `@proliferate/product-client`, where PR 2 left the full
+ * `parseServerCapabilities` parser. Rather than pull the whole desktop parser
+ * across the package boundary, mobile reads only the two operator-status fields
+ * the readiness resolver needs — consuming the SAME wire contract. Sharing the
+ * parser in a common package is deliberately out of scope for this slice and
+ * tracked as tech debt (see the PR 7 spec reconciliation, point 1).
+ *
+ * Fail-closed: any malformed / absent capability payload resolves to
+ * `disabled`, so a garbled or too-old server never reads as ready.
+ *
+ * Pure, DOM-free, no React, no SDK — unit-tested directly.
+ */
+
+import type { OperatorCapabilityStatus } from "@proliferate/product-domain/repos/repo-readiness";
+
+/** The subset of managed-Cloud / GitHub-access capability the resolver needs. */
+export interface MobileServerCapabilities {
+  /** Operator readiness of GitHub repository discovery/authority. */
+  githubRepositoryAccess: OperatorCapabilityStatus;
+  /** Operator readiness of managed-Cloud workspace execution. */
+  managedCloud: OperatorCapabilityStatus;
+  /** App/instance display name for GitHub repository access, when declared. */
+  githubRepositoryAccessDisplayName: string | null;
+}
+
+/** Conservative default: every capability off until the server declares it. */
+export const DISABLED_MOBILE_CAPABILITIES: MobileServerCapabilities = {
+  githubRepositoryAccess: "disabled",
+  managedCloud: "disabled",
+  githubRepositoryAccessDisplayName: null,
+};
+
+const OPERATOR_CAPABILITY_STATUSES: readonly OperatorCapabilityStatus[] = [
+  "disabled",
+  "operator_configuration_required",
+  "ready",
+];
+
+/** The contract version at which the split v2 capability objects appear. */
+const V2_CONTRACT_VERSION = 2;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function operatorStatus(value: unknown): OperatorCapabilityStatus | null {
+  return typeof value === "string"
+    && OPERATOR_CAPABILITY_STATUSES.includes(value as OperatorCapabilityStatus)
+    ? (value as OperatorCapabilityStatus)
+    : null;
+}
+
+function safeDisplayName(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Parse the `capabilities` block from a `GET /meta` body.
+ *
+ * A v2+ contract carries explicit `githubRepositoryAccess` / `managedCloud`
+ * objects; a malformed declared object fails closed to `disabled` for that
+ * capability. A pre-v2 contract projects both from the legacy `cloudWorkspaces`
+ * boolean (true -> ready, false -> disabled), matching the desktop parser.
+ * A wholly absent/garbled block resolves to fully disabled.
+ */
+export function parseMobileServerCapabilities(
+  rawCapabilities: unknown,
+): MobileServerCapabilities {
+  if (!isRecord(rawCapabilities)) {
+    return DISABLED_MOBILE_CAPABILITIES;
+  }
+
+  const contractVersion =
+    typeof rawCapabilities.contractVersion === "number"
+      ? rawCapabilities.contractVersion
+      : 0;
+
+  if (contractVersion >= V2_CONTRACT_VERSION) {
+    const githubRaw = rawCapabilities.githubRepositoryAccess;
+    const managedRaw = rawCapabilities.managedCloud;
+    const githubStatus = isRecord(githubRaw) ? operatorStatus(githubRaw.status) : null;
+    const managedStatus = isRecord(managedRaw) ? operatorStatus(managedRaw.status) : null;
+    return {
+      githubRepositoryAccess: githubStatus ?? "disabled",
+      managedCloud: managedStatus ?? "disabled",
+      githubRepositoryAccessDisplayName: isRecord(githubRaw)
+        ? safeDisplayName(githubRaw.displayName)
+        : null,
+    };
+  }
+
+  // Pre-v2 (or version-absent) contract: project from the legacy boolean.
+  const cloudWorkspaces = rawCapabilities.cloudWorkspaces === true;
+  const status: OperatorCapabilityStatus = cloudWorkspaces ? "ready" : "disabled";
+  return {
+    githubRepositoryAccess: status,
+    managedCloud: status,
+    githubRepositoryAccessDisplayName: null,
+  };
+}
+
+/**
+ * Extract and parse the `capabilities` block from a full `/meta` response body.
+ * Returns fully-disabled capabilities when the body is not an object.
+ */
+export function parseMobileMetaCapabilities(body: unknown): MobileServerCapabilities {
+  if (!isRecord(body)) {
+    return DISABLED_MOBILE_CAPABILITIES;
+  }
+  return parseMobileServerCapabilities(body.capabilities);
+}

--- a/apps/mobile/src/lib/domain/repos/mobile-repo-access-inputs.test.ts
+++ b/apps/mobile/src/lib/domain/repos/mobile-repo-access-inputs.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveMobileInstallationTarget,
+  synthesizeListAuthority,
+} from "./mobile-repo-access-inputs";
+
+describe("synthesizeListAuthority", () => {
+  it("returns null while user authorization is unknown", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "unknown",
+        installation: "unknown",
+        requiresInstallation: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("maps needs_authorize to missing_user_authorization", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "needs_authorize",
+        installation: "unknown",
+        requiresInstallation: true,
+      }),
+    ).toEqual({ authorized: false, status: "missing_user_authorization" });
+  });
+
+  it("maps needs_reauthorize to expired_user_authorization", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "needs_reauthorize",
+        installation: "installed",
+        requiresInstallation: true,
+      }),
+    ).toEqual({ authorized: false, status: "expired_user_authorization" });
+  });
+
+  it("returns null while installation is unknown after auth", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "connected",
+        installation: "unknown",
+        requiresInstallation: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("maps a missing installation to missing_installation", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "connected",
+        installation: "missing",
+        requiresInstallation: true,
+      }),
+    ).toEqual({ authorized: false, status: "missing_installation" });
+  });
+
+  it("is ready when authorized and installed", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "connected",
+        installation: "installed",
+        requiresInstallation: true,
+      }),
+    ).toEqual({ authorized: true, status: "ready" });
+  });
+
+  it("skips the installation gate when no org requires it", () => {
+    expect(
+      synthesizeListAuthority({
+        userAuthorization: "connected",
+        installation: "unknown",
+        requiresInstallation: false,
+      }),
+    ).toEqual({ authorized: true, status: "ready" });
+  });
+});
+
+describe("resolveMobileInstallationTarget", () => {
+  it("returns a null org for a personal-only user", () => {
+    expect(resolveMobileInstallationTarget([])).toEqual({
+      organizationId: null,
+      canManageInstallation: false,
+    });
+  });
+
+  it("prefers an org the member can manage", () => {
+    const target = resolveMobileInstallationTarget([
+      { id: "org-member", role: "member" },
+      { id: "org-admin", role: "admin" },
+    ]);
+    expect(target).toEqual({ organizationId: "org-admin", canManageInstallation: true });
+  });
+
+  it("falls back to the first org as request-only when none is manageable", () => {
+    const target = resolveMobileInstallationTarget([
+      { id: "org-a", role: "member" },
+      { id: "org-b", role: null },
+    ]);
+    expect(target).toEqual({ organizationId: "org-a", canManageInstallation: false });
+  });
+});

--- a/apps/mobile/src/lib/domain/repos/mobile-repo-access-inputs.ts
+++ b/apps/mobile/src/lib/domain/repos/mobile-repo-access-inputs.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers that shape already-fetched mobile access state into inputs for
+ * the shared `resolveRepositoryReadiness` resolver — so mobile reuses the exact
+ * Desktop/Web gate ordering and vocabulary rather than re-implementing policy.
+ *
+ * No React, no SDK, no platform APIs. Unit-tested directly.
+ */
+
+import type {
+  RepoAuthoritySnapshot,
+  RepoAuthorityStatus,
+} from "@proliferate/product-domain/repos/repo-readiness";
+
+/** GitHub App user-authorization status wire values the resolver cares about. */
+export type MobileUserAuthorizationState =
+  | "unknown"
+  | "connected"
+  | "needs_authorize"
+  | "needs_reauthorize";
+
+/** GitHub App installation status wire values the resolver cares about. */
+export type MobileInstallationState =
+  | "unknown"
+  | "installed"
+  | "missing";
+
+/**
+ * Synthesize a list-level authority snapshot (before any specific repo is
+ * chosen) from the account-level GitHub App user-authorization and
+ * organization installation states.
+ *
+ * The list picker cannot know per-repo coverage or human access, so it gates
+ * only through installation; repo coverage (`repo_not_covered`) and human
+ * access (`missing_user_repo_access`) are resolved per-repo when a repository
+ * is picked, via the authority endpoint. Returns `null` when either input is
+ * still unknown/loading so the resolver reports gate 4 (checking).
+ */
+export function synthesizeListAuthority(input: {
+  userAuthorization: MobileUserAuthorizationState;
+  installation: MobileInstallationState;
+  /** Whether an organization is required for installation (i.e. one exists). */
+  requiresInstallation: boolean;
+}): RepoAuthoritySnapshot | null {
+  const { userAuthorization, installation, requiresInstallation } = input;
+
+  if (userAuthorization === "unknown") {
+    return null;
+  }
+  if (userAuthorization === "needs_authorize") {
+    return notReady("missing_user_authorization");
+  }
+  if (userAuthorization === "needs_reauthorize") {
+    return notReady("expired_user_authorization");
+  }
+
+  // User is connected; check organization installation.
+  if (requiresInstallation) {
+    if (installation === "unknown") {
+      return null;
+    }
+    if (installation === "missing") {
+      return notReady("missing_installation");
+    }
+  }
+
+  return { authorized: true, status: "ready" };
+}
+
+function notReady(status: RepoAuthorityStatus): RepoAuthoritySnapshot {
+  return { authorized: false, status };
+}
+
+export interface MobileInstallationOrg {
+  id: string;
+  role: "owner" | "admin" | "member" | null;
+}
+
+export interface MobileInstallationTarget {
+  organizationId: string | null;
+  canManageInstallation: boolean;
+}
+
+/**
+ * Choose the organization mobile installs / grants against. Mobile has no
+ * active-org switcher, so pick the first organization the member can manage
+ * (owner/admin); otherwise the first organization (member, request-only).
+ * Returns a null org when the user belongs to no organizations — a
+ * personal-only user needs no installation gate.
+ */
+export function resolveMobileInstallationTarget(
+  organizations: readonly MobileInstallationOrg[],
+): MobileInstallationTarget {
+  if (organizations.length === 0) {
+    return { organizationId: null, canManageInstallation: false };
+  }
+  const manageable = organizations.find(
+    (org) => org.role === "owner" || org.role === "admin",
+  );
+  const chosen = manageable ?? organizations[0];
+  return {
+    organizationId: chosen.id,
+    canManageInstallation: chosen.role === "owner" || chosen.role === "admin",
+  };
+}

--- a/apps/mobile/src/lib/domain/repos/mobile-repo-readiness-blocker.test.ts
+++ b/apps/mobile/src/lib/domain/repos/mobile-repo-readiness-blocker.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { resolveRepositoryReadiness } from "@proliferate/product-domain/repos/repo-readiness";
+
+import {
+  buildMobileCloudAdminRequestMessage,
+  resolveMobileRepoReadinessBlocker,
+} from "./mobile-repo-readiness-blocker";
+
+const READY_MANAGED = {
+  requirement: "managed_cloud" as const,
+  githubRepositoryAccess: "ready" as const,
+  managedCloud: "ready" as const,
+  signedIn: true,
+  hasSupportedRepoIdentity: true,
+  authorityLoading: false,
+  authorityError: false,
+  canManageInstallation: true,
+  cloudEnvironmentConfigured: false,
+};
+
+function readiness(overrides: Partial<Parameters<typeof resolveRepositoryReadiness>[0]>) {
+  return resolveRepositoryReadiness({ ...READY_MANAGED, authority: null, ...overrides });
+}
+
+describe("resolveMobileRepoReadinessBlocker", () => {
+  it("shows an operator blocker with no CTA when managed Cloud is disabled", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({ managedCloud: "disabled" }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("none");
+    expect(blocker?.actionLabel).toBeNull();
+    expect(blocker?.title).toMatch(/not configured/i);
+  });
+
+  it("names the instance in operator copy when available", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({ managedCloud: "operator_configuration_required" }),
+      githubAccessDisplayName: "Acme Cloud",
+    });
+    expect(blocker?.description).toContain("Acme Cloud");
+    expect(blocker?.actionKind).toBe("none");
+  });
+
+  it("offers authorize_user for missing user authorization", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({
+        authority: { authorized: false, status: "missing_user_authorization" },
+      }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("authorize_user");
+    expect(blocker?.actionLabel).toBe("Connect GitHub App");
+  });
+
+  it("offers reauthorize_user for expired authorization", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({
+        authority: { authorized: false, status: "expired_user_authorization" },
+      }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("reauthorize_user");
+  });
+
+  it("offers install_app for an admin missing installation", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({
+        canManageInstallation: true,
+        authority: { authorized: false, status: "missing_installation" },
+      }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("install_app");
+  });
+
+  it("offers copy_admin_request for a non-admin missing installation", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({
+        canManageInstallation: false,
+        authority: { authorized: false, status: "missing_installation" },
+      }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("copy_admin_request");
+  });
+
+  it("offers grant_repo_access for an admin with repo not covered", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({
+        canManageInstallation: true,
+        authority: { authorized: false, status: "repo_not_covered" },
+      }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("grant_repo_access");
+  });
+
+  it("explains missing human access with no CTA", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({
+        authority: { authorized: false, status: "missing_user_repo_access" },
+      }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("none");
+    expect(blocker?.actionLabel).toBeNull();
+    expect(blocker?.title).toMatch(/no access/i);
+  });
+
+  it("offers retry on an authority error", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({ authorityError: true }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.actionKind).toBe("retry");
+  });
+
+  it("returns a pending, no-CTA blocker while authority loads", () => {
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({ authorityLoading: true }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker?.pending).toBe(true);
+    expect(blocker?.actionKind).toBe("none");
+  });
+
+  it("surfaces a checking state instead of the resolved gate while a prerequisite query loads", () => {
+    // Simulates the cold-open race: capabilities have not resolved yet, so
+    // managedCloud fail-closed to "disabled" and the resolver reports gate 1
+    // (operator-not-configured) on placeholder input. `checking: true` must
+    // take priority so a fully-configured deployment does not flash "Cloud is
+    // not configured on this deployment".
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({ managedCloud: "disabled" }),
+      githubAccessDisplayName: null,
+      checking: true,
+    });
+    expect(blocker?.pending).toBe(true);
+    expect(blocker?.actionKind).toBe("none");
+    expect(blocker?.title).toMatch(/checking/i);
+    expect(blocker?.title).not.toMatch(/not configured/i);
+  });
+
+  it("returns null when every gate is met (ready to save)", () => {
+    // Ready authority + not-yet-configured env => gate 9 (set_up_cloud), which
+    // is the mobile continue point, not a blocker.
+    const blocker = resolveMobileRepoReadinessBlocker({
+      readiness: readiness({ authority: { authorized: true, status: "ready" } }),
+      githubAccessDisplayName: null,
+    });
+    expect(blocker).toBeNull();
+  });
+});
+
+describe("buildMobileCloudAdminRequestMessage", () => {
+  it("names the repo when provided", () => {
+    expect(buildMobileCloudAdminRequestMessage("acme/app")).toContain("acme/app");
+  });
+
+  it("uses a generic message with no repo", () => {
+    expect(buildMobileCloudAdminRequestMessage(null)).toMatch(/Cloud repositories/);
+  });
+});

--- a/apps/mobile/src/lib/domain/repos/mobile-repo-readiness-blocker.ts
+++ b/apps/mobile/src/lib/domain/repos/mobile-repo-readiness-blocker.ts
@@ -1,0 +1,213 @@
+/**
+ * Pure mapping from the shared repository-readiness result to a native mobile
+ * blocker view model. No React, no platform APIs — the modal renders this
+ * directly and wires the action id to a callback.
+ *
+ * Same vocabulary and first-unmet-gate semantics as Desktop/Web
+ * (`CloudRepoActionDialogHost` / `buildGitHubAppPrerequisiteBlocker`), adapted
+ * to a single React Native CTA. Operator (gate 1) and human-access (gate 8)
+ * states offer NO impossible auth CTA; a member who cannot install/grant gets
+ * an admin-request action instead of a broken browser handoff.
+ */
+
+import type {
+  CloudRepoReadinessAction,
+  RepositoryReadiness,
+} from "@proliferate/product-domain/repos/repo-readiness";
+
+/** What the modal should do when the CTA is pressed. `none` renders no button. */
+export type MobileRepoReadinessActionKind =
+  | "none"
+  | "retry"
+  | "authorize_user"
+  | "reauthorize_user"
+  | "install_app"
+  | "grant_repo_access"
+  | "copy_admin_request";
+
+export interface MobileRepoReadinessBlocker {
+  title: string;
+  description: string;
+  /** The action the CTA performs; `none` means explanatory-only, no button. */
+  actionKind: MobileRepoReadinessActionKind;
+  /** CTA label, or null when there is no actionable repair here. */
+  actionLabel: string | null;
+  /** True while the current gate is still resolving (loading), no CTA. */
+  pending: boolean;
+}
+
+export interface MobileRepoReadinessBlockerInput {
+  readiness: RepositoryReadiness;
+  /** App/instance display name for GitHub repository access, when known. */
+  githubAccessDisplayName: string | null;
+  /** Whether the browser action for the current step is in flight. */
+  actionBusy?: boolean;
+  /**
+   * Whether an upstream prerequisite query (server capabilities, user
+   * authorization, installation) is still loading. While true, `readiness`
+   * may already report a fail-closed gate (e.g. managed Cloud defaulted to
+   * "disabled" before `/meta` resolves) — that is presentation state, not a
+   * real blocker, so it takes priority over the resolved gate to avoid
+   * flashing "not configured" on a fully-configured deployment.
+   */
+  checking?: boolean;
+}
+
+const NO_ACTION_KINDS: ReadonlySet<CloudRepoReadinessAction> = new Set([
+  "none",
+  "sign_in",
+  "set_up_cloud",
+]);
+
+/**
+ * Resolve the single blocker the mobile Add Repository / Cloud creation surface
+ * should present, or `null` when every gate is met (ready to list / save).
+ *
+ * `sign_in` (gate 2) and `set_up_cloud` (gate 9) return `null`: mobile is only
+ * reachable when signed in, and Cloud-environment setup is the normal continue
+ * point (mobile saves the environment as part of the pick, no separate CTA).
+ */
+export function resolveMobileRepoReadinessBlocker(
+  input: MobileRepoReadinessBlockerInput,
+): MobileRepoReadinessBlocker | null {
+  const { readiness } = input;
+
+  // While a prerequisite query is still loading, the resolved gate may be a
+  // fail-closed default (e.g. managed Cloud read as "disabled" before `/meta`
+  // returns) rather than a real blocker. Surface a checking state instead of
+  // whatever the resolver produced from placeholder inputs.
+  if (input.checking) {
+    return {
+      title: "Checking Cloud access",
+      description: "Proliferate is checking Cloud access for this deployment.",
+      actionKind: "none",
+      actionLabel: null,
+      pending: true,
+    };
+  }
+
+  // Ready (gate 10) or the continue-point (gate 9 set_up_cloud) / sign-in are
+  // not blockers on mobile.
+  if (readiness.gate >= 9 || NO_ACTION_KINDS.has(readiness.action)) {
+    if (readiness.action === "none") {
+      return operatorOrHumanBlocker(readiness.gate, input);
+    }
+    return null;
+  }
+
+  switch (readiness.action) {
+    case "retry":
+      return {
+        title: "Couldn't check GitHub access",
+        description:
+          "GitHub App access for this repository could not be checked. Pull to refresh or try again.",
+        actionKind: "retry",
+        actionLabel: "Retry",
+        pending: false,
+      };
+    case "authorize_user":
+      return {
+        title: "Connect GitHub App",
+        description:
+          "Authorize the Proliferate GitHub App to set up repositories in Cloud. GitHub opens in your browser and returns you here.",
+        actionKind: "authorize_user",
+        actionLabel: input.actionBusy ? "Opening GitHub…" : "Connect GitHub App",
+        pending: Boolean(input.actionBusy),
+      };
+    case "reauthorize_user":
+      return {
+        title: "Reconnect GitHub App",
+        description:
+          "Your GitHub App authorization expired. Reconnect it to set up repositories in Cloud.",
+        actionKind: "reauthorize_user",
+        actionLabel: input.actionBusy ? "Opening GitHub…" : "Reconnect GitHub App",
+        pending: Boolean(input.actionBusy),
+      };
+    case "install_app":
+      return {
+        title: "Install Proliferate GitHub App",
+        description:
+          "Install the Proliferate GitHub App for your organization to set up repositories in Cloud.",
+        actionKind: "install_app",
+        actionLabel: input.actionBusy ? "Opening GitHub…" : "Install GitHub App",
+        pending: Boolean(input.actionBusy),
+      };
+    case "grant_repo_access":
+      return {
+        title: "Grant repository access",
+        description:
+          "Update the Proliferate GitHub App installation so it can access this repository.",
+        actionKind: "grant_repo_access",
+        actionLabel: input.actionBusy ? "Opening GitHub…" : "Grant repository access",
+        pending: Boolean(input.actionBusy),
+      };
+    case "copy_admin_request":
+      return {
+        title: "Ask an admin",
+        description:
+          "You don't have permission to install or grant access to the Proliferate GitHub App. Copy a request to send to an organization admin.",
+        actionKind: "copy_admin_request",
+        actionLabel: "Copy request",
+        pending: false,
+      };
+    // `sign_in` / `set_up_cloud` handled above; exhaustive fallthrough.
+    case "none":
+    case "sign_in":
+    case "set_up_cloud":
+      return null;
+  }
+}
+
+/**
+ * Gate 1 (operator configuration) and gate 8 (human GitHub repo access) both
+ * resolve to action `none` — neither the user nor this client can repair them,
+ * so no browser CTA is offered. Copy names the instance when available.
+ */
+function operatorOrHumanBlocker(
+  gate: number,
+  input: MobileRepoReadinessBlockerInput,
+): MobileRepoReadinessBlocker {
+  if (gate === 8) {
+    return {
+      title: "No access to this repository",
+      description:
+        "Your GitHub user does not have access to this repository. Ask a repository admin on GitHub to grant you access.",
+      actionKind: "none",
+      actionLabel: null,
+      pending: false,
+    };
+  }
+  if (gate === 4) {
+    // Authority query still loading (action `none` before a result arrives).
+    return {
+      title: "Checking GitHub access",
+      description: "Proliferate is checking GitHub App access for this repository.",
+      actionKind: "none",
+      actionLabel: null,
+      pending: true,
+    };
+  }
+  const appName = input.githubAccessDisplayName;
+  return {
+    title: "Cloud is not configured on this deployment",
+    description: appName
+      ? `Cloud repository access for ${appName} isn't fully configured on this deployment. An operator must finish configuring it.`
+      : "Managed Cloud isn't fully configured on this deployment. An operator must finish configuring it before repositories can be set up in Cloud.",
+    actionKind: "none",
+    actionLabel: null,
+    pending: false,
+  };
+}
+
+/**
+ * Copy for the admin-request clipboard action, mirroring the desktop message.
+ */
+export function buildMobileCloudAdminRequestMessage(
+  repoLabel: string | null,
+): string {
+  const repoClause = repoLabel ? ` so we can set up ${repoLabel} in Cloud` : " so we can add Cloud repositories";
+  return [
+    "Please install the Proliferate GitHub App for our organization",
+    `and grant it repository access${repoClause}.`,
+  ].join(" ");
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -10,5 +10,9 @@
   "include": [
     "**/*.ts",
     "**/*.tsx"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "vitest.config.ts"
   ]
 }

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Node-environment vitest for mobile's pure, DOM-free logic modules
+ * (capability parsing, readiness inputs/blocker, callback detection). React
+ * Native component rendering is out of scope here — these are the same kind of
+ * platform-free units the shared packages test. `@proliferate/product-domain`
+ * resolves to source so the shared readiness resolver is exercised directly.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@proliferate/product-domain": fileURLToPath(
+        new URL("../packages/product-domain/src", import.meta.url),
+      ),
+      "@anyharness/sdk": fileURLToPath(
+        new URL("../../anyharness/sdk/src/index.ts", import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Slice 7 of 7 of the Cloud repository access + workspace materialization stack (stacked on #1276 → #1257; do not merge before them). Needs only PR 1 + PR 2 vocabulary — independent of PRs 3–6.

## What
- Minimal mobile-own `/meta` v2 capability read (`mobile-server-capabilities.ts`): fail-closed on malformed/absent, v1 `cloudWorkspaces` projection; consumes the same wire contract as product-client's parser (parser sharing flagged as tech debt — mobile doesn't depend on product-client).
- Reuses the PR 2 product-domain readiness resolver directly; pure blocker mapping (`mobile-repo-readiness-blocker.ts`): operator (gate 1) and human-access (gate 8) states render explanations with NO auth CTA; non-admins get copy-admin-request. A user is never sent to user OAuth when the operator must configure the deployment.
- Repository picker and Add Repository modal gated (previously zero gating); home-screen workspace creation gated via an additive `readinessBlockedReason`.
- Native authorize/install/grant browser flows (server-issued URLs only — no tokens in UI) with App-auth callback deep-link recovery on cold start and live listener; invalidation via the existing idiom.
- Access-loss state: existing Cloud records stay visible, locked, and explained; no local/clone actions on mobile (Desktop-only, PR 5).

## Verification
- 39 mobile unit tests green (capability parsing v2/v1/legacy/malformed, list-authority synthesis, install-target selection, all blocker states, callback detection).
- `pnpm --filter @proliferate/mobile typecheck` exit 0 (re-verified after rebase onto the repaired PR 2 head 36d4d6dc6).
- `git diff --check` clean.
- Not run: RN component-render tests (no RN test renderer in repo — same posture as shared packages).

## Notes for review
- No mobile CI unit-test lane yet: adding the vitest devDep would rewrite ~2000 lines of pnpm-lock (pre-existing drift); tests run via the shared workspace vitest + `apps/mobile/vitest.config.ts`. Wiring a mobile test lane is a separate infra change.
- Spec: Vault "Mobile Cloud Repository Access Parity - PR 7" (frozen rev with 7-point reconciliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)