### PR TITLE
fix(server): enforce GitHub App discovery gate

### DIFF
--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -36,6 +36,7 @@ from proliferate.server.cloud.github_app.models import (
 )
 from proliferate.server.cloud.github_app.repo_authority import (
     ensure_fresh_github_app_authorization,
+    require_github_app_runtime_configured,
     require_github_cloud_repo_authority,
 )
 from proliferate.server.cloud.materialization import service as materialization_service
@@ -603,6 +604,7 @@ async def list_github_app_accessible_repositories(
     affiliation: str = DEFAULT_REPO_AFFILIATION,
     visibility: str = DEFAULT_REPO_VISIBILITY,
 ) -> CloudGitRepositoriesPageRecord:
+    require_github_app_runtime_configured()
     authorization = await ensure_fresh_github_app_authorization(db, user_id=user.id)
     credentials = CloudRepoGitHubCredentials(
         user_id=user.id,

--- a/server/proliferate/server/cloud/repos/access.py
+++ b/server/proliferate/server/cloud/repos/access.py
@@ -10,6 +10,7 @@ from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.github_app.repo_authority import (
     ensure_fresh_github_app_authorization,
+    require_github_app_runtime_configured,
 )
 from proliferate.server.cloud.repos.domain.github_credentials import (
     CloudRepoGitHubCredentials,
@@ -20,6 +21,7 @@ async def current_cloud_repo_github_credentials(
     user: User = Depends(current_product_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> CloudRepoGitHubCredentials:
+    require_github_app_runtime_configured()
     authorization = await ensure_fresh_github_app_authorization(db, user_id=user.id)
     return CloudRepoGitHubCredentials(
         user_id=user.id,

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -27,6 +27,21 @@ from proliferate.integrations.github import GitHubUserProfile
 from proliferate.utils.crypto import encrypt_text
 
 
+def _configure_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make point-of-use auth tests exercise a ready operator deployment."""
+
+    for field, value in {
+        "github_app_id": "12345",
+        "github_app_slug": "test-cloud",
+        "github_app_client_id": "Iv1.test-client",
+        "github_app_client_secret": "test-client-secret",
+        "github_app_webhook_secret": "test-webhook-secret",
+        "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
+        "github_app_private_key_path": "",
+    }.items():
+        monkeypatch.setattr(settings, field, value)
+
+
 def _make_pkce_pair() -> tuple[str, str]:
     verifier = "test-code-verifier-that-is-long-enough-for-pkce"
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
@@ -604,6 +619,7 @@ class TestSingleOrgProductUserBypass:
         """
         monkeypatch.setattr(settings, "password_auth_enabled", True)
         monkeypatch.setattr(settings, "single_org_mode_override", True)
+        _configure_github_app(monkeypatch)
         await _create_password_user("single-org-no-github@example.com", self.password)
 
         login = await client.post(

--- a/server/tests/integration/test_github_app_reauthorization.py
+++ b/server/tests/integration/test_github_app_reauthorization.py
@@ -54,6 +54,66 @@ async def _seed_expired_authorization(
     await db_session.commit()
 
 
+async def _seed_current_authorization(
+    db_session: AsyncSession,
+    *,
+    user_id: UUID,
+) -> None:
+    await github_app_store.upsert_github_app_authorization(
+        db_session,
+        user_id=user_id,
+        authorization=GitHubAppUserAuthorization(
+            access_token="current-github-app-token",
+            refresh_token="current-refresh-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=8),
+            refresh_token_expires_at=datetime.now(UTC) + timedelta(days=30),
+            github_user_id="12345",
+            github_login="cloud-tester",
+            permissions={},
+        ),
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/v1/cloud/repos",
+        "/v1/cloud/github-app/accessible-repos",
+    ],
+)
+async def test_repo_discovery_fails_closed_when_operator_config_is_incomplete(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+) -> None:
+    for field in (
+        "github_app_id",
+        "github_app_slug",
+        "github_app_client_id",
+        "github_app_client_secret",
+        "github_app_webhook_secret",
+        "github_app_private_key",
+        "github_app_private_key_path",
+    ):
+        monkeypatch.setattr(repo_authority.settings, field, "")
+    session = await register_and_login(
+        client,
+        f"github-operator-config-{uuid4().hex[:8]}@example.com",
+    )
+    await _seed_current_authorization(db_session, user_id=UUID(session["user_id"]))
+
+    response = await client.get(
+        endpoint,
+        headers={"Authorization": f"Bearer {session['access_token']}"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "github_app_not_configured"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failure_mode", ["bad_refresh_token", "missing_refresh_token"])
 @pytest.mark.parametrize(
@@ -70,6 +130,7 @@ async def test_permanent_refresh_failure_returns_409_and_persists_reauth(
     failure_mode: str,
     endpoint: str,
 ) -> None:
+    _configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-reauth-{failure_mode}-{uuid4().hex[:8]}@example.com",
@@ -171,6 +232,7 @@ async def test_background_materialization_runner_persists_reauth(
     test_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-background-reauth-{uuid4().hex[:8]}@example.com",


### PR DESCRIPTION
## Outcome

Cloud repository discovery now fails closed when the deployment GitHub App configuration is incomplete, even if the user still has a valid cached GitHub token.

## Changes

- Gate both repository-discovery entry points on complete operator GitHub App configuration.
- Preserve the separate user-authentication and repository-installation gates.
- Add cached-token regression coverage for both discovery paths.
- Correct single-organization and reauthorization fixtures so they explicitly model an operator-configured deployment.

## Proof

- 22 focused server tests passed at e0cabccf3.
- Ruff passed on the changed Python files.
- git diff --check passed.
- The broader release-suite repairs already landed independently in #1298.