### PR TITLE
fix(ci): forward release SHA into cross builds

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,6 @@
-# `cross` runs the build inside a container, so the release version stamp
+# `cross` runs the build inside a container, so the release identity stamps
 # (set by the `build-binaries` job in .github/workflows/release-runtime.yml)
 # must be forwarded into it — otherwise the aarch64-linux binaries fall back
-# to the crate's Cargo.toml version and the self-update gates never converge.
+# to incomplete identity and production builds fail closed.
 [build.env]
-passthrough = ["PROLIFERATE_BUILD_VERSION"]
+passthrough = ["PROLIFERATE_BUILD_VERSION", "PROLIFERATE_BUILD_SHA"]

--- a/scripts/ci-cd/release-title-propagation.test.mjs
+++ b/scripts/ci-cd/release-title-propagation.test.mjs
@@ -57,6 +57,12 @@ test("runtime production builds stamp both version and deterministic source SHA"
 
   assert.match(resolveStep, /PROLIFERATE_BUILD_VERSION=/);
   assert.match(resolveStep, /PROLIFERATE_BUILD_SHA=\$\(git rev-parse HEAD\)/);
+
+  const crossConfig = await readFile(new URL("../../Cross.toml", import.meta.url), "utf8");
+  assert.match(
+    crossConfig,
+    /passthrough\s*=\s*\[[^\]]*"PROLIFERATE_BUILD_VERSION"[^\]]*"PROLIFERATE_BUILD_SHA"[^\]]*\]/,
+  );
 });
 
 test("desktop updater publication fails closed before overwriting a released version", async () => {


### PR DESCRIPTION
## Summary
- forward the deterministic production release SHA into `cross` containers
- retain fail-closed release identity for aarch64 Linux artifacts
- cover the cross passthrough contract in CI tests

## Verification
- `node --test scripts/ci-cd/*.test.mjs` (108 passed)
- `python3 scripts/check_docs.py`
- `git diff --check`

Emergency production release repair after hotfix run 29522264272 exposed the missing cross-container passthrough.