### PR TITLE
fix(frontend): remount lifecycle root during Fast Refresh

### DIFF
--- a/apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx
+++ b/apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx
@@ -1,3 +1,6 @@
+// @refresh reset
+// This hook-dense application root must remount after an HMR update so React
+// never reuses lifecycle hook cells from the module's previous topology.
 import { useEffect, useRef, type ReactNode } from "react"
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider"
 import type { DesktopDiagnosticsBridge } from "@proliferate/product-client/host/desktop-bridge"


### PR DESCRIPTION
## Summary
- force the hook-dense ProductLifecycles module to remount after Fast Refresh updates
- prevent React from reusing stale hook dependency cells and throwing `prevDeps.length`

## Proof
- `git diff --check`
- change uses the `@vitejs/plugin-react` `// @refresh reset` directive
- full release head proof passed before the v0.3.37 rollout; clean PR CI owns regenerated dependency proof

## Scope
Development/HMR behavior only; production render behavior is unchanged.