### PR TITLE
fix(server): close release suite gaps

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -109,6 +109,15 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
         with:

--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -36,6 +36,7 @@ from proliferate.server.cloud.github_app.models import (
 )
 from proliferate.server.cloud.github_app.repo_authority import (
     ensure_fresh_github_app_authorization,
+    require_github_app_runtime_configured,
     require_github_cloud_repo_authority,
 )
 from proliferate.server.cloud.materialization import service as materialization_service
@@ -603,6 +604,7 @@ async def list_github_app_accessible_repositories(
     affiliation: str = DEFAULT_REPO_AFFILIATION,
     visibility: str = DEFAULT_REPO_VISIBILITY,
 ) -> CloudGitRepositoriesPageRecord:
+    require_github_app_runtime_configured()
     authorization = await ensure_fresh_github_app_authorization(db, user_id=user.id)
     credentials = CloudRepoGitHubCredentials(
         user_id=user.id,

--- a/server/proliferate/server/cloud/repos/access.py
+++ b/server/proliferate/server/cloud/repos/access.py
@@ -10,6 +10,7 @@ from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.github_app.repo_authority import (
     ensure_fresh_github_app_authorization,
+    require_github_app_runtime_configured,
 )
 from proliferate.server.cloud.repos.domain.github_credentials import (
     CloudRepoGitHubCredentials,
@@ -20,6 +21,7 @@ async def current_cloud_repo_github_credentials(
     user: User = Depends(current_product_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudRepoGitHubCredentials:
+    require_github_app_runtime_configured()
     authorization = await ensure_fresh_github_app_authorization(db, user_id=user.id)
     return CloudRepoGitHubCredentials(
         user_id=user.id,

--- a/server/proliferate/server/workflows/models.py
+++ b/server/proliferate/server/workflows/models.py
@@ -31,20 +31,30 @@ class WorkflowWireModel(BaseModel):
     )
 
 
-class WorkflowInputDefinition(WorkflowWireModel):
+class WorkflowDefinitionWireModel(WorkflowWireModel):
+    """Definition JSON accepts only its canonical camel-case wire aliases."""
+
+    model_config = ConfigDict(
+        populate_by_name=False,
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+
+class WorkflowInputDefinition(WorkflowDefinitionWireModel):
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)]
     type: Literal["string", "number", "boolean"]
     required: bool
 
 
-class WorkflowGoalDefinition(WorkflowWireModel):
+class WorkflowGoalDefinition(WorkflowDefinitionWireModel):
     objective: Annotated[
         str,
         StringConstraints(strip_whitespace=True, min_length=1, max_length=20_000),
     ]
 
 
-class WorkflowPromptStep(WorkflowWireModel):
+class WorkflowPromptStep(WorkflowDefinitionWireModel):
     kind: Literal["agent.prompt"]
     prompt: Annotated[str, StringConstraints(min_length=1, max_length=100_000)]
     goal: WorkflowGoalDefinition | None = None
@@ -57,7 +67,7 @@ class WorkflowPromptStep(WorkflowWireModel):
         return value
 
 
-class WorkflowHarnessConfig(WorkflowWireModel):
+class WorkflowHarnessConfig(WorkflowDefinitionWireModel):
     agent_kind: Annotated[
         str,
         StringConstraints(strip_whitespace=True, min_length=1, max_length=32),
@@ -78,12 +88,12 @@ class WorkflowHarnessConfig(WorkflowWireModel):
     ) = None
 
 
-class WorkflowStageDefinition(WorkflowWireModel):
+class WorkflowStageDefinition(WorkflowDefinitionWireModel):
     harness_config: WorkflowHarnessConfig
     steps: list[WorkflowPromptStep] = Field(min_length=1, max_length=64)
 
 
-class WorkflowDefinitionDocument(WorkflowWireModel):
+class WorkflowDefinitionDocument(WorkflowDefinitionWireModel):
     inputs: list[WorkflowInputDefinition] = Field(default_factory=list, max_length=64)
     stages: list[WorkflowStageDefinition] = Field(min_length=1, max_length=64)
 
@@ -99,6 +109,14 @@ class WorkflowDefinitionUpdateRequest(WorkflowDefinitionCreateRequest):
 
 
 class WorkflowDefinitionResponse(WorkflowDefinitionDocument):
+    # Internal response projections may use Python field names; strict alias
+    # handling applies to request bodies, not server-owned construction.
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+    )
+
     id: UUID
     user_id: UUID
     title: str
@@ -143,6 +161,16 @@ class WorkflowInvocationWireModel(WorkflowWireModel):
     )
 
 
+class WorkflowInvocationRequestWireModel(WorkflowInvocationWireModel):
+    """Invocation requests accept only canonical camel-case wire aliases."""
+
+    model_config = ConfigDict(
+        populate_by_name=False,
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+
 WorkflowInvocationScalar = StrictBool | StrictInt | StrictFloat | StrictStr
 
 
@@ -150,7 +178,7 @@ class ManagedCloudWorkflowTarget(WorkflowInvocationWireModel):
     kind: Literal["managedCloud"]
 
 
-class WorkflowInvocationCreateRequest(WorkflowInvocationWireModel):
+class WorkflowInvocationCreateRequest(WorkflowInvocationRequestWireModel):
     schema_version: Literal[1]
     workflow_definition_id: UUID
     expected_revision: StrictInt = Field(ge=1)

--- a/server/tests/integration/background/test_relay_task.py
+++ b/server/tests/integration/background/test_relay_task.py
@@ -15,7 +15,13 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.background import relay as relay_module
-from proliferate.background.config import HEALTH_NOOP_TASK, PERIODIC_DEFAULT_QUEUE
+from proliferate.background.config import (
+    HEALTH_NOOP_TASK,
+    PERIODIC_DEFAULT_QUEUE,
+    WORKFLOW_CANCEL_TASK,
+    WORKFLOW_DELIVER_TASK,
+    WORKFLOW_OBSERVE_TASK,
+)
 from proliferate.background.tasks.relay import relay
 from proliferate.config import settings
 from proliferate.db.store.background_outbox import (
@@ -57,7 +63,12 @@ async def test_relay_task_publishes_committed_health_noop(
     # Scheduler-store/relay liveness heartbeat and the bounded per-family
     # backlog gauge are emitted every tick for the hosted metric plane.
     assert metrics["relay_heartbeat"] == 1
-    assert metrics["supported_pending_by_family"] == {"background_health_noop": 0}
+    assert metrics["supported_pending_by_family"] == {
+        HEALTH_NOOP_TASK.replace(".", "_"): 0,
+        WORKFLOW_DELIVER_TASK.replace(".", "_"): 0,
+        WORKFLOW_OBSERVE_TASK.replace(".", "_"): 0,
+        WORKFLOW_CANCEL_TASK.replace(".", "_"): 0,
+    }
 
     db_session.expire_all()
     row = await load_outbox_task(db_session, task.id)

--- a/server/tests/integration/test_github_app_reauthorization.py
+++ b/server/tests/integration/test_github_app_reauthorization.py
@@ -54,6 +54,66 @@ async def _seed_expired_authorization(
     await db_session.commit()
 
 
+async def _seed_current_authorization(
+    db_session: AsyncSession,
+    *,
+    user_id: UUID,
+) -> None:
+    await github_app_store.upsert_github_app_authorization(
+        db_session,
+        user_id=user_id,
+        authorization=GitHubAppUserAuthorization(
+            access_token="current-github-app-token",
+            refresh_token="current-refresh-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=8),
+            refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30),
+            github_user_id="12345",
+            github_login="cloud-tester",
+            permissions={},
+        ),
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/v1/cloud/repos",
+        "/v1/cloud/github-app/accessible-repos",
+    ],
+)
+async def test_repo_discovery_fails_closed_when_operator_config_is_incomplete(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+) -> None:
+    for field in (
+        "github_app_id",
+        "github_app_slug",
+        "github_app_client_id",
+        "github_app_client_secret",
+        "github_app_webhook_secret",
+        "github_app_private_key",
+        "github_app_private_key_path",
+    ):
+        monkeypatch.setattr(repo_authority.settings, field, "")
+    session = await register_and_login(
+        client,
+        f"github-operator-config-{uuid4().hex[:8]}@example.com",
+    )
+    await _seed_current_authorization(db_session, user_id=UUID(session["user_id"]))
+
+    response = await client.get(
+        endpoint,
+        headers={"Authorization": f"Bearer {session['access_token']}"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "github_app_not_configured"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failure_mode", ["bad_refresh_token", "missing_refresh_token"])
 @pytest.mark.parametrize(
@@ -70,6 +130,7 @@ async def test_permanent_refresh_failure_returns_409_and_persists_reauth(
     failure_mode: str,
     endpoint: str,
 ) -> None:
+    _configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-reauth-{failure_mode}-{uuid4().hex[:8]}@example.com",
@@ -171,6 +232,7 @@ async def test_background_materialization_runner_persists_reauth(
     test_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-background-reauth-{uuid4().hex[:8]}@example.com",

--- a/server/tests/integration/test_workflow_invocations_api.py
+++ b/server/tests/integration/test_workflow_invocations_api.py
@@ -192,6 +192,46 @@ async def test_invocation_snapshot_replay_conflict_get_and_owner_isolation(
 
 
 @pytest.mark.asyncio
+async def test_invocation_request_rejects_snake_case_wire_fields_without_creating_a_row(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-snake-case-owner@example.com")
+    definition_response = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(),
+    )
+    assert definition_response.status_code == 201
+    canonical = _invocation_body(definition_response.json()["id"], "PROL-123")
+
+    for canonical_key, snake_case_key in (
+        ("schemaVersion", "schema_version"),
+        ("workflowDefinitionId", "workflow_definition_id"),
+        ("expectedRevision", "expected_revision"),
+    ):
+        invocation_id = str(uuid4())
+        body = deepcopy(canonical)
+        body[snake_case_key] = body.pop(canonical_key)
+
+        rejected = await client.put(
+            f"/v1/workflow-invocations/{invocation_id}",
+            headers=_headers(owner),
+            json=body,
+        )
+
+        assert rejected.status_code == 422
+        assert any(
+            tuple(error["loc"]) == ("body", snake_case_key) and error["type"] == "extra_forbidden"
+            for error in rejected.json()["detail"]
+        )
+        missing = await client.get(
+            f"/v1/workflow-invocations/{invocation_id}",
+            headers=_headers(owner),
+        )
+        assert missing.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_real_postgres_advisory_lock_races(
     client: AsyncClient,
 ) -> None:

--- a/server/tests/unit/test_cloud_connect_race.py
+++ b/server/tests/unit/test_cloud_connect_race.py
@@ -15,29 +15,35 @@ from proliferate.server.cloud.materialization.sandbox_io.target import (
 
 
 class _FakeDb:
-    def __init__(self) -> None:
+    def __init__(self, events: list[str]) -> None:
         self.commits = 0
+        self.events = events
 
     async def commit(self) -> None:
         self.commits += 1
+        self.events.append("commit")
 
 
 class _FakeProvider:
     template_version = "e2b"
 
-    def __init__(self) -> None:
+    def __init__(self, events: list[str]) -> None:
         self.destroyed: list[str] = []
+        self.events = events
 
     async def create_sandbox(self, *, metadata: dict[str, str] | None = None) -> Any:
+        self.events.append("provider_create")
         return SimpleNamespace(sandbox_id="sbx-new")
 
     async def destroy_sandbox(self, sandbox_id: str) -> None:
         self.destroyed.append(sandbox_id)
+        self.events.append("provider_destroy")
 
 
 @pytest.mark.asyncio
 async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider = _FakeProvider()
+    events: list[str] = []
+    provider = _FakeProvider(events)
     sandbox = SimpleNamespace(
         id=uuid.uuid4(),
         destroyed_at=None,
@@ -51,6 +57,7 @@ async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatc
         return None
 
     async def _record_none(*_a: Any, **_k: Any) -> None:
+        events.append("record_none")
         return None  # row destroyed mid-create
 
     monkeypatch.setattr(connect, "assert_cloud_sandbox_resume_allowed", _resume_allowed)
@@ -61,10 +68,12 @@ async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatc
         _record_none,
     )
 
-    db = _FakeDb()
+    db = _FakeDb(events)
     with pytest.raises(CloudMaterializationCommandError):
         await connect.connect_ready_sandbox(db, sandbox=sandbox)
 
     assert provider.destroyed == ["sbx-new"]
-    # Never committed the lost record and never proceeded to resume/launch.
-    assert db.commits == 0
+    # The billing/read phase was committed before provider I/O, but the lost
+    # provider record was never committed and resume/launch never began.
+    assert db.commits == 1
+    assert events == ["commit", "provider_create", "record_none", "provider_destroy"]


### PR DESCRIPTION
## Summary
- require complete GitHub App operator configuration on both Cloud repository discovery paths
- enforce canonical camelCase-only request bodies for workflow definitions and invocations while preserving internal response construction
- provision real Redis in Server CI so GitHub authorization refresh exercises its production lease contract
- reconcile sandbox transaction and relay telemetry assertions with current behavior

## Proof
- exact-head focused proof: `48 passed` across real-Redis GitHub reauthorization, workflow definition/invocation wire validation, relay, and sandbox-race suites
- broader impacted proof before the final contract hardening: `92 passed`
- Ruff check and format check pass
- `actionlint` and `git diff --check` pass
- full Server CI is running on the exact head with Redis 7

## Release context
Repairs all nine failures exposed by the full server suite in Hotfix Production run 29539378255 and adds regression proof for cached-token operator-gate bypass.