### PR TITLE
feat(desktop): repository clone and explicit workspace linking (PR 5)

### DIFF
--- a/apps/packages/product-client/src/App.tsx
+++ b/apps/packages/product-client/src/App.tsx
@@ -13,6 +13,7 @@ import { RepoSetupModalHost } from "#product/components/workspace/repo-setup/Rep
 import { SupportModalHost } from "#product/components/support/SupportModalHost"
 import { AddRepoFlowHost } from "#product/components/workspace/repo-setup/AddRepoFlowHost"
 import { CloudRepoActionDialogHost } from "#product/components/workspace/repo-setup/CloudRepoActionDialogHost"
+import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
 import { LoginPage } from "#product/pages/LoginPage"
 import { SettingsCloudRedirect } from "#product/pages/SettingsCloudRedirect"
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store"
@@ -199,6 +200,7 @@ export function App({ RoutesComponent }: AppProps) {
         <RepoSetupModalHost />
         <AddRepoFlowHost />
         <CloudRepoActionDialogHost />
+        <WorkspaceAvailabilityActionHost />
         <SupportModalHost />
         {/* Kit Sonner toaster: all toasts (update lifecycle + legacy
             toast-store call sites, which now delegate to Sonner). */}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
@@ -94,9 +94,10 @@ vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
 
 // Expose the resolved cloudPicker.blocker title the host hands the flow.
 vi.mock("@proliferate/product-ui/repos/AddRepoFlow", () => ({
-  AddRepoFlow: ({ cloudPicker }: AddRepoFlowProps) => (
-    <div>{cloudPicker?.blocker ? `blocker:${cloudPicker.blocker.title}` : "no-blocker"}</div>
-  ),
+  AddRepoFlow: ({ step, cloudPicker, clonePicker }: AddRepoFlowProps) => {
+    const picker = step.kind === "clone" ? clonePicker : cloudPicker;
+    return <div>{picker?.blocker ? `blocker:${picker.blocker.title}` : "no-blocker"}</div>;
+  },
 }));
 
 afterEach(() => {
@@ -115,6 +116,12 @@ afterEach(() => {
 function openCloudStep() {
   act(() => {
     useAddRepoFlowStore.setState({ open: true, step: { kind: "cloud" }, onCompleted: null });
+  });
+}
+
+function openCloneStep() {
+  act(() => {
+    useAddRepoFlowStore.setState({ open: true, step: { kind: "clone" }, onCompleted: null });
   });
 }
 
@@ -186,5 +193,31 @@ describe("AddRepoFlowHost cloud gating (PR2-GATING-01)", () => {
         gitRepoName: "Rocket",
       },
     });
+  });
+
+  it("gates Clone on GitHub repository access, not managed Cloud", () => {
+    capabilities.value = {
+      githubRepositoryAccessStatus: "ready",
+      managedCloudStatus: "disabled",
+      githubRepositoryAccessDisplayName: "proliferate-app",
+    };
+    render(<AddRepoFlowHost />);
+    openCloneStep();
+
+    // The GitHub-only preflight is ready, so the picker owns the next gate.
+    expect(screen.getByText(/^blocker:Authorize GitHub App$/)).toBeTruthy();
+  });
+
+  it("shows the operator blocker before Clone when GitHub access is disabled", () => {
+    capabilities.value = {
+      githubRepositoryAccessStatus: "disabled",
+      managedCloudStatus: "ready",
+      githubRepositoryAccessDisplayName: null,
+    };
+    render(<AddRepoFlowHost />);
+    openCloneStep();
+
+    expect(screen.getByText(/^blocker:GitHub repository access is not configured$/)).toBeTruthy();
+    expect(screen.queryByText(/blocker:Authorize GitHub App/)).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
@@ -67,6 +67,15 @@ vi.mock("#product/hooks/workspaces/workflows/use-add-repo", () => ({
   useAddRepo: () => ({ addRepoFromPath: vi.fn(), isAddingRepo: false }),
 }));
 
+// Stub the clone hook (which otherwise pulls in the AnyHarnessRuntime provider);
+// these gating tests only exercise the cloud path, not the clone path.
+vi.mock("#product/hooks/workspaces/workflows/use-clone-repo", () => ({
+  useCloneRepo: () => ({
+    cloneRepo: vi.fn(() => Promise.resolve({ succeeded: true, sourceRoot: "/tmp/clone" })),
+    isCloning: false,
+  }),
+}));
+
 vi.mock("#product/hooks/organizations/facade/use-active-organization", () => ({
   useActiveOrganization: () => ({
     activeOrganization: { name: "Acme", membership: { role: "member" } },

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx
@@ -24,6 +24,8 @@ const capabilities = vi.hoisted(() => ({
 const auth = vi.hoisted(() => ({ status: "authenticated" as string }));
 const cloudHook = vi.hoisted(() => ({
   onRepositorySelected: null as null | ((repo: { gitOwner: string; gitRepoName: string }) => void),
+  legacyManual: vi.fn(),
+  clonePicker: null as CloudRepoPickerProps | null,
 }));
 
 // The OLD prerequisite-model blocker useAddCloudEnvironment produces: a
@@ -48,16 +50,18 @@ vi.mock("@proliferate/product-surfaces/settings/cloud-environments/use-add-cloud
   useAddCloudEnvironment: (input: {
     onRepositorySelected?: (repo: { gitOwner: string; gitRepoName: string }) => void;
   }): CloudRepoPickerProps => {
-    cloudHook.onRepositorySelected = input.onRepositorySelected ?? null;
+    if (input.onRepositorySelected) {
+      cloudHook.onRepositorySelected = input.onRepositorySelected;
+    }
     return {
       query: "",
-      manualValue: "",
+      manualValue: "acme/manual-clone",
       repositories: [],
       blocker: OLD_PREREQ_BLOCKER,
       onQueryChange: vi.fn(),
       onManualValueChange: vi.fn(),
       onAddRepository: vi.fn(),
-      onAddManual: vi.fn(),
+      onAddManual: cloudHook.legacyManual,
       onLoadMore: vi.fn(),
     };
   },
@@ -96,6 +100,7 @@ vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
 vi.mock("@proliferate/product-ui/repos/AddRepoFlow", () => ({
   AddRepoFlow: ({ step, cloudPicker, clonePicker }: AddRepoFlowProps) => {
     const picker = step.kind === "clone" ? clonePicker : cloudPicker;
+    cloudHook.clonePicker = clonePicker ?? null;
     return <div>{picker?.blocker ? `blocker:${picker.blocker.title}` : "no-blocker"}</div>;
   },
 }));
@@ -109,6 +114,8 @@ afterEach(() => {
   };
   auth.status = "authenticated";
   cloudHook.onRepositorySelected = null;
+  cloudHook.clonePicker = null;
+  cloudHook.legacyManual.mockClear();
   useAddRepoFlowStore.setState({ open: false, step: { kind: "entry" }, onCompleted: null });
   useCloudRepositoryIntentStore.setState({ activeIntent: null });
 });
@@ -219,5 +226,22 @@ describe("AddRepoFlowHost cloud gating (PR2-GATING-01)", () => {
 
     expect(screen.getByText(/^blocker:GitHub repository access is not configured$/)).toBeTruthy();
     expect(screen.queryByText(/blocker:Authorize GitHub App/)).toBeNull();
+  });
+
+  it("routes manual owner/repo entry to the clone intent, never Cloud setup", () => {
+    render(<AddRepoFlowHost />);
+    openCloneStep();
+
+    act(() => cloudHook.clonePicker?.onAddManual());
+
+    expect(cloudHook.legacyManual).not.toHaveBeenCalled();
+    expect(useCloudRepositoryIntentStore.getState().activeIntent).toEqual({
+      kind: "clone_from_github",
+      repo: {
+        gitProvider: "github",
+        gitOwner: "acme",
+        gitRepoName: "manual-clone",
+      },
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import type { CloudRepoPickerProps } from "@proliferate/product-ui/repos/CloudRepoPicker";
+import { parseGitRepoId } from "@proliferate/product-domain/repos/repo-id";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { resolveRepositoryReadiness } from "@proliferate/product-domain/repos/repo-readiness";
 import type { CloudRepoPickerBlockerView } from "@proliferate/product-ui/repos/CloudRepoPicker";
@@ -11,6 +13,7 @@ import {
   useAddCloudEnvironment,
 } from "@proliferate/product-surfaces/settings/cloud-environments/use-add-cloud-environment";
 import { useAddRepo } from "#product/hooks/workspaces/workflows/use-add-repo";
+import { useCloneRepo } from "#product/hooks/workspaces/workflows/use-clone-repo";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
 import { isSettingsAdminRole } from "#product/lib/domain/settings/admin-roles";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
@@ -36,6 +39,7 @@ export function AddRepoFlowHost() {
   const beginCloudIntent = useCloudRepositoryIntentStore((state) => state.begin);
 
   const { addRepoFromPath, isAddingRepo } = useAddRepo();
+  const { cloneRepo, isCloning } = useCloneRepo();
   const { activeOrganization, activeOrganizationId } = useActiveOrganization();
   const host = useProductHost();
   const navigate = useNavigate();
@@ -44,6 +48,7 @@ export function AddRepoFlowHost() {
   const files = host.desktop?.files ?? null;
   const showToast = useToastStore((state) => state.show);
   const [flowError, setFlowError] = useState<string | null>(null);
+  const [cloningRepoId, setCloningRepoId] = useState<string | null>(null);
 
   // PR2-GATING-01: the cloud path routes through the SAME ordered readiness
   // resolver every other cloud-repo surface uses, so a deployment with operator
@@ -99,9 +104,10 @@ export function AddRepoFlowHost() {
     navigate,
   ]);
 
-  // Host-truthful options: only Desktop can register an existing local folder.
+  // Host-truthful options: only Desktop can register an existing local folder
+  // or clone locally; Web offers only the managed-Cloud setup.
   const options = useMemo<AddRepoFlowOption[]>(
-    () => (files ? ["add-existing-folder", "cloud"] : ["cloud"]),
+    () => (files ? ["add-existing-folder", "clone-from-github", "cloud"] : ["cloud"]),
     [files],
   );
 
@@ -144,10 +150,87 @@ export function AddRepoFlowHost() {
     },
   });
 
+  // Clone reuses the accessible-repos catalog + GitHub-App gating from the cloud
+  // picker, but on select it clones locally (PR 3) instead of saving a
+  // managed-Cloud environment. Clone needs only GitHub repository access, so it
+  // is available whenever the picker's own GitHub-App prerequisites are met.
+  const clonePickerBase = useAddCloudEnvironment({
+    enabled: open && step.kind === "clone",
+    organizationId: activeOrganizationId,
+    canManageGitHubAppInstallation: isSettingsAdminRole(
+      activeOrganization?.membership?.role,
+    ),
+    userAuthorizationReturnTo: host.links.buildReturnUrl({
+      kind: "settings",
+      section: "environments",
+      source: "github_app_callback",
+    }),
+    // Host-truthful installation return (PR2-WEB-03): derive from the host via
+    // buildReturnUrl instead of a hard-coded `proliferate://` deep link, matching
+    // the cloud picker above.
+    installationReturnTo: host.links.buildReturnUrl({
+      kind: "settings",
+      section: "environments",
+      query: [["source", "github_app_installation_callback"]],
+    }),
+    onOpenExternalUrl: host.links.openExternal,
+    // The clone path never adds a Cloud environment; select is overridden below.
+    onEnvironmentAdded: () => {},
+  });
+
+  const clonePicker = useMemo<CloudRepoPickerProps>(() => ({
+    ...clonePickerBase,
+    addingRepoId: cloningRepoId,
+    onAddRepository: (repo) => {
+      const identity = parseGitRepoId(repo.id);
+      if (!identity) {
+        setFlowError("That repository id is not a supported GitHub owner/name.");
+        return;
+      }
+      void (async () => {
+        setFlowError(null);
+        setCloningRepoId(repo.id);
+        // Stable operation id so a retry reuses the repo-root materialization.
+        const operationId = `clone:${identity.gitOwner}/${identity.gitRepoName}`;
+        const result = await cloneRepo(
+          {
+            gitProvider: "github",
+            gitOwner: identity.gitOwner,
+            gitRepoName: identity.gitRepoName,
+          },
+          operationId,
+        );
+        setCloningRepoId(null);
+        if (result.succeeded) {
+          const onCompleted = useAddRepoFlowStore.getState().onCompleted;
+          closeFlow();
+          showToast(`Cloned ${repo.fullName}`, "info");
+          onCompleted?.({ kind: "local", sourceRoot: result.sourceRoot });
+          return;
+        }
+        if (!result.cancelled) {
+          setFlowError(result.error);
+        }
+      })();
+    },
+  }), [
+    activeOrganizationId,
+    activeOrganization?.membership?.role,
+    clonePickerBase,
+    cloneRepo,
+    cloningRepoId,
+    closeFlow,
+    showToast,
+  ]);
+
   const handlePickOption = useCallback((option: AddRepoFlowOption) => {
     setFlowError(null);
     if (option === "cloud") {
       setStep({ kind: "cloud" });
+      return;
+    }
+    if (option === "clone-from-github") {
+      setStep({ kind: "clone" });
       return;
     }
     // "add-existing-folder": the native folder picker IS the intent signal, so
@@ -183,9 +266,9 @@ export function AddRepoFlowHost() {
   }, [setStep]);
 
   const handleClose = useCallback(() => {
-    // Ignore Escape/overlay-click while a local add is committing so the
-    // dialog cannot vanish mid-add.
-    if (isAddingRepo) {
+    // Ignore Escape/overlay-click while a local add or clone is committing so
+    // the dialog cannot vanish mid-operation.
+    if (isAddingRepo || isCloning) {
       return;
     }
     setFlowError(null);
@@ -205,9 +288,10 @@ export function AddRepoFlowHost() {
       open={open}
       step={step}
       options={options}
-      adding={isAddingRepo}
+      adding={isAddingRepo || isCloning}
       error={step.kind === "cloud" ? null : flowError}
       cloudPicker={resolvedCloudPicker}
+      clonePicker={step.kind === "clone" ? clonePicker : null}
       onPickOption={handlePickOption}
       onBack={handleBack}
       onClose={handleClose}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
@@ -187,29 +187,33 @@ export function AddRepoFlowHost() {
     onEnvironmentAdded: () => {},
   });
 
+  const beginCloneForRepoId = useCallback((repoId: string) => {
+    const identity = parseGitRepoId(repoId);
+    if (!identity) {
+      setFlowError("That repository id is not a supported GitHub owner/name.");
+      return;
+    }
+    setFlowError(null);
+    handoffToCloud();
+    beginCloudIntent({
+      kind: "clone_from_github",
+      repo: {
+        gitProvider: "github",
+        gitOwner: identity.gitOwner,
+        gitRepoName: identity.gitRepoName,
+      },
+    });
+  }, [beginCloudIntent, handoffToCloud]);
+
   const clonePicker = useMemo<CloudRepoPickerProps>(() => ({
     ...clonePickerBase,
-    onAddRepository: (repo) => {
-      const identity = parseGitRepoId(repo.id);
-      if (!identity) {
-        setFlowError("That repository id is not a supported GitHub owner/name.");
-        return;
-      }
-      setFlowError(null);
-      handoffToCloud();
-      beginCloudIntent({
-        kind: "clone_from_github",
-        repo: {
-          gitProvider: "github",
-          gitOwner: identity.gitOwner,
-          gitRepoName: identity.gitRepoName,
-        },
-      });
-    },
+    onAddRepository: (repo) => beginCloneForRepoId(repo.id),
+    // Manual owner/repo entry is the same clone intent as catalog selection;
+    // never inherit useAddCloudEnvironment's managed-Cloud save callback.
+    onAddManual: () => beginCloneForRepoId(clonePickerBase.manualValue),
   }), [
-    beginCloudIntent,
+    beginCloneForRepoId,
     clonePickerBase,
-    handoffToCloud,
   ]);
 
   const handlePickOption = useCallback((option: AddRepoFlowOption) => {

--- a/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/AddRepoFlowHost.tsx
@@ -3,7 +3,10 @@ import { useNavigate } from "react-router-dom";
 import type { CloudRepoPickerProps } from "@proliferate/product-ui/repos/CloudRepoPicker";
 import { parseGitRepoId } from "@proliferate/product-domain/repos/repo-id";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
-import { resolveRepositoryReadiness } from "@proliferate/product-domain/repos/repo-readiness";
+import {
+  resolveRepositoryReadiness,
+  type RepositoryCapabilityRequirement,
+} from "@proliferate/product-domain/repos/repo-readiness";
 import type { CloudRepoPickerBlockerView } from "@proliferate/product-ui/repos/CloudRepoPicker";
 import {
   AddRepoFlow,
@@ -13,7 +16,6 @@ import {
   useAddCloudEnvironment,
 } from "@proliferate/product-surfaces/settings/cloud-environments/use-add-cloud-environment";
 import { useAddRepo } from "#product/hooks/workspaces/workflows/use-add-repo";
-import { useCloneRepo } from "#product/hooks/workspaces/workflows/use-clone-repo";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
 import { isSettingsAdminRole } from "#product/lib/domain/settings/admin-roles";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
@@ -39,7 +41,6 @@ export function AddRepoFlowHost() {
   const beginCloudIntent = useCloudRepositoryIntentStore((state) => state.begin);
 
   const { addRepoFromPath, isAddingRepo } = useAddRepo();
-  const { cloneRepo, isCloning } = useCloneRepo();
   const { activeOrganization, activeOrganizationId } = useActiveOrganization();
   const host = useProductHost();
   const navigate = useNavigate();
@@ -48,7 +49,6 @@ export function AddRepoFlowHost() {
   const files = host.desktop?.files ?? null;
   const showToast = useToastStore((state) => state.show);
   const [flowError, setFlowError] = useState<string | null>(null);
-  const [cloningRepoId, setCloningRepoId] = useState<string | null>(null);
 
   // PR2-GATING-01: the cloud path routes through the SAME ordered readiness
   // resolver every other cloud-repo surface uses, so a deployment with operator
@@ -58,42 +58,51 @@ export function AddRepoFlowHost() {
   // precede repo selection; once past them the per-repo picker (its authority
   // query) owns gates 3+, so we resolve with the later gates satisfied and
   // surface a blocker only when the resolver stops at gate 1 or 2.
-  const preflightBlocker = useMemo<CloudRepoPickerBlockerView | null>(() => {
-    const readiness = resolveRepositoryReadiness({
-      requirement: "managed_cloud",
-      githubRepositoryAccess: capabilities.githubRepositoryAccessStatus,
-      managedCloud: capabilities.managedCloudStatus,
-      signedIn: authStatus === "authenticated",
-      hasSupportedRepoIdentity: true,
-      authorityLoading: false,
-      authorityError: false,
-      authority: { authorized: true, status: "ready" },
-      canManageInstallation: false,
-      cloudEnvironmentConfigured: true,
-    });
-    if (readiness.gate !== 1 && readiness.gate !== 2) {
-      return null;
-    }
-    return describeReadinessBlocker({
-      readiness,
-      repo: null,
-      githubAccessDisplayName: capabilities.githubRepositoryAccessDisplayName,
-      orgName: activeOrganization?.name ?? null,
-      installUrl: "https://github.com/settings/installations",
-      userAuthorization: { authorize: () => {}, authorizing: false, error: null },
-      installation: {
-        install: () => {},
-        openInstallationSettings: () => {},
-        installing: false,
-        error: null,
-      },
-      onCopyAdminRequest: () => {},
-      onRetryAuthority: () => {},
-      onSignIn: () => {
-        closeFlow();
-        navigate("/login");
-      },
-    });
+  const preflightBlockers = useMemo<Record<"cloud" | "clone", CloudRepoPickerBlockerView | null>>(() => {
+    const resolve = (
+      requirement: RepositoryCapabilityRequirement,
+    ): CloudRepoPickerBlockerView | null => {
+      const readiness = resolveRepositoryReadiness({
+        requirement,
+        githubRepositoryAccess: capabilities.githubRepositoryAccessStatus,
+        managedCloud: capabilities.managedCloudStatus,
+        signedIn: authStatus === "authenticated",
+        hasSupportedRepoIdentity: true,
+        authorityLoading: false,
+        authorityError: false,
+        authority: { authorized: true, status: "ready" },
+        canManageInstallation: false,
+        cloudEnvironmentConfigured: true,
+      });
+      if (readiness.gate !== 1 && readiness.gate !== 2) {
+        return null;
+      }
+      return describeReadinessBlocker({
+        readiness,
+        requirement,
+        repo: null,
+        githubAccessDisplayName: capabilities.githubRepositoryAccessDisplayName,
+        orgName: activeOrganization?.name ?? null,
+        installUrl: "https://github.com/settings/installations",
+        userAuthorization: { authorize: () => {}, authorizing: false, error: null },
+        installation: {
+          install: () => {},
+          openInstallationSettings: () => {},
+          installing: false,
+          error: null,
+        },
+        onCopyAdminRequest: () => {},
+        onRetryAuthority: () => {},
+        onSignIn: () => {
+          closeFlow();
+          navigate("/login");
+        },
+      });
+    };
+    return {
+      cloud: resolve("managed_cloud"),
+      clone: resolve("github_repository_access"),
+    };
   }, [
     activeOrganization?.name,
     authStatus,
@@ -180,47 +189,27 @@ export function AddRepoFlowHost() {
 
   const clonePicker = useMemo<CloudRepoPickerProps>(() => ({
     ...clonePickerBase,
-    addingRepoId: cloningRepoId,
     onAddRepository: (repo) => {
       const identity = parseGitRepoId(repo.id);
       if (!identity) {
         setFlowError("That repository id is not a supported GitHub owner/name.");
         return;
       }
-      void (async () => {
-        setFlowError(null);
-        setCloningRepoId(repo.id);
-        // Stable operation id so a retry reuses the repo-root materialization.
-        const operationId = `clone:${identity.gitOwner}/${identity.gitRepoName}`;
-        const result = await cloneRepo(
-          {
-            gitProvider: "github",
-            gitOwner: identity.gitOwner,
-            gitRepoName: identity.gitRepoName,
-          },
-          operationId,
-        );
-        setCloningRepoId(null);
-        if (result.succeeded) {
-          const onCompleted = useAddRepoFlowStore.getState().onCompleted;
-          closeFlow();
-          showToast(`Cloned ${repo.fullName}`, "info");
-          onCompleted?.({ kind: "local", sourceRoot: result.sourceRoot });
-          return;
-        }
-        if (!result.cancelled) {
-          setFlowError(result.error);
-        }
-      })();
+      setFlowError(null);
+      handoffToCloud();
+      beginCloudIntent({
+        kind: "clone_from_github",
+        repo: {
+          gitProvider: "github",
+          gitOwner: identity.gitOwner,
+          gitRepoName: identity.gitRepoName,
+        },
+      });
     },
   }), [
-    activeOrganizationId,
-    activeOrganization?.membership?.role,
+    beginCloudIntent,
     clonePickerBase,
-    cloneRepo,
-    cloningRepoId,
-    closeFlow,
-    showToast,
+    handoffToCloud,
   ]);
 
   const handlePickOption = useCallback((option: AddRepoFlowOption) => {
@@ -266,9 +255,8 @@ export function AddRepoFlowHost() {
   }, [setStep]);
 
   const handleClose = useCallback(() => {
-    // Ignore Escape/overlay-click while a local add or clone is committing so
-    // the dialog cannot vanish mid-operation.
-    if (isAddingRepo || isCloning) {
+    // Ignore Escape/overlay-click while a local add is committing.
+    if (isAddingRepo) {
       return;
     }
     setFlowError(null);
@@ -280,7 +268,14 @@ export function AddRepoFlowHost() {
   // user never sees a user-auth CTA when the operator must configure the
   // deployment (PR2-GATING-01).
   const resolvedCloudPicker = step.kind === "cloud"
-    ? (preflightBlocker ? { ...cloudPicker, blocker: preflightBlocker } : cloudPicker)
+    ? (preflightBlockers.cloud
+      ? { ...cloudPicker, blocker: preflightBlockers.cloud }
+      : cloudPicker)
+    : null;
+  const resolvedClonePicker = step.kind === "clone"
+    ? (preflightBlockers.clone
+      ? { ...clonePicker, blocker: preflightBlockers.clone }
+      : clonePicker)
     : null;
 
   return (
@@ -288,10 +283,10 @@ export function AddRepoFlowHost() {
       open={open}
       step={step}
       options={options}
-      adding={isAddingRepo || isCloning}
+      adding={isAddingRepo}
       error={step.kind === "cloud" ? null : flowError}
       cloudPicker={resolvedCloudPicker}
-      clonePicker={step.kind === "clone" ? clonePicker : null}
+      clonePicker={resolvedClonePicker}
       onPickOption={handlePickOption}
       onBack={handleBack}
       onClose={handleClose}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.test.tsx
@@ -149,6 +149,15 @@ vi.mock("#product/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
   }),
 }));
 
+// The clone path is exercised elsewhere; here we only need the host to mount, so
+// stub the clone hook (which otherwise pulls in the AnyHarnessRuntime provider).
+vi.mock("#product/hooks/workspaces/workflows/use-clone-repo", () => ({
+  useCloneRepo: () => ({
+    cloneRepo: vi.fn(() => Promise.resolve({ succeeded: true, sourceRoot: "/tmp/clone" })),
+    isCloning: false,
+  }),
+}));
+
 vi.mock("#product/lib/domain/settings/github-app-copy", () => ({
   buildCloudAdminRequestMessage: () => "request",
 }));

--- a/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx
@@ -46,9 +46,13 @@ import { useGitHubAppUserAuthorization } from "#product/hooks/settings/workflows
 import { useGitHubAppInstallation } from "#product/hooks/settings/workflows/use-github-app-installation";
 import { useCreateCloudWorkspace } from "#product/hooks/cloud/workflows/use-create-cloud-workspace";
 import { buildCloudAdminRequestMessage } from "#product/lib/domain/settings/github-app-copy";
-import { formatGitRepoId } from "@proliferate/product-domain/repos/repo-id";
+import {
+  useCloneRepo,
+  type CloneRepoAttempt,
+} from "#product/hooks/workspaces/workflows/use-clone-repo";
 import { useAddRepoFlowStore } from "#product/stores/ui/add-repo-flow-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
+import { formatGitRepoId } from "@proliferate/product-domain/repos/repo-id";
 
 const USER_AUTHORIZATION_RETURN_TO_SOURCE = "github_app_callback";
 
@@ -67,6 +71,7 @@ export function CloudRepoActionDialogHost() {
   const clearIntent = useCloudRepositoryIntentStore((state) => state.clear);
   const closeAddRepoFlow = useAddRepoFlowStore((state) => state.close);
   const showToast = useToastStore((state) => state.show);
+  const { cloneRepo } = useCloneRepo();
   const repo = intent ? repoForCloudRepositoryIntent(intent) : null;
   // Clone depends only on GitHub repository access; managed-Cloud intents depend
   // on managed Cloud. Gating by the intent's own requirement lets an
@@ -87,12 +92,15 @@ export function CloudRepoActionDialogHost() {
 
   // Live readiness inputs.
   const repoConfigs = useRepositories(open && signedIn);
-  const managedCloudOperatorReady =
-    capabilities.githubRepositoryAccessStatus === "ready"
-    && capabilities.managedCloudStatus === "ready";
+  const requiredOperatorReady = requirement === "github_repository_access"
+    ? capabilities.githubRepositoryAccessStatus === "ready"
+    : capabilities.githubRepositoryAccessStatus === "ready"
+      && capabilities.managedCloudStatus === "ready";
   const authority = useGitHubRepoAuthority(
     { gitOwner: repo?.gitOwner, gitRepoName: repo?.gitRepoName },
-    open && signedIn && managedCloudOperatorReady && repo !== null,
+    // Never issue a user/authority query while the required operator-owned
+    // capability is disabled or only partially configured.
+    open && signedIn && repo !== null && requiredOperatorReady,
   );
 
   const configuredCloudKeys = useMemo(
@@ -136,6 +144,10 @@ export function CloudRepoActionDialogHost() {
   const saveEnvironment = useSaveRepoEnvironment();
   const validateBranches = useValidateCloudRepoBranches();
   const { createCloudWorkspaceAndEnter } = useCreateCloudWorkspace();
+  const cloneAttemptRef = useRef<{
+    intent: CloudRepositoryIntent;
+    attempt: CloneRepoAttempt;
+  } | null>(null);
 
   const readiness: RepositoryReadiness | null = useMemo(() => {
     if (!intent) return null;
@@ -200,6 +212,34 @@ export function CloudRepoActionDialogHost() {
     onCompleted?.({ kind: "cloud", repoId });
   }, [closeAddRepoFlow, showToast]);
 
+  const cloneFromGitHub = useCallback(async (target: CloudRepoIdentity) => {
+    if (!intent || intent.kind !== "clone_from_github") {
+      throw new Error("The clone request is no longer active.");
+    }
+    const retryAttempt = cloneAttemptRef.current?.intent === intent
+      ? cloneAttemptRef.current.attempt
+      : undefined;
+    const result = await cloneRepo(target, retryAttempt);
+    if (!result.succeeded) {
+      if (result.cancelled) {
+        // The native picker was cancelled. This is a terminal user cancellation,
+        // not an error state requiring a Retry blocker.
+        closeAddRepoFlow();
+        return;
+      }
+      if (result.attempt) {
+        cloneAttemptRef.current = { intent, attempt: result.attempt };
+      }
+      throw new Error(result.error);
+    }
+
+    cloneAttemptRef.current = null;
+    const onCompleted = useAddRepoFlowStore.getState().onCompleted;
+    closeAddRepoFlow();
+    showToast(`Cloned ${formatGitRepoId(target)}`, "info");
+    onCompleted?.({ kind: "local", sourceRoot: result.sourceRoot });
+  }, [cloneRepo, closeAddRepoFlow, intent, showToast]);
+
   // Once every access gate is green, continue the held intent (save env →
   // create). Gate 9 (`set_up_cloud`) is the normal continue point: the resolver
   // has cleared authority and only the Cloud environment save remains, which is
@@ -219,12 +259,14 @@ export function CloudRepoActionDialogHost() {
     saveCloudEnvironment,
     createCloudWorkspace,
     completeRepositoryRegistration,
+    cloneFromGitHub,
   });
   continuationInputsRef.current = {
     cloudEnvironmentConfigured,
     saveCloudEnvironment,
     createCloudWorkspace,
     completeRepositoryRegistration,
+    cloneFromGitHub,
   };
 
   // The intent instance the continuation has already been started for. Because
@@ -244,6 +286,7 @@ export function CloudRepoActionDialogHost() {
     if (!intent) {
       startedForRef.current = null;
       environmentSavedForRef.current = null;
+      cloneAttemptRef.current = null;
       setContinuationError(null);
     }
   }, [intent]);
@@ -263,8 +306,8 @@ export function CloudRepoActionDialogHost() {
       saveCloudEnvironment,
       createCloudWorkspace,
       completeRepositoryRegistration,
-    } =
-      continuationInputsRef.current;
+      cloneFromGitHub,
+    } = continuationInputsRef.current;
     void continueCloudRepositoryIntent({
       intent,
       cloudEnvironmentConfigured:
@@ -275,6 +318,7 @@ export function CloudRepoActionDialogHost() {
       },
       createCloudWorkspace,
       onRepositoryRegistered: completeRepositoryRegistration,
+      cloneFromGitHub,
     })
       .then(() => {
         // Terminal success: clear the intent unconditionally. Nothing should
@@ -302,6 +346,7 @@ export function CloudRepoActionDialogHost() {
 
   const readinessBlocker = describeReadinessBlocker({
     readiness,
+    requirement,
     repo,
     githubAccessDisplayName: capabilities.githubRepositoryAccessDisplayName,
     orgName: activeOrganization?.name ?? null,
@@ -324,7 +369,7 @@ export function CloudRepoActionDialogHost() {
       // A held intent cannot survive a route away, so clear it and send the
       // user to the product sign-in flow (PR2-SIGNIN-04). The settings surfaces
       // are the recovery path after sign-in.
-      if (intent.kind === "add_cloud_repository") {
+      if (intent.kind === "add_cloud_repository" || intent.kind === "clone_from_github") {
         closeAddRepoFlow();
       }
       clearIntent();
@@ -337,7 +382,9 @@ export function CloudRepoActionDialogHost() {
   // null. Earlier completed steps are preserved (spec §Failure).
   const continuationBlocker: CloudRepoPickerBlockerView | null = continuationError
     ? {
-        title: "Couldn't finish Cloud setup",
+        title: intent.kind === "clone_from_github"
+          ? "Couldn't clone repository"
+          : "Couldn't finish Cloud setup",
         description: continuationError,
         actionLabel: "Retry",
         onAction: () => setRetryNonce((nonce) => nonce + 1),
@@ -347,11 +394,12 @@ export function CloudRepoActionDialogHost() {
   const blocker = readinessBlocker ?? continuationBlocker;
 
   const closeDialog = () => {
-    if (intent.kind === "add_cloud_repository") {
+    if (intent.kind === "add_cloud_repository" || intent.kind === "clone_from_github") {
       closeAddRepoFlow();
     }
     clearIntent();
   };
+  const cloning = intent.kind === "clone_from_github";
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) closeDialog(); }}>
@@ -362,7 +410,7 @@ export function CloudRepoActionDialogHost() {
       >
         <DialogHeader>
           <DialogTitle className="text-[15px] font-semibold leading-5">
-            Set up in Cloud
+            {cloning ? "Clone from GitHub" : "Set up in Cloud"}
           </DialogTitle>
         </DialogHeader>
         <div className="mt-3">
@@ -370,7 +418,9 @@ export function CloudRepoActionDialogHost() {
             <CloudRepoPickerBlocker blocker={blocker} />
           ) : (
             <p className="text-ui-sm leading-[1.45] text-muted-foreground" role="status">
-              Preparing this repository for Proliferate Cloud…
+              {cloning
+                ? "Preparing this repository on this Mac…"
+                : "Preparing this repository for Proliferate Cloud…"}
             </p>
           )}
         </div>

--- a/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx
@@ -31,6 +31,7 @@ import { useCloudRepositoryIntentStore } from "#product/stores/cloud/cloud-repos
 import {
   continueCloudRepositoryIntent,
   repoForCloudRepositoryIntent,
+  requirementForCloudRepositoryIntent,
   type CloudRepoIdentity,
   type CloudRepositoryIntent,
   type CreateCloudWorkspaceContinuation,
@@ -67,6 +68,10 @@ export function CloudRepoActionDialogHost() {
   const closeAddRepoFlow = useAddRepoFlowStore((state) => state.close);
   const showToast = useToastStore((state) => state.show);
   const repo = intent ? repoForCloudRepositoryIntent(intent) : null;
+  // Clone depends only on GitHub repository access; managed-Cloud intents depend
+  // on managed Cloud. Gating by the intent's own requirement lets an
+  // App-ready/E2B-disabled deployment clone without a managed-Cloud gate.
+  const requirement = intent ? requirementForCloudRepositoryIntent(intent) : "managed_cloud";
 
   const client = useCloudClient();
   const queryClient = useQueryClient();
@@ -135,7 +140,7 @@ export function CloudRepoActionDialogHost() {
   const readiness: RepositoryReadiness | null = useMemo(() => {
     if (!intent) return null;
     return resolveRepositoryReadiness({
-      requirement: "managed_cloud",
+      requirement,
       githubRepositoryAccess: capabilities.githubRepositoryAccessStatus,
       managedCloud: capabilities.managedCloudStatus,
       signedIn,

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
@@ -17,6 +17,7 @@ import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use
 import { useWorkspaceAvailabilityActions } from "#product/hooks/workspaces/workflows/use-workspace-availability-actions";
 import {
   collectLinkCandidates,
+  linkedCloudWorkspaceByAnyharnessId,
   type LinkCandidate,
 } from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
 import { useWorkspaceAvailabilityIntentStore } from "#product/stores/cloud/workspace-availability-intent-store";
@@ -46,6 +47,14 @@ export function WorkspaceAvailabilityActionHost() {
   // The chosen link candidate, once the user has picked one (or when there is
   // exactly one plausible candidate). Null means "not yet chosen".
   const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
+  const linkedCloudWorkspaceByLocalId = useMemo(
+    () => linkedCloudWorkspaceByAnyharnessId(
+      logicalWorkspaces.flatMap((workspace) => (
+        workspace.cloudWorkspace ? [workspace.cloudWorkspace] : []
+      )),
+    ),
+    [logicalWorkspaces],
+  );
 
   // Resolve an existing local repo root that already hosts the Cloud repo, so
   // Open-on-Mac reuses a clone instead of prompting for a fresh one.
@@ -66,19 +75,14 @@ export function WorkspaceAvailabilityActionHost() {
     if (!intent || intent.kind !== "link_copies" || !cloudWorkspace?.repo) {
       return [];
     }
-    const alreadyLinked = new Set(
-      (cloudWorkspace.materializations ?? [])
-        .filter((m) => m.targetKind === "local_desktop" && m.anyharnessWorkspaceId)
-        .map((m) => m.anyharnessWorkspaceId!),
-    );
     return collectLinkCandidates({
       localWorkspaces,
       repoRoots,
       cloudRepo: cloudWorkspace.repo,
       cloudBranch: cloudWorkspace.repo.branch,
-      alreadyLinkedAnyharnessIds: alreadyLinked,
+      alreadyLinkedAnyharnessIds: new Set(linkedCloudWorkspaceByLocalId.keys()),
     });
-  }, [cloudWorkspace, intent, localWorkspaces, repoRoots]);
+  }, [cloudWorkspace, intent, linkedCloudWorkspaceByLocalId, localWorkspaces, repoRoots]);
 
   const existingRepoRootId = useMemo(() => {
     const repo = cloudWorkspace?.repo;
@@ -135,10 +139,6 @@ export function WorkspaceAvailabilityActionHost() {
     const managed = (cloudWorkspace.materializations ?? []).find(
       (m) => m.targetKind === "managed_cloud",
     );
-    const alreadyLinkedRow = (cloudWorkspace.materializations ?? []).find(
-      (m) => m.targetKind === "local_desktop"
-        && m.anyharnessWorkspaceId === candidate.anyharnessWorkspaceId,
-    );
     setBusy(true);
     const ok = await linkCopies({
       candidate,
@@ -152,13 +152,14 @@ export function WorkspaceAvailabilityActionHost() {
         // (observed head), which the server also independently re-verifies.
         headSha: managed?.observedHeadSha ?? managed?.expectedHeadSha ?? null,
       },
-      alreadyLinkedCloudWorkspaceId: alreadyLinkedRow ? cloudWorkspace.id : null,
+      alreadyLinkedCloudWorkspaceId:
+        linkedCloudWorkspaceByLocalId.get(candidate.anyharnessWorkspaceId) ?? null,
     });
     setBusy(false);
     if (ok) {
       closeIntent();
     }
-  }, [closeIntent, cloudWorkspace, linkCopies]);
+  }, [closeIntent, cloudWorkspace, linkCopies, linkedCloudWorkspaceByLocalId]);
 
   if (!intent) {
     return null;

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
@@ -1,0 +1,344 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@proliferate/ui/kit/AlertDialog";
+import { RadioCardGroup } from "@proliferate/ui/primitives/RadioCardGroup";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { remoteRepoKey } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+import { useLogicalWorkspaces } from "#product/hooks/workspaces/derived/use-logical-workspaces";
+import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
+import { useWorkspaceAvailabilityActions } from "#product/hooks/workspaces/workflows/use-workspace-availability-actions";
+import {
+  collectLinkCandidates,
+  type LinkCandidate,
+} from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
+import { useWorkspaceAvailabilityIntentStore } from "#product/stores/cloud/workspace-availability-intent-store";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+const UNLINK_COPY =
+  "This removes the association on this Mac. It does not delete either checkout, "
+  + "repository, Cloud workspace, or chat history.";
+
+/**
+ * The one connected host that owns the active workspace-availability action
+ * (PR 5 Flows 2/3/5), mirroring CloudRepoActionDialogHost. It resolves the
+ * intent's target from the live projection, shows the required confirmation /
+ * progress, and drives useWorkspaceAvailabilityActions (all orchestration lives
+ * in product-client). A cold restart leaves the store empty (nothing resumes).
+ */
+export function WorkspaceAvailabilityActionHost() {
+  const intent = useWorkspaceAvailabilityIntentStore((state) => state.activeIntent);
+  const clearIntent = useWorkspaceAvailabilityIntentStore((state) => state.clear);
+  const host = useProductHost();
+  const files = host.desktop?.files ?? null;
+  const showToast = useToastStore((state) => state.show);
+  const { logicalWorkspaces } = useLogicalWorkspaces();
+  const { repoRoots, localWorkspaces } = useStandardRepoProjection();
+  const { openOnThisMac, linkCopies, addCloudCopy, unlinkThisMac } = useWorkspaceAvailabilityActions();
+  const [busy, setBusy] = useState(false);
+  // The chosen link candidate, once the user has picked one (or when there is
+  // exactly one plausible candidate). Null means "not yet chosen".
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
+
+  // Resolve an existing local repo root that already hosts the Cloud repo, so
+  // Open-on-Mac reuses a clone instead of prompting for a fresh one.
+  const cloudWorkspace = useMemo(() => {
+    if (!intent || !("cloudWorkspaceId" in intent)) {
+      return null;
+    }
+    const match = logicalWorkspaces.find(
+      (w) => w.cloudWorkspace?.id === intent.cloudWorkspaceId,
+    );
+    return match?.cloudWorkspace ?? null;
+  }, [intent, logicalWorkspaces]);
+
+  // Flow 4 candidates: the plausible same-repo/same-branch local workspaces the
+  // user could link this Cloud copy to. Exact linkability (clean, exact HEAD) is
+  // proven per-candidate at confirm time; this only narrows the choice set.
+  const linkCandidates = useMemo<LinkCandidate[]>(() => {
+    if (!intent || intent.kind !== "link_copies" || !cloudWorkspace?.repo) {
+      return [];
+    }
+    const alreadyLinked = new Set(
+      (cloudWorkspace.materializations ?? [])
+        .filter((m) => m.targetKind === "local_desktop" && m.anyharnessWorkspaceId)
+        .map((m) => m.anyharnessWorkspaceId!),
+    );
+    return collectLinkCandidates({
+      localWorkspaces,
+      repoRoots,
+      cloudRepo: cloudWorkspace.repo,
+      cloudBranch: cloudWorkspace.repo.branch,
+      alreadyLinkedAnyharnessIds: alreadyLinked,
+    });
+  }, [cloudWorkspace, intent, localWorkspaces, repoRoots]);
+
+  const existingRepoRootId = useMemo(() => {
+    const repo = cloudWorkspace?.repo;
+    if (!repo) {
+      return null;
+    }
+    const key = remoteRepoKey(repo.provider, repo.owner, repo.name);
+    const match = repoRoots.find(
+      (root) =>
+        root.remoteProvider
+        && root.remoteOwner
+        && root.remoteRepoName
+        && remoteRepoKey(root.remoteProvider, root.remoteOwner, root.remoteRepoName) === key,
+    );
+    return match?.id ?? null;
+  }, [cloudWorkspace, repoRoots]);
+
+  const runOpenOnMac = useCallback(async (cloudWorkspaceId: string, forceFreshWorktree: boolean) => {
+    let cloneDestinationPath: string | null = null;
+    if (!existingRepoRootId) {
+      if (!files) {
+        showToast("Cloning is only available in Desktop.");
+        return;
+      }
+      const parent = await files.pickDirectory();
+      if (!parent) {
+        return;
+      }
+      const repoName = cloudWorkspace?.repo?.name ?? "repository";
+      cloneDestinationPath = `${parent.replace(/\/+$/u, "")}/${repoName}`;
+    }
+    setBusy(true);
+    const ok = await openOnThisMac({
+      cloudWorkspaceId,
+      existingRepoRootId,
+      cloneDestinationPath,
+      forceFreshWorktree,
+    });
+    setBusy(false);
+    if (ok) {
+      clearIntent();
+    }
+  }, [cloudWorkspace, clearIntent, existingRepoRootId, files, openOnThisMac, showToast]);
+
+  const closeIntent = useCallback(() => {
+    setSelectedCandidateId(null);
+    clearIntent();
+  }, [clearIntent]);
+
+  const runLink = useCallback(async (candidate: LinkCandidate) => {
+    if (!cloudWorkspace) {
+      return;
+    }
+    const managed = (cloudWorkspace.materializations ?? []).find(
+      (m) => m.targetKind === "managed_cloud",
+    );
+    const alreadyLinkedRow = (cloudWorkspace.materializations ?? []).find(
+      (m) => m.targetKind === "local_desktop"
+        && m.anyharnessWorkspaceId === candidate.anyharnessWorkspaceId,
+    );
+    setBusy(true);
+    const ok = await linkCopies({
+      candidate,
+      cloudTarget: {
+        cloudWorkspaceId: cloudWorkspace.id,
+        provider: cloudWorkspace.repo?.provider ?? candidate.provider,
+        owner: cloudWorkspace.repo?.owner ?? candidate.owner,
+        repoName: cloudWorkspace.repo?.name ?? candidate.repoName,
+        branch: cloudWorkspace.repo?.branch ?? null,
+        // The Cloud copy's exact published HEAD from the managed materialization
+        // (observed head), which the server also independently re-verifies.
+        headSha: managed?.observedHeadSha ?? managed?.expectedHeadSha ?? null,
+      },
+      alreadyLinkedCloudWorkspaceId: alreadyLinkedRow ? cloudWorkspace.id : null,
+    });
+    setBusy(false);
+    if (ok) {
+      closeIntent();
+    }
+  }, [closeIntent, cloudWorkspace, linkCopies]);
+
+  if (!intent) {
+    return null;
+  }
+
+  if (intent.kind === "unlink") {
+    return (
+      <AlertDialog open onOpenChange={(open) => { if (!open && !busy) closeIntent(); }}>
+        <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unlink this Mac?</AlertDialogTitle>
+            <AlertDialogDescription>{UNLINK_COPY}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy} onClick={() => closeIntent()}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy}
+              onClick={(event) => {
+                event.preventDefault();
+                setBusy(true);
+                void unlinkThisMac({
+                  cloudWorkspaceId: intent.cloudWorkspaceId,
+                  materializationId: intent.materializationId,
+                }).then((ok) => {
+                  setBusy(false);
+                  if (ok) closeIntent();
+                });
+              }}
+            >
+              {busy ? "Unlinking…" : "Unlink this Mac"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  if (intent.kind === "link_copies") {
+    // Flow 4: association-only. Multiple plausible candidates require explicit
+    // selection; we NEVER auto-pick the first when >1 (PR5-LINK-02). Zero
+    // candidates is a truthful dead end, not a materialization.
+    const chosen = linkCandidates.length === 1
+      ? linkCandidates[0]!
+      : linkCandidates.find((c) => c.anyharnessWorkspaceId === selectedCandidateId) ?? null;
+    const description = linkCandidates.length === 0
+      ? "No local copy of this workspace on this Mac matches the Cloud copy's repository "
+        + "and branch, so there is nothing to link. Use “Open on this Mac” to create one."
+      : linkCandidates.length === 1
+        ? "This links your existing local copy to the Cloud workspace. It changes neither "
+          + "checkout — both must already be the exact same commit."
+        : "Choose which local copy to link. This links the copy you pick to the Cloud "
+          + "workspace and changes neither checkout.";
+    return (
+      <AlertDialog open onOpenChange={(open) => { if (!open && !busy) closeIntent(); }}>
+        <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Link copies</AlertDialogTitle>
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          {linkCandidates.length > 1 ? (
+            <RadioCardGroup
+              className="py-1"
+              orientation="vertical"
+              value={selectedCandidateId}
+              onChange={setSelectedCandidateId}
+              options={linkCandidates.map((candidate) => ({
+                value: candidate.anyharnessWorkspaceId,
+                label: candidate.displayName,
+                description: candidate.worktreePath,
+                disabled: busy,
+              }))}
+            />
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy} onClick={() => closeIntent()}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy || chosen === null}
+              onClick={(event) => {
+                event.preventDefault();
+                if (chosen) {
+                  void runLink(chosen);
+                }
+              }}
+            >
+              {busy ? "Linking…" : "Link copies"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  if (intent.kind === "open_on_mac" || intent.kind === "relink") {
+    const cloudWorkspaceId = intent.cloudWorkspaceId;
+    // Recreate (Flow 5) forces a fresh worktree; open/relink reuse or adopt a
+    // clean checkout at the ref (PR5-MODE-03).
+    const forceFreshWorktree = intent.kind === "relink" && intent.mode === "recreate";
+    const title = intent.kind === "open_on_mac"
+      ? "Open on this Mac"
+      : forceFreshWorktree
+        ? "Recreate on this Mac"
+        : "Relink existing copy";
+    const description = forceFreshWorktree
+      ? "This creates a fresh local checkout of the Cloud workspace's exact published "
+        + "commit on this Mac and links the two."
+      : existingRepoRootId
+        ? "This creates a local checkout of the Cloud workspace's exact published commit "
+          + "on this Mac and links the two."
+        : "This clones the repository to a folder you choose, checks out the exact published "
+          + "commit, and links it to the Cloud workspace.";
+    return (
+      <AlertDialog open onOpenChange={(open) => { if (!open && !busy) closeIntent(); }}>
+        <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={busy} onClick={() => closeIntent()}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={busy}
+              onClick={(event) => {
+                event.preventDefault();
+                void runOpenOnMac(cloudWorkspaceId, forceFreshWorktree);
+              }}
+            >
+              {busy
+                ? "Working…"
+                : forceFreshWorktree
+                  ? "Recreate on this Mac"
+                  : existingRepoRootId
+                    ? "Open on this Mac"
+                    : "Choose folder & clone"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  // add_cloud_copy
+  return (
+    <AlertDialog open onOpenChange={(open) => { if (!open && !busy) closeIntent(); }}>
+      <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Add Cloud copy</AlertDialogTitle>
+          <AlertDialogDescription>
+            This creates a managed-Cloud copy at this workspace's exact published commit.
+            The workspace must be clean and its branch published on GitHub.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy} onClick={() => closeIntent()}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={busy}
+            onClick={(event) => {
+              event.preventDefault();
+              setBusy(true);
+              void addCloudCopy({
+                localAnyharnessWorkspaceId: intent.localWorkspaceId,
+                gitOwner: intent.gitOwner,
+                gitRepoName: intent.gitRepoName,
+              }).then((ok) => {
+                setBusy(false);
+                if (ok) closeIntent();
+              });
+            }}
+          >
+            {busy ? "Adding…" : "Add Cloud copy"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -30,6 +30,10 @@ import { APP_ROUTES } from "#product/config/app-routes";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useSidebarRepoAvailabilityActions } from "#product/hooks/workspaces/workflows/use-sidebar-repo-availability-actions";
+import { useWorkspaceAvailabilityIntentStore } from "#product/stores/cloud/workspace-availability-intent-store";
+import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import { workspaceAvailabilityIntentForCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-intent-mapping";
+import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/sidebar/sidebar-model";
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
@@ -274,6 +278,25 @@ export const MainSidebar = memo(function MainSidebar() {
     handleAddToThisMac,
   } = useSidebarRepoAvailabilityActions();
 
+  const beginWorkspaceAvailabilityIntent = useWorkspaceAvailabilityIntentStore(
+    (state) => state.begin,
+  );
+  const handleWorkspaceAvailabilityCommand = useCallback((
+    item: SidebarWorkspaceItemState,
+    kind: WorkspaceAvailabilityCommandKind,
+  ) => {
+    const intent = workspaceAvailabilityIntentForCommand(kind, {
+      localWorkspaceId: item.localWorkspaceId,
+      cloudWorkspaceId: item.cloudWorkspaceIdForActions,
+      linkedMaterializationId: item.linkedMaterializationId,
+      repoOwner: item.repoOwner,
+      repoName: item.repoName,
+    });
+    if (intent) {
+      beginWorkspaceAvailabilityIntent(intent);
+    }
+  }, [beginWorkspaceAvailabilityIntent]);
+
   const cloudWorkspaceBlocked = billingPlan?.billingMode === "enforce" && billingPlan.startBlocked;
   // Truthful cause for a blocked cloud-workspace action: a signed-in user on a
   // compute-unconfigured deployment sees the operator explanation, not a "sign
@@ -365,6 +388,7 @@ export const MainSidebar = memo(function MainSidebar() {
               onIndicatorAction={actions.handleSidebarIndicatorAction}
               onOpenPullRequest={actions.handleOpenPullRequest}
               onMarkWorkspaceDone={actions.handleMarkWorkspaceDone}
+              onWorkspaceAvailabilityCommand={handleWorkspaceAvailabilityCommand}
               onWorkspaceHover={handleWorkspaceHover}
               shortcutRevealVisible={shortcutRevealVisible}
               shortcutLabelByWorkspaceId={sidebarShortcutLabelById}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -12,6 +12,8 @@ import {
 import { buildSidebarNewWorkspaceCommandScope } from "#product/lib/domain/workspaces/creation/new-workspace-command";
 import { visibleSidebarGroupItems } from "#product/lib/domain/workspaces/sidebar/sidebar-visible-items";
 import type { SidebarIndicatorAction } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/sidebar/sidebar-model";
 import { SkeletonBlock } from "#product/components/feedback/Skeleton";
 import { useWorkspaceCopyActions } from "#product/hooks/workspaces/workflows/use-workspace-copy-actions";
 import { RepoGroup, type RepoGroupEnvironmentKind } from "#product/components/workspace/shell/sidebar/RepoGroup";
@@ -42,6 +44,11 @@ interface SidebarWorkspaceContentProps {
   onIndicatorAction: (action: SidebarIndicatorAction) => void;
   onOpenPullRequest: (url: string) => void;
   onMarkWorkspaceDone: (workspaceId: string, logicalWorkspaceId: string) => void;
+  /** Begin a workspace-copy availability action (PR 5) for the given item. */
+  onWorkspaceAvailabilityCommand: (
+    item: SidebarWorkspaceItemState,
+    kind: WorkspaceAvailabilityCommandKind,
+  ) => void;
   onWorkspaceHover?: () => void;
   shortcutRevealVisible: boolean;
   shortcutLabelByWorkspaceId: ReadonlyMap<string, string>;
@@ -96,6 +103,7 @@ export function SidebarWorkspaceContent({
   onIndicatorAction,
   onOpenPullRequest,
   onMarkWorkspaceDone,
+  onWorkspaceAvailabilityCommand,
   onWorkspaceHover,
   shortcutRevealVisible,
   shortcutLabelByWorkspaceId,
@@ -267,6 +275,8 @@ export function SidebarWorkspaceContent({
                     ? () => onMarkWorkspaceDone(item.localWorkspaceId!, item.id)
                     : undefined
                 }
+                availabilityCommands={item.availabilityCommands}
+                onAvailabilityCommand={(kind) => onWorkspaceAvailabilityCommand(item, kind)}
                 onHover={onWorkspaceHover}
                 onArchive={item.archived ? undefined : () => onArchiveWorkspace(item.id)}
                 onUnarchive={item.archived ? () => onUnarchiveWorkspace(item.id) : undefined}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -23,6 +23,10 @@ import type {
   SidebarStatusIndicator,
   SidebarWorkspaceVariant,
 } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import {
   prStatusViewFromGitStatus,
   sidebarGitGlyphForStatus,
@@ -88,6 +92,10 @@ interface WorkspaceItemProps {
   onArchive?: () => void;
   onUnarchive?: () => void;
   onMarkDone?: () => void;
+  /** Workspace-copy availability commands (PR 5), rendered in both the DOM and
+   * native `…` menus. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
   onIndicatorAction?: (action: SidebarIndicatorAction) => void;
   onHover?: () => void;
   /**
@@ -120,6 +128,8 @@ export function WorkspaceItem({
   onArchive,
   onUnarchive,
   onMarkDone,
+  availabilityCommands = [],
+  onAvailabilityCommand,
   onIndicatorAction,
   onHover,
   workspaceLocationCopyLabel,
@@ -188,6 +198,8 @@ export function WorkspaceItem({
     onArchive: handleArchiveCommand,
     onUnarchive: handleUnarchiveCommand,
     onMarkDone: handleMarkDoneCommand,
+    availabilityCommands,
+    onAvailabilityCommand,
   });
   const hasMenuActions = hasArchiveAction
     || !!onRename
@@ -195,7 +207,8 @@ export function WorkspaceItem({
     || !!onCopyBranchName
     || !!onMarkDone
     || !!branchName
-    || !!handleOpenPullRequestCommand;
+    || !!handleOpenPullRequestCommand
+    || availabilityCommands.length > 0;
 
   const workspaceMenu = hasMenuActions ? (
     <WorkspaceItemMenu
@@ -213,6 +226,8 @@ export function WorkspaceItem({
       }
       onCopyBranchName={onCopyBranchName ? handleCopyBranchNameCommand : undefined}
       onMarkDone={onMarkDone ? handleMarkDoneCommand : undefined}
+      availabilityCommands={availabilityCommands}
+      onAvailabilityCommand={onAvailabilityCommand}
     />
   ) : null;
 
@@ -382,6 +397,22 @@ export function WorkspaceItem({
                   onClick={() => { close(); handleUnarchiveCommand(); }}
                 />
               )}
+              {availabilityCommands.map((command) => {
+                const isBlocker = command.kind === "unsupported-git-state";
+                return (
+                  <PopoverMenuItem
+                    key={command.kind}
+                    icon={<GitBranchIcon className="size-3.5 shrink-0 text-muted-foreground" />}
+                    label={command.blocker ? `${command.label} — ${command.blocker}` : command.label}
+                    variant="sidebar"
+                    disabled={isBlocker}
+                    onClick={() => {
+                      close();
+                      if (!isBlocker) onAvailabilityCommand?.(command.kind);
+                    }}
+                  />
+                );
+              })}
             </>
           )}
         </>

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
@@ -2,13 +2,20 @@ import { useCallback, useRef, useState } from "react";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import {
   Archive,
+  CloudIcon,
   Folder,
   GitBranchIcon,
   GitPullRequest,
+  Link2,
   MoreHorizontal,
   Pencil,
+  RotateCcw,
   Trash,
 } from "@proliferate/ui/icons";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,8 +42,24 @@ interface WorkspaceItemMenuProps {
   onCopyWorkspaceLocation?: () => void;
   onCopyBranchName?: () => void;
   onMarkDone?: () => void;
+  /** Workspace-copy availability commands (PR 5), resolved from the shared
+   * availability command model so this menu and the native menu match. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  /** Invoked with the command kind when an actionable availability command is
+   * selected. Blocker commands (unsupported Git state) render disabled. */
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
   onShowNativeMenu?: (position?: { x: number; y: number }) => Promise<boolean>;
 }
+
+const AVAILABILITY_COMMAND_ICON: Record<WorkspaceAvailabilityCommandKind, typeof CloudIcon> = {
+  "add-cloud-copy": CloudIcon,
+  "open-on-this-mac": Folder,
+  "link-copies": Link2,
+  "relink-existing": Link2,
+  "recreate-on-this-mac": RotateCcw,
+  "unlink-this-mac": Link2,
+  "unsupported-git-state": GitBranchIcon,
+};
 
 /**
  * Three-dot workspace menu (UX spec §2), built on the kit DropdownMenu with
@@ -56,6 +79,8 @@ export function WorkspaceItemMenu({
   onCopyWorkspaceLocation,
   onCopyBranchName,
   onMarkDone,
+  availabilityCommands = [],
+  onAvailabilityCommand,
   onShowNativeMenu,
 }: WorkspaceItemMenuProps) {
   const [fallbackOpen, setFallbackOpen] = useState(false);
@@ -119,6 +144,34 @@ export function WorkspaceItemMenu({
               {getShortcutDisplayLabel(SHORTCUTS.copyWorkspacePath)}
             </DropdownMenuShortcut>
           </DropdownMenuItem>
+        )}
+        {availabilityCommands.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            {availabilityCommands.map((command) => {
+              const Icon = AVAILABILITY_COMMAND_ICON[command.kind];
+              const isBlocker = command.kind === "unsupported-git-state";
+              return (
+                <DropdownMenuItem
+                  key={command.kind}
+                  disabled={isBlocker}
+                  onSelect={() => {
+                    if (!isBlocker) onAvailabilityCommand?.(command.kind);
+                  }}
+                >
+                  <Icon className="size-4 text-muted-foreground" />
+                  <span className="min-w-0">
+                    <span className="block">{command.label}</span>
+                    {command.blocker ? (
+                      <span className="block text-xs leading-[1.4] text-muted-foreground">
+                        {command.blocker}
+                      </span>
+                    ) : null}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </>
         )}
         {(branchName || onCopyBranchName || onOpenPullRequest) && (
           <>

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-desktop-install-id.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-desktop-install-id.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+
+/**
+ * This Mac's native desktop worker install id, or null when there is no native
+ * worker (Web, or a Desktop build without an enrolled worker).
+ *
+ * The worker install id is the durable, server-legible device identity — never
+ * a telemetry/anonymous fallback — so passing it to Cloud list/detail fetches
+ * lets the server select and un-redact THIS device's local materialization.
+ */
+export function useDesktopInstallId(): string | null {
+  const worker = useProductHost().desktop?.worker ?? null;
+  const [installId, setInstallId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!worker) {
+      setInstallId(null);
+      return;
+    }
+    let cancelled = false;
+    void worker
+      .getInstallId()
+      .then((id) => {
+        if (!cancelled) {
+          setInstallId(id?.trim() || null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setInstallId(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [worker]);
+
+  return installId;
+}

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-logical-workspaces.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-logical-workspaces.ts
@@ -3,11 +3,13 @@ import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logi
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { buildLogicalWorkspaces } from "#product/lib/domain/workspaces/cloud/logical-workspaces";
 import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
 
 const EMPTY_LOGICAL_WORKSPACES: LogicalWorkspace[] = [];
 
 export function useLogicalWorkspaces() {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const desktopInstallId = useDesktopInstallId();
   const { repoRoots, localWorkspaces, cloudWorkspaces, isLoading } = useStandardRepoProjection();
 
   const logicalWorkspaces = useMemo(() => {
@@ -20,8 +22,9 @@ export function useLogicalWorkspaces() {
       repoRoots,
       cloudWorkspaces,
       currentSelectionId: selectedWorkspaceId,
+      desktopInstallId,
     });
-  }, [cloudWorkspaces, localWorkspaces, repoRoots, selectedWorkspaceId]);
+  }, [cloudWorkspaces, desktopInstallId, localWorkspaces, repoRoots, selectedWorkspaceId]);
 
   return {
     logicalWorkspaces,

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-sidebar-state.ts
@@ -20,6 +20,7 @@ import {
   useDocumentFocusVisibilityNonce,
 } from "#product/hooks/ui/document/use-document-focus-visibility";
 import { useLogicalWorkspaces } from "#product/hooks/workspaces/derived/use-logical-workspaces";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
 import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
 import { useWorkspaceGitStatuses } from "#product/hooks/workspaces/derived/use-workspace-git-statuses";
 import { useWorkspaceMetadataSync } from "#product/hooks/workspaces/lifecycle/use-workspace-metadata-sync";
@@ -134,6 +135,7 @@ export function useWorkspaceSidebarState({
   const cleanupAttentionWorkspaces =
     workspaceCollections?.cleanupAttentionWorkspaces ?? EMPTY_WORKSPACES;
   const { repoRoots } = useStandardRepoProjection();
+  const desktopInstallId = useDesktopInstallId();
   const { data: gitStatus } = useWorkspaceMetadataSync();
   const { statusesByLogicalId: gitStatusesByLogicalId } = useWorkspaceGitStatuses();
   const computeTargets = useComputeTargetOptions();
@@ -207,10 +209,12 @@ export function useWorkspaceSidebarState({
       sessionLastViewedAt,
       targetAppearanceById: computeTargets.targetAppearanceById,
       suppressActiveNeedsReview: windowFocused,
+      desktopInstallId,
     })), [
     activeSessionTitle,
     archivedSet,
     computeTargets.targetAppearanceById,
+    desktopInstallId,
     gitStatus,
     gitStatusesByLogicalId,
     hiddenRepoRootSet,

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts
@@ -24,4 +24,55 @@ describe("buildWorkspaceActionsNativeMenuItems", () => {
     expect(onRename).toHaveBeenCalledOnce();
     expect(items.some((item) => "id" in item && /commit|push|pull-request/.test(item.id))).toBe(false);
   });
+
+  it("appends workspace-copy availability commands and dispatches by kind", () => {
+    const onAvailabilityCommand = vi.fn();
+    const items = buildWorkspaceActionsNativeMenuItems({
+      canRename: true,
+      canFork: false,
+      canDismiss: true,
+      onRename: vi.fn(),
+      onFork: vi.fn(),
+      onDismiss: vi.fn(),
+      availabilityCommands: [
+        { kind: "add-cloud-copy", label: "Add Cloud copy…" },
+      ],
+      onAvailabilityCommand,
+    });
+
+    const availability = items.find(
+      (item) => "id" in item && item.id === "availability-add-cloud-copy",
+    );
+    expect(availability).toBeDefined();
+    if (availability && "onSelect" in availability) availability.onSelect?.();
+    expect(onAvailabilityCommand).toHaveBeenCalledWith("add-cloud-copy");
+  });
+
+  it("renders an unsupported-git-state blocker as a disabled, non-dispatching item", () => {
+    const onAvailabilityCommand = vi.fn();
+    const items = buildWorkspaceActionsNativeMenuItems({
+      canRename: false,
+      canFork: false,
+      canDismiss: false,
+      onRename: vi.fn(),
+      onFork: vi.fn(),
+      onDismiss: vi.fn(),
+      availabilityCommands: [
+        {
+          kind: "unsupported-git-state",
+          label: "Unsupported Git state",
+          blocker: "The workspace has uncommitted changes.",
+        },
+      ],
+      onAvailabilityCommand,
+    });
+
+    const blocker = items.find(
+      (item) => "id" in item && item.id === "availability-unsupported-git-state",
+    );
+    expect(blocker).toBeDefined();
+    if (blocker && "enabled" in blocker) expect(blocker.enabled).toBe(false);
+    if (blocker && "onSelect" in blocker) blocker.onSelect?.();
+    expect(onAvailabilityCommand).not.toHaveBeenCalled();
+  });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts
@@ -2,6 +2,10 @@ import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useNativeMenu } from "#product/hooks/ui/native/use-native-context-menu";
 import type { NativeMenuItem } from "@proliferate/product-client/host/desktop-bridge";
 import { getShortcutNativeAccelerator } from "#product/lib/domain/shortcuts/native-accelerators";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export interface WorkspaceActionsNativeMenuInput {
   canRename: boolean;
@@ -10,6 +14,11 @@ export interface WorkspaceActionsNativeMenuInput {
   onRename: () => void;
   onFork: () => void;
   onDismiss: () => void;
+  /** Workspace-copy availability commands (PR 5), resolved from the shared
+   * availability command model — the same source the DOM menu renders, so the
+   * two menus stay in manual parity. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
 }
 
 export function useWorkspaceActionsNativeMenu(input: WorkspaceActionsNativeMenuInput) {
@@ -19,7 +28,7 @@ export function useWorkspaceActionsNativeMenu(input: WorkspaceActionsNativeMenuI
 export function buildWorkspaceActionsNativeMenuItems(
   input: WorkspaceActionsNativeMenuInput,
 ): NativeMenuItem[] {
-  return [
+  const items: NativeMenuItem[] = [
     {
       id: "rename-chat",
       label: "Rename chat",
@@ -41,4 +50,24 @@ export function buildWorkspaceActionsNativeMenuItems(
       onSelect: input.onDismiss,
     },
   ];
+
+  const availabilityCommands = input.availabilityCommands ?? [];
+  if (availabilityCommands.length > 0) {
+    items.push({ kind: "separator" });
+    for (const command of availabilityCommands) {
+      // An unsupported-git-state blocker is present but not actionable, mirroring
+      // the disabled DOM item.
+      const isBlocker = command.kind === "unsupported-git-state";
+      items.push({
+        id: `availability-${command.kind}`,
+        label: command.blocker ? `${command.label} — ${command.blocker}` : command.label,
+        enabled: !isBlocker,
+        onSelect: () => {
+          if (!isBlocker) input.onAvailabilityCommand?.(command.kind);
+        },
+      });
+    }
+  }
+
+  return items;
 }

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
@@ -115,4 +115,47 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       { id: "copy-branch-name", label: "Copy branch name" },
     ]);
   });
+
+  it("appends workspace-copy availability commands and dispatches by kind (right-click parity)", () => {
+    let dispatched: string | null = null;
+    const items = buildWorkspaceSidebarNativeContextMenuItems({
+      canRename: false,
+      canCopyWorkspaceLocation: false,
+      copyWorkspaceLocationLabel: "Copy workspace path",
+      canCopyBranchName: false,
+      branchName: null,
+      canOpenPullRequest: false,
+      pullRequestNumber: null,
+      archived: false,
+      canArchive: false,
+      canUnarchive: false,
+      canMarkDone: false,
+      onRename: () => {},
+      onCopyWorkspaceLocation: () => {},
+      onCopyBranchName: () => {},
+      onOpenPullRequest: () => {},
+      onArchive: () => {},
+      onUnarchive: () => {},
+      onMarkDone: () => {},
+      availabilityCommands: [
+        { kind: "unlink-this-mac", label: "Unlink this Mac…" },
+        {
+          kind: "unsupported-git-state",
+          label: "Unsupported Git state",
+          blocker: "This workspace has uncommitted changes.",
+        },
+      ],
+      onAvailabilityCommand: (kind) => { dispatched = kind; },
+    });
+
+    const unlink = items.find((i) => "id" in i && i.id === "availability-unlink-this-mac");
+    const blocker = items.find((i) => "id" in i && i.id === "availability-unsupported-git-state");
+    expect(unlink).toBeDefined();
+    expect(blocker).toBeDefined();
+    if (blocker && "enabled" in blocker) expect(blocker.enabled).toBe(false);
+    if (unlink && "onSelect" in unlink) unlink.onSelect?.();
+    expect(dispatched).toBe("unlink-this-mac");
+    if (blocker && "onSelect" in blocker) blocker.onSelect?.();
+    expect(dispatched).toBe("unlink-this-mac");
+  });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
@@ -2,6 +2,10 @@ import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useNativeContextMenu } from "#product/hooks/ui/native/use-native-context-menu";
 import type { NativeMenuItem } from "@proliferate/product-client/host/desktop-bridge";
 import { getShortcutNativeAccelerator } from "#product/lib/domain/shortcuts/native-accelerators";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export function useWorkspaceSidebarNativeContextMenu({
   canRename,
@@ -22,6 +26,8 @@ export function useWorkspaceSidebarNativeContextMenu({
   onArchive,
   onUnarchive,
   onMarkDone,
+  availabilityCommands,
+  onAvailabilityCommand,
 }: {
   canRename: boolean;
   canCopyWorkspaceLocation: boolean;
@@ -41,6 +47,8 @@ export function useWorkspaceSidebarNativeContextMenu({
   onArchive: () => void;
   onUnarchive: () => void;
   onMarkDone: () => void;
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
 }) {
   return useNativeContextMenu(() =>
     buildWorkspaceSidebarNativeContextMenuItems({
@@ -62,6 +70,8 @@ export function useWorkspaceSidebarNativeContextMenu({
       onArchive,
       onUnarchive,
       onMarkDone,
+      availabilityCommands,
+      onAvailabilityCommand,
     })
   );
 }
@@ -85,6 +95,8 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
   onArchive,
   onUnarchive,
   onMarkDone,
+  availabilityCommands,
+  onAvailabilityCommand,
 }: {
   canRename: boolean;
   canCopyWorkspaceLocation: boolean;
@@ -104,6 +116,8 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
   onArchive: () => void;
   onUnarchive: () => void;
   onMarkDone: () => void;
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
 }): NativeMenuItem[] {
   const items: NativeMenuItem[] = [];
   if (canRename) {
@@ -180,6 +194,24 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
       label: "Delete workspace...",
       onSelect: onMarkDone,
     });
+  }
+
+  const availability = availabilityCommands ?? [];
+  if (availability.length > 0) {
+    if (items.length > 0) {
+      items.push({ kind: "separator" });
+    }
+    for (const command of availability) {
+      const isBlocker = command.kind === "unsupported-git-state";
+      items.push({
+        id: `availability-${command.kind}`,
+        label: command.blocker ? `${command.label} — ${command.blocker}` : command.label,
+        enabled: !isBlocker,
+        onSelect: () => {
+          if (!isBlocker) onAvailabilityCommand?.(command.kind);
+        },
+      });
+    }
   }
 
   return items;

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-clone-repo.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-clone-repo.ts
@@ -42,9 +42,15 @@ function describeCloneFailure(error: unknown): string {
   return error instanceof Error ? error.message : "Failed to clone repository.";
 }
 
+export interface CloneRepoAttempt {
+  /** Unique to one chosen destination, and reused only when retrying it. */
+  operationId: string;
+  destinationPath: string;
+}
+
 export type CloneRepoResult =
   | { succeeded: true; sourceRoot: string }
-  | { succeeded: false; error: string; cancelled?: boolean };
+  | { succeeded: false; error: string; cancelled?: boolean; attempt?: CloneRepoAttempt };
 
 export function useCloneRepo() {
   const desktop = useProductHost().desktop ?? null;
@@ -91,27 +97,36 @@ export function useCloneRepo() {
     });
   }, [saveEnvironment, worker]);
 
-  /** Clone `repo` into a subfolder of the user-picked parent directory. The
-   * native folder picker chooses the parent; the clone lands in
-   * `<parent>/<repoName>`. `operationId` must be stable across retries. */
+  /** Clone `repo` into a subfolder of the user-picked parent directory.
+   *
+   * A fresh attempt receives a random operation id only AFTER its destination
+   * is known. A retry passes the returned attempt back verbatim. This keeps the
+   * id stable for one destination without incorrectly reusing it for every
+   * future clone of the same repository (PR5-CLONE-ID-02). */
   const cloneRepo = useCallback(async (
     repo: ExpectedRepoIdentity,
-    operationId: string,
+    retryAttempt?: CloneRepoAttempt,
   ): Promise<CloneRepoResult> => {
     if (!files) {
       return { succeeded: false, error: "Cloning is only available in Desktop." };
     }
-    const parent = await files.pickDirectory();
-    if (!parent) {
-      return { succeeded: false, error: "Clone cancelled.", cancelled: true };
+    let attempt = retryAttempt;
+    if (!attempt) {
+      const parent = await files.pickDirectory();
+      if (!parent) {
+        return { succeeded: false, error: "Clone cancelled.", cancelled: true };
+      }
+      attempt = {
+        operationId: `clone:${crypto.randomUUID()}`,
+        destinationPath: `${parent.replace(/\/+$/u, "")}/${repo.gitRepoName}`,
+      };
     }
-    const destinationPath = `${parent.replace(/\/+$/u, "")}/${repo.gitRepoName}`;
     setIsCloning(true);
     try {
       const repoRoot = await runCloneRepoWorkflow({
         repo,
-        destinationPath,
-        operationId,
+        destinationPath: attempt.destinationPath,
+        operationId: attempt.operationId,
         ensureRuntimeReady: () => ensureRuntimeReady(localRuntime),
         materializeRepoRoot: (input) => materializeRepoRoot(input),
         upsertRepoRootInWorkspaceCollections,
@@ -123,7 +138,7 @@ export function useCloneRepo() {
     } catch (error) {
       const message = describeCloneFailure(error);
       showToast(message);
-      return { succeeded: false, error: message };
+      return { succeeded: false, error: message, attempt };
     } finally {
       setIsCloning(false);
     }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-clone-repo.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-clone-repo.ts
@@ -1,0 +1,146 @@
+import { AnyHarnessError, type RepoRoot } from "@anyharness/sdk";
+import { useMaterializeRepoRootMutation } from "@anyharness/sdk-react";
+import { useSaveRepoEnvironment } from "@proliferate/cloud-sdk-react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { useCallback, useState } from "react";
+import {
+  AddRepoIdentityMismatchError,
+  type ExpectedRepoIdentity,
+} from "#product/lib/domain/workspaces/creation/add-repo-workflow";
+import { runCloneRepoWorkflow } from "#product/lib/domain/workspaces/creation/clone-repo-workflow";
+import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useWorkspaceCollectionsMutationCacheActions } from "#product/hooks/workspaces/cache/use-workspace-collections-mutation-cache";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useToastStore } from "#product/stores/toast/toast-store";
+import { ensureRuntimeReady } from "#product/hooks/workspaces/workflows/runtime-ready";
+
+/** Map a clone failure to a user-facing message, naming local Git auth and the
+ * PR 3 typed errors without leaking sandbox paths. */
+function describeCloneFailure(error: unknown): string {
+  if (error instanceof AddRepoIdentityMismatchError) {
+    return error.message;
+  }
+  if (error instanceof AnyHarnessError) {
+    switch (error.problem.code) {
+      case "REPOSITORY_AUTH_REQUIRED":
+        return "Cloning requires local Git credentials for this repository. "
+          + "Sign in to GitHub in your local Git setup and try again.";
+      case "REPOSITORY_REMOTE_MISMATCH":
+        return "The destination already contains a different repository.";
+      case "DESTINATION_NOT_EMPTY":
+        return "The chosen folder is not empty. Pick an empty destination folder.";
+      case "DESTINATION_OUTSIDE_ALLOWED_ROOT":
+        return "The chosen folder is outside an allowed location.";
+      case "DESTINATION_CONFLICT":
+        return "Another repository already occupies the chosen folder.";
+      case "REPO_ROOT_WORKTREE_UNSUPPORTED":
+        return "The chosen folder is a Git worktree. Choose a plain destination folder.";
+      default:
+        return error.problem.detail ?? error.message;
+    }
+  }
+  return error instanceof Error ? error.message : "Failed to clone repository.";
+}
+
+export type CloneRepoResult =
+  | { succeeded: true; sourceRoot: string }
+  | { succeeded: false; error: string; cancelled?: boolean };
+
+export function useCloneRepo() {
+  const desktop = useProductHost().desktop ?? null;
+  const files = desktop?.files ?? null;
+  const localRuntime = desktop?.runtime ?? null;
+  const worker = desktop?.worker ?? null;
+  const materializeRepoRoot = useMaterializeRepoRootMutation().mutateAsync;
+  const saveEnvironment = useSaveRepoEnvironment();
+  const { upsertRepoRootInWorkspaceCollections } = useWorkspaceCollectionsMutationCacheActions();
+  const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
+  const unhideRepoRoot = useWorkspaceUiStore((state) => state.unhideRepoRoot);
+  const showToast = useToastStore((state) => state.show);
+  const [isCloning, setIsCloning] = useState(false);
+
+  const saveLocalRepoEnvironment = useCallback((repoRoot: RepoRoot) => {
+    const gitOwner = repoRoot.remoteOwner?.trim();
+    const gitRepoName = repoRoot.remoteRepoName?.trim();
+    if (
+      repoRoot.remoteProvider !== "github"
+      || !gitOwner
+      || !gitRepoName
+      || !repoRoot.path.trim()
+      || !worker
+    ) {
+      return;
+    }
+    void (async () => {
+      const installId = await worker.getInstallId();
+      await saveEnvironment.mutateAsync({
+        gitOwner,
+        gitRepoName,
+        body: {
+          kind: "local",
+          gitProvider: "github",
+          desktopInstallId: installId,
+          localPath: repoRoot.path,
+          defaultBranch: repoRoot.defaultBranch?.trim() || null,
+          setupScript: "",
+          runCommand: "",
+        },
+      });
+    })().catch(() => {
+      // Local clone remains usable even when the environment save fails.
+    });
+  }, [saveEnvironment, worker]);
+
+  /** Clone `repo` into a subfolder of the user-picked parent directory. The
+   * native folder picker chooses the parent; the clone lands in
+   * `<parent>/<repoName>`. `operationId` must be stable across retries. */
+  const cloneRepo = useCallback(async (
+    repo: ExpectedRepoIdentity,
+    operationId: string,
+  ): Promise<CloneRepoResult> => {
+    if (!files) {
+      return { succeeded: false, error: "Cloning is only available in Desktop." };
+    }
+    const parent = await files.pickDirectory();
+    if (!parent) {
+      return { succeeded: false, error: "Clone cancelled.", cancelled: true };
+    }
+    const destinationPath = `${parent.replace(/\/+$/u, "")}/${repo.gitRepoName}`;
+    setIsCloning(true);
+    try {
+      const repoRoot = await runCloneRepoWorkflow({
+        repo,
+        destinationPath,
+        operationId,
+        ensureRuntimeReady: () => ensureRuntimeReady(localRuntime),
+        materializeRepoRoot: (input) => materializeRepoRoot(input),
+        upsertRepoRootInWorkspaceCollections,
+        invalidateWorkspaceCollections: invalidateWorkspaceCollectionsForRuntime,
+        saveLocalRepoEnvironment,
+        unhideRepoRoot,
+      });
+      return { succeeded: true, sourceRoot: repoRoot.path.trim() || repoRoot.id };
+    } catch (error) {
+      const message = describeCloneFailure(error);
+      showToast(message);
+      return { succeeded: false, error: message };
+    } finally {
+      setIsCloning(false);
+    }
+  }, [
+    files,
+    invalidateWorkspaceCollectionsForRuntime,
+    localRuntime,
+    materializeRepoRoot,
+    saveLocalRepoEnvironment,
+    showToast,
+    unhideRepoRoot,
+    upsertRepoRootInWorkspaceCollections,
+  ]);
+
+  return {
+    cloneRepo,
+    canClone: files !== null,
+    isCloning,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-availability-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-availability-actions.ts
@@ -1,0 +1,300 @@
+import { useCallback } from "react";
+import {
+  getAnyHarnessClient,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+  useMaterializeRepoRootMutation,
+  useMaterializeWorkspaceAtRefMutation,
+} from "@anyharness/sdk-react";
+import {
+  useCreateLocalMaterializationIntent,
+  useReportMaterialization,
+  useUnlinkMaterialization,
+} from "@proliferate/cloud-sdk-react";
+import { createCloudWorkspace } from "@proliferate/cloud-sdk/client/workspaces";
+import { runOpenOnMacFlow } from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+import { isStaleMaterializationGenerationError } from "#product/lib/domain/workspaces/cloud/materialization-report-error";
+import {
+  type LinkCloudTargetProof,
+  type LinkLocalCandidateProof,
+  verifyLinkCandidate,
+} from "#product/lib/domain/workspaces/cloud/link-copies-verification";
+import type { LinkCandidate } from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
+import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
+import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+/**
+ * Executes the workspace-copy availability actions (PR 5 Flows 2/3/5). All
+ * orchestration stays here in product-client (never in product-ui or Tauri
+ * commands); the pure sequencing lives in open-on-mac-orchestration.ts.
+ *
+ * Runtime routing: local materialization operations (clone/exact-ref) run
+ * against the local Tauri/AnyHarness runtime via the PR 3 sdk-react mutations,
+ * which resolve the local runtime connection from context. Cloud intent/report
+ * calls go to the control plane.
+ */
+export function useWorkspaceAvailabilityActions() {
+  const runtime = useAnyHarnessRuntimeContext();
+  const materializeRepoRoot = useMaterializeRepoRootMutation().mutateAsync;
+  const materializeWorkspaceAtRef = useMaterializeWorkspaceAtRefMutation().mutateAsync;
+  const createIntent = useCreateLocalMaterializationIntent().mutateAsync;
+  const report = useReportMaterialization().mutateAsync;
+  const unlink = useUnlinkMaterialization().mutateAsync;
+  const desktopInstallId = useDesktopInstallId();
+  const { selectWorkspace } = useWorkspaceSelection();
+  const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
+  const showToast = useToastStore((state) => state.show);
+
+  /**
+   * Flow 2 (open) / Flow 5 (relink + recreate). Reuses the Cloud operationId
+   * across retries; when no local repo root hosts the repository the caller must
+   * supply a clone destination (prompted via the native folder picker).
+   * `forceFreshWorktree` distinguishes recreate (always cut a new worktree) from
+   * relink/open (reuse/adopt a clean checkout at the ref) — PR5-MODE-03.
+   */
+  const openOnThisMac = useCallback(async (args: {
+    cloudWorkspaceId: string;
+    existingRepoRootId: string | null;
+    cloneDestinationPath: string | null;
+    forceFreshWorktree?: boolean;
+  }): Promise<boolean> => {
+    if (!desktopInstallId) {
+      showToast("This Mac is not registered yet. Try again in a moment.");
+      return false;
+    }
+    try {
+      const result = await runOpenOnMacFlow(
+        {
+          existingRepoRootId: args.existingRepoRootId,
+          cloneDestinationPath: args.cloneDestinationPath,
+          forceFreshWorktree: args.forceFreshWorktree,
+        },
+        {
+          createIntent: () =>
+            createIntent({
+              workspaceId: args.cloudWorkspaceId,
+              body: { targetKind: "local_desktop", desktopInstallId },
+            }),
+          materializeRepoRoot: (input) => materializeRepoRoot(input),
+          materializeWorkspaceAtRef: async (repoRootId, input) => {
+            const response = await materializeWorkspaceAtRef({ repoRootId, input });
+            return {
+              workspaceId: response.workspace.id,
+              observedHeadSha: response.observedHeadSha,
+              worktreePath: response.workspace.path,
+            };
+          },
+          report: (materializationId, body) =>
+            report({ workspaceId: args.cloudWorkspaceId, materializationId, body }),
+        },
+      );
+      const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+      if (runtimeUrl) {
+        await invalidateWorkspaceCollectionsForRuntime(runtimeUrl);
+      }
+      // Select and open the local AnyHarness workspace.
+      await selectWorkspace(result.anyharnessWorkspaceId, { force: true });
+      return true;
+    } catch (error) {
+      if (isStaleMaterializationGenerationError(error)) {
+        // The worktree materialized fine; the association just moved on (a newer
+        // intent or an unlink bumped the generation). Quiet, non-error state:
+        // refresh so the sidebar reflects the current ledger (PR5-STALE-07).
+        const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+        if (runtimeUrl) {
+          await invalidateWorkspaceCollectionsForRuntime(runtimeUrl);
+        }
+        showToast("This workspace's link was updated elsewhere; nothing to do here.", "info");
+        return true;
+      }
+      showToast(error instanceof Error ? error.message : "Could not open this workspace on this Mac.");
+      return false;
+    }
+  }, [
+    createIntent,
+    desktopInstallId,
+    invalidateWorkspaceCollectionsForRuntime,
+    materializeRepoRoot,
+    materializeWorkspaceAtRef,
+    report,
+    runtime.runtimeUrl,
+    selectWorkspace,
+    showToast,
+  ]);
+
+  /**
+   * Flow 4 "Link copies": association-only. Proves the chosen EXISTING local
+   * workspace is the SAME exact ref as the Cloud copy (canonical repo identity,
+   * case-sensitive branch, EXACT HEAD, clean/normal state, not already linked
+   * elsewhere) by reading the local runtime git status fresh, then verifying via
+   * the pure gate. On proof it cuts NO worktree: it creates the Cloud intent
+   * (which independently re-verifies the published HEAD) and reports the EXISTING
+   * local workspace as hydrated. On any proof failure it surfaces a truthful
+   * blocker and NEVER materializes (PR5-LINK-01).
+   */
+  const linkCopies = useCallback(async (args: {
+    candidate: LinkCandidate;
+    cloudTarget: LinkCloudTargetProof;
+    /** Cloud workspace ids this candidate is already linked to, for the
+     * "not already linked elsewhere" proof. */
+    alreadyLinkedCloudWorkspaceId: string | null;
+  }): Promise<boolean> => {
+    if (!desktopInstallId) {
+      showToast("This Mac is not registered yet. Try again in a moment.");
+      return false;
+    }
+    let proof: LinkLocalCandidateProof;
+    try {
+      const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
+      const status = await client.git.getStatus(args.candidate.anyharnessWorkspaceId);
+      proof = {
+        anyharnessWorkspaceId: args.candidate.anyharnessWorkspaceId,
+        provider: args.candidate.provider,
+        owner: args.candidate.owner,
+        repoName: args.candidate.repoName,
+        branch: status.currentBranch ?? null,
+        headSha: status.headOid,
+        clean: status.clean,
+        conflicted: status.conflicted,
+        detached: status.detached,
+        operationInProgress: status.operation !== "none",
+        alreadyLinkedCloudWorkspaceId: args.alreadyLinkedCloudWorkspaceId,
+      };
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not read the local workspace status.");
+      return false;
+    }
+
+    const verification = verifyLinkCandidate(proof, args.cloudTarget);
+    if (!verification.linkable) {
+      // Truthful blocker; NEVER fall through to materialization (PR5-LINK-01).
+      showToast(verification.blocker);
+      return false;
+    }
+
+    try {
+      const intent = await createIntent({
+        workspaceId: args.cloudTarget.cloudWorkspaceId,
+        body: { targetKind: "local_desktop", desktopInstallId },
+      });
+      await report({
+        workspaceId: args.cloudTarget.cloudWorkspaceId,
+        materializationId: intent.materialization.id,
+        body: {
+          generation: intent.materialization.generation,
+          state: "hydrated",
+          anyharnessWorkspaceId: args.candidate.anyharnessWorkspaceId,
+          worktreePath: args.candidate.worktreePath,
+          observedBranch: proof.branch,
+          observedHeadSha: proof.headSha,
+        },
+      });
+      const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+      if (runtimeUrl) {
+        await invalidateWorkspaceCollectionsForRuntime(runtimeUrl);
+      }
+      await selectWorkspace(args.candidate.anyharnessWorkspaceId, { force: true });
+      showToast("Linked this Mac's copy to the Cloud workspace.", "info");
+      return true;
+    } catch (error) {
+      if (isStaleMaterializationGenerationError(error)) {
+        const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+        if (runtimeUrl) {
+          await invalidateWorkspaceCollectionsForRuntime(runtimeUrl);
+        }
+        showToast("This workspace's link was updated elsewhere; nothing to do here.", "info");
+        return true;
+      }
+      showToast(error instanceof Error ? error.message : "Could not link these copies.");
+      return false;
+    }
+  }, [
+    createIntent,
+    desktopInstallId,
+    invalidateWorkspaceCollectionsForRuntime,
+    report,
+    runtime,
+    selectWorkspace,
+    showToast,
+  ]);
+
+  /** Flow 3: add a managed-Cloud copy of a clean, published local workspace at
+   * its exact ref. Reads the local exact HEAD from the runtime, then calls the
+   * server exact-ref create path (which re-verifies the published head). */
+  const addCloudCopy = useCallback(async (args: {
+    localAnyharnessWorkspaceId: string;
+    gitOwner: string;
+    gitRepoName: string;
+  }): Promise<boolean> => {
+    try {
+      const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
+      const status = await client.git.getStatus(args.localAnyharnessWorkspaceId);
+      if (
+        status.detached
+        || !status.currentBranch
+        || !status.clean
+        || status.conflicted
+        || status.operation !== "none"
+      ) {
+        showToast("This workspace must be clean and on a normal branch to add a Cloud copy.");
+        return false;
+      }
+      // The materialization's worktreePath is the local AnyHarness workspace's
+      // own worktree, NOT the shared repo root that hosts many worktrees
+      // (PR5-PATH-06).
+      const worktreePath = status.workspacePath;
+      const detail = await createCloudWorkspace({
+        gitProvider: "github",
+        gitOwner: args.gitOwner,
+        gitRepoName: args.gitRepoName,
+        branchName: status.currentBranch,
+        expectedHeadSha: status.headOid,
+        source: "desktop",
+        sourceMaterialization: desktopInstallId
+          ? {
+            targetKind: "local_desktop",
+            desktopInstallId,
+            anyharnessWorkspaceId: args.localAnyharnessWorkspaceId,
+            worktreePath,
+            observedHeadSha: status.headOid,
+          }
+          : null,
+      });
+      showToast("Added a Cloud copy.", "info");
+      await selectWorkspace(cloudWorkspaceSyntheticId(detail.id), { force: true });
+      return true;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not add a Cloud copy.");
+      return false;
+    }
+  }, [desktopInstallId, runtime, selectWorkspace, showToast]);
+
+  /** Flow 5: unlink this Mac's association (non-destructive; idempotent). */
+  const unlinkThisMac = useCallback(async (args: {
+    cloudWorkspaceId: string;
+    materializationId: string;
+  }): Promise<boolean> => {
+    try {
+      await unlink({
+        workspaceId: args.cloudWorkspaceId,
+        materializationId: args.materializationId,
+      });
+      showToast("Unlinked this Mac. Nothing was deleted.", "info");
+      return true;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not unlink this Mac.");
+      return false;
+    }
+  }, [showToast, unlink]);
+
+  return {
+    openOnThisMac,
+    linkCopies,
+    addCloudCopy,
+    unlinkThisMac,
+    desktopInstallId,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.test.ts
@@ -9,11 +9,16 @@ import {
 const REPO = { gitProvider: "github", gitOwner: "acme", gitRepoName: "rocket" } as const;
 
 describe("cloud repository intent", () => {
-  it("maps every cloud intent to the managed_cloud requirement", () => {
+  it("maps every host-owned intent to managed_cloud (local clone is not an intent; PR5-DEAD-04)", () => {
     expect(requirementForCloudRepositoryIntent({ kind: "set_up_cloud", repo: REPO }))
       .toBe("managed_cloud");
     expect(requirementForCloudRepositoryIntent({ kind: "add_cloud_repository", repo: REPO }))
       .toBe("managed_cloud");
+    expect(requirementForCloudRepositoryIntent({
+      kind: "create_cloud_workspace",
+      repo: REPO,
+      continuation: { repoGroupKeyToExpand: null, baseBranch: null },
+    })).toBe("managed_cloud");
   });
 
   it("resolves the target repo for every intent", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.test.ts
@@ -9,7 +9,7 @@ import {
 const REPO = { gitProvider: "github", gitOwner: "acme", gitRepoName: "rocket" } as const;
 
 describe("cloud repository intent", () => {
-  it("maps every host-owned intent to managed_cloud (local clone is not an intent; PR5-DEAD-04)", () => {
+  it("maps Clone to GitHub access without requiring managed Cloud", () => {
     expect(requirementForCloudRepositoryIntent({ kind: "set_up_cloud", repo: REPO }))
       .toBe("managed_cloud");
     expect(requirementForCloudRepositoryIntent({ kind: "add_cloud_repository", repo: REPO }))
@@ -19,12 +19,15 @@ describe("cloud repository intent", () => {
       repo: REPO,
       continuation: { repoGroupKeyToExpand: null, baseBranch: null },
     })).toBe("managed_cloud");
+    expect(requirementForCloudRepositoryIntent({ kind: "clone_from_github", repo: REPO }))
+      .toBe("github_repository_access");
   });
 
   it("resolves the target repo for every intent", () => {
     expect(repoForCloudRepositoryIntent({ kind: "set_up_cloud", repo: REPO })).toEqual(REPO);
     expect(repoForCloudRepositoryIntent({ kind: "add_cloud_repository", repo: REPO }))
       .toEqual(REPO);
+    expect(repoForCloudRepositoryIntent({ kind: "clone_from_github", repo: REPO })).toEqual(REPO);
   });
 
   it("saves the repo environment BEFORE creating the workspace (setup-and-continue)", async () => {
@@ -42,6 +45,7 @@ describe("cloud repository intent", () => {
       cloudEnvironmentConfigured: false,
       saveCloudEnvironment,
       createCloudWorkspace,
+      cloneFromGitHub: vi.fn(),
     });
 
     expect(order).toEqual(["save", "create"]);
@@ -62,6 +66,7 @@ describe("cloud repository intent", () => {
       cloudEnvironmentConfigured: true,
       saveCloudEnvironment,
       createCloudWorkspace,
+      cloneFromGitHub: vi.fn(),
     });
 
     expect(saveCloudEnvironment).not.toHaveBeenCalled();
@@ -77,6 +82,7 @@ describe("cloud repository intent", () => {
       cloudEnvironmentConfigured: false,
       saveCloudEnvironment,
       createCloudWorkspace,
+      cloneFromGitHub: vi.fn(),
     });
 
     expect(saveCloudEnvironment).toHaveBeenCalledTimes(1);
@@ -94,10 +100,29 @@ describe("cloud repository intent", () => {
       saveCloudEnvironment,
       createCloudWorkspace,
       onRepositoryRegistered,
+      cloneFromGitHub: vi.fn(),
     });
 
     expect(saveCloudEnvironment).toHaveBeenCalledWith(REPO);
     expect(createCloudWorkspace).not.toHaveBeenCalled();
     expect(onRepositoryRegistered).toHaveBeenCalledWith(REPO);
+  });
+
+  it("clones locally without saving a Cloud environment", async () => {
+    const saveCloudEnvironment = vi.fn(async () => {});
+    const createCloudWorkspace = vi.fn(async () => {});
+    const cloneFromGitHub = vi.fn(async () => {});
+
+    await continueCloudRepositoryIntent({
+      intent: { kind: "clone_from_github", repo: REPO },
+      cloudEnvironmentConfigured: false,
+      saveCloudEnvironment,
+      createCloudWorkspace,
+      cloneFromGitHub,
+    });
+
+    expect(cloneFromGitHub).toHaveBeenCalledWith(REPO);
+    expect(saveCloudEnvironment).not.toHaveBeenCalled();
+    expect(createCloudWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.ts
@@ -25,6 +25,15 @@ export interface CreateCloudWorkspaceContinuation {
  * The one intent the connected Cloud action host owns. Serializable by
  * construction: on cold restart the store is empty and nothing resumes; the
  * settings surfaces are the recovery path.
+ *
+ * NOTE (PR5-DEAD-04): local clone-from-GitHub is NOT an intent here. It runs
+ * entirely inside AddRepoFlowHost's clone picker (`useAddRepoFlowStore` "clone"
+ * step → `useCloneRepo`), which owns its own repo picker + GitHub-App gating and
+ * does not need this readiness-gate/continuation host. A `clone_from_github`
+ * intent kind was previously declared here but never begun by any surface, so it
+ * was removed rather than left as dead code. If clone ever needs the browser
+ * authorization round-trip this host provides, reintroduce it with a real
+ * `begin({ kind: "clone_from_github" })` call site.
  */
 export type CloudRepositoryIntent =
   | { kind: "set_up_cloud"; repo: CloudRepoIdentity }
@@ -35,7 +44,11 @@ export type CloudRepositoryIntent =
   }
   | { kind: "add_cloud_repository"; repo: CloudRepoIdentity };
 
-/** Every Cloud repository intent depends on managed-Cloud readiness. */
+/**
+ * The capability an intent depends on. Every intent this host owns requires
+ * managed-Cloud execution readiness (the local clone path is not an intent; see
+ * the type note above).
+ */
 export function requirementForCloudRepositoryIntent(
   _intent: CloudRepositoryIntent,
 ): RepositoryCapabilityRequirement {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-repository-intent.ts
@@ -26,14 +26,9 @@ export interface CreateCloudWorkspaceContinuation {
  * construction: on cold restart the store is empty and nothing resumes; the
  * settings surfaces are the recovery path.
  *
- * NOTE (PR5-DEAD-04): local clone-from-GitHub is NOT an intent here. It runs
- * entirely inside AddRepoFlowHost's clone picker (`useAddRepoFlowStore` "clone"
- * step → `useCloneRepo`), which owns its own repo picker + GitHub-App gating and
- * does not need this readiness-gate/continuation host. A `clone_from_github`
- * intent kind was previously declared here but never begun by any surface, so it
- * was removed rather than left as dead code. If clone ever needs the browser
- * authorization round-trip this host provides, reintroduce it with a real
- * `begin({ kind: "clone_from_github" })` call site.
+ * Clone is a first-class intent because it needs the same user/install/repo
+ * authority gates and callback recovery as Cloud operations, while requiring
+ * only `github_repository_access` rather than managed Cloud.
  */
 export type CloudRepositoryIntent =
   | { kind: "set_up_cloud"; repo: CloudRepoIdentity }
@@ -42,17 +37,19 @@ export type CloudRepositoryIntent =
     repo: CloudRepoIdentity;
     continuation: CreateCloudWorkspaceContinuation;
   }
+  | { kind: "clone_from_github"; repo: CloudRepoIdentity }
   | { kind: "add_cloud_repository"; repo: CloudRepoIdentity };
 
 /**
- * The capability an intent depends on. Every intent this host owns requires
- * managed-Cloud execution readiness (the local clone path is not an intent; see
- * the type note above).
+ * The capability an intent depends on. Clone deliberately remains available on
+ * an App-ready deployment whose managed-Cloud executor is disabled.
  */
 export function requirementForCloudRepositoryIntent(
-  _intent: CloudRepositoryIntent,
+  intent: CloudRepositoryIntent,
 ): RepositoryCapabilityRequirement {
-  return "managed_cloud";
+  return intent.kind === "clone_from_github"
+    ? "github_repository_access"
+    : "managed_cloud";
 }
 
 /** The repository an intent targets. */
@@ -82,9 +79,15 @@ export async function continueCloudRepositoryIntent(args: {
   ) => Promise<void>;
   /** Complete the original Add Repository flow after registration succeeds. */
   onRepositoryRegistered?: (repo: CloudRepoIdentity) => void;
+  /** Clone the selected repository locally after GitHub authority is ready. */
+  cloneFromGitHub: (repo: CloudRepoIdentity) => Promise<void>;
 }): Promise<void> {
   const { intent } = args;
 
+  if (intent.kind === "clone_from_github") {
+    await args.cloneFromGitHub(intent.repo);
+    return;
+  }
   // Ensure the Cloud repo environment exists first. A retry that already has an
   // environment skips the save so it is not recreated.
   if (!args.cloudEnvironmentConfigured) {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-model.ts
@@ -152,6 +152,10 @@ export interface CloudWorkspaceSummary {
   executionTarget?: CloudWorkspaceExecutionTargetSummary;
   selectedMaterializationId?: string | null;
   primaryMaterialization?: CloudWorkspaceMaterializationSummary | null;
+  // The full active materialization ledger for this Cloud workspace (PR 4).
+  // Present on server responses; optional so legacy/synthetic fixtures without
+  // it still type-check. The explicit-association projection reads this array.
+  materializations?: CloudWorkspaceMaterializationSummary[];
   cloudAccess?: CloudWorkspaceCloudAccessSummary;
   statusDetail: string | null;
   lastError: string | null;

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/describe-readiness-blocker.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/describe-readiness-blocker.test.ts
@@ -5,6 +5,7 @@ import { describeReadinessBlocker, type ReadinessBlockerInputs } from "./describ
 function inputs(readiness: RepositoryReadiness, overrides: Partial<ReadinessBlockerInputs> = {}): ReadinessBlockerInputs {
   return {
     readiness,
+    requirement: "managed_cloud",
     repo: { gitProvider: "github", gitOwner: "acme", gitRepoName: "app" },
     githubAccessDisplayName: "proliferate-app",
     orgName: "Acme",
@@ -34,6 +35,15 @@ describe("describeReadinessBlocker", () => {
   it("reserves the operator-not-configured copy for the true operator gate (gate 1)", () => {
     const blocker = describeReadinessBlocker(inputs({ gate: 1, action: "none" }));
     expect(blocker?.title).toBe("Cloud is not configured on this deployment");
+  });
+
+  it("names GitHub repository access—not Cloud—for a blocked Clone", () => {
+    const blocker = describeReadinessBlocker(inputs(
+      { gate: 1, action: "none" },
+      { requirement: "github_repository_access" },
+    ));
+    expect(blocker?.title).toBe("GitHub repository access is not configured");
+    expect(blocker?.actionLabel).toBeNull();
   });
 
   it("keeps human-access copy for gate 8", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/describe-readiness-blocker.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/describe-readiness-blocker.ts
@@ -1,9 +1,13 @@
-import type { RepositoryReadiness } from "@proliferate/product-domain/repos/repo-readiness";
+import type {
+  RepositoryCapabilityRequirement,
+  RepositoryReadiness,
+} from "@proliferate/product-domain/repos/repo-readiness";
 import type { CloudRepoPickerBlockerView } from "@proliferate/product-ui/repos/CloudRepoPicker";
 import type { CloudRepoIdentity } from "#product/lib/domain/workspaces/cloud/cloud-repository-intent";
 
 export interface ReadinessBlockerInputs {
   readiness: RepositoryReadiness;
+  requirement: RepositoryCapabilityRequirement;
   repo: CloudRepoIdentity | null;
   githubAccessDisplayName: string | null;
   orgName: string | null;
@@ -39,21 +43,23 @@ export function describeReadinessBlocker(
   input: ReadinessBlockerInputs,
 ): CloudRepoPickerBlockerView | null {
   const { readiness } = input;
+  const operation = input.requirement === "github_repository_access"
+    ? "clone this repository"
+    : "set up this repository in Cloud";
   switch (readiness.action) {
     case "none":
       return operatorOrHumanBlocker(readiness.gate, input);
     case "sign_in":
       return {
         title: "Sign in to continue",
-        description: "Sign in to Proliferate to set up this repository in Cloud.",
+        description: `Sign in to Proliferate to ${operation}.`,
         actionLabel: "Sign in",
         onAction: input.onSignIn,
       };
     case "authorize_user":
       return {
         title: "Connect GitHub App",
-        description:
-          "Authorize the Proliferate GitHub App to set up this repository in Cloud.",
+        description: `Authorize the Proliferate GitHub App to ${operation}.`,
         actionLabel: input.userAuthorization.authorizing ? "Opening GitHub…" : "Connect GitHub App",
         actionLoading: input.userAuthorization.authorizing,
         onAction: input.userAuthorization.authorize,
@@ -62,7 +68,7 @@ export function describeReadinessBlocker(
       return {
         title: "Reconnect GitHub App",
         description:
-          "Your GitHub App authorization expired. Reconnect it to set up this repository in Cloud.",
+          `Your GitHub App authorization expired. Reconnect it to ${operation}.`,
         actionLabel: input.userAuthorization.authorizing ? "Opening GitHub…" : "Reconnect GitHub App",
         actionLoading: input.userAuthorization.authorizing,
         onAction: input.userAuthorization.authorize,
@@ -71,7 +77,7 @@ export function describeReadinessBlocker(
       return {
         title: "Install Proliferate GitHub App",
         description:
-          "Install the Proliferate GitHub App for your organization to set up this repository in Cloud.",
+          `Install the Proliferate GitHub App for your organization to ${operation}.`,
         actionLabel: input.installation.installing ? "Opening GitHub…" : "Install Proliferate GitHub App",
         actionLoading: input.installation.installing,
         onAction: input.installation.install,
@@ -127,6 +133,16 @@ function operatorOrHumanBlocker(
   }
   // Gate 1 (and a per-repo operator_configuration_required) = operator config.
   const appName = input.githubAccessDisplayName;
+  if (input.requirement === "github_repository_access") {
+    return {
+      title: "GitHub repository access is not configured",
+      description: appName
+        ? `GitHub repository access for ${appName} isn't fully configured on this deployment. An operator must finish configuring the GitHub App.`
+        : "GitHub repository access isn't configured on this deployment. An operator must install and configure the GitHub App before repositories can be cloned.",
+      actionLabel: null,
+      onAction: null,
+    };
+  }
   return {
     title: "Cloud is not configured on this deployment",
     description: appName

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { RepoRoot, Workspace } from "@anyharness/sdk";
-import { collectLinkCandidates } from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
+import {
+  collectLinkCandidates,
+  linkedCloudWorkspaceByAnyharnessId,
+} from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 function root(overrides: Partial<RepoRoot> = {}): RepoRoot {
   return {
@@ -101,5 +105,35 @@ describe("collectLinkCandidates", () => {
         cloudBranch: "feat/x",
       }),
     ).toHaveLength(0);
+  });
+});
+
+describe("linkedCloudWorkspaceByAnyharnessId", () => {
+  it("indexes every active association across Cloud workspaces, including missing rows", () => {
+    const cloudWorkspaces = [
+      {
+        id: "cloud-a",
+        materializations: [{
+          targetKind: "local_desktop",
+          anyharnessWorkspaceId: "ws-linked-elsewhere",
+          state: "hydrated",
+        }],
+      },
+      {
+        id: "cloud-b",
+        materializations: [{
+          targetKind: "local_desktop",
+          anyharnessWorkspaceId: "ws-missing",
+          state: "missing",
+        }],
+      },
+    ] as unknown as CloudWorkspaceSummary[];
+
+    expect(linkedCloudWorkspaceByAnyharnessId(cloudWorkspaces)).toEqual(
+      new Map([
+        ["ws-linked-elsewhere", "cloud-a"],
+        ["ws-missing", "cloud-b"],
+      ]),
+    );
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { RepoRoot, Workspace } from "@anyharness/sdk";
+import { collectLinkCandidates } from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
+
+function root(overrides: Partial<RepoRoot> = {}): RepoRoot {
+  return {
+    id: "root-1",
+    kind: "managed",
+    path: "/code/rocket",
+    remoteProvider: "github",
+    remoteOwner: "acme",
+    remoteRepoName: "rocket",
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  } as RepoRoot;
+}
+
+function workspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "ws-1",
+    repoRootId: "root-1",
+    path: "/code/rocket-wt",
+    currentBranch: "feat/x",
+    originalBranch: "feat/x",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    displayName: null,
+    kind: "standard",
+    lifecycleState: "active",
+    surface: "desktop",
+    cleanupState: "none",
+    ...overrides,
+  } as unknown as Workspace;
+}
+
+const CLOUD_REPO = { provider: "github", owner: "acme", name: "rocket" };
+
+describe("collectLinkCandidates", () => {
+  it("returns the same-repo/same-branch local workspace", () => {
+    const candidates = collectLinkCandidates({
+      localWorkspaces: [workspace()],
+      repoRoots: [root()],
+      cloudRepo: CLOUD_REPO,
+      cloudBranch: "feat/x",
+    });
+    expect(candidates.map((c) => c.anyharnessWorkspaceId)).toEqual(["ws-1"]);
+  });
+
+  it("excludes a different repository or branch", () => {
+    const otherRepo = collectLinkCandidates({
+      localWorkspaces: [workspace()],
+      repoRoots: [root({ remoteRepoName: "other" })],
+      cloudRepo: CLOUD_REPO,
+      cloudBranch: "feat/x",
+    });
+    expect(otherRepo).toHaveLength(0);
+
+    const otherBranch = collectLinkCandidates({
+      localWorkspaces: [workspace({ originalBranch: "feat/y", currentBranch: "feat/y" })],
+      repoRoots: [root()],
+      cloudRepo: CLOUD_REPO,
+      cloudBranch: "feat/x",
+    });
+    expect(otherBranch).toHaveLength(0);
+  });
+
+  it("excludes a workspace already linked to this Cloud workspace", () => {
+    const candidates = collectLinkCandidates({
+      localWorkspaces: [workspace({ id: "ws-1" }), workspace({ id: "ws-2", path: "/code/rocket-wt-2" })],
+      repoRoots: [root()],
+      cloudRepo: CLOUD_REPO,
+      cloudBranch: "feat/x",
+      alreadyLinkedAnyharnessIds: new Set(["ws-1"]),
+    });
+    expect(candidates.map((c) => c.anyharnessWorkspaceId)).toEqual(["ws-2"]);
+  });
+
+  it("ambiguous candidates require selection: it returns ALL matches (never auto-picks one)", () => {
+    const candidates = collectLinkCandidates({
+      localWorkspaces: [
+        workspace({ id: "ws-old", createdAt: "2026-01-01T00:00:00Z", path: "/a" }),
+        workspace({ id: "ws-new", createdAt: "2026-02-01T00:00:00Z", path: "/b" }),
+      ],
+      repoRoots: [root()],
+      cloudRepo: CLOUD_REPO,
+      cloudBranch: "feat/x",
+    });
+    // Both plausible candidates surface — the caller must not silently pick the
+    // oldest/first (PR5-LINK-02). Deterministic order (createdAt) for stable UI.
+    expect(candidates.map((c) => c.anyharnessWorkspaceId)).toEqual(["ws-old", "ws-new"]);
+    expect(candidates.length).toBeGreaterThan(1);
+  });
+
+  it("returns nothing when the Cloud repo or branch is unknown", () => {
+    expect(
+      collectLinkCandidates({
+        localWorkspaces: [workspace()],
+        repoRoots: [root()],
+        cloudRepo: null,
+        cloudBranch: "feat/x",
+      }),
+    ).toHaveLength(0);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.ts
@@ -6,6 +6,7 @@ import {
 import {
   workspaceBranchKey,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 
 /** A plausible local workspace the user might link to the Cloud copy. Exact
  * linkability (clean state, exact HEAD) is proven per-candidate at action time
@@ -19,6 +20,26 @@ export interface LinkCandidate {
   provider: string;
   owner: string;
   repoName: string;
+}
+
+/** Index every active visible local association on this installation. The
+ * server redacts other-install runtime ids, so every id present here is safe to
+ * compare and proves that a candidate is already owned by a Cloud workspace. */
+export function linkedCloudWorkspaceByAnyharnessId(
+  cloudWorkspaces: readonly CloudWorkspaceSummary[],
+): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const cloudWorkspace of cloudWorkspaces) {
+    for (const row of cloudWorkspace.materializations ?? []) {
+      if (
+        row.targetKind === "local_desktop"
+        && row.anyharnessWorkspaceId
+      ) {
+        result.set(row.anyharnessWorkspaceId, cloudWorkspace.id);
+      }
+    }
+  }
+  return result;
 }
 
 /**

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-candidates.ts
@@ -1,0 +1,88 @@
+import type { RepoRoot, Workspace } from "@anyharness/sdk";
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+import {
+  normalizeLogicalWorkspaceBranchKey,
+} from "#product/lib/domain/workspaces/cloud/logical-workspace-id";
+import {
+  workspaceBranchKey,
+} from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+
+/** A plausible local workspace the user might link to the Cloud copy. Exact
+ * linkability (clean state, exact HEAD) is proven per-candidate at action time
+ * from the runtime git status; this only narrows to same-repo/same-branch
+ * unlinked locals so the host has an explicit candidate set to choose from. */
+export interface LinkCandidate {
+  anyharnessWorkspaceId: string;
+  worktreePath: string;
+  displayName: string;
+  branch: string;
+  provider: string;
+  owner: string;
+  repoName: string;
+}
+
+/**
+ * Enumerate the plausible local link candidates for a Cloud workspace: local
+ * workspaces whose repo root canonically matches the Cloud repository and whose
+ * branch matches the Cloud branch, excluding any that is already this install's
+ * linked local materialization. Pure so LINK-02's "multiple candidates require
+ * explicit selection; never auto-pick the oldest/first" rule is unit-testable.
+ *
+ * The result is deterministically ordered (createdAt, then id) ONLY so the list
+ * renders stably — the caller must NOT auto-select index 0 when the length > 1.
+ */
+export function collectLinkCandidates(args: {
+  localWorkspaces: Workspace[];
+  repoRoots: RepoRoot[];
+  cloudRepo: { provider: string; owner: string; name: string } | null;
+  cloudBranch: string | null;
+  /** AnyHarness ids already linked to this Cloud workspace (excluded). */
+  alreadyLinkedAnyharnessIds?: ReadonlySet<string>;
+}): LinkCandidate[] {
+  const { cloudRepo, cloudBranch } = args;
+  if (!cloudRepo || !cloudBranch) {
+    return [];
+  }
+  const repoRootsById = new Map(args.repoRoots.map((root) => [root.id, root]));
+  const cloudRepoKey = canonicalRepoKey(cloudRepo.provider, cloudRepo.owner, cloudRepo.name);
+  const cloudBranchKey = normalizeLogicalWorkspaceBranchKey(cloudBranch);
+  const alreadyLinked = args.alreadyLinkedAnyharnessIds ?? new Set<string>();
+
+  const matches: { workspace: Workspace; root: RepoRoot }[] = [];
+  for (const workspace of args.localWorkspaces) {
+    if (alreadyLinked.has(workspace.id)) {
+      continue;
+    }
+    const root = repoRootsById.get(workspace.repoRootId);
+    if (
+      !root?.remoteProvider
+      || !root.remoteOwner
+      || !root.remoteRepoName
+    ) {
+      continue;
+    }
+    if (canonicalRepoKey(root.remoteProvider, root.remoteOwner, root.remoteRepoName) !== cloudRepoKey) {
+      continue;
+    }
+    if (workspaceBranchKey(workspace) !== cloudBranchKey) {
+      continue;
+    }
+    matches.push({ workspace, root });
+  }
+
+  return matches
+    .sort((left, right) => {
+      const byCreatedAt =
+        new Date(left.workspace.createdAt).getTime() - new Date(right.workspace.createdAt).getTime();
+      return byCreatedAt !== 0 ? byCreatedAt : left.workspace.id.localeCompare(right.workspace.id);
+    })
+    .map(({ workspace, root }) => ({
+      anyharnessWorkspaceId: workspace.id,
+      worktreePath: workspace.path,
+      displayName: workspace.displayName?.trim() || workspace.currentBranch?.trim() || workspace.id,
+      branch: workspace.currentBranch?.trim() || cloudBranch,
+      provider: root.remoteProvider!,
+      owner: root.remoteOwner!,
+      repoName: root.remoteRepoName!,
+    }));
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  type LinkCloudTargetProof,
+  type LinkLocalCandidateProof,
+  verifyLinkCandidate,
+} from "#product/lib/domain/workspaces/cloud/link-copies-verification";
+
+const HEAD = "a".repeat(40);
+
+function candidate(overrides: Partial<LinkLocalCandidateProof> = {}): LinkLocalCandidateProof {
+  return {
+    anyharnessWorkspaceId: "ws-1",
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branch: "feat/x",
+    headSha: HEAD,
+    clean: true,
+    conflicted: false,
+    detached: false,
+    operationInProgress: false,
+    alreadyLinkedCloudWorkspaceId: null,
+    ...overrides,
+  };
+}
+
+function target(overrides: Partial<LinkCloudTargetProof> = {}): LinkCloudTargetProof {
+  return {
+    cloudWorkspaceId: "cloud-1",
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branch: "feat/x",
+    headSha: HEAD,
+    ...overrides,
+  };
+}
+
+describe("verifyLinkCandidate", () => {
+  it("links a clean, same-repo, same-branch, exact-HEAD candidate", () => {
+    expect(verifyLinkCandidate(candidate(), target())).toEqual({ linkable: true });
+  });
+
+  it("rejects a different repository (canonical mismatch)", () => {
+    const result = verifyLinkCandidate(candidate({ repoName: "other" }), target());
+    expect(result).toMatchObject({ linkable: false });
+  });
+
+  it("treats provider/owner/repo case-insensitively (canonical repo key)", () => {
+    // canonicalRepoKey case-folds identity, so a case-different repo still matches.
+    expect(
+      verifyLinkCandidate(candidate({ owner: "ACME", repoName: "Rocket" }), target()),
+    ).toEqual({ linkable: true });
+  });
+
+  it("rejects a case-DIFFERENT branch (refs are case-sensitive)", () => {
+    const result = verifyLinkCandidate(candidate({ branch: "feat/X" }), target({ branch: "feat/x" }));
+    expect(result).toMatchObject({ linkable: false });
+    expect((result as { blocker: string }).blocker).toMatch(/different branch/);
+  });
+
+  it("rejects a DIFFERENT commit (no fall-through to materialization)", () => {
+    const result = verifyLinkCandidate(candidate({ headSha: "b".repeat(40) }), target());
+    expect(result).toMatchObject({ linkable: false });
+    expect((result as { blocker: string }).blocker).toMatch(/different commit/);
+  });
+
+  it("rejects dirty / conflicted / detached / mid-operation candidates", () => {
+    expect(verifyLinkCandidate(candidate({ clean: false }), target())).toMatchObject({ linkable: false });
+    expect(verifyLinkCandidate(candidate({ conflicted: true }), target())).toMatchObject({ linkable: false });
+    expect(verifyLinkCandidate(candidate({ detached: true, branch: null }), target())).toMatchObject({ linkable: false });
+    expect(verifyLinkCandidate(candidate({ operationInProgress: true }), target())).toMatchObject({ linkable: false });
+  });
+
+  it("rejects a candidate already linked to a DIFFERENT active Cloud workspace", () => {
+    const result = verifyLinkCandidate(
+      candidate({ alreadyLinkedCloudWorkspaceId: "cloud-other" }),
+      target({ cloudWorkspaceId: "cloud-1" }),
+    );
+    expect(result).toMatchObject({ linkable: false });
+  });
+
+  it("allows a candidate already linked to THIS Cloud workspace (idempotent)", () => {
+    expect(
+      verifyLinkCandidate(
+        candidate({ alreadyLinkedCloudWorkspaceId: "cloud-1" }),
+        target({ cloudWorkspaceId: "cloud-1" }),
+      ),
+    ).toEqual({ linkable: true });
+  });
+
+  it("rejects when either HEAD is unknown", () => {
+    expect(verifyLinkCandidate(candidate({ headSha: null }), target())).toMatchObject({ linkable: false });
+    expect(verifyLinkCandidate(candidate(), target({ headSha: null }))).toMatchObject({ linkable: false });
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.ts
@@ -1,0 +1,102 @@
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+
+/**
+ * Flow 4 "Link copies" is association-only: it links an EXISTING local workspace
+ * to a Cloud workspace when the two are provably the same checkout, and cuts NO
+ * worktree. This module is the pure proof gate. It NEVER falls through to
+ * materialization — a failed proof yields a truthful, typed blocker so the host
+ * can explain why the two are not linkable (e.g. their HEADs differ) instead of
+ * silently creating a second worktree at the Cloud HEAD (the PR5-LINK-01 bug).
+ *
+ * The required proof, per the frozen Flow 4 contract:
+ *  - canonical provider/owner/repo match (case-folded, .git-stripped),
+ *  - case-SENSITIVE branch match (feat/X != feat/x),
+ *  - both sides clean / normal (no dirty, conflicted, detached, mid-op),
+ *  - EXACT HEAD match (same commit sha),
+ *  - the candidate is not already linked to another active Cloud workspace.
+ */
+
+/** A local candidate's proof-relevant facts, read from the local runtime git
+ * status (never inferred). `alreadyLinkedCloudWorkspaceId` is the id of another
+ * active Cloud workspace this local is already the linked local copy of, or null. */
+export interface LinkLocalCandidateProof {
+  anyharnessWorkspaceId: string;
+  provider: string;
+  owner: string;
+  repoName: string;
+  branch: string | null;
+  headSha: string | null;
+  clean: boolean;
+  conflicted: boolean;
+  detached: boolean;
+  /** True when a Git operation (merge/rebase/…) is in progress. */
+  operationInProgress: boolean;
+  alreadyLinkedCloudWorkspaceId: string | null;
+}
+
+/** The Cloud side's proof-relevant facts. `headSha` is the published HEAD the
+ * server will re-verify; the local must equal it exactly. */
+export interface LinkCloudTargetProof {
+  cloudWorkspaceId: string;
+  provider: string;
+  owner: string;
+  repoName: string;
+  branch: string | null;
+  headSha: string | null;
+}
+
+export type LinkVerification =
+  | { linkable: true }
+  | { linkable: false; blocker: string };
+
+/**
+ * Verify a single chosen local candidate against the Cloud target. Pure so the
+ * proof (and every rejection reason) is unit-testable away from the runtime.
+ */
+export function verifyLinkCandidate(
+  candidate: LinkLocalCandidateProof,
+  target: LinkCloudTargetProof,
+): LinkVerification {
+  const notLinkable = (blocker: string): LinkVerification => ({ linkable: false, blocker });
+
+  if (
+    canonicalRepoKey(candidate.provider, candidate.owner, candidate.repoName)
+    !== canonicalRepoKey(target.provider, target.owner, target.repoName)
+  ) {
+    return notLinkable("This local workspace is a different repository than the Cloud copy.");
+  }
+  if (candidate.detached || candidate.branch === null) {
+    return notLinkable("This local workspace is in a detached HEAD state.");
+  }
+  if (candidate.operationInProgress) {
+    return notLinkable("This local workspace has a Git operation in progress.");
+  }
+  if (candidate.conflicted) {
+    return notLinkable("This local workspace has unresolved merge conflicts.");
+  }
+  if (!candidate.clean) {
+    return notLinkable("This local workspace has uncommitted changes.");
+  }
+  // Case-SENSITIVE branch match: Git refs are case-sensitive, so feat/X and
+  // feat/x are different branches and must not be treated as linkable.
+  if (target.branch === null || candidate.branch !== target.branch) {
+    return notLinkable("This local workspace is on a different branch than the Cloud copy.");
+  }
+  if (
+    candidate.headSha === null
+    || target.headSha === null
+    || candidate.headSha !== target.headSha
+  ) {
+    return notLinkable(
+      "This local workspace is at a different commit than the Cloud copy, so the two "
+      + "cannot be linked without changing either checkout.",
+    );
+  }
+  if (
+    candidate.alreadyLinkedCloudWorkspaceId !== null
+    && candidate.alreadyLinkedCloudWorkspaceId !== target.cloudWorkspaceId
+  ) {
+    return notLinkable("This local workspace is already linked to another Cloud workspace.");
+  }
+  return { linkable: true };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-duplicates.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-duplicates.ts
@@ -1,0 +1,147 @@
+import type { Workspace } from "@anyharness/sdk";
+import { buildLocalSlotLogicalWorkspaceId } from "#product/lib/domain/workspaces/cloud/logical-workspace-id";
+import { compareLocalWorkspaceCanonicalOrder, workspaceBranchKey } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+
+// Collapsing of exact path+branch local duplicates for the logical-workspace
+// projection. Extracted from logical-workspaces.ts so the projection file stays
+// focused on materialization-first attachment (PR 5). Behavior is unchanged:
+// two workspaces with the same exact path and case-sensitive branch fold onto
+// one representative unless a duplicate has its own sessions or is selected.
+
+function timestampValue(timestamp: string | null | undefined): number {
+  return timestamp ? new Date(timestamp).getTime() : 0;
+}
+
+function localWorkspaceExactMaterializationKey(workspace: Workspace): string {
+  return `${workspace.path.trim()}\0${workspaceBranchKey(workspace)}`;
+}
+
+function workspaceExecutionPriority(workspace: Workspace): number {
+  const summary = workspace.executionSummary;
+  if (!summary) {
+    return 0;
+  }
+
+  if (summary.totalSessionCount > summary.liveSessionCount) {
+    return 3;
+  }
+
+  if (summary.phase === "running" || summary.phase === "awaiting_interaction") {
+    return 2;
+  }
+
+  if (summary.totalSessionCount > 0) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareExactLocalWorkspaceDuplicateOrder(left: Workspace, right: Workspace): number {
+  const byExecutionPriority = workspaceExecutionPriority(right) - workspaceExecutionPriority(left);
+  if (byExecutionPriority !== 0) {
+    return byExecutionPriority;
+  }
+
+  const byExecutionUpdatedAt = (
+    timestampValue(right.executionSummary?.updatedAt)
+    - timestampValue(left.executionSummary?.updatedAt)
+  );
+  if (byExecutionUpdatedAt !== 0) {
+    return byExecutionUpdatedAt;
+  }
+
+  const byWorkspaceUpdatedAt = timestampValue(right.updatedAt) - timestampValue(left.updatedAt);
+  if (byWorkspaceUpdatedAt !== 0) {
+    return byWorkspaceUpdatedAt;
+  }
+
+  return compareLocalWorkspaceCanonicalOrder(left, right);
+}
+
+export interface CollapsedLocalWorkspace {
+  workspace: Workspace;
+  aliasIds: string[];
+}
+
+function localWorkspaceIdentityIds(workspace: Workspace): string[] {
+  return [workspace.id, buildLocalSlotLogicalWorkspaceId(workspace.id)];
+}
+
+export function localWorkspaceMatchesSelection(
+  workspace: Workspace,
+  currentSelectionId: string | null,
+): boolean {
+  return currentSelectionId !== null
+    && localWorkspaceIdentityIds(workspace).includes(currentSelectionId);
+}
+
+function compareExactLocalWorkspaceDuplicateOrderForSelection(
+  currentSelectionId: string | null,
+): (left: Workspace, right: Workspace) => number {
+  return (left, right) => {
+    const leftSelected = localWorkspaceMatchesSelection(left, currentSelectionId);
+    const rightSelected = localWorkspaceMatchesSelection(right, currentSelectionId);
+    if (leftSelected !== rightSelected) {
+      return leftSelected ? -1 : 1;
+    }
+    return compareExactLocalWorkspaceDuplicateOrder(left, right);
+  };
+}
+
+function workspaceHasOwnSessions(workspace: Workspace): boolean {
+  return (workspace.executionSummary?.totalSessionCount ?? 0) > 0;
+}
+
+export function collapseExactLocalWorkspaceDuplicates(
+  workspaces: readonly Workspace[],
+  currentSelectionId: string | null,
+): CollapsedLocalWorkspace[] {
+  const byMaterialization = new Map<string, Workspace[]>();
+  for (const workspace of workspaces) {
+    const key = localWorkspaceExactMaterializationKey(workspace);
+    const bucket = byMaterialization.get(key);
+    if (bucket) {
+      bucket.push(workspace);
+    } else {
+      byMaterialization.set(key, [workspace]);
+    }
+  }
+
+  return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
+    if (bucket.length === 1) {
+      return [{ workspace: bucket[0]!, aliasIds: [] }];
+    }
+
+    const distinct = bucket.filter(
+      (candidate) =>
+        workspaceHasOwnSessions(candidate)
+        || localWorkspaceMatchesSelection(candidate, currentSelectionId),
+    );
+    const foldable = bucket.filter(
+      (candidate) =>
+        !workspaceHasOwnSessions(candidate)
+        && !localWorkspaceMatchesSelection(candidate, currentSelectionId),
+    );
+
+    if (distinct.length === 0) {
+      const representative = [...foldable]
+        .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
+      return [{
+        workspace: representative,
+        aliasIds: foldable
+          .filter((candidate) => candidate.id !== representative.id)
+          .flatMap(localWorkspaceIdentityIds),
+      }];
+    }
+
+    const sortedDistinct = [...distinct]
+      .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId));
+    const foldedAliasIds = foldable.flatMap(localWorkspaceIdentityIds);
+    return sortedDistinct.map((workspace, index) => ({
+      workspace,
+      // Fold stale empty duplicates onto the first distinct entry.
+      aliasIds: index === 0 ? foldedAliasIds : [],
+    }));
+  });
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-id.ts
@@ -18,7 +18,8 @@ export type LogicalWorkspaceIdKind =
   | "repo-root"
   | "path"
   | "local-slot"
-  | "cloud-workspace";
+  | "cloud-workspace"
+  | "cloud";
 
 export interface ParsedLogicalWorkspaceId {
   kind: LogicalWorkspaceIdKind;
@@ -80,6 +81,20 @@ export function buildCloudWorkspaceLogicalWorkspaceId(cloudWorkspaceId: string):
   ].join(":");
 }
 
+/**
+ * Identity-keyed id for a Cloud workspace that carries an explicit
+ * materialization ledger but no local link on this install (PR 5). Keyed by
+ * `CloudWorkspace.id` so it is stable and never heuristically merged onto a
+ * local slot by repository/branch. Distinct from the `remote:` branch-heuristic
+ * key so legacy Cloud rows and explicit rows never collide.
+ */
+export function buildCloudIdentityLogicalWorkspaceId(cloudWorkspaceId: string): string {
+  return [
+    "cloud",
+    encodeLogicalSegment(cloudWorkspaceId),
+  ].join(":");
+}
+
 export function parseLogicalWorkspaceId(
   logicalWorkspaceId: string | null | undefined,
 ): ParsedLogicalWorkspaceId | null {
@@ -94,6 +109,7 @@ export function parseLogicalWorkspaceId(
     && kind !== "path"
     && kind !== "local-slot"
     && kind !== "cloud-workspace"
+    && kind !== "cloud"
   ) {
     return null;
   }
@@ -108,6 +124,7 @@ export function parseLogicalWorkspaceId(
   if (
     (kind === "remote" && segments.length !== 4)
     || ((kind === "repo-root" || kind === "path") && segments.length !== 2)
+    || (kind === "cloud" && segments.length !== 1)
   ) {
     return null;
   }
@@ -145,7 +162,11 @@ export function replaceLogicalWorkspaceBranch(
   }
 
   const nextBranchKey = normalizeLogicalWorkspaceBranchKey(branchKey);
-  if (parsed.kind === "local-slot" || parsed.kind === "cloud-workspace") {
+  if (
+    parsed.kind === "local-slot"
+    || parsed.kind === "cloud-workspace"
+    || parsed.kind === "cloud"
+  ) {
     // These IDs are keyed by workspace id; branch identity is read from the
     // materialized workspace row, so the logical id has no branch to replace.
     return logicalWorkspaceId ?? null;

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspace-materialization.ts
@@ -1,7 +1,53 @@
 import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import { targetWorkspaceSyntheticId } from "#product/lib/domain/compute/target-workspace-id";
 import { cloudWorkspaceUsesCloudRuntime } from "#product/lib/domain/workspaces/cloud/cloud-runtime-kind";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceSummary,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
+
+/** A local materialization is a durable copy this install can open (vs. a
+ * pending/failed attempt). Only these establish an explicit association. */
+const HEALTHY_LOCAL_MATERIALIZATION_STATES: ReadonlySet<string> = new Set([
+  "hydrated",
+]);
+
+/** True when the Cloud response carries an explicit materialization ledger.
+ * Legacy rows (pre-PR 4) omit the array and fall back to repository/branch
+ * heuristics; rows that carry it use explicit association instead. */
+export function cloudWorkspaceHasMaterializations(
+  workspace: Pick<CloudWorkspaceSummary, "materializations">,
+): boolean {
+  return (workspace.materializations?.length ?? 0) > 0;
+}
+
+/**
+ * The AnyHarness workspace id of this install's explicit, healthy local
+ * materialization for a Cloud workspace, or null. This is the authoritative
+ * `(desktopInstallId, anyharnessWorkspaceId)` link the server selected; a
+ * redacted row from another install (null path/id) never matches here.
+ */
+export function explicitLocalMaterializationAnyharnessId(
+  workspace: Pick<CloudWorkspaceSummary, "materializations">,
+  desktopInstallId: string | null | undefined,
+): string | null {
+  if (!desktopInstallId) {
+    return null;
+  }
+  const rows: CloudWorkspaceMaterializationSummary[] = workspace.materializations ?? [];
+  for (const row of rows) {
+    if (
+      row.targetKind === "local_desktop"
+      && row.desktopInstallId === desktopInstallId
+      && HEALTHY_LOCAL_MATERIALIZATION_STATES.has(row.state)
+      && row.anyharnessWorkspaceId
+    ) {
+      return row.anyharnessWorkspaceId;
+    }
+  }
+  return null;
+}
 
 export function logicalWorkspaceTargetMaterializationId(
   workspace: Pick<LogicalWorkspace, "cloudWorkspace">,

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts
@@ -11,6 +11,7 @@ import {
   logicalWorkspaceRelatedIds,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
+  buildCloudIdentityLogicalWorkspaceId,
   buildLocalSlotLogicalWorkspaceId,
   buildRemoteLogicalWorkspaceId,
   parseLogicalWorkspaceId,
@@ -671,6 +672,155 @@ describe("logical workspaces", () => {
         "hi",
       ),
     ).toBe("path:%2FUsers%2Fpablo%2Fproliferate:hi");
+  });
+
+  it("attaches a Cloud workspace to a local slot by explicit materialization, not branch", () => {
+    // Two different-path local worktrees on the same branch; the Cloud record's
+    // explicit local materialization names ws-b. It must merge with ws-b only.
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "feat/x", path: "/a" });
+    const wsB = makeWorkspace({ id: "ws-b", repoName: "rocket", branch: "feat/x", path: "/b" });
+    const repoRoot = makeRepoRoot({ repoName: "rocket" });
+    const cloud = {
+      ...makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "feat/x" }),
+      materializations: [
+        {
+          id: "m-managed",
+          targetKind: "managed_cloud" as const,
+          desktopInstallId: null,
+          anyharnessWorkspaceId: "ah-managed",
+          worktreePath: null,
+          state: "hydrated" as const,
+          generation: 1,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+        {
+          id: "m-local",
+          targetKind: "local_desktop" as const,
+          desktopInstallId: "mac-a",
+          anyharnessWorkspaceId: "ws-b",
+          worktreePath: "/b",
+          state: "hydrated" as const,
+          generation: 2,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+      ],
+    };
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA, wsB],
+      repoRoots: [repoRoot],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    const withCloud = result.filter((w) => w.cloudWorkspace?.id === "cloud-1");
+    expect(withCloud).toHaveLength(1);
+    expect(withCloud[0]!.localWorkspace?.id).toBe("ws-b");
+    // ws-a stays its own distinct slot with no Cloud record attached.
+    const slotA = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(slotA?.cloudWorkspace).toBeNull();
+  });
+
+  it("keeps a materialized Cloud workspace distinct when no local link exists for this install", () => {
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "feat/x", path: "/a" });
+    const cloud = {
+      ...makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "feat/x" }),
+      materializations: [
+        {
+          id: "m-managed",
+          targetKind: "managed_cloud" as const,
+          desktopInstallId: null,
+          anyharnessWorkspaceId: "ah-managed",
+          worktreePath: null,
+          state: "hydrated" as const,
+          generation: 1,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+      ],
+    };
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA],
+      repoRoots: [makeRepoRoot({ repoName: "rocket" })],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    // No heuristic merge: the same-branch local slot stays local-only and the
+    // Cloud record is its own identity-keyed logical workspace.
+    const slotA = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(slotA?.cloudWorkspace).toBeNull();
+    const cloudOnly = result.find((w) => w.cloudWorkspace?.id === "cloud-1" && !w.localWorkspace);
+    expect(cloudOnly).toBeDefined();
+  });
+
+  it("does not merge another install's redacted local materialization", () => {
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "feat/x", path: "/a" });
+    const cloud = {
+      ...makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "feat/x" }),
+      materializations: [
+        {
+          id: "m-local-other",
+          targetKind: "local_desktop" as const,
+          // Redacted row from a different install: null path/id.
+          desktopInstallId: "mac-other",
+          anyharnessWorkspaceId: null,
+          worktreePath: null,
+          state: "hydrated" as const,
+          generation: 1,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        },
+      ],
+    };
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA],
+      repoRoots: [makeRepoRoot({ repoName: "rocket" })],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    const slotA = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(slotA?.cloudWorkspace).toBeNull();
+  });
+
+  it("falls back to the branch heuristic for a legacy Cloud row without materializations", () => {
+    const wsA = makeWorkspace({ id: "ws-a", repoName: "rocket", branch: "main", path: "/a" });
+    const cloud = makeCloudWorkspace({ id: "cloud-1", repoName: "rocket", branch: "main" });
+
+    const result = buildLogicalWorkspaces({
+      localWorkspaces: [wsA],
+      repoRoots: [makeRepoRoot({ repoName: "rocket" })],
+      cloudWorkspaces: [cloud],
+      desktopInstallId: "mac-a",
+    });
+
+    // Legacy behavior preserved: same repo/branch folds local + Cloud together.
+    const merged = result.find((w) => w.localWorkspace?.id === "ws-a");
+    expect(merged?.cloudWorkspace?.id).toBe("cloud-1");
+  });
+
+  it("parses cloud identity ids and leaves branch replacement unchanged", () => {
+    const cloudId = buildCloudIdentityLogicalWorkspaceId("cloud-1");
+    expect(cloudId).toBe("cloud:cloud-1");
+    expect(parseLogicalWorkspaceId(cloudId)).toEqual({ kind: "cloud", segments: ["cloud-1"] });
+    expect(replaceLogicalWorkspaceBranch(cloudId, "feature/new")).toBe(cloudId);
   });
 
   it("parses local-slot ids strictly and leaves branch replacement unchanged", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.ts
@@ -10,11 +10,17 @@ import {
   repoRootGroupKey,
 } from "#product/lib/domain/workspaces/cloud/collections";
 import {
+  buildCloudIdentityLogicalWorkspaceId,
   buildLocalSlotLogicalWorkspaceId,
   buildRemoteLogicalWorkspaceId,
   normalizeLogicalWorkspaceBranchKey,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-id";
-import { resolvePreferredLogicalWorkspaceMaterialization } from "#product/lib/domain/workspaces/cloud/logical-workspace-materialization";
+import {
+  cloudWorkspaceHasMaterializations,
+  explicitLocalMaterializationAnyharnessId,
+  resolvePreferredLogicalWorkspaceMaterialization,
+} from "#product/lib/domain/workspaces/cloud/logical-workspace-materialization";
+import { collapseExactLocalWorkspaceDuplicates } from "#product/lib/domain/workspaces/cloud/logical-workspace-duplicates";
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
 import {
   buildBaseLogicalWorkspaceIdForLocalWorkspace,
@@ -36,150 +42,16 @@ import {
   preferCloudWorkspaceForLogicalSlot,
 } from "#product/lib/domain/workspaces/cloud/logical-workspace-slot";
 
-function timestampValue(timestamp: string | null | undefined): number {
-  return timestamp ? new Date(timestamp).getTime() : 0;
-}
-
-function localWorkspaceExactMaterializationKey(workspace: Workspace): string {
-  return `${workspace.path.trim()}\0${workspaceBranchKey(workspace)}`;
-}
-
-function workspaceExecutionPriority(workspace: Workspace): number {
-  const summary = workspace.executionSummary;
-  if (!summary) {
-    return 0;
-  }
-
-  if (summary.totalSessionCount > summary.liveSessionCount) {
-    return 3;
-  }
-
-  if (summary.phase === "running" || summary.phase === "awaiting_interaction") {
-    return 2;
-  }
-
-  if (summary.totalSessionCount > 0) {
-    return 1;
-  }
-
-  return 0;
-}
-
-function compareExactLocalWorkspaceDuplicateOrder(left: Workspace, right: Workspace): number {
-  const byExecutionPriority = workspaceExecutionPriority(right) - workspaceExecutionPriority(left);
-  if (byExecutionPriority !== 0) {
-    return byExecutionPriority;
-  }
-
-  const byExecutionUpdatedAt = (
-    timestampValue(right.executionSummary?.updatedAt)
-    - timestampValue(left.executionSummary?.updatedAt)
-  );
-  if (byExecutionUpdatedAt !== 0) {
-    return byExecutionUpdatedAt;
-  }
-
-  const byWorkspaceUpdatedAt = timestampValue(right.updatedAt) - timestampValue(left.updatedAt);
-  if (byWorkspaceUpdatedAt !== 0) {
-    return byWorkspaceUpdatedAt;
-  }
-
-  return compareLocalWorkspaceCanonicalOrder(left, right);
-}
-
-interface CollapsedLocalWorkspace {
-  workspace: Workspace;
-  aliasIds: string[];
-}
-
-function localWorkspaceIdentityIds(workspace: Workspace): string[] {
-  return [workspace.id, buildLocalSlotLogicalWorkspaceId(workspace.id)];
-}
-
-function localWorkspaceMatchesSelection(
-  workspace: Workspace,
-  currentSelectionId: string | null,
-): boolean {
-  return currentSelectionId !== null
-    && localWorkspaceIdentityIds(workspace).includes(currentSelectionId);
-}
-
-function compareExactLocalWorkspaceDuplicateOrderForSelection(
-  currentSelectionId: string | null,
-): (left: Workspace, right: Workspace) => number {
-  return (left, right) => {
-    const leftSelected = localWorkspaceMatchesSelection(left, currentSelectionId);
-    const rightSelected = localWorkspaceMatchesSelection(right, currentSelectionId);
-    if (leftSelected !== rightSelected) {
-      return leftSelected ? -1 : 1;
-    }
-    return compareExactLocalWorkspaceDuplicateOrder(left, right);
-  };
-}
-
-function workspaceHasOwnSessions(workspace: Workspace): boolean {
-  return (workspace.executionSummary?.totalSessionCount ?? 0) > 0;
-}
-
-function collapseExactLocalWorkspaceDuplicates(
-  workspaces: readonly Workspace[],
-  currentSelectionId: string | null,
-): CollapsedLocalWorkspace[] {
-  const byMaterialization = new Map<string, Workspace[]>();
-  for (const workspace of workspaces) {
-    const key = localWorkspaceExactMaterializationKey(workspace);
-    const bucket = byMaterialization.get(key);
-    if (bucket) {
-      bucket.push(workspace);
-    } else {
-      byMaterialization.set(key, [workspace]);
-    }
-  }
-
-  return Array.from(byMaterialization.values()).flatMap((bucket): CollapsedLocalWorkspace[] => {
-    if (bucket.length === 1) {
-      return [{ workspace: bucket[0]!, aliasIds: [] }];
-    }
-
-    const distinct = bucket.filter(
-      (candidate) =>
-        workspaceHasOwnSessions(candidate)
-        || localWorkspaceMatchesSelection(candidate, currentSelectionId),
-    );
-    const foldable = bucket.filter(
-      (candidate) =>
-        !workspaceHasOwnSessions(candidate)
-        && !localWorkspaceMatchesSelection(candidate, currentSelectionId),
-    );
-
-    if (distinct.length === 0) {
-      const representative = [...foldable]
-        .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId))[0]!;
-      return [{
-        workspace: representative,
-        aliasIds: foldable
-          .filter((candidate) => candidate.id !== representative.id)
-          .flatMap(localWorkspaceIdentityIds),
-      }];
-    }
-
-    const sortedDistinct = [...distinct]
-      .sort(compareExactLocalWorkspaceDuplicateOrderForSelection(currentSelectionId));
-    const foldedAliasIds = foldable.flatMap(localWorkspaceIdentityIds);
-    return sortedDistinct.map((workspace, index) => ({
-      workspace,
-      // Fold stale empty duplicates onto the first distinct entry.
-      aliasIds: index === 0 ? foldedAliasIds : [],
-    }));
-  });
-}
-
 export function buildLogicalWorkspaces(args: {
   localWorkspaces: Workspace[];
   repoRoots: RepoRoot[];
   cloudWorkspaces: CloudWorkspaceSummary[];
   cloudMobilityWorkspaces?: CloudMobilityWorkspaceSummary[];
   currentSelectionId?: string | null;
+  /** This desktop install's id. When present, a Cloud workspace with an
+   * explicit healthy local materialization for this install merges with that
+   * exact local workspace by id — never by repository/branch heuristic. */
+  desktopInstallId?: string | null;
 }): LogicalWorkspace[] {
   const repoRootsById = new Map(args.repoRoots.map((repoRoot) => [repoRoot.id, repoRoot]));
   const cloudWorkspacesById = new Map(args.cloudWorkspaces.map((workspace) => [
@@ -217,6 +89,10 @@ export function buildLogicalWorkspaces(args: {
     }
   }
 
+  // Map every placed local workspace's AnyHarness id to its logical slot id so a
+  // Cloud workspace with an explicit local materialization can attach to the
+  // exact same local slot the server linked — never by branch heuristic.
+  const localLogicalIdByAnyharnessId = new Map<string, string>();
   for (const [baseLogicalId, bucket] of localBuckets) {
     const sortedBucket = collapseExactLocalWorkspaceDuplicates(
       bucket,
@@ -234,11 +110,28 @@ export function buildLogicalWorkspaces(args: {
         mobilityWorkspace: null,
         aliasIds: collapsed.aliasIds,
       });
+      localLogicalIdByAnyharnessId.set(workspace.id, logicalId);
     });
   }
 
   for (const workspace of args.cloudWorkspaces) {
-    const logicalId = buildLogicalWorkspaceIdForCloudWorkspace(workspace);
+    // Explicit association takes precedence over the repository/branch
+    // heuristic whenever the Cloud response carries a materialization ledger.
+    // A healthy local materialization for THIS install merges the Cloud record
+    // onto that exact local slot; otherwise the Cloud record stands on its own
+    // identity-keyed slot (no heuristic attachment to a same-branch local).
+    const explicitLocalAnyharnessId = cloudWorkspaceHasMaterializations(workspace)
+      ? explicitLocalMaterializationAnyharnessId(workspace, args.desktopInstallId)
+      : null;
+    const explicitLogicalId = explicitLocalAnyharnessId
+      ? localLogicalIdByAnyharnessId.get(explicitLocalAnyharnessId) ?? null
+      : null;
+
+    const logicalId = explicitLogicalId
+      ?? (cloudWorkspaceHasMaterializations(workspace)
+        ? buildCloudIdentityLogicalWorkspaceId(workspace.id)
+        : buildLogicalWorkspaceIdForCloudWorkspace(workspace));
+
     if (
       isCloudWorkspaceFailedBeforeReady(workspace)
       && !cloudWorkspaceMatchesSelection(workspace, logicalId, args.currentSelectionId)

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-report-error.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-report-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+import {
+  STALE_MATERIALIZATION_GENERATION_CODE,
+  isStaleMaterializationGenerationError,
+} from "#product/lib/domain/workspaces/cloud/materialization-report-error";
+
+describe("isStaleMaterializationGenerationError", () => {
+  it("detects the server's 409 stale-generation code (PR 4 report rejection)", () => {
+    const error = new ProliferateClientError(
+      "This materialization report is stale.",
+      409,
+      STALE_MATERIALIZATION_GENERATION_CODE,
+    );
+    expect(isStaleMaterializationGenerationError(error)).toBe(true);
+  });
+
+  it("does not match a different 409 code or a non-409 status", () => {
+    expect(
+      isStaleMaterializationGenerationError(
+        new ProliferateClientError("mismatch", 409, "materialization_sha_mismatch"),
+      ),
+    ).toBe(false);
+    expect(
+      isStaleMaterializationGenerationError(
+        new ProliferateClientError("stale", 500, STALE_MATERIALIZATION_GENERATION_CODE),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a plain Error", () => {
+    expect(isStaleMaterializationGenerationError(new Error("boom"))).toBe(false);
+    expect(isStaleMaterializationGenerationError(null)).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-report-error.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-report-error.ts
@@ -1,0 +1,19 @@
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+
+/**
+ * The server's stale-generation report rejection (PR 4 emits the RFC7807 code
+ * ``stale_materialization_generation`` with a 409 when a report's generation is
+ * behind the row's — including one bumped by a concurrent unlink or a newer
+ * intent). This is NOT a materialization failure: the local worktree is fine;
+ * the association simply moved on. The UI surfaces it as a distinct quiet state
+ * rather than an error toast (PR5-STALE-07).
+ */
+export const STALE_MATERIALIZATION_GENERATION_CODE = "stale_materialization_generation";
+
+export function isStaleMaterializationGenerationError(error: unknown): boolean {
+  return (
+    error instanceof ProliferateClientError
+    && error.status === 409
+    && error.code === STALE_MATERIALIZATION_GENERATION_CODE
+  );
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MaterializationIntentResponse } from "@proliferate/cloud-sdk/types";
+import { runOpenOnMacFlow } from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+
+const HEAD = "abc123";
+const BRANCH = "feat/x";
+
+function intentResponse(): MaterializationIntentResponse {
+  return {
+    operationId: "row-1:2",
+    materialization: {
+      id: "row-1",
+      targetKind: "local_desktop",
+      desktopInstallId: "mac-a",
+      anyharnessWorkspaceId: null,
+      worktreePath: null,
+      state: "pending",
+      generation: 2,
+      expectedHeadSha: HEAD,
+      observedHeadSha: null,
+      observedBranch: BRANCH,
+      failureCode: null,
+      lastReportedAt: null,
+    },
+    source: {
+      repository: { provider: "github", owner: "acme", name: "rocket", branch: BRANCH, baseBranch: "main" },
+      branchName: BRANCH,
+      headSha: HEAD,
+    },
+  } as MaterializationIntentResponse;
+}
+
+function callbacks(overrides: Record<string, unknown> = {}) {
+  return {
+    createIntent: vi.fn(async () => intentResponse()),
+    materializeRepoRoot: vi.fn(async () => ({
+      repoRoot: {
+        id: "root-1",
+        kind: "managed",
+        path: "/code/rocket",
+        remoteProvider: "github",
+        remoteOwner: "acme",
+        remoteRepoName: "rocket",
+        createdAt: "",
+        updatedAt: "",
+      },
+    })),
+    materializeWorkspaceAtRef: vi.fn(async () => ({
+      workspaceId: "ah-local",
+      observedHeadSha: HEAD,
+      worktreePath: "/code/rocket-wt",
+    })),
+    report: vi.fn(async () => ({})),
+    ...overrides,
+  } as any;
+}
+
+describe("runOpenOnMacFlow", () => {
+  it("threads a DISTINCT workspace-step id derived from the Cloud operationId and reports exactly", async () => {
+    const cb = callbacks();
+    const result = await runOpenOnMacFlow({ existingRepoRootId: "root-1" }, cb);
+
+    expect(cb.materializeRepoRoot).not.toHaveBeenCalled();
+    // The workspace step derives its id from the root op id, never the verbatim
+    // root (which would collide with the repo-root step under PR 3's shared
+    // operation_id PRIMARY KEY). See PR5-OPID-05.
+    expect(cb.materializeWorkspaceAtRef).toHaveBeenCalledWith("root-1", {
+      operationId: "row-1:2:workspace",
+      branchName: BRANCH,
+      headSha: HEAD,
+      destinationId: undefined,
+    });
+    expect(cb.report).toHaveBeenCalledWith("row-1", {
+      generation: 2,
+      state: "hydrated",
+      anyharnessWorkspaceId: "ah-local",
+      worktreePath: "/code/rocket-wt",
+      observedBranch: BRANCH,
+      observedHeadSha: HEAD,
+    });
+    expect(result.anyharnessWorkspaceId).toBe("ah-local");
+  });
+
+  it("derives DISTINCT per-step ids for the repo-root and workspace steps", async () => {
+    const cb = callbacks();
+    await runOpenOnMacFlow(
+      { existingRepoRootId: null, cloneDestinationPath: "/code/rocket" },
+      cb,
+    );
+
+    const repoRootId = cb.materializeRepoRoot.mock.calls[0]![0].operationId;
+    const workspaceId = cb.materializeWorkspaceAtRef.mock.calls[0]![1].operationId;
+    expect(repoRootId).toBe("row-1:2:repo-root");
+    expect(workspaceId).toBe("row-1:2:workspace");
+    // The two steps must never share one operation id (that shared-id reuse is
+    // exactly what PR 3 rejects with MATERIALIZATION_OPERATION_CONFLICT).
+    expect(repoRootId).not.toBe(workspaceId);
+
+    expect(cb.materializeRepoRoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationPath: "/code/rocket",
+        mode: "clone_or_adopt",
+        repository: expect.objectContaining({ cloneUrl: "https://github.com/acme/rocket.git" }),
+      }),
+    );
+    expect(cb.materializeWorkspaceAtRef).toHaveBeenCalledWith("root-1", expect.anything());
+  });
+
+  it("forces a fresh worktree (destinationId) only in recreate mode", async () => {
+    const relinkCb = callbacks();
+    await runOpenOnMacFlow({ existingRepoRootId: "root-1" }, relinkCb);
+    expect(relinkCb.materializeWorkspaceAtRef.mock.calls[0]![1].destinationId).toBeUndefined();
+
+    const recreateCb = callbacks();
+    await runOpenOnMacFlow({ existingRepoRootId: "root-1", forceFreshWorktree: true }, recreateCb);
+    const destinationId = recreateCb.materializeWorkspaceAtRef.mock.calls[0]![1].destinationId;
+    expect(destinationId).toBe("recreate-row-1:2".replace(/[^A-Za-z0-9._-]/gu, "-"));
+    // A single path segment: no slashes, ≤96 chars (PR 3 destinationId contract).
+    expect(destinationId).not.toContain("/");
+    expect(destinationId!.length).toBeLessThanOrEqual(96);
+  });
+
+  it("reuses the SAME per-step ids across a re-issued (crash-retry) run and reports once per success", async () => {
+    // Two runs with the same re-issued intent (the operationId is stable because
+    // the Cloud intent is idempotent on reuse). The per-step ids must be
+    // identical across runs so PR 3 replays rather than cutting a second
+    // worktree, and each successful run reports exactly once (PR5-RETRY-09).
+    const cb1 = callbacks();
+    await runOpenOnMacFlow({ existingRepoRootId: null, cloneDestinationPath: "/code/rocket" }, cb1);
+    const cb2 = callbacks();
+    await runOpenOnMacFlow({ existingRepoRootId: null, cloneDestinationPath: "/code/rocket" }, cb2);
+
+    expect(cb2.materializeRepoRoot.mock.calls[0]![0].operationId)
+      .toBe(cb1.materializeRepoRoot.mock.calls[0]![0].operationId);
+    expect(cb2.materializeWorkspaceAtRef.mock.calls[0]![1].operationId)
+      .toBe(cb1.materializeWorkspaceAtRef.mock.calls[0]![1].operationId);
+    expect(cb1.report).toHaveBeenCalledTimes(1);
+    expect(cb2.report).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report when materialization fails (pending intent left for retry)", async () => {
+    const cb = callbacks({
+      materializeWorkspaceAtRef: vi.fn(async () => {
+        throw new Error("busy");
+      }),
+    });
+
+    await expect(
+      runOpenOnMacFlow({ existingRepoRootId: "root-1" }, cb),
+    ).rejects.toThrow("busy");
+    expect(cb.report).not.toHaveBeenCalled();
+  });
+
+  it("rejects a wrong adopted repo root without materializing a workspace", async () => {
+    const cb = callbacks({
+      materializeRepoRoot: vi.fn(async () => ({
+        repoRoot: {
+          id: "root-x",
+          kind: "managed",
+          path: "/code/other",
+          remoteProvider: "github",
+          remoteOwner: "other",
+          remoteRepoName: "different",
+          createdAt: "",
+          updatedAt: "",
+        },
+      })),
+    });
+
+    await expect(
+      runOpenOnMacFlow(
+        { existingRepoRootId: null, cloneDestinationPath: "/code/rocket" },
+        cb,
+      ),
+    ).rejects.toThrow(/does not match/);
+    expect(cb.materializeWorkspaceAtRef).not.toHaveBeenCalled();
+    expect(cb.report).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.ts
@@ -1,0 +1,162 @@
+import type {
+  MaterializationIntentResponse,
+  ReportMaterializationRequest,
+} from "@proliferate/cloud-sdk/types";
+import type {
+  MaterializeRepoRootRequest,
+  MaterializeWorkspaceAtRefRequest,
+  RepoRoot,
+} from "@anyharness/sdk";
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+import { githubHttpsCloneUrl } from "#product/lib/domain/workspaces/creation/clone-repo-workflow";
+
+/**
+ * Crash-safe "Open on this Mac" orchestration (Flow 2), and the identical
+ * relink path (Flow 5). Pure: it receives already-resolved SDK/AnyHarness
+ * callbacks and sequences them, so ordering and idempotency are unit-testable.
+ *
+ * The invariant: the Cloud-issued `operationId` (`"{rowId}:{generation}"`) is
+ * the stable idempotency root. PR 3's ledger keys `local_materialization_operation`
+ * by a single `operation_id` PRIMARY KEY across BOTH the repo-root and workspace
+ * steps, and rejects a reused id whose request-hash (which encodes the step kind)
+ * differs with MATERIALIZATION_OPERATION_CONFLICT. So the two steps must NOT share
+ * one id: we derive distinct, deterministic per-step ids from the root
+ * (`"{operationId}:repo-root"` and `"{operationId}:workspace"`). Deterministic so a
+ * crash-retry re-issues the SAME per-step ids and replays PR 3's ledger result
+ * (never a second clone or worktree). The hydrated report carries the exact
+ * observed HEAD/branch the runtime returned. See PR5-OPID-05.
+ */
+
+/** Deterministic per-step operation ids derived from the Cloud-issued root, so a
+ * crash-retry reuses each step's id (PR 3 replay) while the repo-root and workspace
+ * steps never collide on one id (which would be an OPERATION_CONFLICT). */
+export function repoRootOperationId(rootOperationId: string): string {
+  return `${rootOperationId}:repo-root`;
+}
+export function workspaceOperationId(rootOperationId: string): string {
+  return `${rootOperationId}:workspace`;
+}
+
+export interface OpenOnMacRepoRootSource {
+  /** An existing local repo root that already hosts this repository, or null to
+   * clone one first. */
+  existingRepoRootId: string | null;
+  /** Destination path for a fresh clone when no existing repo root matches.
+   * Required when existingRepoRootId is null. */
+  cloneDestinationPath?: string | null;
+  /** Recreate mode (Flow 5): force a brand-new worktree instead of reusing or
+   * adopting an existing one. When set, a deterministic per-generation
+   * destination id is threaded into PR 3's exact-ref materialization so the
+   * worktree lands at a fresh managed path; leaving it unset lets PR 3
+   * reuse/adopt an existing clean checkout at the ref (relink / open). Derived
+   * from the generation-bearing operation id so a crash-retry of the SAME
+   * recreate reuses the SAME fresh path (PR5-MODE-03). */
+  forceFreshWorktree?: boolean;
+}
+
+/** A PR 3 `destinationId` is a single path segment (`[A-Za-z0-9._-]`, ≤96). Turn
+ * the generation-bearing operation id into one so recreate targets a fresh,
+ * deterministic managed path per generation. */
+function recreateDestinationId(rootOperationId: string): string {
+  const sanitized = rootOperationId.replace(/[^A-Za-z0-9._-]/gu, "-");
+  return `recreate-${sanitized}`.slice(0, 96);
+}
+
+export interface OpenOnMacCallbacks {
+  /** Create/reuse the Cloud local-materialization intent for this install. */
+  createIntent: () => Promise<MaterializationIntentResponse>;
+  /** Clone-or-adopt a repo root through PR 3 (only when no existing root). */
+  materializeRepoRoot: (input: MaterializeRepoRootRequest) => Promise<{ repoRoot: RepoRoot }>;
+  /** Materialize the exact-ref workspace through PR 3. */
+  materializeWorkspaceAtRef: (
+    repoRootId: string,
+    input: MaterializeWorkspaceAtRefRequest,
+  ) => Promise<{ workspaceId: string; observedHeadSha: string; worktreePath: string }>;
+  /** Report the outcome back to Cloud. */
+  report: (materializationId: string, body: ReportMaterializationRequest) => Promise<unknown>;
+}
+
+export interface OpenOnMacResult {
+  materializationId: string;
+  anyharnessWorkspaceId: string;
+  worktreePath: string;
+}
+
+/**
+ * Run the intent → (clone repo root if needed) → exact-ref materialize →
+ * report sequence. Returns the local AnyHarness workspace id so the caller can
+ * select/open it. Throws on any step failure; the pending intent is left for a
+ * safe retry (same operation id → no duplicate worktree).
+ */
+export async function runOpenOnMacFlow(
+  source: OpenOnMacRepoRootSource,
+  callbacks: OpenOnMacCallbacks,
+): Promise<OpenOnMacResult> {
+  const intent = await callbacks.createIntent();
+  const operationId = intent.operationId;
+  const { repository, branchName, headSha } = intent.source;
+
+  let repoRootId = source.existingRepoRootId;
+  if (!repoRootId) {
+    if (!source.cloneDestinationPath) {
+      throw new Error("A destination path is required to clone the repository.");
+    }
+    const { repoRoot } = await callbacks.materializeRepoRoot({
+      // Derive the repo-root step id from the Cloud operation id so a crash
+      // mid-clone reuses the repo-root materialization rather than cloning twice,
+      // while staying distinct from the workspace step's id (PR5-OPID-05).
+      operationId: repoRootOperationId(operationId),
+      destinationPath: source.cloneDestinationPath,
+      mode: "clone_or_adopt",
+      repository: {
+        provider: "github",
+        owner: repository.owner,
+        name: repository.name,
+        cloneUrl: githubHttpsCloneUrl(repository.owner, repository.name),
+      },
+    });
+    // Guard against adopting the wrong repository.
+    const matches = repoRoot.remoteProvider && repoRoot.remoteOwner && repoRoot.remoteRepoName
+      && canonicalRepoKey(repoRoot.remoteProvider, repoRoot.remoteOwner, repoRoot.remoteRepoName)
+        === canonicalRepoKey(repository.provider, repository.owner, repository.name);
+    if (!matches) {
+      throw new Error(
+        `Cloned repository does not match ${repository.owner}/${repository.name}.`,
+      );
+    }
+    repoRootId = repoRoot.id;
+  }
+
+  let materialized: { workspaceId: string; observedHeadSha: string; worktreePath: string };
+  try {
+    materialized = await callbacks.materializeWorkspaceAtRef(repoRootId, {
+      operationId: workspaceOperationId(operationId),
+      branchName,
+      headSha,
+      // Recreate forces a fresh managed worktree at a deterministic per-generation
+      // path; relink/open omit it so PR 3 may reuse/adopt a clean checkout at the
+      // ref (PR5-MODE-03).
+      destinationId: source.forceFreshWorktree ? recreateDestinationId(operationId) : undefined,
+    });
+  } catch (error) {
+    // Leave the intent pending for a safe retry (same operation id reuses the
+    // ledger result). Do not report a failure that would look like a durable
+    // materialization failure to the server.
+    throw error;
+  }
+
+  await callbacks.report(intent.materialization.id, {
+    generation: intent.materialization.generation,
+    state: "hydrated",
+    anyharnessWorkspaceId: materialized.workspaceId,
+    worktreePath: materialized.worktreePath,
+    observedBranch: branchName,
+    observedHeadSha: materialized.observedHeadSha,
+  });
+
+  return {
+    materializationId: intent.materialization.id,
+    anyharnessWorkspaceId: materialized.workspaceId,
+    worktreePath: materialized.worktreePath,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
@@ -40,6 +40,19 @@ function kinds(input: WorkspaceAvailabilityInput): string[] {
 }
 
 describe("resolveWorkspaceAvailabilityCommands", () => {
+  it("offers Link copies from the separate ledger-backed Cloud slot", () => {
+    expect(resolveWorkspaceAvailabilityCommands({
+      hasLocalWorkspace: false,
+      cloudWorkspace: { materializations: [{
+        id: "managed",
+        targetKind: "managed_cloud",
+      }] as never },
+      desktopInstallId: "install-1",
+      linkCandidate: true,
+      localMaterializationNeedsRepair: false,
+      unsupportedGitBlocker: null,
+    }).map((command) => command.kind)).toEqual(["link-copies"]);
+  });
   it("offers Add Cloud copy for a local-only workspace", () => {
     expect(
       kinds({ hasLocalWorkspace: true, cloudWorkspace: null, desktopInstallId: "mac-a" }),

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveWorkspaceAvailabilityInput,
+  resolveWorkspaceAvailabilityCommands,
+  unsupportedGitBlockerForLocalWorkspace,
+  type WorkspaceAvailabilityInput,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+const CLEAN_PUBLISHED: WorkspaceGitStatus = {
+  branch: "feat/x",
+  dirty: false,
+  conflicted: false,
+  ahead: 0,
+  behind: 0,
+  hasUpstream: true,
+  pr: null,
+  attention: "none",
+  capturedAt: "2026-07-16T00:00:00Z",
+  source: "live",
+};
+
+const HYDRATED_LOCAL = {
+  id: "m-local",
+  targetKind: "local_desktop" as const,
+  desktopInstallId: "mac-a",
+  anyharnessWorkspaceId: "ws-1",
+  worktreePath: "/a",
+  state: "hydrated" as const,
+  generation: 1,
+  expectedHeadSha: null,
+  observedHeadSha: null,
+  observedBranch: null,
+  failureCode: null,
+  lastReportedAt: null,
+};
+
+function kinds(input: WorkspaceAvailabilityInput): string[] {
+  return resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind);
+}
+
+describe("resolveWorkspaceAvailabilityCommands", () => {
+  it("offers Add Cloud copy for a local-only workspace", () => {
+    expect(
+      kinds({ hasLocalWorkspace: true, cloudWorkspace: null, desktopInstallId: "mac-a" }),
+    ).toEqual(["add-cloud-copy"]);
+  });
+
+  it("offers Open on this Mac for a Cloud-only workspace", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: false,
+        cloudWorkspace: { materializations: [] },
+        desktopInstallId: "mac-a",
+      }),
+    ).toEqual(["open-on-this-mac"]);
+  });
+
+  it("offers Link copies for a heuristic local + Cloud exact-ref match", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: true,
+        cloudWorkspace: { materializations: [] },
+        desktopInstallId: "mac-a",
+        linkCandidate: true,
+      }),
+    ).toEqual(["link-copies"]);
+  });
+
+  it("offers only Unlink for a healthy explicit link", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: true,
+        cloudWorkspace: { materializations: [HYDRATED_LOCAL] },
+        desktopInstallId: "mac-a",
+      }),
+    ).toEqual(["unlink-this-mac"]);
+  });
+
+  it("offers relink/recreate/unlink when the linked local copy is missing", () => {
+    expect(
+      kinds({
+        hasLocalWorkspace: false,
+        cloudWorkspace: {
+          materializations: [{ ...HYDRATED_LOCAL, state: "missing" }],
+        },
+        desktopInstallId: "mac-a",
+        localMaterializationNeedsRepair: true,
+      }),
+    ).toEqual(["relink-existing", "recreate-on-this-mac", "unlink-this-mac"]);
+  });
+
+  it("shows a selectable blocker for an unsupported Git state", () => {
+    const commands = resolveWorkspaceAvailabilityCommands({
+      hasLocalWorkspace: true,
+      cloudWorkspace: null,
+      desktopInstallId: "mac-a",
+      unsupportedGitBlocker: "The workspace has uncommitted changes.",
+    });
+    expect(commands).toHaveLength(1);
+    expect(commands[0]!.kind).toBe("unsupported-git-state");
+    expect(commands[0]!.blocker).toBe("The workspace has uncommitted changes.");
+  });
+
+  it("does not un-redact another install's link (no explicit link matched)", () => {
+    // A local_desktop row for a different install must not count as this
+    // install's link; a local-only workspace still offers Add Cloud copy.
+    expect(
+      kinds({
+        hasLocalWorkspace: true,
+        cloudWorkspace: null,
+        desktopInstallId: "mac-a",
+      }),
+    ).toEqual(["add-cloud-copy"]);
+  });
+});
+
+describe("unsupportedGitBlockerForLocalWorkspace", () => {
+  it("accepts a clean, published, in-sync normal branch", () => {
+    expect(unsupportedGitBlockerForLocalWorkspace(CLEAN_PUBLISHED)).toBeNull();
+  });
+
+  it("blocks dirty / conflicted / unpublished / out-of-sync / unknown states", () => {
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, dirty: true })).toMatch(/uncommitted/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, conflicted: true })).toMatch(/conflict/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, hasUpstream: false })).toMatch(/published/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, ahead: 1 })).toMatch(/in sync/);
+    expect(unsupportedGitBlockerForLocalWorkspace({ ...CLEAN_PUBLISHED, dirty: null })).toMatch(/not available/);
+    expect(unsupportedGitBlockerForLocalWorkspace(null)).toMatch(/not available/);
+  });
+});
+
+describe("deriveWorkspaceAvailabilityInput", () => {
+  it("blocks Add Cloud copy on a dirty local source", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: { id: "ws-1" },
+      cloudWorkspace: null,
+      desktopInstallId: "mac-a",
+      localGitStatus: { ...CLEAN_PUBLISHED, dirty: true },
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "unsupported-git-state",
+    ]);
+  });
+
+  it("offers Add Cloud copy on a clean published local source", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: { id: "ws-1" },
+      cloudWorkspace: null,
+      desktopInstallId: "mac-a",
+      localGitStatus: CLEAN_PUBLISHED,
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "add-cloud-copy",
+    ]);
+  });
+
+  it("never blocks a Cloud-only Open on this Mac on local git status", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: null,
+      cloudWorkspace: { materializations: [] },
+      desktopInstallId: "mac-a",
+      localGitStatus: null,
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "open-on-this-mac",
+    ]);
+  });
+
+  it("derives relink/recreate/unlink for a missing explicit link regardless of git status", () => {
+    const input = deriveWorkspaceAvailabilityInput({
+      localWorkspace: null,
+      cloudWorkspace: {
+        materializations: [{
+          id: "m",
+          targetKind: "local_desktop",
+          desktopInstallId: "mac-a",
+          anyharnessWorkspaceId: "ws-1",
+          worktreePath: "/a",
+          state: "missing",
+          generation: 3,
+          expectedHeadSha: null,
+          observedHeadSha: null,
+          observedBranch: null,
+          failureCode: null,
+          lastReportedAt: null,
+        }],
+      },
+      desktopInstallId: "mac-a",
+      localGitStatus: null,
+    });
+    expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
+      "relink-existing",
+      "recreate-on-this-mac",
+      "unlink-this-mac",
+    ]);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
@@ -170,12 +170,6 @@ export function resolveWorkspaceAvailabilityCommands(
   const linkedLocal = localMaterializationForInstall(input.cloudWorkspace, input.desktopInstallId);
   const isExplicitlyLinked = linkedLocal !== null;
 
-  // Cloud-only: no local copy on this install and no explicit link → offer to
-  // open a copy on this Mac.
-  if (input.cloudWorkspace && !input.hasLocalWorkspace && !isExplicitlyLinked) {
-    return [{ kind: "open-on-this-mac", label: "Open on this Mac…" }];
-  }
-
   // Explicitly linked: the linked local copy may be healthy or need repair.
   if (isExplicitlyLinked) {
     if (input.localMaterializationNeedsRepair || !input.hasLocalWorkspace) {
@@ -188,9 +182,17 @@ export function resolveWorkspaceAvailabilityCommands(
     return [{ kind: "unlink-this-mac", label: "Unlink this Mac…" }];
   }
 
-  // Local + unlinked Cloud that match the same exact ref → offer to link.
-  if (input.hasLocalWorkspace && input.cloudWorkspace && input.linkCandidate) {
+  // An unlinked Cloud slot with an independently enumerated same-repo/branch
+  // local candidate offers association-only linking. Explicit ledger-backed
+  // projection keeps those copies in separate logical slots until confirmed,
+  // so this does not require `hasLocalWorkspace` on the Cloud slot itself.
+  if (input.cloudWorkspace && input.linkCandidate) {
     return [{ kind: "link-copies", label: "Link copies…" }];
+  }
+
+  // Cloud-only: no local candidate and no explicit link → offer to materialize.
+  if (input.cloudWorkspace && !input.hasLocalWorkspace && !isExplicitlyLinked) {
+    return [{ kind: "open-on-this-mac", label: "Open on this Mac…" }];
   }
 
   // Local only (no Cloud copy) → offer to add a managed-Cloud copy.

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
@@ -1,0 +1,202 @@
+import type { Workspace } from "@anyharness/sdk";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceSummary,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+/**
+ * The workspace-copy availability commands (PR 5 UI action model). One pure,
+ * DOM-free command model derived from a logical workspace's local/Cloud
+ * materialization state, shared by the DOM three-dot menu (WorkspaceItemMenu)
+ * and the native context-menu builder so the two stay in exact parity.
+ *
+ * The repo `…` menu owns repository availability; this owns workspace-copy
+ * availability. V1 exposes only the safe core lifecycle — unsupported Git
+ * states surface a truthful, selectable blocker rather than an action.
+ */
+export type WorkspaceAvailabilityCommandKind =
+  | "add-cloud-copy"
+  | "open-on-this-mac"
+  | "link-copies"
+  | "relink-existing"
+  | "recreate-on-this-mac"
+  | "unlink-this-mac"
+  | "unsupported-git-state";
+
+export interface WorkspaceAvailabilityCommand {
+  kind: WorkspaceAvailabilityCommandKind;
+  label: string;
+  /** Blockers describe why a command is present but not actionable (unsupported
+   * Git state). An actionable command has no blocker. */
+  blocker?: string;
+}
+
+export interface WorkspaceAvailabilityInput {
+  /** True when this logical workspace has a local AnyHarness workspace on this
+   * install. */
+  hasLocalWorkspace: boolean;
+  /** The Cloud workspace summary, or null for a local-only workspace. */
+  cloudWorkspace: Pick<
+    CloudWorkspaceSummary,
+    "materializations"
+  > | null;
+  /** This install's id, or null on Web / no native worker. */
+  desktopInstallId: string | null;
+  /** True when the local and Cloud copies are the same exact ref and clean,
+   * making them a plausible Link candidate. Only meaningful when both a local
+   * workspace and an unlinked Cloud workspace are present. */
+  linkCandidate?: boolean;
+  /** True when this install's linked local materialization is missing or
+   * inconsistent (needs relink/recreate). */
+  localMaterializationNeedsRepair?: boolean;
+  /** A truthful blocker for an unsupported Git state (dirty, detached, mid-op,
+   * unpublished). When set, the only command is the selectable blocker. */
+  unsupportedGitBlocker?: string | null;
+}
+
+/**
+ * A local workspace's git status is "safe for a durable Cloud association"
+ * only when V1's exact core is met: a known-clean, conflict-free, normal-branch
+ * state with an upstream and zero ahead/behind. Anything else (or unknown
+ * status) yields a truthful blocker string rather than an action. Expansion to
+ * richer repair is PR 6.
+ */
+export function unsupportedGitBlockerForLocalWorkspace(
+  gitStatus: WorkspaceGitStatus | null | undefined,
+): string | null {
+  if (!gitStatus) {
+    // No status yet: do not offer a durable action on an unknown state.
+    return "Git status for this workspace is not available yet.";
+  }
+  if (gitStatus.conflicted === true) {
+    return "This workspace has unresolved merge conflicts.";
+  }
+  if (gitStatus.dirty === true) {
+    return "This workspace has uncommitted changes.";
+  }
+  if (gitStatus.dirty === null || gitStatus.conflicted === null) {
+    return "Git status for this workspace is not available yet.";
+  }
+  if (gitStatus.hasUpstream === false) {
+    return "This workspace branch has not been published upstream.";
+  }
+  if ((gitStatus.ahead ?? 0) !== 0 || (gitStatus.behind ?? 0) !== 0) {
+    return "This workspace branch is not in sync with its upstream.";
+  }
+  return null;
+}
+
+/**
+ * Adapt a logical workspace's parts into the availability input. Pure so the
+ * derivation (unsupported-git-state, link candidacy, repair) is unit-testable
+ * away from the sidebar. `localGitStatus` gates ONLY the actions that mutate a
+ * durable association from a local source (Add Cloud copy / Link); an
+ * already-linked or Cloud-only workspace never blocks on it.
+ */
+export function deriveWorkspaceAvailabilityInput(args: {
+  localWorkspace: Pick<Workspace, "id"> | null;
+  cloudWorkspace: Pick<CloudWorkspaceSummary, "materializations"> | null;
+  desktopInstallId: string | null;
+  localGitStatus: WorkspaceGitStatus | null | undefined;
+  /** True when a heuristic same-repo/branch local+Cloud pair is a plausible,
+   * not-yet-linked Link candidate. */
+  linkCandidate?: boolean;
+}): WorkspaceAvailabilityInput {
+  const linkedLocal = localMaterializationForInstall(args.cloudWorkspace, args.desktopInstallId);
+  const isExplicitlyLinked = linkedLocal !== null;
+  const localNeedsRepair = isExplicitlyLinked
+    && (linkedLocal!.state === "missing"
+      || linkedLocal!.state === "inconsistent"
+      || linkedLocal!.state === "failed");
+
+  // The unsupported-git blocker only applies to the two source-mutating
+  // actions (Add Cloud copy from a local source, Link a local source). A
+  // Cloud-only "Open on this Mac", an explicit link's Unlink, or a repair path
+  // must stay available regardless of the local working tree.
+  const wantsSourceMutation = (!!args.localWorkspace && !args.cloudWorkspace)
+    || (!!args.localWorkspace && !!args.cloudWorkspace && !isExplicitlyLinked && !!args.linkCandidate);
+  const unsupportedGitBlocker = wantsSourceMutation
+    ? unsupportedGitBlockerForLocalWorkspace(args.localGitStatus)
+    : null;
+
+  return {
+    hasLocalWorkspace: !!args.localWorkspace,
+    cloudWorkspace: args.cloudWorkspace,
+    desktopInstallId: args.desktopInstallId,
+    linkCandidate: args.linkCandidate,
+    localMaterializationNeedsRepair: localNeedsRepair,
+    unsupportedGitBlocker,
+  };
+}
+
+function localMaterializationForInstall(
+  cloudWorkspace: WorkspaceAvailabilityInput["cloudWorkspace"],
+  desktopInstallId: string | null,
+): CloudWorkspaceMaterializationSummary | null {
+  if (!cloudWorkspace || !desktopInstallId) {
+    return null;
+  }
+  const rows = cloudWorkspace.materializations ?? [];
+  return (
+    rows.find(
+      (row) =>
+        row.targetKind === "local_desktop" && row.desktopInstallId === desktopInstallId,
+    ) ?? null
+  );
+}
+
+/**
+ * Resolve the availability commands for a workspace's `…` menu, ordered as they
+ * appear in the menu. Pure: given the same input it returns the same commands,
+ * so the DOM and native menus render identically.
+ */
+export function resolveWorkspaceAvailabilityCommands(
+  input: WorkspaceAvailabilityInput,
+): WorkspaceAvailabilityCommand[] {
+  // An unsupported Git state blocks every mutation; show the truthful, still
+  // selectable blocker only (expansion is PR 6). Never offer an action that
+  // would reset/merge/rebase to "fix" it.
+  if (input.unsupportedGitBlocker) {
+    return [
+      {
+        kind: "unsupported-git-state",
+        label: "Unsupported Git state",
+        blocker: input.unsupportedGitBlocker,
+      },
+    ];
+  }
+
+  const linkedLocal = localMaterializationForInstall(input.cloudWorkspace, input.desktopInstallId);
+  const isExplicitlyLinked = linkedLocal !== null;
+
+  // Cloud-only: no local copy on this install and no explicit link → offer to
+  // open a copy on this Mac.
+  if (input.cloudWorkspace && !input.hasLocalWorkspace && !isExplicitlyLinked) {
+    return [{ kind: "open-on-this-mac", label: "Open on this Mac…" }];
+  }
+
+  // Explicitly linked: the linked local copy may be healthy or need repair.
+  if (isExplicitlyLinked) {
+    if (input.localMaterializationNeedsRepair || !input.hasLocalWorkspace) {
+      return [
+        { kind: "relink-existing", label: "Relink existing…" },
+        { kind: "recreate-on-this-mac", label: "Recreate on this Mac…" },
+        { kind: "unlink-this-mac", label: "Unlink this Mac…" },
+      ];
+    }
+    return [{ kind: "unlink-this-mac", label: "Unlink this Mac…" }];
+  }
+
+  // Local + unlinked Cloud that match the same exact ref → offer to link.
+  if (input.hasLocalWorkspace && input.cloudWorkspace && input.linkCandidate) {
+    return [{ kind: "link-copies", label: "Link copies…" }];
+  }
+
+  // Local only (no Cloud copy) → offer to add a managed-Cloud copy.
+  if (input.hasLocalWorkspace && !input.cloudWorkspace) {
+    return [{ kind: "add-cloud-copy", label: "Add Cloud copy…" }];
+  }
+
+  return [];
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { workspaceAvailabilityIntentForCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-intent-mapping";
+
+const FULL = {
+  localWorkspaceId: "ws-1",
+  cloudWorkspaceId: "cloud-1",
+  linkedMaterializationId: "mat-1",
+  repoOwner: "acme",
+  repoName: "rocket",
+};
+
+describe("workspaceAvailabilityIntentForCommand", () => {
+  it("maps add-cloud-copy to an add_cloud_copy intent", () => {
+    expect(workspaceAvailabilityIntentForCommand("add-cloud-copy", FULL)).toEqual({
+      kind: "add_cloud_copy",
+      localWorkspaceId: "ws-1",
+      gitOwner: "acme",
+      gitRepoName: "rocket",
+    });
+  });
+
+  it("maps open-on-this-mac to an open_on_mac intent", () => {
+    expect(workspaceAvailabilityIntentForCommand("open-on-this-mac", FULL)).toEqual({
+      kind: "open_on_mac",
+      cloudWorkspaceId: "cloud-1",
+    });
+  });
+
+  it("maps link-copies to a distinct association-only link_copies intent (not relink)", () => {
+    // Flow 4 is association-only and must NOT map to relink/recreate (which
+    // materialize). See PR5-LINK-01.
+    expect(workspaceAvailabilityIntentForCommand("link-copies", FULL)).toEqual({
+      kind: "link_copies",
+      cloudWorkspaceId: "cloud-1",
+    });
+  });
+
+  it("maps relink to relink mode and recreate to recreate mode", () => {
+    expect(workspaceAvailabilityIntentForCommand("relink-existing", FULL)).toEqual({
+      kind: "relink",
+      cloudWorkspaceId: "cloud-1",
+      mode: "relink",
+    });
+    expect(workspaceAvailabilityIntentForCommand("recreate-on-this-mac", FULL)).toEqual({
+      kind: "relink",
+      cloudWorkspaceId: "cloud-1",
+      mode: "recreate",
+    });
+  });
+
+  it("maps unlink-this-mac to an unlink intent with the materialization id", () => {
+    expect(workspaceAvailabilityIntentForCommand("unlink-this-mac", FULL)).toEqual({
+      kind: "unlink",
+      cloudWorkspaceId: "cloud-1",
+      materializationId: "mat-1",
+    });
+  });
+
+  it("returns null when required identifiers are missing", () => {
+    expect(
+      workspaceAvailabilityIntentForCommand("add-cloud-copy", { ...FULL, localWorkspaceId: null }),
+    ).toBeNull();
+    expect(
+      workspaceAvailabilityIntentForCommand("open-on-this-mac", { ...FULL, cloudWorkspaceId: null }),
+    ).toBeNull();
+    expect(
+      workspaceAvailabilityIntentForCommand("unlink-this-mac", { ...FULL, linkedMaterializationId: null }),
+    ).toBeNull();
+    expect(
+      workspaceAvailabilityIntentForCommand("link-copies", { ...FULL, cloudWorkspaceId: null }),
+    ).toBeNull();
+  });
+
+  it("returns null for the non-actionable blocker", () => {
+    expect(workspaceAvailabilityIntentForCommand("unsupported-git-state", FULL)).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts
@@ -1,0 +1,66 @@
+import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import type { WorkspaceAvailabilityIntent } from "#product/stores/cloud/workspace-availability-intent-store";
+
+/** The identifiers a sidebar item carries for availability actions (PR 5). */
+export interface WorkspaceAvailabilityActionTarget {
+  localWorkspaceId: string | null;
+  cloudWorkspaceId: string | null;
+  linkedMaterializationId: string | null;
+  repoOwner: string | null;
+  repoName: string | null;
+}
+
+/**
+ * Map a selected availability command + its item's identifiers to the intent
+ * the connected host executes, or null when the required identifiers are
+ * missing (or the command is a non-actionable blocker). Pure so the sidebar
+ * wiring is unit-testable without a DOM.
+ */
+export function workspaceAvailabilityIntentForCommand(
+  kind: WorkspaceAvailabilityCommandKind,
+  target: WorkspaceAvailabilityActionTarget,
+): WorkspaceAvailabilityIntent | null {
+  switch (kind) {
+    case "add-cloud-copy":
+      if (target.localWorkspaceId && target.repoOwner && target.repoName) {
+        return {
+          kind: "add_cloud_copy",
+          localWorkspaceId: target.localWorkspaceId,
+          gitOwner: target.repoOwner,
+          gitRepoName: target.repoName,
+        };
+      }
+      return null;
+    case "open-on-this-mac":
+      return target.cloudWorkspaceId
+        ? { kind: "open_on_mac", cloudWorkspaceId: target.cloudWorkspaceId }
+        : null;
+    case "link-copies":
+      // Flow 4 is association-only: adopt an EXISTING local workspace proven to
+      // match the Cloud copy's exact ref. It never re-materializes, so it maps to
+      // a distinct intent from relink/recreate (which do materialize). The host
+      // resolves + verifies the chosen local candidate (PR5-LINK-01/02).
+      return target.cloudWorkspaceId
+        ? { kind: "link_copies", cloudWorkspaceId: target.cloudWorkspaceId }
+        : null;
+    case "relink-existing":
+      return target.cloudWorkspaceId
+        ? { kind: "relink", cloudWorkspaceId: target.cloudWorkspaceId, mode: "relink" }
+        : null;
+    case "recreate-on-this-mac":
+      return target.cloudWorkspaceId
+        ? { kind: "relink", cloudWorkspaceId: target.cloudWorkspaceId, mode: "recreate" }
+        : null;
+    case "unlink-this-mac":
+      return target.cloudWorkspaceId && target.linkedMaterializationId
+        ? {
+          kind: "unlink",
+          cloudWorkspaceId: target.cloudWorkspaceId,
+          materializationId: target.linkedMaterializationId,
+        }
+        : null;
+    case "unsupported-git-state":
+      // A truthful, non-actionable blocker (expansion is PR 6).
+      return null;
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RepoRoot } from "@anyharness/sdk";
+import { AddRepoIdentityMismatchError } from "#product/lib/domain/workspaces/creation/add-repo-workflow";
+import {
+  githubHttpsCloneUrl,
+  runCloneRepoWorkflow,
+} from "#product/lib/domain/workspaces/creation/clone-repo-workflow";
+
+const REPO = { gitProvider: "github", gitOwner: "acme", gitRepoName: "rocket" };
+
+function makeRepoRoot(overrides: Partial<RepoRoot> = {}): RepoRoot {
+  return {
+    id: "root-1",
+    kind: "managed",
+    path: "/Users/dev/code/rocket",
+    displayName: "rocket",
+    defaultBranch: "main",
+    remoteProvider: "github",
+    remoteOwner: "acme",
+    remoteRepoName: "rocket",
+    remoteUrl: "https://github.com/acme/rocket.git",
+    createdAt: "2026-07-16T00:00:00Z",
+    updatedAt: "2026-07-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function baseArgs(overrides: Partial<Parameters<typeof runCloneRepoWorkflow>[0]> = {}) {
+  return {
+    repo: REPO,
+    destinationPath: "/Users/dev/code/rocket",
+    operationId: "op-1",
+    ensureRuntimeReady: vi.fn(async () => "http://runtime"),
+    materializeRepoRoot: vi.fn(async () => ({ repoRoot: makeRepoRoot() })),
+    upsertRepoRootInWorkspaceCollections: vi.fn(),
+    invalidateWorkspaceCollections: vi.fn(async () => {}),
+    saveLocalRepoEnvironment: vi.fn(),
+    unhideRepoRoot: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("runCloneRepoWorkflow", () => {
+  it("builds an un-credentialed HTTPS clone URL", () => {
+    expect(githubHttpsCloneUrl("acme", "rocket")).toBe("https://github.com/acme/rocket.git");
+  });
+
+  it("clones with the exact repository target and reuses the operation id", async () => {
+    const args = baseArgs();
+    await runCloneRepoWorkflow(args);
+
+    expect(args.materializeRepoRoot).toHaveBeenCalledWith({
+      operationId: "op-1",
+      destinationPath: "/Users/dev/code/rocket",
+      mode: "clone_or_adopt",
+      repository: {
+        provider: "github",
+        owner: "acme",
+        name: "rocket",
+        cloneUrl: "https://github.com/acme/rocket.git",
+      },
+    });
+    expect(args.upsertRepoRootInWorkspaceCollections).toHaveBeenCalledWith(
+      "http://runtime",
+      expect.objectContaining({ id: "root-1" }),
+    );
+    expect(args.saveLocalRepoEnvironment).toHaveBeenCalled();
+    expect(args.invalidateWorkspaceCollections).toHaveBeenCalledWith("http://runtime");
+  });
+
+  it("rejects a wrong adopted repo and performs no mutation", async () => {
+    const args = baseArgs({
+      materializeRepoRoot: vi.fn(async () => ({
+        repoRoot: makeRepoRoot({ remoteOwner: "other", remoteRepoName: "different" }),
+      })),
+    });
+
+    await expect(runCloneRepoWorkflow(args)).rejects.toBeInstanceOf(AddRepoIdentityMismatchError);
+    expect(args.upsertRepoRootInWorkspaceCollections).not.toHaveBeenCalled();
+    expect(args.saveLocalRepoEnvironment).not.toHaveBeenCalled();
+    expect(args.invalidateWorkspaceCollections).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/clone-repo-workflow.ts
@@ -1,0 +1,90 @@
+import type { RepoRoot } from "@anyharness/sdk";
+import type { MaterializeRepoRootRequest } from "@anyharness/sdk";
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+import {
+  AddRepoIdentityMismatchError,
+  type ExpectedRepoIdentity,
+} from "#product/lib/domain/workspaces/creation/add-repo-workflow";
+
+/**
+ * The canonical, un-credentialed HTTPS clone URL for a GitHub repository. The
+ * PR 3 contract rejects a credentialed clone URL outright (userinfo in the URL
+ * → 400 REPOSITORY_AUTH_REQUIRED); local clone authenticates only through the
+ * local Git credential chain, so a token is never injected here.
+ */
+export function githubHttpsCloneUrl(owner: string, repoName: string): string {
+  return `https://github.com/${owner}/${repoName}.git`;
+}
+
+function repoRootIdentity(repoRoot: RepoRoot): ExpectedRepoIdentity | null {
+  const gitProvider = repoRoot.remoteProvider?.trim();
+  const gitOwner = repoRoot.remoteOwner?.trim();
+  const gitRepoName = repoRoot.remoteRepoName?.trim();
+  if (!gitProvider || !gitOwner || !gitRepoName) {
+    return null;
+  }
+  return { gitProvider, gitOwner, gitRepoName };
+}
+
+export interface RunCloneRepoWorkflowArgs {
+  /** The authorized GitHub repository to clone. */
+  repo: ExpectedRepoIdentity;
+  /** Absolute destination path the user chose for the clone. */
+  destinationPath: string;
+  /** Stable idempotency key reused across retries so a crash mid-clone reuses
+   * the same repo-root materialization instead of cloning twice. */
+  operationId: string;
+  ensureRuntimeReady: () => Promise<string>;
+  /** PR 3 clone-or-adopt materialization. */
+  materializeRepoRoot: (input: MaterializeRepoRootRequest) => Promise<{ repoRoot: RepoRoot }>;
+  upsertRepoRootInWorkspaceCollections: (runtimeUrl: string, repoRoot: RepoRoot) => void;
+  invalidateWorkspaceCollections: (runtimeUrl: string) => Promise<unknown>;
+  /** Best-effort target-scoped local environment save; a failure never blocks
+   * the clone (local registration stays usable when Cloud is unavailable). */
+  saveLocalRepoEnvironment?: (repoRoot: RepoRoot) => void;
+  unhideRepoRoot: (repoRootId: string) => void;
+}
+
+/**
+ * Flow 1: clone an authorized GitHub repository to this machine.
+ *
+ * Acquires the repository through PR 3's clone-or-adopt materialization, then
+ * verifies the returned repo-root identity matches the requested repository
+ * BEFORE any registration/save (a wrong adopted repo performs no mutation and
+ * no Cloud report). On success it registers the repo root, best-effort saves
+ * the target-scoped local environment, and invalidates the local collections
+ * so one repo group appears.
+ */
+export async function runCloneRepoWorkflow(
+  args: RunCloneRepoWorkflowArgs,
+): Promise<RepoRoot> {
+  const runtimeUrl = await args.ensureRuntimeReady();
+
+  const { repoRoot } = await args.materializeRepoRoot({
+    operationId: args.operationId,
+    destinationPath: args.destinationPath,
+    mode: "clone_or_adopt",
+    repository: {
+      provider: "github",
+      owner: args.repo.gitOwner,
+      name: args.repo.gitRepoName,
+      cloneUrl: githubHttpsCloneUrl(args.repo.gitOwner, args.repo.gitRepoName),
+    },
+  });
+
+  // Verify returned repo identity before mutating anything (wrong adopted repo
+  // → no registration, no Cloud report).
+  const actual = repoRootIdentity(repoRoot);
+  const matches = actual
+    && canonicalRepoKey(actual.gitProvider, actual.gitOwner, actual.gitRepoName)
+      === canonicalRepoKey(args.repo.gitProvider, args.repo.gitOwner, args.repo.gitRepoName);
+  if (!matches) {
+    throw new AddRepoIdentityMismatchError(args.repo, actual);
+  }
+
+  args.upsertRepoRootInWorkspaceCollections(runtimeUrl, repoRoot);
+  args.unhideRepoRoot(repoRoot.id);
+  args.saveLocalRepoEnvironment?.(repoRoot);
+  await args.invalidateWorkspaceCollections(runtimeUrl);
+  return repoRoot;
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
@@ -92,6 +92,12 @@ export function buildPendingSidebarProjection(args: {
       workspaceLocationCopyToastLabel: null,
       branchName: null,
       gitStatus: null,
+      // A pending (not-yet-created) entry has no materialized copies to act on.
+      availabilityCommands: [],
+      cloudWorkspaceIdForActions: null,
+      linkedMaterializationId: null,
+      repoOwner: null,
+      repoName: null,
     },
     sortRecency: {
       activityAt: createdAt,

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-groups.ts
@@ -95,6 +95,7 @@ export function buildSidebarGroupStates(args: {
   sessionLastViewedAt?: Record<string, string>;
   targetAppearanceById?: Record<string, ComputeTargetAppearance>;
   suppressActiveNeedsReview?: boolean;
+  desktopInstallId?: string | null;
 }): SidebarGroupState[] {
   const visibleWorkspaceTypes = new Set(resolveSidebarWorkspaceTypes(args.workspaceTypes));
   const repoRootsByKey = new Map(
@@ -176,6 +177,7 @@ export function buildSidebarGroupStates(args: {
         sessionLastViewedAt: args.sessionLastViewedAt,
         targetAppearanceById: args.targetAppearanceById,
         suppressActiveNeedsReview: args.suppressActiveNeedsReview,
+        desktopInstallId: args.desktopInstallId,
       });
       const items = pendingItem
         ? [pendingItem, ...workspaceItems]

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-link-candidates.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-link-candidates.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
+import { collectCloudWorkspaceLinkCandidates } from "#product/lib/domain/workspaces/sidebar/sidebar-workspace-items";
+
+function slot(overrides: Partial<LogicalWorkspace>): LogicalWorkspace {
+  return {
+    id: "slot",
+    repoKey: "repo",
+    sourceRoot: "/repo",
+    repoRoot: null,
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branchKey: "feat/CaseSensitive",
+    displayName: "Rocket",
+    localWorkspace: null,
+    cloudWorkspace: null,
+    mobilityWorkspace: null,
+    preferredMaterializationId: null,
+    effectiveOwner: "local",
+    lifecycle: "local_active",
+    updatedAt: "2026-07-16T00:00:00Z",
+    ...overrides,
+  } as LogicalWorkspace;
+}
+
+describe("collectCloudWorkspaceLinkCandidates", () => {
+  it("finds an unlinked local slot beside a production-shaped managed Cloud row", () => {
+    const cloud = slot({
+      id: "cloud-slot",
+      effectiveOwner: "cloud",
+      lifecycle: "cloud_active",
+      cloudWorkspace: {
+        id: "cloud-1",
+        materializations: [{ targetKind: "managed_cloud", id: "managed-1" }],
+      } as never,
+    });
+    const local = slot({ id: "local-slot", localWorkspace: { id: "local-1" } as never });
+
+    expect(collectCloudWorkspaceLinkCandidates([cloud, local], "install-1"))
+      .toEqual(new Set(["cloud-1"]));
+  });
+
+  it("does not case-fold branches or offer linking when this install already has a row", () => {
+    const local = slot({
+      id: "local-slot",
+      branchKey: "feat/casesensitive",
+      localWorkspace: { id: "local-1" } as never,
+    });
+    const cloud = slot({
+      id: "cloud-slot",
+      cloudWorkspace: {
+        id: "cloud-1",
+        materializations: [{
+          targetKind: "local_desktop",
+          desktopInstallId: "install-1",
+        }],
+      } as never,
+    });
+
+    expect(collectCloudWorkspaceLinkCandidates([cloud, local], "install-1")).toEqual(new Set());
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts
@@ -10,6 +10,7 @@ import type {
   SidebarWorkspaceVariant,
 } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import type { WorkspaceAvailabilityCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export interface LocalSidebarWorkspaceEntry {
   source: "local";
@@ -92,6 +93,19 @@ export interface SidebarWorkspaceItemState {
    * (§2.7). Null when no status is known for the workspace.
    */
   gitStatus: WorkspaceGitStatus | null;
+  /**
+   * Workspace-copy availability commands (PR 5): Add Cloud copy / Open on this
+   * Mac / Link / Unlink / Relink / Recreate, or an unsupported-git-state
+   * blocker. Resolved from the shared availability command model so the DOM and
+   * native menus render identically.
+   */
+  availabilityCommands: WorkspaceAvailabilityCommand[];
+  /** Ids the availability actions target: the Cloud workspace, this install's
+   * linked local materialization, and the repo owner/name for Add Cloud copy. */
+  cloudWorkspaceIdForActions: string | null;
+  linkedMaterializationId: string | null;
+  repoOwner: string | null;
+  repoName: string | null;
 }
 
 export interface SidebarGroupState {

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
@@ -26,6 +26,10 @@ import { isWorkspaceNeedsReview } from "#product/lib/domain/workspaces/sidebar/s
 import { logicalWorkspaceHasUnreadSessionActivity } from "#product/lib/domain/workspaces/sidebar/workspace-activity-indicator";
 import { workspaceCopyMetadataForLogicalWorkspace } from "#product/lib/domain/workspaces/workspace-copy-metadata";
 import { resolveLogicalWorkspaceRecency } from "#product/lib/domain/workspaces/sidebar/recency";
+import {
+  deriveWorkspaceAvailabilityInput,
+  resolveWorkspaceAvailabilityCommands,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 
 export interface SidebarWorkspaceItemWithWorkspace {
   workspace: LogicalWorkspace;
@@ -51,6 +55,9 @@ export function buildSidebarWorkspaceItems(args: {
   sessionLastViewedAt?: Record<string, string>;
   targetAppearanceById?: Record<string, ComputeTargetAppearance>;
   suppressActiveNeedsReview?: boolean;
+  /** This Mac's native desktop worker install id (PR 5), used to resolve the
+   * workspace-copy availability commands. Null on Web / no worker. */
+  desktopInstallId?: string | null;
 }): SidebarWorkspaceItemState[] {
   const workspaceItemsWithWorkspace = args.workspaces.map((entry) =>
     buildSidebarWorkspaceItem(entry, args)
@@ -94,6 +101,7 @@ function buildSidebarWorkspaceItem(
     sessionLastViewedAt?: Record<string, string>;
     targetAppearanceById?: Record<string, ComputeTargetAppearance>;
     suppressActiveNeedsReview?: boolean;
+    desktopInstallId?: string | null;
   },
 ): SidebarWorkspaceItemWithWorkspace {
   const active = logicalWorkspaceMatchesId(entry, args.selectedLogicalWorkspaceId);
@@ -150,6 +158,37 @@ function buildSidebarWorkspaceItem(
     ? args.targetAppearanceById?.[sshTargetId] ?? null
     : null;
 
+  // Workspace-copy availability commands (PR 5). A logical workspace that has
+  // both a local and a Cloud side without an explicit materialization for this
+  // install is a plausible Link candidate (same repo/branch heuristic already
+  // grouped them). SSH direct-target workspaces are out of PR 5 scope.
+  const gitStatus = args.gitStatusesByLogicalId?.[entry.id] ?? null;
+  const desktopInstallId = args.desktopInstallId ?? null;
+  const cloudSummary = entry.cloudWorkspace;
+  const hasExplicitMaterializations = (cloudSummary?.materializations?.length ?? 0) > 0;
+  const linkCandidate = Boolean(
+    variant !== "ssh"
+    && preferredLocalWorkspace
+    && cloudSummary
+    && !hasExplicitMaterializations,
+  );
+  const availabilityCommands = variant === "ssh"
+    ? []
+    : resolveWorkspaceAvailabilityCommands(
+      deriveWorkspaceAvailabilityInput({
+        localWorkspace: preferredLocalWorkspace ?? null,
+        cloudWorkspace: cloudSummary ?? null,
+        desktopInstallId,
+        localGitStatus: gitStatus,
+        linkCandidate,
+      }),
+    );
+  const linkedMaterialization = desktopInstallId
+    ? (cloudSummary?.materializations ?? []).find(
+      (m) => m.targetKind === "local_desktop" && m.desktopInstallId === desktopInstallId,
+    ) ?? null
+    : null;
+
   return {
     workspace: entry,
     item: {
@@ -188,7 +227,12 @@ function buildSidebarWorkspaceItem(
       workspaceLocationCopyValue: copyMetadata.workspaceLocation?.value ?? null,
       workspaceLocationCopyToastLabel: copyMetadata.workspaceLocation?.toastLabel ?? null,
       branchName: copyMetadata.branchName,
-      gitStatus: args.gitStatusesByLogicalId?.[entry.id] ?? null,
+      gitStatus,
+      availabilityCommands,
+      cloudWorkspaceIdForActions: cloudSummary?.id ?? null,
+      linkedMaterializationId: linkedMaterialization?.id ?? null,
+      repoOwner: entry.owner ?? cloudSummary?.repo?.owner ?? null,
+      repoName: entry.repoName ?? cloudSummary?.repo?.name ?? null,
     },
   };
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
@@ -30,6 +30,7 @@ import {
   deriveWorkspaceAvailabilityInput,
   resolveWorkspaceAvailabilityCommands,
 } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
 
 export interface SidebarWorkspaceItemWithWorkspace {
   workspace: LogicalWorkspace;
@@ -59,8 +60,12 @@ export function buildSidebarWorkspaceItems(args: {
    * workspace-copy availability commands. Null on Web / no worker. */
   desktopInstallId?: string | null;
 }): SidebarWorkspaceItemState[] {
+  const linkCandidateCloudWorkspaceIds = collectCloudWorkspaceLinkCandidates(
+    args.workspaces,
+    args.desktopInstallId ?? null,
+  );
   const workspaceItemsWithWorkspace = args.workspaces.map((entry) =>
-    buildSidebarWorkspaceItem(entry, args)
+    buildSidebarWorkspaceItem(entry, { ...args, linkCandidateCloudWorkspaceIds })
   );
 
   return applyDuplicateLocalNameSuffixes(
@@ -71,6 +76,43 @@ export function buildSidebarWorkspaceItems(args: {
       )
       : workspaceItemsWithWorkspace,
   );
+}
+
+/** Cloud ledger rows intentionally keep an unlinked Cloud workspace in its own
+ * logical slot. Find same-repository, same-case-sensitive-branch local slots
+ * across the whole projection so that production-shaped managed rows can still
+ * offer the explicit Link copies action (PR5-LINK-10). */
+export function collectCloudWorkspaceLinkCandidates(
+  workspaces: LogicalWorkspace[],
+  desktopInstallId: string | null,
+): Set<string> {
+  const localSlots = workspaces.filter((workspace) => workspace.localWorkspace !== null);
+  const result = new Set<string>();
+  for (const cloudSlot of workspaces) {
+    const cloud = cloudSlot.cloudWorkspace;
+    if (!cloud || cloudSlot.localWorkspace) continue;
+    const alreadyLinked = desktopInstallId
+      ? (cloud.materializations ?? []).some(
+        (row) => row.targetKind === "local_desktop"
+          && row.desktopInstallId === desktopInstallId,
+      )
+      : false;
+    if (alreadyLinked || !cloudSlot.provider || !cloudSlot.owner || !cloudSlot.repoName) continue;
+    const cloudRepoKey = canonicalRepoKey(
+      cloudSlot.provider,
+      cloudSlot.owner,
+      cloudSlot.repoName,
+    );
+    const matches = localSlots.some((localSlot) => (
+      localSlot.provider
+      && localSlot.owner
+      && localSlot.repoName
+      && canonicalRepoKey(localSlot.provider, localSlot.owner, localSlot.repoName) === cloudRepoKey
+      && localSlot.branchKey === cloudSlot.branchKey
+    ));
+    if (matches) result.add(cloud.id);
+  }
+  return result;
 }
 
 export function pendingOwnsLogicalWorkspace(
@@ -102,6 +144,7 @@ function buildSidebarWorkspaceItem(
     targetAppearanceById?: Record<string, ComputeTargetAppearance>;
     suppressActiveNeedsReview?: boolean;
     desktopInstallId?: string | null;
+    linkCandidateCloudWorkspaceIds: ReadonlySet<string>;
   },
 ): SidebarWorkspaceItemWithWorkspace {
   const active = logicalWorkspaceMatchesId(entry, args.selectedLogicalWorkspaceId);
@@ -165,12 +208,10 @@ function buildSidebarWorkspaceItem(
   const gitStatus = args.gitStatusesByLogicalId?.[entry.id] ?? null;
   const desktopInstallId = args.desktopInstallId ?? null;
   const cloudSummary = entry.cloudWorkspace;
-  const hasExplicitMaterializations = (cloudSummary?.materializations?.length ?? 0) > 0;
   const linkCandidate = Boolean(
     variant !== "ssh"
-    && preferredLocalWorkspace
     && cloudSummary
-    && !hasExplicitMaterializations,
+    && args.linkCandidateCloudWorkspaceIds.has(cloudSummary.id),
   );
   const availabilityCommands = variant === "ssh"
     ? []

--- a/apps/packages/product-client/src/stores/cloud/workspace-availability-intent-store.ts
+++ b/apps/packages/product-client/src/stores/cloud/workspace-availability-intent-store.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+/**
+ * The active workspace-availability action (PR 5 Flows 2/3/5), owned by one
+ * connected host (WorkspaceAvailabilityActionHost) mirroring the
+ * cloud-repository-intent idiom. Each intent is a minimal serializable object
+ * held only in memory: a cold restart leaves the store empty and nothing
+ * resumes (the workspace menu is the recovery path).
+ *
+ * - open_on_mac: materialize a Cloud workspace's exact published HEAD locally.
+ * - add_cloud_copy: create a managed-Cloud copy of a clean, published local
+ *   workspace at its exact ref.
+ * - link_copies: association-only adoption of an EXISTING local workspace that
+ *   is proven to be the same exact ref as the Cloud copy (Flow 4). It cuts no
+ *   worktree — the host verifies identity/branch/exact-HEAD and reports the
+ *   existing local workspace. The chosen local candidate is resolved by the host
+ *   (multiple candidates require explicit selection; never auto-pick).
+ * - unlink: association-only removal of this install's local materialization.
+ * - relink: reuse/adopt (Flow 5) — a new generation that re-materializes onto an
+ *   existing clean checkout at the ref if one exists.
+ * - recreate: like relink but always cuts a FRESH worktree (never adopts).
+ */
+export type WorkspaceAvailabilityIntent =
+  | { kind: "open_on_mac"; cloudWorkspaceId: string }
+  | {
+    kind: "add_cloud_copy";
+    localWorkspaceId: string;
+    gitOwner: string;
+    gitRepoName: string;
+  }
+  | { kind: "link_copies"; cloudWorkspaceId: string }
+  | { kind: "unlink"; cloudWorkspaceId: string; materializationId: string }
+  | { kind: "relink"; cloudWorkspaceId: string; mode: "relink" | "recreate" };
+
+interface WorkspaceAvailabilityIntentState {
+  activeIntent: WorkspaceAvailabilityIntent | null;
+  begin: (intent: WorkspaceAvailabilityIntent) => void;
+  clear: () => void;
+}
+
+export const useWorkspaceAvailabilityIntentStore = create<WorkspaceAvailabilityIntentState>(
+  (set) => ({
+    activeIntent: null,
+    begin: (intent) => set({ activeIntent: intent }),
+    clear: () => set({ activeIntent: null }),
+  }),
+);

--- a/apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts
+++ b/apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts
@@ -18,7 +18,7 @@ interface AddRepoFlowState {
     onCompleted?: (completion: AddRepoFlowCompletion) => void;
   }) => void;
   setStep: (step: AddRepoFlowStoreStep) => void;
-  /** Hide the picker while the connected Cloud readiness dialog owns it. */
+  /** Hide the picker while the connected repository-readiness host owns it. */
   handoffToCloud: () => void;
   close: () => void;
 }

--- a/apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts
+++ b/apps/packages/product-client/src/stores/ui/add-repo-flow-store.ts
@@ -2,7 +2,8 @@ import { create } from "zustand";
 
 export type AddRepoFlowStoreStep =
   | { kind: "entry" }
-  | { kind: "cloud" };
+  | { kind: "cloud" }
+  | { kind: "clone" };
 
 /** What the unified flow produced, for callers that select the new repo. */
 export type AddRepoFlowCompletion =

--- a/apps/packages/product-ui/src/repos/AddRepoFlow.tsx
+++ b/apps/packages/product-ui/src/repos/AddRepoFlow.tsx
@@ -3,7 +3,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
-import { ArrowLeft, Cloud, FolderOpen } from "lucide-react";
+import { ArrowLeft, Cloud, FolderOpen, GitBranch } from "lucide-react";
 
 import {
   Dialog,
@@ -16,15 +16,17 @@ import { CloudRepoPicker, type CloudRepoPickerProps } from "./CloudRepoPicker";
 
 /**
  * The host-truthful entry choices. `add-existing-folder` registers an existing
- * checkout on this machine (Desktop only); `cloud` walks the readiness → repo
- * picker → authority → save sequence (both hosts). There is deliberately no
- * placeholder Clone choice; Clone ships in a later slice.
+ * checkout on this machine (Desktop only); `clone-from-github` clones an
+ * authorized GitHub repository to this machine (Desktop only, GitHub-App-ready);
+ * `cloud` walks the readiness → repo picker → authority → save sequence (both
+ * hosts).
  */
-export type AddRepoFlowOption = "add-existing-folder" | "cloud";
+export type AddRepoFlowOption = "add-existing-folder" | "clone-from-github" | "cloud";
 
 export type AddRepoFlowStep =
   | { kind: "entry" }
-  | { kind: "cloud" };
+  | { kind: "cloud" }
+  | { kind: "clone" };
 
 export interface AddRepoFlowProps {
   open: boolean;
@@ -37,6 +39,9 @@ export interface AddRepoFlowProps {
   error?: string | null;
   /** View model for the cloud step, wired by the host's controller layer. */
   cloudPicker?: CloudRepoPickerProps | null;
+  /** View model for the clone-from-github step, wired by the host. Reuses the
+   * repo picker; on select the host runs the local clone. */
+  clonePicker?: CloudRepoPickerProps | null;
   onPickOption: (option: AddRepoFlowOption) => void;
   onBack: () => void;
   onClose: () => void;
@@ -55,6 +60,12 @@ const ENTRY_OPTION_DEFS: Record<AddRepoFlowOption, EntryOption> = {
     icon: <FolderOpen size={16} aria-hidden />,
     label: "Add an existing folder",
     description: "Register a repository folder from this machine.",
+  },
+  "clone-from-github": {
+    option: "clone-from-github",
+    icon: <GitBranch size={16} aria-hidden />,
+    label: "Clone from GitHub",
+    description: "Clone an authorized GitHub repository to this machine.",
   },
   cloud: {
     option: "cloud",
@@ -77,6 +88,7 @@ export function AddRepoFlow({
   adding = false,
   error = null,
   cloudPicker = null,
+  clonePicker = null,
   onPickOption,
   onBack,
   onClose,
@@ -99,8 +111,18 @@ export function AddRepoFlow({
       >
         {step.kind === "entry" ? (
           <AddRepoEntryStep options={options} onPickOption={onPickOption} disabled={adding} />
+        ) : step.kind === "clone" ? (
+          <AddRepoPickerStep
+            title="Clone from GitHub"
+            picker={clonePicker}
+            onBack={onBack}
+          />
         ) : (
-          <AddRepoCloudStep cloudPicker={cloudPicker} onBack={onBack} />
+          <AddRepoPickerStep
+            title="Add a cloud repo"
+            picker={cloudPicker}
+            onBack={onBack}
+          />
         )}
         {error ? (
           <p className="mt-3 text-xs leading-[1.45] text-destructive" role="alert">
@@ -176,11 +198,13 @@ function AddRepoEntryStep({
   );
 }
 
-function AddRepoCloudStep({
-  cloudPicker,
+function AddRepoPickerStep({
+  title,
+  picker,
   onBack,
 }: {
-  cloudPicker: CloudRepoPickerProps | null;
+  title: string;
+  picker: CloudRepoPickerProps | null;
   onBack: () => void;
 }) {
   return (
@@ -198,13 +222,13 @@ function AddRepoCloudStep({
             <ArrowLeft size={14} aria-hidden />
           </Button>
           <DialogTitle className="text-[15px] font-semibold leading-5">
-            Add a cloud repo
+            {title}
           </DialogTitle>
         </div>
       </DialogHeader>
-      {cloudPicker ? (
+      {picker ? (
         <div className="mt-3">
-          <CloudRepoPicker {...cloudPicker} />
+          <CloudRepoPicker {...picker} />
         </div>
       ) : null}
     </div>

--- a/apps/packages/product-ui/test/AddRepoFlow.test.tsx
+++ b/apps/packages/product-ui/test/AddRepoFlow.test.tsx
@@ -25,7 +25,7 @@ function renderFlow(overrides: Partial<AddRepoFlowProps> = {}) {
   const props: AddRepoFlowProps = {
     open: true,
     step: { kind: "entry" },
-    options: ["add-existing-folder", "cloud"],
+    options: ["add-existing-folder", "clone-from-github", "cloud"],
     onPickOption: vi.fn(),
     onBack: vi.fn(),
     onClose: vi.fn(),
@@ -43,10 +43,48 @@ describe("AddRepoFlow", () => {
 
     expect(screen.getByText("Add a repository")).toBeTruthy();
     expect(screen.getByText("Add an existing folder")).toBeTruthy();
+    expect(screen.getByText("Clone from GitHub")).toBeTruthy();
     expect(screen.getByText("Set up in Cloud")).toBeTruthy();
     fireEvent.click(screen.getByText("Set up in Cloud"));
 
     expect(onPickOption).toHaveBeenCalledWith("cloud");
+  });
+
+  it("reports the clone-from-github pick", () => {
+    const { onPickOption } = renderFlow();
+
+    fireEvent.click(screen.getByText("Clone from GitHub"));
+
+    expect(onPickOption).toHaveBeenCalledWith("clone-from-github");
+  });
+
+  it("runs the clone step in the same dialog with the repo picker", () => {
+    const onAddRepository = vi.fn();
+    renderFlow({
+      step: { kind: "clone" },
+      clonePicker: buildCloudPicker({
+        repositories: [{
+          id: "acme/rocket",
+          fullName: "acme/rocket",
+          defaultBranch: "main",
+          private: true,
+          fork: false,
+          archived: false,
+          disabled: false,
+          permission: "admin",
+          configured: false,
+          repoConfigState: "missing",
+        }],
+        onAddRepository,
+      }),
+    });
+
+    expect(screen.getByText("Clone from GitHub")).toBeTruthy();
+    expect(screen.getByLabelText("Search GitHub repositories")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Add acme/rocket" }));
+    expect(onAddRepository).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme/rocket" }),
+    );
   });
 
   it("offers only Set up in Cloud on Web (no local folder option)", () => {

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4332,6 +4332,33 @@ export interface components {
             generatedName?: boolean | null;
             /** Source */
             source?: ("desktop" | "web" | "mobile") | null;
+            /** Expectedheadsha */
+            expectedHeadSha?: string | null;
+            sourceMaterialization?: components["schemas"]["CreateCloudWorkspaceSourceMaterialization"] | null;
+        };
+        /**
+         * CreateCloudWorkspaceSourceMaterialization
+         * @description The local source descriptor for an exact-ref managed-Cloud creation.
+         *
+         *     Supplied by Desktop's "Add Cloud copy" flow: it names the local AnyHarness
+         *     workspace the exact ref came from so the resulting managed-Cloud row can be
+         *     associated with it. The server never trusts these fields for the actual ref
+         *     — it independently re-verifies the authorized GitHub branch head.
+         */
+        CreateCloudWorkspaceSourceMaterialization: {
+            /**
+             * Targetkind
+             * @constant
+             */
+            targetKind: "local_desktop";
+            /** Desktopinstallid */
+            desktopInstallId: string;
+            /** Anyharnessworkspaceid */
+            anyharnessWorkspaceId: string;
+            /** Worktreepath */
+            worktreePath: string;
+            /** Observedheadsha */
+            observedHeadSha: string;
         };
         /** CreateMaterializationIntentRequest */
         CreateMaterializationIntentRequest: {

--- a/cloud/sdk/src/types/generated.ts
+++ b/cloud/sdk/src/types/generated.ts
@@ -625,6 +625,8 @@ export type CloudWorktreeRetentionPolicyRequest =
   Schema<"CloudWorktreeRetentionPolicyRequest">;
 export type CloudWorktreeRetentionPolicyResponse =
   Schema<"CloudWorktreeRetentionPolicyResponse">;
+export type CreateCloudWorkspaceSourceMaterialization =
+  Schema<"CreateCloudWorkspaceSourceMaterialization">;
 export interface CreateCloudWorkspaceRequest {
   gitProvider: "github";
   gitOwner: string;
@@ -634,6 +636,12 @@ export interface CreateCloudWorkspaceRequest {
   displayName?: string | null;
   generatedName?: boolean | null;
   source?: "desktop" | "web" | "mobile" | null;
+  // Exact-ref creation from a clean, published local workspace (PR 5). When
+  // set, the server materializes the Cloud copy at this exact commit of the
+  // already-published branch after independently re-verifying the authorized
+  // GitHub head. Old requests (both absent) keep the branch-name fork path.
+  expectedHeadSha?: string | null;
+  sourceMaterialization?: CreateCloudWorkspaceSourceMaterialization | null;
 }
 export type GenerateSessionTitleRequest = Schema<"GenerateSessionTitleRequest">;
 export type GenerateSessionTitleResponse = Schema<"GenerateSessionTitleResponse">;

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -26,7 +26,8 @@ apps/packages/product-ui/src/chat/transcript/VirtualizedTranscriptRowList.tsx 41
 apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx 550 chat diff viewer pending row-renderer split
 apps/packages/product-client/src/components/content/ui/diff/SplitDiffViewer.tsx 465 split diff viewer pending row-renderer split
 apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
-apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 414 workspace sidebar item pending indicator/menu split
+apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 445 workspace sidebar item + PR 5 workspace-copy availability commands in DOM/native/right-click menus; menu split pending
+apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx 413 connected sidebar host; PR 5 availability-intent begin handler threaded alongside existing repo/cloud actions; extraction pending
 apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts 415 injected typed telemetry deps threaded from the calling hook; split deferred
 apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -27,7 +27,8 @@ apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx 5
 apps/packages/product-client/src/components/content/ui/diff/SplitDiffViewer.tsx 465 split diff viewer pending row-renderer split
 apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
 apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx 445 workspace sidebar item + PR 5 workspace-copy availability commands in DOM/native/right-click menus; menu split pending
-apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx 413 connected sidebar host; PR 5 availability-intent begin handler threaded alongside existing repo/cloud actions; extraction pending
+apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx 421 connected sidebar host; PR 5 availability-intent begin handler threaded alongside existing repo/cloud actions; extraction pending
+apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx 433 shared ordered-readiness continuation host for Cloud registration and retry-stable local clone; split by intent owner on next growth
 apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
 apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts 415 injected typed telemetry deps threaded from the calling hook; split deferred
 apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -30,7 +30,7 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1107 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
-cloud/sdk/src/types/generated.ts 788 existing generated cloud SDK type surface (+workspaceKind identity migration (5a); materialization types re-derived from OpenAPI with the documented app-extra overlay)
+cloud/sdk/src/types/generated.ts 789 existing generated cloud SDK type surface (+git numstat line-count fields; materialization types re-derived from OpenAPI; CloudWorkspaceSummary derived from Schema<WorkspaceSummary> with documented normalized/app-extra overlay; +PR 5 exact-ref create request fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
@@ -39,9 +39,9 @@ server/proliferate/config.py 619 managed Cloud and GitHub App completeness predi
 server/proliferate/db/models/cloud/agent_gateway.py 504 agent_auth_harness_settings model added for catalog-driven per-harness settings
 server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PUT routes added for catalog-driven per-harness settings
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
-server/proliferate/server/cloud/workspaces/service.py 859 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + scratch/repo-less read guards); split on next growth per guides/domains.md
+server/proliferate/server/cloud/workspaces/service.py 1074 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + scratch/repo-less read guards) + PR 5 exact-ref managed-Cloud creation path; split on next growth per guides/domains.md
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
-server/tests/integration/test_cloud_workspace_materialization_service.py 1002 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction, generation replay/crash-retry/terminal-reintent)
+server/tests/integration/test_cloud_workspace_materialization_service.py 1066 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction, generation replay/crash-retry/terminal-reintent) + PR 5 exact-ref create coverage
 server/tests/integration/test_auth_flow.py 2220 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
@@ -54,7 +54,7 @@ apps/packages/ui/src/icons/core.tsx 413 existing consolidated icon barrel pendin
 # that fell under the 600 general cap at the deeper path (SplitDiffViewer 540,
 # HomeNextScreen.test 530 — desktop component cap was 500) are dropped, not moved.
 apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx 932 P3 runtime catalog extends All-Models coverage + add-key modal flow + credential refresh + switch disambiguation + surface store mock + ProductHost test-host wiring + authenticated-without-cloud-compute BYOK gating cases
-apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 690 managed sandbox cloud workspace indicators extend existing oversized test file
+apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.test.ts 840 managed sandbox cloud workspace indicators + PR 5 explicit-materialization attachment cases extend existing oversized test file
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 648 existing desktop oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -30,7 +30,7 @@ anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 613 
 anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 613 catalog probe with per-harness model-source fallbacks
 anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1107 custom migration with legacy schema coverage
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
-cloud/sdk/src/types/generated.ts 789 existing generated cloud SDK type surface (+git numstat line-count fields; materialization types re-derived from OpenAPI; CloudWorkspaceSummary derived from Schema<WorkspaceSummary> with documented normalized/app-extra overlay; +PR 5 exact-ref create request fields)
+cloud/sdk/src/types/generated.ts 796 existing generated cloud SDK type surface (+workspaceKind, git numstat fields, OpenAPI-derived materialization types, app-extra overlay, and PR 5 exact-ref create request fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
 anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
@@ -39,9 +39,9 @@ server/proliferate/config.py 619 managed Cloud and GitHub App completeness predi
 server/proliferate/db/models/cloud/agent_gateway.py 504 agent_auth_harness_settings model added for catalog-driven per-harness settings
 server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PUT routes added for catalog-driven per-harness settings
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
-server/proliferate/server/cloud/workspaces/service.py 1074 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + scratch/repo-less read guards) + PR 5 exact-ref managed-Cloud creation path; split on next growth per guides/domains.md
+server/proliferate/server/cloud/workspaces/service.py 1088 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + scratch/repo-less read guards) + PR 5 exact-ref managed-Cloud creation and association path; split on next growth per guides/domains.md
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
-server/tests/integration/test_cloud_workspace_materialization_service.py 1066 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction, generation replay/crash-retry/terminal-reintent) + PR 5 exact-ref create coverage
+server/tests/integration/test_cloud_workspace_materialization_service.py 1173 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction, generation replay/crash-retry/terminal-reintent) + PR 5 exact-ref create coverage; new fail-closed source cases split to test_cloud_workspace_exact_ref_source.py
 server/tests/integration/test_auth_flow.py 2220 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test

--- a/server/proliferate/db/store/cloud_workspace_materializations.py
+++ b/server/proliferate/db/store/cloud_workspace_materializations.py
@@ -207,6 +207,26 @@ async def get_active_local_materialization(
     return cloud_workspace_materialization_value(row) if row is not None else None
 
 
+async def get_active_local_materialization_by_runtime(
+    db: AsyncSession,
+    *,
+    desktop_install_id: str,
+    anyharness_workspace_id: str,
+    lock_row: bool = False,
+) -> CloudWorkspaceMaterializationValue | None:
+    """Find the active Cloud association owning one installation/runtime pair."""
+    stmt = select(CloudWorkspaceMaterialization).where(
+        CloudWorkspaceMaterialization.target_kind == "local_desktop",
+        CloudWorkspaceMaterialization.desktop_install_id == desktop_install_id,
+        CloudWorkspaceMaterialization.anyharness_workspace_id == anyharness_workspace_id,
+        CloudWorkspaceMaterialization.unlinked_at.is_(None),
+    )
+    if lock_row:
+        stmt = stmt.with_for_update()
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    return cloud_workspace_materialization_value(row) if row is not None else None
+
+
 async def insert_managed_cloud_materialization(
     db: AsyncSession,
     *,

--- a/server/proliferate/db/store/cloud_workspace_materializations.py
+++ b/server/proliferate/db/store/cloud_workspace_materializations.py
@@ -246,6 +246,51 @@ async def insert_managed_cloud_materialization(
     return cloud_workspace_materialization_value(row)
 
 
+async def insert_hydrated_local_desktop_materialization(
+    db: AsyncSession,
+    *,
+    cloud_workspace_id: UUID,
+    desktop_install_id: str,
+    anyharness_workspace_id: str,
+    worktree_path: str,
+    expected_head_sha: str,
+    observed_head_sha: str,
+    observed_branch: str,
+) -> CloudWorkspaceMaterializationValue | None:
+    """Insert one active, already-hydrated local-desktop row.
+
+    Used by exact-ref Cloud creation from a local workspace: the local source
+    already exists and matches the exact ref, so the association is recorded as
+    hydrated in a single write rather than through the intent → report cycle.
+    Returns None on an active-uniqueness race (install already linked).
+    """
+    now = utcnow()
+    row = CloudWorkspaceMaterialization(
+        cloud_workspace_id=cloud_workspace_id,
+        target_kind="local_desktop",
+        cloud_sandbox_id=None,
+        desktop_install_id=desktop_install_id,
+        anyharness_workspace_id=anyharness_workspace_id,
+        worktree_path=worktree_path,
+        state="hydrated",
+        generation=1,
+        expected_head_sha=expected_head_sha,
+        observed_head_sha=observed_head_sha,
+        observed_branch=observed_branch,
+        last_reported_at=now,
+        unlinked_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(row)
+            await db.flush()
+    except IntegrityError:
+        return None
+    return cloud_workspace_materialization_value(row)
+
+
 async def create_local_desktop_intent(
     db: AsyncSession,
     *,

--- a/server/proliferate/integrations/anyharness/models.py
+++ b/server/proliferate/integrations/anyharness/models.py
@@ -41,6 +41,15 @@ class ResolvedRemoteWorkspace:
 
 
 @dataclass(frozen=True)
+class MaterializedRemoteWorkspaceAtRef:
+    """The result of an exact-ref workspace materialization (PR 3 endpoint)."""
+
+    workspace_id: str
+    observed_head_sha: str
+    outcome: str
+
+
+@dataclass(frozen=True)
 class RemoteSession:
     session_id: str
 

--- a/server/proliferate/integrations/anyharness/workspaces.py
+++ b/server/proliferate/integrations/anyharness/workspaces.py
@@ -7,6 +7,7 @@ import httpx
 from proliferate.integrations.anyharness.client import auth_headers
 from proliferate.integrations.anyharness.errors import CloudRuntimeReconnectError
 from proliferate.integrations.anyharness.models import (
+    MaterializedRemoteWorkspaceAtRef,
     RemoteGitStatusSnapshot,
     RemoteWorkspaceSummary,
     ResolvedRemoteWorkspace,
@@ -14,6 +15,7 @@ from proliferate.integrations.anyharness.models import (
 
 _CREATE_WORKTREE_TIMEOUT_SECONDS = 180.0
 _GIT_STATUS_TIMEOUT_SECONDS = 15.0
+_MATERIALIZE_AT_REF_TIMEOUT_SECONDS = 600.0
 
 
 def _runtime_status_error_message(
@@ -178,6 +180,81 @@ async def create_remote_worktree_workspace(
         invalid_message="Cloud runtime did not return a valid worktree workspace.",
         workspace_id_message="Cloud runtime did not return a valid worktree workspace id.",
         repo_root_message="Cloud runtime did not return a valid worktree repo root id.",
+    )
+
+
+async def materialize_workspace_at_ref(
+    runtime_url: str,
+    access_token: str,
+    *,
+    repo_root_id: str,
+    operation_id: str,
+    branch_name: str,
+    head_sha: str,
+    preferred_workspace_name: str | None = None,
+    destination_id: str | None = None,
+) -> MaterializedRemoteWorkspaceAtRef:
+    """Create or reuse a workspace at an exact branch + commit (PR 3 endpoint).
+
+    The runtime ledger keys idempotency off ``operation_id``: retrying with the
+    same id reuses the earlier result rather than creating a second worktree.
+    """
+    body: dict[str, object] = {
+        "operationId": operation_id,
+        "branchName": branch_name,
+        "headSha": head_sha,
+    }
+    if preferred_workspace_name:
+        body["preferredWorkspaceName"] = preferred_workspace_name
+    if destination_id:
+        body["destinationId"] = destination_id
+
+    try:
+        async with httpx.AsyncClient(timeout=_MATERIALIZE_AT_REF_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{runtime_url}/v1/repo-roots/{repo_root_id}/workspace-materializations",
+                headers=auth_headers(access_token),
+                json=body,
+            )
+            response.raise_for_status()
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise CloudRuntimeReconnectError(
+                    "Cloud runtime returned invalid JSON when materializing a workspace at ref."
+                ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise CloudRuntimeReconnectError(
+            _runtime_status_error_message(
+                exc.response,
+                "Failed to materialize AnyHarness workspace at ref.",
+            )
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise CloudRuntimeReconnectError(
+            "Failed to materialize AnyHarness workspace at ref."
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime did not return a valid workspace materialization."
+        )
+    workspace = payload.get("workspace")
+    workspace_id = workspace.get("id") if isinstance(workspace, dict) else None
+    observed_head_sha = payload.get("observedHeadSha")
+    outcome = payload.get("outcome")
+    if not isinstance(workspace_id, str) or not workspace_id:
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime did not return a valid materialized workspace id."
+        )
+    if not isinstance(observed_head_sha, str) or not observed_head_sha:
+        raise CloudRuntimeReconnectError(
+            "Cloud runtime did not return a valid observed HEAD for the materialization."
+        )
+    return MaterializedRemoteWorkspaceAtRef(
+        workspace_id=workspace_id,
+        observed_head_sha=observed_head_sha,
+        outcome=outcome if isinstance(outcome, str) else "created",
     )
 
 

--- a/server/proliferate/server/cloud/workspaces/materializations/service.py
+++ b/server/proliferate/server/cloud/workspaces/materializations/service.py
@@ -48,6 +48,7 @@ from proliferate.server.cloud.workspaces.materializations.summaries import (
     operation_id_for,
 )
 from proliferate.server.cloud.workspaces.models import (
+    CreateCloudWorkspaceSourceMaterialization,
     CreateMaterializationIntentRequest,
     MaterializationIntentResponse,
     MaterializationIntentSource,
@@ -55,6 +56,52 @@ from proliferate.server.cloud.workspaces.models import (
     ReportMaterializationRequest,
     WorkspaceMaterializationSummary,
 )
+
+
+async def validate_cloud_copy_local_source(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    source: CreateCloudWorkspaceSourceMaterialization,
+    expected_head_sha: str,
+) -> tuple[str, str, str]:
+    """Validate and reserve-safe-check the local source before Cloud effects.
+
+    The descriptor never establishes the GitHub ref (the authorized branch read
+    does that), but its own observed SHA must agree, the install must be owned
+    and online, and the runtime may not already belong to another active Cloud
+    workspace. The insert still enforces the unique index for concurrent races.
+    """
+    install_id = source.desktop_install_id.strip()
+    workspace_id = source.anyharness_workspace_id.strip()
+    worktree_path = source.worktree_path.strip()
+    observed_head_sha = source.observed_head_sha.strip()
+    if not install_id or not workspace_id or not worktree_path:
+        raise CloudApiError(
+            "invalid_source_materialization",
+            "The local source workspace identity is incomplete.",
+            status_code=400,
+        )
+    if observed_head_sha != expected_head_sha:
+        raise CloudApiError(
+            "materialization_source_blocked",
+            "The local workspace is not at the requested published commit.",
+            status_code=409,
+        )
+    await _require_owned_install(db, user_id=user_id, desktop_install_id=install_id)
+    existing = await materialization_store.get_active_local_materialization_by_runtime(
+        db,
+        desktop_install_id=install_id,
+        anyharness_workspace_id=workspace_id,
+        lock_row=True,
+    )
+    if existing is not None:
+        raise CloudApiError(
+            "local_materialization_already_linked",
+            "This local workspace is already linked to another Cloud workspace.",
+            status_code=409,
+        )
+    return install_id, workspace_id, worktree_path
 
 
 async def _load_user_workspace(

--- a/server/proliferate/server/cloud/workspaces/models.py
+++ b/server/proliferate/server/cloud/workspaces/models.py
@@ -69,6 +69,22 @@ class ReportMaterializationRequest(BaseModel):
     failure_detail: str | None = Field(default=None, alias="failureDetail")
 
 
+class CreateCloudWorkspaceSourceMaterialization(BaseModel):
+    """The local source descriptor for an exact-ref managed-Cloud creation.
+
+    Supplied by Desktop's "Add Cloud copy" flow: it names the local AnyHarness
+    workspace the exact ref came from so the resulting managed-Cloud row can be
+    associated with it. The server never trusts these fields for the actual ref
+    — it independently re-verifies the authorized GitHub branch head.
+    """
+
+    target_kind: Literal["local_desktop"] = Field(alias="targetKind")
+    desktop_install_id: str = Field(alias="desktopInstallId")
+    anyharness_workspace_id: str = Field(alias="anyharnessWorkspaceId")
+    worktree_path: str = Field(alias="worktreePath")
+    observed_head_sha: str = Field(alias="observedHeadSha")
+
+
 class CreateCloudWorkspaceRequest(BaseModel):
     git_provider: Literal["github"] = Field(default="github", alias="gitProvider")
     git_owner: str = Field(alias="gitOwner")
@@ -78,6 +94,16 @@ class CreateCloudWorkspaceRequest(BaseModel):
     display_name: str | None = Field(default=None, alias="displayName")
     generated_name: bool | None = Field(default=None, alias="generatedName")
     source: Literal["desktop", "web", "mobile"] | None = None
+    # Exact-ref creation from a clean, published local workspace (PR 5). When
+    # supplied, the server creates the managed-Cloud copy at this exact commit
+    # of the already-published branch — after independently verifying the
+    # authorized GitHub branch head equals it — instead of forking a new branch
+    # from base. Old requests (both None) retain the branch-name creation path.
+    expected_head_sha: str | None = Field(default=None, alias="expectedHeadSha")
+    source_materialization: CreateCloudWorkspaceSourceMaterialization | None = Field(
+        default=None,
+        alias="sourceMaterialization",
+    )
 
 
 class UpdateCloudWorkspaceDisplayNameRequest(BaseModel):

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -48,6 +48,9 @@ from proliferate.server.cloud.materialization.materialize.repo_environment impor
 from proliferate.server.cloud.repos.domain.github_credentials import CloudRepoGitHubCredentials
 from proliferate.server.cloud.repos.service import get_repo_branches_for_credentials
 from proliferate.server.cloud.workspaces.domain.origin import resolve_workspace_origin_entrypoint
+from proliferate.server.cloud.workspaces.materializations.service import (
+    validate_cloud_copy_local_source,
+)
 from proliferate.server.cloud.workspaces.materializations.summaries import (
     materialization_summary,
     select_primary,
@@ -58,6 +61,7 @@ from proliferate.server.cloud.workspaces.models import (
     CloudWorkspaceRuntimeStatusResponse,
     CloudWorkspaceStatus,
     CreateCloudWorkspaceRequest,
+    CreateCloudWorkspaceSourceMaterialization,
     RepoRef,
     WorkspaceDetail,
     WorkspaceRuntimeSummary,
@@ -403,18 +407,9 @@ async def _create_cloud_workspace_at_exact_ref(
     repo_branches: object,
     display_name: str | None,
     source: str,
-    source_materialization: object,
+    source_materialization: CreateCloudWorkspaceSourceMaterialization | None,
 ) -> WorkspaceDetail:
-    """Create a managed-Cloud workspace at an exact published branch head.
-
-    The branch must be an existing GitHub branch whose authorized head equals
-    ``expected_head_sha`` (server-verified — the client descriptor is never
-    trusted for the ref). The managed Cloud AnyHarness workspace is materialized
-    at that exact commit through PR 3's exact-ref endpoint, then the durable
-    CloudWorkspace + managed materialization are written, and — when a local
-    source descriptor is supplied — the local materialization association is
-    recorded as already hydrated in the same transaction.
-    """
+    """Create managed Cloud and optional owned-local rows at one verified ref."""
     branches = getattr(repo_branches, "branches", [])
     branch_heads = getattr(repo_branches, "branch_heads_by_name", {}) or {}
     if branch_name not in branches:
@@ -436,6 +431,17 @@ async def _create_cloud_workspace_at_exact_ref(
             "The local workspace has commits that are not published on GitHub.",
             status_code=409,
         )
+
+    local_source = (
+        await validate_cloud_copy_local_source(
+            db,
+            user_id=user.id,
+            source=source_materialization,
+            expected_head_sha=expected_head_sha,
+        )
+        if source_materialization is not None
+        else None
+    )
 
     active_workspace_branches = (
         await cloud_workspace_store.list_active_workspace_branches_for_repo_environment(
@@ -504,6 +510,28 @@ async def _create_cloud_workspace_at_exact_ref(
             status_code=409,
         )
 
+    # Reserve the local association before remote materialization. This makes a
+    # uniqueness conflict fail closed instead of returning a misleading Cloud
+    # success after the managed checkout was created (PR5-CLOUD-16).
+    if local_source is not None:
+        install_id, local_workspace_id, worktree_path = local_source
+        local_row = await materialization_store.insert_hydrated_local_desktop_materialization(
+            db,
+            cloud_workspace_id=workspace.id,
+            desktop_install_id=install_id,
+            anyharness_workspace_id=local_workspace_id,
+            worktree_path=worktree_path,
+            expected_head_sha=expected_head_sha,
+            observed_head_sha=expected_head_sha,
+            observed_branch=branch_name,
+        )
+        if local_row is None:
+            raise CloudApiError(
+                "local_materialization_already_linked",
+                "This local workspace is already linked to another Cloud workspace.",
+                status_code=409,
+            )
+
     runtime_url, runtime_token, _data_key = await _load_ready_runtime_access(db, user_id=user.id)
     repo_path = materialization_paths.repo_path(repo_environment)
     repo_root = await _resolve_repo_root(runtime_url, runtime_token, repo_path=repo_path)
@@ -533,35 +561,6 @@ async def _create_cloud_workspace_at_exact_ref(
         observed_branch=branch_name,
     )
 
-    # Record the local source association (already hydrated) when the caller
-    # named its local workspace. Best-effort: a race with a concurrent link
-    # leaves the managed copy intact; the association can be retried via intent.
-    if source_materialization is not None:
-        install_id = getattr(source_materialization, "desktop_install_id", "").strip()
-        worker = (
-            await runtime_workers_store.get_active_desktop_worker_for_user(
-                db,
-                owner_user_id=user.id,
-                desktop_install_id=install_id,
-            )
-            if install_id
-            else None
-        )
-        if worker is not None:
-            await materialization_store.insert_hydrated_local_desktop_materialization(
-                db,
-                cloud_workspace_id=workspace.id,
-                desktop_install_id=install_id,
-                anyharness_workspace_id=getattr(
-                    source_materialization, "anyharness_workspace_id", ""
-                ),
-                worktree_path=getattr(source_materialization, "worktree_path", ""),
-                expected_head_sha=expected_head_sha,
-                observed_head_sha=getattr(
-                    source_materialization, "observed_head_sha", expected_head_sha
-                ),
-                observed_branch=branch_name,
-            )
     return await _workspace_payload(db, workspace, detail=True)
 
 

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -26,9 +26,13 @@ from proliferate.db.store.cloud_workspace_materializations import (
 from proliferate.db.store.cloud_workspaces import CloudWorkspaceValue
 from proliferate.db.store.repositories import RepoEnvironmentValue
 from proliferate.integrations.anyharness.errors import CloudRuntimeReconnectError
-from proliferate.integrations.anyharness.models import ResolvedRemoteWorkspace
+from proliferate.integrations.anyharness.models import (
+    MaterializedRemoteWorkspaceAtRef,
+    ResolvedRemoteWorkspace,
+)
 from proliferate.integrations.anyharness.workspaces import (
     create_remote_worktree_workspace,
+    materialize_workspace_at_ref,
     resolve_runtime_workspace,
 )
 from proliferate.lib.product.workspace_naming import resolve_generated_branch_name
@@ -233,6 +237,28 @@ async def create_cloud_workspace_for_user(
             status_code=400,
         )
 
+    # Exact-ref creation (PR 5, "Add Cloud copy from local"): the branch is an
+    # already-published GitHub branch and the Cloud copy is materialized at that
+    # exact commit, not forked from base. Server independently re-verifies the
+    # authorized GitHub head equals the expected SHA — the client descriptor is
+    # never trusted for the ref.
+    expected_head_sha = (body.expected_head_sha or "").strip()
+    if expected_head_sha:
+        return await _create_cloud_workspace_at_exact_ref(
+            db,
+            user=user,
+            repo_environment=repo_environment,
+            git_owner=git_owner,
+            git_repo_name=git_repo_name,
+            branch_name=branch_name,
+            base_branch=base_branch,
+            expected_head_sha=expected_head_sha,
+            repo_branches=repo_branches,
+            display_name=body.display_name,
+            source=body.source or "desktop",
+            source_materialization=body.source_materialization,
+        )
+
     active_workspace_branches = (
         await cloud_workspace_store.list_active_workspace_branches_for_repo_environment(
             db,
@@ -362,6 +388,210 @@ async def create_cloud_workspace_for_user(
         state="hydrated",
     )
     return await _workspace_payload(db, workspace, detail=True)
+
+
+async def _create_cloud_workspace_at_exact_ref(
+    db: AsyncSession,
+    *,
+    user: _UserWithId,
+    repo_environment: RepoEnvironmentValue,
+    git_owner: str,
+    git_repo_name: str,
+    branch_name: str,
+    base_branch: str,
+    expected_head_sha: str,
+    repo_branches: object,
+    display_name: str | None,
+    source: str,
+    source_materialization: object,
+) -> WorkspaceDetail:
+    """Create a managed-Cloud workspace at an exact published branch head.
+
+    The branch must be an existing GitHub branch whose authorized head equals
+    ``expected_head_sha`` (server-verified — the client descriptor is never
+    trusted for the ref). The managed Cloud AnyHarness workspace is materialized
+    at that exact commit through PR 3's exact-ref endpoint, then the durable
+    CloudWorkspace + managed materialization are written, and — when a local
+    source descriptor is supplied — the local materialization association is
+    recorded as already hydrated in the same transaction.
+    """
+    branches = getattr(repo_branches, "branches", [])
+    branch_heads = getattr(repo_branches, "branch_heads_by_name", {}) or {}
+    if branch_name not in branches:
+        raise CloudApiError(
+            "github_branch_not_found",
+            f"The branch '{branch_name}' was not found on GitHub.",
+            status_code=400,
+        )
+    github_head = branch_heads.get(branch_name)
+    if github_head is None:
+        raise CloudApiError(
+            "materialization_source_blocked",
+            f"The branch '{branch_name}' is not published on GitHub.",
+            status_code=409,
+        )
+    if github_head != expected_head_sha:
+        raise CloudApiError(
+            "materialization_source_blocked",
+            "The local workspace has commits that are not published on GitHub.",
+            status_code=409,
+        )
+
+    active_workspace_branches = (
+        await cloud_workspace_store.list_active_workspace_branches_for_repo_environment(
+            db,
+            repo_environment_id=repo_environment.id,
+        )
+    )
+    if branch_name in active_workspace_branches:
+        raise CloudApiError(
+            "cloud_branch_already_exists",
+            f"A cloud workspace already exists for branch '{branch_name}'.",
+            status_code=409,
+        )
+
+    display_name_value = (display_name or branch_name).strip() or branch_name
+    if len(display_name_value) > MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS:
+        raise CloudApiError(
+            "invalid_display_name",
+            (
+                "Workspace display name cannot exceed "
+                f"{MAX_CLOUD_WORKSPACE_DISPLAY_NAME_CHARS} characters."
+            ),
+            status_code=400,
+        )
+
+    try:
+        await materialization_service.materialize_repo_environment(
+            db,
+            repo_environment_id=repo_environment.id,
+        )
+    except CloudRuntimeReconnectError as exc:
+        raise CloudApiError(
+            "cloud_sandbox_reconnect_failed",
+            "The cloud sandbox runtime could not be reached. Please retry in a moment.",
+            status_code=502,
+        ) from exc
+    except CloudRepoCheckoutError as exc:
+        raise CloudApiError(
+            "cloud_repo_checkout_conflict",
+            _CHECKOUT_CONFLICT_MESSAGES.get(
+                exc.reason,
+                "The cloud checkout for this repository could not be prepared. "
+                "Resolve outstanding changes in the cloud sandbox and retry.",
+            ),
+            status_code=409,
+        ) from exc
+    except CloudMaterializationLockTimeout as exc:
+        raise CloudApiError(
+            "cloud_materialization_busy",
+            "The cloud sandbox is busy preparing another workspace. Please retry in a moment.",
+            status_code=503,
+        ) from exc
+
+    workspace = await cloud_workspace_store.create_cloud_workspace(
+        db,
+        user_id=user.id,
+        repo_environment_id=repo_environment.id,
+        display_name=display_name_value,
+        git_branch=branch_name,
+        git_base_branch=base_branch,
+    )
+    if workspace is None:
+        raise CloudApiError(
+            "cloud_branch_already_exists",
+            f"A cloud workspace already exists for branch '{branch_name}'.",
+            status_code=409,
+        )
+
+    runtime_url, runtime_token, _data_key = await _load_ready_runtime_access(db, user_id=user.id)
+    repo_path = materialization_paths.repo_path(repo_environment)
+    repo_root = await _resolve_repo_root(runtime_url, runtime_token, repo_path=repo_path)
+    materialized = await _materialize_managed_at_exact_ref(
+        runtime_url,
+        runtime_token,
+        repo_root_id=repo_root.repo_root_id,
+        workspace_id=workspace.id,
+        branch_name=branch_name,
+        head_sha=expected_head_sha,
+    )
+
+    sandbox = await cloud_sandbox_store.load_personal_cloud_sandbox(db, user.id)
+    workspace = await cloud_workspace_store.update_workspace_anyharness_workspace_id(
+        db,
+        anyharness_workspace_id=materialized.workspace_id,
+        workspace=workspace,
+    )
+    await materialization_store.insert_managed_cloud_materialization(
+        db,
+        cloud_workspace_id=workspace.id,
+        cloud_sandbox_id=sandbox.id if sandbox is not None else None,
+        anyharness_workspace_id=materialized.workspace_id,
+        state="hydrated",
+        expected_head_sha=expected_head_sha,
+        observed_head_sha=materialized.observed_head_sha,
+        observed_branch=branch_name,
+    )
+
+    # Record the local source association (already hydrated) when the caller
+    # named its local workspace. Best-effort: a race with a concurrent link
+    # leaves the managed copy intact; the association can be retried via intent.
+    if source_materialization is not None:
+        install_id = getattr(source_materialization, "desktop_install_id", "").strip()
+        worker = (
+            await runtime_workers_store.get_active_desktop_worker_for_user(
+                db,
+                owner_user_id=user.id,
+                desktop_install_id=install_id,
+            )
+            if install_id
+            else None
+        )
+        if worker is not None:
+            await materialization_store.insert_hydrated_local_desktop_materialization(
+                db,
+                cloud_workspace_id=workspace.id,
+                desktop_install_id=install_id,
+                anyharness_workspace_id=getattr(
+                    source_materialization, "anyharness_workspace_id", ""
+                ),
+                worktree_path=getattr(source_materialization, "worktree_path", ""),
+                expected_head_sha=expected_head_sha,
+                observed_head_sha=getattr(
+                    source_materialization, "observed_head_sha", expected_head_sha
+                ),
+                observed_branch=branch_name,
+            )
+    return await _workspace_payload(db, workspace, detail=True)
+
+
+async def _materialize_managed_at_exact_ref(
+    runtime_url: str,
+    runtime_token: str,
+    *,
+    repo_root_id: str,
+    workspace_id: UUID,
+    branch_name: str,
+    head_sha: str,
+) -> MaterializedRemoteWorkspaceAtRef:
+    # Reuse the workspace id as the runtime operation id so a retry of the same
+    # create (same workspace row) reuses the runtime ledger result instead of
+    # cutting a second worktree.
+    try:
+        return await materialize_workspace_at_ref(
+            runtime_url,
+            runtime_token,
+            repo_root_id=repo_root_id,
+            operation_id=str(workspace_id),
+            branch_name=branch_name,
+            head_sha=head_sha,
+        )
+    except CloudRuntimeReconnectError as exc:
+        raise CloudApiError(
+            "cloud_workspace_create_failed",
+            str(exc),
+            status_code=502,
+        ) from exc
 
 
 async def sync_cloud_workspace_display_name(

--- a/server/tests/integration/test_cloud_workspace_exact_ref_source.py
+++ b/server/tests/integration/test_cloud_workspace_exact_ref_source.py
@@ -1,0 +1,121 @@
+"""Fail-closed source-association tests for exact-ref Cloud creation."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workspaces import service as workspaces_service
+from proliferate.server.cloud.workspaces.models import (
+    CreateCloudWorkspaceRequest,
+    CreateCloudWorkspaceSourceMaterialization,
+)
+from tests.integration.test_cloud_workspace_materialization_service import (
+    _BRANCH,
+    _HEAD,
+    _INSTALL,
+    _patch_exact_ref_create,
+    _seed,
+)
+
+
+def _request(observed_head: str = _HEAD) -> CreateCloudWorkspaceRequest:
+    return CreateCloudWorkspaceRequest(
+        gitOwner="acme",
+        gitRepoName="widgets",
+        branchName=_BRANCH,
+        baseBranch="main",
+        expectedHeadSha=_HEAD,
+        sourceMaterialization=CreateCloudWorkspaceSourceMaterialization(
+            targetKind="local_desktop",
+            desktopInstallId=_INSTALL,
+            anyharnessWorkspaceId="ws-local",
+            worktreePath="/local/wt",
+            observedHeadSha=observed_head,
+        ),
+    )
+
+
+async def _prepare(
+    db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    with_worker: bool = True,
+    calls: dict[str, Any] | None = None,
+):
+    seed = await _seed(db, with_worker=with_worker)
+    await db.delete(seed.workspace)
+    await db.flush()
+    _patch_exact_ref_create(
+        monkeypatch,
+        seed,
+        branch_heads={_BRANCH: _HEAD},
+        materialized_head=_HEAD,
+        calls=calls,
+    )
+    return seed
+
+
+@pytest.mark.asyncio
+async def test_mismatched_local_descriptor_fails_before_effects(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed = await _prepare(db_session, monkeypatch)
+    effects = {"repo": 0, "runtime": 0}
+
+    async def _repo_effect(*_a: Any, **_k: Any) -> None:
+        effects["repo"] += 1
+
+    async def _runtime_effect(*_a: Any, **_k: Any) -> Any:
+        effects["runtime"] += 1
+        raise AssertionError("runtime materialization must not run")
+
+    monkeypatch.setattr(
+        workspaces_service.materialization_service,
+        "materialize_repo_environment",
+        _repo_effect,
+    )
+    monkeypatch.setattr(workspaces_service, "materialize_workspace_at_ref", _runtime_effect)
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session, SimpleNamespace(id=seed.user.id), _request("different-head")
+        )
+    assert excinfo.value.code == "materialization_source_blocked"
+    assert effects == {"repo": 0, "runtime": 0}
+
+
+@pytest.mark.asyncio
+async def test_source_requires_owned_active_desktop_install(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed = await _prepare(db_session, monkeypatch, with_worker=False)
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session, SimpleNamespace(id=seed.user.id), _request()
+        )
+    assert excinfo.value.code == "desktop_install_not_owned"
+
+
+@pytest.mark.asyncio
+async def test_association_conflict_fails_before_runtime_materialization(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: dict[str, Any] = {}
+    seed = await _prepare(db_session, monkeypatch, calls=calls)
+
+    async def _conflict(*_a: Any, **_k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        workspaces_service.materialization_store,
+        "insert_hydrated_local_desktop_materialization",
+        _conflict,
+    )
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session, SimpleNamespace(id=seed.user.id), _request()
+        )
+    assert excinfo.value.code == "local_materialization_already_linked"
+    assert calls == {}

--- a/server/tests/integration/test_cloud_workspace_materialization_service.py
+++ b/server/tests/integration/test_cloud_workspace_materialization_service.py
@@ -781,6 +781,177 @@ async def test_create_dual_writes_legacy_id_and_managed_materialization(
     assert managed.cloud_sandbox_id == seed.sandbox.id
 
 
+def _patch_exact_ref_create(
+    monkeypatch: pytest.MonkeyPatch,
+    seed,
+    *,
+    branch_heads: dict[str, str],
+    materialized_head: str,
+    calls: dict[str, Any] | None = None,
+) -> None:
+    from proliferate.integrations.anyharness.models import MaterializedRemoteWorkspaceAtRef
+
+    async def _get_repo_environment(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(
+            id=seed.env.id,
+            git_provider="github",
+            git_owner="acme",
+            git_repo_name="widgets",
+            default_branch="main",
+            setup_script="",
+            environment_kind="cloud",
+        )
+
+    async def _authority(*_a: Any, **_k: Any) -> Any:
+        return SimpleNamespace(access_token="gho_test")
+
+    async def _branches(*_a: Any, **_k: Any) -> GitHubRepoBranches:
+        return GitHubRepoBranches(
+            default_branch="main",
+            branches=["main", *branch_heads.keys()],
+            branch_heads_by_name=branch_heads,
+        )
+
+    async def _materialize(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def _runtime_access(*_a: Any, **_k: Any):
+        return ("https://runtime.invalid", "token", "data-key")
+
+    async def _resolve_root(*_a: Any, **_k: Any) -> ResolvedRemoteWorkspace:
+        return ResolvedRemoteWorkspace(workspace_id="ignored", repo_root_id="root-1")
+
+    async def _materialize_at_ref(*_a: Any, **kwargs: Any) -> MaterializedRemoteWorkspaceAtRef:
+        if calls is not None:
+            calls.update(kwargs)
+        return MaterializedRemoteWorkspaceAtRef(
+            workspace_id="ah-exact",
+            observed_head_sha=materialized_head,
+            outcome="created",
+        )
+
+    monkeypatch.setattr(
+        workspaces_service.repositories_store, "get_cloud_repo_environment", _get_repo_environment
+    )
+    monkeypatch.setattr(
+        workspaces_service.repositories_store, "get_repo_environment_by_id", _get_repo_environment
+    )
+    monkeypatch.setattr(workspaces_service, "require_github_cloud_repo_authority", _authority)
+    monkeypatch.setattr(workspaces_service, "get_repo_branches_for_credentials", _branches)
+    monkeypatch.setattr(
+        workspaces_service.materialization_service, "materialize_repo_environment", _materialize
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandboxes_service,
+        "load_cloud_sandbox_runtime_access",
+        _runtime_access,
+    )
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandboxes_service,
+        "require_cloud_provisioning_configured",
+        lambda: None,
+    )
+    monkeypatch.setattr(workspaces_service, "_resolve_repo_root", _resolve_root)
+    monkeypatch.setattr(workspaces_service, "materialize_workspace_at_ref", _materialize_at_ref)
+
+
+@pytest.mark.asyncio
+async def test_exact_ref_create_materializes_at_head_and_records_local_source(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from proliferate.db.store import cloud_workspace_materializations as store
+    from proliferate.server.cloud.workspaces.models import (
+        CreateCloudWorkspaceSourceMaterialization,
+    )
+
+    seed = await _seed(db_session)
+    ws = await db_session.get(CloudWorkspace, seed.workspace.id)
+    assert ws is not None
+    await db_session.delete(ws)
+    await db_session.flush()
+
+    calls: dict[str, Any] = {}
+    _patch_exact_ref_create(
+        monkeypatch,
+        seed,
+        branch_heads={_BRANCH: _HEAD},
+        materialized_head=_HEAD,
+        calls=calls,
+    )
+
+    detail = await workspaces_service.create_cloud_workspace_for_user(
+        db_session,
+        SimpleNamespace(id=seed.user.id),
+        CreateCloudWorkspaceRequest(
+            gitOwner="acme",
+            gitRepoName="widgets",
+            branchName=_BRANCH,
+            baseBranch="main",
+            expectedHeadSha=_HEAD,
+            sourceMaterialization=CreateCloudWorkspaceSourceMaterialization(
+                targetKind="local_desktop",
+                desktopInstallId=_INSTALL,
+                anyharnessWorkspaceId="ws-local",
+                worktreePath="/local/wt",
+                observedHeadSha=_HEAD,
+            ),
+        ),
+    )
+
+    # AnyHarness was asked to materialize at the exact branch + commit.
+    assert calls["branch_name"] == _BRANCH
+    assert calls["head_sha"] == _HEAD
+    assert detail.anyharness_workspace_id == "ah-exact"
+
+    active = await store.list_active_materializations_for_workspace(
+        db_session, cloud_workspace_id=uuid.UUID(detail.id)
+    )
+    managed = [m for m in active if m.target_kind == "managed_cloud"]
+    locals_ = [m for m in active if m.target_kind == "local_desktop"]
+    assert len(managed) == 1
+    assert managed[0].expected_head_sha == _HEAD
+    assert managed[0].observed_head_sha == _HEAD
+    # The local source association was recorded as already hydrated.
+    assert len(locals_) == 1
+    assert locals_[0].desktop_install_id == _INSTALL
+    assert locals_[0].state == "hydrated"
+    assert locals_[0].anyharness_workspace_id == "ws-local"
+
+
+@pytest.mark.asyncio
+async def test_exact_ref_create_rejects_head_not_published(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed = await _seed(db_session)
+    ws = await db_session.get(CloudWorkspace, seed.workspace.id)
+    assert ws is not None
+    await db_session.delete(ws)
+    await db_session.flush()
+
+    # GitHub's head for the branch differs from the client's expected head:
+    # the local workspace has unpublished commits. Must fail-closed.
+    _patch_exact_ref_create(
+        monkeypatch,
+        seed,
+        branch_heads={_BRANCH: "different-sha"},
+        materialized_head=_HEAD,
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session,
+            SimpleNamespace(id=seed.user.id),
+            CreateCloudWorkspaceRequest(
+                gitOwner="acme",
+                gitRepoName="widgets",
+                branchName=_BRANCH,
+                baseBranch="main",
+                expectedHeadSha=_HEAD,
+            ),
+        )
+    assert excinfo.value.code == "materialization_source_blocked"
+
+
 @pytest.mark.asyncio
 async def test_reconciliation_uses_recorded_sandbox_not_current(
     db_session: AsyncSession,

--- a/specs/codebase/platforms/product/workspace-provisioning.md
+++ b/specs/codebase/platforms/product/workspace-provisioning.md
@@ -17,7 +17,19 @@ create cloud workspace
   -> synchronously materialize the repository environment
   -> insert cloud_workspace
   -> call AnyHarness directly to create a worktree
-  -> store anyharness_workspace_id
+  -> atomically store the legacy anyharness_workspace_id and managed materialization
+
+open an existing Cloud workspace on Desktop
+  -> create/replay one local materialization intent for the Desktop install
+  -> AnyHarness clones/adopts the repository and materializes the exact ref
+  -> report the same generation with local runtime id, path, branch, and HEAD
+
+add a Cloud copy from Desktop
+  -> validate the owned Desktop install and local source descriptor
+  -> independently verify the authorized GitHub branch HEAD
+  -> reserve the local association before remote work
+  -> materialize the managed checkout at the exact ref
+  -> return one Cloud workspace with managed and local materializations
 ```
 
 There is no durable delivery queue between Cloud and AnyHarness in this
@@ -54,9 +66,15 @@ defines `cloud_workspace`. It owns:
 - the optional `anyharness_workspace_id`; and
 - archive timestamps.
 
-It does not own a sandbox id, runtime session state, runtime path, or runtime
-events. An AnyHarness workspace id is a reference to runtime truth, not a copy
-of that truth in Cloud.
+`cloud_workspace_materialization` records each target-scoped checkout. A
+managed row identifies the sandbox and runtime workspace; a local row identifies
+the Desktop installation and its local runtime workspace/path. Active unique
+indexes prevent one install/runtime pair from being linked to two Cloud
+workspaces. `unlinked_at` makes unlink non-destructive while generation checks
+prevent stale reports from resurrecting an old association.
+
+The Cloud workspace still does not own runtime session state or events. Every
+AnyHarness workspace id is a reference to runtime truth, not a copy of it.
 
 ### Placement-neutral identity
 
@@ -115,6 +133,9 @@ PATCH  /v1/cloud/workspaces/{id}/display-name
 POST   /v1/cloud/workspaces/{id}/archive
 POST   /v1/cloud/workspaces/{id}/restore
 DELETE /v1/cloud/workspaces/{id}
+POST   /v1/cloud/workspaces/{id}/materializations
+PUT    /v1/cloud/workspaces/{id}/materializations/{materialization_id}
+DELETE /v1/cloud/workspaces/{id}/materializations/{materialization_id}
 ```
 
 There is no mounted workspace `connection` endpoint. Clients reach AnyHarness
@@ -164,8 +185,18 @@ performs the current synchronous flow:
 7. load ready runtime access from `cloud_sandbox`;
 8. resolve the repository root through AnyHarness;
 9. call AnyHarness directly to create the worktree; and
-10. store the returned `anyharness_workspace_id`; and
-11. commit the request transaction after the handler returns successfully.
+10. write the returned `anyharness_workspace_id` and managed materialization;
+11. when this is an exact-ref Desktop source flow, require the local descriptor
+    to match the independently verified HEAD and record the owned local
+    association (a conflict fails the request rather than reporting success);
+12. commit the request transaction after the handler returns successfully.
+
+Desktop clone and open-on-Mac use caller-supplied idempotency ledgers in
+AnyHarness. Clone operation ids are scoped to the chosen destination and reused
+only for that retry. A Cloud local intent returns `{rowId}:{generation}`; an
+in-flight retry returns the same generation and exact source ref, so a crash
+after local success but before the Cloud report replays rather than creating a
+second worktree.
 
 The Cloud transaction and AnyHarness worktree creation are not atomic. A
 propagated failure rolls back the Cloud insert and id update. The inverse
@@ -187,6 +218,14 @@ bounded number of branch-uniqueness races.
 ## Read And Lifecycle Semantics
 
 - `ready` means `anyharness_workspace_id` is present on an active Cloud row.
+- Workspace list/detail responses include every active materialization. Desktop
+  supplies its install id so the server can prefer that install's healthy local
+  row; paths and runtime ids for other installs are redacted.
+- Explicit materialization identity wins over repository/branch heuristics.
+  Unlinked same-repository/branch copies remain separate until the user chooses
+  **Link copies** and the client proves clean, normal, exact-HEAD equality.
+- **Unlink this Mac** soft-deletes only the association. It does not delete a
+  checkout, repository, Cloud workspace, or session history.
 - `materializing` means the id is absent and the row is younger than the
   900-second stale threshold.
 - `error` means that missing-id row exceeded the threshold.
@@ -209,6 +248,8 @@ portions as current creation behavior.
 | Repository configuration routes | [`server/.../cloud/repositories/`](../../../../server/proliferate/server/cloud/repositories/) |
 | Materialization orchestration | [`server/.../cloud/materialization/`](../../../../server/proliferate/server/cloud/materialization/) |
 | Workspace routes and product-row orchestration | [`server/.../cloud/workspaces/`](../../../../server/proliferate/server/cloud/workspaces/) |
+| Durable target association ledger | [`server/.../cloud/workspaces/materializations/`](../../../../server/proliferate/server/cloud/workspaces/materializations/) and [`db/store/cloud_workspace_materializations.py`](../../../../server/proliferate/db/store/cloud_workspace_materializations.py) |
+| Desktop clone/link/open orchestration | [`apps/packages/product-client/src/hooks/workspaces/workflows/`](../../../../apps/packages/product-client/src/hooks/workspaces/workflows/) and [`components/workspace/repo-setup/`](../../../../apps/packages/product-client/src/components/workspace/repo-setup/) |
 | Direct AnyHarness adapter | [`server/proliferate/integrations/anyharness/`](../../../../server/proliferate/integrations/anyharness/) |
 | Sandbox lifecycle and runtime access | [Cloud sandbox provisioning](sandbox-provisioning.md) |
 | GitHub sandbox credentials | [Sandbox GitHub auth](sandbox-github-auth.md) |
@@ -226,6 +267,9 @@ portions as current creation behavior.
 | Existing workspace remains `materializing` | `cloud_workspace.anyharness_workspace_id` and row age |
 | Create failed after runtime worktree creation | Correlate the request, user, repository, and branch with the AnyHarness target path; its suffix carries only the attempted Cloud id's eight-character prefix. Include the AnyHarness workspace id when present and escalate suspected orphan cleanup. |
 | Cloud row is ready but runtime is unavailable | AnyHarness health through the sandbox gateway; do not infer health from the Cloud id |
+| Local report is stale after unlink/relink | Compare the reported generation with `cloud_workspace_materialization.generation`; never retry with a new operation id for the same in-flight intent |
+| Link copies is unavailable | Inspect all active local materializations for the current install, then compare the candidate's canonical repo, case-sensitive branch, clean Git state, and exact HEAD |
+| Add Cloud copy reports an association conflict | The local install/runtime pair already belongs to another active Cloud workspace; do not keep a second logical association |
 
 ## Verification
 
@@ -237,6 +281,10 @@ Use these focused tests as the code-level proof:
 - `server/tests/integration/test_cloud_workspace_backing_kind.py`
 - `server/tests/integration/test_cloud_workspace_backing_kind_migration.py`
 - `server/tests/integration/test_cloud_workspace_identity_payload.py`
+- `server/tests/integration/test_cloud_workspace_materialization_service.py`
+- `apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.test.ts`
+- `apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.test.ts`
+- `apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-link-candidates.test.ts`
 
 For incident diagnosis, use
 [`cloud-provisioning-failure.md`](../../../developing/operating/cloud-provisioning-failure.md).


### PR DESCRIPTION
PR 5 of the Cloud repository access + workspace materialization stack (frozen spec rev 3: `Vault/Workspace/Features/Desktop Repository Clone and Workspace Linking - PR 5.md`).

> Supersedes #1282, which GitHub auto-marked "merged" when this head was merged into the shared integration branch for the combined proof — it was never merged to main. This draft targets the frozen pre-PR5 integration state `codex/cloud-repo-stack-pre5` (@b1f6480b4) so the diff stays exactly PR 5's 53 files and cannot auto-close.

**Stack position**: on top of the final settled heads of PR 2 `5fc725190` (#1276), PR 3 `869c5e9fa` (#1278), PR 4 `653fe764a` (#1277), PR 7 `523001fba` (#1281). Draft review boundary — never merge without Pablo.

## What this adds

- **Clone from GitHub**: third Desktop Add Repository option; repo `Add to this Mac` chooses existing folder vs clone. Clone is gated by `github_repository_access` (new `clone_from_github` intent kind), not managed-Cloud — an App-ready/E2B-disabled instance can clone. Local Git credentials only; never an installation token; install returns use host-derived `buildReturnUrl` (PR2-WEB-03 pattern).
- **Open Cloud workspace on this Mac**: intent → PR 3 two-endpoint local materialization (repo-root acquire, then exact-ref workspace materialization) → report, threading PR 4's `"{rowId}:{generation}"` operationId; crash-safe retry reuses the same operation id (no duplicate worktrees).
- **Add Cloud copy** from a clean published local workspace: exact-ref server creation (`expectedHeadSha` + `sourceMaterialization` on CreateCloudWorkspaceRequest) with server-side branch-HEAD verification.
- **Explicit Link / Unlink / Relink**: association-only (no filesystem mutation); unlink deletes nothing; relink is generation-safe, stale reports rejected.
- **Materialization-first logical projection**: explicit `(desktopInstallId, anyharnessWorkspaceId)` association replaces heuristic Cloud attachment when materializations exist; different-path same-branch worktrees stay distinct; server `select_primary` (via `desktopInstallId` on every fetch) is authoritative.

## Rebase/dedupe notes (vs the founder-repair heads)

- PR 5's hand-authored intent/report/unlink SDK methods + sdk-react hooks were fully subsumed by PR 4's now-canonical ones — deduped, consumers rewired to upstream exports; net SDK diff is only the `Schema<>`-derived `CreateCloudWorkspaceSourceMaterialization` alias + two optional request fields.
- Layers on (never reverts) PR 2's repaired hosts: resolver preflight, ref-driven `retryNonce` continuation (cloneFromGitHub folded into the continuation ref), sign-in CTA, buildReturnUrl returns.
- Nullable-repo guards per merged #1245 semantics.

## Verification

Typecheck exit 0 across cloud/sdk, sdk-react, product-domain/-ui/-surfaces/-client, web, mobile, desktop. Vitest: product-domain 578, product-client 3103, desktop 168 — all green. Frontend structure `--strict` TOTAL 0; max-lines pass; `git diff --check` clean. No Rust changes; Workflow V1 files untouched. Combined proof on the integration branch (`42124f868`, includes this head): frontend 3944 tests + server 776 unit / 42 integration — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)