### PR TITLE
test(server): share GitHub App integration setup

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -46,7 +46,7 @@ server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pe
 server/proliferate/server/cloud/workspaces/service.py 1088 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + scratch/repo-less read guards) + PR 5 exact-ref managed-Cloud creation and association path; split on next growth per guides/domains.md
 server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
 server/tests/integration/test_cloud_workspace_materialization_service.py 1173 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction, generation replay/crash-retry/terminal-reintent) + PR 5 exact-ref create coverage; new fail-closed source cases split to test_cloud_workspace_exact_ref_source.py
-server/tests/integration/test_auth_flow.py 2220 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
+server/tests/integration/test_auth_flow.py 2214 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test
 server/tests/integration/test_billing_api.py 1918 existing server oversized integration test
 server/tests/integration/test_stripe_webhooks.py 1456 existing server oversized integration test

--- a/server/tests/integration/cloud_api_helpers.py
+++ b/server/tests/integration/cloud_api_helpers.py
@@ -95,6 +95,20 @@ async def link_github_account(db_session: AsyncSession, user_id: str) -> None:
     await db_session.commit()
 
 
+def configure_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure a complete GitHub App runtime for integration tests."""
+    for field, value in {
+        "github_app_id": "12345",
+        "github_app_slug": "test-cloud",
+        "github_app_client_id": "Iv1.test-client",
+        "github_app_client_secret": "test-client-secret",
+        "github_app_webhook_secret": "test-webhook-secret",
+        "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
+        "github_app_private_key_path": "",
+    }.items():
+        monkeypatch.setattr(repo_authority.settings, field, value)
+
+
 async def seed_github_app_repo_authority(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -1,7 +1,5 @@
 """Integration tests for the auth flow: GitHub OAuth → desktop PKCE exchange."""
 
-import base64
-import hashlib
 import time
 from datetime import UTC, datetime
 from unittest.mock import Mock
@@ -25,28 +23,8 @@ from proliferate.constants.auth import DESKTOP_GITHUB_CSRF_COOKIE, REFRESH_TOKEN
 from proliferate.db.models.auth import AuthIdentity, ProviderGrant, User
 from proliferate.integrations.github import GitHubUserProfile
 from proliferate.utils.crypto import encrypt_text
-
-
-def _configure_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make point-of-use auth tests exercise a ready operator deployment."""
-
-    for field, value in {
-        "github_app_id": "12345",
-        "github_app_slug": "test-cloud",
-        "github_app_client_id": "Iv1.test-client",
-        "github_app_client_secret": "test-client-secret",
-        "github_app_webhook_secret": "test-webhook-secret",
-        "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
-        "github_app_private_key_path": "",
-    }.items():
-        monkeypatch.setattr(settings, field, value)
-
-
-def _make_pkce_pair() -> tuple[str, str]:
-    verifier = "test-code-verifier-that-is-long-enough-for-pkce"
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    return verifier, challenge
+from tests.helpers.desktop_auth import make_pkce_pair as _make_pkce_pair
+from tests.integration.cloud_api_helpers import configure_github_app
 
 
 async def _create_user_via_manager(
@@ -619,7 +597,7 @@ class TestSingleOrgProductUserBypass:
         """
         monkeypatch.setattr(settings, "password_auth_enabled", True)
         monkeypatch.setattr(settings, "single_org_mode_override", True)
-        _configure_github_app(monkeypatch)
+        configure_github_app(monkeypatch)
         await _create_password_user("single-org-no-github@example.com", self.password)
 
         login = await client.post(

--- a/server/tests/integration/test_github_app_reauthorization.py
+++ b/server/tests/integration/test_github_app_reauthorization.py
@@ -14,22 +14,7 @@ from proliferate.integrations.github.app_user_tokens import GitHubAppUserAuthori
 from proliferate.server.cloud.github_app import repo_authority
 from proliferate.server.cloud.materialization import runner as materialization_runner
 from proliferate.server.cloud.materialization.materialize import github_credentials
-from tests.integration.cloud_api_helpers import register_and_login
-
-
-def _configure_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make user-authorization tests exercise a complete operator config."""
-    values = {
-        "github_app_id": "12345",
-        "github_app_slug": "test-cloud",
-        "github_app_client_id": "Iv1.test-client",
-        "github_app_client_secret": "test-client-secret",
-        "github_app_webhook_secret": "test-webhook-secret",
-        "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----",
-        "github_app_private_key_path": "",
-    }
-    for field, value in values.items():
-        monkeypatch.setattr(repo_authority.settings, field, value)
+from tests.integration.cloud_api_helpers import configure_github_app, register_and_login
 
 
 async def _seed_expired_authorization(
@@ -130,7 +115,7 @@ async def test_permanent_refresh_failure_returns_409_and_persists_reauth(
     failure_mode: str,
     endpoint: str,
 ) -> None:
-    _configure_github_app(monkeypatch)
+    configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-reauth-{failure_mode}-{uuid4().hex[:8]}@example.com",
@@ -184,7 +169,7 @@ async def test_authority_endpoint_returns_actionable_response_and_persists_reaut
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _configure_github_app(monkeypatch)
+    configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-authority-reauth-{uuid4().hex[:8]}@example.com",
@@ -232,7 +217,7 @@ async def test_background_materialization_runner_persists_reauth(
     test_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _configure_github_app(monkeypatch)
+    configure_github_app(monkeypatch)
     session = await register_and_login(
         client,
         f"github-background-reauth-{uuid4().hex[:8]}@example.com",


### PR DESCRIPTION
## Outcome

Repairs the current-main max-lines regression introduced by #1299 without increasing or weakening the allowlist:

- extracts the duplicated complete GitHub App integration-test setup into the existing Cloud API helper owner;
- reuses that helper from the auth-flow and reauthorization suites;
- replaces the duplicate local PKCE implementation with the existing shared desktop-auth helper;
- lowers the existing `test_auth_flow.py` allowance from 2220 to its new exact 2214 lines.

## Exact custody

- Base: `5848d3e7a564a6b1f6a266c4703676124ebc2f7b` — current main, including the independently merged UTC-midnight billing repair #1301.
- Head: `d3d1633550846cf3ef5e841ab5626096e56738c6`.
- One test-only commit; four files; no product-code or #1295 changes.
- Clean non-overlapping rebase from the prior reviewed head.

## Verification on the exact head

- Full affected integration suites plus the previously failing billing regression: `57 passed` against native Postgres and Redis.
- `python3 scripts/check_max_lines.py`: passed.
- `python3 scripts/check_server_boundaries.py`: passed.
- Touched-file Ruff check and format-check: passed.
- `git diff --check`: passed.
- Full GitHub CI: rerunning on this exact head.

## Scope

No production behavior, deployment, release, protected state, or Workflow contract changed. This separate support repair only restores current-main repository shape so #1295 can restack onto a green base.