### PR TITLE
fix(workflows): enforce managed runtime transaction boundaries

### DIFF
--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -48,6 +48,9 @@ SERVICE_DB_SESSION_OPS_METHODS = {
 API_DB_METHODS = {"execute", "commit", "rollback", "add", "delete", "refresh"}
 STORE_FORBIDDEN_SESSION_METHODS = {"commit", "rollback"}
 RAW_HTTP_MODULES = {"httpx", "requests"}
+# Named product concerns that own service orchestration outside a generic
+# service.py retain the same database-boundary rules even when relocated.
+OWNED_SERVICE_CONCERN_FILES = {"workflow_runtime.py"}
 # Lane 6 split service.py into top-level agent-auth concern modules. Until those
 # concerns move to documented subdomains or entry points, keep service boundary
 # debt visible for the same layer law that applies to service.py.
@@ -178,7 +181,12 @@ def classify_path(path: Path) -> SourceKind:
     return SourceKind(
         is_api=is_product and name == "api.py",
         is_service=(
-            is_product and (name == "service.py" or is_agent_auth_service_concern)
+            is_product
+            and (
+                name == "service.py"
+                or name in OWNED_SERVICE_CONCERN_FILES
+                or is_agent_auth_service_concern
+            )
         ),
         is_service_boundary_debt=relative in SERVICE_BOUNDARY_DEBT_MODULES,
         is_domain=is_product and "domain" in path.parts,

--- a/server/proliferate/server/cloud/materialization/materialize/workflow_runtime.py
+++ b/server/proliferate/server/cloud/materialization/materialize/workflow_runtime.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
 from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandboxes_service
+from proliferate.server.cloud.cloud_sandboxes import transactions as cloud_sandbox_transactions
 from proliferate.server.cloud.materialization import operation
 from proliferate.server.cloud.materialization.materialize import agent_auth
 
@@ -25,7 +26,7 @@ async def run_managed_workflow_runtime_operation[T](
     sandbox = await cloud_sandboxes_store.load_cloud_sandbox_by_id(db, sandbox_id)
     if sandbox is None or sandbox.destroyed_at is not None or sandbox.status == "destroyed":
         raise operation.CloudMaterializationTargetUnavailable()
-    await db.commit()
+    await cloud_sandbox_transactions.commit_cloud_sandbox_session(db)
 
     async def _refresh_locked() -> cloud_sandboxes_store.CloudSandboxValue:
         refreshed = await cloud_sandboxes_store.load_cloud_sandbox_by_id(
@@ -39,7 +40,7 @@ async def run_managed_workflow_runtime_operation[T](
             or refreshed.status == "destroyed"
         ):
             raise operation.CloudMaterializationTargetUnavailable()
-        await db.commit()
+        await cloud_sandbox_transactions.commit_cloud_sandbox_session(db)
         return refreshed
 
     async def _run_locked(ctx: operation.MaterializationContext) -> T:
@@ -65,7 +66,7 @@ async def run_managed_workflow_runtime_operation[T](
             access_token,
             _data_key,
         ) = await cloud_sandboxes_service.load_cloud_sandbox_runtime_access(refreshed)
-        await db.commit()
+        await cloud_sandbox_transactions.commit_cloud_sandbox_session(db)
         return await run(runtime_url, access_token)
 
     return await operation.run_cloud_sandbox_operation(

--- a/server/tests/integration/test_workflow_managed_worker_retries.py
+++ b/server/tests/integration/test_workflow_managed_worker_retries.py
@@ -203,36 +203,54 @@ async def test_deterministic_target_failures_terminalize_without_successor(
     assert successor is None
 
 
+@pytest.mark.parametrize(
+    "failure,expected_code",
+    [
+        (
+            CloudMaterializationCommandError("provider temporarily unavailable"),
+            "workflow_target_unreachable",
+        ),
+        (
+            SandboxProviderUnavailableError("provider temporarily unavailable"),
+            "workflow_target_unreachable",
+        ),
+        (
+            CloudMaterializationLockUnavailable("redis is unavailable"),
+            "workflow_materialization_unavailable",
+        ),
+    ],
+)
 @pytest.mark.asyncio
 async def test_transient_target_failure_queues_one_successor(
     client: AsyncClient,
     db_session: AsyncSession,
     test_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    expected_code: str,
 ) -> None:
     monkeypatch.setattr(settings, "workflow_managed_runs_enabled", True)
-    owner = await register_and_login(client, "managed-transient-target@example.com")
+    owner = await register_and_login(
+        client,
+        f"managed-transient-{type(failure).__name__}@example.com",
+    )
     invocation_id, _sandbox_id = await _seed_target_plan(client, db_session, owner)
     factory = async_sessionmaker(test_engine, expire_on_commit=False)
 
-    transient_failures = iter(
-        (
-            CloudMaterializationCommandError("provider temporarily unavailable"),
-            SandboxProviderUnavailableError("provider temporarily unavailable"),
-            CloudMaterializationLockUnavailable("redis is unavailable"),
-        )
-    )
-
     async def unavailable(*_args: object, **_kwargs: object) -> None:
-        raise next(transient_failures)
+        raise failure
 
     monkeypatch.setattr(delivery, "runtime_access", unavailable)
-    for generation in (2, 3, 4):
-        await delivery.run_delivery_task(
-            factory,
-            invocation_id=invocation_id,
-            generation=generation,
-        )
+    await delivery.run_delivery_task(
+        factory,
+        invocation_id=invocation_id,
+        generation=2,
+    )
+    await delivery.run_delivery_task(
+        factory,
+        invocation_id=invocation_id,
+        generation=2,
+    )
 
     async with factory() as db:
         settled = await managed_store.get_managed_execution(
@@ -241,11 +259,22 @@ async def test_transient_target_failure_queues_one_successor(
         )
         successor = await db.scalar(
             select(BackgroundOutboxTask).where(
-                BackgroundOutboxTask.idempotency_key == f"workflow:deliver:{invocation_id}:5"
+                BackgroundOutboxTask.idempotency_key == f"workflow:deliver:{invocation_id}:3"
             )
+        )
+        successor_count = len(
+            (
+                await db.scalars(
+                    select(BackgroundOutboxTask).where(
+                        BackgroundOutboxTask.idempotency_key
+                        == f"workflow:deliver:{invocation_id}:3"
+                    )
+                )
+            ).all()
         )
     assert settled is not None
     assert settled.delivery_status == "queued"
-    assert settled.delivery_generation == 5
-    assert settled.last_delivery_error_code == "workflow_materialization_unavailable"
+    assert settled.delivery_generation == 3
+    assert settled.last_delivery_error_code == expected_code
     assert successor is not None
+    assert successor_count == 1

--- a/server/tests/unit/test_server_boundary_checker.py
+++ b/server/tests/unit/test_server_boundary_checker.py
@@ -105,6 +105,27 @@ def test_service_rejects_db_commit_call(tmp_path: Path) -> None:
     assert any(".commit()" in item.message for item in violations)
 
 
+def test_owned_service_concern_rejects_db_commit_after_relocation(tmp_path: Path) -> None:
+    module = _load_checker_module()
+    module.REPO_ROOT = tmp_path
+    path = (
+        tmp_path
+        / "server"
+        / "proliferate"
+        / "server"
+        / "cloud"
+        / "materialization"
+        / "materialize"
+        / "workflow_runtime.py"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text("async def run(db) -> None:\n    await db.commit()\n")
+
+    violations = module.check_paths([path])
+
+    assert any(item.rule_id == "SERVICE_DB_METHOD_CALL" for item in violations)
+
+
 def test_service_rejects_session_ops_import_and_call(tmp_path: Path) -> None:
     module = _load_checker_module()
     path = tmp_path / "server" / "proliferate" / "server" / "example" / "service.py"

--- a/specs/codebase/systems/product/workflows/managed-cloud-execution.md
+++ b/specs/codebase/systems/product/workflows/managed-cloud-execution.md
@@ -47,6 +47,13 @@ the existing per-sandbox Cloud materialization lock. Duplicate task claims can
 therefore replay workspace/run PUTs, but cannot establish competing provider or
 runtime custody.
 
+The locked Workflow runtime concern ends each PostgreSQL read/write phase
+through the Cloud sandbox transaction owner before provider or AnyHarness I/O.
+It does not call `AsyncSession.commit()` directly. The server-boundary checker
+classifies this named concern as service orchestration even though it lives
+under `materialization/materialize/`, so moving it out of a generic
+`service.py` cannot weaken that transaction rule.
+
 `run_put_started` is the response-ambiguity boundary. Cancellation before it
 invalidates delivery and creates no run. Cancellation at or after it reconciles
 the exact idempotent run PUT, then calls the Workflow cancel endpoint. Cloud


### PR DESCRIPTION
## Summary

- follows merged managed Cloud execution PR #1294 with the two review corrections that were identified before merge but did not land in its source head;
- routes all locked Workflow runtime transaction closes through the canonical Cloud sandbox transaction owner;
- extends the server-boundary ratchet so moving the named Workflow runtime concern outside `service.py` cannot hide raw session commits;
- restores independent real-Postgres retry proofs for transient command, provider, and Redis-lock failures; each pins its exact safe code and exactly one successor under duplicate delivery.

## Exact custody

- Base: `77c1e1faf56c589052b4c6a6a58f98eb41a782a0` — current main, including merged support repairs #1298, #1301, and #1300.
- Head: `fd9774322dcf8eb35708832c1086789ec4bc8b69`.
- Predecessor: PR #1294 merged as `0c3121cf9e427eb5f6898b1aec18366ad733ad20` from source `61579867f3d35699e768b10e0e5948190131ee5e`.
- One scoped repair commit, rebased without conflicts; no unrelated behavior.

## Findings closed

- `MC5B-SERVER-BOUNDARY-01`: canonical transaction helper plus relocation-resistant static boundary proof.
- `MC5B-PROOF-02`: per-error mutation-sensitive retry and exactly-one-successor proofs.

## Verification on the exact final-rebase head

- Affected target-runtime, worker-retry, and boundary-checker tests: `27 passed`.
- Independent transient command/provider/Redis retry matrix: `3 passed`.
- `python3 scripts/check_server_boundaries.py`: passed.
- `python3 scripts/check_docs.py`: passed.
- `python3 scripts/check_max_lines.py`: passed, including inherited #1300 integration.
- Affected Ruff check and format-check: passed.
- `git diff --check`: passed.
- Full GitHub CI: running on the exact head.

## Safety

Feature gate remains disabled by default. No deployment, provisioning, production enablement, schema change, or release mutation is part of this repair.