### PR TITLE
feat(workflows): add managed Cloud product experience

### DIFF
--- a/apps/packages/product-client/src/config/app-routes.test.ts
+++ b/apps/packages/product-client/src/config/app-routes.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { APP_ROUTES, LEGACY_APP_ROUTES } from "#product/config/app-routes";
+import { APP_ROUTES, LEGACY_APP_ROUTES, workflowRunRoute } from "#product/config/app-routes";
 
 describe("app routes", () => {
   it("registers workflows as a top-level route", () => {
     expect(APP_ROUTES.workflows).toBe("/workflows");
+  });
+
+  it("builds the canonical definition-scoped run route", () => {
+    expect(workflowRunRoute("definition/one", "run two"))
+      .toBe("/workflows/definition%2Fone/runs/run%20two");
   });
 
   it("does not keep named constants for merged plugin, integration and automation routes", () => {

--- a/apps/packages/product-client/src/config/app-routes.ts
+++ b/apps/packages/product-client/src/config/app-routes.ts
@@ -5,6 +5,10 @@ export const APP_ROUTES = {
   settings: "/settings",
 } as const;
 
+export function workflowRunRoute(workflowDefinitionId: string, runId: string): string {
+  return `${APP_ROUTES.workflows}/${encodeURIComponent(workflowDefinitionId)}/runs/${encodeURIComponent(runId)}`;
+}
+
 export const LEGACY_APP_ROUTES = {
   automations: "/automations",
 } as const;

--- a/apps/packages/product-client/src/hooks/workflows/workflows/use-workflow-run-open-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workflows/workflows/use-workflow-run-open-actions.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useWorkflowRunOpenActions } from "./use-workflow-run-open-actions";
+
+const deps = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  open: vi.fn(),
+}));
+
+vi.mock("#product/hooks/cloud/workflows/use-cloud-workspace-actions", () => ({
+  useCloudWorkspaceActions: () => ({ refreshCloudWorkspace: deps.refresh }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-activation-workflow", () => ({
+  useWorkspaceActivationWorkflow: () => ({ openWorkspaceSession: deps.open }),
+}));
+
+const target = {
+  cloudWorkspaceId: "cloud-1",
+  anyharnessWorkspaceId: "runtime-1",
+  sessionId: "session-1",
+};
+
+describe("useWorkflowRunOpenActions", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it.each(["repositoryWorktree", "scratch"])(
+    "refreshes and opens the exact %s Cloud workspace/session correlation",
+    async (workspaceKind) => {
+      deps.refresh.mockResolvedValue({
+        id: "cloud-1",
+        workspaceKind,
+        productLifecycle: "active",
+        workspaceStatus: "ready",
+        anyharnessWorkspaceId: "runtime-1",
+      });
+      deps.open.mockResolvedValue({ result: "completed" });
+      const { result } = renderHook(() => useWorkflowRunOpenActions());
+
+      let outcome;
+      await act(async () => {
+        outcome = await result.current.openWorkflowRunSession(target);
+      });
+
+      expect(outcome).toEqual({ opened: true });
+      expect(deps.refresh).toHaveBeenCalledWith("cloud-1");
+      expect(deps.open).toHaveBeenCalledWith({
+        workspaceId: "cloud:cloud-1",
+        sessionId: "session-1",
+      });
+    },
+  );
+
+  it.each([
+    ["wrong row", { id: "cloud-2", productLifecycle: "active", workspaceStatus: "ready", anyharnessWorkspaceId: "runtime-1" }],
+    ["archived", { id: "cloud-1", productLifecycle: "archived", workspaceStatus: "archived", anyharnessWorkspaceId: "runtime-1" }],
+    ["replaced runtime", { id: "cloud-1", productLifecycle: "active", workspaceStatus: "ready", anyharnessWorkspaceId: "runtime-2" }],
+  ])("refuses %s without minting or opening a replacement", async (_name, workspace) => {
+    deps.refresh.mockResolvedValue(workspace);
+    const { result } = renderHook(() => useWorkflowRunOpenActions());
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.openWorkflowRunSession(target);
+    });
+
+    expect(outcome).toEqual({
+      opened: false,
+      message: "This workflow session is no longer available.",
+    });
+    expect(deps.open).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/hooks/workflows/workflows/use-workflow-run-open-actions.ts
+++ b/apps/packages/product-client/src/hooks/workflows/workflows/use-workflow-run-open-actions.ts
@@ -1,0 +1,46 @@
+import type { ManagedWorkflowOpenTarget } from "@proliferate/cloud-sdk";
+import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import { useCloudWorkspaceActions } from "#product/hooks/cloud/workflows/use-cloud-workspace-actions";
+import { useWorkspaceActivationWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-activation-workflow";
+
+export interface WorkflowRunOpenResult {
+  opened: boolean;
+  message?: string;
+}
+
+export function useWorkflowRunOpenActions() {
+  const { refreshCloudWorkspace } = useCloudWorkspaceActions();
+  const { openWorkspaceSession } = useWorkspaceActivationWorkflow();
+
+  const openWorkflowRunSession = async (
+    target: ManagedWorkflowOpenTarget,
+  ): Promise<WorkflowRunOpenResult> => {
+    try {
+      const workspace = await refreshCloudWorkspace(target.cloudWorkspaceId);
+      if (
+        workspace.id !== target.cloudWorkspaceId
+        || workspace.productLifecycle !== "active"
+        || workspace.workspaceStatus === "archived"
+        || workspace.anyharnessWorkspaceId !== target.anyharnessWorkspaceId
+      ) {
+        return unavailable();
+      }
+      const result = await openWorkspaceSession({
+        workspaceId: cloudWorkspaceSyntheticId(target.cloudWorkspaceId),
+        sessionId: target.sessionId,
+      });
+      return result.result === "completed" ? { opened: true } : unavailable();
+    } catch {
+      return unavailable();
+    }
+  };
+
+  return { openWorkflowRunSession };
+}
+
+function unavailable(): WorkflowRunOpenResult {
+  return {
+    opened: false,
+    message: "This workflow session is no longer available.",
+  };
+}

--- a/apps/packages/product-client/src/lib/access/cloud/workflow-polling-hook-contract.test.tsx
+++ b/apps/packages/product-client/src/lib/access/cloud/workflow-polling-hook-contract.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import type { ProliferateCloudClient } from "@proliferate/cloud-sdk";
+import { CloudClientProvider } from "@proliferate/cloud-sdk-react/context/CloudClientProvider";
+import { useWorkflowRun } from "@proliferate/cloud-sdk-react/hooks/workflows";
+import { workflowRunDetailKey } from "@proliferate/cloud-sdk-react/lib/query-keys";
+
+describe("managed Workflow polling hook", () => {
+  it("wires the exact cadence and stops for terminal or target-lost projections", async () => {
+    const client = {
+      baseUrl: "https://cloud.example",
+      requestJson: vi.fn().mockResolvedValue(run("queued", null, "pending")),
+    } as unknown as ProliferateCloudClient;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <CloudClientProvider client={client}>{children}</CloudClientProvider>
+      </QueryClientProvider>
+    );
+    const { result, unmount } = renderHook(
+      () => useWorkflowRun("definition-a", "run-a", "user-a"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const key = workflowRunDetailKey(
+      "https://cloud.example",
+      "user-a",
+      "definition-a",
+      "run-a",
+    );
+    const query = queryClient.getQueryCache().find({ queryKey: key });
+    if (!query) throw new Error("workflow run query missing");
+    const interval = (query.options as {
+      refetchInterval?: number | false | ((query: unknown) => number | false);
+    }).refetchInterval;
+    expect(typeof interval).toBe("function");
+    if (typeof interval !== "function") throw new Error("polling callback missing");
+    expect(interval(query)).toBe(3_000);
+
+    queryClient.setQueryData(key, run("accepted", "completed", "live"));
+    expect(interval(query)).toBe(false);
+    queryClient.setQueryData(key, run("accepted", "running", "target_lost"));
+    expect(interval(query)).toBe(false);
+
+    unmount();
+    queryClient.clear();
+  });
+});
+
+function run(
+  deliveryStatus: string,
+  executionStatus: string | null,
+  freshnessStatus: string,
+) {
+  return {
+    id: "run-a",
+    workflowDefinitionId: "definition-a",
+    managedExecution: {
+      deliveryStatus,
+      execution: executionStatus ? { status: executionStatus, cancelRequestedAt: null } : null,
+      freshness: { status: freshnessStatus },
+    },
+  };
+}

--- a/apps/packages/product-client/src/lib/access/cloud/workflow-surface-boundary.test.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/workflow-surface-boundary.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "../../../../../../..");
+
+describe("shared Workflow surface boundary", () => {
+  it("uses only injected open-session callbacks and contains no raw runtime/Tauri clients", () => {
+    const files = [
+      "apps/packages/product-surfaces/src/workflows/WorkflowRunsSurface.tsx",
+      "apps/packages/product-ui/src/workflows/WorkflowRunDetail.tsx",
+      "apps/packages/product-ui/src/workflows/WorkflowRunForm.tsx",
+    ];
+    for (const file of files) {
+      const source = readFileSync(resolve(root, file), "utf8");
+      expect(source).not.toMatch(/@anyharness|\/v1\/workflow-runs|invoke\(|@tauri/iu);
+    }
+  });
+});

--- a/apps/packages/product-client/src/lib/access/cloud/workflows-sdk-contract.test.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/workflows-sdk-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { InfiniteData } from "@tanstack/react-query";
 
 import {
   cancelWorkflowInvocation,
@@ -7,6 +8,20 @@ import {
   listWorkflowInvocationHistory,
 } from "@proliferate/cloud-sdk/client/workflows";
 import type { ProliferateCloudClient } from "@proliferate/cloud-sdk/client/core";
+import type {
+  ManagedWorkflowHistoryItem,
+  ManagedWorkflowHistoryResponse,
+} from "@proliferate/cloud-sdk";
+import {
+  workflowRunDetailKey,
+  workflowRunEligibilityKey,
+  workflowRunHistoryKey,
+} from "@proliferate/cloud-sdk-react/lib/query-keys";
+import {
+  mergeWorkflowRunIntoHistory,
+  workflowRunNeedsPolling,
+  workflowRunRefetchInterval,
+} from "@proliferate/cloud-sdk-react/hooks/workflows";
 
 describe("managed Workflow Cloud SDK contract", () => {
   it("pins detail, deliver, cancel, and cursor-scoped history requests", async () => {
@@ -58,4 +73,144 @@ describe("managed Workflow Cloud SDK contract", () => {
       query: { workflowDefinitionId: "definition-a" },
     });
   });
+
+  it("threads abort signals through every managed-run request", async () => {
+    const requestJson = vi.fn(async (_request: unknown) => ({}));
+    const client = { requestJson } as unknown as ProliferateCloudClient;
+    const signal = new AbortController().signal;
+
+    await getWorkflowInvocation("invocation-a", client, { signal });
+    await deliverWorkflowInvocation("invocation-a", client, { signal });
+    await cancelWorkflowInvocation("invocation-a", client, { signal });
+    await listWorkflowInvocationHistory("definition-a", undefined, client, { signal });
+
+    expect(requestJson.mock.calls.every(([request]) =>
+      (request as { signal?: AbortSignal }).signal === signal
+    )).toBe(true);
+  });
+
+  it("isolates eligibility, history and detail by server, identity, definition and run", () => {
+    expect(workflowRunEligibilityKey("https://a", "user-a", "definition-a", 1))
+      .not.toEqual(workflowRunEligibilityKey("https://b", "user-a", "definition-a", 1));
+    expect(workflowRunEligibilityKey("https://a", "user-a", "definition-a", 1))
+      .not.toEqual(workflowRunEligibilityKey("https://a", "user-a", "definition-a", 2));
+    expect(workflowRunHistoryKey("https://a", "user-a", "definition-a"))
+      .not.toEqual(workflowRunHistoryKey("https://a", "user-b", "definition-a"));
+    expect(workflowRunHistoryKey("https://a", "user-a", "definition-a"))
+      .not.toEqual(workflowRunHistoryKey("https://a", "user-a", "definition-b"));
+    expect(workflowRunDetailKey("https://a", "user-a", "definition-a", "run-a"))
+      .not.toEqual(workflowRunDetailKey("https://a", "user-a", "definition-a", "run-b"));
+    expect(workflowRunHistoryKey("https://a", "user-a", "definition-a"))
+      .not.toContain("cursor-a");
+  });
+
+  it("polls only nonterminal Cloud truth and stops at terminal or target loss", () => {
+    const base = {
+      managedExecution: {
+        deliveryStatus: "queued",
+        freshness: { status: "pending" },
+        execution: null,
+      },
+    };
+    expect(workflowRunNeedsPolling(base as never)).toBe(true);
+    expect(workflowRunRefetchInterval(base as never)).toBe(3_000);
+    expect(workflowRunNeedsPolling({
+      managedExecution: {
+        ...base.managedExecution,
+        deliveryStatus: "accepted",
+        freshness: { status: "live" },
+        execution: { status: "completed", cancelRequestedAt: null },
+      },
+    } as never)).toBe(false);
+    expect(workflowRunRefetchInterval({
+      managedExecution: {
+        ...base.managedExecution,
+        freshness: { status: "target_lost" },
+      },
+    } as never)).toBe(false);
+    expect(workflowRunNeedsPolling({
+      managedExecution: {
+        ...base.managedExecution,
+        freshness: { status: "target_lost" },
+      },
+    } as never)).toBe(false);
+  });
+
+  it("projects known mutation results without synthesizing cursor order", () => {
+    const current: InfiniteData<
+      ManagedWorkflowHistoryResponse,
+      string | undefined
+    > = {
+      pages: [
+        { items: [historyItem("run-new", "queued"), historyItem("run-target", "queued")], nextCursor: "cursor-2" },
+        { items: [historyItem("run-old", "accepted")], nextCursor: null },
+      ],
+      pageParams: [undefined, "cursor-2"],
+    };
+    const result = mergeWorkflowRunIntoHistory(
+      current,
+      managedRun("run-target", "delivery_cancelled") as never,
+    );
+
+    if (!result) throw new Error("known history cache unexpectedly missing");
+    expect(result.pageParams).toEqual([undefined, "cursor-2"]);
+    expect(result.pages.map((page) => page.nextCursor)).toEqual(["cursor-2", null]);
+    expect(result.pages.flatMap((page) => page.items).map((item) => item.id))
+      .toEqual(["run-new", "run-target", "run-old"]);
+    expect(result.pages[0]?.items[1]?.deliveryStatus).toBe("delivery_cancelled");
+
+    const absentOlder = mergeWorkflowRunIntoHistory(
+      current,
+      {
+        ...managedRun("run-older", "accepted"),
+        createdAt: "2026-07-15T00:00:00Z",
+      } as never,
+    );
+    expect(absentOlder).toBe(current);
+    expect(absentOlder?.pages.flatMap((page) => page.items).map((item) => item.id))
+      .toEqual(["run-new", "run-target", "run-old"]);
+  });
 });
+
+function historyItem(
+  id: string,
+  deliveryStatus: ManagedWorkflowHistoryItem["deliveryStatus"],
+): ManagedWorkflowHistoryItem {
+  return {
+    id,
+    workflowDefinitionId: "definition-a",
+    definitionRevision: 1,
+    title: "Triage",
+    placementKind: "scratch",
+    targetKind: "managedCloud",
+    deliveryStatus,
+    desiredState: "active",
+    executionStatus: null,
+    freshness: "pending",
+    latestObservedAt: null,
+    cloudWorkspaceId: null,
+    sessionId: null,
+    createdAt: "2026-07-16T00:00:00Z",
+    updatedAt: "2026-07-16T00:00:00Z",
+  };
+}
+
+function managedRun(id: string, deliveryStatus: string) {
+  return {
+    id,
+    workflowDefinitionId: "definition-a",
+    definitionRevision: 1,
+    title: "Triage",
+    placement: { kind: "scratch" },
+    target: { kind: "managedCloud" },
+    createdAt: "2026-07-16T00:00:00Z",
+    managedExecution: {
+      deliveryStatus,
+      desiredState: deliveryStatus === "delivery_cancelled" ? "cancelled" : "active",
+      execution: null,
+      freshness: { status: "pending", latestObservedAt: null },
+      correlations: { cloudWorkspaceId: null, sessionId: null },
+      updatedAt: "2026-07-16T00:01:00Z",
+    },
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/capabilities/app-capabilities.ts
+++ b/apps/packages/product-client/src/lib/domain/capabilities/app-capabilities.ts
@@ -41,6 +41,8 @@ export interface AppCapabilities {
   managedCloudStatus: OperatorCapabilityStatus;
   /** The bundled agent LLM gateway is enabled on this server. */
   agentGatewayEnabled: boolean;
+  /** New managed Workflow delivery is enabled by the connected server. */
+  workflowManagedRunsEnabled: boolean;
   /** Server-declared deployment mode. */
   deploymentMode: DeploymentMode;
   /** True when the connected server is not the hosted product. */
@@ -140,6 +142,7 @@ export function deriveAppCapabilities(
       githubRepositoryAccessDisplayName: null,
       managedCloudStatus: "disabled",
       agentGatewayEnabled: false,
+      workflowManagedRunsEnabled: false,
       deploymentMode: "self_managed",
       isSelfManaged: true,
       serverDisplayName: connectedServerHost,
@@ -165,6 +168,7 @@ export function deriveAppCapabilities(
     githubRepositoryAccessDisplayName: githubRepositoryAccess.displayName,
     managedCloudStatus: managedCloud.status,
     agentGatewayEnabled: reachable && contract.agentGateway,
+    workflowManagedRunsEnabled: reachable && contract.workflowManagedRuns === true,
     deploymentMode: contract.deployment.mode,
     isSelfManaged: !hosted,
     serverDisplayName: hosted

--- a/apps/packages/product-client/src/lib/domain/capabilities/derive-app-capabilities.test.ts
+++ b/apps/packages/product-client/src/lib/domain/capabilities/derive-app-capabilities.test.ts
@@ -52,6 +52,7 @@ describe("deriveAppCapabilities", () => {
     expect(caps.usageMeteringEnabled).toBe(true);
     expect(caps.cloudComputeEnabled).toBe(true);
     expect(caps.agentGatewayEnabled).toBe(true);
+    expect(caps.workflowManagedRunsEnabled).toBe(false);
     expect(caps.isSelfManaged).toBe(false);
     expect(caps.serverDisplayName).toBeNull();
     expect(caps.serverLogoUrl).toBeNull();
@@ -145,6 +146,7 @@ describe("deriveAppCapabilities", () => {
         billing: true,
         cloudWorkspaces: true,
         agentGateway: true,
+        workflowManagedRuns: true,
       }),
     });
 
@@ -152,6 +154,20 @@ describe("deriveAppCapabilities", () => {
     expect(caps.billingEnabled).toBe(false);
     expect(caps.cloudComputeEnabled).toBe(false);
     expect(caps.agentGatewayEnabled).toBe(false);
+    expect(caps.workflowManagedRunsEnabled).toBe(false);
+  });
+
+  it("enables managed Workflow runs only from a reachable explicit contract", () => {
+    expect(deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "app.proliferate.com",
+      contract: contract({ workflowManagedRuns: true }),
+    }).workflowManagedRunsEnabled).toBe(true);
+    expect(deriveAppCapabilities({
+      reachable: true,
+      connectedServerHost: "old.example.com",
+      contract: null,
+    }).workflowManagedRunsEnabled).toBe(false);
   });
 });
 

--- a/apps/packages/product-client/src/pages/AuthenticatedAppHost.test.tsx
+++ b/apps/packages/product-client/src/pages/AuthenticatedAppHost.test.tsx
@@ -119,4 +119,15 @@ describe("AuthenticatedAppHost", () => {
     });
     expect(screen.getByTestId("workflows")).toBeTruthy();
   });
+
+  it("keeps a managed Workflow run deep link on the Workflow route", () => {
+    render(
+      <MemoryRouter initialEntries={["/workflows/workflow-1/runs/run-1"]}>
+        <AuthenticatedAppHost MainComponent={TestMain} SettingsComponent={TestSettings} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("workflows")).toBeTruthy();
+    expect(screen.getByTestId("workspace").dataset.visible).toBe("false");
+  });
 });

--- a/apps/packages/product-client/src/pages/AuthenticatedAppHost.tsx
+++ b/apps/packages/product-client/src/pages/AuthenticatedAppHost.tsx
@@ -60,6 +60,7 @@ export function AuthenticatedAppHost({
           <Route path="setup" element={<Navigate to={APP_ROUTES.home} replace />} />
           <Route path="workflows" element={<WorkflowsPage />} />
           <Route path="workflows/:workflowId" element={<WorkflowsPage />} />
+          <Route path="workflows/:workflowId/runs/:runId" element={<WorkflowsPage />} />
           <Route path="automations" element={<LegacyRouteRedirect to={APP_ROUTES.workflows} />} />
           <Route path="automations/:workflowId" element={<LegacyRouteRedirect to={APP_ROUTES.workflows} />} />
           <Route path="workspaces" element={<WorkspacesPage />} />

--- a/apps/packages/product-client/src/pages/WorkflowsPage.test.tsx
+++ b/apps/packages/product-client/src/pages/WorkflowsPage.test.tsx
@@ -13,6 +13,7 @@ import { WorkflowsPage } from "#product/pages/WorkflowsPage";
 import { useAuthStore } from "#product/test/auth-store-double";
 
 const workflowSurface = vi.hoisted(() => vi.fn());
+const runSurface = vi.hoisted(() => vi.fn());
 const authMode = vi.hoisted(() => ({ devBypassed: false }));
 
 class TestIntersectionObserver {
@@ -45,10 +46,30 @@ vi.mock("@proliferate/product-surfaces/workflows/WorkflowDefinitionsSurface", ()
   WorkflowDefinitionsSurface: (props: {
     authCacheScope: string;
     selectedWorkflowId: string | null;
+    managedRunsEnabled: boolean;
   }) => {
     workflowSurface(props);
     return <section data-testid="workflow-definitions" />;
   },
+}));
+
+vi.mock("@proliferate/product-surfaces/workflows/WorkflowRunsSurface", () => ({
+  WorkflowRunsSurface: (props: {
+    authCacheScope: string;
+    workflowDefinitionId: string;
+    runId: string;
+  }) => {
+    runSurface(props);
+    return <section data-testid="workflow-run" />;
+  },
+}));
+
+vi.mock("#product/hooks/capabilities/derived/use-app-capabilities", () => ({
+  useAppCapabilities: () => ({ workflowManagedRunsEnabled: true }),
+}));
+
+vi.mock("#product/hooks/workflows/workflows/use-workflow-run-open-actions", () => ({
+  useWorkflowRunOpenActions: () => ({ openWorkflowRunSession: vi.fn() }),
 }));
 
 vi.mock("#product/components/workspace/shell/screen/MainSidebarPageShell", () => ({
@@ -69,6 +90,7 @@ function renderWorkflows(path = "/workflows") {
       <Routes>
         <Route path="/workflows" element={<WorkflowsPage />} />
         <Route path="/workflows/:workflowId" element={<WorkflowsPage />} />
+        <Route path="/workflows/:workflowId/runs/:runId" element={<WorkflowsPage />} />
         <Route path="/login" element={<LoginProbe />} />
       </Routes>
     </MemoryRouter>,
@@ -89,6 +111,7 @@ describe("WorkflowsPage authentication boundary", () => {
   afterEach(() => {
     cleanup();
     workflowSurface.mockClear();
+    runSurface.mockClear();
   });
 
   it("shows a sign-in gate without mounting cloud workflow queries", () => {
@@ -150,6 +173,30 @@ describe("WorkflowsPage authentication boundary", () => {
     expect(workflowSurface).toHaveBeenCalledWith(expect.objectContaining({
       authCacheScope: "user-1",
       selectedWorkflowId: "workflow-1",
+      managedRunsEnabled: true,
     }));
+  });
+
+  it("mounts the definition-scoped run deep link with the authenticated scope", () => {
+    useAuthStore.setState({
+      status: "authenticated",
+      session: null,
+      user: {
+        id: "user-1",
+        email: "user@example.com",
+        display_name: "Test User",
+      },
+      error: null,
+    });
+
+    renderWorkflows("/workflows/workflow-1/runs/run-1");
+
+    expect(screen.getByTestId("workflow-run")).toBeTruthy();
+    expect(runSurface).toHaveBeenCalledWith(expect.objectContaining({
+      authCacheScope: "user-1",
+      workflowDefinitionId: "workflow-1",
+      runId: "run-1",
+    }));
+    expect(workflowSurface).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/pages/WorkflowsPage.tsx
+++ b/apps/packages/product-client/src/pages/WorkflowsPage.tsx
@@ -1,19 +1,22 @@
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { WorkflowDefinitionsSurface } from "@proliferate/product-surfaces/workflows/WorkflowDefinitionsSurface";
+import { WorkflowRunsSurface } from "@proliferate/product-surfaces/workflows/WorkflowRunsSurface";
 import { WorkflowDefinitionsAccessScreen } from "#product/components/workflows/definitions/WorkflowDefinitionsAccessScreen";
 import { MainSidebarPageShell } from "#product/components/workspace/shell/screen/MainSidebarPageShell";
-import { APP_ROUTES } from "#product/config/app-routes";
+import { APP_ROUTES, workflowRunRoute } from "#product/config/app-routes";
 import { WORKFLOW_AUTH_COPY } from "#product/copy/workflows/workflow-copy";
 import { isDevAuthBypassed } from "#product/lib/domain/auth/auth-mode";
 import {
   useProductAuthStatus,
   useProductAuthUserId,
 } from "#product/hooks/auth/facade/use-product-auth";
+import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
+import { useWorkflowRunOpenActions } from "#product/hooks/workflows/workflows/use-workflow-run-open-actions";
 
 export function WorkflowsPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { workflowId } = useParams<{ workflowId: string }>();
+  const { workflowId, runId } = useParams<{ workflowId: string; runId: string }>();
   const authStatus = useProductAuthStatus();
   const authUserId = useProductAuthUserId();
 
@@ -47,14 +50,43 @@ export function WorkflowsPage() {
     );
   }
 
+  return <AuthenticatedWorkflowsPage authUserId={authUserId} workflowId={workflowId} runId={runId} />;
+}
+
+function AuthenticatedWorkflowsPage({
+  authUserId,
+  workflowId,
+  runId,
+}: {
+  authUserId: string;
+  workflowId?: string;
+  runId?: string;
+}) {
+  const navigate = useNavigate();
+  const capabilities = useAppCapabilities();
+  const { openWorkflowRunSession } = useWorkflowRunOpenActions();
+
   return (
     <MainSidebarPageShell>
-      <WorkflowDefinitionsSurface
-        authCacheScope={authUserId}
-        selectedWorkflowId={workflowId ?? null}
-        onSelectWorkflow={(id) => navigate(`${APP_ROUTES.workflows}/${encodeURIComponent(id)}`)}
-        onBackToList={() => navigate(APP_ROUTES.workflows)}
-      />
+      {workflowId && runId ? (
+        <WorkflowRunsSurface
+          authCacheScope={authUserId}
+          workflowDefinitionId={workflowId}
+          runId={runId}
+          managedRunsEnabled={capabilities.workflowManagedRunsEnabled}
+          onBack={() => navigate(`${APP_ROUTES.workflows}/${encodeURIComponent(workflowId)}`)}
+          onOpenSession={openWorkflowRunSession}
+        />
+      ) : (
+        <WorkflowDefinitionsSurface
+          authCacheScope={authUserId}
+          selectedWorkflowId={workflowId ?? null}
+          managedRunsEnabled={capabilities.workflowManagedRunsEnabled}
+          onSelectWorkflow={(id) => navigate(`${APP_ROUTES.workflows}/${encodeURIComponent(id)}`)}
+          onOpenRun={(definitionId, invocationId) => navigate(workflowRunRoute(definitionId, invocationId))}
+          onBackToList={() => navigate(APP_ROUTES.workflows)}
+        />
+      )}
     </MainSidebarPageShell>
   );
 }

--- a/apps/packages/product-domain/package.json
+++ b/apps/packages/product-domain/package.json
@@ -67,6 +67,14 @@
       "types": "./dist/workflows/validation.d.ts",
       "import": "./dist/workflows/validation.js"
     },
+    "./workflows/arguments": {
+      "types": "./dist/workflows/arguments.d.ts",
+      "import": "./dist/workflows/arguments.js"
+    },
+    "./workflows/run-presentation": {
+      "types": "./dist/workflows/run-presentation.d.ts",
+      "import": "./dist/workflows/run-presentation.js"
+    },
     "./chats/model": {
       "types": "./dist/chats/model.d.ts",
       "import": "./dist/chats/model.js"

--- a/apps/packages/product-domain/src/workflows/arguments.test.ts
+++ b/apps/packages/product-domain/src/workflows/arguments.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { WorkflowInputDefinition } from "@proliferate/cloud-sdk";
+import {
+  createManagedWorkflowLaunchAttempt,
+  createWorkflowArgumentDraft,
+  normalizeWorkflowArguments,
+} from "./arguments";
+
+const inputs: WorkflowInputDefinition[] = [
+  { name: "ticket", type: "string", required: true },
+  { name: "attempts", type: "number", required: false },
+  { name: "notify", type: "boolean", required: false },
+];
+
+describe("workflow run arguments", () => {
+  it("preserves definition order and omits unreferenced optional inputs", () => {
+    const draft = createWorkflowArgumentDraft(inputs);
+    draft.ticket = { supplied: true, value: "PROL-123" };
+
+    expect(normalizeWorkflowArguments(inputs, "Investigate {{inputs.ticket}}", draft))
+      .toEqual({ arguments: { ticket: "PROL-123" }, issues: [] });
+  });
+
+  it("requires optional inputs referenced by the prompt", () => {
+    const draft = createWorkflowArgumentDraft(inputs);
+    draft.ticket = { supplied: true, value: "PROL-123" };
+
+    expect(normalizeWorkflowArguments(
+      inputs,
+      "Try {{inputs.attempts}} times for {{inputs.ticket}}",
+      draft,
+    ).issues).toContainEqual({
+      path: "arguments.attempts",
+      code: "missing",
+      message: "This optional input is used by the prompt and must be supplied for this run.",
+    });
+  });
+
+  it.each([
+    ["1", 1],
+    ["1.5", 1.5],
+    ["1e2", 100],
+    ["-0", 0],
+    ["9007199254740991", 9_007_199_254_740_991],
+  ])("accepts portable number %s", (raw, expected) => {
+    const draft = createWorkflowArgumentDraft(inputs);
+    draft.ticket = { supplied: true, value: "PROL-123" };
+    draft.attempts = { supplied: true, value: raw };
+
+    expect(normalizeWorkflowArguments(inputs, "Investigate", draft))
+      .toEqual({ arguments: { ticket: "PROL-123", attempts: expected }, issues: [] });
+  });
+
+  it.each(["", "NaN", "Infinity", "9007199254740992"])(
+    "rejects nonportable number %s",
+    (raw) => {
+      const draft = createWorkflowArgumentDraft(inputs);
+      draft.ticket = { supplied: true, value: "PROL-123" };
+      draft.attempts = { supplied: true, value: raw };
+
+      expect(normalizeWorkflowArguments(inputs, "Investigate", draft).issues)
+        .toContainEqual(expect.objectContaining({
+          path: "arguments.attempts",
+          code: "invalid_number",
+        }));
+    },
+  );
+
+  it("keeps explicit false and rejects extra inputs", () => {
+    const draft = createWorkflowArgumentDraft(inputs);
+    draft.ticket = { supplied: true, value: "PROL-123" };
+    draft.notify = { supplied: true, value: false };
+    draft.extra = { supplied: true, value: "private" };
+
+    const result = normalizeWorkflowArguments(inputs, "Investigate", draft);
+    expect(result.arguments).toEqual({ ticket: "PROL-123", notify: false });
+    expect(result.issues).toContainEqual(expect.objectContaining({
+      path: "arguments.extra",
+      code: "unknown",
+    }));
+  });
+
+  it("builds one immutable managed-Cloud request identity for retries", () => {
+    const attempt = createManagedWorkflowLaunchAttempt(
+      "40000000-0000-4000-8000-000000000001",
+      "10000000-0000-4000-8000-000000000001",
+      7,
+      { ticket: "PROL-123", notify: false },
+    );
+
+    expect(attempt).toEqual({
+      invocationId: "40000000-0000-4000-8000-000000000001",
+      request: {
+        schemaVersion: 1,
+        workflowDefinitionId: "10000000-0000-4000-8000-000000000001",
+        expectedRevision: 7,
+        arguments: { ticket: "PROL-123", notify: false },
+        target: { kind: "managedCloud" },
+      },
+    });
+    expect(attempt.request).toBe(attempt.request);
+  });
+});

--- a/apps/packages/product-domain/src/workflows/arguments.ts
+++ b/apps/packages/product-domain/src/workflows/arguments.ts
@@ -1,0 +1,134 @@
+import type {
+  WorkflowInputDefinition,
+  WorkflowInvocationCreateRequest,
+} from "@proliferate/cloud-sdk";
+
+export type WorkflowArgumentScalar = string | number | boolean;
+
+export interface WorkflowArgumentDraftValue {
+  supplied: boolean;
+  value: string | boolean;
+}
+
+export type WorkflowArgumentDraft = Record<string, WorkflowArgumentDraftValue>;
+
+export interface WorkflowArgumentIssue {
+  path: string;
+  code: "missing" | "invalid_number" | "unknown";
+  message: string;
+}
+
+export interface WorkflowArgumentsResult {
+  arguments: Record<string, WorkflowArgumentScalar>;
+  issues: WorkflowArgumentIssue[];
+}
+
+const SAFE_INTEGER_LIMIT = 9_007_199_254_740_991;
+const INPUT_REFERENCE = /\{\{inputs\.([A-Za-z][A-Za-z0-9_]*)\}\}/gu;
+
+export function createWorkflowArgumentDraft(
+  inputs: readonly WorkflowInputDefinition[],
+): WorkflowArgumentDraft {
+  return Object.fromEntries(inputs.map((input) => [
+    input.name,
+    {
+      supplied: false,
+      value: input.type === "boolean" ? false : "",
+    },
+  ]));
+}
+
+export function referencedWorkflowInputNames(prompt: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const match of prompt.matchAll(INPUT_REFERENCE)) {
+    if (match[1]) names.add(match[1]);
+  }
+  return names;
+}
+
+export function normalizeWorkflowArguments(
+  inputs: readonly WorkflowInputDefinition[],
+  prompt: string,
+  draft: WorkflowArgumentDraft,
+): WorkflowArgumentsResult {
+  const argumentsValue: Record<string, WorkflowArgumentScalar> = {};
+  const issues: WorkflowArgumentIssue[] = [];
+  const declared = new Set(inputs.map((input) => input.name));
+  const referenced = referencedWorkflowInputNames(prompt);
+
+  for (const key of Object.keys(draft)) {
+    if (!declared.has(key)) {
+      issues.push({
+        path: `arguments.${key}`,
+        code: "unknown",
+        message: "This input is not declared by the workflow.",
+      });
+    }
+  }
+
+  for (const input of inputs) {
+    const value = draft[input.name];
+    const requiredForRun = input.required || referenced.has(input.name);
+    if (!value?.supplied) {
+      if (requiredForRun) {
+        issues.push({
+          path: `arguments.${input.name}`,
+          code: "missing",
+          message: input.required
+            ? "This input is required."
+            : "This optional input is used by the prompt and must be supplied for this run.",
+        });
+      }
+      continue;
+    }
+
+    if (input.type === "boolean") {
+      argumentsValue[input.name] = value.value === true;
+      continue;
+    }
+    if (input.type === "string") {
+      argumentsValue[input.name] = String(value.value);
+      continue;
+    }
+
+    const raw = String(value.value).trim();
+    const parsed = raw === "" ? Number.NaN : Number(raw);
+    if (
+      !Number.isFinite(parsed)
+      || (Number.isInteger(parsed) && Math.abs(parsed) > SAFE_INTEGER_LIMIT)
+    ) {
+      issues.push({
+        path: `arguments.${input.name}`,
+        code: "invalid_number",
+        message: "Enter a finite portable number within the safe integer range.",
+      });
+      continue;
+    }
+    argumentsValue[input.name] = Object.is(parsed, -0) ? 0 : parsed;
+  }
+
+  return { arguments: argumentsValue, issues };
+}
+
+export interface ManagedWorkflowLaunchAttempt {
+  invocationId: string;
+  request: WorkflowInvocationCreateRequest;
+}
+
+export function createManagedWorkflowLaunchAttempt(
+  invocationId: string,
+  workflowDefinitionId: string,
+  expectedRevision: number,
+  argumentsValue: Record<string, WorkflowArgumentScalar>,
+): ManagedWorkflowLaunchAttempt {
+  return {
+    invocationId,
+    request: {
+      schemaVersion: 1,
+      workflowDefinitionId,
+      expectedRevision,
+      arguments: { ...argumentsValue },
+      target: { kind: "managedCloud" },
+    },
+  };
+}

--- a/apps/packages/product-domain/src/workflows/run-presentation.test.ts
+++ b/apps/packages/product-domain/src/workflows/run-presentation.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import type { ManagedWorkflowInvocationResponse } from "@proliferate/cloud-sdk";
+import {
+  safeWorkflowFailureCopy,
+  workflowHistoryItemPresentation,
+  workflowRunPresentation,
+  workflowRunTelemetryView,
+} from "./run-presentation";
+
+function run(overrides: {
+  delivery?: ManagedWorkflowInvocationResponse["managedExecution"]["deliveryStatus"];
+  desired?: ManagedWorkflowInvocationResponse["managedExecution"]["desiredState"];
+  execution?: NonNullable<ManagedWorkflowInvocationResponse["managedExecution"]["execution"]>["status"] | null;
+  freshness?: ManagedWorkflowInvocationResponse["managedExecution"]["freshness"]["status"];
+  observedAt?: string | null;
+  open?: boolean;
+  cancelRequestedAt?: string | null;
+} = {}): ManagedWorkflowInvocationResponse {
+  return {
+    id: "run-1",
+    schemaVersion: 1,
+    workflowDefinitionId: "workflow-1",
+    definitionRevision: 1,
+    title: "Triage",
+    description: "",
+    definition: {
+      inputs: [{ name: "ticket", type: "string", required: true }],
+      stages: [{
+        harnessConfig: {
+          agentKind: "claude",
+          modelSelection: { kind: "targetDefault" },
+          permissionPolicy: "workflowDefault",
+          effort: null,
+        },
+        steps: [{ kind: "agent.prompt", prompt: "Investigate {{inputs.ticket}}" }],
+      }],
+    },
+    arguments: { ticket: "PROL-123" },
+    placement: { kind: "scratch" },
+    target: { kind: "managedCloud" },
+    createdAt: "2026-07-16T00:00:00Z",
+    managedExecution: {
+      deliveryStatus: overrides.delivery ?? "queued",
+      deliveryCheckpoint: "target_plan_frozen",
+      desiredState: overrides.desired ?? "active",
+      execution: overrides.execution === null || overrides.execution === undefined
+        ? null
+        : {
+          status: overrides.execution,
+          stateVersion: 2,
+          cancelRequestedAt: overrides.cancelRequestedAt ?? null,
+          failureCode: null,
+          interruptionCode: overrides.execution === "interrupted" ? "runtime_restarted" : null,
+          stopReason: null,
+          startedAt: null,
+          finishedAt: null,
+          steps: [],
+        },
+      freshness: {
+        status: overrides.freshness ?? "pending",
+        latestObservedAt: overrides.observedAt ?? null,
+      },
+      correlations: {
+        cloudWorkspaceId: overrides.open ? "cloud-1" : null,
+        anyharnessWorkspaceId: overrides.open ? "runtime-1" : null,
+        sessionId: overrides.open ? "session-1" : null,
+        promptId: null,
+        turnId: null,
+      },
+      openTarget: overrides.open ? {
+        cloudWorkspaceId: "cloud-1",
+        anyharnessWorkspaceId: "runtime-1",
+        sessionId: "session-1",
+      } : null,
+      deliveryErrorCode: null,
+      observationErrorCode: null,
+      acceptedAt: null,
+      updatedAt: "2026-07-16T00:00:00Z",
+    },
+  } as ManagedWorkflowInvocationResponse;
+}
+
+describe("workflow run presentation", () => {
+  it("covers the complete delivery, desired, execution, and freshness matrix", () => {
+    const deliveries = ["prepared", "queued", "delivering", "accepted", "delivery_failed", "delivery_cancelled"] as const;
+    const desiredStates = ["active", "cancelled"] as const;
+    const executions = [null, "accepted", "running", "completed", "failed", "cancelled", "interrupted"] as const;
+    const freshnessStates = ["pending", "live", "stale", "unreachable", "target_lost"] as const;
+    let combinations = 0;
+
+    for (const delivery of deliveries) {
+      for (const desired of desiredStates) {
+        for (const execution of executions) {
+          for (const freshness of freshnessStates) {
+            const view = workflowRunPresentation(run({ delivery, desired, execution, freshness }));
+            expect(view.delivery.label).toBeTruthy();
+            expect(view.desired.label).toBeTruthy();
+            expect(view.execution.label).toBeTruthy();
+            expect(view.freshness.label).toBeTruthy();
+            expect(view.primary.label).toBeTruthy();
+            if (freshness === "target_lost") {
+              expect(view.canCancel).toBe(false);
+              expect(view.shouldPoll).toBe(false);
+            }
+            if (execution && ["completed", "failed", "cancelled", "interrupted"].includes(execution)) {
+              expect(view.shouldPoll).toBe(false);
+            }
+            if (delivery === "delivery_failed" || delivery === "delivery_cancelled") {
+              expect(view.shouldPoll).toBe(false);
+            }
+            combinations += 1;
+          }
+        }
+      }
+    }
+
+    expect(combinations).toBe(420);
+  });
+
+  it.each([
+    ["prepared", "Prepared"],
+    ["queued", "Queued"],
+    ["delivering", "Delivering"],
+    ["accepted", "Accepted"],
+    ["delivery_failed", "Delivery failed"],
+    ["delivery_cancelled", "Delivery cancelled"],
+  ] as const)("retains delivery status %s with authored label", (delivery, label) => {
+    expect(workflowRunPresentation(run({ delivery })).delivery.label).toBe(label);
+  });
+
+  it.each([
+    ["accepted", "Accepted"],
+    ["running", "Running"],
+    ["completed", "Completed"],
+    ["failed", "Failed"],
+    ["cancelled", "Cancelled"],
+    ["interrupted", "Interrupted"],
+  ] as const)("maps execution %s without collapsing dimensions", (execution, label) => {
+    expect(workflowRunPresentation(run({ execution })).execution.label).toBe(label);
+  });
+
+  it.each(["pending", "live", "stale", "unreachable", "target_lost"] as const)(
+    "preserves freshness %s",
+    (freshness) => expect(workflowRunPresentation(run({ freshness })).freshness.label).toBeTruthy(),
+  );
+
+  it("shows pending cancellation instead of a false terminal state", () => {
+    const view = workflowRunPresentation(run({
+      desired: "cancelled",
+      execution: "running",
+      cancelRequestedAt: "2026-07-16T00:01:00Z",
+    }));
+    expect(view.primary.label).toBe("Cancellation requested");
+    expect(view.canCancel).toBe(false);
+    expect(view.shouldPoll).toBe(true);
+  });
+
+  it("ends cancellation-pending presentation when delivery is durably cancelled", () => {
+    const cancelled = run({ delivery: "delivery_cancelled", desired: "cancelled" });
+    expect(workflowRunPresentation(cancelled).primary.label).toBe("Delivery cancelled");
+    expect(workflowHistoryItemPresentation({
+      id: cancelled.id,
+      workflowDefinitionId: cancelled.workflowDefinitionId,
+      definitionRevision: cancelled.definitionRevision,
+      title: cancelled.title,
+      placementKind: cancelled.placement.kind,
+      targetKind: cancelled.target.kind,
+      deliveryStatus: cancelled.managedExecution.deliveryStatus,
+      desiredState: cancelled.managedExecution.desiredState,
+      executionStatus: null,
+      freshness: cancelled.managedExecution.freshness.status,
+      latestObservedAt: null,
+      cloudWorkspaceId: null,
+      sessionId: null,
+      createdAt: cancelled.createdAt,
+      updatedAt: cancelled.managedExecution.updatedAt,
+    }).label).toBe("Delivery cancelled");
+  });
+
+  it("distinguishes never-observed unreachable from retained last state", () => {
+    expect(workflowRunPresentation(run({ freshness: "unreachable" })).notice)
+      .toBe("Runtime unreachable; no execution observation yet.");
+    expect(workflowRunPresentation(run({
+      freshness: "unreachable",
+      observedAt: "2026-07-16T00:02:00Z",
+      execution: "running",
+    })).notice).toContain("Last observed");
+  });
+
+  it("absorbs target loss, disables actions, and stops polling", () => {
+    const view = workflowRunPresentation(run({
+      freshness: "target_lost",
+      desired: "cancelled",
+      execution: "running",
+      open: true,
+    }));
+    expect(view.primary.label).toBe("Target lost after cancellation request");
+    expect(view.canCancel).toBe(false);
+    expect(view.canOpenSession).toBe(true);
+    expect(view.shouldPoll).toBe(false);
+  });
+
+  it("preserves the cancellation-before-target-loss truth in history", () => {
+    const cancelled = run({ desired: "cancelled", freshness: "target_lost", execution: "running" });
+    expect(workflowHistoryItemPresentation({
+      id: cancelled.id,
+      workflowDefinitionId: cancelled.workflowDefinitionId,
+      definitionRevision: cancelled.definitionRevision,
+      title: cancelled.title,
+      placementKind: cancelled.placement.kind,
+      targetKind: cancelled.target.kind,
+      deliveryStatus: cancelled.managedExecution.deliveryStatus,
+      desiredState: cancelled.managedExecution.desiredState,
+      executionStatus: "running",
+      freshness: "target_lost",
+      latestObservedAt: cancelled.managedExecution.freshness.latestObservedAt,
+      cloudWorkspaceId: null,
+      sessionId: null,
+      createdAt: cancelled.createdAt,
+      updatedAt: cancelled.managedExecution.updatedAt,
+    }).label).toBe("Target lost after cancellation request");
+  });
+
+  it("uses authored interrupted and stale status copy", () => {
+    expect(workflowRunPresentation(run({ execution: "interrupted", freshness: "live" })).notice)
+      .toBe("The runtime restarted and interrupted this run; it was not replayed.");
+    expect(workflowRunPresentation(run({ freshness: "stale", observedAt: "2026-07-16T00:02:00Z" })).notice)
+      .toContain("Last observed");
+  });
+
+  it("allows exact session opening for terminal runs while keeping polling stopped", () => {
+    const view = workflowRunPresentation(run({
+      delivery: "accepted",
+      execution: "completed",
+      freshness: "live",
+      open: true,
+    }));
+    expect(view.canOpenSession).toBe(true);
+    expect(view.shouldPoll).toBe(false);
+  });
+
+  it("maps stable codes and never reflects raw upstream text", () => {
+    expect(safeWorkflowFailureCopy("session_create_failed"))
+      .toBe("The workflow session could not be created.");
+    expect(safeWorkflowFailureCopy("provider said secret=abc"))
+      .toBe("The workflow could not be completed. Refresh for the latest safe status.");
+  });
+
+  it("excludes frozen argument values from the telemetry projection", () => {
+    const value = workflowRunTelemetryView(run());
+    expect(value).not.toHaveProperty("arguments");
+    expect(JSON.stringify(value)).not.toContain("PROL-123");
+  });
+});

--- a/apps/packages/product-domain/src/workflows/run-presentation.ts
+++ b/apps/packages/product-domain/src/workflows/run-presentation.ts
@@ -1,0 +1,213 @@
+import type {
+  ManagedWorkflowHistoryItem,
+  ManagedWorkflowInvocationResponse,
+} from "@proliferate/cloud-sdk";
+
+export type WorkflowRun = ManagedWorkflowInvocationResponse;
+export type WorkflowRunHistoryItem = ManagedWorkflowHistoryItem;
+
+export type WorkflowRunTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+export interface WorkflowRunStatusView {
+  label: string;
+  tone: WorkflowRunTone;
+}
+
+export interface WorkflowRunPresentation {
+  primary: WorkflowRunStatusView;
+  delivery: WorkflowRunStatusView;
+  desired: WorkflowRunStatusView;
+  execution: WorkflowRunStatusView;
+  freshness: WorkflowRunStatusView;
+  notice: string | null;
+  failure: string | null;
+  canStartDelivery: boolean;
+  canCancel: boolean;
+  canOpenSession: boolean;
+  shouldPoll: boolean;
+}
+
+const TERMINAL_EXECUTION = new Set(["completed", "failed", "cancelled", "interrupted"]);
+
+export function workflowRunPresentation(
+  run: ManagedWorkflowInvocationResponse,
+): WorkflowRunPresentation {
+  const managed = run.managedExecution;
+  const execution = managed.execution;
+  const targetLost = managed.freshness.status === "target_lost";
+  const cancellationPending = isCancellationPending({
+    desiredState: managed.desiredState,
+    deliveryStatus: managed.deliveryStatus,
+    executionStatus: execution?.status ?? null,
+  });
+  const delivery = deliveryPresentation(managed.deliveryStatus);
+  const desired = managed.desiredState === "cancelled"
+    ? { label: "Cancellation requested", tone: "warning" as const }
+    : { label: "Active", tone: "neutral" as const };
+  const executionView = execution
+    ? executionPresentation(execution.status)
+    : { label: "No runtime result", tone: "neutral" as const };
+  const freshness = freshnessPresentation(managed.freshness.status);
+
+  const primary = targetLost
+    ? { label: cancellationPending ? "Target lost after cancellation request" : "Target lost", tone: "warning" as const }
+    : cancellationPending
+      ? { label: "Cancellation requested", tone: "warning" as const }
+      : execution
+        ? executionView
+        : delivery;
+
+  return {
+    primary,
+    delivery,
+    desired,
+    execution: executionView,
+    freshness,
+    notice: workflowRunNotice(run),
+    failure: safeWorkflowFailureCopy(
+      execution?.failureCode
+      ?? managed.deliveryErrorCode
+      ?? managed.observationErrorCode,
+    ),
+    canStartDelivery: managed.deliveryStatus === "prepared"
+      && managed.desiredState === "active"
+      && !targetLost,
+    canCancel: managed.desiredState === "active"
+      && !targetLost
+      && managed.deliveryStatus !== "delivery_failed"
+      && managed.deliveryStatus !== "delivery_cancelled"
+      && (!execution || !TERMINAL_EXECUTION.has(execution.status)),
+    canOpenSession: managed.openTarget !== null,
+    shouldPoll: shouldPollWorkflowRun(run),
+  };
+}
+
+export function shouldPollWorkflowRun(run: ManagedWorkflowInvocationResponse): boolean {
+  const managed = run.managedExecution;
+  if (managed.freshness.status === "target_lost") return false;
+  const execution = managed.execution;
+  if (execution && TERMINAL_EXECUTION.has(execution.status)) return false;
+  if (["delivery_failed", "delivery_cancelled"].includes(managed.deliveryStatus)) return false;
+  return true;
+}
+
+export function workflowHistoryItemPresentation(
+  item: ManagedWorkflowHistoryItem,
+): WorkflowRunStatusView {
+  if (item.freshness === "target_lost") {
+    return {
+      label: item.desiredState === "cancelled"
+        ? "Target lost after cancellation request"
+        : "Target lost",
+      tone: "warning",
+    };
+  }
+  if (isCancellationPending(item)) {
+    return { label: "Cancellation requested", tone: "warning" };
+  }
+  return item.executionStatus
+    ? executionPresentation(item.executionStatus)
+    : deliveryPresentation(item.deliveryStatus);
+}
+
+function isCancellationPending(value: {
+  desiredState: ManagedWorkflowInvocationResponse["managedExecution"]["desiredState"];
+  deliveryStatus: ManagedWorkflowInvocationResponse["managedExecution"]["deliveryStatus"];
+  executionStatus: ManagedWorkflowHistoryItem["executionStatus"];
+}): boolean {
+  return value.desiredState === "cancelled"
+    && value.deliveryStatus !== "delivery_cancelled"
+    && (!value.executionStatus || !TERMINAL_EXECUTION.has(value.executionStatus));
+}
+
+export function safeWorkflowFailureCopy(code: string | null | undefined): string | null {
+  if (!code) return null;
+  const normalized = code.toLowerCase();
+  const known: Record<string, string> = {
+    workflow_target_lost: "The managed runtime was replaced, so the final outcome is unknown.",
+    workflow_run_target_unresolvable: "The selected agent or model is not available on the managed runtime.",
+    workspace_unavailable: "The managed workspace is unavailable.",
+    session_create_failed: "The workflow session could not be created.",
+    session_config_apply_failed: "The workflow session could not apply its required configuration.",
+    prompt_dispatch_failed: "The workflow prompt could not be accepted by the session.",
+    runtime_restarted: "The runtime restarted and interrupted this run; it was not replayed.",
+  };
+  return known[normalized] ?? "The workflow could not be completed. Refresh for the latest safe status.";
+}
+
+export function workflowRunTelemetryView(run: ManagedWorkflowInvocationResponse) {
+  return {
+    invocationId: run.id,
+    workflowDefinitionId: run.workflowDefinitionId,
+    deliveryStatus: run.managedExecution.deliveryStatus,
+    desiredState: run.managedExecution.desiredState,
+    executionStatus: run.managedExecution.execution?.status ?? null,
+    freshness: run.managedExecution.freshness.status,
+    placementKind: run.placement.kind,
+  };
+}
+
+function workflowRunNotice(run: ManagedWorkflowInvocationResponse): string | null {
+  const managed = run.managedExecution;
+  const observed = managed.freshness.latestObservedAt;
+  switch (managed.freshness.status) {
+    case "unreachable":
+      return observed
+        ? `Runtime unreachable. Last observed ${formatDateTime(observed)}.`
+        : "Runtime unreachable; no execution observation yet.";
+    case "stale":
+      return observed ? `Status may be stale. Last observed ${formatDateTime(observed)}.` : "Status may be stale.";
+    case "target_lost":
+      return managed.desiredState === "cancelled"
+        ? "Target lost after cancellation request. The final outcome is unknown."
+        : "The managed runtime was replaced. The final outcome is unknown.";
+    default:
+      if (managed.execution?.status === "interrupted") {
+        return "The runtime restarted and interrupted this run; it was not replayed.";
+      }
+      return null;
+  }
+}
+
+function deliveryPresentation(status: ManagedWorkflowInvocationResponse["managedExecution"]["deliveryStatus"]): WorkflowRunStatusView {
+  const labels = {
+    prepared: ["Prepared", "neutral"],
+    queued: ["Queued", "info"],
+    delivering: ["Delivering", "info"],
+    accepted: ["Accepted", "info"],
+    delivery_failed: ["Delivery failed", "danger"],
+    delivery_cancelled: ["Delivery cancelled", "neutral"],
+  } as const;
+  const [label, tone] = labels[status];
+  return { label, tone };
+}
+
+function executionPresentation(status: NonNullable<ManagedWorkflowInvocationResponse["managedExecution"]["execution"]>["status"]): WorkflowRunStatusView {
+  const labels = {
+    accepted: ["Accepted", "info"],
+    running: ["Running", "info"],
+    completed: ["Completed", "success"],
+    failed: ["Failed", "danger"],
+    cancelled: ["Cancelled", "neutral"],
+    interrupted: ["Interrupted", "warning"],
+  } as const;
+  const [label, tone] = labels[status];
+  return { label, tone };
+}
+
+function freshnessPresentation(status: ManagedWorkflowInvocationResponse["managedExecution"]["freshness"]["status"]): WorkflowRunStatusView {
+  const labels = {
+    pending: ["Pending", "neutral"],
+    live: ["Live", "success"],
+    stale: ["Stale", "warning"],
+    unreachable: ["Runtime unreachable", "warning"],
+    target_lost: ["Target lost", "warning"],
+  } as const;
+  const [label, tone] = labels[status];
+  return { label, tone };
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}

--- a/apps/packages/product-surfaces/package.json
+++ b/apps/packages/product-surfaces/package.json
@@ -42,6 +42,10 @@
     "./workflows/WorkflowDefinitionsSurface": {
       "types": "./dist/workflows/WorkflowDefinitionsSurface.d.ts",
       "import": "./dist/workflows/WorkflowDefinitionsSurface.js"
+    },
+    "./workflows/WorkflowRunsSurface": {
+      "types": "./dist/workflows/WorkflowRunsSurface.d.ts",
+      "import": "./dist/workflows/WorkflowRunsSurface.js"
     }
   },
   "scripts": {

--- a/apps/packages/product-surfaces/src/workflows/PersistedWorkflowEditor.tsx
+++ b/apps/packages/product-surfaces/src/workflows/PersistedWorkflowEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useWorkflowDefinitionActions } from "@proliferate/cloud-sdk-react";
 import {
   isWorkflowRevisionConflict,
@@ -26,6 +26,7 @@ export function PersistedWorkflowEditor({
   reloadDefinition,
   onSaved,
   onBack,
+  supplementalContent,
 }: {
   authCacheScope: string;
   definition: WorkflowDefinition;
@@ -37,6 +38,7 @@ export function PersistedWorkflowEditor({
   reloadDefinition: () => Promise<WorkflowDefinition>;
   onSaved: (workflowId: string) => void;
   onBack: () => void;
+  supplementalContent?: ReactNode;
 }) {
   // The draft is seeded from `base`, not from the live query value: a passive
   // background refetch may bump `definition.revision` while the user is
@@ -140,6 +142,7 @@ export function PersistedWorkflowEditor({
       onCancel={onBack}
       onDelete={() => void remove()}
       onReload={showReload ? () => void reload() : undefined}
+      supplementalContent={supplementalContent}
     />
   );
 }

--- a/apps/packages/product-surfaces/src/workflows/WorkflowDefinitionsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/workflows/WorkflowDefinitionsSurface.test.tsx
@@ -29,6 +29,8 @@ const cloud = vi.hoisted(() => ({
   useWorkflowDefinition: vi.fn(),
   useCloudAgentCatalog: vi.fn(),
   useRepositories: vi.fn(),
+  useWorkflowRunEligibility: vi.fn(),
+  useWorkflowRunHistory: vi.fn(),
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
@@ -36,6 +38,14 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   useWorkflowDefinition: cloud.useWorkflowDefinition,
   useCloudAgentCatalog: cloud.useCloudAgentCatalog,
   useRepositories: cloud.useRepositories,
+  useWorkflowRunEligibility: cloud.useWorkflowRunEligibility,
+  useWorkflowRunHistory: cloud.useWorkflowRunHistory,
+  useWorkflowRunActions: () => ({
+    putWorkflowInvocation: vi.fn(),
+    deliverWorkflowInvocation: vi.fn(),
+    cancelWorkflowInvocation: vi.fn(),
+    checkWorkflowInvocation: vi.fn(),
+  }),
   useWorkflowDefinitionActions: () => ({
     createWorkflowDefinition: cloud.create,
     creatingWorkflowDefinition: false,
@@ -122,6 +132,20 @@ describe("WorkflowDefinitionsSurface", () => {
       data: { repositories: [] },
       isLoading: false,
       isError: false,
+    });
+    cloud.useWorkflowRunEligibility.mockReturnValue({
+      data: { eligible: true, blockers: [] },
+      isLoading: false,
+      isError: false,
+    });
+    cloud.useWorkflowRunHistory.mockReturnValue({
+      data: { pages: [{ items: [], nextCursor: null }] },
+      isLoading: false,
+      isError: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
     cloud.create.mockResolvedValue(persisted);
     cloud.update.mockResolvedValue(persisted);

--- a/apps/packages/product-surfaces/src/workflows/WorkflowDefinitionsSurface.tsx
+++ b/apps/packages/product-surfaces/src/workflows/WorkflowDefinitionsSurface.tsx
@@ -21,12 +21,15 @@ import {
 import { WorkflowDefinitionList } from "@proliferate/product-ui/workflows/WorkflowDefinitionList";
 import { PersistedWorkflowEditor } from "./PersistedWorkflowEditor";
 import { WorkflowResourceState } from "./WorkflowResourceState";
+import { WorkflowDefinitionRunsPanel } from "./WorkflowRunsSurface";
 
 export interface WorkflowDefinitionsSurfaceProps {
   authCacheScope: string;
   selectedWorkflowId?: string | null;
   onSelectWorkflow: (workflowId: string) => void;
   onBackToList: () => void;
+  managedRunsEnabled?: boolean;
+  onOpenRun?: (workflowId: string, runId: string) => void;
 }
 
 export function WorkflowDefinitionsSurface({
@@ -34,6 +37,8 @@ export function WorkflowDefinitionsSurface({
   selectedWorkflowId = null,
   onSelectWorkflow,
   onBackToList,
+  managedRunsEnabled = false,
+  onOpenRun = () => {},
 }: WorkflowDefinitionsSurfaceProps) {
   const [creating, setCreating] = useState(false);
   useEffect(() => {
@@ -65,6 +70,8 @@ export function WorkflowDefinitionsSurface({
         repositoriesLoading={repositoriesQuery.isLoading}
         onSaved={onSelectWorkflow}
         onBack={onBackToList}
+        managedRunsEnabled={managedRunsEnabled}
+        onOpenRun={(runId) => onOpenRun(selectedWorkflowId, runId)}
       />
     );
   }
@@ -197,6 +204,8 @@ function ExistingWorkflowDefinitionEditor({
   repositoriesLoading,
   onSaved,
   onBack,
+  managedRunsEnabled,
+  onOpenRun,
 }: {
   authCacheScope: string;
   workflowId: string;
@@ -207,6 +216,8 @@ function ExistingWorkflowDefinitionEditor({
   repositoriesLoading: boolean;
   onSaved: (workflowId: string) => void;
   onBack: () => void;
+  managedRunsEnabled: boolean;
+  onOpenRun: (runId: string) => void;
 }) {
   const definitionQuery = useWorkflowDefinition(workflowId, authCacheScope);
 
@@ -265,6 +276,14 @@ function ExistingWorkflowDefinitionEditor({
       }}
       onSaved={onSaved}
       onBack={onBack}
+      supplementalContent={(
+        <WorkflowDefinitionRunsPanel
+          authCacheScope={authCacheScope}
+          definition={definition}
+          managedRunsEnabled={managedRunsEnabled}
+          onOpenRun={onOpenRun}
+        />
+      )}
     />
   );
 }

--- a/apps/packages/product-surfaces/src/workflows/WorkflowRunsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/workflows/WorkflowRunsSurface.test.tsx
@@ -1,0 +1,539 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
+import type { WorkflowDefinition } from "@proliferate/product-domain/workflows/definition";
+import { WorkflowDefinitionRunsPanel, WorkflowRunsSurface } from "./WorkflowRunsSurface";
+
+class TestIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+
+const cloud = vi.hoisted(() => ({
+  put: vi.fn(),
+  deliver: vi.fn(),
+  cancel: vi.fn(),
+  check: vi.fn(),
+  useEligibility: vi.fn(),
+  useRun: vi.fn(),
+  useHistory: vi.fn(),
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useWorkflowRunEligibility: cloud.useEligibility,
+  useWorkflowRunHistory: cloud.useHistory,
+  useWorkflowRun: cloud.useRun,
+  useWorkflowRunActions: () => ({
+    putWorkflowInvocation: cloud.put,
+    deliverWorkflowInvocation: cloud.deliver,
+    cancelWorkflowInvocation: cloud.cancel,
+    checkWorkflowInvocation: cloud.check,
+  }),
+}));
+
+const definition: WorkflowDefinition = {
+  id: "10000000-0000-4000-8000-000000000001",
+  userId: "user-1",
+  title: "Triage",
+  description: "",
+  schemaVersion: 1,
+  revision: 3,
+  validatedCatalogVersion: "catalog-1",
+  defaultRepoConfigId: null,
+  inputs: [{ name: "ticket", type: "string", required: true }],
+  stages: [{
+    harnessConfig: { agentKind: "claude", modelId: null, effort: null },
+    steps: [{ kind: "agent.prompt", prompt: "Investigate {{inputs.ticket}}", goal: null }],
+  }],
+  createdAt: "2026-07-16T00:00:00Z",
+  updatedAt: "2026-07-16T00:00:00Z",
+  deletedAt: null,
+};
+
+describe("Workflow managed run surfaces", () => {
+  beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+    vi.stubGlobal("crypto", { randomUUID: () => "40000000-0000-4000-8000-000000000001" });
+    cloud.put.mockResolvedValue({ id: "40000000-0000-4000-8000-000000000001" });
+    cloud.deliver.mockResolvedValue(runFixture());
+    cloud.check.mockResolvedValue(runFixture());
+    cloud.cancel.mockResolvedValue(runFixture());
+    cloud.useEligibility.mockReturnValue({
+      data: { eligible: true, blockers: [] },
+      isLoading: false,
+      isError: false,
+    });
+    cloud.useRun.mockReturnValue({ data: runFixture(), isLoading: false, isError: false, refetch: vi.fn() });
+    cloud.useHistory.mockReturnValue({
+      data: { pages: [{ items: [], nextCursor: null }] },
+      isLoading: false,
+      isError: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("creates then delivers exactly once with one stable UUID", async () => {
+    let acceptPut!: (value: { id: string }) => void;
+    cloud.put.mockImplementationOnce(() => new Promise((resolve) => {
+      acceptPut = resolve;
+    }));
+    const onOpenRun = vi.fn();
+    render(
+      <WorkflowDefinitionRunsPanel
+        authCacheScope="user-1"
+        definition={definition}
+        managedRunsEnabled
+        onOpenRun={onOpenRun}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("ticket"), { target: { value: "PROL-123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+    expect(cloud.put).toHaveBeenCalledTimes(1);
+    acceptPut({ id: "40000000-0000-4000-8000-000000000001" });
+
+    await waitFor(() => expect(onOpenRun).toHaveBeenCalledWith("40000000-0000-4000-8000-000000000001"));
+    expect(cloud.put).toHaveBeenCalledTimes(1);
+    expect(cloud.put).toHaveBeenCalledWith(expect.objectContaining({
+      invocationId: "40000000-0000-4000-8000-000000000001",
+      body: expect.objectContaining({
+        workflowDefinitionId: definition.id,
+        expectedRevision: 3,
+        arguments: { ticket: "PROL-123" },
+        target: { kind: "managedCloud" },
+      }),
+    }));
+    expect(cloud.deliver).toHaveBeenCalledTimes(1);
+    expect(cloud.deliver.mock.invocationCallOrder[0]).toBeGreaterThan(cloud.put.mock.invocationCallOrder[0]!);
+  });
+
+  it("retains the UUID after create response loss and retries the same request", async () => {
+    cloud.put.mockRejectedValueOnce(new DOMException("timed out", "AbortError"));
+    cloud.check.mockRejectedValueOnce(
+      new ProliferateClientError("missing", 404, "workflow_invocation_not_found"),
+    );
+    const onOpenRun = vi.fn();
+    render(
+      <WorkflowDefinitionRunsPanel
+        authCacheScope="user-1"
+        definition={definition}
+        managedRunsEnabled
+        onOpenRun={onOpenRun}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("ticket"), { target: { value: "PROL-123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+
+    await screen.findByRole("button", { name: "Check or retry this run" });
+    const launch = screen.getByRole("button", { name: "Run in Cloud" }) as HTMLButtonElement;
+    expect(launch.disabled).toBe(true);
+    fireEvent.click(launch);
+    expect(cloud.put).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Check or retry this run" }));
+
+    await waitFor(() => expect(onOpenRun).toHaveBeenCalledTimes(1));
+    expect(cloud.put).toHaveBeenCalledTimes(2);
+    expect(cloud.put.mock.calls[1]?.[0].invocationId).toBe(cloud.put.mock.calls[0]?.[0].invocationId);
+    expect(cloud.put.mock.calls[1]?.[0].body).toEqual(cloud.put.mock.calls[0]?.[0].body);
+  });
+
+  it("recovers a prepared run after delivery response loss without minting a successor", async () => {
+    cloud.deliver.mockRejectedValueOnce(new DOMException("timed out", "AbortError"));
+    cloud.check.mockResolvedValueOnce({
+      ...runFixture(),
+      managedExecution: {
+        ...runFixture().managedExecution,
+        deliveryStatus: "prepared",
+      },
+    });
+    const onOpenRun = vi.fn();
+    render(
+      <WorkflowDefinitionRunsPanel
+        authCacheScope="user-1"
+        definition={definition}
+        managedRunsEnabled
+        onOpenRun={onOpenRun}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("ticket"), { target: { value: "PROL-123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+
+    await screen.findByRole("button", { name: "Check or retry this run" });
+    fireEvent.click(screen.getByRole("button", { name: "Check or retry this run" }));
+
+    await waitFor(() => expect(onOpenRun).toHaveBeenCalledTimes(1));
+    expect(cloud.put).toHaveBeenCalledTimes(1);
+    expect(cloud.deliver).toHaveBeenCalledTimes(2);
+    expect(cloud.deliver.mock.calls[1]?.[0].invocationId)
+      .toBe(cloud.deliver.mock.calls[0]?.[0].invocationId);
+  });
+
+  it("fails closed until durable history resolves and while history is unavailable", () => {
+    cloud.useHistory.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+    });
+    const props = {
+      authCacheScope: "user-1",
+      definition,
+      managedRunsEnabled: true,
+      onOpenRun: vi.fn(),
+    };
+    const { rerender } = render(<WorkflowDefinitionRunsPanel {...props} />);
+    expect((screen.getByRole("button", { name: "Run in Cloud" }) as HTMLButtonElement).disabled)
+      .toBe(true);
+
+    cloud.useHistory.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+    });
+    rerender(<WorkflowDefinitionRunsPanel {...props} />);
+    expect((screen.getByRole("button", { name: "Run in Cloud" }) as HTMLButtonElement).disabled)
+      .toBe(true);
+    expect(screen.getByText(/history must load before starting/u)).toBeTruthy();
+
+    cloud.useHistory.mockReturnValue({
+      data: { pages: [{ items: [], nextCursor: null }] },
+      isLoading: false,
+      isError: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
+    });
+    cloud.useEligibility.mockReturnValue({
+      data: { eligible: true, blockers: [] },
+      isLoading: false,
+      isError: true,
+    });
+    rerender(<WorkflowDefinitionRunsPanel {...props} />);
+    expect((screen.getByRole("button", { name: "Run in Cloud" }) as HTMLButtonElement).disabled)
+      .toBe(true);
+    expect(screen.getByText("Run eligibility could not be loaded.")).toBeTruthy();
+  });
+
+  it("reconciles argument drafts and eligibility to a saved definition revision", async () => {
+    const props = {
+      authCacheScope: "user-1",
+      managedRunsEnabled: true,
+      onOpenRun: vi.fn(),
+    };
+    const { rerender } = render(
+      <WorkflowDefinitionRunsPanel {...props} definition={definition} />,
+    );
+    fireEvent.change(screen.getByLabelText("ticket"), { target: { value: "stale" } });
+
+    const revised = {
+      ...definition,
+      revision: 4,
+      inputs: [{ name: "summary", type: "string" as const, required: true }],
+      stages: [{
+        ...definition.stages[0]!,
+        steps: [{ kind: "agent.prompt" as const, prompt: "Summarize {{inputs.summary}}", goal: null }],
+      }],
+    };
+    rerender(<WorkflowDefinitionRunsPanel {...props} definition={revised} />);
+
+    expect(screen.queryByLabelText("ticket")).toBeNull();
+    fireEvent.change(screen.getByLabelText("summary"), { target: { value: "fresh" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+
+    await waitFor(() => expect(cloud.put).toHaveBeenCalledTimes(1));
+    expect(cloud.put).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.objectContaining({ expectedRevision: 4, arguments: { summary: "fresh" } }),
+    }));
+    expect(cloud.useEligibility).toHaveBeenLastCalledWith(definition.id, 4, "user-1");
+  });
+
+  it("aborts a launch operation at the exact bounded timeout", async () => {
+    vi.useFakeTimers();
+    let signal!: AbortSignal;
+    cloud.put.mockImplementationOnce(({ signal: requestSignal }) => new Promise((_, reject) => {
+      signal = requestSignal;
+      requestSignal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+    }));
+    render(
+      <WorkflowDefinitionRunsPanel
+        authCacheScope="user-1"
+        definition={definition}
+        managedRunsEnabled
+        onOpenRun={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("ticket"), { target: { value: "PROL-123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+
+    await act(async () => vi.advanceTimersByTimeAsync(14_999));
+    expect(signal.aborted).toBe(false);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(signal.aborted).toBe(true);
+    expect(screen.getByText(/request timed out/u)).toBeTruthy();
+  });
+
+  it("fails closed when the route workflow does not match the returned run", () => {
+    cloud.useRun.mockReturnValue({
+      data: { ...runFixture(), workflowDefinitionId: "another-workflow" },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    render(
+      <WorkflowRunsSurface
+        authCacheScope="user-1"
+        workflowDefinitionId={definition.id}
+        runId="40000000-0000-4000-8000-000000000001"
+        managedRunsEnabled
+        onBack={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Run not found")).toBeTruthy();
+    expect(screen.queryByText("PROL-123")).toBeNull();
+  });
+
+  it("keeps a prepared run visible but fails closed when delivery capability is off", () => {
+    cloud.useRun.mockReturnValue({
+      data: runFixture({ deliveryStatus: "prepared" }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    render(
+      <WorkflowRunsSurface
+        authCacheScope="user-1"
+        workflowDefinitionId={definition.id}
+        runId="40000000-0000-4000-8000-000000000001"
+        managedRunsEnabled={false}
+        onBack={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    expect((screen.getByRole("button", { name: "Start delivery" }) as HTMLButtonElement).disabled)
+      .toBe(true);
+    expect(screen.getByText(/prepared run remains available/u)).toBeTruthy();
+  });
+
+  it("absorbs typed target loss, stops cancel, and retains an exact open target", async () => {
+    const refetch = vi.fn();
+    cloud.useRun.mockReturnValue({
+      data: runFixture({ open: true }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch,
+    });
+    cloud.cancel.mockRejectedValueOnce(
+      new ProliferateClientError("raw upstream detail", 409, "workflow_target_lost"),
+    );
+    render(
+      <WorkflowRunsSurface
+        authCacheScope="user-1"
+        workflowDefinitionId={definition.id}
+        runId="40000000-0000-4000-8000-000000000001"
+        managedRunsEnabled
+        onBack={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel run" }));
+
+    await screen.findByText("Target lost");
+    expect(screen.queryByRole("button", { name: "Cancel run" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open session" })).toBeTruthy();
+    expect(screen.queryByText("raw upstream detail")).toBeNull();
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(cloud.useRun).toHaveBeenLastCalledWith(
+      definition.id,
+      "40000000-0000-4000-8000-000000000001",
+      "user-1",
+      false,
+    );
+  });
+
+  it("retains cached detail on a transient refresh error", () => {
+    cloud.useRun.mockReturnValue({
+      data: runFixture(),
+      isLoading: false,
+      isError: true,
+      error: new ProliferateClientError("raw", 503, "upstream_unavailable"),
+      refetch: vi.fn(),
+    });
+    render(
+      <WorkflowRunsSurface
+        authCacheScope="user-1"
+        workflowDefinitionId={definition.id}
+        runId="40000000-0000-4000-8000-000000000001"
+        managedRunsEnabled
+        onBack={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Run details")).toBeTruthy();
+    expect(screen.getByText(/last known state is shown/u)).toBeTruthy();
+    expect(screen.queryByText("raw")).toBeNull();
+  });
+
+  it("discards cached detail after an authoritative not-found response", () => {
+    cloud.useRun.mockReturnValue({
+      data: runFixture(),
+      isLoading: false,
+      isError: true,
+      error: new ProliferateClientError("raw", 404, "workflow_invocation_not_found"),
+      refetch: vi.fn(),
+    });
+    render(
+      <WorkflowRunsSurface
+        authCacheScope="user-1"
+        workflowDefinitionId={definition.id}
+        runId="40000000-0000-4000-8000-000000000001"
+        managedRunsEnabled
+        onBack={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Run not found")).toBeTruthy();
+    expect(screen.queryByText("Run details")).toBeNull();
+    expect(screen.queryByText("PROL-123")).toBeNull();
+    expect(screen.queryByText("raw")).toBeNull();
+  });
+
+  it.each([
+    [503, "upstream_unavailable", "Run unavailable"],
+    [404, "workflow_invocation_not_found", "Run not found"],
+  ])("distinguishes initial HTTP %s detail failure", (status, code, title) => {
+    cloud.useRun.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new ProliferateClientError("raw detail", status, code),
+      refetch: vi.fn(),
+    });
+    render(
+      <WorkflowRunsSurface
+        authCacheScope="user-1"
+        workflowDefinitionId={definition.id}
+        runId="40000000-0000-4000-8000-000000000001"
+        managedRunsEnabled
+        onBack={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(title)).toBeTruthy();
+    expect(screen.queryByText("raw detail")).toBeNull();
+  });
+
+  it("appends cursor pages in server order and removes replayed boundary rows", () => {
+    const fetchNextPage = vi.fn();
+    cloud.useHistory.mockReturnValue({
+      data: {
+        pages: [
+          { items: [historyItem("run-3"), historyItem("run-2")], nextCursor: "cursor-2" },
+          { items: [historyItem("run-2"), historyItem("run-1")], nextCursor: null },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+      fetchNextPage,
+      refetch: vi.fn(),
+    });
+    render(
+      <WorkflowDefinitionRunsPanel
+        authCacheScope="user-1"
+        definition={definition}
+        managedRunsEnabled
+        onOpenRun={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText(/Revision 3/u)).toHaveLength(3);
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+function runFixture(overrides: { deliveryStatus?: string; open?: boolean } = {}) {
+  return {
+    id: "40000000-0000-4000-8000-000000000001",
+    schemaVersion: 1,
+    workflowDefinitionId: definition.id,
+    definitionRevision: 3,
+    title: "Triage",
+    description: "",
+    definition: { inputs: definition.inputs, stages: [] },
+    arguments: { ticket: "PROL-123" },
+    placement: { kind: "scratch" },
+    target: { kind: "managedCloud" },
+    createdAt: "2026-07-16T00:00:00Z",
+    managedExecution: {
+      deliveryStatus: overrides.deliveryStatus ?? "queued",
+      deliveryCheckpoint: "target_plan_frozen",
+      desiredState: "active",
+      execution: null,
+      freshness: { status: "pending", latestObservedAt: null },
+      correlations: {
+        cloudWorkspaceId: overrides.open ? "cloud-1" : null,
+        anyharnessWorkspaceId: overrides.open ? "runtime-1" : null,
+        sessionId: overrides.open ? "session-1" : null,
+        promptId: null,
+        turnId: null,
+      },
+      openTarget: overrides.open ? {
+        cloudWorkspaceId: "cloud-1",
+        anyharnessWorkspaceId: "runtime-1",
+        sessionId: "session-1",
+      } : null,
+      deliveryErrorCode: null,
+      observationErrorCode: null,
+      acceptedAt: null,
+      updatedAt: "2026-07-16T00:00:00Z",
+    },
+  };
+}
+
+function historyItem(id: string) {
+  return {
+    id,
+    workflowDefinitionId: definition.id,
+    definitionRevision: 3,
+    title: "Triage",
+    placementKind: "scratch",
+    targetKind: "managedCloud",
+    deliveryStatus: "queued",
+    desiredState: "active",
+    executionStatus: null,
+    freshness: "pending",
+    latestObservedAt: null,
+    cloudWorkspaceId: null,
+    sessionId: null,
+    createdAt: "2026-07-16T00:00:00Z",
+    updatedAt: "2026-07-16T00:00:00Z",
+  };
+}

--- a/apps/packages/product-surfaces/src/workflows/WorkflowRunsSurface.tsx
+++ b/apps/packages/product-surfaces/src/workflows/WorkflowRunsSurface.tsx
@@ -1,0 +1,387 @@
+import { useMemo, useRef, useState } from "react";
+import type {
+  ManagedWorkflowInvocationResponse,
+  ManagedWorkflowOpenTarget,
+} from "@proliferate/cloud-sdk";
+import {
+  useWorkflowRun,
+  useWorkflowRunActions,
+  useWorkflowRunEligibility,
+  useWorkflowRunHistory,
+} from "@proliferate/cloud-sdk-react";
+import {
+  createManagedWorkflowLaunchAttempt,
+  createWorkflowArgumentDraft,
+  normalizeWorkflowArguments,
+  referencedWorkflowInputNames,
+  type ManagedWorkflowLaunchAttempt,
+  type WorkflowArgumentIssue,
+} from "@proliferate/product-domain/workflows/arguments";
+import type { WorkflowDefinition } from "@proliferate/product-domain/workflows/definition";
+import {
+  safeWorkflowFailureCopy,
+  workflowRunPresentation,
+} from "@proliferate/product-domain/workflows/run-presentation";
+import { WorkflowRunDetail } from "@proliferate/product-ui/workflows/WorkflowRunDetail";
+import { WorkflowRunForm } from "@proliferate/product-ui/workflows/WorkflowRunForm";
+import { WorkflowRunList } from "@proliferate/product-ui/workflows/WorkflowRunList";
+import { WorkflowResourceState } from "./WorkflowResourceState";
+
+const OPERATION_TIMEOUT_MS = 15_000;
+
+export interface WorkflowRunOpenResult {
+  opened: boolean;
+  message?: string;
+}
+
+export interface WorkflowDefinitionRunsPanelProps {
+  authCacheScope: string;
+  definition: WorkflowDefinition;
+  managedRunsEnabled: boolean;
+  onOpenRun: (runId: string) => void;
+}
+
+export function WorkflowDefinitionRunsPanel({
+  authCacheScope,
+  definition,
+  managedRunsEnabled,
+  onOpenRun,
+}: WorkflowDefinitionRunsPanelProps) {
+  const eligibility = useWorkflowRunEligibility(
+    definition.id,
+    definition.revision,
+    authCacheScope,
+  );
+  const history = useWorkflowRunHistory(definition.id, authCacheScope);
+  const actions = useWorkflowRunActions(authCacheScope);
+  const definitionKey = `${definition.id}:${definition.revision}`;
+  const freshDraft = useMemo(
+    () => createWorkflowArgumentDraft(definition.inputs),
+    [definitionKey, definition.inputs],
+  );
+  const [argumentState, setArgumentState] = useState<{
+    definitionKey: string;
+    draft: ReturnType<typeof createWorkflowArgumentDraft>;
+    issues: WorkflowArgumentIssue[];
+  }>(() => ({ definitionKey, draft: freshDraft, issues: [] }));
+  const currentArguments = argumentState.definitionKey === definitionKey
+    ? argumentState
+    : { definitionKey, draft: freshDraft, issues: [] };
+  const [attempt, setAttempt] = useState<ManagedWorkflowLaunchAttempt | null>(null);
+  const [attemptMessage, setAttemptMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const launchInFlight = useRef(false);
+  const prompt = definition.stages[0]?.steps[0]?.prompt ?? "";
+  const runs = useMemo(() => {
+    const unique = new Map<string, NonNullable<typeof history.data>["pages"][number]["items"][number]>();
+    for (const page of history.data?.pages ?? []) {
+      for (const item of page.items) {
+        if (!unique.has(item.id)) unique.set(item.id, item);
+      }
+    }
+    return [...unique.values()];
+  }, [history.data]);
+
+  const executeAttempt = async (
+    current: ManagedWorkflowLaunchAttempt,
+    lockAlreadyHeld = false,
+  ) => {
+    if (!lockAlreadyHeld && launchInFlight.current) return;
+    if (!lockAlreadyHeld) launchInFlight.current = true;
+    setBusy(true);
+    setError(null);
+    setAttemptMessage(null);
+    try {
+      await withTimeout((signal) => actions.putWorkflowInvocation({
+        invocationId: current.invocationId,
+        body: current.request,
+        signal,
+      }));
+      const delivered = await withTimeout((signal) => actions.deliverWorkflowInvocation({
+        invocationId: current.invocationId,
+        signal,
+      }));
+      setAttempt(null);
+      onOpenRun(delivered.id);
+    } catch (caught) {
+      setAttempt(current);
+      setAttemptMessage("This launch may already exist. Check or retry the same run identity.");
+      setError(safeActionError(caught));
+    } finally {
+      if (!lockAlreadyHeld) launchInFlight.current = false;
+      setBusy(false);
+    }
+  };
+
+  const submit = () => {
+    if (
+      launchInFlight.current
+      || attempt !== null
+      || eligibility.isLoading
+      || eligibility.isError
+      || history.isLoading
+      || history.isError
+      || !eligibility.data?.eligible
+      || !managedRunsEnabled
+    ) return;
+    const normalized = normalizeWorkflowArguments(
+      definition.inputs,
+      prompt,
+      currentArguments.draft,
+    );
+    setArgumentState({ ...currentArguments, issues: normalized.issues });
+    if (normalized.issues.length > 0) return;
+    const current = createManagedWorkflowLaunchAttempt(
+      crypto.randomUUID(),
+      definition.id,
+      definition.revision,
+      normalized.arguments,
+    );
+    setAttempt(current);
+    void executeAttempt(current);
+  };
+
+  const recover = async () => {
+    if (!attempt || launchInFlight.current) return;
+    launchInFlight.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const existing = await withTimeout((signal) => actions.checkWorkflowInvocation({
+        invocationId: attempt.invocationId,
+        signal,
+      }));
+      if (existing.managedExecution.deliveryStatus === "prepared") {
+        const delivered = await withTimeout((signal) => actions.deliverWorkflowInvocation({
+          invocationId: attempt.invocationId,
+          signal,
+        }));
+        setAttempt(null);
+        onOpenRun(delivered.id);
+      } else {
+        setAttempt(null);
+        onOpenRun(existing.id);
+      }
+    } catch (caught) {
+      if (workflowCloudError(caught)?.status === 404) {
+        await executeAttempt(attempt, true);
+        return;
+      }
+      setError(safeActionError(caught));
+    } finally {
+      launchInFlight.current = false;
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-6 space-y-4">
+      <WorkflowRunForm
+        inputs={definition.inputs}
+        draft={currentArguments.draft}
+        issues={currentArguments.issues}
+        blockers={eligibility.data?.blockers ?? []}
+        requiredForRunInputNames={referencedWorkflowInputNames(prompt)}
+        capabilityEnabled={managedRunsEnabled}
+        launchBlocked={eligibility.isError || history.isError || attempt !== null}
+        submitting={busy || eligibility.isLoading || history.isLoading}
+        serverError={eligibility.isError
+          ? "Run eligibility could not be loaded."
+          : history.isError
+            ? "Recent run history must load before starting another run."
+            : error}
+        attemptMessage={attemptMessage}
+        onChange={(next) => {
+          setArgumentState({ definitionKey, draft: next, issues: [] });
+        }}
+        onSubmit={submit}
+        onRetryAttempt={attempt ? () => void recover() : undefined}
+      />
+      <WorkflowRunList
+        runs={runs}
+        loading={history.isLoading}
+        error={history.isError ? "Run history could not be loaded." : null}
+        hasMore={history.hasNextPage}
+        loadingMore={history.isFetchingNextPage}
+        onSelect={onOpenRun}
+        onLoadMore={() => void history.fetchNextPage()}
+        onRetry={() => void history.refetch()}
+      />
+    </div>
+  );
+}
+
+export interface WorkflowRunsSurfaceProps {
+  authCacheScope: string;
+  workflowDefinitionId: string;
+  runId: string;
+  managedRunsEnabled: boolean;
+  onBack: () => void;
+  onOpenSession: (target: ManagedWorkflowOpenTarget) => Promise<WorkflowRunOpenResult>;
+}
+
+export function WorkflowRunsSurface({
+  authCacheScope,
+  workflowDefinitionId,
+  runId,
+  managedRunsEnabled,
+  onBack,
+  onOpenSession,
+}: WorkflowRunsSurfaceProps) {
+  const [targetLostInvocationId, setTargetLostInvocationId] = useState<string | null>(null);
+  const targetLostByCancel = targetLostInvocationId === runId;
+  const query = useWorkflowRun(
+    workflowDefinitionId,
+    runId,
+    authCacheScope,
+    !targetLostByCancel,
+  );
+  const actions = useWorkflowRunActions(authCacheScope);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [openError, setOpenError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const run = targetLostByCancel && query.data
+    ? projectTargetLost(query.data)
+    : query.data;
+
+  if (query.isLoading) {
+    return <WorkflowResourceState loading title="Loading run" description="Loading the current managed status." onBack={onBack} />;
+  }
+  const queryError = workflowCloudError(query.error);
+  if (queryError?.status === 404) {
+    return (
+      <WorkflowResourceState
+        title="Run not found"
+        description="It may have been deleted or you may not have access."
+        onBack={onBack}
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+  if (!run) {
+    return (
+      <WorkflowResourceState
+        title="Run unavailable"
+        description="The current managed status could not be loaded. Try again."
+        onBack={onBack}
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+  if (run.workflowDefinitionId !== workflowDefinitionId) {
+    return (
+      <WorkflowResourceState
+        title="Run not found"
+        description="It may have been deleted or you may not have access."
+        onBack={onBack}
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+
+  const presentation = workflowRunPresentation(run);
+  const perform = async (operation: "deliver" | "cancel") => {
+    setBusy(true);
+    setActionError(null);
+    try {
+      if (operation === "deliver") {
+        await withTimeout((signal) => actions.deliverWorkflowInvocation({ invocationId: run.id, signal }));
+      } else {
+        await withTimeout((signal) => actions.cancelWorkflowInvocation({ invocationId: run.id, signal }));
+      }
+    } catch (caught) {
+      const cloudError = workflowCloudError(caught);
+      if (
+        operation === "cancel"
+        && cloudError?.status === 409
+        && cloudError.code === "workflow_target_lost"
+      ) {
+        setTargetLostInvocationId(run.id);
+        setActionError("The managed target was replaced. The final outcome is unknown.");
+        await query.refetch();
+      } else {
+        setActionError(safeActionError(caught));
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const open = async () => {
+    const target = run.managedExecution.openTarget;
+    if (!target) return;
+    setBusy(true);
+    setOpenError(null);
+    try {
+      const result = await onOpenSession(target);
+      if (!result.opened) {
+        setOpenError(result.message ?? "This workflow session is no longer available.");
+      }
+    } catch {
+      setOpenError("This workflow session is no longer available.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <WorkflowRunDetail
+      run={run}
+      presentation={presentation}
+      deliveryCapabilityEnabled={managedRunsEnabled}
+      busy={busy}
+      actionError={actionError ?? (query.isError
+        ? "The latest status could not be refreshed. The last known state is shown."
+        : null)}
+      openSessionUnavailable={openError}
+      onBack={onBack}
+      onRefresh={() => void query.refetch()}
+      onStartDelivery={() => void perform("deliver")}
+      onCancel={() => void perform("cancel")}
+      onOpenSession={() => void open()}
+    />
+  );
+}
+
+function projectTargetLost(
+  run: ManagedWorkflowInvocationResponse,
+): ManagedWorkflowInvocationResponse {
+  return {
+    ...run,
+    managedExecution: {
+      ...run.managedExecution,
+      freshness: { ...run.managedExecution.freshness, status: "target_lost" },
+    },
+  };
+}
+
+async function withTimeout<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPERATION_TIMEOUT_MS);
+  try {
+    return await operation(controller.signal);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function safeActionError(error: unknown): string {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return "The request timed out. Its durable status may still have changed.";
+  }
+  const cloudError = workflowCloudError(error);
+  if (cloudError) {
+    return safeWorkflowFailureCopy(cloudError.code)
+      ?? "The workflow request could not be completed. Refresh for the latest status.";
+  }
+  return "The workflow request could not be completed. Refresh for the latest status.";
+}
+
+function workflowCloudError(error: unknown): { status: number; code: string | null } | null {
+  if (!error || typeof error !== "object") return null;
+  const status = "status" in error ? error.status : null;
+  const code = "code" in error ? error.code : null;
+  if (typeof status !== "number" || (code !== null && typeof code !== "string")) return null;
+  return { status, code };
+}

--- a/apps/packages/product-ui/package.json
+++ b/apps/packages/product-ui/package.json
@@ -147,6 +147,18 @@
       "types": "./dist/workflows/WorkflowDefinitionList.d.ts",
       "import": "./dist/workflows/WorkflowDefinitionList.js"
     },
+    "./workflows/WorkflowRunForm": {
+      "types": "./dist/workflows/WorkflowRunForm.d.ts",
+      "import": "./dist/workflows/WorkflowRunForm.js"
+    },
+    "./workflows/WorkflowRunList": {
+      "types": "./dist/workflows/WorkflowRunList.d.ts",
+      "import": "./dist/workflows/WorkflowRunList.js"
+    },
+    "./workflows/WorkflowRunDetail": {
+      "types": "./dist/workflows/WorkflowRunDetail.d.ts",
+      "import": "./dist/workflows/WorkflowRunDetail.js"
+    },
     "./billing/BillingSettingsPane": {
       "types": "./dist/billing/BillingSettingsPane.d.ts",
       "import": "./dist/billing/BillingSettingsPane.js"

--- a/apps/packages/product-ui/src/workflows/WorkflowDefinitionEditor.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowDefinitionEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useState, type FormEvent, type ReactNode } from "react";
 import { Plus, Save, Trash2 } from "lucide-react";
 import {
   workflowAgentOptions,
@@ -39,6 +39,7 @@ export interface WorkflowDefinitionEditorProps {
   onCancel: () => void;
   onDelete?: () => void;
   onReload?: () => void;
+  supplementalContent?: ReactNode;
 }
 
 export function WorkflowDefinitionEditor({
@@ -57,6 +58,7 @@ export function WorkflowDefinitionEditor({
   onCancel,
   onDelete,
   onReload,
+  supplementalContent,
 }: WorkflowDefinitionEditorProps) {
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
   const busy = saving || deleting;
@@ -74,7 +76,7 @@ export function WorkflowDefinitionEditor({
     <>
       <ProductPageShell
         title={formTitle}
-        description="Define inputs and sequential agent stages. This PR stores and validates the definition only."
+        description="Define inputs and sequential agent stages. Saved eligible workflows can run in managed Cloud."
         actions={(
           <div className="flex items-center gap-2">
             <Button type="button" variant="ghost" disabled={busy} onClick={onCancel}>
@@ -241,6 +243,7 @@ export function WorkflowDefinitionEditor({
             ) : null}
           </div>
         </form>
+        {supplementalContent}
       </ProductPageShell>
       <ConfirmationDialog
         open={deleteConfirmationOpen}

--- a/apps/packages/product-ui/src/workflows/WorkflowDefinitionList.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowDefinitionList.tsx
@@ -24,7 +24,7 @@ export function WorkflowDefinitionList({
   return (
     <ProductPageShell
       title="Workflows"
-      description="Define reusable, sequential agent workflows. Execution is added in the next step."
+      description="Define reusable agent workflows and inspect their managed Cloud runs."
       actions={(
         <Button type="button" onClick={onNew}>
           <Plus className="size-4" aria-hidden />

--- a/apps/packages/product-ui/src/workflows/WorkflowRunDetail.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunDetail.tsx
@@ -1,0 +1,143 @@
+import type {
+  WorkflowRun,
+  WorkflowRunPresentation,
+} from "@proliferate/product-domain/workflows/run-presentation";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { ProductPageShell } from "../layout/ProductPageShell";
+
+export interface WorkflowRunDetailProps {
+  run: WorkflowRun;
+  presentation: WorkflowRunPresentation;
+  deliveryCapabilityEnabled?: boolean;
+  busy?: boolean;
+  actionError?: string | null;
+  openSessionUnavailable?: string | null;
+  onBack: () => void;
+  onRefresh: () => void;
+  onStartDelivery: () => void;
+  onCancel: () => void;
+  onOpenSession: () => void;
+}
+
+export function WorkflowRunDetail({
+  run,
+  presentation,
+  deliveryCapabilityEnabled = true,
+  busy = false,
+  actionError = null,
+  openSessionUnavailable = null,
+  onBack,
+  onRefresh,
+  onStartDelivery,
+  onCancel,
+  onOpenSession,
+}: WorkflowRunDetailProps) {
+  const managed = run.managedExecution;
+  return (
+    <ProductPageShell
+      title={run.title}
+      description={`Managed run · revision ${run.definitionRevision}`}
+      maxWidthClassName="max-w-5xl"
+      telemetryBlocked
+      actions={(
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" variant="ghost" onClick={onBack}>Back</Button>
+          <Button type="button" variant="secondary" disabled={busy} onClick={onRefresh}>Refresh</Button>
+          {presentation.canStartDelivery ? (
+            <Button
+              type="button"
+              disabled={busy || !deliveryCapabilityEnabled}
+              onClick={onStartDelivery}
+            >
+              Start delivery
+            </Button>
+          ) : null}
+          {presentation.canCancel ? (
+            <Button type="button" variant="secondary" disabled={busy} onClick={onCancel}>Cancel run</Button>
+          ) : null}
+          {presentation.canOpenSession ? (
+            <Button type="button" disabled={busy} onClick={onOpenSession}>Open session</Button>
+          ) : null}
+        </div>
+      )}
+    >
+      <div className="space-y-4">
+        <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <StatusCard label="Delivery" value={presentation.delivery.label} tone={presentation.delivery.tone} />
+          <StatusCard label="Desired state" value={presentation.desired.label} tone={presentation.desired.tone} />
+          <StatusCard label="Execution" value={presentation.execution.label} tone={presentation.execution.tone} />
+          <StatusCard label="Freshness" value={presentation.freshness.label} tone={presentation.freshness.tone} />
+        </section>
+
+        {presentation.notice ? <p className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-sm text-warning" role="status">{presentation.notice}</p> : null}
+        {presentation.canStartDelivery && !deliveryCapabilityEnabled ? (
+          <p className="rounded-md border border-border bg-surface-raised px-3 py-2 text-sm text-muted-foreground" role="status">
+            Managed Workflow delivery is not enabled on this server. This prepared run remains available.
+          </p>
+        ) : null}
+        {presentation.failure ? <p className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">{presentation.failure}</p> : null}
+        {actionError ? <p className="text-sm text-destructive" role="alert">{actionError}</p> : null}
+        {openSessionUnavailable ? <p className="text-sm text-muted-foreground" role="status">{openSessionUnavailable}</p> : null}
+
+        <section className="rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-medium text-foreground">Run details</h2>
+          <dl className="mt-3 grid gap-3 text-xs sm:grid-cols-2">
+            <Detail label="Created" value={formatDateTime(run.createdAt)} />
+            <Detail label="Placement" value={run.placement.kind === "scratch" ? "Scratch workspace" : "Repository worktree"} />
+            <Detail label="Run ID" value={run.id} />
+            <Detail label="Last observation" value={managed.freshness.latestObservedAt ? formatDateTime(managed.freshness.latestObservedAt) : "No observation yet"} />
+          </dl>
+        </section>
+
+        <details className="rounded-lg border border-border bg-card p-4">
+          <summary className="cursor-pointer text-sm font-medium text-foreground">
+            Inputs ({Object.keys(run.arguments).length})
+          </summary>
+          <dl className="mt-3 space-y-2" data-telemetry-mask>
+            {Object.entries(run.arguments).map(([name, value]) => (
+              <div key={name} className="flex items-start justify-between gap-4 text-xs">
+                <dt className="font-mono text-muted-foreground">{name}</dt>
+                <dd className="max-w-[70%] break-words text-right text-foreground">{String(value)}</dd>
+              </div>
+            ))}
+          </dl>
+        </details>
+
+        <section className="rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-medium text-foreground">Steps</h2>
+          {managed.execution?.steps.length ? managed.execution.steps.map((step) => (
+            <div key={step.index} className="mt-3 flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
+              <span>Prompt</span>
+              <span className="text-muted-foreground">{step.status}</span>
+            </div>
+          )) : <p className="mt-2 text-xs text-muted-foreground">Waiting for runtime acceptance.</p>}
+        </section>
+      </div>
+    </ProductPageShell>
+  );
+}
+
+function StatusCard({ label, value, tone }: { label: string; value: string; tone: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`mt-1 text-sm font-medium ${toneClass(tone)}`}>{value}</p>
+    </div>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return <div><dt className="text-muted-foreground">{label}</dt><dd className="mt-0.5 break-all text-foreground">{value}</dd></div>;
+}
+
+function toneClass(tone: string): string {
+  if (tone === "danger") return "text-destructive";
+  if (tone === "warning") return "text-warning";
+  if (tone === "success") return "text-success";
+  return "text-foreground";
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}

--- a/apps/packages/product-ui/src/workflows/WorkflowRunForm.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunForm.tsx
@@ -1,0 +1,184 @@
+import type { WorkflowDefinitionInput } from "@proliferate/product-domain/workflows/definition";
+import type {
+  WorkflowArgumentDraft,
+  WorkflowArgumentIssue,
+} from "@proliferate/product-domain/workflows/arguments";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Checkbox } from "@proliferate/ui/primitives/Checkbox";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@proliferate/ui/primitives/Label";
+import { Select } from "@proliferate/ui/primitives/Select";
+
+export interface WorkflowRunFormProps {
+  inputs: readonly WorkflowDefinitionInput[];
+  draft: WorkflowArgumentDraft;
+  issues: readonly WorkflowArgumentIssue[];
+  blockers: readonly WorkflowRunEligibilityBlockerView[];
+  requiredForRunInputNames?: ReadonlySet<string>;
+  capabilityEnabled: boolean;
+  launchBlocked?: boolean;
+  submitting?: boolean;
+  serverError?: string | null;
+  attemptMessage?: string | null;
+  onChange: (draft: WorkflowArgumentDraft) => void;
+  onSubmit: () => void;
+  onRetryAttempt?: () => void;
+}
+
+export interface WorkflowRunEligibilityBlockerView {
+  code: string;
+  path: string;
+  message: string;
+}
+
+export function WorkflowRunForm({
+  inputs,
+  draft,
+  issues,
+  blockers,
+  requiredForRunInputNames = new Set<string>(),
+  capabilityEnabled,
+  launchBlocked = false,
+  submitting = false,
+  serverError = null,
+  attemptMessage = null,
+  onChange,
+  onSubmit,
+  onRetryAttempt,
+}: WorkflowRunFormProps) {
+  const ineligible = blockers.length > 0;
+  const disabled = submitting || launchBlocked || ineligible || !capabilityEnabled;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4" data-telemetry-block>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">Run in Cloud</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Starts one managed session using this saved workflow revision.
+          </p>
+        </div>
+        <Button type="button" disabled={disabled} loading={submitting} onClick={onSubmit}>
+          Run in Cloud
+        </Button>
+      </div>
+
+      {!capabilityEnabled ? (
+        <p className="mt-3 rounded-md border border-border bg-surface-raised px-3 py-2 text-xs text-muted-foreground" role="status">
+          Managed Workflow runs are not enabled on this server. Saved workflows and existing run history remain available.
+        </p>
+      ) : null}
+      {blockers.length > 0 ? (
+        <div className="mt-3 rounded-md border border-warning/30 bg-warning/5 px-3 py-2" role="status">
+          <p className="text-xs font-medium text-warning">This workflow cannot run yet.</p>
+          <ul className="mt-1 space-y-1 text-xs text-warning">
+            {[...blockers]
+              .sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code))
+              .map((blocker) => (
+                <li key={`${blocker.path}:${blocker.code}`}>
+                  <span className="font-mono">{blocker.path}</span>: {blocker.message}
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {inputs.length === 0 ? (
+        <p className="mt-4 text-xs text-muted-foreground">This workflow has no inputs.</p>
+      ) : (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {inputs.map((input) => {
+            const value = draft[input.name] ?? {
+              supplied: false,
+              value: input.type === "boolean" ? false : "",
+            };
+            const issue = issues.find((candidate) => candidate.path === `arguments.${input.name}`);
+            const controlId = `workflow-run-input-${input.name}`;
+            const includeControlId = `${controlId}-included`;
+            const requiredByPrompt = !input.required && requiredForRunInputNames.has(input.name);
+            const canOmit = !input.required && !requiredByPrompt;
+            return (
+              <div key={input.name} className="rounded-md border border-border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <Label htmlFor={controlId}>{input.name}</Label>
+                  {canOmit ? (
+                    <Label htmlFor={includeControlId} className="mb-0 flex items-center gap-2">
+                      <Checkbox
+                        id={includeControlId}
+                        checked={value.supplied}
+                        disabled={submitting}
+                        onCheckedChange={(checked) => onChange({
+                          ...draft,
+                          [input.name]: { ...value, supplied: checked === true },
+                        })}
+                      />
+                      Include
+                    </Label>
+                  ) : input.required ? (
+                    <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Required</span>
+                  ) : (
+                    <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Required for run</span>
+                  )}
+                </div>
+                {requiredByPrompt ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    This optional input is used by the prompt and must be supplied for this run.
+                  </p>
+                ) : null}
+                <div className="mt-2" data-telemetry-mask>
+                  {input.type === "boolean" ? (
+                    <Select
+                      id={controlId}
+                      value={value.supplied ? String(value.value) : ""}
+                      disabled={submitting || (canOmit && !value.supplied)}
+                      aria-invalid={issue ? "true" : undefined}
+                      onChange={(event) => onChange({
+                        ...draft,
+                        [input.name]: {
+                          supplied: event.currentTarget.value !== "",
+                          value: event.currentTarget.value === "true",
+                        },
+                      })}
+                    >
+                      <option value="">Choose true or false</option>
+                      <option value="true">True</option>
+                      <option value="false">False</option>
+                    </Select>
+                  ) : (
+                    <Input
+                      id={controlId}
+                      type={input.type === "number" ? "number" : "text"}
+                      value={String(value.value)}
+                      disabled={submitting || (canOmit && !value.supplied)}
+                      aria-invalid={issue ? "true" : undefined}
+                      onChange={(event) => onChange({
+                        ...draft,
+                        [input.name]: {
+                          supplied: true,
+                          value: event.currentTarget.value,
+                        },
+                      })}
+                    />
+                  )}
+                </div>
+                {issue ? <p className="mt-1 text-xs text-destructive" role="alert">{issue.message}</p> : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {serverError ? <p className="mt-3 text-xs text-destructive" role="alert">{serverError}</p> : null}
+      {attemptMessage ? (
+        <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground" role="status">
+          <span>{attemptMessage}</span>
+          {onRetryAttempt ? (
+            <Button type="button" variant="secondary" size="sm" disabled={submitting} onClick={onRetryAttempt}>
+              Check or retry this run
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/packages/product-ui/src/workflows/WorkflowRunList.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunList.tsx
@@ -1,0 +1,87 @@
+import {
+  workflowHistoryItemPresentation,
+  type WorkflowRunHistoryItem,
+} from "@proliferate/product-domain/workflows/run-presentation";
+import { Button } from "@proliferate/ui/primitives/Button";
+
+export interface WorkflowRunListProps {
+  runs: readonly WorkflowRunHistoryItem[];
+  loading?: boolean;
+  error?: string | null;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onSelect: (runId: string) => void;
+  onLoadMore?: () => void;
+  onRetry?: () => void;
+}
+
+export function WorkflowRunList({
+  runs,
+  loading = false,
+  error = null,
+  hasMore = false,
+  loadingMore = false,
+  onSelect,
+  onLoadMore,
+  onRetry,
+}: WorkflowRunListProps) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">Recent runs</h2>
+          <p className="mt-1 text-xs text-muted-foreground">Managed Cloud history for this workflow.</p>
+        </div>
+        {error && onRetry ? <Button type="button" variant="secondary" size="sm" onClick={onRetry}>Retry</Button> : null}
+      </div>
+      {loading ? (
+        <p className="py-4 text-xs text-muted-foreground" role="status">Loading runs</p>
+      ) : error ? (
+        <p className="py-4 text-xs text-destructive" role="alert">{error}</p>
+      ) : runs.length === 0 ? (
+        <p className="py-4 text-xs text-muted-foreground">No managed runs yet.</p>
+      ) : (
+        <div className="mt-3 overflow-hidden rounded-md border border-border">
+          {runs.map((run, index) => {
+            const status = workflowHistoryItemPresentation(run);
+            return (
+              <Button
+                key={run.id}
+                type="button"
+                variant="unstyled"
+                size="unstyled"
+                className={`flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-list-hover ${index > 0 ? "border-t border-border" : ""}`}
+                onClick={() => onSelect(run.id)}
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm text-foreground">Revision {run.definitionRevision}</span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    {run.placementKind === "scratch" ? "Scratch workspace" : "Repository worktree"} · {formatDateTime(run.createdAt)}
+                  </span>
+                </span>
+                <span className={`shrink-0 text-xs ${toneClass(status.tone)}`}>{status.label}</span>
+              </Button>
+            );
+          })}
+        </div>
+      )}
+      {hasMore && onLoadMore ? (
+        <Button type="button" variant="secondary" size="sm" className="mt-3" loading={loadingMore} onClick={onLoadMore}>
+          Load more
+        </Button>
+      ) : null}
+    </section>
+  );
+}
+
+function toneClass(tone: string): string {
+  if (tone === "danger") return "text-destructive";
+  if (tone === "warning") return "text-warning";
+  if (tone === "success") return "text-success";
+  return "text-muted-foreground";
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toLocaleString();
+}

--- a/apps/packages/product-ui/src/workflows/WorkflowRuns.test.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRuns.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowRun } from "@proliferate/product-domain/workflows/run-presentation";
+import { workflowRunPresentation } from "@proliferate/product-domain/workflows/run-presentation";
+import { createWorkflowArgumentDraft } from "@proliferate/product-domain/workflows/arguments";
+import { WorkflowRunDetail } from "./WorkflowRunDetail";
+import { WorkflowRunForm } from "./WorkflowRunForm";
+
+class TestIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+
+afterEach(cleanup);
+
+const input = { name: "ticket", type: "string" as const, required: true };
+
+describe("Workflow run UI", () => {
+  it("keeps a disabled launch visible with authored capability copy", () => {
+    render(
+      <WorkflowRunForm
+        inputs={[input]}
+        draft={createWorkflowArgumentDraft([input])}
+        issues={[]}
+        blockers={[]}
+        capabilityEnabled={false}
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByRole("button", { name: "Run in Cloud" }) as HTMLButtonElement).disabled)
+      .toBe(true);
+    expect(screen.getByText(/not enabled on this server/u)).toBeTruthy();
+    expect(screen.getByText(/existing run history remain available/u)).toBeTruthy();
+  });
+
+  it("orders exact eligibility blockers and never submits while ineligible", () => {
+    const onSubmit = vi.fn();
+    render(
+      <WorkflowRunForm
+        inputs={[]}
+        draft={{}}
+        issues={[]}
+        blockers={[
+          { path: "stages[1]", code: "stage_count_not_supported", message: "One stage only." },
+          { path: "stages[0].steps[0].goal", code: "goal_not_supported", message: "Goals are unavailable." },
+        ]}
+        capabilityEnabled
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text.indexOf("stages[0]")).toBeLessThan(text.indexOf("stages[1]"));
+    fireEvent.click(screen.getByRole("button", { name: "Run in Cloud" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("explains prompt-referenced optional inputs before submission", () => {
+    const optional = { name: "context", type: "string" as const, required: false };
+    render(
+      <WorkflowRunForm
+        inputs={[optional]}
+        draft={createWorkflowArgumentDraft([optional])}
+        issues={[]}
+        blockers={[]}
+        requiredForRunInputNames={new Set(["context"])}
+        capabilityEnabled
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Required for run")).toBeTruthy();
+    expect(screen.getByText(/optional input is used by the prompt/u)).toBeTruthy();
+    expect(screen.queryByText("Include")).toBeNull();
+    expect((screen.getByLabelText("context") as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it("renders frozen inputs collapsed and replay-masked", () => {
+    const run = fixtureRun();
+    const { container } = render(
+      <WorkflowRunDetail
+        run={run}
+        presentation={workflowRunPresentation(run)}
+        onBack={vi.fn()}
+        onRefresh={vi.fn()}
+        onStartDelivery={vi.fn()}
+        onCancel={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+
+    const details = screen.getByText("Inputs (1)").closest("details");
+    expect(details?.hasAttribute("open")).toBe(false);
+    expect(container.querySelector("[data-telemetry-mask]")?.textContent).toContain("PROL-123");
+    expect(screen.queryByRole("button", { name: "Open session" })).toBeNull();
+    expect(screen.getByText("Scratch workspace")).toBeTruthy();
+  });
+});
+
+function fixtureRun(): WorkflowRun {
+  return {
+    id: "run-1",
+    schemaVersion: 1,
+    workflowDefinitionId: "workflow-1",
+    definitionRevision: 1,
+    title: "Triage",
+    description: "",
+    definition: { inputs: [input], stages: [] },
+    arguments: { ticket: "PROL-123" },
+    placement: { kind: "scratch" },
+    target: { kind: "managedCloud" },
+    createdAt: "2026-07-16T00:00:00Z",
+    managedExecution: {
+      deliveryStatus: "queued",
+      deliveryCheckpoint: "target_plan_frozen",
+      desiredState: "active",
+      execution: null,
+      freshness: { status: "pending", latestObservedAt: null },
+      correlations: {
+        cloudWorkspaceId: null,
+        anyharnessWorkspaceId: null,
+        sessionId: null,
+        promptId: null,
+        turnId: null,
+      },
+      openTarget: null,
+      deliveryErrorCode: null,
+      observationErrorCode: null,
+      acceptedAt: null,
+      updatedAt: "2026-07-16T00:00:00Z",
+    },
+  } as WorkflowRun;
+}

--- a/cloud/sdk-react/src/hooks/workflows.ts
+++ b/cloud/sdk-react/src/hooks/workflows.ts
@@ -1,27 +1,72 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  type InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  cancelWorkflowInvocation,
   createWorkflowDefinition,
   deleteWorkflowDefinition,
+  deliverWorkflowInvocation,
   getWorkflowDefinition,
+  getWorkflowInvocation,
+  getWorkflowRunEligibility,
+  listWorkflowInvocationHistory,
   listWorkflowDefinitions,
+  putWorkflowInvocation,
   updateWorkflowDefinition,
+  type ManagedWorkflowHistoryResponse,
+  type ManagedWorkflowHistoryItem,
+  type ManagedWorkflowInvocationResponse,
   type WorkflowDefinitionCreateRequest,
   type WorkflowDefinitionListResponse,
   type WorkflowDefinitionResponse,
   type WorkflowDefinitionUpdateRequest,
+  type WorkflowInvocationCreateRequest,
+  type WorkflowInvocationResponse,
+  type WorkflowRunEligibilityResponse,
 } from "@proliferate/cloud-sdk";
 import { useCloudClient } from "../context/CloudClientProvider.js";
 import {
   workflowDefinitionDetailKey,
   workflowDefinitionsListKey,
   workflowDefinitionsRootKey,
+  workflowRunDetailKey,
+  workflowRunEligibilityKey,
+  workflowRunHistoryKey,
+  workflowRunsRootKey,
 } from "../lib/query-keys.js";
+
+export const WORKFLOW_RUN_POLL_INTERVAL_MS = 3_000;
+
+export function workflowRunNeedsPolling(run: ManagedWorkflowInvocationResponse | undefined): boolean {
+  if (!run || run.managedExecution.freshness.status === "target_lost") return false;
+  const execution = run.managedExecution.execution;
+  if (execution?.cancelRequestedAt && !isTerminalExecution(execution.status)) return true;
+  if (execution && isTerminalExecution(execution.status)) return false;
+  return ![
+    "delivery_failed",
+    "delivery_cancelled",
+  ].includes(run.managedExecution.deliveryStatus);
+}
+
+export function workflowRunRefetchInterval(
+  run: ManagedWorkflowInvocationResponse | undefined,
+): number | false {
+  return workflowRunNeedsPolling(run) ? WORKFLOW_RUN_POLL_INTERVAL_MS : false;
+}
+
+function isTerminalExecution(status: string): boolean {
+  return ["completed", "failed", "cancelled", "interrupted"].includes(status);
+}
 
 export function useWorkflowDefinitions(authCacheScope: string, enabled = true) {
   const client = useCloudClient();
   return useQuery<WorkflowDefinitionListResponse>({
     queryKey: workflowDefinitionsListKey(client.baseUrl, authCacheScope),
-    queryFn: () => listWorkflowDefinitions(client),
+    queryFn: ({ signal }) => listWorkflowDefinitions(client, { signal }),
     enabled,
   });
 }
@@ -38,9 +83,203 @@ export function useWorkflowDefinition(
       authCacheScope,
       workflowDefinitionId,
     ),
-    queryFn: () => getWorkflowDefinition(workflowDefinitionId!, client),
+    queryFn: ({ signal }) => getWorkflowDefinition(workflowDefinitionId!, client, { signal }),
     enabled: enabled && workflowDefinitionId !== null,
   });
+}
+
+export function useWorkflowRunEligibility(
+  workflowDefinitionId: string | null,
+  definitionRevision: number | null,
+  authCacheScope: string,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useQuery<WorkflowRunEligibilityResponse>({
+    queryKey: workflowRunEligibilityKey(
+      client.baseUrl,
+      authCacheScope,
+      workflowDefinitionId,
+      definitionRevision,
+    ),
+    queryFn: ({ signal }) =>
+      getWorkflowRunEligibility(workflowDefinitionId!, client, { signal }),
+    enabled: enabled && workflowDefinitionId !== null && definitionRevision !== null,
+  });
+}
+
+export function useWorkflowRun(
+  workflowDefinitionId: string | null,
+  invocationId: string | null,
+  authCacheScope: string,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useQuery<ManagedWorkflowInvocationResponse>({
+    queryKey: workflowRunDetailKey(
+      client.baseUrl,
+      authCacheScope,
+      workflowDefinitionId,
+      invocationId,
+    ),
+    queryFn: ({ signal }) => getWorkflowInvocation(invocationId!, client, { signal }),
+    enabled: enabled && workflowDefinitionId !== null && invocationId !== null,
+    refetchInterval: (query) => workflowRunRefetchInterval(query.state.data),
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+  });
+}
+
+export function useWorkflowRunHistory(
+  workflowDefinitionId: string | null,
+  authCacheScope: string,
+  enabled = true,
+) {
+  const client = useCloudClient();
+  return useInfiniteQuery<
+    ManagedWorkflowHistoryResponse,
+    Error,
+    { pages: ManagedWorkflowHistoryResponse[]; pageParams: Array<string | undefined> },
+    ReturnType<typeof workflowRunHistoryKey>,
+    string | undefined
+  >({
+    queryKey: workflowRunHistoryKey(
+      client.baseUrl,
+      authCacheScope,
+      workflowDefinitionId,
+    ),
+    queryFn: ({ pageParam, signal }) =>
+      listWorkflowInvocationHistory(workflowDefinitionId!, pageParam, client, { signal }),
+    initialPageParam: undefined,
+    getNextPageParam: (page) => page.nextCursor ?? undefined,
+    enabled: enabled && workflowDefinitionId !== null,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+  });
+}
+
+export function useWorkflowRunActions(authCacheScope: string) {
+  const client = useCloudClient();
+  const queryClient = useQueryClient();
+
+  const storeRun = async (run: ManagedWorkflowInvocationResponse) => {
+    const historyKey = workflowRunHistoryKey(
+      client.baseUrl,
+      authCacheScope,
+      run.workflowDefinitionId,
+    );
+    queryClient.setQueryData(
+      workflowRunDetailKey(
+        client.baseUrl,
+        authCacheScope,
+        run.workflowDefinitionId,
+        run.id,
+      ),
+      run,
+    );
+    queryClient.setQueryData<InfiniteData<ManagedWorkflowHistoryResponse, string | undefined>>(
+      historyKey,
+      (current) => mergeWorkflowRunIntoHistory(current, run),
+    );
+    await queryClient.invalidateQueries({
+      queryKey: historyKey,
+    });
+  };
+
+  const createMutation = useMutation<
+    WorkflowInvocationResponse,
+    Error,
+    { invocationId: string; body: WorkflowInvocationCreateRequest; signal?: AbortSignal }
+  >({
+    mutationFn: ({ invocationId, body, signal }) =>
+      putWorkflowInvocation(invocationId, body, client, { signal }),
+  });
+
+  const deliverMutation = useMutation<
+    ManagedWorkflowInvocationResponse,
+    Error,
+    { invocationId: string; signal?: AbortSignal }
+  >({
+    mutationFn: ({ invocationId, signal }) =>
+      deliverWorkflowInvocation(invocationId, client, { signal }),
+    onSuccess: storeRun,
+  });
+
+  const cancelMutation = useMutation<
+    ManagedWorkflowInvocationResponse,
+    Error,
+    { invocationId: string; signal?: AbortSignal }
+  >({
+    mutationFn: ({ invocationId, signal }) =>
+      cancelWorkflowInvocation(invocationId, client, { signal }),
+    onSuccess: storeRun,
+  });
+
+  const checkMutation = useMutation<
+    ManagedWorkflowInvocationResponse,
+    Error,
+    { invocationId: string; signal?: AbortSignal }
+  >({
+    mutationFn: ({ invocationId, signal }) =>
+      getWorkflowInvocation(invocationId, client, { signal }),
+    onSuccess: storeRun,
+  });
+
+  return {
+    putWorkflowInvocation: createMutation.mutateAsync,
+    puttingWorkflowInvocation: createMutation.isPending,
+    deliverWorkflowInvocation: deliverMutation.mutateAsync,
+    deliveringWorkflowInvocation: deliverMutation.isPending,
+    cancelWorkflowInvocation: cancelMutation.mutateAsync,
+    cancellingWorkflowInvocation: cancelMutation.isPending,
+    checkWorkflowInvocation: checkMutation.mutateAsync,
+    checkingWorkflowInvocation: checkMutation.isPending,
+    invalidateWorkflowRuns: () => queryClient.invalidateQueries({
+      queryKey: workflowRunsRootKey(client.baseUrl, authCacheScope),
+    }),
+  };
+}
+
+export function mergeWorkflowRunIntoHistory(
+  current: InfiniteData<ManagedWorkflowHistoryResponse, string | undefined> | undefined,
+  run: ManagedWorkflowInvocationResponse,
+): InfiniteData<ManagedWorkflowHistoryResponse, string | undefined> | undefined {
+  const item = workflowHistoryItemFromRun(run);
+  if (!current || current.pages.length === 0) return current;
+
+  let replaced = false;
+  const pages = current.pages.map((page) => ({
+    ...page,
+    items: page.items.map((existing) => {
+      if (existing.id !== item.id) return existing;
+      replaced = true;
+      return item;
+    }),
+  }));
+  return replaced ? { ...current, pages } : current;
+}
+
+function workflowHistoryItemFromRun(
+  run: ManagedWorkflowInvocationResponse,
+): ManagedWorkflowHistoryItem {
+  return {
+    id: run.id,
+    workflowDefinitionId: run.workflowDefinitionId,
+    definitionRevision: run.definitionRevision,
+    title: run.title,
+    placementKind: run.placement.kind,
+    targetKind: run.target.kind,
+    deliveryStatus: run.managedExecution.deliveryStatus,
+    desiredState: run.managedExecution.desiredState,
+    executionStatus: run.managedExecution.execution?.status ?? null,
+    freshness: run.managedExecution.freshness.status,
+    latestObservedAt: run.managedExecution.freshness.latestObservedAt,
+    cloudWorkspaceId: run.managedExecution.correlations.cloudWorkspaceId,
+    sessionId: run.managedExecution.correlations.sessionId,
+    createdAt: run.createdAt,
+    updatedAt: run.managedExecution.updatedAt,
+  };
 }
 
 export function useWorkflowDefinitionActions(authCacheScope: string) {

--- a/cloud/sdk-react/src/lib/query-keys.ts
+++ b/cloud/sdk-react/src/lib/query-keys.ts
@@ -440,6 +440,46 @@ export function workflowDefinitionDetailKey(
   ] as const;
 }
 
+export function workflowRunsRootKey(apiBaseUrl: string, authCacheScope: string) {
+  return [...cloudRootKey(), "workflow-runs", apiBaseUrl, authCacheScope] as const;
+}
+
+export function workflowRunEligibilityKey(
+  apiBaseUrl: string,
+  authCacheScope: string,
+  workflowDefinitionId: string | null,
+  definitionRevision: number | null,
+) {
+  return [
+    ...workflowRunsRootKey(apiBaseUrl, authCacheScope),
+    "eligibility",
+    workflowDefinitionId,
+    definitionRevision,
+  ] as const;
+}
+
+export function workflowRunHistoryKey(
+  apiBaseUrl: string,
+  authCacheScope: string,
+  workflowDefinitionId: string | null,
+) {
+  return [...workflowRunsRootKey(apiBaseUrl, authCacheScope), "history", workflowDefinitionId] as const;
+}
+
+export function workflowRunDetailKey(
+  apiBaseUrl: string,
+  authCacheScope: string,
+  workflowDefinitionId: string | null,
+  invocationId: string | null,
+) {
+  return [
+    ...workflowRunsRootKey(apiBaseUrl, authCacheScope),
+    "detail",
+    workflowDefinitionId,
+    invocationId,
+  ] as const;
+}
+
 export interface AutomationsListKeyOptions {
   ownerScope?: CloudOwnerScope | null;
   organizationId?: string | null;

--- a/cloud/sdk/src/client/workflows.ts
+++ b/cloud/sdk/src/client/workflows.ts
@@ -11,34 +11,44 @@ import type {
 } from "../types/index.js";
 import { getProliferateClient, type ProliferateCloudClient } from "./core.js";
 
+export interface WorkflowRequestOptions {
+  signal?: AbortSignal;
+}
+
 export async function listWorkflowDefinitions(
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<WorkflowDefinitionListResponse> {
   return client.requestJson<WorkflowDefinitionListResponse>({
     method: "GET",
     path: "/v1/workflows",
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
 export async function getWorkflowDefinition(
   workflowDefinitionId: string,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<WorkflowDefinitionResponse> {
   return client.requestJson<WorkflowDefinitionResponse>({
     method: "GET",
     path: "/v1/workflows/{workflow_definition_id}",
     pathParams: { workflow_definition_id: workflowDefinitionId },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
 export async function getWorkflowRunEligibility(
   workflowDefinitionId: string,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<WorkflowRunEligibilityResponse> {
   return client.requestJson<WorkflowRunEligibilityResponse>({
     method: "GET",
     path: "/v1/workflows/{workflow_definition_id}/run-eligibility",
     pathParams: { workflow_definition_id: workflowDefinitionId },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
@@ -46,45 +56,53 @@ export async function putWorkflowInvocation(
   invocationId: string,
   body: WorkflowInvocationCreateRequest,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<WorkflowInvocationResponse> {
   return client.requestJson<WorkflowInvocationResponse>({
     method: "PUT",
     path: "/v1/workflow-invocations/{invocation_id}",
     pathParams: { invocation_id: invocationId },
     body,
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
 export async function getWorkflowInvocation(
   invocationId: string,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<ManagedWorkflowInvocationResponse> {
   return client.requestJson<ManagedWorkflowInvocationResponse>({
     method: "GET",
     path: "/v1/workflow-invocations/{invocation_id}",
     pathParams: { invocation_id: invocationId },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
 export async function deliverWorkflowInvocation(
   invocationId: string,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<ManagedWorkflowInvocationResponse> {
   return client.requestJson<ManagedWorkflowInvocationResponse>({
     method: "POST",
     path: "/v1/workflow-invocations/{invocation_id}/deliver",
     pathParams: { invocation_id: invocationId },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
 export async function cancelWorkflowInvocation(
   invocationId: string,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<ManagedWorkflowInvocationResponse> {
   return client.requestJson<ManagedWorkflowInvocationResponse>({
     method: "POST",
     path: "/v1/workflow-invocations/{invocation_id}/cancel",
     pathParams: { invocation_id: invocationId },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
@@ -92,6 +110,7 @@ export async function listWorkflowInvocationHistory(
   workflowDefinitionId: string,
   cursor?: string,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<ManagedWorkflowHistoryResponse> {
   return client.requestJson<ManagedWorkflowHistoryResponse>({
     method: "GET",
@@ -100,17 +119,20 @@ export async function listWorkflowInvocationHistory(
       workflowDefinitionId,
       ...(cursor === undefined ? {} : { cursor }),
     },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
 export async function createWorkflowDefinition(
   body: WorkflowDefinitionCreateRequest,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<WorkflowDefinitionResponse> {
   return client.requestJson<WorkflowDefinitionResponse>({
     method: "POST",
     path: "/v1/workflows",
     body,
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
@@ -118,12 +140,14 @@ export async function updateWorkflowDefinition(
   workflowDefinitionId: string,
   body: WorkflowDefinitionUpdateRequest,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<WorkflowDefinitionResponse> {
   return client.requestJson<WorkflowDefinitionResponse>({
     method: "PUT",
     path: "/v1/workflows/{workflow_definition_id}",
     pathParams: { workflow_definition_id: workflowDefinitionId },
     body,
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }
 
@@ -131,11 +155,13 @@ export async function deleteWorkflowDefinition(
   workflowDefinitionId: string,
   expectedRevision: number,
   client: ProliferateCloudClient = getProliferateClient(),
+  options: WorkflowRequestOptions = {},
 ): Promise<void> {
   await client.requestJson<void>({
     method: "DELETE",
     path: "/v1/workflows/{workflow_definition_id}",
     pathParams: { workflow_definition_id: workflowDefinitionId },
     query: { expectedRevision },
+    ...(options.signal ? { signal: options.signal } : {}),
   });
 }

--- a/specs/codebase/systems/product/workflows/README.md
+++ b/specs/codebase/systems/product/workflows/README.md
@@ -13,5 +13,6 @@
   run-state versioning, interruption vocabulary, and exclusive execution
   mutation admission for workflow-owned sessions.
 - [Managed Cloud Execution](managed-cloud-execution.md) — feature-gated durable
-  delivery, exact target custody, monotonic observation, history, and
-  cancellation without Desktop presence.
+  delivery, exact target custody, monotonic observation, Cloud product
+  experience, history, cancellation, and exact-session opening without Desktop
+  presence.

--- a/specs/codebase/systems/product/workflows/managed-cloud-execution.md
+++ b/specs/codebase/systems/product/workflows/managed-cloud-execution.md
@@ -102,3 +102,41 @@ Runtime, worker, and Beat use the same image through the background substrate.
 This implementation defines no production enablement: hosted exact-image proof
 and controlled rollout are qualification work, and production remains a hard
 separate approval gate.
+
+## Product experience
+
+The authenticated Workflow definition surface consumes the managed Cloud API
+through `cloud/sdk` and `cloud/sdk-react`. It does not call AnyHarness, Tauri,
+or a raw runtime route. New launch is available only when the capability probe
+is reachable and reports `workflowManagedRuns`; older, unreachable, and
+capability-disabled servers keep a visible disabled control while existing-run
+history, detail, and cancellation remain usable.
+
+An eligible saved definition renders its scalar inputs in authored order. The
+client mirrors server validation for finite numbers, explicit booleans,
+required values, and exact input names. It mints one invocation UUID per user
+launch and retains the exact canonical request across create or delivery
+transport ambiguity. A response-loss recovery first reads that UUID and only
+replays the immutable PUT when it is still absent; a double click cannot mint a
+second run.
+
+Run history is definition-scoped and cursor-paginated. Run detail keeps
+delivery, desired state, execution state, and freshness distinct, polls Cloud
+only while the projection is nonterminal, and uses authored copy for
+unreachable, stale, interrupted, cancellation-pending, and target-lost states.
+Frozen argument values are owner-visible only in a collapsed, masked-on-replay
+Inputs section and are excluded from telemetry projections and error copy.
+
+Repository and scratch placement share one result path. Scratch runs never
+invent repository metadata or repository actions. Opening a result refreshes
+the exact correlated Cloud workspace and requires the same active,
+non-archived row plus matching `anyharnessWorkspaceId`; only then does the host
+open the exact ordinary `cloud:<workspaceId>` session. The Workflow surface
+never embeds a second transcript.
+
+The Tier-2 acceptance journey boots the real Web and Server against Postgres
+with `WORKFLOW_MANAGED_RUNS_ENABLED=true` and external background workers
+disabled. It proves saved-definition launch, one immutable invocation despite a
+duplicate click, durable reload/deep link, queued-before-sandbox cancellation,
+and persisted cancelled history without pretending to qualify E2B or agent
+execution.

--- a/tests/intent/specs/workflow-runs.spec.ts
+++ b/tests/intent/specs/workflow-runs.spec.ts
@@ -1,0 +1,127 @@
+// T2-WF-RUN: real ProductClient renderer + real Server/Postgres. The shared
+// intent stack enables managed Workflow admission but disables background
+// workers, so delivery remains durably queued before any sandbox/E2B effect.
+
+import { expect, test, type Page } from "@playwright/test";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  apiBaseUrl,
+  apiRequest,
+  ensureInstanceClaimed,
+  passwordLogin,
+  webBaseUrl,
+} from "../stack/seed.ts";
+
+test.describe.configure({ mode: "serial" });
+
+const RUN_MARKER = Date.now();
+const TITLE = `T2 managed workflow ${RUN_MARKER}`;
+const TICKET = `PROL-${RUN_MARKER}`;
+let workflowId: string;
+let ownerToken: string;
+
+test.beforeAll(async () => {
+  await ensureInstanceClaimed();
+  ownerToken = await waitForOwnerToken();
+  const created = await apiRequest<{ id: string }>("/v1/workflows", {
+    method: "POST",
+    token: ownerToken,
+    body: {
+      title: TITLE,
+      description: "Managed Workflow product acceptance.",
+      defaultRepoConfigId: null,
+      inputs: [{ name: "ticket", type: "string", required: true }],
+      stages: [{
+        harnessConfig: { agentKind: "claude", modelId: null, effort: null },
+        steps: [{ kind: "agent.prompt", prompt: "Return {{inputs.ticket}}", goal: null }],
+      }],
+    },
+  });
+  expect(created.status).toBe(201);
+  workflowId = created.body.id;
+  await waitForDefinition(ownerToken, workflowId);
+});
+
+test("launches once, reloads durable history, and cancels before sandbox execution", async ({ page }) => {
+  await signIn(page);
+  await page.goto(`${webBaseUrl()}/workflows/${workflowId}`);
+
+  await expect(page.getByRole("heading", { name: TITLE, level: 1 })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Run in Cloud" })).toBeEnabled();
+  await page.getByRole("textbox", { name: "ticket", exact: true }).fill(TICKET);
+
+  let invocationPutCount = 0;
+  page.on("request", (request) => {
+    if (request.method() === "PUT" && request.url().includes("/v1/workflow-invocations/")) {
+      invocationPutCount += 1;
+    }
+  });
+
+  await page.getByRole("button", { name: "Run in Cloud" }).dblclick();
+  await expect(page).toHaveURL(new RegExp(`/workflows/${workflowId}/runs/[0-9a-f-]+$`, "u"));
+  expect(invocationPutCount).toBe(1);
+
+  const runId = page.url().split("/").at(-1)!;
+  await expect(page.getByText("Queued", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Scratch workspace", { exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole("heading", { name: TITLE, level: 1 })).toBeVisible();
+  await expect(page.getByText("Queued", { exact: true }).first()).toBeVisible();
+
+  const cancelResponsePromise = page.waitForResponse((response) =>
+    response.request().method() === "POST"
+      && response.url() === `${apiBaseUrl()}/v1/workflow-invocations/${runId}/cancel`
+  );
+  await page.getByRole("button", { name: "Cancel run", exact: true }).click();
+  expect((await cancelResponsePromise).status()).toBe(200);
+  await expect(page.getByText("Delivery cancelled", { exact: true }).first()).toBeVisible();
+
+  await page.getByRole("button", { name: "Back", exact: true }).click();
+  await expect(page).toHaveURL(`${webBaseUrl()}/workflows/${workflowId}`);
+  await expect(page.getByRole("heading", { name: "Recent runs", exact: true })).toBeVisible();
+  await expect(page.getByText("Delivery cancelled", { exact: true })).toBeVisible();
+
+  const history = await apiRequest<{
+    items: Array<{ id: string; deliveryStatus: string }>;
+  }>(`/v1/workflow-invocations?workflowDefinitionId=${workflowId}`, {
+    token: ownerToken,
+  });
+  expect(history.status).toBe(200);
+  expect(history.body.items.filter((item) => item.id === runId)).toEqual([
+    expect.objectContaining({ id: runId, deliveryStatus: "delivery_cancelled" }),
+  ]);
+});
+
+async function signIn(page: Page): Promise<void> {
+  await page.goto(webBaseUrl());
+  await page.getByLabel("Email").fill(ADMIN_EMAIL);
+  await page.getByLabel("Password").fill(ADMIN_PASSWORD);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await expect(page.getByLabel("Password")).toHaveCount(0, { timeout: 30_000 });
+}
+
+async function waitForDefinition(token: string, definitionId: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await apiRequest(`/v1/workflows/${definitionId}`, { token });
+    if (result.status === 200) return;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Workflow ${definitionId} was not durably readable within 15 seconds.`);
+}
+
+async function waitForOwnerToken(): Promise<string> {
+  const deadline = Date.now() + 10_000;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      return (await passwordLogin(ADMIN_EMAIL, ADMIN_PASSWORD)).access_token;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw lastError ?? new Error("Owner login did not become ready after instance claim.");
+}

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -60,6 +60,12 @@ export interface BootOptions {
 const here = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(here, "..", "..", "..");
 
+function serverVenvExecutable(name: string): string {
+  const binDir = process.env.TIER2_INTENT_SERVER_VENV_BIN
+    ?? path.join(REPO_ROOT, "server", ".venv", "bin");
+  return path.join(binDir, name);
+}
+
 export interface BootedStack {
   profile: string;
   apiBaseUrl: string;
@@ -304,7 +310,7 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
   rmSync(setupTokenFile, { force: true });
 
   log(`running alembic migrations against ${instance.databaseName}...`);
-  run(path.join(REPO_ROOT, "server", ".venv", "bin", "alembic"), ["upgrade", "head"], {
+  run(serverVenvExecutable("alembic"), ["upgrade", "head"], {
     cwd: path.join(REPO_ROOT, "server"),
     env: { DATABASE_URL: databaseUrl, DEBUG: "true" },
   });
@@ -397,7 +403,7 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
   }
   spawnTracked(
     children,
-    path.join(REPO_ROOT, "server", ".venv", "bin", "uvicorn"),
+    serverVenvExecutable("uvicorn"),
     ["proliferate.main:app", "--host", "127.0.0.1", "--port", String(instance.ports.api)],
     { cwd: path.join(REPO_ROOT, "server"), env: serverEnv, name: "server" },
   );

--- a/tests/intent/stack/global-setup.ts
+++ b/tests/intent/stack/global-setup.ts
@@ -10,7 +10,16 @@ import { bootStack } from "./boot.ts";
 import { resetPasswordLoginRateLimits } from "./seed.ts";
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
-  const stack = await bootStack();
+  const stack = await bootStack({
+    profile: process.env.TIER2_INTENT_PROFILE || undefined,
+    extraServerEnv: {
+      // T2-WF-RUN: admit new managed Workflow delivery while keeping the
+      // external worker phase stopped. The browser can therefore prove the
+      // durable queued/cancelled product journey without E2B.
+      WORKFLOW_MANAGED_RUNS_ENABLED: "true",
+      RUN_BACKGROUND_WORKERS: "false",
+    },
+  });
   process.env.TIER2_INTENT_API_BASE_URL = stack.apiBaseUrl;
   process.env.TIER2_INTENT_WEB_BASE_URL = stack.webBaseUrl;
   process.env.TIER2_INTENT_ANYHARNESS_BASE_URL = stack.anyharnessBaseUrl;


### PR DESCRIPTION
## Outcome

Adds the authenticated managed Cloud run experience to saved Workflows: scalar argument entry, fail-closed eligibility/capability presentation, one immutable launch identity, durable history/detail, cancellation, and exact ordinary-session opening.

The production capability remains off by default. This PR does not add Server/OpenAPI behavior, Desktop delivery, E2B qualification, deployment, or production enablement.

## What changed

- Cloud SDK and React Query resources for eligibility, detail, cursor-safe history, create/deliver/cancel/check, exact 3-second nonterminal polling, abort signals, and server/auth/definition/revision/run-isolated keys
- product-domain argument normalization and exhaustive delivery × desired × execution × freshness presentation
- product-ui launch form, prompt-referenced optional-input guidance, recent runs, four-dimensional run detail, collapsed owner-visible inputs, and safe failure states
- connected definition/run surfaces with eligibility/history gates, revision-keyed drafts, synchronous double-click fencing, and same-UUID response-loss recovery
- fail-closed `workflowManagedRunsEnabled` capability for launch and prepared delivery
- absorbing `workflow_target_lost` projection that stops polling/cancel while preserving a verified existing-session open target
- exact Cloud workspace refresh plus active/non-archived/runtime-ID verification before opening the existing session
- canonical operating documentation and a real Tier-2 Web + Server + Postgres journey through queued-before-sandbox cancellation

## Custody

- Frozen implementation predecessor: `3e6e4fa901274e8126a83b35772b29867c23944e`
- Reconciled current base and merge base: `ee9735f0742c2aacdda38b8c2e1ffe5599554e5e`
- Exact head: `c84df4921edd11a851b3c3bc33f3a3f361559872`
- One intentional implementation commit; protected primary checkout untouched
- The current-main dependency/lockfile upgrade is preserved unchanged; this PR adds only its Workflow exports and has no lockfile delta

## Verification

- ProductClient typecheck, including all shared package builds: pass
- product-domain: 629 tests pass
- product-ui: 191 tests pass
- product-surfaces: 48 tests pass
- product-client: 3,297 tests pass across 556 files
- focused SDK/polling contract: 7 tests pass
- Tier-2 `workflow-runs.spec.ts`: fresh-profile first-attempt pass in 49.7s (6.6s journey) against real Web + Server + Postgres; runtime/E2B intentionally skipped by the frozen contract
- max-lines, frontend boundaries, frontend structure, docs integrity, and `git diff --check`: pass
- Local pnpm 11 verification used a command-scoped `minimum-release-age=0` solely to consume the exact current-main lockfile entries merged by #1240; no repository policy, dependency version, or lockfile was changed
- GitHub exact-head rollup: all checks pass, including shared frontend packages on the #1240 lockfile, Web/Desktop/Mobile, SDK, Cargo, CodeQL, candidate handoff, workflow lifecycle Tier-2, intent suites, and production compose smoke

## Review-repair proof

- Definition revision is part of eligibility and launch-form identity; changed input schemas cannot reuse stale draft values.
- Launch fails closed until eligibility and history have both resolved successfully.
- Mutation responses update known history rows in place without synthesizing cursor order; absent rows rely on authoritative invalidation.
- Polling is pinned to 3 seconds and stops for terminal or target-lost projections; request abort behavior is pinned at the 15-second boundary.
- Capability-off prepared delivery, response-loss same-ID recovery, hard new-UUID fencing while an attempt is unresolved, cached authoritative 404, target loss, transient detail errors, and the complete delivery/execution/freshness presentation matrix are regression-tested.

## Frozen contract

`/Users/pablohansen/Vault/Vault/Workspace/Workflows/1 - Core V1 Implementation/First Supported Product PR Stack/6 - Managed Workflow Product Experience.md` — FROZEN RC1.0.
