### PR TITLE
feat(desktop): repository clone and explicit workspace linking (PR 5)

### DIFF
--- a/apps/packages/product-client/src/App.tsx
+++ b/apps/packages/product-client/src/App.tsx
@@ -14,6 +14,7 @@ import { RepoSetupModalHost } from "#product/components/workspace/repo-setup/Rep
 import { SupportModalHost } from "#product/components/support/SupportModalHost"
 import { AddRepoFlowHost } from "#product/components/workspace/repo-setup/AddRepoFlowHost"
 import { CloudRepoActionDialogHost } from "#product/components/workspace/repo-setup/CloudRepoActionDialogHost"
+import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
 import { LoginPage } from "#product/pages/LoginPage"
 import { SettingsCloudRedirect } from "#product/pages/SettingsCloudRedirect"
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store"
@@ -200,6 +201,7 @@ export function App({ RoutesComponent }: AppProps) {
         <RepoSetupModalHost />
         <AddRepoFlowHost />
         <CloudRepoActionDialogHost />
+        <WorkspaceAvailabilityActionHost />
         <SupportModalHost />
         {/* Legacy toast store container (non-update toasts) — kept until all
             toast call sites migrate to Sonner. */}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
@@ -58,6 +58,15 @@ vi.mock("#product/hooks/workspaces/workflows/use-add-repo", () => ({
   useAddRepo: () => ({ addRepoFromPath: vi.fn(), isAddingRepo: false }),
 }));
 
+// Stub the clone hook (which otherwise pulls in the AnyHarnessRuntime provider);
+// these gating tests only exercise the cloud path, not the clone path.
+vi.mock("#product/hooks/workspaces/workflows/use-clone-repo", () => ({
+  useCloneRepo: () => ({
+    cloneRepo: vi.fn(() => Promise.resolve({ succeeded: true, sourceRoot: "/tmp/clone" })),
+    isCloning: false,
+  }),
+}));
+
 vi.mock("#product/hooks/organizations/facade/use-active-organization", () => ({
   useActiveOrganization: () => ({
     activeOrganization: { name: "Acme", membership: { role: "member" } },

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import type { CloudRepoPickerProps } from "@proliferate/product-ui/repos/CloudRepoPicker";
+import { parseGitRepoId } from "@proliferate/product-domain/repos/repo-id";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { resolveRepositoryReadiness } from "@proliferate/product-domain/repos/repo-readiness";
 import type { CloudRepoPickerBlockerView } from "@proliferate/product-ui/repos/CloudRepoPicker";
@@ -11,6 +13,7 @@ import {
   useAddCloudEnvironment,
 } from "@proliferate/product-surfaces/settings/cloud-environments/use-add-cloud-environment";
 import { useAddRepo } from "#product/hooks/workspaces/workflows/use-add-repo";
+import { useCloneRepo } from "#product/hooks/workspaces/workflows/use-clone-repo";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
 import { isSettingsAdminRole } from "#product/lib/domain/settings/admin-roles";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
@@ -33,6 +36,7 @@ export function AddRepoFlowHost() {
   const closeFlow = useAddRepoFlowStore((state) => state.close);
 
   const { addRepoFromPath, isAddingRepo } = useAddRepo();
+  const { cloneRepo, isCloning } = useCloneRepo();
   const { activeOrganization, activeOrganizationId } = useActiveOrganization();
   const host = useProductHost();
   const navigate = useNavigate();
@@ -41,6 +45,7 @@ export function AddRepoFlowHost() {
   const files = host.desktop?.files ?? null;
   const showToast = useToastStore((state) => state.show);
   const [flowError, setFlowError] = useState<string | null>(null);
+  const [cloningRepoId, setCloningRepoId] = useState<string | null>(null);
 
   // PR2-GATING-01: the cloud path routes through the SAME ordered readiness
   // resolver every other cloud-repo surface uses, so a deployment with operator
@@ -96,9 +101,10 @@ export function AddRepoFlowHost() {
     navigate,
   ]);
 
-  // Host-truthful options: only Desktop can register an existing local folder.
+  // Host-truthful options: only Desktop can register an existing local folder
+  // or clone locally; Web offers only the managed-Cloud setup.
   const options = useMemo<AddRepoFlowOption[]>(
-    () => (files ? ["add-existing-folder", "cloud"] : ["cloud"]),
+    () => (files ? ["add-existing-folder", "clone-from-github", "cloud"] : ["cloud"]),
     [files],
   );
 
@@ -134,10 +140,87 @@ export function AddRepoFlowHost() {
     },
   });
 
+  // Clone reuses the accessible-repos catalog + GitHub-App gating from the cloud
+  // picker, but on select it clones locally (PR 3) instead of saving a
+  // managed-Cloud environment. Clone needs only GitHub repository access, so it
+  // is available whenever the picker's own GitHub-App prerequisites are met.
+  const clonePickerBase = useAddCloudEnvironment({
+    enabled: open && step.kind === "clone",
+    organizationId: activeOrganizationId,
+    canManageGitHubAppInstallation: isSettingsAdminRole(
+      activeOrganization?.membership?.role,
+    ),
+    userAuthorizationReturnTo: host.links.buildReturnUrl({
+      kind: "settings",
+      section: "environments",
+      source: "github_app_callback",
+    }),
+    // Host-truthful installation return (PR2-WEB-03): derive from the host via
+    // buildReturnUrl instead of a hard-coded `proliferate://` deep link, matching
+    // the cloud picker above.
+    installationReturnTo: host.links.buildReturnUrl({
+      kind: "settings",
+      section: "environments",
+      query: [["source", "github_app_installation_callback"]],
+    }),
+    onOpenExternalUrl: host.links.openExternal,
+    // The clone path never adds a Cloud environment; select is overridden below.
+    onEnvironmentAdded: () => {},
+  });
+
+  const clonePicker = useMemo<CloudRepoPickerProps>(() => ({
+    ...clonePickerBase,
+    addingRepoId: cloningRepoId,
+    onAddRepository: (repo) => {
+      const identity = parseGitRepoId(repo.id);
+      if (!identity) {
+        setFlowError("That repository id is not a supported GitHub owner/name.");
+        return;
+      }
+      void (async () => {
+        setFlowError(null);
+        setCloningRepoId(repo.id);
+        // Stable operation id so a retry reuses the repo-root materialization.
+        const operationId = `clone:${identity.gitOwner}/${identity.gitRepoName}`;
+        const result = await cloneRepo(
+          {
+            gitProvider: "github",
+            gitOwner: identity.gitOwner,
+            gitRepoName: identity.gitRepoName,
+          },
+          operationId,
+        );
+        setCloningRepoId(null);
+        if (result.succeeded) {
+          const onCompleted = useAddRepoFlowStore.getState().onCompleted;
+          closeFlow();
+          showToast(`Cloned ${repo.fullName}`, "info");
+          onCompleted?.({ kind: "local", sourceRoot: result.sourceRoot });
+          return;
+        }
+        if (!result.cancelled) {
+          setFlowError(result.error);
+        }
+      })();
+    },
+  }), [
+    activeOrganizationId,
+    activeOrganization?.membership?.role,
+    clonePickerBase,
+    cloneRepo,
+    cloningRepoId,
+    closeFlow,
+    showToast,
+  ]);
+
   const handlePickOption = useCallback((option: AddRepoFlowOption) => {
     setFlowError(null);
     if (option === "cloud") {
       setStep({ kind: "cloud" });
+      return;
+    }
+    if (option === "clone-from-github") {
+      setStep({ kind: "clone" });
       return;
     }
     // "add-existing-folder": the native folder picker IS the intent signal, so
@@ -173,9 +256,9 @@ export function AddRepoFlowHost() {
   }, [setStep]);
 
   const handleClose = useCallback(() => {
-    // Ignore Escape/overlay-click while a local add is committing so the
-    // dialog cannot vanish mid-add.
-    if (isAddingRepo) {
+    // Ignore Escape/overlay-click while a local add or clone is committing so
+    // the dialog cannot vanish mid-operation.
+    if (isAddingRepo || isCloning) {
       return;
     }
     setFlowError(null);
@@ -195,9 +278,10 @@ export function AddRepoFlowHost() {
       open={open}
       step={step}
       options={options}
-      adding={isAddingRepo}
+      adding={isAddingRepo || isCloning}
       error={step.kind === "cloud" ? null : flowError}
       cloudPicker={resolvedCloudPicker}
+      clonePicker={step.kind === "clone" ? clonePicker : null}
       onPickOption={handlePickOption}
       onBack={handleBack}
       onClose={handleClose}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.test.tsx
@@ -139,6 +139,15 @@ vi.mock("#product/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
   }),
 }));
 
+// The clone path is exercised elsewhere; here we only need the host to mount, so
+// stub the clone hook (which otherwise pulls in the AnyHarnessRuntime provider).
+vi.mock("#product/hooks/workspaces/workflows/use-clone-repo", () => ({
+  useCloneRepo: () => ({
+    cloneRepo: vi.fn(() => Promise.resolve({ succeeded: true, sourceRoot: "/tmp/clone" })),
+    isCloning: false,
+  }),
+}));
+
 vi.mock("#product/lib/domain/settings/github-app-copy", () => ({
   buildCloudAdminRequestMessage: () => "request",
 }));

--- a/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx
@@ -31,10 +31,13 @@ import { useCloudRepositoryIntentStore } from "#product/stores/cloud/cloud-repos
 import {
   continueCloudRepositoryIntent,
   repoForCloudRepositoryIntent,
+  requirementForCloudRepositoryIntent,
+  type CloneFromGitHubContinuation,
   type CloudRepoIdentity,
   type CloudRepositoryIntent,
   type CreateCloudWorkspaceContinuation,
 } from "#product/lib/domain/workspaces/cloud/cloud-repository-intent";
+import { useCloneRepo } from "#product/hooks/workspaces/workflows/use-clone-repo";
 import { buildConfiguredCloudRepoKeys } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
 import { cloudRepositoryKey } from "#product/lib/domain/settings/repositories";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
@@ -62,6 +65,10 @@ export function CloudRepoActionDialogHost() {
   const intent = useCloudRepositoryIntentStore((state) => state.activeIntent);
   const clearIntent = useCloudRepositoryIntentStore((state) => state.clear);
   const repo = intent ? repoForCloudRepositoryIntent(intent) : null;
+  // Clone depends only on GitHub repository access; managed-Cloud intents depend
+  // on managed Cloud. Gating by the intent's own requirement lets an
+  // App-ready/E2B-disabled deployment clone without a managed-Cloud gate.
+  const requirement = intent ? requirementForCloudRepositoryIntent(intent) : "managed_cloud";
 
   const client = useCloudClient();
   const queryClient = useQueryClient();
@@ -79,7 +86,14 @@ export function CloudRepoActionDialogHost() {
   const repoConfigs = useRepositories(open && signedIn);
   const authority = useGitHubRepoAuthority(
     { gitOwner: repo?.gitOwner, gitRepoName: repo?.gitRepoName },
-    open && signedIn && capabilities.managedCloudStatus !== "disabled" && repo !== null,
+    // Clone needs per-repo authority even when managed Cloud is disabled, so it
+    // gates on GitHub repository access rather than managed Cloud.
+    open
+      && signedIn
+      && repo !== null
+      && (requirement === "github_repository_access"
+        ? capabilities.githubRepositoryAccessStatus !== "disabled"
+        : capabilities.managedCloudStatus !== "disabled"),
   );
 
   const configuredCloudKeys = useMemo(
@@ -123,11 +137,12 @@ export function CloudRepoActionDialogHost() {
   const saveEnvironment = useSaveRepoEnvironment();
   const validateBranches = useValidateCloudRepoBranches();
   const { createCloudWorkspaceAndEnter } = useCreateCloudWorkspace();
+  const { cloneRepo } = useCloneRepo();
 
   const readiness: RepositoryReadiness | null = useMemo(() => {
     if (!intent) return null;
     return resolveRepositoryReadiness({
-      requirement: "managed_cloud",
+      requirement,
       githubRepositoryAccess: capabilities.githubRepositoryAccessStatus,
       managedCloud: capabilities.managedCloudStatus,
       signedIn,
@@ -179,6 +194,28 @@ export function CloudRepoActionDialogHost() {
     );
   }, [createCloudWorkspaceAndEnter]);
 
+  const cloneFromGitHub = useCallback(async (
+    target: CloudRepoIdentity,
+    _continuation: CloneFromGitHubContinuation,
+  ) => {
+    // Reuse a stable operation id across retries so a crash mid-clone reuses the
+    // repo-root materialization instead of cloning twice. Keyed on the repo the
+    // held intent targets (one active clone intent per repo).
+    const operationId = `clone:${target.gitOwner}/${target.gitRepoName}`;
+    const result = await cloneRepo(
+      {
+        gitProvider: target.gitProvider,
+        gitOwner: target.gitOwner,
+        gitRepoName: target.gitRepoName,
+      },
+      operationId,
+    );
+    if (!result.succeeded && !result.cancelled) {
+      // Surface to the continuation guard so the dialog stays open for retry.
+      throw new Error(result.error);
+    }
+  }, [cloneRepo]);
+
   // Once every access gate is green, continue the held intent (save env →
   // create). Gate 9 (`set_up_cloud`) is the normal continue point: the resolver
   // has cleared authority and only the Cloud environment save remains, which is
@@ -197,11 +234,13 @@ export function CloudRepoActionDialogHost() {
     cloudEnvironmentConfigured,
     saveCloudEnvironment,
     createCloudWorkspace,
+    cloneFromGitHub,
   });
   continuationInputsRef.current = {
     cloudEnvironmentConfigured,
     saveCloudEnvironment,
     createCloudWorkspace,
+    cloneFromGitHub,
   };
 
   // The intent instance the continuation has already been started for. Because
@@ -230,13 +269,18 @@ export function CloudRepoActionDialogHost() {
     }
     startedForRef.current = intent;
     setContinuationError(null);
-    const { cloudEnvironmentConfigured, saveCloudEnvironment, createCloudWorkspace } =
-      continuationInputsRef.current;
+    const {
+      cloudEnvironmentConfigured,
+      saveCloudEnvironment,
+      createCloudWorkspace,
+      cloneFromGitHub,
+    } = continuationInputsRef.current;
     void continueCloudRepositoryIntent({
       intent,
       cloudEnvironmentConfigured,
       saveCloudEnvironment,
       createCloudWorkspace,
+      cloneFromGitHub,
     })
       .then(() => {
         // Terminal success: clear the intent unconditionally. Nothing should

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@proliferate/ui/kit/AlertDialog";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { remoteRepoKey } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+import { useLogicalWorkspaces } from "#product/hooks/workspaces/derived/use-logical-workspaces";
+import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
+import { useWorkspaceAvailabilityActions } from "#product/hooks/workspaces/workflows/use-workspace-availability-actions";
+import { useWorkspaceAvailabilityIntentStore } from "#product/stores/cloud/workspace-availability-intent-store";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+const UNLINK_COPY =
+  "This removes the association on this Mac. It does not delete either checkout, "
+  + "repository, Cloud workspace, or chat history.";
+
+/**
+ * The one connected host that owns the active workspace-availability action
+ * (PR 5 Flows 2/3/5), mirroring CloudRepoActionDialogHost. It resolves the
+ * intent's target from the live projection, shows the required confirmation /
+ * progress, and drives useWorkspaceAvailabilityActions (all orchestration lives
+ * in product-client). A cold restart leaves the store empty (nothing resumes).
+ */
+export function WorkspaceAvailabilityActionHost() {
+  const intent = useWorkspaceAvailabilityIntentStore((state) => state.activeIntent);
+  const clearIntent = useWorkspaceAvailabilityIntentStore((state) => state.clear);
+  const host = useProductHost();
+  const files = host.desktop?.files ?? null;
+  const showToast = useToastStore((state) => state.show);
+  const { logicalWorkspaces } = useLogicalWorkspaces();
+  const { repoRoots } = useStandardRepoProjection();
+  const { openOnThisMac, addCloudCopy, unlinkThisMac } = useWorkspaceAvailabilityActions();
+  const [busy, setBusy] = useState(false);
+
+  // Resolve an existing local repo root that already hosts the Cloud repo, so
+  // Open-on-Mac reuses a clone instead of prompting for a fresh one.
+  const cloudWorkspace = useMemo(() => {
+    if (!intent || !("cloudWorkspaceId" in intent)) {
+      return null;
+    }
+    const match = logicalWorkspaces.find(
+      (w) => w.cloudWorkspace?.id === intent.cloudWorkspaceId,
+    );
+    return match?.cloudWorkspace ?? null;
+  }, [intent, logicalWorkspaces]);
+
+  const existingRepoRootId = useMemo(() => {
+    const repo = cloudWorkspace?.repo;
+    if (!repo) {
+      return null;
+    }
+    const key = remoteRepoKey(repo.provider, repo.owner, repo.name);
+    const match = repoRoots.find(
+      (root) =>
+        root.remoteProvider
+        && root.remoteOwner
+        && root.remoteRepoName
+        && remoteRepoKey(root.remoteProvider, root.remoteOwner, root.remoteRepoName) === key,
+    );
+    return match?.id ?? null;
+  }, [cloudWorkspace, repoRoots]);
+
+  const runOpenOnMac = useCallback(async (cloudWorkspaceId: string) => {
+    let cloneDestinationPath: string | null = null;
+    if (!existingRepoRootId) {
+      if (!files) {
+        showToast("Cloning is only available in Desktop.");
+        return;
+      }
+      const parent = await files.pickDirectory();
+      if (!parent) {
+        return;
+      }
+      const repoName = cloudWorkspace?.repo?.name ?? "repository";
+      cloneDestinationPath = `${parent.replace(/\/+$/u, "")}/${repoName}`;
+    }
+    setBusy(true);
+    const ok = await openOnThisMac({
+      cloudWorkspaceId,
+      existingRepoRootId,
+      cloneDestinationPath,
+    });
+    setBusy(false);
+    if (ok) {
+      clearIntent();
+    }
+  }, [cloudWorkspace, clearIntent, existingRepoRootId, files, openOnThisMac, showToast]);
+
+  if (!intent) {
+    return null;
+  }
+
+  if (intent.kind === "unlink") {
+    return (
+      <AlertDialog open onOpenChange={(open) => { if (!open && !busy) clearIntent(); }}>
+        <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unlink this Mac?</AlertDialogTitle>
+            <AlertDialogDescription>{UNLINK_COPY}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy} onClick={() => clearIntent()}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy}
+              onClick={(event) => {
+                event.preventDefault();
+                setBusy(true);
+                void unlinkThisMac({
+                  cloudWorkspaceId: intent.cloudWorkspaceId,
+                  materializationId: intent.materializationId,
+                }).then((ok) => {
+                  setBusy(false);
+                  if (ok) clearIntent();
+                });
+              }}
+            >
+              {busy ? "Unlinking…" : "Unlink this Mac"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  if (intent.kind === "open_on_mac" || intent.kind === "relink") {
+    const cloudWorkspaceId = intent.kind === "open_on_mac"
+      ? intent.cloudWorkspaceId
+      : intent.cloudWorkspaceId;
+    const title = intent.kind === "open_on_mac"
+      ? "Open on this Mac"
+      : "Relink existing copy";
+    const description = existingRepoRootId
+      ? "This creates a local checkout of the Cloud workspace's exact published commit "
+        + "on this Mac and links the two."
+      : "This clones the repository to a folder you choose, checks out the exact published "
+        + "commit, and links it to the Cloud workspace.";
+    return (
+      <AlertDialog open onOpenChange={(open) => { if (!open && !busy) clearIntent(); }}>
+        <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy} onClick={() => clearIntent()}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy}
+              onClick={(event) => {
+                event.preventDefault();
+                void runOpenOnMac(cloudWorkspaceId);
+              }}
+            >
+              {busy
+                ? "Working…"
+                : existingRepoRootId
+                  ? "Open on this Mac"
+                  : "Choose folder & clone"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  // add_cloud_copy
+  return (
+    <AlertDialog open onOpenChange={(open) => { if (!open && !busy) clearIntent(); }}>
+      <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Add Cloud copy</AlertDialogTitle>
+          <AlertDialogDescription>
+            This creates a managed-Cloud copy at this workspace's exact published commit.
+            The workspace must be clean and its branch published on GitHub.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy} onClick={() => clearIntent()}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={busy}
+            onClick={(event) => {
+              event.preventDefault();
+              setBusy(true);
+              void addCloudCopy({
+                localAnyharnessWorkspaceId: intent.localWorkspaceId,
+                gitOwner: intent.gitOwner,
+                gitRepoName: intent.gitRepoName,
+              }).then((ok) => {
+                setBusy(false);
+                if (ok) clearIntent();
+              });
+            }}
+          >
+            {busy ? "Adding…" : "Add Cloud copy"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -30,6 +30,10 @@ import { APP_ROUTES } from "#product/config/app-routes";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useSidebarRepoAvailabilityActions } from "#product/hooks/workspaces/workflows/use-sidebar-repo-availability-actions";
+import { useWorkspaceAvailabilityIntentStore } from "#product/stores/cloud/workspace-availability-intent-store";
+import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import { workspaceAvailabilityIntentForCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-intent-mapping";
+import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/sidebar/sidebar-model";
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
@@ -272,6 +276,25 @@ export const MainSidebar = memo(function MainSidebar() {
     handleAddToThisMac,
   } = useSidebarRepoAvailabilityActions();
 
+  const beginWorkspaceAvailabilityIntent = useWorkspaceAvailabilityIntentStore(
+    (state) => state.begin,
+  );
+  const handleWorkspaceAvailabilityCommand = useCallback((
+    item: SidebarWorkspaceItemState,
+    kind: WorkspaceAvailabilityCommandKind,
+  ) => {
+    const intent = workspaceAvailabilityIntentForCommand(kind, {
+      localWorkspaceId: item.localWorkspaceId,
+      cloudWorkspaceId: item.cloudWorkspaceIdForActions,
+      linkedMaterializationId: item.linkedMaterializationId,
+      repoOwner: item.repoOwner,
+      repoName: item.repoName,
+    });
+    if (intent) {
+      beginWorkspaceAvailabilityIntent(intent);
+    }
+  }, [beginWorkspaceAvailabilityIntent]);
+
   const cloudWorkspaceBlocked = billingPlan?.billingMode === "enforce" && billingPlan.startBlocked;
   const cloudWorkspaceTooltip = cloudUnavailable
     ? CAPABILITY_COPY.cloudDisabledTooltip
@@ -357,6 +380,7 @@ export const MainSidebar = memo(function MainSidebar() {
               onIndicatorAction={actions.handleSidebarIndicatorAction}
               onOpenPullRequest={actions.handleOpenPullRequest}
               onMarkWorkspaceDone={actions.handleMarkWorkspaceDone}
+              onWorkspaceAvailabilityCommand={handleWorkspaceAvailabilityCommand}
               onWorkspaceHover={handleWorkspaceHover}
               shortcutRevealVisible={shortcutRevealVisible}
               shortcutLabelByWorkspaceId={sidebarShortcutLabelById}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -12,6 +12,8 @@ import {
 import { buildSidebarNewWorkspaceCommandScope } from "#product/lib/domain/workspaces/creation/new-workspace-command";
 import { visibleSidebarGroupItems } from "#product/lib/domain/workspaces/sidebar/sidebar-visible-items";
 import type { SidebarIndicatorAction } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/sidebar/sidebar-model";
 import { SkeletonBlock } from "#product/components/feedback/Skeleton";
 import { useWorkspaceCopyActions } from "#product/hooks/workspaces/workflows/use-workspace-copy-actions";
 import { RepoGroup, type RepoGroupEnvironmentKind } from "#product/components/workspace/shell/sidebar/RepoGroup";
@@ -43,6 +45,11 @@ interface SidebarWorkspaceContentProps {
   onIndicatorAction: (action: SidebarIndicatorAction) => void;
   onOpenPullRequest: (url: string) => void;
   onMarkWorkspaceDone: (workspaceId: string, logicalWorkspaceId: string) => void;
+  /** Begin a workspace-copy availability action (PR 5) for the given item. */
+  onWorkspaceAvailabilityCommand: (
+    item: SidebarWorkspaceItemState,
+    kind: WorkspaceAvailabilityCommandKind,
+  ) => void;
   onWorkspaceHover?: () => void;
   shortcutRevealVisible: boolean;
   shortcutLabelByWorkspaceId: ReadonlyMap<string, string>;
@@ -98,6 +105,7 @@ export function SidebarWorkspaceContent({
   onIndicatorAction,
   onOpenPullRequest,
   onMarkWorkspaceDone,
+  onWorkspaceAvailabilityCommand,
   onWorkspaceHover,
   shortcutRevealVisible,
   shortcutLabelByWorkspaceId,
@@ -269,6 +277,8 @@ export function SidebarWorkspaceContent({
                     ? () => onMarkWorkspaceDone(item.localWorkspaceId!, item.id)
                     : undefined
                 }
+                availabilityCommands={item.availabilityCommands}
+                onAvailabilityCommand={(kind) => onWorkspaceAvailabilityCommand(item, kind)}
                 onHover={onWorkspaceHover}
                 onArchive={item.archived ? undefined : () => onArchiveWorkspace(item.id)}
                 onUnarchive={item.archived ? () => onUnarchiveWorkspace(item.id) : undefined}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -23,6 +23,10 @@ import type {
   SidebarStatusIndicator,
   SidebarWorkspaceVariant,
 } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import {
   prStatusViewFromGitStatus,
   sidebarGitGlyphForStatus,
@@ -88,6 +92,10 @@ interface WorkspaceItemProps {
   onArchive?: () => void;
   onUnarchive?: () => void;
   onMarkDone?: () => void;
+  /** Workspace-copy availability commands (PR 5), rendered in both the DOM and
+   * native `…` menus. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
   onIndicatorAction?: (action: SidebarIndicatorAction) => void;
   onHover?: () => void;
   /**
@@ -120,6 +128,8 @@ export function WorkspaceItem({
   onArchive,
   onUnarchive,
   onMarkDone,
+  availabilityCommands = [],
+  onAvailabilityCommand,
   onIndicatorAction,
   onHover,
   workspaceLocationCopyLabel,
@@ -188,6 +198,8 @@ export function WorkspaceItem({
     onArchive: handleArchiveCommand,
     onUnarchive: handleUnarchiveCommand,
     onMarkDone: handleMarkDoneCommand,
+    availabilityCommands,
+    onAvailabilityCommand,
   });
   const hasMenuActions = hasArchiveAction
     || !!onRename
@@ -195,7 +207,8 @@ export function WorkspaceItem({
     || !!onCopyBranchName
     || !!onMarkDone
     || !!branchName
-    || !!handleOpenPullRequestCommand;
+    || !!handleOpenPullRequestCommand
+    || availabilityCommands.length > 0;
 
   const workspaceMenu = hasMenuActions ? (
     <WorkspaceItemMenu
@@ -213,6 +226,8 @@ export function WorkspaceItem({
       }
       onCopyBranchName={onCopyBranchName ? handleCopyBranchNameCommand : undefined}
       onMarkDone={onMarkDone ? handleMarkDoneCommand : undefined}
+      availabilityCommands={availabilityCommands}
+      onAvailabilityCommand={onAvailabilityCommand}
     />
   ) : null;
 
@@ -382,6 +397,22 @@ export function WorkspaceItem({
                   onClick={() => { close(); handleUnarchiveCommand(); }}
                 />
               )}
+              {availabilityCommands.map((command) => {
+                const isBlocker = command.kind === "unsupported-git-state";
+                return (
+                  <PopoverMenuItem
+                    key={command.kind}
+                    icon={<GitBranchIcon className="size-3.5 shrink-0 text-muted-foreground" />}
+                    label={command.blocker ? `${command.label} — ${command.blocker}` : command.label}
+                    variant="sidebar"
+                    disabled={isBlocker}
+                    onClick={() => {
+                      close();
+                      if (!isBlocker) onAvailabilityCommand?.(command.kind);
+                    }}
+                  />
+                );
+              })}
             </>
           )}
         </>

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
@@ -2,13 +2,20 @@ import { useCallback, useRef, useState } from "react";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import {
   Archive,
+  CloudIcon,
   Folder,
   GitBranchIcon,
   GitPullRequest,
+  Link2,
   MoreHorizontal,
   Pencil,
+  RotateCcw,
   Trash,
 } from "@proliferate/ui/icons";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,8 +42,24 @@ interface WorkspaceItemMenuProps {
   onCopyWorkspaceLocation?: () => void;
   onCopyBranchName?: () => void;
   onMarkDone?: () => void;
+  /** Workspace-copy availability commands (PR 5), resolved from the shared
+   * availability command model so this menu and the native menu match. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  /** Invoked with the command kind when an actionable availability command is
+   * selected. Blocker commands (unsupported Git state) render disabled. */
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
   onShowNativeMenu?: (position?: { x: number; y: number }) => Promise<boolean>;
 }
+
+const AVAILABILITY_COMMAND_ICON: Record<WorkspaceAvailabilityCommandKind, typeof CloudIcon> = {
+  "add-cloud-copy": CloudIcon,
+  "open-on-this-mac": Folder,
+  "link-copies": Link2,
+  "relink-existing": Link2,
+  "recreate-on-this-mac": RotateCcw,
+  "unlink-this-mac": Link2,
+  "unsupported-git-state": GitBranchIcon,
+};
 
 /**
  * Three-dot workspace menu (UX spec §2), built on the kit DropdownMenu with
@@ -56,6 +79,8 @@ export function WorkspaceItemMenu({
   onCopyWorkspaceLocation,
   onCopyBranchName,
   onMarkDone,
+  availabilityCommands = [],
+  onAvailabilityCommand,
   onShowNativeMenu,
 }: WorkspaceItemMenuProps) {
   const [fallbackOpen, setFallbackOpen] = useState(false);
@@ -119,6 +144,34 @@ export function WorkspaceItemMenu({
               {getShortcutDisplayLabel(SHORTCUTS.copyWorkspacePath)}
             </DropdownMenuShortcut>
           </DropdownMenuItem>
+        )}
+        {availabilityCommands.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            {availabilityCommands.map((command) => {
+              const Icon = AVAILABILITY_COMMAND_ICON[command.kind];
+              const isBlocker = command.kind === "unsupported-git-state";
+              return (
+                <DropdownMenuItem
+                  key={command.kind}
+                  disabled={isBlocker}
+                  onSelect={() => {
+                    if (!isBlocker) onAvailabilityCommand?.(command.kind);
+                  }}
+                >
+                  <Icon className="size-4 text-muted-foreground" />
+                  <span className="min-w-0">
+                    <span className="block">{command.label}</span>
+                    {command.blocker ? (
+                      <span className="block text-xs leading-[1.4] text-muted-foreground">
+                        {command.blocker}
+                      </span>
+                    ) : null}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </>
         )}
         {(branchName || onCopyBranchName || onOpenPullRequest) && (
           <>

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-desktop-install-id.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-desktop-install-id.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+
+/**
+ * This Mac's native desktop worker install id, or null when there is no native
+ * worker (Web, or a Desktop build without an enrolled worker).
+ *
+ * The worker install id is the durable, server-legible device identity — never
+ * a telemetry/anonymous fallback — so passing it to Cloud list/detail fetches
+ * lets the server select and un-redact THIS device's local materialization.
+ */
+export function useDesktopInstallId(): string | null {
+  const worker = useProductHost().desktop?.worker ?? null;
+  const [installId, setInstallId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!worker) {
+      setInstallId(null);
+      return;
+    }
+    let cancelled = false;
+    void worker
+      .getInstallId()
+      .then((id) => {
+        if (!cancelled) {
+          setInstallId(id?.trim() || null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setInstallId(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [worker]);
+
+  return installId;
+}

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-logical-workspaces.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-logical-workspaces.ts
@@ -3,11 +3,13 @@ import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logi
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { buildLogicalWorkspaces } from "#product/lib/domain/workspaces/cloud/logical-workspaces";
 import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
 
 const EMPTY_LOGICAL_WORKSPACES: LogicalWorkspace[] = [];
 
 export function useLogicalWorkspaces() {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const desktopInstallId = useDesktopInstallId();
   const { repoRoots, localWorkspaces, cloudWorkspaces, isLoading } = useStandardRepoProjection();
 
   const logicalWorkspaces = useMemo(() => {
@@ -20,8 +22,9 @@ export function useLogicalWorkspaces() {
       repoRoots,
       cloudWorkspaces,
       currentSelectionId: selectedWorkspaceId,
+      desktopInstallId,
     });
-  }, [cloudWorkspaces, localWorkspaces, repoRoots, selectedWorkspaceId]);
+  }, [cloudWorkspaces, desktopInstallId, localWorkspaces, repoRoots, selectedWorkspaceId]);
 
   return {
     logicalWorkspaces,

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
@@ -20,6 +20,7 @@ import {
   useDocumentFocusVisibilityNonce,
 } from "#product/hooks/ui/document/use-document-focus-visibility";
 import { useLogicalWorkspaces } from "#product/hooks/workspaces/derived/use-logical-workspaces";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
 import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
 import { useWorkspaceGitStatuses } from "#product/hooks/workspaces/derived/use-workspace-git-statuses";
 import { useWorkspaceMetadataSync } from "#product/hooks/workspaces/lifecycle/use-workspace-metadata-sync";
@@ -134,6 +135,7 @@ export function useWorkspaceSidebarState({
   const cleanupAttentionWorkspaces =
     workspaceCollections?.cleanupAttentionWorkspaces ?? EMPTY_WORKSPACES;
   const { repoRoots } = useStandardRepoProjection();
+  const desktopInstallId = useDesktopInstallId();
   const { data: gitStatus } = useWorkspaceMetadataSync();
   const { statusesByLogicalId: gitStatusesByLogicalId } = useWorkspaceGitStatuses();
   const computeTargets = useComputeTargetOptions();
@@ -207,10 +209,12 @@ export function useWorkspaceSidebarState({
       sessionLastViewedAt,
       targetAppearanceById: computeTargets.targetAppearanceById,
       suppressActiveNeedsReview: windowFocused,
+      desktopInstallId,
     })), [
     activeSessionTitle,
     archivedSet,
     computeTargets.targetAppearanceById,
+    desktopInstallId,
     gitStatus,
     gitStatusesByLogicalId,
     hiddenRepoRootSet,

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts
@@ -24,4 +24,55 @@ describe("buildWorkspaceActionsNativeMenuItems", () => {
     expect(onRename).toHaveBeenCalledOnce();
     expect(items.some((item) => "id" in item && /commit|push|pull-request/.test(item.id))).toBe(false);
   });
+
+  it("appends workspace-copy availability commands and dispatches by kind", () => {
+    const onAvailabilityCommand = vi.fn();
+    const items = buildWorkspaceActionsNativeMenuItems({
+      canRename: true,
+      canFork: false,
+      canDismiss: true,
+      onRename: vi.fn(),
+      onFork: vi.fn(),
+      onDismiss: vi.fn(),
+      availabilityCommands: [
+        { kind: "add-cloud-copy", label: "Add Cloud copy…" },
+      ],
+      onAvailabilityCommand,
+    });
+
+    const availability = items.find(
+      (item) => "id" in item && item.id === "availability-add-cloud-copy",
+    );
+    expect(availability).toBeDefined();
+    if (availability && "onSelect" in availability) availability.onSelect?.();
+    expect(onAvailabilityCommand).toHaveBeenCalledWith("add-cloud-copy");
+  });
+
+  it("renders an unsupported-git-state blocker as a disabled, non-dispatching item", () => {
+    const onAvailabilityCommand = vi.fn();
+    const items = buildWorkspaceActionsNativeMenuItems({
+      canRename: false,
+      canFork: false,
+      canDismiss: false,
+      onRename: vi.fn(),
+      onFork: vi.fn(),
+      onDismiss: vi.fn(),
+      availabilityCommands: [
+        {
+          kind: "unsupported-git-state",
+          label: "Unsupported Git state",
+          blocker: "The workspace has uncommitted changes.",
+        },
+      ],
+      onAvailabilityCommand,
+    });
+
+    const blocker = items.find(
+      (item) => "id" in item && item.id === "availability-unsupported-git-state",
+    );
+    expect(blocker).toBeDefined();
+    if (blocker && "enabled" in blocker) expect(blocker.enabled).toBe(false);
+    if (blocker && "onSelect" in blocker) blocker.onSelect?.();
+    expect(onAvailabilityCommand).not.toHaveBeenCalled();
+  });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts
@@ -2,6 +2,10 @@ import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useNativeMenu } from "#product/hooks/ui/native/use-native-context-menu";
 import type { NativeMenuItem } from "@proliferate/product-client/host/desktop-bridge";
 import { getShortcutNativeAccelerator } from "#product/lib/domain/shortcuts/native-accelerators";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export interface WorkspaceActionsNativeMenuInput {
   canRename: boolean;
@@ -10,6 +14,11 @@ export interface WorkspaceActionsNativeMenuInput {
   onRename: () => void;
   onFork: () => void;
   onDismiss: () => void;
+  /** Workspace-copy availability commands (PR 5), resolved from the shared
+   * availability command model — the same source the DOM menu renders, so the
+   * two menus stay in manual parity. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
 }
 
 export function useWorkspaceActionsNativeMenu(input: WorkspaceActionsNativeMenuInput) {
@@ -19,7 +28,7 @@ export function useWorkspaceActionsNativeMenu(input: WorkspaceActionsNativeMenuI
 export function buildWorkspaceActionsNativeMenuItems(
   input: WorkspaceActionsNativeMenuInput,
 ): NativeMenuItem[] {
-  return [
+  const items: NativeMenuItem[] = [
     {
       id: "rename-chat",
       label: "Rename chat",
@@ -41,4 +50,24 @@ export function buildWorkspaceActionsNativeMenuItems(
       onSelect: input.onDismiss,
     },
   ];
+
+  const availabilityCommands = input.availabilityCommands ?? [];
+  if (availabilityCommands.length > 0) {
+    items.push({ kind: "separator" });
+    for (const command of availabilityCommands) {
+      // An unsupported-git-state blocker is present but not actionable, mirroring
+      // the disabled DOM item.
+      const isBlocker = command.kind === "unsupported-git-state";
+      items.push({
+        id: `availability-${command.kind}`,
+        label: command.blocker ? `${command.label} — ${command.blocker}` : command.label,
+        enabled: !isBlocker,
+        onSelect: () => {
+          if (!isBlocker) input.onAvailabilityCommand?.(command.kind);
+        },
+      });
+    }
+  }
+
+  return items;
 }

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
@@ -115,4 +115,47 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       { id: "copy-branch-name", label: "Copy branch name" },
     ]);
   });
+
+  it("appends workspace-copy availability commands and dispatches by kind (right-click parity)", () => {
+    let dispatched: string | null = null;
+    const items = buildWorkspaceSidebarNativeContextMenuItems({
+      canRename: false,
+      canCopyWorkspaceLocation: false,
+      copyWorkspaceLocationLabel: "Copy workspace path",
+      canCopyBranchName: false,
+      branchName: null,
+      canOpenPullRequest: false,
+      pullRequestNumber: null,
+      archived: false,
+      canArchive: false,
+      canUnarchive: false,
+      canMarkDone: false,
+      onRename: () => {},
+      onCopyWorkspaceLocation: () => {},
+      onCopyBranchName: () => {},
+      onOpenPullRequest: () => {},
+      onArchive: () => {},
+      onUnarchive: () => {},
+      onMarkDone: () => {},
+      availabilityCommands: [
+        { kind: "unlink-this-mac", label: "Unlink this Mac…" },
+        {
+          kind: "unsupported-git-state",
+          label: "Unsupported Git state",
+          blocker: "This workspace has uncommitted changes.",
+        },
+      ],
+      onAvailabilityCommand: (kind) => { dispatched = kind; },
+    });
+
+    const unlink = items.find((i) => "id" in i && i.id === "availability-unlink-this-mac");
+    const blocker = items.find((i) => "id" in i && i.id === "availability-unsupported-git-state");
+    expect(unlink).toBeDefined();
+    expect(blocker).toBeDefined();
+    if (blocker && "enabled" in blocker) expect(blocker.enabled).toBe(false);
+    if (unlink && "onSelect" in unlink) unlink.onSelect?.();
+    expect(dispatched).toBe("unlink-this-mac");
+    if (blocker && "onSelect" in blocker) blocker.onSelect?.();
+    expect(dispatched).toBe("unlink-this-mac");
+  });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
@@ -2,6 +2,10 @@ import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useNativeContextMenu } from "#product/hooks/ui/native/use-native-context-menu";
 import type { NativeMenuItem } from "@proliferate/product-client/host/desktop-bridge";
 import { getShortcutNativeAccelerator } from "#product/lib/domain/shortcuts/native-accelerators";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export function useWorkspaceSidebarNativeContextMenu({
   canRename,
@@ -22,6 +26,8 @@ export function useWorkspaceSidebarNativeContextMenu({
   onArchive,
   onUnarchive,
   onMarkDone,
+  availabilityCommands,
+  onAvailabilityCommand,
 }: {
   canRename: boolean;
   canCopyWorkspaceLocation: boolean;
@@ -41,6 +47,8 @@ export function useWorkspaceSidebarNativeContextMenu({
   onArchive: () => void;
   onUnarchive: () => void;
   onMarkDone: () => void;
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
 }) {
   return useNativeContextMenu(() =>
     buildWorkspaceSidebarNativeContextMenuItems({
@@ -62,6 +70,8 @@ export function useWorkspaceSidebarNativeContextMenu({
       onArchive,
       onUnarchive,
       onMarkDone,
+      availabilityCommands,
+      onAvailabilityCommand,
     })
   );
 }
@@ -85,6 +95,8 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
   onArchive,
   onUnarchive,
   onMarkDone,
+  availabilityCommands,
+  onAvailabilityCommand,
 }: {
   canRename: boolean;
   canCopyWorkspaceLocation: boolean;
@@ -104,6 +116,8 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
   onArchive: () => void;
   onUnarchive: () => void;
   onMarkDone: () => void;
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
 }): NativeMenuItem[] {
   const items: NativeMenuItem[] = [];
   if (canRename) {
@@ -180,6 +194,24 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
       label: "Delete workspace...",
       onSelect: onMarkDone,
     });
+  }
+
+  const availability = availabilityCommands ?? [];
+  if (availability.length > 0) {
+    if (items.length > 0) {
+      items.push({ kind: "separator" });
+    }
+    for (const command of availability) {
+      const isBlocker = command.kind === "unsupported-git-state";
+      items.push({
+        id: `availability-${command.kind}`,
+        label: command.blocker ? `${command.label} — ${command.blocker}` : command.label,
+        enabled: !isBlocker,
+        onSelect: () => {
+          if (!isBlocker) onAvailabilityCommand?.(command.kind);
+        },
+      });
+    }
   }
 
   return items;

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-clone-repo.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-clone-repo.ts
@@ -1,0 +1,146 @@
+import { AnyHarnessError, type RepoRoot } from "@anyharness/sdk";
+import { useMaterializeRepoRootMutation } from "@anyharness/sdk-react";
+import { useSaveRepoEnvironment } from "@proliferate/cloud-sdk-react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { useCallback, useState } from "react";
+import {
+  AddRepoIdentityMismatchError,
+  type ExpectedRepoIdentity,
+} from "#product/lib/domain/workspaces/creation/add-repo-workflow";
+import { runCloneRepoWorkflow } from "#product/lib/domain/workspaces/creation/clone-repo-workflow";
+import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCacheActions } from "#product/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useToastStore } from "#product/stores/toast/toast-store";
+import { ensureRuntimeReady } from "#product/hooks/workspaces/workflows/runtime-ready";
+
+/** Map a clone failure to a user-facing message, naming local Git auth and the
+ * PR 3 typed errors without leaking sandbox paths. */
+function describeCloneFailure(error: unknown): string {
+  if (error instanceof AddRepoIdentityMismatchError) {
+    return error.message;
+  }
+  if (error instanceof AnyHarnessError) {
+    switch (error.problem.code) {
+      case "REPOSITORY_AUTH_REQUIRED":
+        return "Cloning requires local Git credentials for this repository. "
+          + "Sign in to GitHub in your local Git setup and try again.";
+      case "REPOSITORY_REMOTE_MISMATCH":
+        return "The destination already contains a different repository.";
+      case "DESTINATION_NOT_EMPTY":
+        return "The chosen folder is not empty. Pick an empty destination folder.";
+      case "DESTINATION_OUTSIDE_ALLOWED_ROOT":
+        return "The chosen folder is outside an allowed location.";
+      case "DESTINATION_CONFLICT":
+        return "Another repository already occupies the chosen folder.";
+      case "REPO_ROOT_WORKTREE_UNSUPPORTED":
+        return "The chosen folder is a Git worktree. Choose a plain destination folder.";
+      default:
+        return error.problem.detail ?? error.message;
+    }
+  }
+  return error instanceof Error ? error.message : "Failed to clone repository.";
+}
+
+export type CloneRepoResult =
+  | { succeeded: true; sourceRoot: string }
+  | { succeeded: false; error: string; cancelled?: boolean };
+
+export function useCloneRepo() {
+  const desktop = useProductHost().desktop ?? null;
+  const files = desktop?.files ?? null;
+  const localRuntime = desktop?.runtime ?? null;
+  const worker = desktop?.worker ?? null;
+  const materializeRepoRoot = useMaterializeRepoRootMutation().mutateAsync;
+  const saveEnvironment = useSaveRepoEnvironment();
+  const { upsertRepoRootInWorkspaceCollections } = useWorkspaceCollectionsMutationCacheActions();
+  const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
+  const unhideRepoRoot = useWorkspaceUiStore((state) => state.unhideRepoRoot);
+  const showToast = useToastStore((state) => state.show);
+  const [isCloning, setIsCloning] = useState(false);
+
+  const saveLocalRepoEnvironment = useCallback((repoRoot: RepoRoot) => {
+    const gitOwner = repoRoot.remoteOwner?.trim();
+    const gitRepoName = repoRoot.remoteRepoName?.trim();
+    if (
+      repoRoot.remoteProvider !== "github"
+      || !gitOwner
+      || !gitRepoName
+      || !repoRoot.path.trim()
+      || !worker
+    ) {
+      return;
+    }
+    void (async () => {
+      const installId = await worker.getInstallId();
+      await saveEnvironment.mutateAsync({
+        gitOwner,
+        gitRepoName,
+        body: {
+          kind: "local",
+          gitProvider: "github",
+          desktopInstallId: installId,
+          localPath: repoRoot.path,
+          defaultBranch: repoRoot.defaultBranch?.trim() || null,
+          setupScript: "",
+          runCommand: "",
+        },
+      });
+    })().catch(() => {
+      // Local clone remains usable even when the environment save fails.
+    });
+  }, [saveEnvironment, worker]);
+
+  /** Clone `repo` into a subfolder of the user-picked parent directory. The
+   * native folder picker chooses the parent; the clone lands in
+   * `<parent>/<repoName>`. `operationId` must be stable across retries. */
+  const cloneRepo = useCallback(async (
+    repo: ExpectedRepoIdentity,
+    operationId: string,
+  ): Promise<CloneRepoResult> => {
+    if (!files) {
+      return { succeeded: false, error: "Cloning is only available in Desktop." };
+    }
+    const parent = await files.pickDirectory();
+    if (!parent) {
+      return { succeeded: false, error: "Clone cancelled.", cancelled: true };
+    }
+    const destinationPath = `${parent.replace(/\/+$/u, "")}/${repo.gitRepoName}`;
+    setIsCloning(true);
+    try {
+      const repoRoot = await runCloneRepoWorkflow({
+        repo,
+        destinationPath,
+        operationId,
+        ensureRuntimeReady: () => ensureRuntimeReady(localRuntime),
+        materializeRepoRoot: (input) => materializeRepoRoot(input),
+        upsertRepoRootInWorkspaceCollections,
+        invalidateWorkspaceCollections: invalidateWorkspaceCollectionsForRuntime,
+        saveLocalRepoEnvironment,
+        unhideRepoRoot,
+      });
+      return { succeeded: true, sourceRoot: repoRoot.path.trim() || repoRoot.id };
+    } catch (error) {
+      const message = describeCloneFailure(error);
+      showToast(message);
+      return { succeeded: false, error: message };
+    } finally {
+      setIsCloning(false);
+    }
+  }, [
+    files,
+    invalidateWorkspaceCollectionsForRuntime,
+    localRuntime,
+    materializeRepoRoot,
+    saveLocalRepoEnvironment,
+    showToast,
+    unhideRepoRoot,
+    upsertRepoRootInWorkspaceCollections,
+  ]);
+
+  return {
+    cloneRepo,
+    canClone: files !== null,
+    isCloning,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-availability-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-availability-actions.ts
@@ -1,0 +1,178 @@
+import { useCallback } from "react";
+import {
+  getAnyHarnessClient,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+  useMaterializeRepoRootMutation,
+  useMaterializeWorkspaceAtRefMutation,
+} from "@anyharness/sdk-react";
+import {
+  useCreateLocalMaterializationIntent,
+  useReportMaterialization,
+  useUnlinkMaterialization,
+} from "@proliferate/cloud-sdk-react";
+import { createCloudWorkspace } from "@proliferate/cloud-sdk/client/workspaces";
+import { runOpenOnMacFlow } from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
+import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+/**
+ * Executes the workspace-copy availability actions (PR 5 Flows 2/3/5). All
+ * orchestration stays here in product-client (never in product-ui or Tauri
+ * commands); the pure sequencing lives in open-on-mac-orchestration.ts.
+ *
+ * Runtime routing: local materialization operations (clone/exact-ref) run
+ * against the local Tauri/AnyHarness runtime via the PR 3 sdk-react mutations,
+ * which resolve the local runtime connection from context. Cloud intent/report
+ * calls go to the control plane.
+ */
+export function useWorkspaceAvailabilityActions() {
+  const runtime = useAnyHarnessRuntimeContext();
+  const materializeRepoRoot = useMaterializeRepoRootMutation().mutateAsync;
+  const materializeWorkspaceAtRef = useMaterializeWorkspaceAtRefMutation().mutateAsync;
+  const createIntent = useCreateLocalMaterializationIntent().mutateAsync;
+  const report = useReportMaterialization().mutateAsync;
+  const unlink = useUnlinkMaterialization().mutateAsync;
+  const desktopInstallId = useDesktopInstallId();
+  const { selectWorkspace } = useWorkspaceSelection();
+  const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
+  const showToast = useToastStore((state) => state.show);
+
+  /**
+   * Flow 2 / Flow 5 relink+recreate. Reuses the Cloud operationId across
+   * retries; when no local repo root hosts the repository the caller must
+   * supply a clone destination (prompted via the native folder picker).
+   */
+  const openOnThisMac = useCallback(async (args: {
+    cloudWorkspaceId: string;
+    existingRepoRootId: string | null;
+    cloneDestinationPath: string | null;
+  }): Promise<boolean> => {
+    if (!desktopInstallId) {
+      showToast("This Mac is not registered yet. Try again in a moment.");
+      return false;
+    }
+    try {
+      const result = await runOpenOnMacFlow(
+        {
+          existingRepoRootId: args.existingRepoRootId,
+          cloneDestinationPath: args.cloneDestinationPath,
+        },
+        {
+          createIntent: () =>
+            createIntent({
+              workspaceId: args.cloudWorkspaceId,
+              body: { targetKind: "local_desktop", desktopInstallId },
+            }),
+          materializeRepoRoot: (input) => materializeRepoRoot(input),
+          materializeWorkspaceAtRef: async (repoRootId, input) => {
+            const response = await materializeWorkspaceAtRef({ repoRootId, input });
+            return {
+              workspaceId: response.workspace.id,
+              observedHeadSha: response.observedHeadSha,
+              worktreePath: response.workspace.path,
+            };
+          },
+          report: (materializationId, body) =>
+            report({ workspaceId: args.cloudWorkspaceId, materializationId, body }),
+        },
+      );
+      const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+      if (runtimeUrl) {
+        await invalidateWorkspaceCollectionsForRuntime(runtimeUrl);
+      }
+      // Select and open the local AnyHarness workspace.
+      await selectWorkspace(result.anyharnessWorkspaceId, { force: true });
+      return true;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not open this workspace on this Mac.");
+      return false;
+    }
+  }, [
+    createIntent,
+    desktopInstallId,
+    invalidateWorkspaceCollectionsForRuntime,
+    materializeRepoRoot,
+    materializeWorkspaceAtRef,
+    report,
+    runtime.runtimeUrl,
+    selectWorkspace,
+    showToast,
+  ]);
+
+  /** Flow 3: add a managed-Cloud copy of a clean, published local workspace at
+   * its exact ref. Reads the local exact HEAD from the runtime, then calls the
+   * server exact-ref create path (which re-verifies the published head). */
+  const addCloudCopy = useCallback(async (args: {
+    localAnyharnessWorkspaceId: string;
+    gitOwner: string;
+    gitRepoName: string;
+  }): Promise<boolean> => {
+    try {
+      const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
+      const status = await client.git.getStatus(args.localAnyharnessWorkspaceId);
+      if (
+        status.detached
+        || !status.currentBranch
+        || !status.clean
+        || status.conflicted
+        || status.operation !== "none"
+      ) {
+        showToast("This workspace must be clean and on a normal branch to add a Cloud copy.");
+        return false;
+      }
+      const worktreePath = status.repoRootPath;
+      const detail = await createCloudWorkspace({
+        gitProvider: "github",
+        gitOwner: args.gitOwner,
+        gitRepoName: args.gitRepoName,
+        branchName: status.currentBranch,
+        expectedHeadSha: status.headOid,
+        source: "desktop",
+        sourceMaterialization: desktopInstallId
+          ? {
+            targetKind: "local_desktop",
+            desktopInstallId,
+            anyharnessWorkspaceId: args.localAnyharnessWorkspaceId,
+            worktreePath,
+            observedHeadSha: status.headOid,
+          }
+          : null,
+      });
+      showToast("Added a Cloud copy.", "info");
+      await selectWorkspace(cloudWorkspaceSyntheticId(detail.id), { force: true });
+      return true;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not add a Cloud copy.");
+      return false;
+    }
+  }, [desktopInstallId, runtime, selectWorkspace, showToast]);
+
+  /** Flow 5: unlink this Mac's association (non-destructive; idempotent). */
+  const unlinkThisMac = useCallback(async (args: {
+    cloudWorkspaceId: string;
+    materializationId: string;
+  }): Promise<boolean> => {
+    try {
+      await unlink({
+        workspaceId: args.cloudWorkspaceId,
+        materializationId: args.materializationId,
+      });
+      showToast("Unlinked this Mac. Nothing was deleted.", "info");
+      return true;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not unlink this Mac.");
+      return false;
+    }
+  }, [showToast, unlink]);
+
+  return {
+    openOnThisMac,
+    addCloudCopy,
+    unlinkThisMac,
+    desktopInstallId,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.test.ts
@@ -9,11 +9,21 @@ import {
 const REPO = { gitProvider: "github", gitOwner: "acme", gitRepoName: "rocket" } as const;
 
 describe("cloud repository intent", () => {
-  it("maps every cloud intent to the managed_cloud requirement", () => {
+  it("maps managed-cloud intents to managed_cloud and clone to github_repository_access", () => {
     expect(requirementForCloudRepositoryIntent({ kind: "set_up_cloud", repo: REPO }))
       .toBe("managed_cloud");
     expect(requirementForCloudRepositoryIntent({ kind: "add_cloud_repository" }))
       .toBe("managed_cloud");
+    expect(requirementForCloudRepositoryIntent({
+      kind: "clone_from_github",
+      repo: REPO,
+      continuation: {
+        repoGroupKeyToExpand: null,
+        cloneUrl: "https://github.com/acme/rocket.git",
+        defaultBranch: "main",
+        destinationParentPath: null,
+      },
+    })).toBe("github_repository_access");
   });
 
   it("resolves the target repo, or null for the repo-agnostic add flow", () => {
@@ -90,5 +100,29 @@ describe("cloud repository intent", () => {
 
     expect(saveCloudEnvironment).not.toHaveBeenCalled();
     expect(createCloudWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("clones without creating a Cloud environment or workspace", async () => {
+    const saveCloudEnvironment = vi.fn(async () => {});
+    const createCloudWorkspace = vi.fn(async () => {});
+    const cloneFromGitHub = vi.fn(async () => {});
+    const continuation = {
+      repoGroupKeyToExpand: "github:acme:rocket",
+      cloneUrl: "https://github.com/acme/rocket.git",
+      defaultBranch: "main",
+      destinationParentPath: "/Users/dev/code",
+    };
+
+    await continueCloudRepositoryIntent({
+      intent: { kind: "clone_from_github", repo: REPO, continuation },
+      cloudEnvironmentConfigured: false,
+      saveCloudEnvironment,
+      createCloudWorkspace,
+      cloneFromGitHub,
+    });
+
+    expect(saveCloudEnvironment).not.toHaveBeenCalled();
+    expect(createCloudWorkspace).not.toHaveBeenCalled();
+    expect(cloneFromGitHub).toHaveBeenCalledWith(REPO, continuation);
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.ts
@@ -22,6 +22,20 @@ export interface CreateCloudWorkspaceContinuation {
 }
 
 /**
+ * Everything the clone-from-github continuation needs, kept as a minimal
+ * serializable object rather than a captured closure so it survives a browser
+ * authorization callback while the app stays open. `destinationParentPath` is
+ * the user-chosen parent directory the clone lands under; null means the host
+ * still needs to prompt for it.
+ */
+export interface CloneFromGitHubContinuation {
+  repoGroupKeyToExpand: string | null;
+  cloneUrl: string;
+  defaultBranch: string | null;
+  destinationParentPath: string | null;
+}
+
+/**
  * The one intent the connected Cloud action host owns. Serializable by
  * construction: on cold restart the store is empty and nothing resumes; the
  * settings surfaces are the recovery path.
@@ -33,13 +47,24 @@ export type CloudRepositoryIntent =
     repo: CloudRepoIdentity;
     continuation: CreateCloudWorkspaceContinuation;
   }
+  | {
+    kind: "clone_from_github";
+    repo: CloudRepoIdentity;
+    continuation: CloneFromGitHubContinuation;
+  }
   | { kind: "add_cloud_repository" };
 
-/** Every Cloud repository intent depends on managed-Cloud readiness. */
+/**
+ * The capability an intent depends on. Every managed-Cloud intent
+ * (set_up_cloud / create_cloud_workspace / add_cloud_repository) requires
+ * managed-Cloud execution readiness, but `clone_from_github` only needs GitHub
+ * repository access: a GitHub-App-ready deployment with managed Cloud disabled
+ * can still clone locally, so it must not be gated behind managed Cloud.
+ */
 export function requirementForCloudRepositoryIntent(
-  _intent: CloudRepositoryIntent,
+  intent: CloudRepositoryIntent,
 ): RepositoryCapabilityRequirement {
-  return "managed_cloud";
+  return intent.kind === "clone_from_github" ? "github_repository_access" : "managed_cloud";
 }
 
 /** The repository an intent targets, or null for the repo-agnostic add flow. */
@@ -67,11 +92,24 @@ export async function continueCloudRepositoryIntent(args: {
     repo: CloudRepoIdentity,
     continuation: CreateCloudWorkspaceContinuation,
   ) => Promise<void>;
+  /** Clone the target GitHub repository to this machine. */
+  cloneFromGitHub?: (
+    repo: CloudRepoIdentity,
+    continuation: CloneFromGitHubContinuation,
+  ) => Promise<void>;
 }): Promise<void> {
   const { intent } = args;
 
   if (intent.kind === "add_cloud_repository") {
     // The repo picker owns its own save; nothing to continue here.
+    return;
+  }
+
+  // Clone never touches the Cloud repo environment: it uses only GitHub
+  // repository access + the local Git credential chain, so it must not create a
+  // managed-Cloud environment as a side effect.
+  if (intent.kind === "clone_from_github") {
+    await args.cloneFromGitHub?.(intent.repo, intent.continuation);
     return;
   }
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
@@ -151,6 +151,10 @@ export interface CloudWorkspaceSummary {
   executionTarget?: CloudWorkspaceExecutionTargetSummary;
   selectedMaterializationId?: string | null;
   primaryMaterialization?: CloudWorkspaceMaterializationSummary | null;
+  // The full active materialization ledger for this Cloud workspace (PR 4).
+  // Present on server responses; optional so legacy/synthetic fixtures without
+  // it still type-check. The explicit-association projection reads this array.
+  materializations?: CloudWorkspaceMaterializationSummary[];
   cloudAccess?: CloudWorkspaceCloudAccessSummary;
   statusDetail: string | null;
   lastError: string | null;

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-duplicates.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-duplicates.ts
@@ -1,0 +1,147 @@
+import type { Workspace } from "@anyharness/sdk";
+import { buildLocalSlotLogicalWorkspaceId } from "#product/lib/domain/workspaces/cloud/logical-workspace-id";
+import { compareLocalWorkspaceCanonicalOrder, workspaceBranchKey } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+
+// Collapsing of exact path+branch local duplicates for the logical-workspace
+// projection. Extracted from logical-workspaces.ts so the projection file stays
+// focused on materialization-first attachment (PR 5). Behavior is unchanged:
+// two workspaces with the same exact path and case-sensitive branch fold onto
+// one representative unless a duplicate has its own sessions or is selected.
+
+function timestampValue(timestamp: string | null | undefined): number {
+  return timestamp ? new Date(timestamp).getTime() : 0;
+}
+
+function localWorkspaceExactMaterializationKey(workspace: Workspace): string {
+  return `${workspace.path.trim()}\0${workspaceBranchKey(workspace)}`;
+}
+
+function workspaceExecutionPriority(workspace: Workspace): number {
+  const summary = workspace.executionSummary;
+  if (!summary) {
+    return 0;
+  }
+
+  if (summary.totalSessionCount > summary.liveSessionCount) {
+    return 3;
+  }
+
+  if (summary.phase === "running" || summary.phase === "awaiting_interaction") {
+    return 2;
+  }
+
+  if (summary.totalSessionCount > 0) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareExactLocalWorkspaceDuplicateOrder(left: Workspace, right: Workspace): number {
+  const byExecutionPriority = workspaceExecutionPriority(right) - workspaceExecutionPriority(left);
+  if (byExecutionPriority !== 0) {
+    return byExecutionPriority;
+  }
+
+  const byExecutionUpdatedAt = (
+    timestampValue(right.executionSummary?.updatedAt)
+    - timestampValue(left.executionSummary?.updatedAt)
+  );
+  if (byExecutionUpdatedAt !== 0) {
+    return byExecutionUpdatedAt;
+  }
+
+  const byWorkspaceUpdatedAt = timestampValue(right.updatedAt) - timestampValue(left.updatedAt);
+  if (byWorkspaceUpdatedAt !== 0) {
+    return byWorkspaceUpdatedAt;
+  }
+
+  return compareLocalWorkspaceCanonicalOrder(left, right);
+}
+
+export interface CollapsedLocalWorkspace {
+  workspace: Workspace;
+  aliasIds: string[];
+}
+
+function localWorkspaceIdentityIds(workspace: Workspace): string[] {
+  return [workspace.id, buildLocalSlotLogicalWorkspaceId(workspace.id)];
+}
+
+export function localWorkspaceMatchesSelection(
+  workspace: Workspace,
+  currentSelectionId: string | null,
+): boolean {
+  return currentSelectionId !== null
+    && localWorkspaceIdentityIds(workspace).includes(currentSelectionId);
+}
+
+function compareExactLocalWorkspaceDuplicateOrderForSelection(
+  currentSelectionId: string | null,
+): (left: Workspace, right: Workspace) => number {
+  return (left, right) => {
+    const leftSelected = localWorkspaceMatchesSelection(left, currentSelectionId);
+    const rightSelected = localWorkspaceMatchesSelection(right, currentSelectionId);
+    if (leftSelected !== rightSelected) {
+      return leftSelected ? -1 : 1;
+    }
+    return compareExactLocalWorkspaceDuplicateOrder(left, right);
+  };
+}
+
+function workspaceHasOwnSessions(workspace: Workspace): boolean {
+  return (workspace.executionSummary?.totalSessionCount ?? 0) > 0;
+}
+
+export function collapseExactLocalWorkspaceDuplicates(
+  workspaces: readonly Workspace[],
+  currentSelectionId: string | null,
+): CollapsedLocalWorkspace[] {
+  const byMaterialization = new Map<string, Workspace[]>();
+  for (const workspace of workspaces) {
+    const key = localWorkspaceExactMaterializationKey(workspace);
+    const bucket = byMaterialization.get(key);
+    if (bucket) {
+      bucket.push(workspace);
+    } else {
+      byMaterialization.set(key, [workspace]);
+    }
+  }
+
+  return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
+    if (bucket.length === 1) {
+      return [{ workspace: bucket[0]!, aliasIds: [] }];
+    }
+
+    const distinct = bucket.filter(
+      (candidate) =>
+        workspaceHasOwnSessions(candidate)
+        || localWorkspaceMatchesSelection(candidate, currentSelectionId),
+    );
+    const foldable = bucket.filter(
+      (candidate) =>
+        !workspaceHasOwnSessions(candidate)
+        && !localWorkspaceMatchesSelection(candidate, currentSelectionId),
+    );
+
+    if (distinct.length === 0) {
+      const representative = [...foldable]
+        .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
+      return [{
+        workspace: representative,
+        aliasIds: foldable
+          .filter((candidate) => candidate.id !== representative.id)
+          .flatMap(localWorkspaceIdentityIds),
+      }];
+    }
+
+    const sortedDistinct = [...distinct]
+      .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId));
+    const foldedAliasIds = foldable.flatMap(localWorkspaceIdentityIds);
+    return sortedDistinct.map((workspace, index) => ({
+      workspace,
+      // Fold stale empty duplicates onto the first distinct entry.
+      aliasIds: index === 0 ? foldedAliasIds : [],
+    }));
+  });
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
@@ -13,7 +13,12 @@ export function normalizeLogicalWorkspaceBranchKey(
   return trimmed && trimmed.length > 0 ? trimmed : "HEAD";
 }
 
-export type LogicalWorkspaceIdKind = "remote" | "repo-root" | "path" | "local-slot";
+export type LogicalWorkspaceIdKind =
+  | "remote"
+  | "repo-root"
+  | "path"
+  | "local-slot"
+  | "cloud";
 
 export interface ParsedLogicalWorkspaceId {
   kind: LogicalWorkspaceIdKind;
@@ -64,6 +69,20 @@ export function buildLocalSlotLogicalWorkspaceId(workspaceId: string): string {
   ].join(":");
 }
 
+/**
+ * Identity-keyed id for a Cloud workspace that carries an explicit
+ * materialization ledger but no local link on this install (PR 5). Keyed by
+ * `CloudWorkspace.id` so it is stable and never heuristically merged onto a
+ * local slot by repository/branch. Distinct from the `remote:` branch-heuristic
+ * key so legacy Cloud rows and explicit rows never collide.
+ */
+export function buildCloudIdentityLogicalWorkspaceId(cloudWorkspaceId: string): string {
+  return [
+    "cloud",
+    encodeLogicalSegment(cloudWorkspaceId),
+  ].join(":");
+}
+
 export function parseLogicalWorkspaceId(
   logicalWorkspaceId: string | null | undefined,
 ): ParsedLogicalWorkspaceId | null {
@@ -72,7 +91,13 @@ export function parseLogicalWorkspaceId(
   }
 
   const [kind, ...encodedSegments] = logicalWorkspaceId.split(":");
-  if (kind !== "remote" && kind !== "repo-root" && kind !== "path" && kind !== "local-slot") {
+  if (
+    kind !== "remote"
+    && kind !== "repo-root"
+    && kind !== "path"
+    && kind !== "local-slot"
+    && kind !== "cloud"
+  ) {
     return null;
   }
 
@@ -86,6 +111,7 @@ export function parseLogicalWorkspaceId(
   if (
     (kind === "remote" && segments.length !== 4)
     || ((kind === "repo-root" || kind === "path") && segments.length !== 2)
+    || (kind === "cloud" && segments.length !== 1)
   ) {
     return null;
   }
@@ -123,9 +149,9 @@ export function replaceLogicalWorkspaceBranch(
   }
 
   const nextBranchKey = normalizeLogicalWorkspaceBranchKey(branchKey);
-  if (parsed.kind === "local-slot") {
-    // A local-slot ID is keyed by workspace id; branch identity is read from
-    // the materialized workspace row.
+  if (parsed.kind === "local-slot" || parsed.kind === "cloud") {
+    // A local-slot / cloud-identity ID is keyed by workspace id; branch
+    // identity is read from the underlying workspace row, not the id.
     return logicalWorkspaceId ?? null;
   }
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
@@ -1,7 +1,53 @@
 import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import { targetWorkspaceSyntheticId } from "#product/lib/domain/compute/target-workspace-id";
 import { cloudWorkspaceUsesCloudRuntime } from "#product/lib/domain/workspaces/cloud/cloud-runtime-kind";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceSummary,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
+
+/** A local materialization is a durable copy this install can open (vs. a
+ * pending/failed attempt). Only these establish an explicit association. */
+const HEALTHY_LOCAL_MATERIALIZATION_STATES: ReadonlySet<string> = new Set([
+  "hydrated",
+]);
+
+/** True when the Cloud response carries an explicit materialization ledger.
+ * Legacy rows (pre-PR 4) omit the array and fall back to repository/branch
+ * heuristics; rows that carry it use explicit association instead. */
+export function cloudWorkspaceHasMaterializations(
+  workspace: Pick<CloudWorkspaceSummary, "materializations">,
+): boolean {
+  return (workspace.materializations?.length ?? 0) > 0;
+}
+
+/**
+ * The AnyHarness workspace id of this install's explicit, healthy local
+ * materialization for a Cloud workspace, or null. This is the authoritative
+ * `(desktopInstallId, anyharnessWorkspaceId)` link the server selected; a
+ * redacted row from another install (null path/id) never matches here.
+ */
+export function explicitLocalMaterializationAnyharnessId(
+  workspace: Pick<CloudWorkspaceSummary, "materializations">,
+  desktopInstallId: string | null | undefined,
+): string | null {
+  if (!desktopInstallId) {
+    return null;
+  }
+  const rows: CloudWorkspaceMaterializationSummary[] = workspace.materializations ?? [];
+  for (const row of rows) {
+    if (
+      row.targetKind === "local_desktop"
+      && row.desktopInstallId === desktopInstallId
+      && HEALTHY_LOCAL_MATERIALIZATION_STATES.has(row.state)
+      && row.anyharnessWorkspaceId
+    ) {
+      return row.anyharnessWorkspaceId;
+    }
+  }
+  return null;
+}
 
 export function logicalWorkspaceTargetMaterializationId(
   workspace: Pick<LogicalWorkspace, "cloudWorkspace">,

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
@@ -11,6 +11,7 @@ import {
   logicalWorkspaceRelatedIds,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
+  buildCloudIdentityLogicalWorkspaceId,
   buildLocalSlotLogicalWorkspaceId,
   buildRemoteLogicalWorkspaceId,
   parseLogicalWorkspaceId,
@@ -671,6 +672,155 @@ describe("logical workspaces", () => {
         "hi",
       ),
     ).toBe("path:%2FUsers%2Fpablo%2Fproliferate:hi");
+  });
+
+  it("attaches a Cloud workspace to a local slot by explicit materialization, not branch", () => {
+    // Two different-path local worktrees on the same branch; the Cloud record's
+    // explicit local materialization names ws-b. It must merge with ws-b only.
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "feat/x", path: "/a" });
+    const wsB = makeWorkspace({ id: "ws-b", repoName: "rocket", branch: "feat/x", path: "/b" });
+    const repoRoot = makeRepoRoot({ repoName: "rocket" });
+    const cloud = {
+      ...makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "feat/x" }),
+      materializations: [
+        {
+          id: "m-managed",
+          targetKind: "managed_cloud" as const,
+          desktopInstallId: null,
+          anyharnessWorkspaceId: "ah-managed",
+          worktreePath: null,
+          state: "hydrated" as const,
+          generation: 1,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+        {
+          id: "m-local",
+          targetKind: "local_desktop" as const,
+          desktopInstallId: "mac-a",
+          anyharnessWorkspaceId: "ws-b",
+          worktreePath: "/b",
+          state: "hydrated" as const,
+          generation: 2,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+      ],
+    };
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA, wsB],
+      repoRoots: [repoRoot],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    const withCloud = result.filter((w) => w.cloudWorkspace?.id === "cloud-1");
+    expect(withCloud).toHaveLength(1);
+    expect(withCloud[0]!.localWorkspace?.id).toBe("ws-b");
+    // ws-a stays its own distinct slot with no Cloud record attached.
+    const slotA = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(slotA?.cloudWorkspace).toBeNull();
+  });
+
+  it("keeps a materialized Cloud workspace distinct when no local link exists for this install", () => {
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "feat/x", path: "/a" });
+    const cloud = {
+      ...makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "feat/x" }),
+      materializations: [
+        {
+          id: "m-managed",
+          targetKind: "managed_cloud" as const,
+          desktopInstallId: null,
+          anyharnessWorkspaceId: "ah-managed",
+          worktreePath: null,
+          state: "hydrated" as const,
+          generation: 1,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+      ],
+    };
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA],
+      repoRoots: [makeRepoRoot({ repoName: "rocket" })],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    // No heuristic merge: the same-branch local slot stays local-only and the
+    // Cloud record is its own identity-keyed logical workspace.
+    const slotA = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(slotA?.cloudWorkspace).toBeNull();
+    const cloudOnly = result.find((w) => w.cloudWorkspace?.id === "cloud-1" && !w.localWorkspace);
+    expect(cloudOnly).toBeDefined();
+  });
+
+  it("does not merge another install's redacted local materialization", () => {
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "feat/x", path: "/a" });
+    const cloud = {
+      ...makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "feat/x" }),
+      materializations: [
+        {
+          id: "m-local-other",
+          targetKind: "local_desktop" as const,
+          // Redacted row from a different install: null path/id.
+          desktopInstallId: "mac-other",
+          anyharnessWorkspaceId: null,
+          worktreePath: null,
+          state: "hydrated" as const,
+          generation: 1,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+      ],
+    };
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA],
+      repoRoots: [makeRepoRoot({ repoName: "rocket" })],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    const slotA = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(slotA?.cloudWorkspace).toBeNull();
+  });
+
+  it("falls back to the branch heuristic for a legacy Cloud row without materializations", () => {
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "main", path: "/a" });
+    const cloud = makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "main" });
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA],
+      repoRoots: [makeRepoRoot({ repoName: "rocket" })],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    // Legacy behavior preserved: same repo/branch folds local + Cloud together.
+    const merged = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(merged?.cloudWorkspace?.id).toBe("cloud-1");
+  });
+
+  it("parses cloud identity ids and leaves branch replacement unchanged", () => {
+    const cloudId = buildCloudIdentityLogicalWorkspaceId("cloud-1");
+    expect(cloudId).toBe("cloud:cloud-1");
+    expect(parseLogicalWorkspaceId(cloudId)).toEqual({ kind: "cloud", segments: ["cloud-1"] });
+    expect(replaceLogicalWorkspaceBranch(cloudId, "feature/new")).toBe(cloudId);
   });
 
   it("parses local-slot ids strictly and leaves branch replacement unchanged", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -10,11 +10,17 @@ import {
   repoRootGroupKey,
 } from "#product/lib/domain/workspaces/cloud/collections";
 import {
+  buildCloudIdentityLogicalWorkspaceId,
   buildLocalSlotLogicalWorkspaceId,
   buildRemoteLogicalWorkspaceId,
   normalizeLogicalWorkspaceBranchKey,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-id";
-import { resolvePreferredLogicalWorkspaceMaterialization } from "#product/lib/domain/workspaces/cloud/logical-workspace-materialization";
+import {
+  cloudWorkspaceHasMaterializations,
+  explicitLocalMaterializationAnyharnessId,
+  resolvePreferredLogicalWorkspaceMaterialization,
+} from "#product/lib/domain/workspaces/cloud/logical-workspace-materialization";
+import { collapseExactLocalWorkspaceDuplicates } from "#product/lib/domain/workspaces/cloud/logical-workspace-duplicates";
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   buildBaseLogicalWorkspaceIdForLocalWorkspace,
@@ -36,150 +42,16 @@ import {
   preferCloudWorkspaceForLogicalSlot,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-slot";
 
-function timestampValue(timestamp: string | null | undefined): number {
-  return timestamp ? new Date(timestamp).getTime() : 0;
-}
-
-function localWorkspaceExactMaterializationKey(workspace: Workspace): string {
-  return `${workspace.path.trim()}\0${workspaceBranchKey(workspace)}`;
-}
-
-function workspaceExecutionPriority(workspace: Workspace): number {
-  const summary = workspace.executionSummary;
-  if (!summary) {
-    return 0;
-  }
-
-  if (summary.totalSessionCount > summary.liveSessionCount) {
-    return 3;
-  }
-
-  if (summary.phase === "running" || summary.phase === "awaiting_interaction") {
-    return 2;
-  }
-
-  if (summary.totalSessionCount > 0) {
-    return 1;
-  }
-
-  return 0;
-}
-
-function compareExactLocalWorkspaceDuplicateOrder(left: Workspace, right: Workspace): number {
-  const byExecutionPriority = workspaceExecutionPriority(right) - workspaceExecutionPriority(left);
-  if (byExecutionPriority !== 0) {
-    return byExecutionPriority;
-  }
-
-  const byExecutionUpdatedAt = (
-    timestampValue(right.executionSummary?.updatedAt)
-    - timestampValue(left.executionSummary?.updatedAt)
-  );
-  if (byExecutionUpdatedAt !== 0) {
-    return byExecutionUpdatedAt;
-  }
-
-  const byWorkspaceUpdatedAt = timestampValue(right.updatedAt) - timestampValue(left.updatedAt);
-  if (byWorkspaceUpdatedAt !== 0) {
-    return byWorkspaceUpdatedAt;
-  }
-
-  return compareLocalWorkspaceCanonicalOrder(left, right);
-}
-
-interface CollapsedLocalWorkspace {
-  workspace: Workspace;
-  aliasIds: string[];
-}
-
-function localWorkspaceIdentityIds(workspace: Workspace): string[] {
-  return [workspace.id, buildLocalSlotLogicalWorkspaceId(workspace.id)];
-}
-
-function localWorkspaceMatchesSelection(
-  workspace: Workspace,
-  currentSelectionId: string | null,
-): boolean {
-  return currentSelectionId !== null
-    && localWorkspaceIdentityIds(workspace).includes(currentSelectionId);
-}
-
-function compareExactLocalWorkspaceDuplicateOrderForSelection(
-  currentSelectionId: string | null,
-): (left: Workspace, right: Workspace) => number {
-  return (left, right) => {
-    const leftSelected = localWorkspaceMatchesSelection(left, currentSelectionId);
-    const rightSelected = localWorkspaceMatchesSelection(right, currentSelectionId);
-    if (leftSelected !== rightSelected) {
-      return leftSelected ? -1 : 1;
-    }
-    return compareExactLocalWorkspaceDuplicateOrder(left, right);
-  };
-}
-
-function workspaceHasOwnSessions(workspace: Workspace): boolean {
-  return (workspace.executionSummary?.totalSessionCount ?? 0) > 0;
-}
-
-function collapseExactLocalWorkspaceDuplicates(
-  workspaces: readonly Workspace[],
-  currentSelectionId: string | null,
-): CollapsedLocalWorkspace[] {
-  const byMaterialization = new Map<string, Workspace[]>();
-  for (const workspace of workspaces) {
-    const key = localWorkspaceExactMaterializationKey(workspace);
-    const bucket = byMaterialization.get(key);
-    if (bucket) {
-      bucket.push(workspace);
-    } else {
-      byMaterialization.set(key, [workspace]);
-    }
-  }
-
-  return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
-    if (bucket.length === 1) {
-      return [{ workspace: bucket[0]!, aliasIds: [] }];
-    }
-
-    const distinct = bucket.filter(
-      (candidate) =>
-        workspaceHasOwnSessions(candidate)
-        || localWorkspaceMatchesSelection(candidate, currentSelectionId),
-    );
-    const foldable = bucket.filter(
-      (candidate) =>
-        !workspaceHasOwnSessions(candidate)
-        && !localWorkspaceMatchesSelection(candidate, currentSelectionId),
-    );
-
-    if (distinct.length === 0) {
-      const representative = [...foldable]
-        .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
-      return [{
-        workspace: representative,
-        aliasIds: foldable
-          .filter((candidate) => candidate.id !== representative.id)
-          .flatMap(localWorkspaceIdentityIds),
-      }];
-    }
-
-    const sortedDistinct = [...distinct]
-      .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId));
-    const foldedAliasIds = foldable.flatMap(localWorkspaceIdentityIds);
-    return sortedDistinct.map((workspace, index) => ({
-      workspace,
-      // Fold stale empty duplicates onto the first distinct entry.
-      aliasIds: index === 0 ? foldedAliasIds : [],
-    }));
-  });
-}
-
 export function buildLogicalWorkspaces(args: {
   localWorkspaces: Workspace[];
   repoRoots: RepoRoot[];
   cloudWorkspaces: CloudWorkspaceSummary[];
   cloudMobilityWorkspaces?: CloudMobilityWorkspaceSummary[];
   currentSelectionId?: string | null;
+  /** This desktop install's id. When present, a Cloud workspace with an
+   * explicit healthy local materialization for this install merges with that
+   * exact local workspace by id — never by repository/branch heuristic. */
+  desktopInstallId?: string | null;
 }): LogicalWorkspace[] {
   const repoRootsById = new Map(args.repoRoots.map((repoRoot) => [repoRoot.id, repoRoot]));
   const cloudWorkspacesById = new Map(args.cloudWorkspaces.map((workspace) => [
@@ -217,6 +89,10 @@ export function buildLogicalWorkspaces(args: {
     }
   }
 
+  // Map every placed local workspace's AnyHarness id to its logical slot id so a
+  // Cloud workspace with an explicit local materialization can attach to the
+  // exact same local slot the server linked — never by branch heuristic.
+  const localLogicalIdByAnyharnessId = new Map<string, string>();
   for (const [baseLogicalId, bucket] of localBuckets) {
     const sortedBucket = collapseExactLocalWorkspaceDuplicates(
       bucket,
@@ -234,11 +110,28 @@ export function buildLogicalWorkspaces(args: {
         mobilityWorkspace: null,
         aliasIds: collapsed.aliasIds,
       });
+      localLogicalIdByAnyharnessId.set(workspace.id, logicalId);
     });
   }
 
   for (const workspace of args.cloudWorkspaces) {
-    const logicalId = buildLogicalWorkspaceIdForCloudWorkspace(workspace);
+    // Explicit association takes precedence over the repository/branch
+    // heuristic whenever the Cloud response carries a materialization ledger.
+    // A healthy local materialization for THIS install merges the Cloud record
+    // onto that exact local slot; otherwise the Cloud record stands on its own
+    // identity-keyed slot (no heuristic attachment to a same-branch local).
+    const explicitLocalAnyharnessId = cloudWorkspaceHasMaterializations(workspace)
+      ? explicitLocalMaterializationAnyharnessId(workspace, args.desktopInstallId)
+      : null;
+    const explicitLogicalId = explicitLocalAnyharnessId
+      ? localLogicalIdByAnyharnessId.get(explicitLocalAnyharnessId) ?? null
+      : null;
+
+    const logicalId = explicitLogicalId
+      ?? (cloudWorkspaceHasMaterializations(workspace)
+        ? buildCloudIdentityLogicalWorkspaceId(workspace.id)
+        : buildLogicalWorkspaceIdForCloudWorkspace(workspace));
+
     if (
       isCloudWorkspaceFailedBeforeReady(workspace)
       && !cloudWorkspaceMatchesSelection(workspace, logicalId, args.currentSelectionId)

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MaterializationIntentResponse } from "@proliferate/cloud-sdk/types";
+import { runOpenOnMacFlow } from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+
+const HEAD = "abc123";
+const BRANCH = "feat/x";
+
+function intentResponse(): MaterializationIntentResponse {
+  return {
+    operationId: "row-1:2",
+    materialization: {
+      id: "row-1",
+      targetKind: "local_desktop",
+      desktopInstallId: "mac-a",
+      anyharnessWorkspaceId: null,
+      worktreePath: null,
+      state: "pending",
+      generation: 2,
+      expectedHeadSha: HEAD,
+      observedHeadSha: null,
+      observedBranch: BRANCH,
+      failureCode: null,
+      lastReportedAt: null,
+    },
+    source: {
+      repository: { provider: "github", owner: "acme", name: "rocket", branch: BRANCH, baseBranch: "main" },
+      branchName: BRANCH,
+      headSha: HEAD,
+    },
+  } as MaterializationIntentResponse;
+}
+
+function callbacks(overrides: Record<string, unknown> = {}) {
+  return {
+    createIntent: vi.fn(async () => intentResponse()),
+    materializeRepoRoot: vi.fn(async () => ({
+      repoRoot: {
+        id: "root-1",
+        kind: "managed",
+        path: "/code/rocket",
+        remoteProvider: "github",
+        remoteOwner: "acme",
+        remoteRepoName: "rocket",
+        createdAt: "",
+        updatedAt: "",
+      },
+    })),
+    materializeWorkspaceAtRef: vi.fn(async () => ({
+      workspaceId: "ah-local",
+      observedHeadSha: HEAD,
+      worktreePath: "/code/rocket-wt",
+    })),
+    report: vi.fn(async () => ({})),
+    ...overrides,
+  } as any;
+}
+
+describe("runOpenOnMacFlow", () => {
+  it("threads the Cloud operationId into the exact-ref materialization and reports exactly", async () => {
+    const cb = callbacks();
+    const result = await runOpenOnMacFlow({ existingRepoRootId: "root-1" }, cb);
+
+    expect(cb.materializeRepoRoot).not.toHaveBeenCalled();
+    expect(cb.materializeWorkspaceAtRef).toHaveBeenCalledWith("root-1", {
+      operationId: "row-1:2",
+      branchName: BRANCH,
+      headSha: HEAD,
+    });
+    expect(cb.report).toHaveBeenCalledWith("row-1", {
+      generation: 2,
+      state: "hydrated",
+      anyharnessWorkspaceId: "ah-local",
+      worktreePath: "/code/rocket-wt",
+      observedBranch: BRANCH,
+      observedHeadSha: HEAD,
+    });
+    expect(result.anyharnessWorkspaceId).toBe("ah-local");
+  });
+
+  it("clones a repo root first when none exists, reusing the operation id", async () => {
+    const cb = callbacks();
+    await runOpenOnMacFlow(
+      { existingRepoRootId: null, cloneDestinationPath: "/code/rocket" },
+      cb,
+    );
+
+    expect(cb.materializeRepoRoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationId: "row-1:2",
+        destinationPath: "/code/rocket",
+        mode: "clone_or_adopt",
+        repository: expect.objectContaining({ cloneUrl: "https://github.com/acme/rocket.git" }),
+      }),
+    );
+    expect(cb.materializeWorkspaceAtRef).toHaveBeenCalledWith("root-1", expect.anything());
+  });
+
+  it("does not report when materialization fails (pending intent left for retry)", async () => {
+    const cb = callbacks({
+      materializeWorkspaceAtRef: vi.fn(async () => {
+        throw new Error("busy");
+      }),
+    });
+
+    await expect(
+      runOpenOnMacFlow({ existingRepoRootId: "root-1" }, cb),
+    ).rejects.toThrow("busy");
+    expect(cb.report).not.toHaveBeenCalled();
+  });
+
+  it("rejects a wrong adopted repo root without materializing a workspace", async () => {
+    const cb = callbacks({
+      materializeRepoRoot: vi.fn(async () => ({
+        repoRoot: {
+          id: "root-x",
+          kind: "managed",
+          path: "/code/other",
+          remoteProvider: "github",
+          remoteOwner: "other",
+          remoteRepoName: "different",
+          createdAt: "",
+          updatedAt: "",
+        },
+      })),
+    });
+
+    await expect(
+      runOpenOnMacFlow(
+        { existingRepoRootId: null, cloneDestinationPath: "/code/rocket" },
+        cb,
+      ),
+    ).rejects.toThrow(/does not match/);
+    expect(cb.materializeWorkspaceAtRef).not.toHaveBeenCalled();
+    expect(cb.report).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.ts
@@ -1,0 +1,127 @@
+import type {
+  MaterializationIntentResponse,
+  ReportMaterializationRequest,
+} from "@proliferate/cloud-sdk/types";
+import type {
+  MaterializeRepoRootRequest,
+  MaterializeWorkspaceAtRefRequest,
+  RepoRoot,
+} from "@anyharness/sdk";
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+import { githubHttpsCloneUrl } from "#product/lib/domain/workspaces/creation/clone-repo-workflow";
+
+/**
+ * Crash-safe "Open on this Mac" orchestration (Flow 2), and the identical
+ * relink path (Flow 5). Pure: it receives already-resolved SDK/AnyHarness
+ * callbacks and sequences them, so ordering and idempotency are unit-testable.
+ *
+ * The invariant: the Cloud-issued `operationId` (`"{rowId}:{generation}"`) is
+ * threaded verbatim into PR 3's materialization operation id and reused across
+ * retries. PR 3's ledger makes AnyHarness idempotent, so a crash after the
+ * worktree is created but before the report retries onto the same worktree and
+ * reports it — never a second worktree. The hydrated report carries the exact
+ * observed HEAD/branch the runtime returned.
+ */
+
+export interface OpenOnMacRepoRootSource {
+  /** An existing local repo root that already hosts this repository, or null to
+   * clone one first. */
+  existingRepoRootId: string | null;
+  /** Destination path for a fresh clone when no existing repo root matches.
+   * Required when existingRepoRootId is null. */
+  cloneDestinationPath?: string | null;
+}
+
+export interface OpenOnMacCallbacks {
+  /** Create/reuse the Cloud local-materialization intent for this install. */
+  createIntent: () => Promise<MaterializationIntentResponse>;
+  /** Clone-or-adopt a repo root through PR 3 (only when no existing root). */
+  materializeRepoRoot: (input: MaterializeRepoRootRequest) => Promise<{ repoRoot: RepoRoot }>;
+  /** Materialize the exact-ref workspace through PR 3. */
+  materializeWorkspaceAtRef: (
+    repoRootId: string,
+    input: MaterializeWorkspaceAtRefRequest,
+  ) => Promise<{ workspaceId: string; observedHeadSha: string; worktreePath: string }>;
+  /** Report the outcome back to Cloud. */
+  report: (materializationId: string, body: ReportMaterializationRequest) => Promise<unknown>;
+}
+
+export interface OpenOnMacResult {
+  materializationId: string;
+  anyharnessWorkspaceId: string;
+  worktreePath: string;
+}
+
+/**
+ * Run the intent → (clone repo root if needed) → exact-ref materialize →
+ * report sequence. Returns the local AnyHarness workspace id so the caller can
+ * select/open it. Throws on any step failure; the pending intent is left for a
+ * safe retry (same operation id → no duplicate worktree).
+ */
+export async function runOpenOnMacFlow(
+  source: OpenOnMacRepoRootSource,
+  callbacks: OpenOnMacCallbacks,
+): Promise<OpenOnMacResult> {
+  const intent = await callbacks.createIntent();
+  const operationId = intent.operationId;
+  const { repository, branchName, headSha } = intent.source;
+
+  let repoRootId = source.existingRepoRootId;
+  if (!repoRootId) {
+    if (!source.cloneDestinationPath) {
+      throw new Error("A destination path is required to clone the repository.");
+    }
+    const { repoRoot } = await callbacks.materializeRepoRoot({
+      // Reuse the Cloud operation id so a crash mid-clone reuses the repo-root
+      // materialization rather than cloning twice.
+      operationId,
+      destinationPath: source.cloneDestinationPath,
+      mode: "clone_or_adopt",
+      repository: {
+        provider: "github",
+        owner: repository.owner,
+        name: repository.name,
+        cloneUrl: githubHttpsCloneUrl(repository.owner, repository.name),
+      },
+    });
+    // Guard against adopting the wrong repository.
+    const matches = repoRoot.remoteProvider && repoRoot.remoteOwner && repoRoot.remoteRepoName
+      && canonicalRepoKey(repoRoot.remoteProvider, repoRoot.remoteOwner, repoRoot.remoteRepoName)
+        === canonicalRepoKey(repository.provider, repository.owner, repository.name);
+    if (!matches) {
+      throw new Error(
+        `Cloned repository does not match ${repository.owner}/${repository.name}.`,
+      );
+    }
+    repoRootId = repoRoot.id;
+  }
+
+  let materialized: { workspaceId: string; observedHeadSha: string; worktreePath: string };
+  try {
+    materialized = await callbacks.materializeWorkspaceAtRef(repoRootId, {
+      operationId,
+      branchName,
+      headSha,
+    });
+  } catch (error) {
+    // Leave the intent pending for a safe retry (same operation id reuses the
+    // ledger result). Do not report a failure that would look like a durable
+    // materialization failure to the server.
+    throw error;
+  }
+
+  await callbacks.report(intent.materialization.id, {
+    generation: intent.materialization.generation,
+    state: "hydrated",
+    anyharnessWorkspaceId: materialized.workspaceId,
+    worktreePath: materialized.worktreePath,
+    observedBranch: branchName,
+    observedHeadSha: materialized.observedHeadSha,
+  });
+
+  return {
+    materializationId: intent.materialization.id,
+    anyharnessWorkspaceId: materialized.workspaceId,
+    worktreePath: materialized.worktreePath,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveWorkspaceAvailabilityInput,
+  resolveWorkspaceAvailabilityCommands,
+  unsupportedGitBlockerForLocalWorkspace,
+  type WorkspaceAvailabilityInput,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+const CLEAN_PUBLISHED: WorkspaceGitStatus = {
+  branch: "feat/x",
+  dirty: false,
+  conflicted: false,
+  ahead: 0,
+  behind: 0,
+  hasUpstream: true,
+  pr: null,
+  attention: "none",
+  capturedAt: "2026-07-16T00:00:00Z",
+  source: "live",
+};
+
+const HYDRATED_LOCAL = {
+  id: "m-local",
+  targetKind: "local_desktop" as const,
+  desktopInstallId: "mac-a",
+  anyharnessWorkspaceId: "ws-1",
+  worktreePath: "/a",
+  state: "hydrated" as const,
+  generation: 1,
+  expectedHeadSha: null,
+  observedHeadSha: null,
+  observedBranch: null,
+  failureCode: null,
+  lastReportedAt: null,
+};
+
+function kinds(input: WorkspaceAvailabilityInput): string[] {
+  return resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind);
+}
+
+describe("resolveWorkspaceAvailabilityCommands", () => {
+  it("offers Add Cloud copy for a local-only workspace", () => {
+    expect(
+      kinds({ hasLocalWorkspace: true, cloudWorkspace: null, desktopInstallId: "mac-a" }),
+    ).toEqual(["add-cloud-copy"]);
+  });
+
+  it("offers Open on this Mac for a Cloud-only workspace", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: false,
+        cloudWorkspace: { materializations: [] },
+        desktopInstallId: "mac-a",
+      }),
+    ).toEqual(["open-on-this-mac"]);
+  });
+
+  it("offers Link copies for a heuristic local + Cloud exact-ref match", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: true,
+        cloudWorkspace: { materializations: [] },
+        desktopInstallId: "mac-a",
+        linkCandidate: true,
+      }),
+    ).toEqual(["link-copies"]);
+  });
+
+  it("offers only Unlink for a healthy explicit link", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: true,
+        cloudWorkspace: { materializations: [HYDRATED_LOCAL] },
+        desktopInstallId: "mac-a",
+      }),
+    ).toEqual(["unlink-this-mac"]);
+  });
+
+  it("offers relink/recreate/unlink when the linked local copy is missing", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: false,
+        cloudWorkspace: {
+          materializations: [{ ...HYDRATED_LOCAL, state: "missing" }],
+        },
+        desktopInstallId: "mac-a",
+        localMaterializationNeedsRepair: true,
+      }),
+    ).toEqual(["relink-existing", "recreate-on-this-mac", "unlink-this-mac"]);
+  });
+
+  it("shows a selectable blocker for an unsupported Git state", () => {
+    const commands = resolveWorkspaceAvailabilityCommands({
+      hasLocalWorkspace: true,
+      cloudWorkspace: null,
+      desktopInstallId: "mac-a",
+      unsupportedGitBlocker: "The workspace has uncommitted changes.",
+    });
+    expect(commands).toHaveLength(1);
+    expect(commands[0]!.kind).toBe("unsupported-git-state");
+    expect(commands[0]!.blocker).toBe("The workspace has uncommitted changes.");
+  });
+
+  it("does not un-redact another install's link (no explicit link matched)", () => {
+    // A local_desktop row for a different install must not count as this
+    // install's link; a local-only workspace still offers Add Cloud copy.
+    expect(
+      kinds({
+        hasLocalWorkspace: true,
+        cloudWorkspace: null,
+        desktopInstallId: "mac-a",
+      }),
+    ).toEqual(["add-cloud-copy"]);
+  });
+});
+
+describe("unsupportedGitBlockerForLocalWorkspace", () => {
+  it("accepts a clean, published, in-sync normal branch", () => {
+    expect(unsupportedGitBlockerForLocalWorkspace(CLEAN_PUBLISHED)).toBeNull();
+  });
+
+  it("blocks dirty / conflicted / unpublished / out-of-sync / unknown states", () => {
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, dirty: true })).toMatch(/uncommitted/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, conflicted: true })).toMatch(/conflict/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, hasUpstream: false })).toMatch(/published/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, ahead: 1 })).toMatch(/in sync/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, dirty: null })).toMatch(/not available/);
+    expect(unsupportedGitBlockerForLocalWorkspace(null)).toMatch(/not available/);
+  });
+});
+
+describe("deriveWorkspaceAvailabilityInput", () => {
+  it("blocks Add Cloud copy on a dirty local source", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: { id: "ws-1" },
+      cloudWorkspace: null,
+      desktopInstallId: "mac-a",
+      localGitStatus: { ...CLEAN_PUBLISHED, dirty: true },
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "unsupported-git-state",
+    ]);
+  });
+
+  it("offers Add Cloud copy on a clean published local source", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: { id: "ws-1" },
+      cloudWorkspace: null,
+      desktopInstallId: "mac-a",
+      localGitStatus: CLEAN_PUBLISHED,
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "add-cloud-copy",
+    ]);
+  });
+
+  it("never blocks a Cloud-only Open on this Mac on local git status", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: null,
+      cloudWorkspace: { materializations: [] },
+      desktopInstallId: "mac-a",
+      localGitStatus: null,
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "open-on-this-mac",
+    ]);
+  });
+
+  it("derives relink/recreate/unlink for a missing explicit link regardless of git status", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: null,
+      cloudWorkspace: {
+        materializations: [{
+          id: "m",
+          targetKind: "local_desktop",
+          desktopInstallId: "mac-a",
+          anyharnessWorkspaceId: "ws-1",
+          worktreePath: "/a",
+          state: "missing",
+          generation: 3,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        }],
+      },
+      desktopInstallId: "mac-a",
+      localGitStatus: null,
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "relink-existing",
+      "recreate-on-this-mac",
+      "unlink-this-mac",
+    ]);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
@@ -1,0 +1,202 @@
+import type { Workspace } from "@anyharness/sdk";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceSummary,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+/**
+ * The workspace-copy availability commands (PR 5 UI action model). One pure,
+ * DOM-free command model derived from a logical workspace's local/Cloud
+ * materialization state, shared by the DOM three-dot menu (WorkspaceItemMenu)
+ * and the native context-menu builder so the two stay in exact parity.
+ *
+ * The repo `…` menu owns repository availability; this owns workspace-copy
+ * availability. V1 exposes only the safe core lifecycle — unsupported Git
+ * states surface a truthful, selectable blocker rather than an action.
+ */
+export type WorkspaceAvailabilityCommandKind =
+  | "add-cloud-copy"
+  | "open-on-this-mac"
+  | "link-copies"
+  | "relink-existing"
+  | "recreate-on-this-mac"
+  | "unlink-this-mac"
+  | "unsupported-git-state";
+
+export interface WorkspaceAvailabilityCommand {
+  kind: WorkspaceAvailabilityCommandKind;
+  label: string;
+  /** Blockers describe why a command is present but not actionable (unsupported
+   * Git state). An actionable command has no blocker. */
+  blocker?: string;
+}
+
+export interface WorkspaceAvailabilityInput {
+  /** True when this logical workspace has a local AnyHarness workspace on this
+   * install. */
+  hasLocalWorkspace: boolean;
+  /** The Cloud workspace summary, or null for a local-only workspace. */
+  cloudWorkspace: Pick<
+    CloudWorkspaceSummary,
+    "materializations"
+  > | null;
+  /** This install's id, or null on Web / no native worker. */
+  desktopInstallId: string | null;
+  /** True when the local and Cloud copies are the same exact ref and clean,
+   * making them a plausible Link candidate. Only meaningful when both a local
+   * workspace and an unlinked Cloud workspace are present. */
+  linkCandidate?: boolean;
+  /** True when this install's linked local materialization is missing or
+   * inconsistent (needs relink/recreate). */
+  localMaterializationNeedsRepair?: boolean;
+  /** A truthful blocker for an unsupported Git state (dirty, detached, mid-op,
+   * unpublished). When set, the only command is the selectable blocker. */
+  unsupportedGitBlocker?: string | null;
+}
+
+/**
+ * A local workspace's git status is "safe for a durable Cloud association"
+ * only when V1's exact core is met: a known-clean, conflict-free, normal-branch
+ * state with an upstream and zero ahead/behind. Anything else (or unknown
+ * status) yields a truthful blocker string rather than an action. Expansion to
+ * richer repair is PR 6.
+ */
+export function unsupportedGitBlockerForLocalWorkspace(
+  gitStatus: WorkspaceGitStatus | null | undefined,
+): string | null {
+  if (!gitStatus) {
+    // No status yet: do not offer a durable action on an unknown state.
+    return "Git status for this workspace is not available yet.";
+  }
+  if (gitStatus.conflicted === true) {
+    return "This workspace has unresolved merge conflicts.";
+  }
+  if (gitStatus.dirty === true) {
+    return "This workspace has uncommitted changes.";
+  }
+  if (gitStatus.dirty === null || gitStatus.conflicted === null) {
+    return "Git status for this workspace is not available yet.";
+  }
+  if (gitStatus.hasUpstream === false) {
+    return "This workspace branch has not been published upstream.";
+  }
+  if ((gitStatus.ahead ?? 0) !== 0 || (gitStatus.behind ?? 0) !== 0) {
+    return "This workspace branch is not in sync with its upstream.";
+  }
+  return null;
+}
+
+/**
+ * Adapt a logical workspace's parts into the availability input. Pure so the
+ * derivation (unsupported-git-state, link candidacy, repair) is unit-testable
+ * away from the sidebar. `localGitStatus` gates ONLY the actions that mutate a
+ * durable association from a local source (Add Cloud copy / Link); an
+ * already-linked or Cloud-only workspace never blocks on it.
+ */
+export function deriveWorkspaceAvailabilityInput(args: {
+  localWorkspace: Pick<Workspace, "id"> | null;
+  cloudWorkspace: Pick<CloudWorkspaceSummary, "materializations"> | null;
+  desktopInstallId: string | null;
+  localGitStatus: WorkspaceGitStatus | null | undefined;
+  /** True when a heuristic same-repo/branch local+Cloud pair is a plausible,
+   * not-yet-linked Link candidate. */
+  linkCandidate?: boolean;
+}): WorkspaceAvailabilityInput {
+  const linkedLocal = localMaterializationForInstall(args.cloudWorkspace, args.desktopInstallId);
+  const isExplicitlyLinked = linkedLocal !== null;
+  const localNeedsRepair = isExplicitlyLinked
+    && (linkedLocal!.state === "missing"
+      || linkedLocal!.state === "inconsistent"
+      || linkedLocal!.state === "failed");
+
+  // The unsupported-git blocker only applies to the two source-mutating
+  // actions (Add Cloud copy from a local source, Link a local source). A
+  // Cloud-only "Open on this Mac", an explicit link's Unlink, or a repair path
+  // must stay available regardless of the local working tree.
+  const wantsSourceMutation = (!!args.localWorkspace && !args.cloudWorkspace)
+    || (!!args.localWorkspace && !!args.cloudWorkspace && !isExplicitlyLinked && !!args.linkCandidate);
+  const unsupportedGitBlocker = wantsSourceMutation
+    ? unsupportedGitBlockerForLocalWorkspace(args.localGitStatus)
+    : null;
+
+  return {
+    hasLocalWorkspace: !!args.localWorkspace,
+    cloudWorkspace: args.cloudWorkspace,
+    desktopInstallId: args.desktopInstallId,
+    linkCandidate: args.linkCandidate,
+    localMaterializationNeedsRepair: localNeedsRepair,
+    unsupportedGitBlocker,
+  };
+}
+
+function localMaterializationForInstall(
+  cloudWorkspace: WorkspaceAvailabilityInput["cloudWorkspace"],
+  desktopInstallId: string | null,
+): CloudWorkspaceMaterializationSummary | null {
+  if (!cloudWorkspace || !desktopInstallId) {
+    return null;
+  }
+  const rows = cloudWorkspace.materializations ?? [];
+  return (
+    rows.find(
+      (row) =>
+        row.targetKind === "local_desktop" && row.desktopInstallId === desktopInstallId,
+    ) ?? null
+  );
+}
+
+/**
+ * Resolve the availability commands for a workspace's `…` menu, ordered as they
+ * appear in the menu. Pure: given the same input it returns the same commands,
+ * so the DOM and native menus render identically.
+ */
+export function resolveWorkspaceAvailabilityCommands(
+  input: WorkspaceAvailabilityInput,
+): WorkspaceAvailabilityCommand[] {
+  // An unsupported Git state blocks every mutation; show the truthful, still
+  // selectable blocker only (expansion is PR 6). Never offer an action that
+  // would reset/merge/rebase to "fix" it.
+  if (input.unsupportedGitBlocker) {
+    return [
+      {
+        kind: "unsupported-git-state",
+        label: "Unsupported Git state",
+        blocker: input.unsupportedGitBlocker,
+      },
+    ];
+  }
+
+  const linkedLocal = localMaterializationForInstall(input.cloudWorkspace, input.desktopInstallId);
+  const isExplicitlyLinked = linkedLocal !== null;
+
+  // Cloud-only: no local copy on this install and no explicit link → offer to
+  // open a copy on this Mac.
+  if (input.cloudWorkspace && !input.hasLocalWorkspace && !isExplicitlyLinked) {
+    return [{ kind: "open-on-this-mac", label: "Open on this Mac…" }];
+  }
+
+  // Explicitly linked: the linked local copy may be healthy or need repair.
+  if (isExplicitlyLinked) {
+    if (input.localMaterializationNeedsRepair || !input.hasLocalWorkspace) {
+      return [
+        { kind: "relink-existing", label: "Relink existing…" },
+        { kind: "recreate-on-this-mac", label: "Recreate on this Mac…" },
+        { kind: "unlink-this-mac", label: "Unlink this Mac…" },
+      ];
+    }
+    return [{ kind: "unlink-this-mac", label: "Unlink this Mac…" }];
+  }
+
+  // Local + unlinked Cloud that match the same exact ref → offer to link.
+  if (input.hasLocalWorkspace && input.cloudWorkspace && input.linkCandidate) {
+    return [{ kind: "link-copies", label: "Link copies…" }];
+  }
+
+  // Local only (no Cloud copy) → offer to add a managed-Cloud copy.
+  if (input.hasLocalWorkspace && !input.cloudWorkspace) {
+    return [{ kind: "add-cloud-copy", label: "Add Cloud copy…" }];
+  }
+
+  return [];
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { workspaceAvailabilityIntentForCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-intent-mapping";
+
+const FULL = {
+  localWorkspaceId: "ws-1",
+  cloudWorkspaceId: "cloud-1",
+  linkedMaterializationId: "mat-1",
+  repoOwner: "acme",
+  repoName: "rocket",
+};
+
+describe("workspaceAvailabilityIntentForCommand", () => {
+  it("maps add-cloud-copy to an add_cloud_copy intent", () => {
+    expect(workspaceAvailabilityIntentForCommand("add-cloud-copy", FULL)).toEqual({
+      kind: "add_cloud_copy",
+      localWorkspaceId: "ws-1",
+      gitOwner: "acme",
+      gitRepoName: "rocket",
+    });
+  });
+
+  it("maps open-on-this-mac to an open_on_mac intent", () => {
+    expect(workspaceAvailabilityIntentForCommand("open-on-this-mac", FULL)).toEqual({
+      kind: "open_on_mac",
+      cloudWorkspaceId: "cloud-1",
+    });
+  });
+
+  it("maps link/relink to relink and recreate to recreate", () => {
+    expect(workspaceAvailabilityIntentForCommand("link-copies", FULL)).toEqual({
+      kind: "relink",
+      cloudWorkspaceId: "cloud-1",
+      mode: "relink",
+    });
+    expect(workspaceAvailabilityIntentForCommand("relink-existing", FULL)).toMatchObject({
+      mode: "relink",
+    });
+    expect(workspaceAvailabilityIntentForCommand("recreate-on-this-mac", FULL)).toEqual({
+      kind: "relink",
+      cloudWorkspaceId: "cloud-1",
+      mode: "recreate",
+    });
+  });
+
+  it("maps unlink-this-mac to an unlink intent with the materialization id", () => {
+    expect(workspaceAvailabilityIntentForCommand("unlink-this-mac", FULL)).toEqual({
+      kind: "unlink",
+      cloudWorkspaceId: "cloud-1",
+      materializationId: "mat-1",
+    });
+  });
+
+  it("returns null when required identifiers are missing", () => {
+    expect(
+      workspaceAvailabilityIntentForCommand("add-cloud-copy", { ...FULL, localWorkspaceId: null }),
+    ).toBeNull();
+    expect(
+      workspaceAvailabilityIntentForCommand("open-on-this-mac", { ...FULL, cloudWorkspaceId: null }),
+    ).toBeNull();
+    expect(
+      workspaceAvailabilityIntentForCommand("unlink-this-mac", { ...FULL, linkedMaterializationId: null }),
+    ).toBeNull();
+  });
+
+  it("returns null for the non-actionable blocker", () => {
+    expect(workspaceAvailabilityIntentForCommand("unsupported-git-state", FULL)).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts
@@ -1,0 +1,59 @@
+import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import type { WorkspaceAvailabilityIntent } from "#product/stores/cloud/workspace-availability-intent-store";
+
+/** The identifiers a sidebar item carries for availability actions (PR 5). */
+export interface WorkspaceAvailabilityActionTarget {
+  localWorkspaceId: string | null;
+  cloudWorkspaceId: string | null;
+  linkedMaterializationId: string | null;
+  repoOwner: string | null;
+  repoName: string | null;
+}
+
+/**
+ * Map a selected availability command + its item's identifiers to the intent
+ * the connected host executes, or null when the required identifiers are
+ * missing (or the command is a non-actionable blocker). Pure so the sidebar
+ * wiring is unit-testable without a DOM.
+ */
+export function workspaceAvailabilityIntentForCommand(
+  kind: WorkspaceAvailabilityCommandKind,
+  target: WorkspaceAvailabilityActionTarget,
+): WorkspaceAvailabilityIntent | null {
+  switch (kind) {
+    case "add-cloud-copy":
+      if (target.localWorkspaceId && target.repoOwner && target.repoName) {
+        return {
+          kind: "add_cloud_copy",
+          localWorkspaceId: target.localWorkspaceId,
+          gitOwner: target.repoOwner,
+          gitRepoName: target.repoName,
+        };
+      }
+      return null;
+    case "open-on-this-mac":
+      return target.cloudWorkspaceId
+        ? { kind: "open_on_mac", cloudWorkspaceId: target.cloudWorkspaceId }
+        : null;
+    case "link-copies":
+    case "relink-existing":
+      return target.cloudWorkspaceId
+        ? { kind: "relink", cloudWorkspaceId: target.cloudWorkspaceId, mode: "relink" }
+        : null;
+    case "recreate-on-this-mac":
+      return target.cloudWorkspaceId
+        ? { kind: "relink", cloudWorkspaceId: target.cloudWorkspaceId, mode: "recreate" }
+        : null;
+    case "unlink-this-mac":
+      return target.cloudWorkspaceId && target.linkedMaterializationId
+        ? {
+          kind: "unlink",
+          cloudWorkspaceId: target.cloudWorkspaceId,
+          materializationId: target.linkedMaterializationId,
+        }
+        : null;
+    case "unsupported-git-state":
+      // A truthful, non-actionable blocker (expansion is PR 6).
+      return null;
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RepoRoot } from "@anyharness/sdk";
+import { AddRepoIdentityMismatchError } from "#product/lib/domain/workspaces/creation/add-repo-workflow";
+import {
+  githubHttpsCloneUrl,
+  runCloneRepoWorkflow,
+} from "#product/lib/domain/workspaces/creation/clone-repo-workflow";
+
+const REPO = { gitProvider: "github", gitOwner: "acme", gitRepoName: "rocket" };
+
+function makeRepoRoot(overrides: Partial<RepoRoot> = {}): RepoRoot {
+  return {
+    id: "root-1",
+    kind: "managed",
+    path: "/Users/dev/code/rocket",
+    displayName: "rocket",
+    defaultBranch: "main",
+    remoteProvider: "github",
+    remoteOwner: "acme",
+    remoteRepoName: "rocket",
+    remoteUrl: "https://github.com/acme/rocket.git",
+    createdAt: "2026-07-16T00:00:00Z",
+    updatedAt: "2026-07-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function baseArgs(overrides: Partial<Parameters<typeof runCloneRepoWorkflow>[0]> = {}) {
+  return {
+    repo: REPO,
+    destinationPath: "/Users/dev/code/rocket",
+    operationId: "op-1",
+    ensureRuntimeReady: vi.fn(async () => "http://runtime"),
+    materializeRepoRoot: vi.fn(async () => ({ repoRoot: makeRepoRoot() })),
+    upsertRepoRootInWorkspaceCollections: vi.fn(),
+    invalidateWorkspaceCollections: vi.fn(async () => {}),
+    saveLocalRepoEnvironment: vi.fn(),
+    unhideRepoRoot: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("runCloneRepoWorkflow", () => {
+  it("builds an un-credentialed HTTPS clone URL", () => {
+    expect(githubHttpsCloneUrl("acme", "rocket")).toBe("https://github.com/acme/rocket.git");
+  });
+
+  it("clones with the exact repository target and reuses the operation id", async () => {
+    const args = baseArgs();
+    await runCloneRepoWorkflow(args);
+
+    expect(args.materializeRepoRoot).toHaveBeenCalledWith({
+      operationId: "op-1",
+      destinationPath: "/Users/dev/code/rocket",
+      mode: "clone_or_adopt",
+      repository: {
+        provider: "github",
+        owner: "acme",
+        name: "rocket",
+        cloneUrl: "https://github.com/acme/rocket.git",
+      },
+    });
+    expect(args.upsertRepoRootInWorkspaceCollections).toHaveBeenCalledWith(
+      "http://runtime",
+      expect.objectContaining({ id: "root-1" }),
+    );
+    expect(args.saveLocalRepoEnvironment).toHaveBeenCalled();
+    expect(args.invalidateWorkspaceCollections).toHaveBeenCalledWith("http://runtime");
+  });
+
+  it("rejects a wrong adopted repo and performs no mutation", async () => {
+    const args = baseArgs({
+      materializeRepoRoot: vi.fn(async () => ({
+        repoRoot: makeRepoRoot({ remoteOwner: "other", remoteRepoName: "different" }),
+      })),
+    });
+
+    await expect(runCloneRepoWorkflow(args)).rejects.toBeInstanceOf(AddRepoIdentityMismatchError);
+    expect(args.upsertRepoRootInWorkspaceCollections).not.toHaveBeenCalled();
+    expect(args.saveLocalRepoEnvironment).not.toHaveBeenCalled();
+    expect(args.invalidateWorkspaceCollections).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.ts
@@ -1,0 +1,90 @@
+import type { RepoRoot } from "@anyharness/sdk";
+import type { MaterializeRepoRootRequest } from "@anyharness/sdk";
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+import {
+  AddRepoIdentityMismatchError,
+  type ExpectedRepoIdentity,
+} from "#product/lib/domain/workspaces/creation/add-repo-workflow";
+
+/**
+ * The canonical, un-credentialed HTTPS clone URL for a GitHub repository. The
+ * PR 3 contract rejects a credentialed clone URL outright (userinfo in the URL
+ * → 400 REPOSITORY_AUTH_REQUIRED); local clone authenticates only through the
+ * local Git credential chain, so a token is never injected here.
+ */
+export function githubHttpsCloneUrl(owner: string, repoName: string): string {
+  return `https://github.com/${owner}/${repoName}.git`;
+}
+
+function repoRootIdentity(repoRoot: RepoRoot): ExpectedRepoIdentity | null {
+  const gitProvider = repoRoot.remoteProvider?.trim();
+  const gitOwner = repoRoot.remoteOwner?.trim();
+  const gitRepoName = repoRoot.remoteRepoName?.trim();
+  if (!gitProvider || !gitOwner || !gitRepoName) {
+    return null;
+  }
+  return { gitProvider, gitOwner, gitRepoName };
+}
+
+export interface RunCloneRepoWorkflowArgs {
+  /** The authorized GitHub repository to clone. */
+  repo: ExpectedRepoIdentity;
+  /** Absolute destination path the user chose for the clone. */
+  destinationPath: string;
+  /** Stable idempotency key reused across retries so a crash mid-clone reuses
+   * the same repo-root materialization instead of cloning twice. */
+  operationId: string;
+  ensureRuntimeReady: () => Promise<string>;
+  /** PR 3 clone-or-adopt materialization. */
+  materializeRepoRoot: (input: MaterializeRepoRootRequest) => Promise<{ repoRoot: RepoRoot }>;
+  upsertRepoRootInWorkspaceCollections: (runtimeUrl: string, repoRoot: RepoRoot) => void;
+  invalidateWorkspaceCollections: (runtimeUrl: string) => Promise<unknown>;
+  /** Best-effort target-scoped local environment save; a failure never blocks
+   * the clone (local registration stays usable when Cloud is unavailable). */
+  saveLocalRepoEnvironment?: (repoRoot: RepoRoot) => void;
+  unhideRepoRoot: (repoRootId: string) => void;
+}
+
+/**
+ * Flow 1: clone an authorized GitHub repository to this machine.
+ *
+ * Acquires the repository through PR 3's clone-or-adopt materialization, then
+ * verifies the returned repo-root identity matches the requested repository
+ * BEFORE any registration/save (a wrong adopted repo performs no mutation and
+ * no Cloud report). On success it registers the repo root, best-effort saves
+ * the target-scoped local environment, and invalidates the local collections
+ * so one repo group appears.
+ */
+export async function runCloneRepoWorkflow(
+  args: RunCloneRepoWorkflowArgs,
+): Promise<RepoRoot> {
+  const runtimeUrl = await args.ensureRuntimeReady();
+
+  const { repoRoot } = await args.materializeRepoRoot({
+    operationId: args.operationId,
+    destinationPath: args.destinationPath,
+    mode: "clone_or_adopt",
+    repository: {
+      provider: "github",
+      owner: args.repo.gitOwner,
+      name: args.repo.gitRepoName,
+      cloneUrl: githubHttpsCloneUrl(args.repo.gitOwner, args.repo.gitRepoName),
+    },
+  });
+
+  // Verify returned repo identity before mutating anything (wrong adopted repo
+  // → no registration, no Cloud report).
+  const actual = repoRootIdentity(repoRoot);
+  const matches = actual
+    && canonicalRepoKey(actual.gitProvider, actual.gitOwner, actual.gitRepoName)
+      === canonicalRepoKey(args.repo.gitProvider, args.repo.gitOwner, args.repo.gitRepoName);
+  if (!matches) {
+    throw new AddRepoIdentityMismatchError(args.repo, actual);
+  }
+
+  args.upsertRepoRootInWorkspaceCollections(runtimeUrl, repoRoot);
+  args.unhideRepoRoot(repoRoot.id);
+  args.saveLocalRepoEnvironment?.(repoRoot);
+  await args.invalidateWorkspaceCollections(runtimeUrl);
+  return repoRoot;
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
@@ -92,6 +92,12 @@ export function buildPendingSidebarProjection(args: {
       workspaceLocationCopyToastLabel: null,
       branchName: null,
       gitStatus: null,
+      // A pending (not-yet-created) entry has no materialized copies to act on.
+      availabilityCommands: [],
+      cloudWorkspaceIdForActions: null,
+      linkedMaterializationId: null,
+      repoOwner: null,
+      repoName: null,
     },
     sortRecency: {
       activityAt: createdAt,

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
@@ -95,6 +95,7 @@ export function buildSidebarGroupStates(args: {
   sessionLastViewedAt?: Record<string, string>;
   targetAppearanceById?: Record<string, ComputeTargetAppearance>;
   suppressActiveNeedsReview?: boolean;
+  desktopInstallId?: string | null;
 }): SidebarGroupState[] {
   const visibleWorkspaceTypes = new Set(resolveSidebarWorkspaceTypes(args.workspaceTypes));
   const repoRootsByKey = new Map(
@@ -176,6 +177,7 @@ export function buildSidebarGroupStates(args: {
         sessionLastViewedAt: args.sessionLastViewedAt,
         targetAppearanceById: args.targetAppearanceById,
         suppressActiveNeedsReview: args.suppressActiveNeedsReview,
+        desktopInstallId: args.desktopInstallId,
       });
       const items = pendingItem
         ? [pendingItem, ...workspaceItems]

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts
@@ -10,6 +10,7 @@ import type {
   SidebarWorkspaceVariant,
 } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import type { WorkspaceAvailabilityCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export interface LocalSidebarWorkspaceEntry {
   source: "local";
@@ -92,6 +93,19 @@ export interface SidebarWorkspaceItemState {
    * (§2.7). Null when no status is known for the workspace.
    */
   gitStatus: WorkspaceGitStatus | null;
+  /**
+   * Workspace-copy availability commands (PR 5): Add Cloud copy / Open on this
+   * Mac / Link / Unlink / Relink / Recreate, or an unsupported-git-state
+   * blocker. Resolved from the shared availability command model so the DOM and
+   * native menus render identically.
+   */
+  availabilityCommands: WorkspaceAvailabilityCommand[];
+  /** Ids the availability actions target: the Cloud workspace, this install's
+   * linked local materialization, and the repo owner/name for Add Cloud copy. */
+  cloudWorkspaceIdForActions: string | null;
+  linkedMaterializationId: string | null;
+  repoOwner: string | null;
+  repoName: string | null;
 }
 
 export interface SidebarGroupState {

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
@@ -24,6 +24,10 @@ import { isWorkspaceNeedsReview } from "#product/lib/domain/workspaces/sidebar/s
 import { logicalWorkspaceHasUnreadSessionActivity } from "#product/lib/domain/workspaces/sidebar/workspace-activity-indicator";
 import { workspaceCopyMetadataForLogicalWorkspace } from "#product/lib/domain/workspaces/workspace-copy-metadata";
 import { resolveLogicalWorkspaceRecency } from "#product/lib/domain/workspaces/sidebar/recency";
+import {
+  deriveWorkspaceAvailabilityInput,
+  resolveWorkspaceAvailabilityCommands,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export interface SidebarWorkspaceItemWithWorkspace {
   workspace: LogicalWorkspace;
@@ -49,6 +53,9 @@ export function buildSidebarWorkspaceItems(args: {
   sessionLastViewedAt?: Record<string, string>;
   targetAppearanceById?: Record<string, ComputeTargetAppearance>;
   suppressActiveNeedsReview?: boolean;
+  /** This Mac's native desktop worker install id (PR 5), used to resolve the
+   * workspace-copy availability commands. Null on Web / no worker. */
+  desktopInstallId?: string | null;
 }): SidebarWorkspaceItemState[] {
   const workspaceItemsWithWorkspace = args.workspaces.map((entry) =>
     buildSidebarWorkspaceItem(entry, args)
@@ -92,6 +99,7 @@ function buildSidebarWorkspaceItem(
     sessionLastViewedAt?: Record<string, string>;
     targetAppearanceById?: Record<string, ComputeTargetAppearance>;
     suppressActiveNeedsReview?: boolean;
+    desktopInstallId?: string | null;
   },
 ): SidebarWorkspaceItemWithWorkspace {
   const active = logicalWorkspaceMatchesId(entry, args.selectedLogicalWorkspaceId);
@@ -148,6 +156,37 @@ function buildSidebarWorkspaceItem(
     ? args.targetAppearanceById?.[sshTargetId] ?? null
     : null;
 
+  // Workspace-copy availability commands (PR 5). A logical workspace that has
+  // both a local and a Cloud side without an explicit materialization for this
+  // install is a plausible Link candidate (same repo/branch heuristic already
+  // grouped them). SSH direct-target workspaces are out of PR 5 scope.
+  const gitStatus = args.gitStatusesByLogicalId?.[entry.id] ?? null;
+  const desktopInstallId = args.desktopInstallId ?? null;
+  const cloudSummary = entry.cloudWorkspace;
+  const hasExplicitMaterializations = (cloudSummary?.materializations?.length ?? 0) > 0;
+  const linkCandidate = Boolean(
+    variant !== "ssh"
+    && preferredLocalWorkspace
+    && cloudSummary
+    && !hasExplicitMaterializations,
+  );
+  const availabilityCommands = variant === "ssh"
+    ? []
+    : resolveWorkspaceAvailabilityCommands(
+      deriveWorkspaceAvailabilityInput({
+        localWorkspace: preferredLocalWorkspace ?? null,
+        cloudWorkspace: cloudSummary ?? null,
+        desktopInstallId,
+        localGitStatus: gitStatus,
+        linkCandidate,
+      }),
+    );
+  const linkedMaterialization = desktopInstallId
+    ? (cloudSummary?.materializations ?? []).find(
+      (m) => m.targetKind === "local_desktop" && m.desktopInstallId === desktopInstallId,
+    ) ?? null
+    : null;
+
   return {
     workspace: entry,
     item: {
@@ -181,7 +220,12 @@ function buildSidebarWorkspaceItem(
       workspaceLocationCopyValue: copyMetadata.workspaceLocation?.value ?? null,
       workspaceLocationCopyToastLabel: copyMetadata.workspaceLocation?.toastLabel ?? null,
       branchName: copyMetadata.branchName,
-      gitStatus: args.gitStatusesByLogicalId?.[entry.id] ?? null,
+      gitStatus,
+      availabilityCommands,
+      cloudWorkspaceIdForActions: cloudSummary?.id ?? null,
+      linkedMaterializationId: linkedMaterialization?.id ?? null,
+      repoOwner: entry.owner ?? cloudSummary?.repo?.owner ?? null,
+      repoName: entry.repoName ?? cloudSummary?.repo?.name ?? null,
     },
   };
 }

--- a/apps/packages/product-client/src/stores/cloud/workspace-availability-intent-store.ts
+++ b/apps/packages/product-client/src/stores/cloud/workspace-availability-intent-store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+
+/**
+ * The active workspace-availability action (PR 5 Flows 2/3/5), owned by one
+ * connected host (WorkspaceAvailabilityActionHost) mirroring the
+ * cloud-repository-intent idiom. Each intent is a minimal serializable object
+ * held only in memory: a cold restart leaves the store empty and nothing
+ * resumes (the workspace menu is the recovery path).
+ *
+ * - open_on_mac: materialize a Cloud workspace's exact published HEAD locally.
+ * - add_cloud_copy: create a managed-Cloud copy of a clean, published local
+ *   workspace at its exact ref.
+ * - unlink: association-only removal of this install's local materialization.
+ * - relink: create a new generation and re-materialize/attach the local copy.
+ * - recreate: same as relink but always re-materializes a fresh worktree.
+ */
+export type WorkspaceAvailabilityIntent =
+  | { kind: "open_on_mac"; cloudWorkspaceId: string }
+  | {
+    kind: "add_cloud_copy";
+    localWorkspaceId: string;
+    gitOwner: string;
+    gitRepoName: string;
+  }
+  | { kind: "unlink"; cloudWorkspaceId: string; materializationId: string }
+  | { kind: "relink"; cloudWorkspaceId: string; mode: "relink" | "recreate" };
+
+interface WorkspaceAvailabilityIntentState {
+  activeIntent: WorkspaceAvailabilityIntent | null;
+  begin: (intent: WorkspaceAvailabilityIntent) => void;
+  clear: () => void;
+}
+
+export const useWorkspaceAvailabilityIntentStore = create<WorkspaceAvailabilityIntentState>(
+  (set) => ({
+    activeIntent: null,
+    begin: (intent) => set({ activeIntent: intent }),
+    clear: () => set({ activeIntent: null }),
+  }),
+);

--- a/apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts
+++ b/apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts
@@ -2,7 +2,8 @@ import { create } from "zustand";
 
 export type AddRepoFlowStoreStep =
   | { kind: "entry" }
-  | { kind: "cloud" };
+  | { kind: "cloud" }
+  | { kind: "clone" };
 
 /** What the unified flow produced, for callers that select the new repo. */
 export type AddRepoFlowCompletion =

--- a/apps/packages/product-ui/src/repos/AddRepoFlow.tsx
+++ b/apps/packages/product-ui/src/repos/AddRepoFlow.tsx
@@ -3,7 +3,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
-import { ArrowLeft, Cloud, FolderOpen } from "lucide-react";
+import { ArrowLeft, Cloud, FolderOpen, GitBranch } from "lucide-react";
 
 import {
   Dialog,
@@ -16,15 +16,17 @@ import { CloudRepoPicker, type CloudRepoPickerProps } from "./CloudRepoPicker";
 
 /**
  * The host-truthful entry choices. `add-existing-folder` registers an existing
- * checkout on this machine (Desktop only); `cloud` walks the readiness → repo
- * picker → authority → save sequence (both hosts). There is deliberately no
- * placeholder Clone choice; Clone ships in a later slice.
+ * checkout on this machine (Desktop only); `clone-from-github` clones an
+ * authorized GitHub repository to this machine (Desktop only, GitHub-App-ready);
+ * `cloud` walks the readiness → repo picker → authority → save sequence (both
+ * hosts).
  */
-export type AddRepoFlowOption = "add-existing-folder" | "cloud";
+export type AddRepoFlowOption = "add-existing-folder" | "clone-from-github" | "cloud";
 
 export type AddRepoFlowStep =
   | { kind: "entry" }
-  | { kind: "cloud" };
+  | { kind: "cloud" }
+  | { kind: "clone" };
 
 export interface AddRepoFlowProps {
   open: boolean;
@@ -37,6 +39,9 @@ export interface AddRepoFlowProps {
   error?: string | null;
   /** View model for the cloud step, wired by the host's controller layer. */
   cloudPicker?: CloudRepoPickerProps | null;
+  /** View model for the clone-from-github step, wired by the host. Reuses the
+   * repo picker; on select the host runs the local clone. */
+  clonePicker?: CloudRepoPickerProps | null;
   onPickOption: (option: AddRepoFlowOption) => void;
   onBack: () => void;
   onClose: () => void;
@@ -55,6 +60,12 @@ const ENTRY_OPTION_DEFS: Record<AddRepoFlowOption, EntryOption> = {
     icon: <FolderOpen size={16} aria-hidden />,
     label: "Add an existing folder",
     description: "Register a repository folder from this machine.",
+  },
+  "clone-from-github": {
+    option: "clone-from-github",
+    icon: <GitBranch size={16} aria-hidden />,
+    label: "Clone from GitHub",
+    description: "Clone an authorized GitHub repository to this machine.",
   },
   cloud: {
     option: "cloud",
@@ -77,6 +88,7 @@ export function AddRepoFlow({
   adding = false,
   error = null,
   cloudPicker = null,
+  clonePicker = null,
   onPickOption,
   onBack,
   onClose,
@@ -99,8 +111,18 @@ export function AddRepoFlow({
       >
         {step.kind === "entry" ? (
           <AddRepoEntryStep options={options} onPickOption={onPickOption} disabled={adding} />
+        ) : step.kind === "clone" ? (
+          <AddRepoPickerStep
+            title="Clone from GitHub"
+            picker={clonePicker}
+            onBack={onBack}
+          />
         ) : (
-          <AddRepoCloudStep cloudPicker={cloudPicker} onBack={onBack} />
+          <AddRepoPickerStep
+            title="Add a cloud repo"
+            picker={cloudPicker}
+            onBack={onBack}
+          />
         )}
         {error ? (
           <p className="mt-3 text-xs leading-[1.45] text-destructive" role="alert">
@@ -176,11 +198,13 @@ function AddRepoEntryStep({
   );
 }
 
-function AddRepoCloudStep({
-  cloudPicker,
+function AddRepoPickerStep({
+  title,
+  picker,
   onBack,
 }: {
-  cloudPicker: CloudRepoPickerProps | null;
+  title: string;
+  picker: CloudRepoPickerProps | null;
   onBack: () => void;
 }) {
   return (
@@ -198,13 +222,13 @@ function AddRepoCloudStep({
             <ArrowLeft size={14} aria-hidden />
           </Button>
           <DialogTitle className="text-[15px] font-semibold leading-5">
-            Add a cloud repo
+            {title}
           </DialogTitle>
         </div>
       </DialogHeader>
-      {cloudPicker ? (
+      {picker ? (
         <div className="mt-3">
-          <CloudRepoPicker {...cloudPicker} />
+          <CloudRepoPicker {...picker} />
         </div>
       ) : null}
     </div>

--- a/apps/packages/product-ui/test/AddRepoFlow.test.tsx
+++ b/apps/packages/product-ui/test/AddRepoFlow.test.tsx
@@ -25,7 +25,7 @@ function renderFlow(overrides: Partial<AddRepoFlowProps> = {}) {
   const props: AddRepoFlowProps = {
     open: true,
     step: { kind: "entry" },
-    options: ["add-existing-folder", "cloud"],
+    options: ["add-existing-folder", "clone-from-github", "cloud"],
     onPickOption: vi.fn(),
     onBack: vi.fn(),
     onClose: vi.fn(),
@@ -43,10 +43,48 @@ describe("AddRepoFlow", () => {
 
     expect(screen.getByText("Add a repository")).toBeTruthy();
     expect(screen.getByText("Add an existing folder")).toBeTruthy();
+    expect(screen.getByText("Clone from GitHub")).toBeTruthy();
     expect(screen.getByText("Set up in Cloud")).toBeTruthy();
     fireEvent.click(screen.getByText("Set up in Cloud"));
 
     expect(onPickOption).toHaveBeenCalledWith("cloud");
+  });
+
+  it("reports the clone-from-github pick", () => {
+    const { onPickOption } = renderFlow();
+
+    fireEvent.click(screen.getByText("Clone from GitHub"));
+
+    expect(onPickOption).toHaveBeenCalledWith("clone-from-github");
+  });
+
+  it("runs the clone step in the same dialog with the repo picker", () => {
+    const onAddRepository = vi.fn();
+    renderFlow({
+      step: { kind: "clone" },
+      clonePicker: buildCloudPicker({
+        repositories: [{
+          id: "acme/rocket",
+          fullName: "acme/rocket",
+          defaultBranch: "main",
+          private: true,
+          fork: false,
+          archived: false,
+          disabled: false,
+          permission: "admin",
+          configured: false,
+          repoConfigState: "missing",
+        }],
+        onAddRepository,
+      }),
+    });
+
+    expect(screen.getByText("Clone from GitHub")).toBeTruthy();
+    expect(screen.getByLabelText("Search GitHub repositories")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Add acme/rocket" }));
+    expect(onAddRepository).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme/rocket" }),
+    );
   });
 
   it("offers only Set up in Cloud on Web (no local folder option)", () => {

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4332,6 +4332,33 @@ export interface components {
             generatedName?: boolean | null;
             /** Source */
             source?: ("desktop" | "web" | "mobile") | null;
+            /** Expectedheadsha */
+            expectedHeadSha?: string | null;
+            sourceMaterialization?: components["schemas"]["CreateCloudWorkspaceSourceMaterialization"] | null;
+        };
+        /**
+         * CreateCloudWorkspaceSourceMaterialization
+         * @description The local source descriptor for an exact-ref managed-Cloud creation.
+         *
+         *     Supplied by Desktop's "Add Cloud copy" flow: it names the local AnyHarness
+         *     workspace the exact ref came from so the resulting managed-Cloud row can be
+         *     associated with it. The server never trusts these fields for the actual ref
+         *     — it independently re-verifies the authorized GitHub branch head.
+         */
+        CreateCloudWorkspaceSourceMaterialization: {
+            /**
+             * Targetkind
+             * @constant
+             */
+            targetKind: "local_desktop";
+            /** Desktopinstallid */
+            desktopInstallId: string;
+            /** Anyharnessworkspaceid */
+            anyharnessWorkspaceId: string;
+            /** Worktreepath */
+            worktreePath: string;
+            /** Observedheadsha */
+            observedHeadSha: string;
         };
         /** CreateMaterializationIntentRequest */
         CreateMaterializationIntentRequest: {

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -618,6 +618,8 @@ export type CloudWorktreeRetentionPolicyRequest =
   Schema<"CloudWorktreeRetentionPolicyRequest">;
 export type CloudWorktreeRetentionPolicyResponse =
   Schema<"CloudWorktreeRetentionPolicyResponse">;
+export type CreateCloudWorkspaceSourceMaterialization =
+  Schema<"CreateCloudWorkspaceSourceMaterialization">;
 export interface CreateCloudWorkspaceRequest {
   gitProvider: "github";
   gitOwner: string;
@@ -627,6 +629,12 @@ export interface CreateCloudWorkspaceRequest {
   displayName?: string | null;
   generatedName?: boolean | null;
   source?: "desktop" | "web" | "mobile" | null;
+  // Exact-ref creation from a clean, published local workspace (PR 5). When
+  // set, the server materializes the Cloud copy at this exact commit of the
+  // already-published branch after independently re-verifying the authorized
+  // GitHub head. Old requests (both absent) keep the branch-name fork path.
+  expectedHeadSha?: string | null;
+  sourceMaterialization?: CreateCloudWorkspaceSourceMaterialization | null;
 }
 export type GenerateSessionTitleRequest = Schema<"GenerateSessionTitleRequest">;
 export type GenerateSessionTitleResponse = Schema<"GenerateSessionTitleResponse">;

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -26,7 +26,8 @@ apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx 41
 apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx 550 chat diff viewer pending row-renderer split
 apps/packages/product-client/src/components/content/ui/diff/SplitDiffViewer.tsx 465 split diff viewer pending row-renderer split
 apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
-apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 414 workspace sidebar item pending indicator/menu split
+apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 445 workspace sidebar item + PR 5 workspace-copy availability commands in DOM/native/right-click menus; menu split pending
+apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx 452 connected sidebar host; PR 5 availability-intent begin handler threaded alongside existing repo/cloud actions; extraction pending
 apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts 415 injected typed telemetry deps threaded from the calling hook; split deferred
 apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -30,7 +30,7 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1107 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
-cloud/sdk/src/types/generated.ts 781 existing generated cloud SDK type surface (+git numstat line-count fields; materialization types re-derived from OpenAPI; CloudWorkspaceSummary derived from Schema<WorkspaceSummary> with documented normalized/app-extra overlay)
+cloud/sdk/src/types/generated.ts 789 existing generated cloud SDK type surface (+git numstat line-count fields; materialization types re-derived from OpenAPI; CloudWorkspaceSummary derived from Schema<WorkspaceSummary> with documented normalized/app-extra overlay; +PR 5 exact-ref create request fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
@@ -38,9 +38,9 @@ server/proliferate/auth/identity/store.py 686 managed sandbox GitHub grant read 
 server/proliferate/db/models/cloud/agent_gateway.py 504 agent_auth_harness_settings model added for catalog-driven per-harness settings
 server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PUT routes added for catalog-driven per-harness settings
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
-server/proliferate/server/cloud/workspaces/service.py 844 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + repo-less read guards); split on next growth per guides/domains.md
+server/proliferate/server/cloud/workspaces/service.py 1074 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + repo-less read guards) + PR 5 exact-ref managed-Cloud creation path; split on next growth per guides/domains.md
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
-server/tests/integration/test_cloud_workspace_materialization_service.py 895 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction)
+server/tests/integration/test_cloud_workspace_materialization_service.py 1066 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction) + PR 5 exact-ref create coverage
 server/tests/integration/test_auth_flow.py 2220 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
@@ -53,7 +53,7 @@ apps/packages/ui/src/icons/core.tsx 413 existing consolidated icon barrel pendin
 # that fell under the 600 general cap at the deeper path (SplitDiffViewer 540,
 # HomeNextScreen.test 530 — desktop component cap was 500) are dropped, not moved.
 apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 908 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock + ProductHost test-host wiring
-apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
+apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 840 managed sandbox cloud workspace indicators + PR 5 explicit-materialization attachment cases extend existing oversized test file
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 630 existing desktop oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred

--- a/server/proliferate/db/store/cloud_workspace_materializations.py
+++ b/server/proliferate/db/store/cloud_workspace_materializations.py
@@ -246,6 +246,51 @@ async def insert_managed_cloud_materialization(
     return cloud_workspace_materialization_value(row)
 
 
+async def insert_hydrated_local_desktop_materialization(
+    db: AsyncSession,
+    *,
+    cloud_workspace_id: UUID,
+    desktop_install_id: str,
+    anyharness_workspace_id: str,
+    worktree_path: str,
+    expected_head_sha: str,
+    observed_head_sha: str,
+    observed_branch: str,
+) -> CloudWorkspaceMaterializationValue | None:
+    """Insert one active, already-hydrated local-desktop row.
+
+    Used by exact-ref Cloud creation from a local workspace: the local source
+    already exists and matches the exact ref, so the association is recorded as
+    hydrated in a single write rather than through the intent → report cycle.
+    Returns None on an active-uniqueness race (install already linked).
+    """
+    now = utcnow()
+    row = CloudWorkspaceMaterialization(
+        cloud_workspace_id=cloud_workspace_id,
+        target_kind="local_desktop",
+        cloud_sandbox_id=None,
+        desktop_install_id=desktop_install_id,
+        anyharness_workspace_id=anyharness_workspace_id,
+        worktree_path=worktree_path,
+        state="hydrated",
+        generation=1,
+        expected_head_sha=expected_head_sha,
+        observed_head_sha=observed_head_sha,
+        observed_branch=observed_branch,
+        last_reported_at=now,
+        unlinked_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(row)
+            await db.flush()
+    except IntegrityError:
+        return None
+    return cloud_workspace_materialization_value(row)
+
+
 async def create_local_desktop_intent(
     db: AsyncSession,
     *,

--- a/server/proliferate/integrations/anyharness/models.py
+++ b/server/proliferate/integrations/anyharness/models.py
@@ -41,6 +41,15 @@ class ResolvedRemoteWorkspace:
 
 
 @dataclass(frozen=True)
+class MaterializedRemoteWorkspaceAtRef:
+    """The result of an exact-ref workspace materialization (PR 3 endpoint)."""
+
+    workspace_id: str
+    observed_head_sha: str
+    outcome: str
+
+
+@dataclass(frozen=True)
 class RemoteSession:
     session_id: str
 

--- a/server/proliferate/integrations/anyharness/workspaces.py
+++ b/server/proliferate/integrations/anyharness/workspaces.py
@@ -7,6 +7,7 @@ import httpx
 from proliferate.integrations.anyharness.client import auth_headers
 from proliferate.integrations.anyharness.errors import CloudRuntimeReconnectError
 from proliferate.integrations.anyharness.models import (
+    MaterializedRemoteWorkspaceAtRef,
     RemoteGitStatusSnapshot,
     RemoteWorkspaceSummary,
     ResolvedRemoteWorkspace,
@@ -14,6 +15,7 @@ from proliferate.integrations.anyharness.models import (
 
 _CREATE_WORKTREE_TIMEOUT_SECONDS = 180.0
 _GIT_STATUS_TIMEOUT_SECONDS = 15.0
+_MATERIALIZE_AT_REF_TIMEOUT_SECONDS = 600.0
 
 
 def _runtime_status_error_message(
@@ -178,6 +180,81 @@ async def create_remote_worktree_workspace(
         invalid_message="Cloud runtime did not return a valid worktree workspace.",
         workspace_id_message="Cloud runtime did not return a valid worktree workspace id.",
         repo_root_message="Cloud runtime did not return a valid worktree repo root id.",
+    )
+
+
+async def materialize_workspace_at_ref(
+    runtime_url: str,
+    access_token: str,
+    *,
+    repo_root_id: str,
+    operation_id: str,
+    branch_name: str,
+    head_sha: str,
+    preferred_workspace_name: str | None = None,
+    destination_id: str | None = None,
+) -> MaterializedRemoteWorkspaceAtRef:
+    """Create or reuse a workspace at an exact branch + commit (PR 3 endpoint).
+
+    The runtime ledger keys idempotency off ``operation_id``: retrying with the
+    same id reuses the earlier result rather than creating a second worktree.
+    """
+    body: dict[str, object] = {
+        "operationId": operation_id,
+        "branchName": branch_name,
+        "headSha": head_sha,
+    }
+    if preferred_workspace_name:
+        body["preferredWorkspaceName"] = preferred_workspace_name
+    if destination_id:
+        body["destinationId"] = destination_id
+
+    try:
+        async with httpx.AsyncClient(timeout=_MATERIALIZE_AT_REF_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{runtime_url}/v1/repo-roots/{repo_root_id}/workspace-materializations",
+                headers=auth_headers(access_token),
+                json=body,
+            )
+            response.raise_for_status()
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise CloudRuntimeReconnectError(
+                    "Cloud runtime returned invalid JSON when materializing a workspace at ref."
+                ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise CloudRuntimeReconnectError(
+            _runtime_status_error_message(
+                exc.response,
+                "Failed to materialize AnyHarness workspace at ref.",
+            )
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise CloudRuntimeReconnectError(
+            "Failed to materialize AnyHarness workspace at ref."
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime did not return a valid workspace materialization."
+        )
+    workspace = payload.get("workspace")
+    workspace_id = workspace.get("id") if isinstance(workspace, dict) else None
+    observed_head_sha = payload.get("observedHeadSha")
+    outcome = payload.get("outcome")
+    if not isinstance(workspace_id, str) or not workspace_id:
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime did not return a valid materialized workspace id."
+        )
+    if not isinstance(observed_head_sha, str) or not observed_head_sha:
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime did not return a valid observed HEAD for the materialization."
+        )
+    return MaterializedRemoteWorkspaceAtRef(
+        workspace_id=workspace_id,
+        observed_head_sha=observed_head_sha,
+        outcome=outcome if isinstance(outcome, str) else "created",
     )
 
 

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -65,6 +65,22 @@ class ReportMaterializationRequest(BaseModel):
     failure_detail: str | None = Field(default=None, alias="failureDetail")
 
 
+class CreateCloudWorkspaceSourceMaterialization(BaseModel):
+    """The local source descriptor for an exact-ref managed-Cloud creation.
+
+    Supplied by Desktop's "Add Cloud copy" flow: it names the local AnyHarness
+    workspace the exact ref came from so the resulting managed-Cloud row can be
+    associated with it. The server never trusts these fields for the actual ref
+    — it independently re-verifies the authorized GitHub branch head.
+    """
+
+    target_kind: Literal["local_desktop"] = Field(alias="targetKind")
+    desktop_install_id: str = Field(alias="desktopInstallId")
+    anyharness_workspace_id: str = Field(alias="anyharnessWorkspaceId")
+    worktree_path: str = Field(alias="worktreePath")
+    observed_head_sha: str = Field(alias="observedHeadSha")
+
+
 class CreateCloudWorkspaceRequest(BaseModel):
     git_provider: Literal["github"] = Field(default="github", alias="gitProvider")
     git_owner: str = Field(alias="gitOwner")
@@ -74,6 +90,16 @@ class CreateCloudWorkspaceRequest(BaseModel):
     display_name: str | None = Field(default=None, alias="displayName")
     generated_name: bool | None = Field(default=None, alias="generatedName")
     source: Literal["desktop", "web", "mobile"] | None = None
+    # Exact-ref creation from a clean, published local workspace (PR 5). When
+    # supplied, the server creates the managed-Cloud copy at this exact commit
+    # of the already-published branch — after independently verifying the
+    # authorized GitHub branch head equals it — instead of forking a new branch
+    # from base. Old requests (both None) retain the branch-name creation path.
+    expected_head_sha: str | None = Field(default=None, alias="expectedHeadSha")
+    source_materialization: CreateCloudWorkspaceSourceMaterialization | None = Field(
+        default=None,
+        alias="sourceMaterialization",
+    )
 
 
 class UpdateCloudWorkspaceDisplayNameRequest(BaseModel):

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -26,9 +26,13 @@ from proliferate.db.store.cloud_workspace_materializations import (
 from proliferate.db.store.cloud_workspaces import CloudWorkspaceValue
 from proliferate.db.store.repositories import RepoEnvironmentValue
 from proliferate.integrations.anyharness.errors import CloudRuntimeReconnectError
-from proliferate.integrations.anyharness.models import ResolvedRemoteWorkspace
+from proliferate.integrations.anyharness.models import (
+    MaterializedRemoteWorkspaceAtRef,
+    ResolvedRemoteWorkspace,
+)
 from proliferate.integrations.anyharness.workspaces import (
     create_remote_worktree_workspace,
+    materialize_workspace_at_ref,
     resolve_runtime_workspace,
 )
 from proliferate.lib.product.workspace_naming import resolve_generated_branch_name
@@ -232,6 +236,28 @@ async def create_cloud_workspace_for_user(
             status_code=400,
         )
 
+    # Exact-ref creation (PR 5, "Add Cloud copy from local"): the branch is an
+    # already-published GitHub branch and the Cloud copy is materialized at that
+    # exact commit, not forked from base. Server independently re-verifies the
+    # authorized GitHub head equals the expected SHA — the client descriptor is
+    # never trusted for the ref.
+    expected_head_sha = (body.expected_head_sha or "").strip()
+    if expected_head_sha:
+        return await _create_cloud_workspace_at_exact_ref(
+            db,
+            user=user,
+            repo_environment=repo_environment,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            branch_name=branch_name,
+            base_branch=base_branch,
+            expected_head_sha=expected_head_sha,
+            repo_branches=repo_branches,
+            display_name=body.display_name,
+            source=body.source or "desktop",
+            source_materialization=body.source_materialization,
+        )
+
     active_workspace_branches = (
         await cloud_workspace_store.list_active_workspace_branches_for_repo_environment(
             db,
@@ -361,6 +387,210 @@ async def create_cloud_workspace_for_user(
         state="hydrated",
     )
     return await _workspace_payload(db, workspace, detail=True)
+
+
+async def _create_cloud_workspace_at_exact_ref(
+    db: AsyncSession,
+    *,
+    user: _UserWithId,
+    repo_environment: RepoEnvironmentValue,
+    git_owner: str,
+    git_repo_name: str,
+    branch_name: str,
+    base_branch: str,
+    expected_head_sha: str,
+    repo_branches: object,
+    display_name: str | None,
+    source: str,
+    source_materialization: object,
+) -> WorkspaceDetail:
+    """Create a managed-Cloud workspace at an exact published branch head.
+
+    The branch must be an existing GitHub branch whose authorized head equals
+    ``expected_head_sha`` (server-verified — the client descriptor is never
+    trusted for the ref). The managed Cloud AnyHarness workspace is materialized
+    at that exact commit through PR 3's exact-ref endpoint, then the durable
+    CloudWorkspace + managed materialization are written, and — when a local
+    source descriptor is supplied — the local materialization association is
+    recorded as already hydrated in the same transaction.
+    """
+    branches = getattr(repo_branches, "branches", [])
+    branch_heads = getattr(repo_branches, "branch_heads_by_name", {}) or {}
+    if branch_name not in branches:
+        raise CloudApiError(
+            "github_branch_not_found",
+            f"The branch '{branch_name}' was not found on GitHub.",
+            status_code=400,
+        )
+    github_head = branch_heads.get(branch_name)
+    if github_head is None:
+        raise CloudApiError(
+            "materialization_source_blocked",
+            f"The branch '{branch_name}' is not published on GitHub.",
+            status_code=409,
+        )
+    if github_head != expected_head_sha:
+        raise CloudApiError(
+            "materialization_source_blocked",
+            "The local workspace has commits that are not published on GitHub.",
+            status_code=409,
+        )
+
+    active_workspace_branches = (
+        await cloud_workspace_store.list_active_workspace_branches_for_repo_environment(
+            db,
+            repo_environment_id=repo_environment.id,
+        )
+    )
+    if branch_name in active_workspace_branches:
+        raise CloudApiError(
+            "cloud_branch_already_exists",
+            f"A cloud workspace already exists for branch '{branch_name}'.",
+            status_code=409,
+        )
+
+    display_name_value = (display_name or branch_name).strip() or branch_name
+    if len(display_name_value) > MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS:
+        raise CloudApiError(
+            "invalid_display_name",
+            (
+                "Workspace display name cannot exceed "
+                f"{MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS} characters."
+            ),
+            status_code=400,
+        )
+
+    try:
+        await materialization_service.materialize_repo_environment(
+            db,
+            repo_environment_id=repo_environment.id,
+        )
+    except CloudRuntimeReconnectError as exc:
+        raise CloudApiError(
+            "cloud_sandbox_reconnect_failed",
+            "The cloud sandbox runtime could not be reached. Please retry in a moment.",
+            status_code=502,
+        ) from exc
+    except CloudRepoCheckoutError as exc:
+        raise CloudApiError(
+            "cloud_repo_checkout_conflict",
+            _CHECKOUT_CONFLICT_MESSAGES.get(
+                exc.reason,
+                "The cloud checkout for this repository could not be prepared. "
+                "Resolve outstanding changes in the cloud sandbox and retry.",
+            ),
+            status_code=409,
+        ) from exc
+    except CloudMaterializationLockTimeout as exc:
+        raise CloudApiError(
+            "cloud_materialization_busy",
+            "The cloud sandbox is busy preparing another workspace. Please retry in a moment.",
+            status_code=503,
+        ) from exc
+
+    workspace = await cloud_workspace_store.create_cloud_workspace(
+        db,
+        user_id=user.id,
+        repo_environment_id=repo_environment.id,
+        display_name=display_name_value,
+        git_branch=branch_name,
+        git_base_branch=base_branch,
+    )
+    if workspace is None:
+        raise CloudApiError(
+            "cloud_branch_already_exists",
+            f"A cloud workspace already exists for branch '{branch_name}'.",
+            status_code=409,
+        )
+
+    runtime_url, runtime_token, _data_key = await _load_ready_runtime_access(db, user_id=user.id)
+    repo_path = materialization_paths.repo_path(repo_environment)
+    repo_root = await _resolve_repo_root(runtime_url, runtime_token, repo_path=repo_path)
+    materialized = await _materialize_managed_at_exact_ref(
+        runtime_url,
+        runtime_token,
+        repo_root_id=repo_root.repo_root_id,
+        workspace_id=workspace.id,
+        branch_name=branch_name,
+        head_sha=expected_head_sha,
+    )
+
+    sandbox = await cloud_sandbox_store.load_personal_cloud_sandbox(db, user.id)
+    workspace = await cloud_workspace_store.update_workspace_anyharness_workspace_id(
+        db,
+        anyharness_workspace_id=materialized.workspace_id,
+        workspace=workspace,
+    )
+    await materialization_store.insert_managed_cloud_materialization(
+        db,
+        cloud_workspace_id=workspace.id,
+        cloud_sandbox_id=sandbox.id if sandbox is not None else None,
+        anyharness_workspace_id=materialized.workspace_id,
+        state="hydrated",
+        expected_head_sha=expected_head_sha,
+        observed_head_sha=materialized.observed_head_sha,
+        observed_branch=branch_name,
+    )
+
+    # Record the local source association (already hydrated) when the caller
+    # named its local workspace. Best-effort: a race with a concurrent link
+    # leaves the managed copy intact; the association can be retried via intent.
+    if source_materialization is not None:
+        install_id = getattr(source_materialization, "desktop_install_id", "").strip()
+        worker = (
+            await runtime_workers_store.get_active_desktop_worker_for_user(
+                db,
+                owner_user_id=user.id,
+                desktop_install_id=install_id,
+            )
+            if install_id
+            else None
+        )
+        if worker is not None:
+            await materialization_store.insert_hydrated_local_desktop_materialization(
+                db,
+                cloud_workspace_id=workspace.id,
+                desktop_install_id=install_id,
+                anyharness_workspace_id=getattr(
+                    source_materialization, "anyharness_workspace_id", ""
+                ),
+                worktree_path=getattr(source_materialization, "worktree_path", ""),
+                expected_head_sha=expected_head_sha,
+                observed_head_sha=getattr(
+                    source_materialization, "observed_head_sha", expected_head_sha
+                ),
+                observed_branch=branch_name,
+            )
+    return await _workspace_payload(db, workspace, detail=True)
+
+
+async def _materialize_managed_at_exact_ref(
+    runtime_url: str,
+    runtime_token: str,
+    *,
+    repo_root_id: str,
+    workspace_id: UUID,
+    branch_name: str,
+    head_sha: str,
+) -> MaterializedRemoteWorkspaceAtRef:
+    # Reuse the workspace id as the runtime operation id so a retry of the same
+    # create (same workspace row) reuses the runtime ledger result instead of
+    # cutting a second worktree.
+    try:
+        return await materialize_workspace_at_ref(
+            runtime_url,
+            runtime_token,
+            repo_root_id=repo_root_id,
+            operation_id=str(workspace_id),
+            branch_name=branch_name,
+            head_sha=head_sha,
+        )
+    except CloudRuntimeReconnectError as exc:
+        raise CloudApiError(
+            "cloud_workspace_create_failed",
+            str(exc),
+            status_code=502,
+        ) from exc
 
 
 async def sync_cloud_workspace_display_name(

--- a/server/tests/integration/test_cloud_workspace_materialization_service.py
+++ b/server/tests/integration/test_cloud_workspace_materialization_service.py
@@ -674,6 +674,177 @@ async def test_create_dual_writes_legacy_id_and_managed_materialization(
     assert managed.cloud_sandbox_id == seed.sandbox.id
 
 
+def _patch_exact_ref_create(
+    monkeypatch: pytest.MonkeyPatch,
+    seed,
+    *,
+    branch_heads: dict[str, str],
+    materialized_head: str,
+    calls: dict[str, Any] | None = None,
+) -> None:
+    from proliferate.integrations.anyharness.models import MaterializedRemoteWorkspaceAtRef
+
+    async def _get_repo_environment(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(
+            id=seed.env.id,
+            git_provider="github",
+            git_owner="acme",
+            git_repo_name="widgets",
+            default_branch="main",
+            setup_script="",
+            environment_kind="cloud",
+        )
+
+    async def _authority(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(access_token="gho_test")
+
+    async def _branches(*_a: Any, **_k: Any) -> GitHubRepoBranches:
+        return GitHubRepoBranches(
+            default_branch="main",
+            branches=["main", *branch_heads.keys()],
+            branch_heads_by_name=branch_heads,
+        )
+
+    async def _materialize(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _runtime_access(*_a: Any, **_k: Any):
+        return ("https://runtime.invalid", "token", "data-key")
+
+    async def _resolve_root(*_a: Any, **_k: Any) -> ResolvedRemoteWorkspace:
+        return ResolvedRemoteWorkspace(workspace_id="ignored", repo_root_id="root-1")
+
+    async def _materialize_at_ref(*_a: Any, **kwargs: Any) -> MaterializedRemoteWorkspaceAtRef:
+        if calls is not None:
+            calls.update(kwargs)
+        return MaterializedRemoteWorkspaceAtRef(
+            workspace_id="ah-exact",
+            observed_head_sha=materialized_head,
+            outcome="created",
+        )
+
+    monkeypatch.setattr(
+        workspaces_service.repositories_store, "get_cloud_repo_environment", _get_repo_environment
+    )
+    monkeypatch.setattr(
+        workspaces_service.repositories_store, "get_repo_environment_by_id", _get_repo_environment
+    )
+    monkeypatch.setattr(workspaces_service, "require_github_cloud_repo_authority", _authority)
+    monkeypatch.setattr(workspaces_service, "get_repo_branches_for_credentials", _branches)
+    monkeypatch.setattr(
+        workspaces_service.materialization_service, "materialize_repo_environment", _materialize
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandboxes_service,
+        "load_cloud_sandbox_runtime_access",
+        _runtime_access,
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandboxes_service,
+        "require_cloud_provisioning_configured",
+        lambda: None,
+    )
+    monkeypatch.setattr(workspaces_service, "_resolve_repo_root", _resolve_root)
+    monkeypatch.setattr(workspaces_service, "materialize_workspace_at_ref", _materialize_at_ref)
+
+
+@pytest.mark.asyncio
+async def test_exact_ref_create_materializes_at_head_and_records_local_source(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from proliferate.db.store import cloud_workspace_materializations as store
+    from proliferate.server.cloud.workspaces.models import (
+        CreateCloudWorkspaceSourceMaterialization,
+    )
+
+    seed = await _seed(db_session)
+    ws = await db_session.get(CloudWorkspace, seed.workspace.id)
+    assert ws is not None
+    await db_session.delete(ws)
+    await db_session.flush()
+
+    calls: dict[str, Any] = {}
+    _patch_exact_ref_create(
+        monkeypatch,
+        seed,
+        branch_heads={_BRANCH: _HEAD},
+        materialized_head=_HEAD,
+        calls=calls,
+    )
+
+    detail = await workspaces_service.create_cloud_workspace_for_user(
+        db_session,
+        SimpleNamespace(id=seed.user.id),
+        CreateCloudWorkspaceRequest(
+            gitOwner="acme",
+            gitRepoName="widgets",
+            branchName=_BRANCH,
+            baseBranch="main",
+            expectedHeadSha=_HEAD,
+            sourceMaterialization=CreateCloudWorkspaceSourceMaterialization(
+                targetKind="local_desktop",
+                desktopInstallId=_INSTALL,
+                anyharnessWorkspaceId="ws-local",
+                worktreePath="/local/wt",
+                observedHeadSha=_HEAD,
+            ),
+        ),
+    )
+
+    # AnyHarness was asked to materialize at the exact branch + commit.
+    assert calls["branch_name"] == _BRANCH
+    assert calls["head_sha"] == _HEAD
+    assert detail.anyharness_workspace_id == "ah-exact"
+
+    active = await store.list_active_materializations_for_workspace(
+        db_session, cloud_workspace_id=uuid.UUID(detail.id)
+    )
+    managed = [m for m in active if m.target_kind == "managed_cloud"]
+    locals_ = [m for m in active if m.target_kind == "local_desktop"]
+    assert len(managed) == 1
+    assert managed[0].expected_head_sha == _HEAD
+    assert managed[0].observed_head_sha == _HEAD
+    # The local source association was recorded as already hydrated.
+    assert len(locals_) == 1
+    assert locals_[0].desktop_install_id == _INSTALL
+    assert locals_[0].state == "hydrated"
+    assert locals_[0].anyharness_workspace_id == "ws-local"
+
+
+@pytest.mark.asyncio
+async def test_exact_ref_create_rejects_head_not_published(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed = await _seed(db_session)
+    ws = await db_session.get(CloudWorkspace, seed.workspace.id)
+    assert ws is not None
+    await db_session.delete(ws)
+    await db_session.flush()
+
+    # GitHub's head for the branch differs from the client's expected head:
+    # the local workspace has unpublished commits. Must fail-closed.
+    _patch_exact_ref_create(
+        monkeypatch,
+        seed,
+        branch_heads={_BRANCH: "different-sha"},
+        materialized_head=_HEAD,
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session,
+            SimpleNamespace(id=seed.user.id),
+            CreateCloudWorkspaceRequest(
+                gitOwner="acme",
+                gitRepoName="widgets",
+                branchName=_BRANCH,
+                baseBranch="main",
+                expectedHeadSha=_HEAD,
+            ),
+        )
+    assert excinfo.value.code == "materialization_source_blocked"
+
+
 @pytest.mark.asyncio
 async def test_reconciliation_uses_recorded_sandbox_not_current(
     db_session: AsyncSession,


### PR DESCRIPTION
PR 5 of the Cloud repository access + workspace materialization stack (frozen spec rev 3: `Vault/Workspace/Features/Desktop Repository Clone and Workspace Linking - PR 5.md`).

**Stack position**: based on integration branch `codex/cloud-repo-stack-full` (base 4e3af77aa + final settled heads of PR 2 `5fc725190` #1276, PR 3 `869c5e9fa` #1278, PR 4 `653fe764a` #1277, PR 7 `523001fba` #1281). Draft review boundary — never merge without Pablo.

## What this adds

- **Clone from GitHub**: third Desktop Add Repository option; repo `Add to this Mac` chooses existing folder vs clone. Clone is gated by `github_repository_access` (new `clone_from_github` intent kind), not managed-Cloud — an App-ready/E2B-disabled instance can clone. Local Git credentials only; never an installation token; install returns use host-derived `buildReturnUrl` (PR2-WEB-03 pattern).
- **Open Cloud workspace on this Mac**: intent → PR 3 two-endpoint local materialization (repo-root acquire, then exact-ref workspace materialization) → report, threading PR 4's `"{rowId}:{generation}"` operationId; crash-safe retry reuses the same operation id (no duplicate worktrees).
- **Add Cloud copy** from a clean published local workspace: exact-ref server creation (`expectedHeadSha` + `sourceMaterialization` on CreateCloudWorkspaceRequest) with server-side branch-HEAD verification.
- **Explicit Link / Unlink / Relink**: association-only (no filesystem mutation); unlink deletes nothing; relink is generation-safe, stale reports rejected.
- **Materialization-first logical projection**: explicit `(desktopInstallId, anyharnessWorkspaceId)` association replaces heuristic Cloud attachment when materializations exist; different-path same-branch worktrees stay distinct; server `select_primary` (via `desktopInstallId` on every fetch) is authoritative.

## Rebase/dedupe notes (vs the founder-repair heads)

- PR 5's hand-authored intent/report/unlink SDK methods + sdk-react hooks were fully subsumed by PR 4's now-canonical ones — deduped, consumers rewired to upstream exports; net SDK diff is only the `Schema<>`-derived `CreateCloudWorkspaceSourceMaterialization` alias + two optional request fields.
- Layers on (never reverts) PR 2's repaired hosts: resolver preflight, ref-driven `retryNonce` continuation (cloneFromGitHub folded into the continuation ref), sign-in CTA, buildReturnUrl returns.
- Nullable-repo guards per merged #1245 semantics.

## Verification

Typecheck exit 0 across cloud/sdk, sdk-react, product-domain/-ui/-surfaces/-client, web, mobile, desktop. Vitest: product-domain 578, product-client 3103, desktop 168 — all green. Frontend structure `--strict` TOTAL 0; max-lines pass; `git diff --check` clean. No Rust changes; Workflow V1 files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)