### PR TITLE
fix(desktop): launch dev cloud worker directly

### DIFF
--- a/apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs
+++ b/apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs
@@ -10,6 +10,11 @@ use tokio::process::Command;
 
 use crate::agent_seed_env::current_target_triple;
 
+const DESKTOP_DEV_CARGO_RUNNER_ENV_VARS: [&str; 2] = [
+    "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER",
+    "CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER",
+];
+
 pub(super) enum WorkerLauncher {
     Binary(PathBuf),
     CargoRun {
@@ -39,6 +44,14 @@ impl WorkerLauncher {
                     .arg("--")
                     .arg("--config")
                     .arg(config_path);
+                // The local Desktop launcher sets these runners so Cargo copies
+                // the Tauri app to a profile-specific executable before running
+                // it. A nested `cargo run` for the worker must execute the worker
+                // directly: inheriting the app runner overwrites that Desktop
+                // path and macOS rejects the copied worker's code signature.
+                for env_var in DESKTOP_DEV_CARGO_RUNNER_ENV_VARS {
+                    command.env_remove(env_var);
+                }
                 command
             }
         }
@@ -193,7 +206,11 @@ fn is_placeholder_sidecar(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::Cell, path::PathBuf};
+    use std::{
+        cell::Cell,
+        ffi::OsStr,
+        path::{Path, PathBuf},
+    };
 
     use super::{select_worker_launcher, WorkerLauncher};
 
@@ -241,5 +258,19 @@ mod tests {
         assert!(
             matches!(launcher, Some(WorkerLauncher::Binary(path)) if path == PathBuf::from("/packaged"))
         );
+    }
+
+    #[test]
+    fn cargo_run_does_not_inherit_the_desktop_app_runner() {
+        let command = cargo_run().command(Path::new("/worker/config.toml"));
+        let removed_env = command
+            .as_std()
+            .get_envs()
+            .filter_map(|(name, value)| value.is_none().then_some(name))
+            .collect::<Vec<_>>();
+
+        for env_var in super::DESKTOP_DEV_CARGO_RUNNER_ENV_VARS {
+            assert!(removed_env.contains(&OsStr::new(env_var)));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- prevent the nested development `cargo run -p proliferate-worker` from inheriting Desktop's profile app runner
- preserve the checked-out worker freshness behavior introduced in #1136
- add a regression proving both macOS Desktop runner variables are removed from the worker command

## Root cause

The local launcher exports `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER` and `CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER` so Cargo copies the Tauri app to a profile-specific executable. The Desktop child process inherited those variables when it invoked `cargo run` for Proliferate Worker, so Cargo sent the worker through the app runner too. That overwrote the profile Desktop executable path and macOS terminated the copied worker with `SIGKILL (Code Signature Invalid)` / `Taskgated Invalid Signature`.

## Verification

- `CARGO_TARGET_DIR=/Users/pablohansen/proliferate/target cargo test -p proliferate commands::cloud_worker::` — 11 passed
- `rustfmt --edition 2021 --check apps/desktop/src-tauri/src/commands/cloud_worker/launcher.rs`
- `python3 scripts/check_max_lines.py`
- `git diff --check`

Repository-wide `cargo fmt --all --check` currently reports pre-existing formatting drift outside this PR; the changed file passes focused rustfmt.
