### PR TITLE
fix(server): restore release suite contracts

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -109,6 +109,15 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
         with:

--- a/server/proliferate/server/workflows/models.py
+++ b/server/proliferate/server/workflows/models.py
@@ -31,20 +31,32 @@ class WorkflowWireModel(BaseModel):
     )
 
 
-class WorkflowInputDefinition(WorkflowWireModel):
+class WorkflowDefinitionWireModel(WorkflowWireModel):
+    """Definition JSON accepts only its canonical camel-case wire aliases."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=False,
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+
+class WorkflowInputDefinition(WorkflowDefinitionWireModel):
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=64)]
     type: Literal["string", "number", "boolean"]
     required: bool
 
 
-class WorkflowGoalDefinition(WorkflowWireModel):
+class WorkflowGoalDefinition(WorkflowDefinitionWireModel):
     objective: Annotated[
         str,
         StringConstraints(strip_whitespace=True, min_length=1, max_length=20_000),
     ]
 
 
-class WorkflowPromptStep(WorkflowWireModel):
+class WorkflowPromptStep(WorkflowDefinitionWireModel):
     kind: Literal["agent.prompt"]
     prompt: Annotated[str, StringConstraints(min_length=1, max_length=100_000)]
     goal: WorkflowGoalDefinition | None = None
@@ -57,7 +69,7 @@ class WorkflowPromptStep(WorkflowWireModel):
         return value
 
 
-class WorkflowHarnessConfig(WorkflowWireModel):
+class WorkflowHarnessConfig(WorkflowDefinitionWireModel):
     agent_kind: Annotated[
         str,
         StringConstraints(strip_whitespace=True, min_length=1, max_length=32),
@@ -78,12 +90,12 @@ class WorkflowHarnessConfig(WorkflowWireModel):
     ) = None
 
 
-class WorkflowStageDefinition(WorkflowWireModel):
+class WorkflowStageDefinition(WorkflowDefinitionWireModel):
     harness_config: WorkflowHarnessConfig
     steps: list[WorkflowPromptStep] = Field(min_length=1, max_length=64)
 
 
-class WorkflowDefinitionDocument(WorkflowWireModel):
+class WorkflowDefinitionDocument(WorkflowDefinitionWireModel):
     inputs: list[WorkflowInputDefinition] = Field(default_factory=list, max_length=64)
     stages: list[WorkflowStageDefinition] = Field(min_length=1, max_length=64)
 
@@ -99,6 +111,16 @@ class WorkflowDefinitionUpdateRequest(WorkflowDefinitionCreateRequest):
 
 
 class WorkflowDefinitionResponse(WorkflowDefinitionDocument):
+    # Response construction remains name-friendly for internal Python callers;
+    # only the HTTP request models reject non-canonical snake-case wire keys.
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+    )
+
     id: UUID
     user_id: UUID
     title: str
@@ -143,6 +165,18 @@ class WorkflowInvocationWireModel(WorkflowWireModel):
     )
 
 
+class WorkflowInvocationRequestWireModel(WorkflowInvocationWireModel):
+    """Invocation requests accept only canonical camel-case wire aliases."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=False,
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+
 WorkflowInvocationScalar = StrictBool | StrictInt | StrictFloat | StrictStr
 
 
@@ -150,7 +184,7 @@ class ManagedCloudWorkflowTarget(WorkflowInvocationWireModel):
     kind: Literal["managedCloud"]
 
 
-class WorkflowInvocationCreateRequest(WorkflowInvocationWireModel):
+class WorkflowInvocationCreateRequest(WorkflowInvocationRequestWireModel):
     schema_version: Literal[1]
     workflow_definition_id: UUID
     expected_revision: StrictInt = Field(ge=1)

