### PR TITLE
fix(server): bucket usage timeseries in UTC

### DIFF
--- a/server/proliferate/db/store/agent_gateway/usage.py
+++ b/server/proliferate/db/store/agent_gateway/usage.py
@@ -142,7 +142,7 @@ async def llm_cost_usd_timeseries(
     Scoped to a billing subject (org or personal); optionally filtered to one
     user. Missing buckets are not zero-filled here — the caller fills gaps.
     """
-    bucket = func.date_trunc(granularity, AgentLlmUsageEvent.occurred_at)
+    bucket = func.date_trunc(granularity, AgentLlmUsageEvent.occurred_at, "UTC")
     conditions = [
         AgentLlmUsageEvent.billing_subject_id == billing_subject_id,
         AgentLlmUsageEvent.occurred_at >= _coerce_utc(start),
@@ -161,7 +161,7 @@ async def llm_cost_usd_timeseries(
             .order_by(bucket)
         )
     ).all()
-    return [(_coerce_utc(bucket_start), float(cost or 0.0)) for bucket_start, cost in rows]
+    return [(bucket_start.astimezone(UTC), float(cost or 0.0)) for bucket_start, cost in rows]
 
 
 async def llm_cost_usd_by_user(

--- a/server/proliferate/db/store/billing.py
+++ b/server/proliferate/db/store/billing.py
@@ -320,7 +320,7 @@ async def compute_usage_seconds_timeseries(
     Buckets are attributed by ``started_at`` (see ``_clipped_segment_seconds``).
     Missing buckets are not zero-filled here — the caller fills gaps.
     """
-    bucket = func.date_trunc(granularity, UsageSegment.started_at)
+    bucket = func.date_trunc(granularity, UsageSegment.started_at, "UTC")
     window_start = coerce_utc(start) or start
     window_end = coerce_utc(end) or end
     conditions = [

--- a/server/tests/integration/test_billing_usage_api.py
+++ b/server/tests/integration/test_billing_usage_api.py
@@ -152,6 +152,7 @@ async def test_usage_timeseries_zero_fills_missing_buckets(
     user_id = uuid.UUID(session["user_id"])
     subject = await ensure_personal_billing_subject(db_session, user_id)
     now = datetime.now(UTC)
+    segment_start = now - timedelta(minutes=30)
 
     db_session.add(
         UsageSegment(
@@ -160,7 +161,7 @@ async def test_usage_timeseries_zero_fills_missing_buckets(
             workspace_id=uuid.uuid4(),
             sandbox_id=uuid.uuid4(),
             external_sandbox_id=f"sandbox-{uuid.uuid4().hex[:8]}",
-            started_at=now - timedelta(minutes=30),
+            started_at=segment_start,
             ended_at=now - timedelta(minutes=10),
             is_billable=True,
             opened_by="provision",
@@ -180,10 +181,12 @@ async def test_usage_timeseries_zero_fills_missing_buckets(
     assert len(buckets) >= 7
     starts = [b["bucketStart"] for b in buckets]
     assert starts == sorted(starts)
-    today_bucket = buckets[-1]
-    assert today_bucket["computeSeconds"] == 1200.0
-    assert today_bucket["llmCostUsd"] == 0.0
-    assert sum(b["computeSeconds"] for b in buckets[:-1]) == 0.0
+    expected_bucket_start = segment_start.replace(hour=0, minute=0, second=0, microsecond=0)
+    usage_by_start = {datetime.fromisoformat(bucket["bucketStart"]): bucket for bucket in buckets}
+    segment_bucket = usage_by_start[expected_bucket_start]
+    assert segment_bucket["computeSeconds"] == 1200.0
+    assert segment_bucket["llmCostUsd"] == 0.0
+    assert sum(b["computeSeconds"] for b in buckets) == 1200.0
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_organization_usage_api.py
+++ b/server/tests/integration/test_organization_usage_api.py
@@ -216,6 +216,7 @@ async def test_user_usage_timeseries_admin_scoped_to_one_user(
     )
     subject = await ensure_organization_billing_subject(db_session, organization.id)
     now = datetime.now(UTC)
+    segment_start = now - timedelta(minutes=20)
     db_session.add_all(
         [
             UsageSegment(
@@ -224,7 +225,7 @@ async def test_user_usage_timeseries_admin_scoped_to_one_user(
                 workspace_id=uuid.uuid4(),
                 sandbox_id=uuid.uuid4(),
                 external_sandbox_id=f"sandbox-{uuid.uuid4().hex[:8]}",
-                started_at=now - timedelta(minutes=20),
+                started_at=segment_start,
                 ended_at=now - timedelta(minutes=10),
                 is_billable=True,
                 opened_by="provision",
@@ -236,7 +237,7 @@ async def test_user_usage_timeseries_admin_scoped_to_one_user(
                 workspace_id=uuid.uuid4(),
                 sandbox_id=uuid.uuid4(),
                 external_sandbox_id=f"sandbox-{uuid.uuid4().hex[:8]}",
-                started_at=now - timedelta(minutes=20),
+                started_at=segment_start,
                 ended_at=now - timedelta(minutes=10),
                 is_billable=True,
                 opened_by="provision",
@@ -254,7 +255,9 @@ async def test_user_usage_timeseries_admin_scoped_to_one_user(
 
     assert response.status_code == 200
     buckets = response.json()["buckets"]
-    assert buckets[-1]["computeSeconds"] == 600.0
+    expected_bucket_start = segment_start.replace(hour=0, minute=0, second=0, microsecond=0)
+    usage_by_start = {datetime.fromisoformat(bucket["bucketStart"]): bucket for bucket in buckets}
+    assert usage_by_start[expected_bucket_start]["computeSeconds"] == 600.0
     # Only the member's segment counts, not the owner's identical one.
     assert sum(b["computeSeconds"] for b in buckets) == 600.0
 


### PR DESCRIPTION
## Outcome

Usage timeseries now bucket compute and LLM events by UTC regardless of the PostgreSQL session timezone. The release-suite assertions also locate the segment started_at bucket instead of assuming a recent segment always started today.

## Root cause

The 0.3.38 release suite crossed UTC midnight. Two tests created 20–30 minute-old segments in the prior UTC day but asserted against the final current-day bucket. Local reproduction also exposed that PostgreSQL date_trunc inherited the session timezone while API zero-fill buckets are UTC.

## Proof

- 13 billing and organization usage integration tests passed against PostgreSQL configured for America/Los_Angeles.
- Ruff check and format passed.
- git diff --check passed.