### PR TITLE
feat(product): workspace git reconciliation and recovery (PR 6)

### DIFF
--- a/apps/packages/product-client/src/App.tsx
+++ b/apps/packages/product-client/src/App.tsx
@@ -14,6 +14,7 @@ import { SupportModalHost } from "#product/components/support/SupportModalHost"
 import { AddRepoFlowHost } from "#product/components/workspace/repo-setup/AddRepoFlowHost"
 import { CloudRepoActionDialogHost } from "#product/components/workspace/repo-setup/CloudRepoActionDialogHost"
 import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
+import { MaterializationHealthPassHost } from "#product/components/workspace/repo-setup/MaterializationHealthPassHost"
 import { LoginPage } from "#product/pages/LoginPage"
 import { SettingsCloudRedirect } from "#product/pages/SettingsCloudRedirect"
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store"
@@ -201,6 +202,7 @@ export function App({ RoutesComponent }: AppProps) {
         <AddRepoFlowHost />
         <CloudRepoActionDialogHost />
         <WorkspaceAvailabilityActionHost />
+        <MaterializationHealthPassHost />
         <SupportModalHost />
         {/* Kit Sonner toaster: all toasts (update lifecycle + legacy
             toast-store call sites, which now delegate to Sonner). */}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/MaterializationHealthPassHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/MaterializationHealthPassHost.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+import { useMaterializationHealthPass } from "#product/hooks/workspaces/workflows/use-materialization-health-pass";
+import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+/**
+ * PR 6 — the connected driver that runs the materialization reconciliation
+ * health pass on Desktop startup and on relevant workspace selection. Mounted
+ * once next to the availability host (App). The pass is bounded (current-install
+ * rows vs local inventory) and idempotent (a session-scoped memo suppresses
+ * re-reporting unchanged states), so firing on load + selection change never
+ * thrashes the ledger. Explicit Retry is exposed separately from the
+ * reconciliation dialog. This component renders nothing.
+ */
+export function MaterializationHealthPassHost() {
+  const runHealthPass = useMaterializationHealthPass();
+  const { cloudWorkspaces, isLoading } = useStandardRepoProjection();
+  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const didStartupRef = useRef(false);
+  const lastSelectionRef = useRef<string | null>(null);
+
+  // Startup: once cloud workspaces have first loaded.
+  useEffect(() => {
+    if (isLoading || didStartupRef.current || cloudWorkspaces.length === 0) {
+      return;
+    }
+    didStartupRef.current = true;
+    void runHealthPass(cloudWorkspaces);
+  }, [cloudWorkspaces, isLoading, runHealthPass]);
+
+  // Relevant workspace selection change.
+  useEffect(() => {
+    if (!selectedWorkspaceId || selectedWorkspaceId === lastSelectionRef.current) {
+      return;
+    }
+    lastSelectionRef.current = selectedWorkspaceId;
+    if (cloudWorkspaces.length > 0) {
+      void runHealthPass(cloudWorkspaces);
+    }
+  }, [cloudWorkspaces, runHealthPass, selectedWorkspaceId]);
+
+  return null;
+}

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceAvailabilityActionHost.tsx
@@ -20,7 +20,11 @@ import {
   linkedCloudWorkspaceByAnyharnessId,
   type LinkCandidate,
 } from "#product/lib/domain/workspaces/cloud/link-copies-candidates";
-import { useWorkspaceAvailabilityIntentStore } from "#product/stores/cloud/workspace-availability-intent-store";
+import { WorkspaceReconciliationDialog } from "#product/components/workspace/repo-setup/WorkspaceReconciliationDialog";
+import {
+  useWorkspaceAvailabilityIntentStore,
+  type WorkspaceAvailabilityIntent,
+} from "#product/stores/cloud/workspace-availability-intent-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
 
 const UNLINK_COPY =
@@ -37,6 +41,7 @@ const UNLINK_COPY =
 export function WorkspaceAvailabilityActionHost() {
   const intent = useWorkspaceAvailabilityIntentStore((state) => state.activeIntent);
   const clearIntent = useWorkspaceAvailabilityIntentStore((state) => state.clear);
+  const beginIntent = useWorkspaceAvailabilityIntentStore((state) => state.begin);
   const host = useProductHost();
   const files = host.desktop?.files ?? null;
   const showToast = useToastStore((state) => state.show);
@@ -163,6 +168,45 @@ export function WorkspaceAvailabilityActionHost() {
 
   if (!intent) {
     return null;
+  }
+
+  if (intent.kind === "reconcile") {
+    // PR 6: the one reconciliation dialog. Its recovery verbs hand off to the
+    // EXISTING availability intents (relink/recreate/unlink/link) so there is one
+    // command model, not a parallel one.
+    const beginReconcileHandoff = (next: WorkspaceAvailabilityIntent) => {
+      closeIntent();
+      beginIntent(next);
+    };
+    return (
+      <WorkspaceReconciliationDialog
+        target={{
+          localWorkspaceId: intent.localWorkspaceId,
+          cloudWorkspaceId: intent.cloudWorkspaceId,
+          materializationId: intent.materializationId,
+          continuation: intent.continuation,
+        }}
+        logicalWorkspaces={logicalWorkspaces}
+        onRelink={(cloudWorkspaceId) =>
+          beginReconcileHandoff({ kind: "relink", cloudWorkspaceId, mode: "relink" })}
+        onRecreate={(cloudWorkspaceId) =>
+          beginReconcileHandoff({ kind: "relink", cloudWorkspaceId, mode: "recreate" })}
+        onUnlink={(cloudWorkspaceId, materializationId) =>
+          beginReconcileHandoff({ kind: "unlink", cloudWorkspaceId, materializationId })}
+        onLink={(cloudWorkspaceId) =>
+          beginReconcileHandoff({ kind: "link_copies", cloudWorkspaceId })}
+        onResumeContinuation={(continuation) => {
+          // PR6-CONTINUATION-02: resume the originating action with its serialized
+          // inputs, re-entering the existing intent (one command model).
+          if (continuation.kind === "standalone") {
+            closeIntent();
+            return;
+          }
+          beginReconcileHandoff(continuation);
+        }}
+        onClose={closeIntent}
+      />
+    );
   }
 
   if (intent.kind === "unlink") {

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceReconciliationDialog.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceReconciliationDialog.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceGitReconciliationPlan } from "#product/lib/domain/workspaces/cloud/workspace-git-reconciliation";
+
+// Inline the AlertDialog kit so the body renders in jsdom without a portal.
+vi.mock("@proliferate/ui/kit/AlertDialog", () => ({
+  AlertDialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogAction: ({ children, onClick, disabled }: any) => (
+    <button type="button" onClick={onClick} disabled={disabled} data-testid="action">{children}</button>
+  ),
+  AlertDialogCancel: ({ children, onClick, disabled }: any) => (
+    <button type="button" onClick={onClick} disabled={disabled} data-testid="cancel">{children}</button>
+  ),
+  AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: any) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: any) => <h2>{children}</h2>,
+}));
+vi.mock("@proliferate/product-ui/workspaces/WorkspaceReconciliationBody", () => ({
+  WorkspaceReconciliationBody: () => <div data-testid="body" />,
+}));
+
+const readRelation = vi.fn();
+const pushAndContinue = vi.fn();
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-git-reconciliation-actions", () => ({
+  useWorkspaceGitReconciliationActions: () => ({ readRelation, pushAndContinue }),
+}));
+vi.mock("#product/hooks/workspaces/workflows/use-materialization-health-pass", () => ({
+  useMaterializationHealthPass: () => vi.fn(async () => []),
+}));
+vi.mock("#product/hooks/workspaces/workflows/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({ selectWorkspace: vi.fn(async () => {}) }),
+}));
+vi.mock("#product/components/workspace/shell/providers/WorkspaceShellActionsContext", () => ({
+  useWorkspaceShellActions: () => null,
+}));
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: any) => selector({ show: vi.fn() }),
+}));
+vi.mock("#product/lib/domain/workspaces/cloud/reconciliation-body-view", () => ({
+  buildReconciliationBodyView: () => ({ title: "t", columns: [], actionDetail: "", cancelPreserves: "" }),
+}));
+
+import { WorkspaceReconciliationDialog } from "#product/components/workspace/repo-setup/WorkspaceReconciliationDialog";
+import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
+
+const localWorkspace = { id: "ws-1" } as LogicalWorkspace["localWorkspace"];
+const logical = {
+  id: "log-1",
+  localWorkspace,
+  cloudWorkspace: { id: "cloud-1", repo: { owner: "acme", name: "rocket" } },
+} as unknown as LogicalWorkspace;
+
+function pushLocalAheadPlan(): WorkspaceGitReconciliationPlan {
+  return {
+    relation: { kind: "local_ahead", localHead: "a".repeat(40), remoteHead: null, commits: 1 },
+    title: "This Mac is ahead",
+    action: {
+      verb: "push-local",
+      label: "Push from this Mac and continue…",
+      detail: "d",
+      requiresConfirmation: true,
+      target: "local",
+    },
+    cancelPreserves: "x",
+    linkable: false,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("WorkspaceReconciliationDialog — continuation resume (PR6-CONTINUATION-02)", () => {
+  it("resumes the originating add_cloud_copy after a converged push", async () => {
+    // Blocked Add Cloud copy entered reconciliation; the state reads local_ahead
+    // (clean, unpushed), and the push converges.
+    readRelation.mockResolvedValue({
+      relation: pushLocalAheadPlan().relation,
+      local: {},
+      cloud: {},
+    });
+    pushAndContinue.mockResolvedValue({ status: "continued", relation: { kind: "same_head", headSha: "a" } });
+    const onResumeContinuation = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <WorkspaceReconciliationDialog
+        target={{
+          localWorkspaceId: "ws-1",
+          cloudWorkspaceId: "cloud-1",
+          materializationId: null,
+          continuation: {
+            kind: "add_cloud_copy",
+            localWorkspaceId: "ws-1",
+            gitOwner: "acme",
+            gitRepoName: "rocket",
+          },
+        }}
+        logicalWorkspaces={[logical]}
+        onRelink={vi.fn()}
+        onRecreate={vi.fn()}
+        onUnlink={vi.fn()}
+        onLink={vi.fn()}
+        onResumeContinuation={onResumeContinuation}
+        onClose={onClose}
+      />,
+    );
+
+    // Wait for the relation to load and the action button to reflect the plan.
+    const button = await screen.findByTestId("action");
+    expect(button.textContent).toMatch(/Push from this Mac/);
+    await act(async () => {
+      button.click();
+    });
+
+    await waitFor(() => expect(onResumeContinuation).toHaveBeenCalledTimes(1));
+    // Resumes the ORIGINAL action with the SAME serialized inputs — not a dead end.
+    expect(onResumeContinuation).toHaveBeenCalledWith({
+      kind: "add_cloud_copy",
+      localWorkspaceId: "ws-1",
+      gitOwner: "acme",
+      gitRepoName: "rocket",
+    });
+    expect(pushAndContinue).toHaveBeenCalledWith(
+      expect.objectContaining({ expected: "local_ahead" }),
+    );
+  });
+
+  it("does NOT resume when the push did not converge (re-reads instead)", async () => {
+    readRelation.mockResolvedValue({ relation: pushLocalAheadPlan().relation, local: {}, cloud: {} });
+    pushAndContinue.mockResolvedValue({ status: "still_ahead", relation: pushLocalAheadPlan().relation });
+    const onResumeContinuation = vi.fn();
+
+    render(
+      <WorkspaceReconciliationDialog
+        target={{
+          localWorkspaceId: "ws-1",
+          cloudWorkspaceId: "cloud-1",
+          materializationId: null,
+          continuation: { kind: "add_cloud_copy", localWorkspaceId: "ws-1", gitOwner: "acme", gitRepoName: "rocket" },
+        }}
+        logicalWorkspaces={[logical]}
+        onRelink={vi.fn()}
+        onRecreate={vi.fn()}
+        onUnlink={vi.fn()}
+        onLink={vi.fn()}
+        onResumeContinuation={onResumeContinuation}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const button = await screen.findByTestId("action");
+    await act(async () => {
+      button.click();
+    });
+    await waitFor(() => expect(pushAndContinue).toHaveBeenCalled());
+    expect(onResumeContinuation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceReconciliationDialog.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspaceReconciliationDialog.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@proliferate/ui/kit/AlertDialog";
+import { WorkspaceReconciliationBody } from "@proliferate/product-ui/workspaces/WorkspaceReconciliationBody";
+import {
+  resolveWorkspaceGitReconciliation,
+  type WorkspaceGitReconciliationPlan,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-reconciliation";
+import type { WorkspaceGitSide } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+import { buildReconciliationBodyView } from "#product/lib/domain/workspaces/cloud/reconciliation-body-view";
+import { useWorkspaceGitReconciliationActions } from "#product/hooks/workspaces/workflows/use-workspace-git-reconciliation-actions";
+import { useMaterializationHealthPass } from "#product/hooks/workspaces/workflows/use-materialization-health-pass";
+import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
+import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
+import { useWorkspaceShellActions } from "#product/components/workspace/shell/providers/WorkspaceShellActionsContext";
+import { useToastStore } from "#product/stores/toast/toast-store";
+import type { WorkspaceReconcileContinuation } from "#product/stores/cloud/workspace-availability-intent-store";
+
+export interface ReconcileTarget {
+  localWorkspaceId: string | null;
+  cloudWorkspaceId: string | null;
+  materializationId: string | null;
+  /** PR6-CONTINUATION-02: the originating action to resume after resolution. */
+  continuation: WorkspaceReconcileContinuation;
+}
+
+/**
+ * PR 6 — the one reconciliation dialog (extends the availability host's dialog
+ * anatomy). It reads the current cross-target relation, renders the This Mac /
+ * Cloud / GitHub comparison, states the ONE safe next action, and says what
+ * cancelling preserves. Concrete verbs only. It NEVER resets/stashes/rebases/
+ * merges/force-pushes and never claims two different commits are linked. When
+ * the relation re-evaluates (after a push or Retry), the newer relation wins.
+ */
+export function WorkspaceReconciliationDialog({
+  target,
+  logicalWorkspaces,
+  onRelink,
+  onRecreate,
+  onUnlink,
+  onLink,
+  onResumeContinuation,
+  onClose,
+}: {
+  target: ReconcileTarget;
+  logicalWorkspaces: LogicalWorkspace[];
+  onRelink: (cloudWorkspaceId: string) => void;
+  onRecreate: (cloudWorkspaceId: string) => void;
+  onUnlink: (cloudWorkspaceId: string, materializationId: string) => void;
+  onLink: (cloudWorkspaceId: string) => void;
+  /** Resume the originating action (add_cloud_copy / open_on_mac / link / relink)
+   * after the blocking state is resolved. No-op for a standalone entry. */
+  onResumeContinuation: (continuation: WorkspaceReconcileContinuation) => void;
+  onClose: () => void;
+}) {
+  const { readRelation, pushAndContinue } = useWorkspaceGitReconciliationActions();
+  const runHealthPass = useMaterializationHealthPass();
+  const { selectWorkspace } = useWorkspaceSelection();
+  const shellActions = useWorkspaceShellActions();
+  const showToast = useToastStore((state) => state.show);
+  const [busy, setBusy] = useState(false);
+  const [state, setState] = useState<{
+    plan: WorkspaceGitReconciliationPlan;
+    local: WorkspaceGitSide;
+    cloud: WorkspaceGitSide;
+  } | null>(null);
+
+  const logical = useMemo(() => {
+    return logicalWorkspaces.find((w) =>
+      (target.cloudWorkspaceId && w.cloudWorkspace?.id === target.cloudWorkspaceId)
+      || (target.localWorkspaceId && w.localWorkspace?.id === target.localWorkspaceId))
+      ?? null;
+  }, [logicalWorkspaces, target]);
+
+  const refresh = useCallback(async () => {
+    const result = await readRelation({
+      local: logical?.localWorkspace ?? null,
+      cloud: logical?.cloudWorkspace ?? null,
+    });
+    setState({
+      plan: resolveWorkspaceGitReconciliation(result.relation),
+      local: result.local,
+      cloud: result.cloud,
+    });
+  }, [logical, readRelation]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const runAction = useCallback(async () => {
+    if (!state) {
+      return;
+    }
+    const cloudId = target.cloudWorkspaceId;
+    const verb = state.plan.action.verb;
+    setBusy(true);
+    try {
+      switch (verb) {
+        case "link":
+          // Provably same_head: adopt via the existing link entry point.
+          if (cloudId) {
+            onLink(cloudId);
+          }
+          onClose();
+          break;
+        case "push-local":
+        case "push-cloud": {
+          const outcome = await pushAndContinue({
+            local: logical?.localWorkspace ?? null,
+            cloud: logical?.cloudWorkspace ?? null,
+            expected: verb === "push-local" ? "local_ahead" : "cloud_ahead",
+          });
+          // On convergence, RESUME the originating action (e.g. the blocked Add
+          // Cloud copy / Link) instead of dead-ending (PR6-CONTINUATION-02).
+          if (outcome?.status === "continued" && target.continuation.kind !== "standalone") {
+            onResumeContinuation(target.continuation);
+            onClose();
+            break;
+          }
+          // Otherwise re-evaluation wins: re-read and re-render the new state.
+          await refresh();
+          break;
+        }
+        case "open-git-panel":
+          if (logical?.localWorkspace) {
+            await selectWorkspace(logical.localWorkspace.id, { force: true });
+            shellActions?.openPublishDialog("commit");
+          } else {
+            showToast("Open this workspace on this Mac to resolve it in the Git panel.");
+          }
+          onClose();
+          break;
+        case "recreate":
+          if (cloudId) {
+            onRecreate(cloudId);
+          }
+          onClose();
+          break;
+        case "relink":
+          if (cloudId) {
+            onRelink(cloudId);
+          }
+          onClose();
+          break;
+        case "unlink":
+          if (cloudId && target.materializationId) {
+            onUnlink(cloudId, target.materializationId);
+          }
+          onClose();
+          break;
+        case "add-cloud-copy":
+        case "open-on-mac":
+          // No copy exists yet on a target. Resume the originating action if one
+          // was carried; otherwise begin the appropriate add/open intent.
+          if (target.continuation.kind !== "standalone") {
+            onResumeContinuation(target.continuation);
+          } else if (verb === "add-cloud-copy" && logical?.localWorkspace && logical.cloudWorkspace?.repo) {
+            onResumeContinuation({
+              kind: "add_cloud_copy",
+              localWorkspaceId: logical.localWorkspace.id,
+              gitOwner: logical.cloudWorkspace.repo.owner,
+              gitRepoName: logical.cloudWorkspace.repo.name,
+            });
+          } else if (verb === "open-on-mac" && cloudId) {
+            onResumeContinuation({ kind: "open_on_mac", cloudWorkspaceId: cloudId });
+          }
+          onClose();
+          break;
+        case "retry":
+          // Explicit Retry re-runs the bounded health pass for this workspace
+          // (report/replay any drift), then re-reads the relation.
+          if (logical?.cloudWorkspace) {
+            await runHealthPass([logical.cloudWorkspace]);
+          }
+          await refresh();
+          break;
+        case "none":
+          onClose();
+          break;
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    logical,
+    onClose,
+    onLink,
+    onRecreate,
+    onRelink,
+    onResumeContinuation,
+    onUnlink,
+    pushAndContinue,
+    refresh,
+    runHealthPass,
+    selectWorkspace,
+    shellActions,
+    showToast,
+    state,
+    target,
+  ]);
+
+  const view = useMemo(() => {
+    if (!state) {
+      return null;
+    }
+    return buildReconciliationBodyView({ plan: state.plan, local: state.local, cloud: state.cloud });
+  }, [state]);
+
+  return (
+    <AlertDialog open onOpenChange={(open) => { if (!open && !busy) onClose(); }}>
+      <AlertDialogContent overlayClassName="bg-black/70 backdrop-blur-sm" data-telemetry-block>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{state?.plan.title ?? "Reconcile Git state"}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {state
+              ? "Compare this Mac and Cloud and choose the one safe next step."
+              : "Checking the current state of both copies…"}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {view ? <WorkspaceReconciliationBody view={view} /> : null}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy} onClick={() => onClose()}>
+            Cancel
+          </AlertDialogCancel>
+          {state && state.plan.action.verb !== "none" ? (
+            <AlertDialogAction
+              disabled={busy}
+              onClick={(event) => {
+                event.preventDefault();
+                void runAction();
+              }}
+            >
+              {busy ? "Working…" : state.plan.action.label}
+            </AlertDialogAction>
+          ) : null}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -397,22 +397,18 @@ export function WorkspaceItem({
                   onClick={() => { close(); handleUnarchiveCommand(); }}
                 />
               )}
-              {availabilityCommands.map((command) => {
-                const isBlocker = command.kind === "unsupported-git-state";
-                return (
-                  <PopoverMenuItem
-                    key={command.kind}
-                    icon={<GitBranchIcon className="size-3.5 shrink-0 text-muted-foreground" />}
-                    label={command.blocker ? `${command.label} — ${command.blocker}` : command.label}
-                    variant="sidebar"
-                    disabled={isBlocker}
-                    onClick={() => {
-                      close();
-                      if (!isBlocker) onAvailabilityCommand?.(command.kind);
-                    }}
-                  />
-                );
-              })}
+              {availabilityCommands.map((command) => (
+                <PopoverMenuItem
+                  key={command.kind}
+                  icon={<GitBranchIcon className="size-3.5 shrink-0 text-muted-foreground" />}
+                  label={command.blocker ? `${command.label} — ${command.blocker}` : command.label}
+                  variant="sidebar"
+                  onClick={() => {
+                    close();
+                    onAvailabilityCommand?.(command.kind);
+                  }}
+                />
+              ))}
             </>
           )}
         </>

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemMenu.tsx
@@ -58,7 +58,7 @@ const AVAILABILITY_COMMAND_ICON: Record<WorkspaceAvailabilityCommandKind, typeof
   "relink-existing": Link2,
   "recreate-on-this-mac": RotateCcw,
   "unlink-this-mac": Link2,
-  "unsupported-git-state": GitBranchIcon,
+  "reconcile-git-state": GitBranchIcon,
 };
 
 /**
@@ -150,13 +150,11 @@ export function WorkspaceItemMenu({
             <DropdownMenuSeparator />
             {availabilityCommands.map((command) => {
               const Icon = AVAILABILITY_COMMAND_ICON[command.kind];
-              const isBlocker = command.kind === "unsupported-git-state";
               return (
                 <DropdownMenuItem
                   key={command.kind}
-                  disabled={isBlocker}
                   onSelect={() => {
-                    if (!isBlocker) onAvailabilityCommand?.(command.kind);
+                    onAvailabilityCommand?.(command.kind);
                   }}
                 >
                   <Icon className="size-4 text-muted-foreground" />

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.test.ts
@@ -48,7 +48,7 @@ describe("buildWorkspaceActionsNativeMenuItems", () => {
     expect(onAvailabilityCommand).toHaveBeenCalledWith("add-cloud-copy");
   });
 
-  it("renders an unsupported-git-state blocker as a disabled, non-dispatching item", () => {
+  it("renders reconcile-git-state as an actionable, dispatching item (PR 6)", () => {
     const onAvailabilityCommand = vi.fn();
     const items = buildWorkspaceActionsNativeMenuItems({
       canRename: false,
@@ -59,20 +59,20 @@ describe("buildWorkspaceActionsNativeMenuItems", () => {
       onDismiss: vi.fn(),
       availabilityCommands: [
         {
-          kind: "unsupported-git-state",
-          label: "Unsupported Git state",
+          kind: "reconcile-git-state",
+          label: "Reconcile Git state…",
           blocker: "The workspace has uncommitted changes.",
         },
       ],
       onAvailabilityCommand,
     });
 
-    const blocker = items.find(
-      (item) => "id" in item && item.id === "availability-unsupported-git-state",
+    const item = items.find(
+      (entry) => "id" in entry && entry.id === "availability-reconcile-git-state",
     );
-    expect(blocker).toBeDefined();
-    if (blocker && "enabled" in blocker) expect(blocker.enabled).toBe(false);
-    if (blocker && "onSelect" in blocker) blocker.onSelect?.();
-    expect(onAvailabilityCommand).not.toHaveBeenCalled();
+    expect(item).toBeDefined();
+    if (item && "enabled" in item) expect(item.enabled).toBe(true);
+    if (item && "onSelect" in item) item.onSelect?.();
+    expect(onAvailabilityCommand).toHaveBeenCalledWith("reconcile-git-state");
   });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-actions-native-menu.ts
@@ -55,15 +55,14 @@ export function buildWorkspaceActionsNativeMenuItems(
   if (availabilityCommands.length > 0) {
     items.push({ kind: "separator" });
     for (const command of availabilityCommands) {
-      // An unsupported-git-state blocker is present but not actionable, mirroring
-      // the disabled DOM item.
-      const isBlocker = command.kind === "unsupported-git-state";
+      // PR 6: every availability command (incl. reconcile-git-state) is
+      // actionable; the note is appended as context.
       items.push({
         id: `availability-${command.kind}`,
         label: command.blocker ? `${command.label} — ${command.blocker}` : command.label,
-        enabled: !isBlocker,
+        enabled: true,
         onSelect: () => {
-          if (!isBlocker) input.onAvailabilityCommand?.(command.kind);
+          input.onAvailabilityCommand?.(command.kind);
         },
       });
     }

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.test.ts
@@ -140,8 +140,8 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
       availabilityCommands: [
         { kind: "unlink-this-mac", label: "Unlink this Mac…" },
         {
-          kind: "unsupported-git-state",
-          label: "Unsupported Git state",
+          kind: "reconcile-git-state",
+          label: "Reconcile Git state…",
           blocker: "This workspace has uncommitted changes.",
         },
       ],
@@ -149,13 +149,14 @@ describe("buildWorkspaceSidebarNativeContextMenuItems", () => {
     });
 
     const unlink = items.find((i) => "id" in i && i.id === "availability-unlink-this-mac");
-    const blocker = items.find((i) => "id" in i && i.id === "availability-unsupported-git-state");
+    const reconcile = items.find((i) => "id" in i && i.id === "availability-reconcile-git-state");
     expect(unlink).toBeDefined();
-    expect(blocker).toBeDefined();
-    if (blocker && "enabled" in blocker) expect(blocker.enabled).toBe(false);
+    expect(reconcile).toBeDefined();
+    // PR 6: reconcile-git-state is actionable and dispatches.
+    if (reconcile && "enabled" in reconcile) expect(reconcile.enabled).toBe(true);
     if (unlink && "onSelect" in unlink) unlink.onSelect?.();
     expect(dispatched).toBe("unlink-this-mac");
-    if (blocker && "onSelect" in blocker) blocker.onSelect?.();
-    expect(dispatched).toBe("unlink-this-mac");
+    if (reconcile && "onSelect" in reconcile) reconcile.onSelect?.();
+    expect(dispatched).toBe("reconcile-git-state");
   });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu.ts
@@ -202,13 +202,14 @@ export function buildWorkspaceSidebarNativeContextMenuItems({
       items.push({ kind: "separator" });
     }
     for (const command of availability) {
-      const isBlocker = command.kind === "unsupported-git-state";
+      // PR 6: reconcile-git-state (and every other) is actionable; the note is
+      // appended as context.
       items.push({
         id: `availability-${command.kind}`,
         label: command.blocker ? `${command.label} — ${command.blocker}` : command.label,
-        enabled: !isBlocker,
+        enabled: true,
         onSelect: () => {
-          if (!isBlocker) onAvailabilityCommand?.(command.kind);
+          onAvailabilityCommand?.(command.kind);
         },
       });
     }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-materialization-health-pass.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-materialization-health-pass.ts
@@ -1,0 +1,234 @@
+import { useCallback, useRef } from "react";
+import {
+  getAnyHarnessClient,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+  useMaterializeRepoRootMutation,
+  useMaterializeWorkspaceAtRefMutation,
+} from "@anyharness/sdk-react";
+import { useReportMaterialization } from "@proliferate/cloud-sdk-react";
+import {
+  planMaterializationReconciliation,
+  type LocalInventoryEntry,
+  type MaterializationReconciliationAction,
+} from "#product/lib/domain/workspaces/cloud/materialization-reconciliation";
+import { buildReplayContext } from "#product/lib/domain/workspaces/cloud/materialization-replay";
+import { runMaterializeAndReportSteps } from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+import { isStaleMaterializationGenerationError } from "#product/lib/domain/workspaces/cloud/materialization-report-error";
+import { remoteRepoKey } from "#product/lib/domain/workspaces/cloud/logical-workspace-source";
+import { useStandardRepoProjection } from "#product/hooks/workspaces/derived/use-standard-repo-projection";
+import { useDesktopInstallId } from "#product/hooks/workspaces/derived/use-desktop-install-id";
+import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceRepoRef,
+  CloudWorkspaceSummary,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+/**
+ * PR 6 — the materialization reconciliation health pass. Runs on Desktop
+ * startup, relevant workspace selection, and explicit Retry. It compares THIS
+ * install's local_desktop materialization rows to the local AnyHarness inventory
+ * (bounded to the passed workspaces — never an arbitrary repo scan) and issues
+ * the derived reports/replays:
+ *   - missing id/path      → PUT state:"missing"
+ *   - branch/HEAD mismatch → PUT state:"inconsistent" with observed fields
+ *   - interrupted op       → REPLAY the SAME {rowId}:{generation} operation via
+ *                            the shared PR 5 orchestration (idempotent, no dup),
+ *                            then the hydrated report the steps already emit
+ *   - unreachable runtime  → association preserved, nothing reported
+ *
+ * The planning is pure (materialization-reconciliation.ts); this hook does the
+ * I/O (read live git status, PUT reports, replay via runMaterializeAndReportSteps)
+ * and query invalidation. It NEVER mutates a checkout for a report and NEVER PUTs
+ * a re-`hydrated` for a mismatched head (a hard server 409 — §C-11).
+ *
+ * Thrash guard: a session-scoped memo suppresses re-PUTting the SAME state for
+ * an unchanged (materializationId, generation, state) so repeated passes on
+ * unchanged inputs are no-ops (the reviewer's idempotence flag).
+ */
+export function useMaterializationHealthPass() {
+  const runtime = useAnyHarnessRuntimeContext();
+  const desktopInstallId = useDesktopInstallId();
+  const report = useReportMaterialization().mutateAsync;
+  const materializeRepoRoot = useMaterializeRepoRootMutation().mutateAsync;
+  const materializeWorkspaceAtRef = useMaterializeWorkspaceAtRefMutation().mutateAsync;
+  const { localWorkspaces, repoRoots } = useStandardRepoProjection();
+  const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
+  // Session-scoped last-reported memo: materializationId → "generation:state".
+  const reportedMemo = useRef<Map<string, string>>(new Map());
+
+  return useCallback(async (
+    cloudWorkspaces: CloudWorkspaceSummary[],
+  ): Promise<MaterializationReconciliationAction[]> => {
+    if (!desktopInstallId) {
+      return [];
+    }
+
+    // Bounded inventory: only the current-install local_desktop rows and the
+    // local workspaces already loaded in the projection.
+    const localById = new Map(localWorkspaces.map((w) => [w.id, w]));
+    const unreachable: string[] = [];
+    const inventory: LocalInventoryEntry[] = [];
+    const rows = cloudWorkspaces.flatMap((cloud) =>
+      (cloud.materializations ?? [])
+        .filter((m) => m.targetKind === "local_desktop" && m.desktopInstallId === desktopInstallId)
+        .map((m) => ({ cloud, row: m })));
+
+    const client = runtime.runtimeUrl
+      ? getAnyHarnessClient(resolveRuntimeConnection(runtime))
+      : null;
+
+    for (const { row } of rows) {
+      const localId = row.anyharnessWorkspaceId;
+      if (!localId) {
+        continue;
+      }
+      // Only workspaces present in the local projection are queried; a row whose
+      // id is absent from the projection is left for the planner to mark missing.
+      if (!localById.has(localId) || !client) {
+        continue;
+      }
+      try {
+        const status = await client.git.getStatus(localId);
+        inventory.push({
+          anyharnessWorkspaceId: localId,
+          worktreePath: status.workspacePath,
+          observedBranch: status.currentBranch ?? null,
+          observedHeadSha: status.headOid,
+        });
+      } catch {
+        // The runtime could not be queried for this id: preserve the record.
+        unreachable.push(localId);
+      }
+    }
+
+    const actions = planMaterializationReconciliation({
+      rows: rows.map(({ row }) => row),
+      inventory,
+      unreachableAnyharnessWorkspaceIds: unreachable,
+    });
+
+    let didMutate = false;
+    for (const { cloud, row } of rows) {
+      const action = actions.find((a) => a.materializationId === row.id);
+      if (!action) {
+        continue;
+      }
+
+      if (action.report) {
+        // Thrash guard: skip a re-PUT of the SAME (generation, state) this session.
+        const memoKey = `${action.generation}:${action.report.state}`;
+        if (reportedMemo.current.get(row.id) === memoKey) {
+          continue;
+        }
+        try {
+          await report({ workspaceId: cloud.id, materializationId: row.id, body: action.report });
+          reportedMemo.current.set(row.id, memoKey);
+          didMutate = true;
+        } catch (error) {
+          // A stale generation means the association already moved on — quiet.
+          // Other errors are best-effort; the pass never throws to the caller.
+          if (isStaleMaterializationGenerationError(error)) {
+            reportedMemo.current.set(row.id, memoKey);
+          }
+        }
+        continue;
+      }
+
+      if (action.kind === "replay-operation") {
+        const replayed = await runReplayAction({
+          cloudWorkspaceId: cloud.id,
+          repo: cloud.repo,
+          row,
+          repoRoots,
+          materializeRepoRoot,
+          materializeWorkspaceAtRef,
+          report,
+        });
+        if (replayed) {
+          didMutate = true;
+        }
+      }
+    }
+
+    if (didMutate) {
+      const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+      if (runtimeUrl) {
+        await invalidateWorkspaceCollectionsForRuntime(runtimeUrl);
+      }
+    }
+    return actions;
+  }, [
+    desktopInstallId,
+    invalidateWorkspaceCollectionsForRuntime,
+    localWorkspaces,
+    materializeRepoRoot,
+    materializeWorkspaceAtRef,
+    report,
+    repoRoots,
+    runtime,
+  ]);
+}
+
+/**
+ * Execute a single-generation replay of an interrupted materialization via the
+ * shared orchestration. Resolves an existing repo root that already hosts the
+ * repo (never clones during a background health pass — a missing root is left
+ * for explicit recovery); re-issues the EXACT {rowId}:{generation} op id so PR 3
+ * replays idempotently. Returns true when the replay reported hydrated.
+ */
+async function runReplayAction(args: {
+  cloudWorkspaceId: string;
+  repo: CloudWorkspaceRepoRef | null;
+  row: CloudWorkspaceMaterializationSummary;
+  repoRoots: ReturnType<typeof useStandardRepoProjection>["repoRoots"];
+  materializeRepoRoot: ReturnType<typeof useMaterializeRepoRootMutation>["mutateAsync"];
+  materializeWorkspaceAtRef: ReturnType<typeof useMaterializeWorkspaceAtRefMutation>["mutateAsync"];
+  report: ReturnType<typeof useReportMaterialization>["mutateAsync"];
+}): Promise<boolean> {
+  const context = buildReplayContext({ row: args.row, repo: args.repo });
+  if (!context) {
+    return false;
+  }
+  const key = remoteRepoKey(context.repository.provider, context.repository.owner, context.repository.name);
+  const existingRepoRoot = args.repoRoots.find(
+    (root) =>
+      root.remoteProvider
+      && root.remoteOwner
+      && root.remoteRepoName
+      && remoteRepoKey(root.remoteProvider, root.remoteOwner, root.remoteRepoName) === key,
+  );
+  if (!existingRepoRoot) {
+    // No local repo root hosts this repo: do not silently clone in a background
+    // pass. Explicit relink/recreate owns that path.
+    return false;
+  }
+  try {
+    await runMaterializeAndReportSteps(
+      context,
+      { existingRepoRootId: existingRepoRoot.id },
+      {
+        materializeRepoRoot: (input) => args.materializeRepoRoot(input),
+        materializeWorkspaceAtRef: async (repoRootId, input) => {
+          const response = await args.materializeWorkspaceAtRef({ repoRootId, input });
+          return {
+            workspaceId: response.workspace.id,
+            observedHeadSha: response.observedHeadSha,
+            worktreePath: response.workspace.path,
+          };
+        },
+        report: (materializationId, body) =>
+          args.report({ workspaceId: args.cloudWorkspaceId, materializationId, body }),
+      },
+    );
+    return true;
+  } catch (error) {
+    // Best-effort; a stale generation or transient failure leaves the row for a
+    // later pass. Never throw from the health pass.
+    if (isStaleMaterializationGenerationError(error)) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-git-reconciliation-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-git-reconciliation-actions.ts
@@ -1,0 +1,179 @@
+import { useCallback } from "react";
+import {
+  getAnyHarnessClient,
+  resolveRuntimeConnection,
+  useAnyHarnessRuntimeContext,
+} from "@anyharness/sdk-react";
+import {
+  cloudGitSideFromStatus,
+  cloudGitSideLastReported,
+  localGitSideAbsent,
+  localGitSideFromStatus,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-sides";
+import {
+  deriveWorkspaceGitRelation,
+  type WorkspaceGitRelation,
+  type WorkspaceGitSide,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+import {
+  runPushAndContinue,
+  type PushAndContinueOutcome,
+} from "#product/lib/domain/workspaces/cloud/push-and-continue-orchestration";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import { useCloudWorkspaceConnectionCache } from "#product/hooks/access/cloud/use-cloud-workspace-connection-cache";
+import { useToastStore } from "#product/stores/toast/toast-store";
+import type { Workspace } from "@anyharness/sdk";
+
+/**
+ * PR 6 — the client actions the reconciliation dialog drives: read the current
+ * cross-target Git relation from LIVE status on BOTH sides (local runtime +
+ * Cloud runtime, the latter reached through the resolved cloud connection), and
+ * run push-and-continue for a clean ahead relation via the EXISTING AnyHarness
+ * push capability on whichever side is ahead. All git mutation is `push` only;
+ * no reset/stash/rebase/merge/force is ever invoked. Re-evaluation between
+ * preflight and push wins (the pure orchestration cancels a stale action).
+ *
+ * Truthfulness (PR6-CLOUD-TRUTH-01): the Cloud side is read LIVE. If its runtime
+ * can't be reached, its cleanliness fields stay UNKNOWN (last-reported head only)
+ * and the relation resolver withholds any same_head/safe claim.
+ */
+export function useWorkspaceGitReconciliationActions() {
+  const runtime = useAnyHarnessRuntimeContext();
+  const { refreshCloudWorkspaceConnection } = useCloudWorkspaceConnectionCache();
+  const showToast = useToastStore((state) => state.show);
+
+  const readLocalSide = useCallback(async (
+    local: Pick<Workspace, "id"> | null,
+    cloud: CloudWorkspaceSummary | null,
+  ): Promise<WorkspaceGitSide> => {
+    const repo = cloud?.repo ?? null;
+    if (!local) {
+      // No local copy exists on this Mac yet (Open-on-Mac territory), unless the
+      // caller is a linked-but-gone case — the planner/relation handles missing
+      // separately via the health pass. Here, absent means "not created".
+      return localGitSideAbsent("absent", repo, repo?.branch ?? null);
+    }
+    if (!runtime.runtimeUrl) {
+      return localGitSideAbsent("unreachable", repo, repo?.branch ?? null);
+    }
+    try {
+      const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
+      const status = await client.git.getStatus(local.id);
+      return localGitSideFromStatus(status, repo);
+    } catch {
+      return localGitSideAbsent("unreachable", repo, repo?.branch ?? null);
+    }
+  }, [runtime]);
+
+  /** Read the CLOUD side LIVE through the resolved cloud connection. Falls back
+   * to last-reported (unknown-clean) only when the runtime can't be reached. */
+  const readCloudSide = useCallback(async (
+    cloud: CloudWorkspaceSummary | null,
+  ): Promise<WorkspaceGitSide> => {
+    const repo = cloud?.repo ?? null;
+    const managed = (cloud?.materializations ?? []).find((m) => m.targetKind === "managed_cloud")
+      ?? null;
+    if (!cloud || !managed) {
+      // No managed Cloud copy → absent (Add-Cloud-copy), or a missing/failed row.
+      return cloudGitSideLastReported(managed, repo);
+    }
+    try {
+      const connection = await refreshCloudWorkspaceConnection(cloud.id);
+      const anyharnessWorkspaceId = connection.anyharnessWorkspaceId;
+      if (!connection.runtimeUrl || !anyharnessWorkspaceId) {
+        return cloudGitSideLastReported(managed, repo);
+      }
+      const client = getAnyHarnessClient({
+        runtimeUrl: connection.runtimeUrl,
+        authToken: connection.accessToken ?? undefined,
+      });
+      const status = await client.git.getStatus(anyharnessWorkspaceId);
+      return cloudGitSideFromStatus(status, repo);
+    } catch {
+      // Runtime not reachable this pass: last-reported head, cleanliness unknown.
+      return cloudGitSideLastReported(managed, repo);
+    }
+  }, [refreshCloudWorkspaceConnection]);
+
+  /** Read the current relation between the local checkout and the Cloud copy,
+   * both sides LIVE where reachable. */
+  const readRelation = useCallback(async (args: {
+    local: Pick<Workspace, "id"> | null;
+    cloud: CloudWorkspaceSummary | null;
+  }): Promise<{ relation: WorkspaceGitRelation; local: WorkspaceGitSide; cloud: WorkspaceGitSide }> => {
+    const [local, cloud] = await Promise.all([
+      readLocalSide(args.local, args.cloud),
+      readCloudSide(args.cloud),
+    ]);
+    return { relation: deriveWorkspaceGitRelation({ local, cloud }), local, cloud };
+  }, [readCloudSide, readLocalSide]);
+
+  /** Push from the ahead side and continue, re-reading state around the push.
+   * `expected` selects the direction: local pushes from this Mac's runtime;
+   * cloud pushes from the Cloud workspace's own runtime (resolved connection).
+   * Returns the outcome so the host can re-render the (possibly changed) state. */
+  const pushAndContinue = useCallback(async (args: {
+    local: Pick<Workspace, "id"> | null;
+    cloud: CloudWorkspaceSummary | null;
+    expected: "local_ahead" | "cloud_ahead";
+  }): Promise<PushAndContinueOutcome | null> => {
+    let push: () => Promise<import("@anyharness/sdk").PushResponse>;
+    try {
+      if (args.expected === "local_ahead") {
+        if (!args.local || !runtime.runtimeUrl) {
+          showToast("This Mac's copy isn't available to push right now.");
+          return null;
+        }
+        const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
+        push = () => client.git.push(args.local!.id, {});
+      } else {
+        const managed = (args.cloud?.materializations ?? [])
+          .find((m) => m.targetKind === "managed_cloud") ?? null;
+        if (!args.cloud || !managed) {
+          showToast("The Cloud copy isn't available to push right now.");
+          return null;
+        }
+        const connection = await refreshCloudWorkspaceConnection(args.cloud.id);
+        const cloudWorkspaceId = connection.anyharnessWorkspaceId;
+        if (!connection.runtimeUrl || !cloudWorkspaceId) {
+          showToast("The Cloud copy's runtime isn't reachable right now.");
+          return null;
+        }
+        const client = getAnyHarnessClient({
+          runtimeUrl: connection.runtimeUrl,
+          authToken: connection.accessToken ?? undefined,
+        });
+        push = () => client.git.push(cloudWorkspaceId, {});
+      }
+
+      const outcome = await runPushAndContinue(args.expected, {
+        readLocalSide: () => readLocalSide(args.local, args.cloud),
+        readCloudSide: () => readCloudSide(args.cloud),
+        push,
+      });
+      switch (outcome.status) {
+        case "continued":
+          showToast("Pushed and reconciled.", "info");
+          break;
+        case "cancelled_stale":
+          showToast("The workspace changed; re-checked before pushing. Review the new state.", "info");
+          break;
+        case "not_published":
+          showToast("The push did not publish to the remote. Try again once the remote is reachable.");
+          break;
+        case "still_ahead":
+          showToast("Pushed, but the copies still differ. Re-check before pushing again.", "info");
+          break;
+        case "blocked":
+          showToast("This state needs manual resolution; nothing was changed.", "info");
+          break;
+      }
+      return outcome;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Could not push.");
+      return null;
+    }
+  }, [readCloudSide, readLocalSide, refreshCloudWorkspaceConnection, runtime, showToast]);
+
+  return { readRelation, pushAndContinue };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/link-copies-verification.ts
@@ -1,4 +1,8 @@
-import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+import {
+  deriveWorkspaceGitRelation,
+  type WorkspaceGitRelation,
+  type WorkspaceGitSide,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
 
 /**
  * Flow 4 "Link copies" is association-only: it links an EXISTING local workspace
@@ -7,6 +11,12 @@ import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
  * materialization — a failed proof yields a truthful, typed blocker so the host
  * can explain why the two are not linkable (e.g. their HEADs differ) instead of
  * silently creating a second worktree at the Cloud HEAD (the PR5-LINK-01 bug).
+ *
+ * PR 6 refactor: the proof is no longer a parallel model. The link gate is now
+ * exactly `deriveWorkspaceGitRelation(...) === "same_head"` — the shared relation
+ * resolver decides same-repo / case-sensitive branch / clean-normal / EXACT-HEAD.
+ * The one gate this module keeps on top is the association-level "not already
+ * linked to another active Cloud workspace" check, which is not a Git relation.
  *
  * The required proof, per the frozen Flow 4 contract:
  *  - canonical provider/owner/repo match (case-folded, .git-stripped),
@@ -49,9 +59,80 @@ export type LinkVerification =
   | { linkable: true }
   | { linkable: false; blocker: string };
 
+/** Adapt a link candidate's proof facts to a clean-comparable local Git side.
+ * The candidate proof only carries linkability-relevant fields, so ahead/behind
+ * are unknown here (null) — link never depends on tracking-ref counts, only on
+ * an exact HEAD of two clean/normal sides. */
+function candidateGitSide(candidate: LinkLocalCandidateProof): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: candidate.provider,
+    owner: candidate.owner,
+    repoName: candidate.repoName,
+    branch: candidate.branch,
+    headSha: candidate.headSha,
+    clean: candidate.clean,
+    conflicted: candidate.conflicted,
+    detached: candidate.detached,
+    operationInProgress: candidate.operationInProgress,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+  };
+}
+
+function targetGitSide(target: LinkCloudTargetProof): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: target.provider,
+    owner: target.owner,
+    repoName: target.repoName,
+    branch: target.branch,
+    headSha: target.headSha,
+    clean: true,
+    conflicted: false,
+    detached: false,
+    operationInProgress: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+  };
+}
+
+/** Map a non-same_head relation to the truthful link blocker string. Only the
+ * local-side blockers are surfaced with candidate-specific copy; every other
+ * verdict means the two are not the exact same commit. */
+function linkBlockerForRelation(relation: WorkspaceGitRelation): string {
+  switch (relation.kind) {
+    case "unknown":
+      // A repo mismatch or unknown status both land here.
+      return relation.reason.startsWith("The two copies are different")
+        ? "This local workspace is a different repository than the Cloud copy."
+        : "This local workspace is at a different commit than the Cloud copy, so the two "
+          + "cannot be linked without changing either checkout.";
+    case "detached":
+      return "This local workspace is in a detached HEAD state.";
+    case "git_operation_in_progress":
+      return "This local workspace has a Git operation in progress.";
+    case "conflicted":
+      return "This local workspace has unresolved merge conflicts.";
+    case "local_dirty":
+    case "cloud_dirty":
+      return "This local workspace has uncommitted changes.";
+    default:
+      // diverged / local_ahead / cloud_ahead / behind: heads differ (branch or
+      // commit), so the two are not the same checkout.
+      return "This local workspace is at a different commit than the Cloud copy, so the two "
+        + "cannot be linked without changing either checkout.";
+  }
+}
+
 /**
- * Verify a single chosen local candidate against the Cloud target. Pure so the
- * proof (and every rejection reason) is unit-testable away from the runtime.
+ * Verify a single chosen local candidate against the Cloud target. PR 6: the
+ * repo/branch/clean/exact-HEAD proof is delegated to the shared relation
+ * resolver (linkable ⟺ relation.kind === "same_head"); only the association-level
+ * "already linked elsewhere" check remains here. Pure so every rejection reason
+ * is unit-testable away from the runtime.
  */
 export function verifyLinkCandidate(
   candidate: LinkLocalCandidateProof,
@@ -59,39 +140,28 @@ export function verifyLinkCandidate(
 ): LinkVerification {
   const notLinkable = (blocker: string): LinkVerification => ({ linkable: false, blocker });
 
-  if (
-    canonicalRepoKey(candidate.provider, candidate.owner, candidate.repoName)
-    !== canonicalRepoKey(target.provider, target.owner, target.repoName)
-  ) {
-    return notLinkable("This local workspace is a different repository than the Cloud copy.");
+  const relation = deriveWorkspaceGitRelation({
+    local: candidateGitSide(candidate),
+    cloud: targetGitSide(target),
+  });
+  if (relation.kind !== "same_head") {
+    // A case-sensitive branch mismatch is link-specific (the relation union has
+    // no branch member); surface it with its own truthful message.
+    if (
+      candidate.branch !== null
+      && target.branch !== null
+      && candidate.branch !== target.branch
+      && !candidate.detached
+      && !candidate.conflicted
+      && !candidate.operationInProgress
+      && candidate.clean
+    ) {
+      return notLinkable("This local workspace is on a different branch than the Cloud copy.");
+    }
+    return notLinkable(linkBlockerForRelation(relation));
   }
-  if (candidate.detached || candidate.branch === null) {
-    return notLinkable("This local workspace is in a detached HEAD state.");
-  }
-  if (candidate.operationInProgress) {
-    return notLinkable("This local workspace has a Git operation in progress.");
-  }
-  if (candidate.conflicted) {
-    return notLinkable("This local workspace has unresolved merge conflicts.");
-  }
-  if (!candidate.clean) {
-    return notLinkable("This local workspace has uncommitted changes.");
-  }
-  // Case-SENSITIVE branch match: Git refs are case-sensitive, so feat/X and
-  // feat/x are different branches and must not be treated as linkable.
-  if (target.branch === null || candidate.branch !== target.branch) {
-    return notLinkable("This local workspace is on a different branch than the Cloud copy.");
-  }
-  if (
-    candidate.headSha === null
-    || target.headSha === null
-    || candidate.headSha !== target.headSha
-  ) {
-    return notLinkable(
-      "This local workspace is at a different commit than the Cloud copy, so the two "
-      + "cannot be linked without changing either checkout.",
-    );
-  }
+  // The relation proves an exact-HEAD clean match; the remaining gate is
+  // association-level, not a Git relation.
   if (
     candidate.alreadyLinkedCloudWorkspaceId !== null
     && candidate.alreadyLinkedCloudWorkspaceId !== target.cloudWorkspaceId

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-reconciliation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-reconciliation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  materializationOperationIdFor,
+  planMaterializationReconciliation,
+  type LocalInventoryEntry,
+} from "#product/lib/domain/workspaces/cloud/materialization-reconciliation";
+import type { CloudWorkspaceMaterializationSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+function row(
+  overrides: Partial<CloudWorkspaceMaterializationSummary> = {},
+): CloudWorkspaceMaterializationSummary {
+  return {
+    id: "mat-1",
+    targetKind: "local_desktop",
+    desktopInstallId: "mac-a",
+    anyharnessWorkspaceId: "ws-1",
+    worktreePath: "/repo/ws-1",
+    state: "hydrated",
+    generation: 2,
+    expectedHeadSha: HEAD_A,
+    observedHeadSha: HEAD_A,
+    observedBranch: "feat/x",
+    failureCode: null,
+    lastReportedAt: null,
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<LocalInventoryEntry> = {}): LocalInventoryEntry {
+  return {
+    anyharnessWorkspaceId: "ws-1",
+    worktreePath: "/repo/ws-1",
+    observedBranch: "feat/x",
+    observedHeadSha: HEAD_A,
+    ...overrides,
+  };
+}
+
+describe("materializationOperationIdFor", () => {
+  it("is the single-generation idempotency root {rowId}:{generation}", () => {
+    expect(materializationOperationIdFor("mat-1", 2)).toBe("mat-1:2");
+  });
+});
+
+describe("planMaterializationReconciliation", () => {
+  it("reports a row with no matching local id as missing", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row({ state: "hydrated" })],
+      inventory: [],
+    });
+    expect(action.kind).toBe("report-missing");
+    expect(action.report).toEqual({ generation: 2, state: "missing" });
+  });
+
+  it("reports a moved worktree path as missing", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row()],
+      inventory: [entry({ worktreePath: "/repo/moved" })],
+    });
+    expect(action.kind).toBe("report-missing");
+  });
+
+  it("reports a HEAD mismatch as inconsistent with observed fields (never re-hydrated)", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row({ observedHeadSha: HEAD_A })],
+      inventory: [entry({ observedHeadSha: HEAD_B })],
+    });
+    expect(action.kind).toBe("report-inconsistent");
+    expect(action.report).toMatchObject({
+      state: "inconsistent",
+      observedHeadSha: HEAD_B,
+      observedBranch: "feat/x",
+    });
+  });
+
+  it("reports a branch mismatch as inconsistent", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row({ observedBranch: "feat/x" })],
+      inventory: [entry({ observedBranch: "feat/y" })],
+    });
+    expect(action.kind).toBe("report-inconsistent");
+    expect(action.report).toMatchObject({ state: "inconsistent", observedBranch: "feat/y" });
+  });
+
+  it("is healthy when the local checkout matches the ledger", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row()],
+      inventory: [entry()],
+    });
+    expect(action.kind).toBe("healthy");
+  });
+
+  it("does not re-report a row that is already missing / inconsistent", () => {
+    expect(
+      planMaterializationReconciliation({ rows: [row({ state: "missing" })], inventory: [] })[0]!.kind,
+    ).toBe("healthy");
+    expect(
+      planMaterializationReconciliation({
+        rows: [row({ state: "inconsistent", observedHeadSha: HEAD_A })],
+        inventory: [entry({ observedHeadSha: HEAD_B })],
+      })[0]!.kind,
+    ).toBe("healthy");
+  });
+
+  it("replays an interrupted (pending/hydrating) operation for the SAME generation", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row({ state: "hydrating", generation: 5 })],
+      inventory: [],
+    });
+    expect(action.kind).toBe("replay-operation");
+    expect(action.replayOperationId).toBe("mat-1:5");
+  });
+
+  it("preserves records for an unreachable runtime (never reports missing)", () => {
+    const [action] = planMaterializationReconciliation({
+      rows: [row({ state: "hydrated" })],
+      inventory: [],
+      unreachableAnyharnessWorkspaceIds: ["ws-1"],
+    });
+    expect(action.kind).toBe("unreachable-preserve");
+  });
+
+  it("ignores non-local_desktop rows (bounded scope)", () => {
+    expect(
+      planMaterializationReconciliation({
+        rows: [row({ targetKind: "managed_cloud" })],
+        inventory: [],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-reconciliation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-reconciliation.ts
@@ -1,0 +1,219 @@
+import type { ReportMaterializationRequest } from "@proliferate/cloud-sdk/types";
+import type { CloudWorkspaceMaterializationSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import { pathsEqualCanonical } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+/**
+ * PR 6 — the pure materialization health/reconciliation planner. On Desktop
+ * startup, relevant workspace selection, and explicit Retry, the health pass
+ * compares THIS install's local_desktop materialization rows to the local
+ * AnyHarness inventory and derives the reports/replays to issue. Pure so the
+ * matrix (missing id/path, branch/HEAD mismatch, single-generation replay,
+ * unreachable preserves records) is unit-testable away from the network.
+ *
+ * Bounded scope (§ Materialization reconciliation): the planner only ever
+ * reasons over the rows it is handed (current-install materializations for
+ * current/recent workspaces) against the local inventory. It NEVER scans
+ * arbitrary local repos and NEVER adopts an unrelated path/workspace.
+ *
+ * Server contract rails (reconciliation §C-10/§C-11):
+ *  - Only `state:"hydrated"` reports are sha/branch-guarded by the server, so a
+ *    detected branch/HEAD mismatch is reported EXPLICITLY as `inconsistent`
+ *    (with the observed fields) — never as a re-`hydrated` that expects the
+ *    server to downgrade it (that is a hard 409).
+ *  - A missing id/path is reported as `missing`.
+ *  - Replay is single-generation only: re-issue against the SAME row+generation;
+ *    a bumped generation is a fresh operation, never a cross-generation replay.
+ */
+
+/** One local AnyHarness workspace's identity + live head, as read from the
+ * runtime inventory / git status. `unreachable` marks a row whose runtime could
+ * not be queried at all (the association must be preserved, never mutated). */
+export interface LocalInventoryEntry {
+  anyharnessWorkspaceId: string;
+  worktreePath: string | null;
+  /** The live current branch, or null if unknown/detached. */
+  observedBranch: string | null;
+  /** The live HEAD sha, or null if unknown. */
+  observedHeadSha: string | null;
+}
+
+export type MaterializationReconciliationActionKind =
+  | "report-missing"
+  | "report-inconsistent"
+  | "replay-operation"
+  | "healthy"
+  | "unreachable-preserve";
+
+export interface MaterializationReconciliationAction {
+  kind: MaterializationReconciliationActionKind;
+  materializationId: string;
+  generation: number;
+  /** A ready-to-send report body for report-missing / report-inconsistent.
+   * Absent for replay/healthy/unreachable. */
+  report?: ReportMaterializationRequest;
+  /** For replay-operation: the single-generation operation id root to re-issue
+   * (`"{rowId}:{generation}"`). Deterministic per-step ids are derived by the
+   * orchestration; this is the root only. */
+  replayOperationId?: string;
+  /** Human-facing reason (diagnosis), for logging/telemetry. */
+  reason: string;
+}
+
+export interface MaterializationReconciliationInput {
+  /** THIS install's local_desktop materialization rows for the workspaces in
+   * scope (already filtered to current-install by the caller). */
+  rows: CloudWorkspaceMaterializationSummary[];
+  /** The local AnyHarness inventory, keyed by anyharnessWorkspaceId. */
+  inventory: LocalInventoryEntry[];
+  /** Ids whose runtime could not be reached at all this pass; their rows are
+   * preserved (unreachable), never reported missing. */
+  unreachableAnyharnessWorkspaceIds?: string[];
+}
+
+/** The idempotency root PR 3/PR 4 established: `"{rowId}:{generation}"`. Replay
+ * re-issues the SAME id; a bumped generation yields a new id (fresh op). */
+export function materializationOperationIdFor(rowId: string, generation: number): string {
+  return `${rowId}:${generation}`;
+}
+
+/**
+ * Plan the health pass. Returns one action per row. The caller executes them
+ * (PUT reports / replay) and invalidates queries; this function performs no I/O
+ * and mutates nothing.
+ */
+export function planMaterializationReconciliation(
+  input: MaterializationReconciliationInput,
+): MaterializationReconciliationAction[] {
+  const unreachable = new Set(input.unreachableAnyharnessWorkspaceIds ?? []);
+  const byId = new Map<string, LocalInventoryEntry>();
+  for (const entry of input.inventory) {
+    byId.set(entry.anyharnessWorkspaceId, entry);
+  }
+
+  const actions: MaterializationReconciliationAction[] = [];
+  for (const row of input.rows) {
+    if (row.targetKind !== "local_desktop") {
+      continue;
+    }
+    actions.push(planRow(row, byId, unreachable));
+  }
+  return actions;
+}
+
+function planRow(
+  row: CloudWorkspaceMaterializationSummary,
+  byId: Map<string, LocalInventoryEntry>,
+  unreachable: Set<string>,
+): MaterializationReconciliationAction {
+  const opId = materializationOperationIdFor(row.id, row.generation);
+
+  // A row that never finished hydrating (pending/hydrating/failed) with no local
+  // presence is a candidate for single-generation replay of the interrupted
+  // operation. We only replay when the row is still mid-flight for THIS
+  // generation — a hydrated row is complete, a missing/inconsistent row is a
+  // durable diagnosis, not an interrupted op.
+  const localId = row.anyharnessWorkspaceId;
+  const entry = localId ? byId.get(localId) ?? null : null;
+
+  if (localId && unreachable.has(localId)) {
+    return {
+      kind: "unreachable-preserve",
+      materializationId: row.id,
+      generation: row.generation,
+      reason: "Local runtime unreachable this pass; association preserved.",
+    };
+  }
+
+  if (row.state === "pending" || row.state === "hydrating") {
+    // Interrupted operation: re-issue the exact same-generation op id so PR 3
+    // replays its ledger result (no duplicate worktree) and PR 4 re-reports.
+    return {
+      kind: "replay-operation",
+      materializationId: row.id,
+      generation: row.generation,
+      replayOperationId: opId,
+      reason: `Row is ${row.state}; replay the interrupted operation ${opId}.`,
+    };
+  }
+
+  // Missing id or path: no local workspace matches this row's recorded id, or
+  // the recorded worktree path is gone. Report `missing` (unless already so).
+  const idMissing = !localId || entry === null;
+  if (idMissing) {
+    if (row.state === "missing") {
+      return healthy(row, "Already reported missing.");
+    }
+    return {
+      kind: "report-missing",
+      materializationId: row.id,
+      generation: row.generation,
+      report: { generation: row.generation, state: "missing" },
+      reason: "No local workspace matches this materialization's id.",
+    };
+  }
+
+  // A row that records a worktree path which no longer matches the inventory
+  // entry's path is also missing (the checkout moved/gone).
+  if (
+    row.worktreePath
+    && entry.worktreePath
+    && !pathsEqualCanonical(row.worktreePath, entry.worktreePath)
+  ) {
+    if (row.state === "missing") {
+      return healthy(row, "Already reported missing.");
+    }
+    return {
+      kind: "report-missing",
+      materializationId: row.id,
+      generation: row.generation,
+      report: { generation: row.generation, state: "missing" },
+      reason: "The recorded worktree path no longer matches the local checkout.",
+    };
+  }
+
+  // Branch/HEAD mismatch on a present checkout: the materialization is at a
+  // DIFFERENT head than expected → `inconsistent` (never re-`hydrated`).
+  const expectedHead = row.observedHeadSha ?? row.expectedHeadSha ?? null;
+  const headMismatch = expectedHead !== null
+    && entry.observedHeadSha !== null
+    && entry.observedHeadSha !== expectedHead;
+  const branchMismatch = row.observedBranch !== null
+    && entry.observedBranch !== null
+    && entry.observedBranch !== row.observedBranch;
+
+  if (headMismatch || branchMismatch) {
+    if (row.state === "inconsistent") {
+      return healthy(row, "Already reported inconsistent.");
+    }
+    return {
+      kind: "report-inconsistent",
+      materializationId: row.id,
+      generation: row.generation,
+      report: {
+        generation: row.generation,
+        state: "inconsistent",
+        anyharnessWorkspaceId: entry.anyharnessWorkspaceId,
+        worktreePath: entry.worktreePath,
+        observedBranch: entry.observedBranch,
+        observedHeadSha: entry.observedHeadSha,
+      },
+      reason: headMismatch
+        ? "The local checkout is at a different commit than the ledger records."
+        : "The local checkout is on a different branch than the ledger records.",
+    };
+  }
+
+  return healthy(row, "Local checkout matches the ledger.");
+}
+
+function healthy(
+  row: CloudWorkspaceMaterializationSummary,
+  reason: string,
+): MaterializationReconciliationAction {
+  return {
+    kind: "healthy",
+    materializationId: row.id,
+    generation: row.generation,
+    reason,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-replay.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-replay.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildReplayContext } from "#product/lib/domain/workspaces/cloud/materialization-replay";
+import {
+  repoRootOperationId,
+  runMaterializeAndReportSteps,
+  workspaceOperationId,
+} from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+import { planMaterializationReconciliation } from "#product/lib/domain/workspaces/cloud/materialization-reconciliation";
+import type { CloudWorkspaceMaterializationSummary, CloudWorkspaceRepoRef } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+const HEAD = "a".repeat(40);
+const BRANCH = "feat/x";
+const repo: CloudWorkspaceRepoRef = {
+  provider: "github",
+  owner: "acme",
+  name: "rocket",
+  branch: BRANCH,
+  baseBranch: "main",
+};
+
+function interruptedRow(
+  overrides: Partial<CloudWorkspaceMaterializationSummary> = {},
+): CloudWorkspaceMaterializationSummary {
+  return {
+    id: "row-7",
+    targetKind: "local_desktop",
+    desktopInstallId: "mac-a",
+    anyharnessWorkspaceId: null,
+    worktreePath: null,
+    state: "hydrating",
+    generation: 3,
+    expectedHeadSha: HEAD,
+    observedHeadSha: null,
+    observedBranch: BRANCH,
+    failureCode: null,
+    lastReportedAt: null,
+    ...overrides,
+  };
+}
+
+describe("buildReplayContext", () => {
+  it("re-issues the EXACT {rowId}:{generation} op id from the interrupted row", () => {
+    const context = buildReplayContext({ row: interruptedRow(), repo });
+    expect(context?.operationId).toBe("row-7:3");
+    expect(context?.materializationId).toBe("row-7");
+    expect(context?.generation).toBe(3);
+    expect(context?.branchName).toBe(BRANCH);
+    expect(context?.headSha).toBe(HEAD);
+  });
+
+  it("returns null when the source ref can't be reconstructed (no repo / no head)", () => {
+    expect(buildReplayContext({ row: interruptedRow(), repo: null })).toBeNull();
+    expect(
+      buildReplayContext({ row: interruptedRow({ expectedHeadSha: null, observedHeadSha: null }), repo }),
+    ).toBeNull();
+  });
+});
+
+describe("interrupted-operation replay convergence", () => {
+  it("replays with IDENTICAL per-step ids, reports exactly once, and converges", async () => {
+    const context = buildReplayContext({ row: interruptedRow(), repo })!;
+    const materializeWorkspaceAtRef = vi.fn(
+      async (_repoRootId: string, _input: { operationId: string; branchName: string; headSha: string }) => ({
+        workspaceId: "ah-local",
+        observedHeadSha: HEAD,
+        worktreePath: "/code/rocket-wt",
+      }),
+    );
+    const report = vi.fn(async (_materializationId: string, _body: unknown) => ({}));
+    const materializeRepoRoot = vi.fn(async () => ({ repoRoot: {} as never }));
+
+    const result = await runMaterializeAndReportSteps(
+      context,
+      { existingRepoRootId: "root-1" },
+      { materializeRepoRoot, materializeWorkspaceAtRef, report },
+    );
+
+    // Existing repo root → no clone step.
+    expect(materializeRepoRoot).not.toHaveBeenCalled();
+    // The workspace step uses the derived id from the SAME root op id.
+    expect(materializeWorkspaceAtRef).toHaveBeenCalledOnce();
+    expect(materializeWorkspaceAtRef.mock.calls[0]![1]).toMatchObject({
+      operationId: workspaceOperationId("row-7:3"),
+      branchName: BRANCH,
+      headSha: HEAD,
+    });
+    // Exactly one hydrated report for the SAME generation.
+    expect(report).toHaveBeenCalledOnce();
+    expect(report.mock.calls[0]![1]).toMatchObject({
+      generation: 3,
+      state: "hydrated",
+      anyharnessWorkspaceId: "ah-local",
+      observedHeadSha: HEAD,
+    });
+    expect(result.anyharnessWorkspaceId).toBe("ah-local");
+  });
+
+  it("derives the same ids on a crash-retry (deterministic per-step ids)", () => {
+    // Two independent context builds from the same row yield identical ids, so a
+    // crash-retry replays PR 3's ledger result rather than cloning twice.
+    const a = buildReplayContext({ row: interruptedRow(), repo })!;
+    const b = buildReplayContext({ row: interruptedRow(), repo })!;
+    expect(repoRootOperationId(a.operationId)).toBe(repoRootOperationId(b.operationId));
+    expect(workspaceOperationId(a.operationId)).toBe(workspaceOperationId(b.operationId));
+  });
+
+  it("a second pass AFTER convergence is a no-op (planner emits healthy, no replay)", () => {
+    // After the replay reported hydrated with the observed head, the row is
+    // hydrated and the local inventory matches → planner returns healthy.
+    const converged = interruptedRow({
+      state: "hydrated",
+      anyharnessWorkspaceId: "ah-local",
+      worktreePath: "/code/rocket-wt",
+      observedHeadSha: HEAD,
+    });
+    const [action] = planMaterializationReconciliation({
+      rows: [converged],
+      inventory: [{
+        anyharnessWorkspaceId: "ah-local",
+        worktreePath: "/code/rocket-wt",
+        observedBranch: BRANCH,
+        observedHeadSha: HEAD,
+      }],
+    });
+    expect(action.kind).toBe("healthy");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-replay.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/materialization-replay.ts
@@ -1,0 +1,48 @@
+import type { MaterializeSequenceContext } from "#product/lib/domain/workspaces/cloud/open-on-mac-orchestration";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceRepoRef,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import { materializationOperationIdFor } from "#product/lib/domain/workspaces/cloud/materialization-reconciliation";
+
+/**
+ * PR 6 — pure builder of the single-generation REPLAY context for an interrupted
+ * materialization row. The replay must re-issue the EXACT `{rowId}:{generation}`
+ * operation id root of the interrupted row (never a fresh `createIntent`, which
+ * bumps the generation on the server → a new op, defeating idempotent replay).
+ * The shared `runMaterializeAndReportSteps` then derives identical per-step ids
+ * (`:repo-root` / `:workspace`), so PR 3's ledger replays deterministically with
+ * no duplicate clone or worktree, and PR 4 re-reports the same hydrated outcome.
+ *
+ * Returns null when the row's source ref can't be reconstructed (no repo, no
+ * head, or a repo-less workspace) — such a row is not safely replayable and is
+ * left to the planner's missing/inconsistent diagnosis instead.
+ */
+export function buildReplayContext(args: {
+  row: CloudWorkspaceMaterializationSummary;
+  repo: CloudWorkspaceRepoRef | null;
+}): MaterializeSequenceContext | null {
+  const { row, repo } = args;
+  if (!repo) {
+    return null;
+  }
+  const branchName = row.observedBranch ?? repo.branch;
+  const headSha = row.expectedHeadSha ?? row.observedHeadSha;
+  if (!branchName || !headSha) {
+    return null;
+  }
+  return {
+    operationId: materializationOperationIdFor(row.id, row.generation),
+    materializationId: row.id,
+    generation: row.generation,
+    repository: {
+      provider: repo.provider,
+      owner: repo.owner,
+      name: repo.name,
+      branch: repo.branch,
+      baseBranch: repo.baseBranch,
+    },
+    branchName,
+    headSha,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.ts
@@ -82,19 +82,32 @@ export interface OpenOnMacResult {
   worktreePath: string;
 }
 
+/** The exact source ref + operation id a materialize→report sequence needs. For
+ * a fresh Open/relink it comes from `createIntent()`; for a single-generation
+ * REPLAY it comes verbatim from the interrupted ledger row (`"{rowId}:{gen}"`),
+ * so PR 3's per-step ids are identical and its ledger replays idempotently. */
+export interface MaterializeSequenceContext {
+  operationId: string;
+  materializationId: string;
+  generation: number;
+  repository: MaterializationIntentResponse["source"]["repository"];
+  branchName: string;
+  headSha: string;
+}
+
 /**
- * Run the intent → (clone repo root if needed) → exact-ref materialize →
- * report sequence. Returns the local AnyHarness workspace id so the caller can
- * select/open it. Throws on any step failure; the pending intent is left for a
- * safe retry (same operation id → no duplicate worktree).
+ * Run the (clone repo root if needed) → exact-ref materialize → report steps for
+ * a resolved operation context. Shared by the fresh Open/relink flow and the
+ * reconciliation REPLAY so there is ONE orchestration: replay simply supplies an
+ * existing row's `{rowId}:{generation}` as the context instead of minting a new
+ * intent, guaranteeing identical per-step ids (`:repo-root`/`:workspace`).
  */
-export async function runOpenOnMacFlow(
+export async function runMaterializeAndReportSteps(
+  context: MaterializeSequenceContext,
   source: OpenOnMacRepoRootSource,
-  callbacks: OpenOnMacCallbacks,
+  callbacks: Pick<OpenOnMacCallbacks, "materializeRepoRoot" | "materializeWorkspaceAtRef" | "report">,
 ): Promise<OpenOnMacResult> {
-  const intent = await callbacks.createIntent();
-  const operationId = intent.operationId;
-  const { repository, branchName, headSha } = intent.source;
+  const { operationId, repository, branchName, headSha } = context;
 
   let repoRootId = source.existingRepoRootId;
   if (!repoRootId) {
@@ -102,9 +115,6 @@ export async function runOpenOnMacFlow(
       throw new Error("A destination path is required to clone the repository.");
     }
     const { repoRoot } = await callbacks.materializeRepoRoot({
-      // Derive the repo-root step id from the Cloud operation id so a crash
-      // mid-clone reuses the repo-root materialization rather than cloning twice,
-      // while staying distinct from the workspace step's id (PR5-OPID-05).
       operationId: repoRootOperationId(operationId),
       destinationPath: source.cloneDestinationPath,
       mode: "clone_or_adopt",
@@ -115,7 +125,6 @@ export async function runOpenOnMacFlow(
         cloneUrl: githubHttpsCloneUrl(repository.owner, repository.name),
       },
     });
-    // Guard against adopting the wrong repository.
     const matches = repoRoot.remoteProvider && repoRoot.remoteOwner && repoRoot.remoteRepoName
       && canonicalRepoKey(repoRoot.remoteProvider, repoRoot.remoteOwner, repoRoot.remoteRepoName)
         === canonicalRepoKey(repository.provider, repository.owner, repository.name);
@@ -127,26 +136,15 @@ export async function runOpenOnMacFlow(
     repoRootId = repoRoot.id;
   }
 
-  let materialized: { workspaceId: string; observedHeadSha: string; worktreePath: string };
-  try {
-    materialized = await callbacks.materializeWorkspaceAtRef(repoRootId, {
-      operationId: workspaceOperationId(operationId),
-      branchName,
-      headSha,
-      // Recreate forces a fresh managed worktree at a deterministic per-generation
-      // path; relink/open omit it so PR 3 may reuse/adopt a clean checkout at the
-      // ref (PR5-MODE-03).
-      destinationId: source.forceFreshWorktree ? recreateDestinationId(operationId) : undefined,
-    });
-  } catch (error) {
-    // Leave the intent pending for a safe retry (same operation id reuses the
-    // ledger result). Do not report a failure that would look like a durable
-    // materialization failure to the server.
-    throw error;
-  }
+  const materialized = await callbacks.materializeWorkspaceAtRef(repoRootId, {
+    operationId: workspaceOperationId(operationId),
+    branchName,
+    headSha,
+    destinationId: source.forceFreshWorktree ? recreateDestinationId(operationId) : undefined,
+  });
 
-  await callbacks.report(intent.materialization.id, {
-    generation: intent.materialization.generation,
+  await callbacks.report(context.materializationId, {
+    generation: context.generation,
     state: "hydrated",
     anyharnessWorkspaceId: materialized.workspaceId,
     worktreePath: materialized.worktreePath,
@@ -155,8 +153,33 @@ export async function runOpenOnMacFlow(
   });
 
   return {
-    materializationId: intent.materialization.id,
+    materializationId: context.materializationId,
     anyharnessWorkspaceId: materialized.workspaceId,
     worktreePath: materialized.worktreePath,
   };
+}
+
+/**
+ * Run the intent → (clone repo root if needed) → exact-ref materialize →
+ * report sequence. Returns the local AnyHarness workspace id so the caller can
+ * select/open it. Throws on any step failure; the pending intent is left for a
+ * safe retry (same operation id → no duplicate worktree).
+ */
+export async function runOpenOnMacFlow(
+  source: OpenOnMacRepoRootSource,
+  callbacks: OpenOnMacCallbacks,
+): Promise<OpenOnMacResult> {
+  const intent = await callbacks.createIntent();
+  return runMaterializeAndReportSteps(
+    {
+      operationId: intent.operationId,
+      materializationId: intent.materialization.id,
+      generation: intent.materialization.generation,
+      repository: intent.source.repository,
+      branchName: intent.source.branchName,
+      headSha: intent.source.headSha,
+    },
+    source,
+    callbacks,
+  );
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/push-and-continue-orchestration.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/push-and-continue-orchestration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PushResponse } from "@anyharness/sdk";
+import { runPushAndContinue } from "#product/lib/domain/workspaces/cloud/push-and-continue-orchestration";
+import type { WorkspaceGitSide } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+function side(overrides: Partial<WorkspaceGitSide> = {}): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branch: "feat/x",
+    headSha: HEAD_A,
+    clean: true,
+    conflicted: false,
+    detached: false,
+    operationInProgress: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    ...overrides,
+  };
+}
+
+const published: PushResponse = { branch: "feat/x", published: true, remote: "origin" };
+const notPublished: PushResponse = { branch: "feat/x", published: false, remote: "origin" };
+
+describe("runPushAndContinue", () => {
+  it("pushes a clean local_ahead then continues on same_head after re-read", async () => {
+    const push = vi.fn().mockResolvedValue(published);
+    // Preflight: local ahead. Post-push: converged.
+    const localSides = [side({ ahead: 2, headSha: HEAD_A }), side({ headSha: HEAD_B })];
+    const readLocalSide = vi.fn().mockImplementation(() => Promise.resolve(localSides.shift()!));
+    const readCloudSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_B }));
+    const outcome = await runPushAndContinue("local_ahead", { readLocalSide, readCloudSide, push });
+    expect(push).toHaveBeenCalledOnce();
+    expect(outcome.status).toBe("continued");
+  });
+
+  it("cancels the stale action when the relation changed between preflight and push", async () => {
+    const push = vi.fn().mockResolvedValue(published);
+    // Preflight now reads DIRTY (someone edited): the confirmed local_ahead is stale.
+    const readLocalSide = vi.fn().mockResolvedValue(side({ clean: false }));
+    const readCloudSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_B }));
+    const outcome = await runPushAndContinue("local_ahead", { readLocalSide, readCloudSide, push });
+    expect(push).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("cancelled_stale");
+  });
+
+  it("does not treat an unpublished push as success (published is the signal)", async () => {
+    const push = vi.fn().mockResolvedValue(notPublished);
+    const readLocalSide = vi.fn().mockResolvedValue(side({ ahead: 1, headSha: HEAD_A }));
+    const readCloudSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_B }));
+    const outcome = await runPushAndContinue("local_ahead", { readLocalSide, readCloudSide, push });
+    expect(outcome.status).toBe("not_published");
+  });
+
+  it("reports still_ahead when a published push did not converge", async () => {
+    const push = vi.fn().mockResolvedValue(published);
+    const readLocalSide = vi.fn().mockResolvedValue(side({ ahead: 1, headSha: HEAD_A }));
+    const readCloudSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_B }));
+    const outcome = await runPushAndContinue("local_ahead", { readLocalSide, readCloudSide, push });
+    expect(outcome.status).toBe("still_ahead");
+  });
+
+  it("continues immediately if a concurrent push already converged the sides", async () => {
+    const push = vi.fn().mockResolvedValue(published);
+    const readLocalSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_A }));
+    const readCloudSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_A }));
+    const outcome = await runPushAndContinue("local_ahead", { readLocalSide, readCloudSide, push });
+    expect(push).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("continued");
+  });
+
+  // PR6-CLOUD-PUSH-03: the cloud direction now EXECUTES (was previously blocked).
+  it("EXECUTES a cloud_ahead push and continues on convergence (cloud push path)", async () => {
+    const push = vi.fn().mockResolvedValue(published);
+    // Preflight: cloud ahead. Post-push: converged.
+    const cloudSides = [side({ ahead: 2, headSha: HEAD_B }), side({ headSha: HEAD_A })];
+    const readCloudSide = vi.fn().mockImplementation(() => Promise.resolve(cloudSides.shift()!));
+    const readLocalSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_A }));
+    const outcome = await runPushAndContinue("cloud_ahead", { readLocalSide, readCloudSide, push });
+    expect(push).toHaveBeenCalledOnce();
+    expect(outcome.status).toBe("continued");
+  });
+
+  it("cancels a stale cloud_ahead when the cloud state becomes unverifiable before push", async () => {
+    const push = vi.fn().mockResolvedValue(published);
+    // Cloud live status now unknown (couldn't read) → cloud_state_unverified, not
+    // cloud_ahead: the confirmed action is stale, no blind push.
+    const readCloudSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_B, clean: null, conflicted: null }));
+    const readLocalSide = vi.fn().mockResolvedValue(side({ headSha: HEAD_A }));
+    const outcome = await runPushAndContinue("cloud_ahead", { readLocalSide, readCloudSide, push });
+    expect(push).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("cancelled_stale");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/push-and-continue-orchestration.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/push-and-continue-orchestration.ts
@@ -1,0 +1,94 @@
+import type { PushResponse } from "@anyharness/sdk";
+import {
+  deriveWorkspaceGitRelation,
+  type WorkspaceGitRelation,
+  type WorkspaceGitSide,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+/**
+ * PR 6 — pure "push-and-continue" orchestration for a clean, local-ahead
+ * relation. Reuses the EXISTING AnyHarness push capability (the caller supplies
+ * `push`, wired to `client.git.push` / `usePushGitMutation`), then re-reads
+ * status and re-derives the relation. Pure so the "state changed between
+ * preflight and push" cancellation and the "published is the confirmation
+ * signal" rule are unit-testable away from the runtime.
+ *
+ * Binding safety rules (frozen spec Failure rules):
+ *  - Re-evaluation wins: if the relation changes between preflight and the push,
+ *    the stale action is CANCELLED (never a blind push against a moved tree).
+ *  - `published` in PushResponse is the confirmation signal: a push whose
+ *    response says `published: false` is NOT treated as success even if it
+ *    resolved without throwing.
+ *  - Continue is gated on a fresh LOCAL+Cloud re-read reaching `same_head`, using
+ *    the LIVE Cloud status the caller supplies (PR6-CLOUD-TRUTH-01) — never a
+ *    fabricated cloud state. If it does not converge, the caller retries.
+ *  - No reset/stash/rebase/merge/force is ever issued — only `push`.
+ *  - Both directions execute: `local_ahead` pushes from this Mac, `cloud_ahead`
+ *    pushes from the Cloud runtime (the caller wires `push` to the right runtime;
+ *    PR6-CLOUD-PUSH-03).
+ */
+
+export type PushAndContinueOutcome =
+  | { status: "continued"; relation: WorkspaceGitRelation }
+  | { status: "cancelled_stale"; relation: WorkspaceGitRelation; expected: WorkspaceGitRelation["kind"] }
+  | { status: "not_published"; response: PushResponse }
+  | { status: "still_ahead"; relation: WorkspaceGitRelation }
+  | { status: "blocked"; relation: WorkspaceGitRelation };
+
+export interface PushAndContinueCallbacks {
+  /** Re-read the CURRENT local Git side (fresh live status). */
+  readLocalSide: () => Promise<WorkspaceGitSide>;
+  /** Re-read the CURRENT Cloud Git side (fresh live status where reachable). */
+  readCloudSide: () => Promise<WorkspaceGitSide>;
+  /** Push from the ahead target via the existing AnyHarness push capability
+   * (wired by the caller to the correct — local or Cloud — runtime). */
+  push: () => Promise<PushResponse>;
+}
+
+/**
+ * Run push-and-continue for a `local_ahead`/`cloud_ahead` preflight. `expected`
+ * is the relation kind the confirmation was shown for; if a fresh re-read no
+ * longer matches, the action is cancelled (re-evaluation wins). Both directions
+ * execute — the caller wires `push` to this Mac's runtime (local) or the Cloud
+ * workspace's runtime (cloud).
+ */
+export async function runPushAndContinue(
+  expected: "local_ahead" | "cloud_ahead",
+  callbacks: PushAndContinueCallbacks,
+): Promise<PushAndContinueOutcome> {
+  // Re-read both sides and re-derive BEFORE pushing (preflight validity).
+  const preRelation = deriveWorkspaceGitRelation({
+    local: await callbacks.readLocalSide(),
+    cloud: await callbacks.readCloudSide(),
+  });
+  if (preRelation.kind === "same_head") {
+    // Already converged (a concurrent push landed): nothing to do, continue.
+    return { status: "continued", relation: preRelation };
+  }
+  if (preRelation.kind !== expected) {
+    // The tree moved out from under the confirmation (incl. the Cloud state
+    // becoming unverifiable): cancel the stale action, re-evaluation wins.
+    return { status: "cancelled_stale", relation: preRelation, expected };
+  }
+
+  const response = await callbacks.push();
+  if (!response.published) {
+    // Do not assume success from resolution alone — published is the signal.
+    return { status: "not_published", response };
+  }
+
+  // Re-read after push and re-derive. Continue only when converged/clean.
+  const postRelation = deriveWorkspaceGitRelation({
+    local: await callbacks.readLocalSide(),
+    cloud: await callbacks.readCloudSide(),
+  });
+  if (postRelation.kind === "same_head") {
+    return { status: "continued", relation: postRelation };
+  }
+  if (postRelation.kind === expected) {
+    // Still ahead in the same direction after a published push: the caller
+    // retries reading state before pushing again.
+    return { status: "still_ahead", relation: postRelation };
+  }
+  return { status: "blocked", relation: postRelation };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/reconciliation-body-view.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/reconciliation-body-view.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildReconciliationBodyView } from "#product/lib/domain/workspaces/cloud/reconciliation-body-view";
+import { resolveWorkspaceGitReconciliation } from "#product/lib/domain/workspaces/cloud/workspace-git-reconciliation";
+import type { WorkspaceGitSide } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+function side(overrides: Partial<WorkspaceGitSide> = {}): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branch: "feat/x",
+    headSha: HEAD_A,
+    clean: true,
+    conflicted: false,
+    detached: false,
+    operationInProgress: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    ...overrides,
+  };
+}
+
+describe("buildReconciliationBodyView", () => {
+  it("renders This Mac / Cloud / GitHub columns with abbreviated heads", () => {
+    const view = buildReconciliationBodyView({
+      plan: resolveWorkspaceGitReconciliation({ kind: "local_ahead", localHead: HEAD_A, remoteHead: null, commits: 2 }),
+      local: side({ ahead: 2, headSha: HEAD_A }),
+      cloud: side({ headSha: HEAD_B }),
+    });
+    expect(view.columns.map((c) => c.title)).toEqual(["This Mac", "Cloud", "GitHub branch"]);
+    expect(view.columns[0]!.headShort).toBe(HEAD_A.slice(0, 7));
+    expect(view.columns[0]!.stateLabel).toBe("2 ahead");
+  });
+
+  it("labels the GitHub remote HEAD as last-known with a truthful staleness caveat (never fabricated)", () => {
+    const view = buildReconciliationBodyView({
+      plan: resolveWorkspaceGitReconciliation({ kind: "same_head", headSha: HEAD_A }),
+      local: side(),
+      cloud: side(),
+    });
+    const github = view.columns[2]!;
+    expect(github.stateLabel).toBe("last-known");
+    expect(github.headShort).toBeNull();
+    expect(github.caveat).toMatch(/isn't checked here|verified when the action runs/i);
+  });
+
+  it("carries the plan's action detail and cancel-preserves line", () => {
+    const plan = resolveWorkspaceGitReconciliation({ kind: "missing", target: "local" });
+    const view = buildReconciliationBodyView({ plan, local: side({ presence: "missing" }), cloud: side() });
+    expect(view.actionDetail).toBe(plan.action.detail);
+    expect(view.cancelPreserves).toBe(plan.cancelPreserves);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/reconciliation-body-view.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/reconciliation-body-view.ts
@@ -1,0 +1,113 @@
+import type {
+  WorkspaceReconciliationBodyView,
+  WorkspaceReconciliationColumnView,
+} from "@proliferate/product-ui/workspaces/WorkspaceReconciliationBody";
+import {
+  classifyWorkspaceGitSide,
+  type WorkspaceGitSide,
+  type WorkspaceGitSideState,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+import type { WorkspaceGitReconciliationPlan } from "#product/lib/domain/workspaces/cloud/workspace-git-reconciliation";
+
+/**
+ * PR 6 — pure mapping from a reconciliation plan + the two Git sides to the
+ * props-only WorkspaceReconciliationBody view. Keeps the truthfulness rules in
+ * one place: the GitHub column is only rendered when a remote head is actually
+ * client-visible (it never is in this PR), so it is shown as a "last-known"
+ * caveat rather than a fabricated authoritative HEAD.
+ */
+
+export function buildReconciliationBodyView(args: {
+  plan: WorkspaceGitReconciliationPlan;
+  local: WorkspaceGitSide;
+  cloud: WorkspaceGitSide;
+}): WorkspaceReconciliationBodyView {
+  const { plan, local, cloud } = args;
+  const columns: WorkspaceReconciliationColumnView[] = [
+    columnFor("This Mac", local, false),
+    columnFor("Cloud", cloud, true),
+    githubColumn(local, cloud),
+  ];
+  return {
+    title: plan.title,
+    columns,
+    actionDetail: plan.action.detail,
+    cancelPreserves: plan.cancelPreserves,
+  };
+}
+
+function columnFor(
+  title: string,
+  side: WorkspaceGitSide,
+  isCloud: boolean,
+): WorkspaceReconciliationColumnView {
+  const state = classifyWorkspaceGitSide(side);
+  const { label, tone } = labelForSideState(state);
+  // PR6-CLOUD-TRUTH-01: when the Cloud side couldn't be read live (unknown /
+  // unreachable), its head is last-REPORTED — label it so and never imply live.
+  const cloudLastReported = isCloud
+    && (state.kind === "unknown" || state.kind === "unreachable");
+  return {
+    title,
+    branch: side.branch,
+    headShort: side.headSha ? side.headSha.slice(0, 7) : null,
+    stateLabel: cloudLastReported ? "last-reported" : label,
+    stateTone: cloudLastReported ? "neutral" : tone,
+    caveat: cloudLastReported
+      ? "Cloud runtime wasn't reachable; this is the last-reported commit, not live."
+      : undefined,
+  };
+}
+
+/** The GitHub branch-HEAD column. The authoritative remote HEAD is NOT
+ * client-visible (verified GAP §B-9/§D-14): there is no live remote probe and
+ * the branches route carries no per-branch SHA. So we render the branch name
+ * only, with a "last-known" state and an explicit staleness caveat — never a
+ * fabricated remote sha. */
+function githubColumn(
+  local: WorkspaceGitSide,
+  cloud: WorkspaceGitSide,
+): WorkspaceReconciliationColumnView {
+  const branch = local.branch ?? cloud.branch;
+  return {
+    title: "GitHub branch",
+    branch,
+    headShort: null,
+    stateLabel: "last-known",
+    stateTone: "neutral",
+    caveat: "Remote HEAD isn't checked here; verified when the action runs.",
+  };
+}
+
+function labelForSideState(
+  state: WorkspaceGitSideState,
+): { label: string; tone: WorkspaceReconciliationColumnView["stateTone"] } {
+  switch (state.kind) {
+    case "clean":
+      return { label: "clean", tone: "success" };
+    case "ahead":
+      return { label: `${state.commits} ahead`, tone: "info" };
+    case "behind":
+      return { label: `${state.commits} behind`, tone: "warning" };
+    case "diverged":
+      return { label: `${state.ahead} ahead, ${state.behind} behind`, tone: "warning" };
+    case "dirty":
+      return { label: "uncommitted changes", tone: "warning" };
+    case "conflicted":
+      return { label: "conflicts", tone: "destructive" };
+    case "operation":
+      return { label: "operation in progress", tone: "warning" };
+    case "detached":
+      return { label: "detached HEAD", tone: "warning" };
+    case "unpublished":
+      return { label: "not published", tone: "warning" };
+    case "missing":
+      return { label: "missing", tone: "destructive" };
+    case "absent":
+      return { label: "not created", tone: "neutral" };
+    case "unreachable":
+      return { label: "unreachable", tone: "neutral" };
+    case "unknown":
+      return { label: "unknown", tone: "neutral" };
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/reconciliation-no-destructive-git.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/reconciliation-no-destructive-git.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PushResponse } from "@anyharness/sdk";
+import { runPushAndContinue } from "#product/lib/domain/workspaces/cloud/push-and-continue-orchestration";
+import { resolveWorkspaceGitReconciliation } from "#product/lib/domain/workspaces/cloud/workspace-git-reconciliation";
+import type { WorkspaceGitRelation, WorkspaceGitSide } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+/**
+ * Absolute safety rail (frozen spec Tests): NO reset/stash/rebase/merge/force
+ * command is issued by these workflows. This spies on the exact git-client
+ * surface a workflow could reach and asserts that (a) the client exposes no
+ * destructive verb at all, and (b) push-and-continue only ever calls `push`.
+ */
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+const DESTRUCTIVE_METHODS = ["reset", "stash", "rebase", "merge", "forcePush", "checkout", "clean", "revert"];
+
+function side(overrides: Partial<WorkspaceGitSide> = {}): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branch: "feat/x",
+    headSha: HEAD_A,
+    clean: true,
+    conflicted: false,
+    detached: false,
+    operationInProgress: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    ...overrides,
+  };
+}
+
+describe("no destructive git verb is ever invoked by reconciliation workflows", () => {
+  it("push-and-continue calls ONLY push on the git surface (spy)", async () => {
+    const published: PushResponse = { branch: "feat/x", published: true, remote: "origin" };
+    // A fake git client with the full mutating surface spied; only push is legal.
+    const gitSurface = {
+      push: vi.fn().mockResolvedValue(published),
+      reset: vi.fn(),
+      stash: vi.fn(),
+      rebase: vi.fn(),
+      merge: vi.fn(),
+      forcePush: vi.fn(),
+      checkout: vi.fn(),
+      clean: vi.fn(),
+      revert: vi.fn(),
+    };
+    const localSides = [side({ ahead: 2, headSha: HEAD_A }), side({ headSha: HEAD_B })];
+    await runPushAndContinue("local_ahead", {
+      readLocalSide: () => Promise.resolve(localSides.shift() ?? side({ headSha: HEAD_B })),
+      readCloudSide: () => Promise.resolve(side({ headSha: HEAD_B })),
+      push: () => gitSurface.push(),
+    });
+    expect(gitSurface.push).toHaveBeenCalledOnce();
+    for (const method of DESTRUCTIVE_METHODS) {
+      expect(gitSurface[method as keyof typeof gitSurface]).not.toHaveBeenCalled();
+    }
+  });
+
+  it("no action plan across the whole matrix names a destructive verb", () => {
+    const relations: WorkspaceGitRelation[] = [
+      { kind: "same_head", headSha: HEAD_A },
+      { kind: "local_ahead", localHead: HEAD_A, remoteHead: null, commits: 2 },
+      { kind: "cloud_ahead", cloudHead: HEAD_B, remoteHead: null, commits: 1 },
+      { kind: "local_dirty" },
+      { kind: "cloud_dirty" },
+      { kind: "conflicted", target: "local" },
+      { kind: "git_operation_in_progress", target: "cloud" },
+      { kind: "detached", target: "local" },
+      { kind: "behind", target: "local" },
+      { kind: "diverged", localHead: HEAD_A, cloudHead: HEAD_B, remoteHead: null },
+      { kind: "missing", target: "local" },
+      { kind: "missing", target: "cloud" },
+      { kind: "unreachable", target: "local" },
+      { kind: "cloud_state_unverified", localHead: HEAD_A, cloudLastReportedHead: HEAD_B },
+      { kind: "no_cloud_copy" },
+      { kind: "no_local_copy" },
+      { kind: "unknown", reason: "x" },
+    ];
+    // The safety note deliberately mentions these words in a NEGATED form, so we
+    // assert against the machine-readable verb, not free text.
+    const allowedVerbs = new Set([
+      "link", "push-local", "push-cloud", "open-git-panel", "recreate", "relink", "unlink",
+      "retry", "add-cloud-copy", "open-on-mac", "none",
+    ]);
+    for (const relation of relations) {
+      const verb = resolveWorkspaceGitReconciliation(relation).action.verb;
+      expect(allowedVerbs.has(verb)).toBe(true);
+      expect(verb).not.toMatch(/reset|stash|rebase|merge|force/);
+    }
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.test.ts
@@ -103,7 +103,9 @@ describe("resolveWorkspaceAvailabilityCommands", () => {
     ).toEqual(["relink-existing", "recreate-on-this-mac", "unlink-this-mac"]);
   });
 
-  it("shows a selectable blocker for an unsupported Git state", () => {
+  it("offers an actionable reconcile-git-state entry for an unsupported Git state", () => {
+    // PR 6: no longer a dead-end blocker — it opens the reconciliation dialog,
+    // carrying the truthful note as context.
     const commands = resolveWorkspaceAvailabilityCommands({
       hasLocalWorkspace: true,
       cloudWorkspace: null,
@@ -111,7 +113,7 @@ describe("resolveWorkspaceAvailabilityCommands", () => {
       unsupportedGitBlocker: "The workspace has uncommitted changes.",
     });
     expect(commands).toHaveLength(1);
-    expect(commands[0]!.kind).toBe("unsupported-git-state");
+    expect(commands[0]!.kind).toBe("reconcile-git-state");
     expect(commands[0]!.blocker).toBe("The workspace has uncommitted changes.");
   });
 
@@ -152,7 +154,7 @@ describe("deriveWorkspaceAvailabilityInput", () => {
       localGitStatus: { ...CLEAN_PUBLISHED, dirty: true },
     });
     expect(resolveWorkspaceAvailabilityCommands(input).map((c) => c.kind)).toEqual([
-      "unsupported-git-state",
+      "reconcile-git-state",
     ]);
   });
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-commands.ts
@@ -22,13 +22,14 @@ export type WorkspaceAvailabilityCommandKind =
   | "relink-existing"
   | "recreate-on-this-mac"
   | "unlink-this-mac"
-  | "unsupported-git-state";
+  | "reconcile-git-state";
 
 export interface WorkspaceAvailabilityCommand {
   kind: WorkspaceAvailabilityCommandKind;
   label: string;
-  /** Blockers describe why a command is present but not actionable (unsupported
-   * Git state). An actionable command has no blocker. */
+  /** A truthful one-line note on why this command is offered (e.g. the
+   * unsupported Git state that needs reconciling). Actionable commands may still
+   * carry a note; PR 6's `reconcile-git-state` is actionable AND explains why. */
   blocker?: string;
 }
 
@@ -154,14 +155,15 @@ function localMaterializationForInstall(
 export function resolveWorkspaceAvailabilityCommands(
   input: WorkspaceAvailabilityInput,
 ): WorkspaceAvailabilityCommand[] {
-  // An unsupported Git state blocks every mutation; show the truthful, still
-  // selectable blocker only (expansion is PR 6). Never offer an action that
-  // would reset/merge/rebase to "fix" it.
+  // PR 6: an unsupported Git state is no longer a dead-end blocker. It is a
+  // truthful, ACTIONABLE entry into the one reconciliation dialog, which diagnoses
+  // the cross-target relation and offers the ONE safe next action (Push, Open Git
+  // panel, Recreate, Relink, Unlink, Retry). Never a reset/merge/rebase to "fix".
   if (input.unsupportedGitBlocker) {
     return [
       {
-        kind: "unsupported-git-state",
-        label: "Unsupported Git state",
+        kind: "reconcile-git-state",
+        label: "Reconcile Git state…",
         blocker: input.unsupportedGitBlocker,
       },
     ];

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.test.ts
@@ -71,7 +71,47 @@ describe("workspaceAvailabilityIntentForCommand", () => {
     ).toBeNull();
   });
 
-  it("returns null for the non-actionable blocker", () => {
-    expect(workspaceAvailabilityIntentForCommand("unsupported-git-state", FULL)).toBeNull();
+  it("maps reconcile-git-state (local + cloud) to a reconcile intent resuming Link", () => {
+    expect(workspaceAvailabilityIntentForCommand("reconcile-git-state", FULL)).toEqual({
+      kind: "reconcile",
+      localWorkspaceId: "ws-1",
+      cloudWorkspaceId: "cloud-1",
+      materializationId: "mat-1",
+      // PR6-CONTINUATION-02: a local + Cloud blocked source-mutation resumes Link.
+      continuation: { kind: "link_copies", cloudWorkspaceId: "cloud-1" },
+    });
+  });
+
+  it("carries an add_cloud_copy continuation for a blocked local-only Add Cloud copy", () => {
+    // Local-only source (no Cloud copy): the blocked action to resume is Add Cloud
+    // copy with its exact inputs — never a dead end (PR6-CONTINUATION-02).
+    expect(
+      workspaceAvailabilityIntentForCommand("reconcile-git-state", {
+        ...FULL,
+        cloudWorkspaceId: null,
+        linkedMaterializationId: null,
+      }),
+    ).toEqual({
+      kind: "reconcile",
+      localWorkspaceId: "ws-1",
+      cloudWorkspaceId: null,
+      materializationId: null,
+      continuation: {
+        kind: "add_cloud_copy",
+        localWorkspaceId: "ws-1",
+        gitOwner: "acme",
+        gitRepoName: "rocket",
+      },
+    });
+  });
+
+  it("returns null for reconcile-git-state when neither side is present", () => {
+    expect(
+      workspaceAvailabilityIntentForCommand("reconcile-git-state", {
+        ...FULL,
+        localWorkspaceId: null,
+        cloudWorkspaceId: null,
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts
@@ -59,8 +59,44 @@ export function workspaceAvailabilityIntentForCommand(
           materializationId: target.linkedMaterializationId,
         }
         : null;
-    case "unsupported-git-state":
-      // A truthful, non-actionable blocker (expansion is PR 6).
-      return null;
+    case "reconcile-git-state": {
+      // PR 6: open the one reconciliation dialog. reconcile-git-state is only
+      // offered when a SOURCE-MUTATING action was blocked by Git state (Add Cloud
+      // copy from a local source, or Link a local source), so we resume THAT
+      // action after the user resolves the block — never a dead end
+      // (PR6-CONTINUATION-02). Infer the continuation from the target shape.
+      if (!target.localWorkspaceId && !target.cloudWorkspaceId) {
+        return null;
+      }
+      const continuation = resolveReconcileContinuation(target);
+      return {
+        kind: "reconcile",
+        localWorkspaceId: target.localWorkspaceId,
+        cloudWorkspaceId: target.cloudWorkspaceId,
+        materializationId: target.linkedMaterializationId,
+        continuation,
+      };
+    }
   }
+}
+
+/** Infer the originating (blocked) action to resume after reconciliation. The
+ * reconcile-git-state command replaces a blocked source-mutating action: a
+ * local-only source wanted Add Cloud copy; a local + unlinked Cloud pair wanted
+ * Link. A cloud-only / linked case has no source mutation to resume. */
+function resolveReconcileContinuation(
+  target: WorkspaceAvailabilityActionTarget,
+): NonNullable<Extract<WorkspaceAvailabilityIntent, { kind: "reconcile" }>["continuation"]> {
+  if (target.localWorkspaceId && target.cloudWorkspaceId) {
+    return { kind: "link_copies", cloudWorkspaceId: target.cloudWorkspaceId };
+  }
+  if (target.localWorkspaceId && target.repoOwner && target.repoName) {
+    return {
+      kind: "add_cloud_copy",
+      localWorkspaceId: target.localWorkspaceId,
+      gitOwner: target.repoOwner,
+      gitRepoName: target.repoName,
+    };
+  }
+  return { kind: "standalone" };
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-reconciliation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-reconciliation.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { resolveWorkspaceGitReconciliation } from "#product/lib/domain/workspaces/cloud/workspace-git-reconciliation";
+import type { WorkspaceGitRelation } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+const DESTRUCTIVE = /reset|stash|rebase|merge|force|pull/i;
+
+function plan(relation: WorkspaceGitRelation) {
+  return resolveWorkspaceGitReconciliation(relation);
+}
+
+describe("resolveWorkspaceGitReconciliation — action matrix", () => {
+  it("same_head → immediate link, no confirmation, linkable", () => {
+    const p = plan({ kind: "same_head", headSha: HEAD_A });
+    expect(p.action.verb).toBe("link");
+    expect(p.action.requiresConfirmation).toBe(false);
+    expect(p.linkable).toBe(true);
+  });
+
+  it("local_ahead → push-local with confirmation", () => {
+    const p = plan({ kind: "local_ahead", localHead: HEAD_A, remoteHead: null, commits: 2 });
+    expect(p.action.verb).toBe("push-local");
+    expect(p.action.requiresConfirmation).toBe(true);
+    expect(p.action.label).toMatch(/Push from this Mac/);
+    expect(p.action.detail).toMatch(/2 commits/);
+  });
+
+  it("cloud_ahead → push-cloud with confirmation and Cloud authority wording", () => {
+    const p = plan({ kind: "cloud_ahead", cloudHead: HEAD_B, remoteHead: null, commits: 1 });
+    expect(p.action.verb).toBe("push-cloud");
+    expect(p.action.requiresConfirmation).toBe(true);
+    expect(p.action.detail).toMatch(/1 commit\b/);
+  });
+
+  it("local_dirty → open git panel (manual), never a mutation verb", () => {
+    const p = plan({ kind: "local_dirty" });
+    expect(p.action.verb).toBe("open-git-panel");
+    expect(p.linkable).toBe(false);
+  });
+
+  it("cloud_dirty → informational (no local git panel to open)", () => {
+    const p = plan({ kind: "cloud_dirty" });
+    expect(p.action.verb).toBe("none");
+  });
+
+  it("conflicted local → open git panel; conflicted cloud → informational", () => {
+    expect(plan({ kind: "conflicted", target: "local" }).action.verb).toBe("open-git-panel");
+    expect(plan({ kind: "conflicted", target: "cloud" }).action.verb).toBe("none");
+  });
+
+  it("detached / operation route to manual guidance", () => {
+    expect(plan({ kind: "detached", target: "local" }).action.verb).toBe("open-git-panel");
+    expect(plan({ kind: "git_operation_in_progress", target: "local" }).action.verb).toBe("open-git-panel");
+  });
+
+  it("behind → manual update guidance, no implicit pull", () => {
+    const p = plan({ kind: "behind", target: "local" });
+    expect(p.action.verb).toBe("open-git-panel");
+    expect(p.action.detail).toMatch(/manually/i);
+  });
+
+  it("diverged → manual resolution, no direction chosen", () => {
+    const p = plan({ kind: "diverged", localHead: HEAD_A, cloudHead: HEAD_B, remoteHead: null });
+    expect(p.action.verb).toBe("open-git-panel");
+    expect(p.action.detail).toMatch(/will not choose/i);
+  });
+
+  it("missing local → recreate (with relink/unlink in copy)", () => {
+    const p = plan({ kind: "missing", target: "local" });
+    expect(p.action.verb).toBe("recreate");
+    expect(p.action.requiresConfirmation).toBe(true);
+  });
+
+  it("missing cloud / unreachable / unknown → retry, association preserved", () => {
+    expect(plan({ kind: "missing", target: "cloud" }).action.verb).toBe("retry");
+    expect(plan({ kind: "unreachable", target: "local" }).action.verb).toBe("retry");
+    expect(plan({ kind: "unknown", reason: "x" }).action.verb).toBe("retry");
+    expect(plan({ kind: "unreachable", target: "cloud" }).cancelPreserves).toMatch(/preserved/i);
+  });
+
+  it("cloud_state_unverified → retry only, labels head as last-reported, no safety claim", () => {
+    const p = plan({ kind: "cloud_state_unverified", localHead: "a".repeat(40), cloudLastReportedHead: "b".repeat(40) });
+    expect(p.action.verb).toBe("retry");
+    expect(p.linkable).toBe(false);
+    expect(p.action.detail).toMatch(/last-reported|couldn't be read|can't be confirmed/i);
+  });
+
+  it("no_cloud_copy → add-cloud-copy (not a failure, not 'Cloud missing')", () => {
+    const p = plan({ kind: "no_cloud_copy" });
+    expect(p.action.verb).toBe("add-cloud-copy");
+    expect(p.title).toMatch(/no cloud copy/i);
+  });
+
+  it("no_local_copy → open-on-mac", () => {
+    expect(plan({ kind: "no_local_copy" }).action.verb).toBe("open-on-mac");
+  });
+
+  it("NEVER offers a destructive git verb in any action label or detail", () => {
+    const relations: WorkspaceGitRelation[] = [
+      { kind: "same_head", headSha: HEAD_A },
+      { kind: "local_ahead", localHead: HEAD_A, remoteHead: null, commits: 2 },
+      { kind: "cloud_ahead", cloudHead: HEAD_B, remoteHead: null, commits: 1 },
+      { kind: "local_dirty" },
+      { kind: "cloud_dirty" },
+      { kind: "conflicted", target: "local" },
+      { kind: "conflicted", target: "cloud" },
+      { kind: "git_operation_in_progress", target: "local" },
+      { kind: "detached", target: "cloud" },
+      { kind: "behind", target: "local" },
+      { kind: "diverged", localHead: HEAD_A, cloudHead: HEAD_B, remoteHead: null },
+      { kind: "missing", target: "local" },
+      { kind: "missing", target: "cloud" },
+      { kind: "unreachable", target: "local" },
+      { kind: "cloud_state_unverified", localHead: HEAD_A, cloudLastReportedHead: HEAD_B },
+      { kind: "no_cloud_copy" },
+      { kind: "no_local_copy" },
+      { kind: "unknown", reason: "x" },
+    ];
+    for (const relation of relations) {
+      const p = plan(relation);
+      // The word may appear only in a NEGATED safety note ("nothing is reset,
+      // merged, rebased, or deleted"); assert the LABEL never carries it.
+      expect(p.action.label).not.toMatch(DESTRUCTIVE);
+      expect(p.action.label).not.toMatch(/\bsync\b/i);
+    }
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-reconciliation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-reconciliation.ts
@@ -1,0 +1,310 @@
+import type { WorkspaceGitRelation } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+/**
+ * PR 6 — the pure action policy that maps a cross-target Git relation to the ONE
+ * safe next action (or a truthful, non-actionable blocker). Pure and DOM-free so
+ * the exhaustive relation → action matrix is unit-testable.
+ *
+ * Concrete verbs only — Push, Commit, Open Git panel, Recreate, Relink, Unlink,
+ * Retry — never a generic "Sync". Absolute safety rails: no reset/stash/rebase/
+ * merge/force is EVER an offered action; diverged/dirty/conflict/detached/
+ * in-operation states require manual resolution on a selected target; a Cloud
+ * copy at a different clean head is `cloud_ahead` (needs Cloud authority), never
+ * silently adopted.
+ */
+
+/** The action verb the reconciliation dialog offers. `none` = an informational
+ * blocker with no in-product action (the user resolves it in Git themselves). */
+export type WorkspaceGitReconciliationVerb =
+  | "link"
+  | "push-local"
+  | "push-cloud"
+  | "open-git-panel"
+  | "recreate"
+  | "relink"
+  | "unlink"
+  | "retry"
+  | "add-cloud-copy"
+  | "open-on-mac"
+  | "none";
+
+export interface WorkspaceGitReconciliationAction {
+  verb: WorkspaceGitReconciliationVerb;
+  /** The confirmation CTA label (concrete verb). */
+  label: string;
+  /** One-line explanation of what this action does and its safety boundary. */
+  detail: string;
+  /** Whether this verb mutates git state and therefore requires explicit
+   * confirmation before running (push/recreate). */
+  requiresConfirmation: boolean;
+  /** Which target the action operates on, when target-scoped. */
+  target?: "local" | "cloud";
+}
+
+export interface WorkspaceGitReconciliationPlan {
+  relation: WorkspaceGitRelation;
+  /** A short truthful title for the state. */
+  title: string;
+  /** The one safe next action. */
+  action: WorkspaceGitReconciliationAction;
+  /** What stays unchanged if the user cancels (never destructive). */
+  cancelPreserves: string;
+  /** True when the two copies are provably the exact same commit (safe to
+   * link/open immediately). Mirrors relation.kind === "same_head". */
+  linkable: boolean;
+}
+
+const NO_DESTRUCTIVE_NOTE =
+  "Nothing is reset, merged, rebased, or deleted.";
+
+/**
+ * Resolve the single safe action for a relation. The blocked/manual states all
+ * resolve to a non-mutating verb (Open Git panel or an informational blocker);
+ * only same-head link and clean-ahead push are actionable mutations, and push
+ * always requires explicit confirmation.
+ */
+export function resolveWorkspaceGitReconciliation(
+  relation: WorkspaceGitRelation,
+): WorkspaceGitReconciliationPlan {
+  switch (relation.kind) {
+    case "same_head":
+      return {
+        relation,
+        title: "Copies are at the same commit",
+        action: {
+          verb: "link",
+          label: "Link and continue",
+          detail: "Both copies are the exact same commit, so they can be linked without changing "
+            + "either checkout.",
+          requiresConfirmation: false,
+        },
+        cancelPreserves: "Both checkouts stay exactly as they are.",
+        linkable: true,
+      };
+    case "local_ahead":
+      return {
+        relation,
+        title: "This Mac is ahead",
+        action: {
+          verb: "push-local",
+          label: "Push from this Mac and continue…",
+          detail: `Push ${commitsLabel(relation.commits)} from this Mac to the remote, then re-read `
+            + "state and continue. " + NO_DESTRUCTIVE_NOTE,
+          requiresConfirmation: true,
+          target: "local",
+        },
+        cancelPreserves: "No commits are pushed; both checkouts stay as they are.",
+        linkable: false,
+      };
+    case "cloud_ahead":
+      return {
+        relation,
+        title: "Cloud is ahead",
+        action: {
+          verb: "push-cloud",
+          label: "Push from Cloud and continue…",
+          detail: `Push ${commitsLabel(relation.commits)} from the Cloud copy to the remote, then `
+            + "re-read state and continue. " + NO_DESTRUCTIVE_NOTE,
+          requiresConfirmation: true,
+          target: "cloud",
+        },
+        cancelPreserves: "No commits are pushed; both checkouts stay as they are.",
+        linkable: false,
+      };
+    case "local_dirty":
+      return manualPlan(relation, {
+        title: "This Mac has uncommitted changes",
+        detail: "This Mac has uncommitted changes. Commit or set them aside in the Git panel, "
+          + "then try again. " + NO_DESTRUCTIVE_NOTE,
+        target: "local",
+        canOpenGitPanel: true,
+      });
+    case "cloud_dirty":
+      return manualPlan(relation, {
+        title: "Cloud has uncommitted changes",
+        detail: "The Cloud copy has uncommitted changes. Commit or set them aside on Cloud, then "
+          + "try again. " + NO_DESTRUCTIVE_NOTE,
+        target: "cloud",
+        canOpenGitPanel: false,
+      });
+    case "conflicted":
+      return manualPlan(relation, {
+        title: "Unresolved merge conflicts",
+        detail: `The ${targetName(relation.target)} copy has unresolved merge conflicts. Resolve `
+          + "them, then try again. " + NO_DESTRUCTIVE_NOTE,
+        target: relation.target,
+        canOpenGitPanel: relation.target === "local",
+      });
+    case "git_operation_in_progress":
+      return manualPlan(relation, {
+        title: "A Git operation is in progress",
+        detail: `The ${targetName(relation.target)} copy is mid-operation (merge/rebase/…). Finish `
+          + "or abort it in Git, then try again. " + NO_DESTRUCTIVE_NOTE,
+        target: relation.target,
+        canOpenGitPanel: relation.target === "local",
+      });
+    case "detached":
+      return manualPlan(relation, {
+        title: "Detached HEAD",
+        detail: `The ${targetName(relation.target)} copy is on a detached HEAD. Check out a branch, `
+          + "then try again. " + NO_DESTRUCTIVE_NOTE,
+        target: relation.target,
+        canOpenGitPanel: relation.target === "local",
+      });
+    case "behind":
+      return manualPlan(relation, {
+        title: "Behind the remote",
+        detail: `The ${targetName(relation.target)} copy is behind its remote branch. Update it `
+          + "manually in Git — the product will not pull or rebase for you. " + NO_DESTRUCTIVE_NOTE,
+        target: relation.target,
+        canOpenGitPanel: relation.target === "local",
+      });
+    case "diverged":
+      return manualPlan(relation, {
+        title: "Copies have diverged",
+        detail: "This Mac and Cloud have different commits that are not a simple ahead/behind. "
+          + "Resolve the divergence yourself on one target — the product will not choose a reset or "
+          + "rebase direction. " + NO_DESTRUCTIVE_NOTE,
+        canOpenGitPanel: true,
+      });
+    case "missing":
+      // Local missing is the Recreate/Relink/Unlink recovery (built on PR 5's
+      // localMaterializationNeedsRepair branch). Cloud missing surfaces a retry.
+      if (relation.target === "local") {
+        return {
+          relation,
+          title: "This Mac's copy is missing",
+          action: {
+            verb: "recreate",
+            label: "Recreate on this Mac…",
+            detail: "The local checkout for this workspace is gone. Recreate it on this Mac, relink "
+              + "an existing copy, or unlink this Mac. " + NO_DESTRUCTIVE_NOTE,
+            requiresConfirmation: true,
+            target: "local",
+          },
+          cancelPreserves: "The Cloud copy, repository, and chat history are untouched.",
+          linkable: false,
+        };
+      }
+      return retryPlan(relation, {
+        title: "The Cloud copy is missing",
+        detail: "The Cloud copy is not currently available. Retry once it is back; the association "
+          + "is preserved. " + NO_DESTRUCTIVE_NOTE,
+        target: "cloud",
+      });
+    case "unreachable":
+      return retryPlan(relation, {
+        title: `The ${targetName(relation.target)} copy is unreachable`,
+        detail: `The ${targetName(relation.target)} copy can't be reached right now. Retry when it `
+          + "is back; the association is preserved. " + NO_DESTRUCTIVE_NOTE,
+        target: relation.target,
+      });
+    case "cloud_state_unverified":
+      // PR6-CLOUD-TRUTH-01: the Cloud copy's live state could not be read, so we
+      // will NOT claim it is safe/same. Manual re-check (Retry) only; the head we
+      // show is last-reported, not live.
+      return retryPlan(relation, {
+        title: "Cloud state can't be verified",
+        detail: "The Cloud copy's live Git state couldn't be read, so its cleanliness can't be "
+          + "confirmed. Its commit shown here is last-reported, not live. Retry to re-check; nothing "
+          + "is assumed safe. " + NO_DESTRUCTIVE_NOTE,
+        target: "cloud",
+      });
+    case "no_cloud_copy":
+      // Not a failure: there simply is no Cloud copy yet. The action is to add one
+      // (this is the resume target for a blocked Add Cloud copy).
+      return {
+        relation,
+        title: "No Cloud copy yet",
+        action: {
+          verb: "add-cloud-copy",
+          label: "Add Cloud copy…",
+          detail: "This workspace has no Cloud copy yet. Once this Mac is clean and published, add a "
+            + "managed Cloud copy at its exact commit. " + NO_DESTRUCTIVE_NOTE,
+          requiresConfirmation: true,
+          target: "cloud",
+        },
+        cancelPreserves: "This Mac's checkout stays exactly as it is; no Cloud copy is created.",
+        linkable: false,
+      };
+    case "no_local_copy":
+      return {
+        relation,
+        title: "No copy on this Mac yet",
+        action: {
+          verb: "open-on-mac",
+          label: "Open on this Mac…",
+          detail: "This workspace has no local copy on this Mac yet. Open one at the Cloud copy's "
+            + "exact published commit. " + NO_DESTRUCTIVE_NOTE,
+          requiresConfirmation: true,
+          target: "local",
+        },
+        cancelPreserves: "The Cloud copy stays exactly as it is; nothing is created on this Mac.",
+        linkable: false,
+      };
+    case "unknown":
+      return retryPlan(relation, {
+        title: "Can't compare the copies yet",
+        detail: relation.reason + " Retry once status is available. " + NO_DESTRUCTIVE_NOTE,
+      });
+  }
+}
+
+function manualPlan(
+  relation: WorkspaceGitRelation,
+  args: {
+    title: string;
+    detail: string;
+    target?: "local" | "cloud";
+    canOpenGitPanel: boolean;
+  },
+): WorkspaceGitReconciliationPlan {
+  return {
+    relation,
+    title: args.title,
+    action: args.canOpenGitPanel
+      ? {
+        verb: "open-git-panel",
+        label: "Open Git panel",
+        detail: args.detail,
+        requiresConfirmation: false,
+        target: args.target,
+      }
+      : {
+        verb: "none",
+        label: "OK",
+        detail: args.detail,
+        requiresConfirmation: false,
+        target: args.target,
+      },
+    cancelPreserves: "Both checkouts stay exactly as they are.",
+    linkable: false,
+  };
+}
+
+function retryPlan(
+  relation: WorkspaceGitRelation,
+  args: { title: string; detail: string; target?: "local" | "cloud" },
+): WorkspaceGitReconciliationPlan {
+  return {
+    relation,
+    title: args.title,
+    action: {
+      verb: "retry",
+      label: "Retry",
+      detail: args.detail,
+      requiresConfirmation: false,
+      target: args.target,
+    },
+    cancelPreserves: "The association and both copies are preserved.",
+    linkable: false,
+  };
+}
+
+function targetName(target: "local" | "cloud"): string {
+  return target === "local" ? "This Mac" : "Cloud";
+}
+
+function commitsLabel(commits: number): string {
+  return commits === 1 ? "1 commit" : `${commits} commits`;
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-relation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-relation.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyWorkspaceGitSide,
+  deriveWorkspaceGitRelation,
+  type WorkspaceGitSide,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+function side(overrides: Partial<WorkspaceGitSide> = {}): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: "github",
+    owner: "acme",
+    repoName: "rocket",
+    branch: "feat/x",
+    headSha: HEAD_A,
+    clean: true,
+    conflicted: false,
+    detached: false,
+    operationInProgress: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    ...overrides,
+  };
+}
+
+function relation(local: Partial<WorkspaceGitSide>, cloud: Partial<WorkspaceGitSide> = {}) {
+  return deriveWorkspaceGitRelation({ local: side(local), cloud: side(cloud) });
+}
+
+describe("classifyWorkspaceGitSide", () => {
+  it("orders blocking states: conflict > operation > detached > dirty", () => {
+    expect(classifyWorkspaceGitSide(side({ conflicted: true, clean: false })).kind).toBe("conflicted");
+    expect(classifyWorkspaceGitSide(side({ operationInProgress: true, clean: false })).kind).toBe("operation");
+    expect(classifyWorkspaceGitSide(side({ detached: true, branch: null, clean: false })).kind).toBe("detached");
+    expect(classifyWorkspaceGitSide(side({ clean: false })).kind).toBe("dirty");
+  });
+
+  it("classifies unknown when clean/conflicted are unavailable", () => {
+    expect(classifyWorkspaceGitSide(side({ clean: null })).kind).toBe("unknown");
+    expect(classifyWorkspaceGitSide(side({ conflicted: null })).kind).toBe("unknown");
+  });
+
+  it("classifies presence first", () => {
+    expect(classifyWorkspaceGitSide(side({ presence: "missing" })).kind).toBe("missing");
+    expect(classifyWorkspaceGitSide(side({ presence: "unreachable" })).kind).toBe("unreachable");
+  });
+
+  it("classifies unpublished / ahead / behind / diverged / clean", () => {
+    expect(classifyWorkspaceGitSide(side({ hasUpstream: false })).kind).toBe("unpublished");
+    expect(classifyWorkspaceGitSide(side({ ahead: 2 })).kind).toBe("ahead");
+    expect(classifyWorkspaceGitSide(side({ behind: 3 })).kind).toBe("behind");
+    expect(classifyWorkspaceGitSide(side({ ahead: 1, behind: 1 })).kind).toBe("diverged");
+    expect(classifyWorkspaceGitSide(side()).kind).toBe("clean");
+  });
+});
+
+describe("deriveWorkspaceGitRelation — exhaustive matrix", () => {
+  it("same_head: equal clean heads on the same branch", () => {
+    expect(relation({}, {})).toEqual({ kind: "same_head", headSha: HEAD_A });
+  });
+
+  it("differing exact heads are NEVER same_head (diverged when clean)", () => {
+    const r = relation({ headSha: HEAD_A }, { headSha: HEAD_B });
+    expect(r.kind).toBe("diverged");
+    expect(r).toMatchObject({ localHead: HEAD_A, cloudHead: HEAD_B, remoteHead: null });
+  });
+
+  it("local_ahead: local ahead of tracking, cloud clean; remoteHead is null (not client-verifiable)", () => {
+    const r = relation({ ahead: 2, headSha: HEAD_A }, { headSha: HEAD_B });
+    expect(r).toEqual({ kind: "local_ahead", localHead: HEAD_A, remoteHead: null, commits: 2 });
+  });
+
+  it("cloud_ahead: cloud ahead, local clean", () => {
+    const r = relation({ headSha: HEAD_A }, { ahead: 3, headSha: HEAD_B });
+    expect(r).toEqual({ kind: "cloud_ahead", cloudHead: HEAD_B, remoteHead: null, commits: 3 });
+  });
+
+  it("local_dirty / cloud_dirty block before head comparison", () => {
+    expect(relation({ clean: false }).kind).toBe("local_dirty");
+    expect(relation({}, { clean: false }).kind).toBe("cloud_dirty");
+  });
+
+  it("conflicted / operation / detached carry the target", () => {
+    expect(relation({ conflicted: true })).toMatchObject({ kind: "conflicted", target: "local" });
+    expect(relation({}, { operationInProgress: true })).toMatchObject({
+      kind: "git_operation_in_progress",
+      target: "cloud",
+    });
+    expect(relation({ detached: true, branch: null })).toMatchObject({ kind: "detached", target: "local" });
+  });
+
+  it("behind: one side clean-behind at a different head, other clean", () => {
+    // Equal heads are same_head regardless of tracking-ref counts; `behind`
+    // fires only when the heads actually differ.
+    expect(relation({ behind: 1, headSha: HEAD_B }, { headSha: HEAD_A }))
+      .toMatchObject({ kind: "behind", target: "local" });
+    expect(relation({ headSha: HEAD_A }, { behind: 1, headSha: HEAD_B }))
+      .toMatchObject({ kind: "behind", target: "cloud" });
+  });
+
+  it("diverged: both diverged, or clean-but-different heads, or case-different branch", () => {
+    expect(relation({ ahead: 1, behind: 1, headSha: HEAD_A }, { headSha: HEAD_B }).kind).toBe("diverged");
+    expect(relation({ branch: "feat/X", headSha: HEAD_A }, { branch: "feat/x", headSha: HEAD_A }).kind)
+      .toBe("diverged");
+  });
+
+  it("missing / unreachable surface first with the target", () => {
+    expect(relation({ presence: "missing" })).toEqual({ kind: "missing", target: "local" });
+    expect(relation({}, { presence: "missing" })).toEqual({ kind: "missing", target: "cloud" });
+    expect(relation({ presence: "unreachable" })).toEqual({ kind: "unreachable", target: "local" });
+    expect(relation({}, { presence: "unreachable" })).toEqual({ kind: "unreachable", target: "cloud" });
+  });
+
+  it("unreachable beats missing when local is unreachable and cloud missing", () => {
+    expect(relation({ presence: "unreachable" }, { presence: "missing" }))
+      .toEqual({ kind: "unreachable", target: "local" });
+  });
+
+  it("different repositories are unknown, never compared", () => {
+    const r = relation({ repoName: "rocket" }, { repoName: "other" });
+    expect(r).toMatchObject({ kind: "unknown" });
+  });
+
+  it("unknown when status unavailable on a side", () => {
+    expect(relation({ clean: null }).kind).toBe("unknown");
+  });
+
+  it("unknown when heads differ but a head sha is unknown (never guesses)", () => {
+    expect(relation({ ahead: 1, headSha: null }, { headSha: HEAD_B }).kind).toBe("unknown");
+  });
+
+  it("local dirty takes precedence over cloud conflicted (local-first severity)", () => {
+    expect(relation({ clean: false }, { conflicted: true }).kind).toBe("local_dirty");
+  });
+
+  // PR6-CLOUD-TRUTH-01: a Cloud side whose live status is UNKNOWN must never be
+  // called same_head or safe, even when the last-reported head matches locally.
+  it("does NOT claim same_head when the cloud side's live state is unknown (unproven)", () => {
+    // Cloud presence "present" with null cleanliness = last-reported head, no
+    // live proof (the real shape produced by cloudGitSideLastReported).
+    const r = relation(
+      { headSha: HEAD_A },
+      { headSha: HEAD_A, clean: null, conflicted: null },
+    );
+    expect(r.kind).not.toBe("same_head");
+    expect(r.kind).toBe("cloud_state_unverified");
+    expect(r).toMatchObject({ cloudLastReportedHead: HEAD_A, localHead: HEAD_A });
+  });
+
+  it("does NOT claim safe when the cloud checkout CHANGED after materialization (unknown clean)", () => {
+    // Cloud head still reads last-reported HEAD_A but live clean/conflict are
+    // unknown (couldn't read): the resolver withholds any safety verdict.
+    const cloudUnknownClean = side({ headSha: HEAD_A, clean: null, conflicted: null });
+    const r = deriveWorkspaceGitRelation({ local: side({ headSha: HEAD_A }), cloud: cloudUnknownClean });
+    expect(r.kind).toBe("cloud_state_unverified");
+  });
+
+  it("DOES claim same_head only when BOTH sides are proven clean at the exact head", () => {
+    const r = relation({ headSha: HEAD_A }, { headSha: HEAD_A }); // both live-clean
+    expect(r).toEqual({ kind: "same_head", headSha: HEAD_A });
+  });
+
+  it("no_cloud_copy for a local-only workspace (absent cloud), never 'Cloud missing'", () => {
+    const r = deriveWorkspaceGitRelation({
+      local: side(),
+      cloud: side({ presence: "absent" }),
+    });
+    expect(r.kind).toBe("no_cloud_copy");
+  });
+
+  it("no_local_copy when the local side is absent", () => {
+    const r = deriveWorkspaceGitRelation({
+      local: side({ presence: "absent" }),
+      cloud: side(),
+    });
+    expect(r.kind).toBe("no_local_copy");
+  });
+
+  it("surfaces a hard LOCAL blocker before cloud_state_unverified (honest regardless)", () => {
+    const r = deriveWorkspaceGitRelation({
+      local: side({ clean: false }),
+      cloud: side({ headSha: HEAD_A, clean: null, conflicted: null }),
+    });
+    expect(r.kind).toBe("local_dirty");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-relation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-relation.ts
@@ -1,0 +1,319 @@
+import { canonicalRepoKey } from "@proliferate/product-domain/repos/repo-id";
+
+/**
+ * PR 6 — the ONE pure cross-target Git relation resolver. It classifies a local
+ * checkout and a Cloud copy of the same logical workspace into a single typed
+ * relation, from which the action policy (workspace-git-reconciliation.ts)
+ * derives the one safe next action. Pure and DOM-free so the exhaustive
+ * relation/action matrix is unit-testable.
+ *
+ * Absolute safety rails encoded here:
+ *  - differing exact HEADs are NEVER `same_head` (never "linked");
+ *  - a side that is dirty / conflicted / detached / mid-operation blocks BEFORE
+ *    any head comparison (we never reason about a moving tree);
+ *  - when two heads differ and no single clean ahead/behind direction is
+ *    provable client-side, the relation is `diverged` (manual resolution),
+ *    never a guessed reset/rebase direction.
+ *
+ * Truthfulness rule (verified GAP, reconciliation §B-9/§D-14): the runtime has
+ * NO live remote-HEAD probe and the client-facing branches route carries no
+ * per-branch SHA, so an authoritative GitHub remote HEAD is NOT client-visible.
+ * `ahead`/`behind` come from `git status`'s tracking-ref counts, i.e. only as
+ * fresh as the last fetch. This resolver therefore reports `remoteHead: null`
+ * ("last-known / not client-verifiable") everywhere; authoritative remote
+ * verification stays server-side (existing intent-time verification). The UX
+ * must label remote staleness honestly.
+ */
+
+/** Whether a target's checkout is reachable at all.
+ *  - present: a live, queried checkout.
+ *  - missing: a checkout that WAS materialized and is now gone.
+ *  - unreachable: the runtime could not be queried this pass (transient).
+ *  - absent: no copy exists yet on this target (e.g. a local-only workspace with
+ *    no Cloud copy — the point of "Add Cloud copy"). Distinct from `missing`. */
+export type WorkspaceGitSidePresence = "present" | "missing" | "unreachable" | "absent";
+
+/** One target's proof-relevant Git facts, read from a structured AnyHarness
+ * `GitStatusSnapshot` (never inferred). For a Cloud copy whose runtime could NOT
+ * be read live, `headSha` is the last-REPORTED observed HEAD from the
+ * materialization row (a legitimate exact ref) but clean/conflicted/operation/
+ * ahead/behind MUST be null (unknown) — never fabricated. A same_head/safe claim
+ * is then withheld until proof (unknown → manual guidance). */
+export interface WorkspaceGitSide {
+  presence: WorkspaceGitSidePresence;
+  provider: string | null;
+  owner: string | null;
+  repoName: string | null;
+  branch: string | null;
+  headSha: string | null;
+  clean: boolean | null;
+  conflicted: boolean | null;
+  detached: boolean | null;
+  /** True when a Git operation (merge/rebase/cherry-pick/revert) is in progress. */
+  operationInProgress: boolean | null;
+  /** Commits ahead of the tracking ref (last-known; null = unknown). */
+  ahead: number | null;
+  /** Commits behind the tracking ref (last-known; null = unknown). */
+  behind: number | null;
+  hasUpstream: boolean | null;
+}
+
+/** A single side's classification, independent of the other target. `clean` here
+ * means "known clean, conflict-free, normal branch" — the only state safe to
+ * compare heads from. */
+export type WorkspaceGitSideState =
+  | { kind: "missing" }
+  | { kind: "absent" }
+  | { kind: "unreachable" }
+  | { kind: "unknown"; reason: string }
+  | { kind: "conflicted" }
+  | { kind: "operation" }
+  | { kind: "detached" }
+  | { kind: "dirty" }
+  | { kind: "unpublished" }
+  | { kind: "ahead"; commits: number }
+  | { kind: "behind"; commits: number }
+  | { kind: "diverged"; ahead: number; behind: number }
+  | { kind: "clean" };
+
+export type WorkspaceGitRelation =
+  | { kind: "same_head"; headSha: string }
+  | { kind: "local_ahead"; localHead: string; remoteHead: string | null; commits: number }
+  | { kind: "cloud_ahead"; cloudHead: string; remoteHead: string | null; commits: number }
+  | { kind: "local_dirty" }
+  | { kind: "cloud_dirty" }
+  | { kind: "conflicted"; target: "local" | "cloud" }
+  | { kind: "git_operation_in_progress"; target: "local" | "cloud" }
+  | { kind: "detached"; target: "local" | "cloud" }
+  | { kind: "behind"; target: "local" | "cloud" }
+  | { kind: "diverged"; localHead: string; cloudHead: string; remoteHead: string | null }
+  | { kind: "missing"; target: "local" | "cloud" }
+  // No copy exists yet on this target (local-only → no Cloud copy, or vice
+  // versa). Distinct from `missing`; the action is Add-the-copy, not recover.
+  | { kind: "no_cloud_copy" }
+  | { kind: "no_local_copy" }
+  | { kind: "unreachable"; target: "local" | "cloud" }
+  // The Cloud side's live status could NOT be read; its head is last-REPORTED
+  // only, so no cleanliness/exact-match safety claim can be made. Manual only.
+  | { kind: "cloud_state_unverified"; localHead: string | null; cloudLastReportedHead: string | null }
+  | { kind: "unknown"; reason: string };
+
+/**
+ * Classify ONE side. Order matters: unreachable/missing first, then the blocking
+ * working-tree states (conflicted → operation → detached → dirty) before any
+ * ahead/behind reasoning, then publish/sync. A side with unknown counts but a
+ * clean tree is `clean` (heads still compare exactly).
+ */
+export function classifyWorkspaceGitSide(side: WorkspaceGitSide): WorkspaceGitSideState {
+  if (side.presence === "unreachable") {
+    return { kind: "unreachable" };
+  }
+  if (side.presence === "absent") {
+    return { kind: "absent" };
+  }
+  if (side.presence === "missing") {
+    return { kind: "missing" };
+  }
+  if (side.clean === null || side.conflicted === null) {
+    // Status could not be read live — do NOT infer cleanliness/safety.
+    return { kind: "unknown", reason: "Git status is not available yet." };
+  }
+  if (side.conflicted === true) {
+    return { kind: "conflicted" };
+  }
+  if (side.operationInProgress === true) {
+    return { kind: "operation" };
+  }
+  if (side.detached === true || side.branch === null) {
+    return { kind: "detached" };
+  }
+  if (side.clean === false) {
+    return { kind: "dirty" };
+  }
+  if (side.hasUpstream === false) {
+    return { kind: "unpublished" };
+  }
+  const ahead = side.ahead ?? 0;
+  const behind = side.behind ?? 0;
+  if (ahead > 0 && behind > 0) {
+    return { kind: "diverged", ahead, behind };
+  }
+  if (ahead > 0) {
+    return { kind: "ahead", commits: ahead };
+  }
+  if (behind > 0) {
+    return { kind: "behind", commits: behind };
+  }
+  return { kind: "clean" };
+}
+
+function sidesShareRepo(local: WorkspaceGitSide, cloud: WorkspaceGitSide): boolean {
+  if (!local.provider || !local.owner || !local.repoName) {
+    return true; // Identity unknown on one side: don't manufacture a mismatch.
+  }
+  if (!cloud.provider || !cloud.owner || !cloud.repoName) {
+    return true;
+  }
+  return (
+    canonicalRepoKey(local.provider, local.owner, local.repoName)
+    === canonicalRepoKey(cloud.provider, cloud.owner, cloud.repoName)
+  );
+}
+
+/**
+ * Resolve the cross-target relation between the local checkout and the Cloud
+ * copy of the same logical workspace. Pure. Branch names are case-sensitive and
+ * commit SHAs are exact.
+ */
+export function deriveWorkspaceGitRelation(input: {
+  local: WorkspaceGitSide;
+  cloud: WorkspaceGitSide;
+}): WorkspaceGitRelation {
+  const { local, cloud } = input;
+  const localState = classifyWorkspaceGitSide(local);
+  const cloudState = classifyWorkspaceGitSide(cloud);
+
+  // No copy yet on a target: this is Add-the-copy, NOT a recovery. Surfaced
+  // before missing/unreachable so a local-only workspace is never misread as
+  // "Cloud missing" (PR6-CONTINUATION-02).
+  if (cloudState.kind === "absent") {
+    return { kind: "no_cloud_copy" };
+  }
+  if (localState.kind === "absent") {
+    return { kind: "no_local_copy" };
+  }
+
+  // Unreachable/missing surface next (association is preserved by the action
+  // policy, never mutated here).
+  if (localState.kind === "unreachable") {
+    return { kind: "unreachable", target: "local" };
+  }
+  if (cloudState.kind === "unreachable") {
+    return { kind: "unreachable", target: "cloud" };
+  }
+  if (localState.kind === "missing") {
+    return { kind: "missing", target: "local" };
+  }
+  if (cloudState.kind === "missing") {
+    return { kind: "missing", target: "cloud" };
+  }
+
+  // A different repository on the two sides is a hard unknown: never compare.
+  if (!sidesShareRepo(local, cloud)) {
+    return { kind: "unknown", reason: "The two copies are different repositories." };
+  }
+
+  // TRUTHFULNESS RAIL (PR6-CLOUD-TRUTH-01): if the CLOUD side's live status
+  // could not be read (its clean/conflict/op/ahead-behind are unknown), we may
+  // NOT claim same_head or any safety verdict from a fabricated-clean cloud. The
+  // cloud head is last-REPORTED only. Emit cloud_state_unverified → manual
+  // guidance, EXCEPT when the local side itself has a hard blocker we should
+  // surface first (that's honest regardless of the cloud).
+  const localBlocking = firstBlockingRelation(localState, "local");
+  if (localBlocking) {
+    return localBlocking;
+  }
+  if (cloudState.kind === "unknown") {
+    return {
+      kind: "cloud_state_unverified",
+      localHead: local.headSha,
+      cloudLastReportedHead: cloud.headSha,
+    };
+  }
+
+  // Remaining cloud-side blocking states (proven, live).
+  const cloudBlocking = firstBlockingRelation(cloudState, "cloud");
+  if (cloudBlocking) {
+    return cloudBlocking;
+  }
+
+  // Both sides are clean/normal from here. A case-sensitive branch mismatch is
+  // never "linked": it is diverged work on separate branches.
+  const branchMismatch = local.branch !== null
+    && cloud.branch !== null
+    && local.branch !== cloud.branch;
+
+  // Exact-HEAD equality is the ONLY "linked" verdict.
+  if (
+    !branchMismatch
+    && local.headSha !== null
+    && cloud.headSha !== null
+    && local.headSha === cloud.headSha
+  ) {
+    return { kind: "same_head", headSha: local.headSha };
+  }
+
+  // Heads differ (or are unknowable). A single clean ahead/behind direction vs
+  // the tracking ref is a push/update candidate; anything else is diverged. We
+  // never report a live remoteHead (not client-verifiable — §B-9/§D-14).
+  if (localState.kind === "diverged" || cloudState.kind === "diverged") {
+    return divergedRelation(local, cloud);
+  }
+  if (localState.kind === "ahead" && cloudState.kind !== "ahead") {
+    if (local.headSha === null) {
+      return divergedRelation(local, cloud);
+    }
+    return {
+      kind: "local_ahead",
+      localHead: local.headSha,
+      remoteHead: null,
+      commits: localState.commits,
+    };
+  }
+  if (cloudState.kind === "ahead" && localState.kind !== "ahead") {
+    if (cloud.headSha === null) {
+      return divergedRelation(local, cloud);
+    }
+    return {
+      kind: "cloud_ahead",
+      cloudHead: cloud.headSha,
+      remoteHead: null,
+      commits: cloudState.commits,
+    };
+  }
+  if (localState.kind === "behind" && cloudState.kind === "clean") {
+    return { kind: "behind", target: "local" };
+  }
+  if (cloudState.kind === "behind" && localState.kind === "clean") {
+    return { kind: "behind", target: "cloud" };
+  }
+
+  // Clean on both, heads differ (or a head is unknown, or a branch mismatch):
+  // require manual resolution — never guess a direction.
+  return divergedRelation(local, cloud);
+}
+
+function firstBlockingRelation(
+  state: WorkspaceGitSideState,
+  target: "local" | "cloud",
+): WorkspaceGitRelation | null {
+  switch (state.kind) {
+    case "unknown":
+      return { kind: "unknown", reason: state.reason };
+    case "conflicted":
+      return { kind: "conflicted", target };
+    case "operation":
+      return { kind: "git_operation_in_progress", target };
+    case "detached":
+      return { kind: "detached", target };
+    case "dirty":
+      return target === "local" ? { kind: "local_dirty" } : { kind: "cloud_dirty" };
+    default:
+      return null;
+  }
+}
+
+function divergedRelation(
+  local: WorkspaceGitSide,
+  cloud: WorkspaceGitSide,
+): WorkspaceGitRelation {
+  if (local.headSha !== null && cloud.headSha !== null) {
+    return {
+      kind: "diverged",
+      localHead: local.headSha,
+      cloudHead: cloud.headSha,
+      remoteHead: null,
+    };
+  }
+  return { kind: "unknown", reason: "The two copies are at different commits." };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-sides.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-sides.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { GitStatusSnapshot } from "@anyharness/sdk";
+import {
+  cloudGitSideFromStatus,
+  cloudGitSideLastReported,
+  localGitSideAbsent,
+  localGitSideFromStatus,
+} from "#product/lib/domain/workspaces/cloud/workspace-git-sides";
+import type { CloudWorkspaceMaterializationSummary, CloudWorkspaceRepoRef } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+
+const HEAD = "a".repeat(40);
+const repo: CloudWorkspaceRepoRef = {
+  provider: "github",
+  owner: "acme",
+  name: "rocket",
+  branch: "feat/x",
+  baseBranch: "main",
+};
+
+function status(overrides: Partial<GitStatusSnapshot> = {}): GitStatusSnapshot {
+  return {
+    actions: {
+      canCommit: true,
+      canCreateBranchWorkspace: true,
+      canCreateDraftPullRequest: true,
+      canCreatePullRequest: true,
+      canPush: true,
+      pushLabel: "Push",
+    },
+    ahead: 0,
+    behind: 0,
+    clean: true,
+    conflicted: false,
+    currentBranch: "feat/x",
+    detached: false,
+    files: [],
+    headOid: HEAD,
+    operation: "none",
+    repoRootPath: "/repo",
+    summary: { additions: 0, changedFiles: 0, conflictedFiles: 0, deletions: 0, includedFiles: 0 },
+    upstreamBranch: "origin/feat/x",
+    workspaceId: "ws-1",
+    workspacePath: "/repo/ws-1",
+    ...overrides,
+  };
+}
+
+describe("localGitSideFromStatus — §B-7 field mapping", () => {
+  it("maps dirty=!clean, operation, ahead/behind, hasUpstream", () => {
+    const side = localGitSideFromStatus(
+      status({ clean: false, operation: "rebase", ahead: 2, behind: 1, upstreamBranch: "origin/feat/x" }),
+      repo,
+    );
+    expect(side).toMatchObject({
+      presence: "present",
+      branch: "feat/x",
+      headSha: HEAD,
+      clean: false,
+      operationInProgress: true,
+      ahead: 2,
+      behind: 1,
+      hasUpstream: true,
+    });
+  });
+
+  it("treats a blank/absent upstream as not published", () => {
+    expect(localGitSideFromStatus(status({ upstreamBranch: null }), repo).hasUpstream).toBe(false);
+    expect(localGitSideFromStatus(status({ upstreamBranch: "  " }), repo).hasUpstream).toBe(false);
+  });
+});
+
+describe("localGitSideAbsent", () => {
+  it("marks presence and leaves facts unknown", () => {
+    const side = localGitSideAbsent("missing", repo, "feat/x");
+    expect(side.presence).toBe("missing");
+    expect(side.clean).toBeNull();
+    expect(side.headSha).toBeNull();
+  });
+});
+
+describe("cloudGitSideFromStatus — live cloud read (§B-7)", () => {
+  it("maps the LIVE cloud status truthfully (no fabricated clean)", () => {
+    const side = cloudGitSideFromStatus(
+      status({ clean: false, conflicted: true, ahead: 2, headOid: HEAD }),
+      repo,
+    );
+    expect(side).toMatchObject({
+      presence: "present",
+      headSha: HEAD,
+      clean: false,
+      conflicted: true,
+      ahead: 2,
+    });
+  });
+});
+
+describe("cloudGitSideLastReported — no live read (PR6-CLOUD-TRUTH-01)", () => {
+  const managed: CloudWorkspaceMaterializationSummary = {
+    id: "m",
+    targetKind: "managed_cloud",
+    desktopInstallId: null,
+    anyharnessWorkspaceId: "cloud-ws",
+    worktreePath: "/cloud",
+    state: "hydrated",
+    generation: 1,
+    expectedHeadSha: HEAD,
+    observedHeadSha: HEAD,
+    observedBranch: "feat/x",
+    failureCode: null,
+    lastReportedAt: null,
+  };
+
+  it("keeps the last-reported head but marks cleanliness UNKNOWN (never fabricated clean)", () => {
+    // presence "present" + null cleanliness → classifies as unknown →
+    // cloud_state_unverified in the resolver (blocks any same_head/safe claim).
+    const side = cloudGitSideLastReported(managed, repo);
+    expect(side.presence).toBe("present");
+    expect(side.headSha).toBe(HEAD);
+    expect(side.clean).toBeNull();
+    expect(side.conflicted).toBeNull();
+    expect(side.ahead).toBeNull();
+    expect(side.behind).toBeNull();
+  });
+
+  it("marks the cloud side missing when the managed row is missing/failed, absent when none", () => {
+    expect(cloudGitSideLastReported({ ...managed, state: "missing" }, repo).presence).toBe("missing");
+    expect(cloudGitSideLastReported(null, repo).presence).toBe("absent");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-sides.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-git-sides.ts
@@ -1,0 +1,158 @@
+import type { GitStatusSnapshot } from "@anyharness/sdk";
+import type {
+  CloudWorkspaceMaterializationSummary,
+  CloudWorkspaceRepoRef,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import type { WorkspaceGitSide } from "#product/lib/domain/workspaces/cloud/workspace-git-relation";
+
+/**
+ * PR 6 — pure adapters that build a `WorkspaceGitSide` for the relation resolver
+ * from the structured inputs the runtime and control plane actually expose. Kept
+ * pure so the exact field mapping (§B-7: `dirty = !clean`, `detached`,
+ * `operation !== "none"`, `ahead>0`, `behind>0`, `hasUpstream`) is testable.
+ */
+
+/** The local side from a fresh AnyHarness `GitStatusSnapshot`. */
+export function localGitSideFromStatus(
+  status: GitStatusSnapshot,
+  repo: Pick<CloudWorkspaceRepoRef, "provider" | "owner" | "name"> | null,
+): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: repo?.provider ?? null,
+    owner: repo?.owner ?? null,
+    repoName: repo?.name ?? null,
+    branch: status.currentBranch ?? null,
+    headSha: status.headOid,
+    clean: status.clean,
+    conflicted: status.conflicted,
+    detached: status.detached,
+    operationInProgress: status.operation !== "none",
+    ahead: status.ahead,
+    behind: status.behind,
+    hasUpstream: Boolean(status.upstreamBranch?.trim()),
+  };
+}
+
+/** A local side marked absent/missing/unreachable when no live status applies.
+ * `absent` = no copy exists yet (Add/Open the copy); `missing` = a materialized
+ * checkout is gone; `unreachable` = the runtime couldn't be queried this pass. */
+export function localGitSideAbsent(
+  presence: "absent" | "missing" | "unreachable",
+  repo: Pick<CloudWorkspaceRepoRef, "provider" | "owner" | "name"> | null,
+  branch: string | null,
+): WorkspaceGitSide {
+  return {
+    presence,
+    provider: repo?.provider ?? null,
+    owner: repo?.owner ?? null,
+    repoName: repo?.name ?? null,
+    branch,
+    headSha: null,
+    clean: null,
+    conflicted: null,
+    detached: null,
+    operationInProgress: null,
+    ahead: null,
+    behind: null,
+    hasUpstream: null,
+  };
+}
+
+/**
+ * The Cloud side from a LIVE `GitStatusSnapshot` read against the Cloud
+ * workspace's own AnyHarness runtime (client-reachable via the resolved cloud
+ * connection). This is the truthful path (PR6-CLOUD-TRUTH-01): clean/conflicted/
+ * operation/ahead/behind come from the live read, never fabricated.
+ */
+export function cloudGitSideFromStatus(
+  status: GitStatusSnapshot,
+  repo: Pick<CloudWorkspaceRepoRef, "provider" | "owner" | "name"> | null,
+): WorkspaceGitSide {
+  return {
+    presence: "present",
+    provider: repo?.provider ?? null,
+    owner: repo?.owner ?? null,
+    repoName: repo?.name ?? null,
+    branch: status.currentBranch ?? null,
+    headSha: status.headOid,
+    clean: status.clean,
+    conflicted: status.conflicted,
+    detached: status.detached,
+    operationInProgress: status.operation !== "none",
+    ahead: status.ahead,
+    behind: status.behind,
+    hasUpstream: Boolean(status.upstreamBranch?.trim()),
+  };
+}
+
+/**
+ * The Cloud side when NO live status could be read — the runtime was not
+ * reachable this pass. The head/branch reflect the LAST-REPORTED materialization
+ * row (a legitimate exact ref), but every cleanliness/sync field is UNKNOWN
+ * (null): the relation resolver must NOT claim same_head or "safe" from this
+ * (PR6-CLOUD-TRUTH-01) — it emits `cloud_state_unverified` → manual guidance.
+ *
+ * `missing` (the managed row itself reports missing/failed, or is absent) still
+ * surfaces as a missing/absent presence so recovery/Add flows apply.
+ */
+export function cloudGitSideLastReported(
+  managed: CloudWorkspaceMaterializationSummary | null,
+  repo: CloudWorkspaceRepoRef | null,
+): WorkspaceGitSide {
+  if (!managed) {
+    // No managed Cloud copy exists yet — this is Add-Cloud-copy territory.
+    return {
+      presence: "absent",
+      provider: repo?.provider ?? null,
+      owner: repo?.owner ?? null,
+      repoName: repo?.name ?? null,
+      branch: repo?.branch ?? null,
+      headSha: null,
+      clean: null,
+      conflicted: null,
+      detached: null,
+      operationInProgress: null,
+      ahead: null,
+      behind: null,
+      hasUpstream: null,
+    };
+  }
+  if (managed.state === "missing" || managed.state === "failed") {
+    return {
+      presence: "missing",
+      provider: repo?.provider ?? null,
+      owner: repo?.owner ?? null,
+      repoName: repo?.name ?? null,
+      branch: managed.observedBranch ?? repo?.branch ?? null,
+      headSha: managed.observedHeadSha ?? managed.expectedHeadSha ?? null,
+      clean: null,
+      conflicted: null,
+      detached: null,
+      operationInProgress: null,
+      ahead: null,
+      behind: null,
+      hasUpstream: null,
+    };
+  }
+  // We have a last-REPORTED record of the Cloud copy (presence "present") but did
+  // NOT read its live state, so every cleanliness/sync field is UNKNOWN (null).
+  // classifyWorkspaceGitSide → "unknown" → deriveWorkspaceGitRelation emits
+  // `cloud_state_unverified`, which blocks any same_head/safe claim while still
+  // showing the last-reported head. Never a fabricated-clean side.
+  return {
+    presence: "present",
+    provider: repo?.provider ?? null,
+    owner: repo?.owner ?? null,
+    repoName: repo?.name ?? null,
+    branch: managed.observedBranch ?? repo?.branch ?? null,
+    headSha: managed.observedHeadSha ?? managed.expectedHeadSha ?? null,
+    clean: null,
+    conflicted: null,
+    detached: null,
+    operationInProgress: null,
+    ahead: null,
+    behind: null,
+    hasUpstream: null,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-model.ts
@@ -95,9 +95,9 @@ export interface SidebarWorkspaceItemState {
   gitStatus: WorkspaceGitStatus | null;
   /**
    * Workspace-copy availability commands (PR 5): Add Cloud copy / Open on this
-   * Mac / Link / Unlink / Relink / Recreate, or an unsupported-git-state
-   * blocker. Resolved from the shared availability command model so the DOM and
-   * native menus render identically.
+   * Mac / Link / Unlink / Relink / Recreate, or a PR 6 reconcile-git-state entry
+   * into the reconciliation dialog. Resolved from the shared availability command
+   * model so the DOM and native menus render identically.
    */
   availabilityCommands: WorkspaceAvailabilityCommand[];
   /** Ids the availability actions target: the Cloud workspace, this install's

--- a/apps/packages/product-client/src/stores/cloud/workspace-availability-intent-store.ts
+++ b/apps/packages/product-client/src/stores/cloud/workspace-availability-intent-store.ts
@@ -19,6 +19,11 @@ import { create } from "zustand";
  * - relink: reuse/adopt (Flow 5) — a new generation that re-materializes onto an
  *   existing clean checkout at the ref if one exists.
  * - recreate: like relink but always cuts a FRESH worktree (never adopts).
+ * - reconcile: PR 6 — open the one reconciliation dialog to diagnose Git/
+ *   materialization drift between the local and Cloud copies and offer the ONE
+ *   safe next action (Push, Open Git panel, Recreate, Relink, Unlink, Retry).
+ *   It NEVER resets/stashes/rebases/merges/force-pushes and never claims two
+ *   different commits are linked. At least one of local/cloud ids is present.
  */
 export type WorkspaceAvailabilityIntent =
   | { kind: "open_on_mac"; cloudWorkspaceId: string }
@@ -30,6 +35,30 @@ export type WorkspaceAvailabilityIntent =
   }
   | { kind: "link_copies"; cloudWorkspaceId: string }
   | { kind: "unlink"; cloudWorkspaceId: string; materializationId: string }
+  | { kind: "relink"; cloudWorkspaceId: string; mode: "relink" | "recreate" }
+  | {
+    kind: "reconcile";
+    localWorkspaceId: string | null;
+    cloudWorkspaceId: string | null;
+    /** The linked materialization id, when an explicit link exists (enables the
+     * Unlink recovery from the dialog). */
+    materializationId: string | null;
+    /** PR6-CONTINUATION-02: the ORIGINATING action this reconciliation was
+     * entered from, serialized so the dialog can RESUME it after the user
+     * resolves the blocking state (commit/push/re-check). `standalone` = entered
+     * directly from the workspace menu, with no action to resume. Serializable
+     * (no functions/refs) per PR 5's intent-store discipline. */
+    continuation: WorkspaceReconcileContinuation;
+  };
+
+/** The action to resume after a successful reconciliation, carrying exactly the
+ * inputs that action needs. A tagged union mirroring the availability intents so
+ * the dialog can `begin()` the original intent again with its own inputs. */
+export type WorkspaceReconcileContinuation =
+  | { kind: "standalone" }
+  | { kind: "add_cloud_copy"; localWorkspaceId: string; gitOwner: string; gitRepoName: string }
+  | { kind: "open_on_mac"; cloudWorkspaceId: string }
+  | { kind: "link_copies"; cloudWorkspaceId: string }
   | { kind: "relink"; cloudWorkspaceId: string; mode: "relink" | "recreate" };
 
 interface WorkspaceAvailabilityIntentState {

--- a/apps/packages/product-ui/package.json
+++ b/apps/packages/product-ui/package.json
@@ -379,6 +379,10 @@
       "types": "./dist/workspaces/WorkspaceRow.d.ts",
       "import": "./dist/workspaces/WorkspaceRow.js"
     },
+    "./workspaces/WorkspaceReconciliationBody": {
+      "types": "./dist/workspaces/WorkspaceReconciliationBody.d.ts",
+      "import": "./dist/workspaces/WorkspaceReconciliationBody.js"
+    },
     "./workspaces/RecentWorkStatusDot": {
       "types": "./dist/workspaces/RecentWorkStatusDot.d.ts",
       "import": "./dist/workspaces/RecentWorkStatusDot.js"

--- a/apps/packages/product-ui/src/workspaces/WorkspaceReconciliationBody.tsx
+++ b/apps/packages/product-ui/src/workspaces/WorkspaceReconciliationBody.tsx
@@ -1,0 +1,74 @@
+import { GitBranch } from "lucide-react";
+import { Badge, type BadgeTone } from "@proliferate/ui/primitives/Badge";
+
+/** One target column's presentation, derived entirely by the caller
+ * (product-client) from the pure relation model. Props-only: this component
+ * computes nothing and reaches for no store. */
+export interface WorkspaceReconciliationColumnView {
+  /** "This Mac" | "Cloud" | "GitHub branch". */
+  title: string;
+  /** Short branch label, or null when unknown. */
+  branch: string | null;
+  /** Abbreviated head sha, or null when unknown/not client-verifiable. */
+  headShort: string | null;
+  /** A truthful state chip label (e.g. "clean", "2 ahead", "dirty", "missing",
+   * "last-known"). */
+  stateLabel: string;
+  stateTone: BadgeTone;
+  /** A truthfulness caveat rendered under the column (e.g. remote staleness). */
+  caveat?: string | null;
+}
+
+export interface WorkspaceReconciliationBodyView {
+  title: string;
+  /** This Mac / Cloud / GitHub branch HEAD columns. GitHub may be null when the
+   * remote head is not client-visible. */
+  columns: WorkspaceReconciliationColumnView[];
+  /** The single safe next action's explanation. */
+  actionDetail: string;
+  /** What stays unchanged if the user cancels. */
+  cancelPreserves: string;
+}
+
+/**
+ * PR 6 — the props-only reconciliation comparison body shared by the
+ * WorkspaceAvailabilityActionHost's dialog. It renders the This Mac / Cloud /
+ * GitHub branch-HEAD comparison, the one safe next action's explanation, and the
+ * what-cancel-preserves line. It uses the app's quiet atoms (Badge chips, a mono
+ * glyph) and NEVER a colored left-border / edge-ownership treatment.
+ */
+export function WorkspaceReconciliationBody({ view }: { view: WorkspaceReconciliationBodyView }) {
+  return (
+    <div className="space-y-3">
+      <dl className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {view.columns.map((column) => (
+          <div
+            key={column.title}
+            className="rounded-lg bg-surface-control px-3 py-2.5"
+          >
+            <dt className="flex items-center gap-1.5 text-ui-sm font-medium text-foreground">
+              <GitBranch size={13} className="text-muted-foreground" aria-hidden />
+              {column.title}
+            </dt>
+            <dd className="mt-1.5 space-y-1">
+              <Badge tone={column.stateTone} className="text-ui-sm">
+                {column.stateLabel}
+              </Badge>
+              <p className="truncate font-mono text-ui-sm leading-[1.5] text-muted-foreground">
+                {column.branch ?? "—"}
+                {column.headShort ? ` @ ${column.headShort}` : ""}
+              </p>
+              {column.caveat ? (
+                <p className="text-ui-sm leading-[1.4] text-muted-foreground">{column.caveat}</p>
+              ) : null}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <p className="text-ui-sm leading-[1.5] text-foreground">{view.actionDetail}</p>
+      <p className="text-ui-sm leading-[1.45] text-muted-foreground">
+        If you cancel: {view.cancelPreserves}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
PR 6 of the Cloud repository access + workspace materialization stack (frozen spec rev 2: `Vault/Workspace/Features/Workspace Git Reconciliation and Recovery - PR 6.md`).

**Stack position**: based on PR 5 final head `4accb2dab` (#1283); targets that branch as a stacked draft. Draft review boundary — never merge without Pablo.

## What this adds

- **One pure Git relation resolver** (`workspace-git-relation.ts`): same_head / local_ahead / cloud_ahead / dirty / conflicted / operation-in-progress / detached / behind / diverged / missing / unreachable / unknown, derived from structured AnyHarness Git status; PR 5's `verifyLinkCandidate` refactored so the link gate IS `relation === "same_head"` — no parallel model.
- **Action policy + reconciliation dialog**: one dialog (extending the availability-host anatomy) comparing This Mac / Cloud / last-known remote, surfacing exactly one safe next action with concrete verbs (Push, Commit, Open Git panel, Recreate, Relink, Unlink, Retry) — never a generic "Sync". The dead `unsupported-git-state` blocker item became the actionable `reconcile-git-state` entry.
- **Push-and-continue** for clean ahead states after explicit confirmation, via the existing `client.git.push` capability; success gated on the `PushResponse.published` signal plus a post-push status re-read; if state changed between preflight and action, re-evaluation wins and the stale action is cancelled.
- **Materialization health pass** (`use-materialization-health-pass.ts`): bounded comparison of current-install rows vs local AnyHarness inventory; missing ids/paths → PUT `state:"missing"`, branch/HEAD mismatch → PUT `state:"inconsistent"` (client-decided per PR 4's contract — server only guards hydrated); single-generation replay of interrupted operations via PR 5's deterministic per-step operation ids; unreachable targets preserve all records.
- **Safety rails, tested**: a spy test proves no reset/stash/rebase/merge/force verb is ever issued; differing exact HEADs are never called linked; dirty work is never deleted by Recreate.

## Disclosed decisions / deferrals

- **Remote HEAD is last-known only** (frozen-spec Option b): the runtime has no fetch/remote-probe primitive and the branches route carries no SHAs, so authoritative remote verification stays server-side (intent-time) and the client labels staleness truthfully. A client-visible GitHub HEAD column would need a net-new server+SDK query — explicitly out of scope per the reconciled spec.
- **Health pass is built + unit-covered but not auto-wired** into app bootstrap; exposed for startup/selection callers. Flagged for founder preference.
- **Cloud-side push execution** routes to manual guidance when re-evaluation still shows cloud_ahead (Cloud runtime not client-reachable for live push in this PR); local push is fully live.

## Verification

Typecheck exit 0 across product-domain/-ui/-surfaces/-client, web, desktop, mobile. Vitest: product-client 3170 (540 files), product-domain 578, desktop 168 — all green. Frontend structure `--strict` TOTAL 0; max-lines pass (no allowlist changes needed); `git diff --check` clean. TS-only: no Rust, no server changes, Workflow V1 untouched. Known pre-existing: desktop design-system pretest red on 3 unrelated files at the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)