### PR TITLE
fix(server): configure GitHub App in reauth test

### DIFF
--- a/server/tests/integration/cloud_api_helpers.py
+++ b/server/tests/integration/cloud_api_helpers.py
@@ -95,16 +95,10 @@ async def link_github_account(db_session: AsyncSession, user_id: str) -> None:
     await db_session.commit()
 
 
-async def seed_github_app_repo_authority(
-    db_session: AsyncSession,
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    user_id: str,
-    git_owner: str = "proliferate-ai",
-) -> None:
+def configure_github_app_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     # Repo-backed Cloud mutations fail closed unless the operator's GitHub App
     # runtime config is complete (require_github_app_runtime_configured), so
-    # seeding user authority also configures the App for the test deployment.
+    # tests exercising user authority must configure the App deployment first.
     for field, value in {
         "github_app_id": "12345",
         "github_app_slug": "proliferate-test",
@@ -115,6 +109,16 @@ async def seed_github_app_repo_authority(
         "github_app_private_key_path": "",
     }.items():
         monkeypatch.setattr(repo_authority.settings, field, value)
+
+
+async def seed_github_app_repo_authority(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    user_id: str,
+    git_owner: str = "proliferate-ai",
+) -> None:
+    configure_github_app_runtime(monkeypatch)
     await github_app_store.upsert_github_app_authorization(
         db_session,
         user_id=uuid.UUID(user_id),

--- a/server/tests/integration/test_github_app_reauthorization.py
+++ b/server/tests/integration/test_github_app_reauthorization.py
@@ -14,7 +14,10 @@ from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthori
 from proliferate.server.cloud.github_app import repo_authority
 from proliferate.server.cloud.materialization import runner as materialization_runner
 from proliferate.server.cloud.materialization.materialize import github_credentials
-from tests.integration.cloud_api_helpers import register_and_login
+from tests.integration.cloud_api_helpers import (
+    configure_github_app_runtime,
+    register_and_login,
+)
 
 
 async def _seed_expired_authorization(
@@ -108,6 +111,7 @@ async def test_authority_endpoint_returns_actionable_response_and_persists_reaut
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    configure_github_app_runtime(monkeypatch)
     session = await register_and_login(
         client,
         f"github-authority-reauth-{uuid4().hex[:8]}@example.com",


### PR DESCRIPTION
## Summary
- configure the complete GitHub App runtime before exercising the user-reauthorization authority state
- extract the existing integration configuration setup into a shared test helper
- preserve the operator-configuration gate precedence in production code

## Verification
- `DEBUG=true uv run --python 3.12 --extra dev pytest tests/integration/test_github_app_reauthorization.py -q` (6 passed)
- focused Ruff check and format check
- `git diff --check`

Repairs the sole failure from production release run 29525835452 (1,476 other server tests passed).