### PR TITLE
fix(ci): stamp runtime release source SHA

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -87,8 +87,10 @@ jobs:
           set -euo pipefail
           if [[ -n "${{ inputs.version }}" ]]; then
             echo "PROLIFERATE_BUILD_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+            echo "PROLIFERATE_BUILD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
           elif [[ "${GITHUB_REF_NAME:-}" == runtime-v* ]]; then
             echo "PROLIFERATE_BUILD_VERSION=${GITHUB_REF_NAME#runtime-v}" >> "$GITHUB_ENV"
+            echo "PROLIFERATE_BUILD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
           fi
 
       - name: Install musl-tools (x86_64 linux)

--- a/scripts/ci-cd/release-title-propagation.test.mjs
+++ b/scripts/ci-cd/release-title-propagation.test.mjs
@@ -48,6 +48,17 @@ test("release coordinators pass the title into the desktop release lane", async 
   assert.match(deployDesktop, /release_title: \$\{\{ inputs\.release_title \}\}/);
 });
 
+test("runtime production builds stamp both version and deterministic source SHA", async () => {
+  const source = await workflow("release-runtime.yml");
+  const resolveStep = source.slice(
+    source.indexOf("- name: Resolve build version"),
+    source.indexOf("- name: Install musl-tools"),
+  );
+
+  assert.match(resolveStep, /PROLIFERATE_BUILD_VERSION=/);
+  assert.match(resolveStep, /PROLIFERATE_BUILD_SHA=\$\(git rev-parse HEAD\)/);
+});
+
 test("desktop updater publication fails closed before overwriting a released version", async () => {
   const [source, infra] = await Promise.all([
     workflow("release-desktop.yml"),


### PR DESCRIPTION
## Summary
- stamp `PROLIFERATE_BUILD_SHA` beside the release version for reusable and tag-triggered Runtime builds
- add a CI/CD regression test for the fail-closed production build contract

## Verification
- `node --test scripts/ci-cd/*.test.mjs` (108 passed)
- `python3 scripts/check_docs.py`

This repairs the deterministic failure observed in production run 29521679960.