--- a/server/tests/integration/background/test_relay_task.py
+++ b/server/tests/integration/background/test_relay_task.py
@@ -57,7 +57,12 @@ async def test_relay_task_publishes_committed_health_noop(
     # Scheduler-store/relay liveness heartbeat and the bounded per-family
     # backlog gauge are emitted every tick for the hosted metric plane.
     assert metrics["relay_heartbeat"] == 1
-    assert metrics["supported_pending_by_family"] == {"background_health_noop": 0}
+    assert metrics["supported_pending_by_family"] == {
+        "background_health_noop": 0,
+        "workflows_deliver": 0,
+        "workflows_observe": 0,
+        "workflows_cancel": 0,
+    }
 
     db_session.expire_all()
     row = await load_outbox_task(db_session, task.id)

--- a/server/tests/integration/test_workflow_invocations_api.py
+++ b/server/tests/integration/test_workflow_invocations_api.py
@@ -192,6 +192,47 @@ async def test_invocation_snapshot_replay_conflict_get_and_owner_isolation(
 
 
 @pytest.mark.asyncio
+async def test_invocation_request_rejects_snake_case_wire_fields_without_creating_a_row(
+    client: AsyncClient,
+) -> None:
+    owner = await register_and_login(client, "invocation-snake-case-owner@example.com")
+    definition_response = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json=_definition_payload(),
+    )
+    assert definition_response.status_code == 201
+    canonical = _invocation_body(definition_response.json()["id"], "PROL-123")
+
+    for canonical_key, snake_case_key in (
+        ("schemaVersion", "schema_version"),
+        ("workflowDefinitionId", "workflow_definition_id"),
+        ("expectedRevision", "expected_revision"),
+    ):
+        invocation_id = str(uuid4())
+        body = deepcopy(canonical)
+        body[snake_case_key] = body.pop(canonical_key)
+
+        rejected = await client.put(
+            f"/v1/workflow-invocations/{invocation_id}",
+            headers=_headers(owner),
+            json=body,
+        )
+
+        assert rejected.status_code == 422
+        assert any(
+            tuple(error["loc"]) == ("body", snake_case_key) and error["type"] == "extra_forbidden"
+            for error in rejected.json()["detail"]
+        )
+        assert (
+            await client.get(
+                f"/v1/workflow-invocations/{invocation_id}",
+                headers=_headers(owner),
+            )
+        ).status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_real_postgres_advisory_lock_races(
     client: AsyncClient,
 ) -> None:

--- a/server/tests/unit/test_cloud_connect_race.py
+++ b/server/tests/unit/test_cloud_connect_race.py
@@ -15,29 +15,35 @@ from proliferate.server.cloud.materialization.sandbox_io.target import (
 
 
 class _FakeDb:
-    def __init__(self) -> None:
+    def __init__(self, events: list[str]) -> None:
         self.commits = 0
+        self.events = events
 
     async def commit(self) -> None:
         self.commits += 1
+        self.events.append("commit")
 
 
 class _FakeProvider:
     template_version = "e2b"
 
-    def __init__(self) -> None:
+    def __init__(self, events: list[str]) -> None:
         self.destroyed: list[str] = []
+        self.events = events
 
     async def create_sandbox(self, *, metadata: dict[str, str] | None = None) -> Any:
+        self.events.append("provider_create")
         return SimpleNamespace(sandbox_id="sbx-new")
 
     async def destroy_sandbox(self, sandbox_id: str) -> None:
         self.destroyed.append(sandbox_id)
+        self.events.append("provider_destroy")
 
 
 @pytest.mark.asyncio
 async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    provider = _FakeProvider()
+    events: list[str] = []
+    provider = _FakeProvider(events)
     sandbox = SimpleNamespace(
         id=uuid.uuid4(),
         destroyed_at=None,
@@ -51,6 +57,7 @@ async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatc
         return None
 
     async def _record_none(*_a: Any, **_k: Any) -> None:
+        events.append("record_none")
         return None  # row destroyed mid-create
 
     monkeypatch.setattr(connect, "assert_cloud_sandbox_resume_allowed", _resume_allowed)
@@ -61,10 +68,12 @@ async def test_lost_record_destroys_vm_and_raises(monkeypatch: pytest.MonkeyPatc
         _record_none,
     )
 
-    db = _FakeDb()
+    db = _FakeDb(events)
     with pytest.raises(CloudMaterializationCommandError):
         await connect.connect_ready_sandbox(db, sandbox=sandbox)
 
     assert provider.destroyed == ["sbx-new"]
-    # Never committed the lost record and never proceeded to resume/launch.
-    assert db.commits == 0
+    # The billing/read phase was committed before provider I/O, but the lost
+    # provider record was never committed and resume/launch never began.
+    assert db.commits == 1
+    assert events == ["commit", "provider_create", "record_none", "provider_destroy"]


### PR DESCRIPTION
## Outcome

Restores the Server CI contracts inherited by current main without widening product behavior:

- runs the existing GitHub App refresh lease tests against a real Redis 7 service;
- pins the cloud-connect lost-record proof to the current one-commit-before-provider-I/O order;
- updates the relay heartbeat assertion to the literal supported Workflow task-family keys;
- makes workflow definition and invocation create requests accept canonical camelCase only while preserving name-friendly response and internal construction;
- proves rejected snake_case invocation payloads create no durable row.

## Exact custody

- Base: `719b3a9666a2da9038a18a0d2c391c04047f6839`
- Head: `7cc325d99e176689096720917a1c886b93e39df1`
- One scoped commit; five files; no deploy, provision, release, or protected-state mutation.

## Acceptance proof

- 13 focused tests passed against native real Postgres and Redis: all six GitHub App reauthorization paths, cloud-connect ordering and cleanup, relay metrics, strict definition and invocation request boundaries, zero-row-on-reject, replay/conflict, and response fixture parsing.
- 2 managed Workflow output regressions passed: detail projection and history pagination/ownership.
- Ruff check and format-check passed.
- Server-boundary, max-lines, Actionlint, YAML parse, and `git diff --check` passed.

## Scope boundary

This is the narrow canonical support repair for current main. It does not mock the Redis lease, alter GitHub operator configuration, change delivery behavior, adopt PR #1297, or modify PR #1295.