### PR TITLE
fix(product): preserve repository readiness hook order

### DIFF
--- a/apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-action-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-action-state.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCloudRepoActionState } from "#product/hooks/cloud/derived/use-cloud-repo-action-state";
+
+vi.mock("@proliferate/cloud-sdk-react", async () => {
+  const { useState } = await import("react");
+  return {
+    useGitHubRepoAuthority: () => {
+      const [authority] = useState({
+        data: { authorized: true, status: "authorized" },
+        isError: false,
+        isPending: false,
+      });
+      return authority;
+    },
+  };
+});
+
+vi.mock("#product/hooks/capabilities/derived/use-app-capabilities", () => ({
+  useAppCapabilities: () => ({
+    githubRepositoryAccessStatus: "ready",
+    managedCloudStatus: "ready",
+  }),
+}));
+
+vi.mock("#product/hooks/auth/facade/use-product-auth", () => ({
+  useProductAuthStatus: () => "authenticated",
+}));
+
+vi.mock("#product/hooks/organizations/facade/use-active-organization", () => ({
+  useActiveOrganization: () => ({
+    activeOrganization: { membership: { role: "owner" } },
+  }),
+}));
+
+vi.mock("#product/lib/domain/settings/admin-roles", () => ({
+  isSettingsAdminRole: () => true,
+}));
+
+vi.mock("#product/lib/domain/settings/repositories", () => ({
+  cloudRepositoryKey: (owner: string, repo: string) => `${owner}/${repo}`,
+}));
+
+vi.mock("@proliferate/product-domain/repos/repo-readiness", () => ({
+  resolveRepositoryReadiness: () => ({ gate: 10 }),
+}));
+
+vi.mock("#product/lib/domain/workspaces/cloud/cloud-workspace-creation", () => ({
+  cloudRepoActionStateFromReadiness: () => ({
+    kind: "ready",
+    label: "New cloud workspace",
+    accessState: "ready",
+  }),
+}));
+
+describe("useCloudRepoActionState", () => {
+  it("keeps its hook order stable when a repository command target appears", () => {
+    const configuredRepoKeys = new Set<string>();
+    const { result, rerender } = renderHook(
+      ({ repoTarget }) => useCloudRepoActionState({
+        repoTarget,
+        configuredRepoKeys,
+        isInitialConfigLoad: false,
+        cloudConnected: true,
+      }),
+      { initialProps: { repoTarget: null as { gitOwner: string; gitRepoName: string } | null } },
+    );
+
+    expect(result.current.kind).toBe("hidden");
+
+    rerender({ repoTarget: { gitOwner: "proliferate-ai", gitRepoName: "proliferate" } });
+
+    expect(result.current.kind).not.toBe("hidden");
+  });
+});

--- a/apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-action-state.ts
+++ b/apps/packages/product-client/src/hooks/cloud/derived/use-cloud-repo-action-state.ts
@@ -20,25 +20,25 @@ export function useCloudRepoActionState(args: {
   const signedIn = useProductAuthStatus() === "authenticated";
   const { activeOrganization } = useActiveOrganization();
   const canManageInstallation = isSettingsAdminRole(activeOrganization?.membership?.role);
-  if (!args.repoTarget) {
-    return { kind: "hidden", label: null, accessState: "hidden" } as const;
-  }
-  const configured = args.repoTarget
-    ? args.configuredRepoKeys.has(cloudRepositoryKey(
-      args.repoTarget.gitOwner,
-      args.repoTarget.gitRepoName,
-    ))
-    : false;
   const operatorReady =
     capabilities.githubRepositoryAccessStatus === "ready"
     && capabilities.managedCloudStatus === "ready";
   // The authority endpoint is meaningful only after the deployment and actor
   // gates, but it must run whether or not a Cloud environment already exists.
-  const shouldCheckAuthority = signedIn && operatorReady;
+  // Keep this hook unconditional: the command target changes from null to a
+  // repository when a repo's create menu opens.
+  const shouldCheckAuthority = args.repoTarget !== null && signedIn && operatorReady;
   const authority = useGitHubRepoAuthority({
     gitOwner: args.repoTarget?.gitOwner,
     gitRepoName: args.repoTarget?.gitRepoName,
   }, shouldCheckAuthority);
+  if (!args.repoTarget) {
+    return { kind: "hidden", label: null, accessState: "hidden" } as const;
+  }
+  const configured = args.configuredRepoKeys.has(cloudRepositoryKey(
+    args.repoTarget.gitOwner,
+    args.repoTarget.gitRepoName,
+  ));
 
   const readiness = resolveRepositoryReadiness({
     requirement: "managed_cloud",


### PR DESCRIPTION
## What changed

- call the GitHub repository-authority query hook on every `useCloudRepoActionState` render
- disable that query while no repository target exists
- add a regression for the exact null-to-repository transition triggered by the sidebar New workspace popover

## Root cause

`useCloudRepoActionState` returned before `useGitHubRepoAuthority` while the command target was null. Opening a repository create menu populated that target, so the next render called an additional React hook and crashed the production Desktop renderer with `undefined is not an object (evaluating l.length)`.

Sentry: `PROLIFERATE-DESKTOP-5N` (release 0.3.38).

## User impact

Opening **New workspace** for a repository no longer trips the application error boundary. The readiness/authority gate still runs only when a concrete repository is present.

## Proof

- ProductClient typecheck
- focused ProductClient tests: 9/9
- Desktop production renderer build
- Web production renderer build
- `git diff --check`