### PR TITLE
fix(product): keep repository hosts off login shell

### DIFF
--- a/apps/packages/product-client/src/App.tsx
+++ b/apps/packages/product-client/src/App.tsx
@@ -9,12 +9,7 @@ import { Toaster } from "@proliferate/ui/kit/Sonner"
 import { MacWindowControlsSafeArea } from "#product/components/app/chrome/MacWindowControlsSafeArea"
 import { useLocalWorktreeSettingsTarget } from "#product/hooks/workspaces/facade/use-local-worktree-settings-target"
 import { useWorktreeCleanupPolicySync } from "#product/hooks/workspaces/lifecycle/use-worktree-cleanup-policy-sync"
-import { RepoSetupModalHost } from "#product/components/workspace/repo-setup/RepoSetupModalHost"
 import { SupportModalHost } from "#product/components/support/SupportModalHost"
-import { AddRepoFlowHost } from "#product/components/workspace/repo-setup/AddRepoFlowHost"
-import { CloudRepoActionDialogHost } from "#product/components/workspace/repo-setup/CloudRepoActionDialogHost"
-import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
-import { MaterializationHealthPassHost } from "#product/components/workspace/repo-setup/MaterializationHealthPassHost"
 import { LoginPage } from "#product/pages/LoginPage"
 import { SettingsCloudRedirect } from "#product/pages/SettingsCloudRedirect"
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store"
@@ -96,7 +91,8 @@ interface AppProps {
 // Thin product route/UI tree. Shared and Desktop lifecycle wiring lives above
 // this component in `ProductLifecycleRoot`, which also owns the single
 // `AppErrorBoundary` enclosing both the lifecycle hooks and this tree; `App`
-// owns only the route tree, modal hosts, and toasts.
+// owns only the route tree, public feedback hosts, and toasts. Repository and
+// workspace hosts live behind the lazy authenticated product boundary.
 export function App({ RoutesComponent }: AppProps) {
   return (
       <ShortcutRevealProvider>
@@ -198,11 +194,6 @@ export function App({ RoutesComponent }: AppProps) {
           )}
           <Route path="*" element={<Navigate to="/" replace />} />
         </RoutesComponent>
-        <RepoSetupModalHost />
-        <AddRepoFlowHost />
-        <CloudRepoActionDialogHost />
-        <WorkspaceAvailabilityActionHost />
-        <MaterializationHealthPassHost />
         <SupportModalHost />
         {/* Kit Sonner toaster: all toasts (update lifecycle + legacy
             toast-store call sites, which now delegate to Sonner). */}

--- a/apps/packages/product-client/src/app/AuthenticatedProductClient.tsx
+++ b/apps/packages/product-client/src/app/AuthenticatedProductClient.tsx
@@ -1,16 +1,30 @@
 import type { ReactElement } from "react"
 
+import { AddRepoFlowHost } from "#product/components/workspace/repo-setup/AddRepoFlowHost"
+import { CloudRepoActionDialogHost } from "#product/components/workspace/repo-setup/CloudRepoActionDialogHost"
+import { MaterializationHealthPassHost } from "#product/components/workspace/repo-setup/MaterializationHealthPassHost"
+import { RepoSetupModalHost } from "#product/components/workspace/repo-setup/RepoSetupModalHost"
+import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
 import { AuthenticatedAppHost } from "#product/pages/AuthenticatedAppHost"
 
 /**
  * Internal, lazy-loaded authenticated product root.
  *
  * Loaded via `React.lazy(() => import("#product/app/AuthenticatedProductClient"))`
- * from the public shell (`App`), so the authenticated app host subtree (and its
- * editor/terminal chunks) is a dynamic chunk that the login/public routes never
- * eagerly pull. It is a stable default export because that is the shape
+ * from the public shell (`App`), so the authenticated app host subtree and its
+ * repository/workspace hosts are a dynamic chunk that login/public routes
+ * never eagerly pull. It is a stable default export because that is the shape
  * `React.lazy` requires.
  */
 export default function AuthenticatedProductClient(): ReactElement {
-  return <AuthenticatedAppHost />
+  return (
+    <>
+      <AuthenticatedAppHost />
+      <RepoSetupModalHost />
+      <AddRepoFlowHost />
+      <CloudRepoActionDialogHost />
+      <WorkspaceAvailabilityActionHost />
+      <MaterializationHealthPassHost />
+    </>
+  )
 }

--- a/specs/codebase/systems/product/clients/web-desktop-unification/entry-contract.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/entry-contract.md
@@ -113,8 +113,10 @@ Moved modules resolve package-private imports through the compiled package:
 `ProductClient` is a lightweight public/auth shell. The authenticated product
 root is internal and lazy-loaded via `#product/app/AuthenticatedProductClient`,
 so Web login and callback entrypoints do not eagerly load editor, terminal, or
-other authenticated-only chunks. The mechanical move applies this exact shape to
-the real Desktop product.
+other authenticated-only chunks. Connected repository/workspace action hosts
+also mount inside that authenticated root; they must not be imported by the
+public `App` shell. The mechanical move applies this exact shape to the real
+Desktop product.
 
 ## Reserved-file rule
 


### PR DESCRIPTION
## Summary

- Move connected repository/workspace action hosts from the eager public `App` shell into the existing lazy `AuthenticatedProductClient` boundary.
- Preserve the same signed-in host composition and ordering.
- Document that repository/workspace action hosts are authenticated-only bundle content.

This is the narrow repair for the inherited required `/login` first-load budget failure. It does not raise the budget, weaken the gate, or change product behavior.

## Proof

Exact base: `d11bf7dec257ed0da04aad0709e99cea1ea7a6cb`
Exact head: `3c2fd7cb0bc5d8730de9b9d0249859b8ac868f64`

### Runtime budget

- Current-main baseline before the patch: JS `503,631 / 485,000 B` (failed), CSS `65,290 / 66,000 B`.
- Exact-head patched result: JS `477,141 / 485,000 B` (+7,859 B headroom), CSS `65,290 / 66,000 B` (+710 B headroom).
- Fonts/images/audio: `0 / 0 / 0`.
- Reduction: `26,490` gzip JS bytes from anonymous `/login`.

```bash
pnpm shared:build
VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build
node scripts/measure-login-runtime-budget.mjs --no-build
```

### Focused verification

```bash
pnpm --filter @proliferate/product-client exec vitest run \
  src/components/workspace/repo-setup/RepoSetupModalHost.test.ts \
  src/components/workspace/repo-setup/AddRepoFlowHost.test.tsx \
  src/components/workspace/repo-setup/CloudRepoActionDialogHost.test.tsx
# 3 files, 16 tests passed

pnpm --filter @proliferate/product-client typecheck
python3 scripts/check_max_lines.py
python3 scripts/check_migration_heads.py
python3 scripts/check_anyharness_old_paths.py
python3 scripts/check_proliferate_worker_structure.py
python3 scripts/check_frontend_boundaries.py
python3 scripts/report_frontend_structure.py --strict --summary-only
python3 scripts/check_server_boundaries.py
python3 scripts/check_anyharness_boundaries.py
python3 -m unittest scripts/test_check_docs.py
python3 scripts/check_docs.py
git diff --check
```

All passed. No Rust build, deployment, or production mutation was performed.
