### PR TITLE
test(release): retained-release receipts for Tier 4 N-1 artifact identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -867,6 +867,29 @@ qualification-candidate-build-map:
 # target dir and clear any ambient cross-compile target so an operator's
 # CARGO_TARGET_DIR/CARGO_BUILD_TARGET cannot make this qualify a stale binary
 # at target/release/ while cargo wrote somewhere else.
+# Validate and materialize a committed retained-release receipt — the exact
+# immutable production N-1 artifact set Tier 4 update proofs start from
+# (specs/developing/testing/tier-4-scenario-contract.md "Artifact Identity").
+# Shape + policy validation run before any download; every byte is verified
+# against the receipt on every use (a cache hit is re-hashed, never trusted).
+# Read-only toward providers: LIVE=1 adds an E2B metadata lookup proving the
+# recorded immutable source tag still resolves to the recorded build id.
+#
+# RETAINED_RELEASE_ID=vX.Y.Z   Receipt to validate (see
+#                              tests/release/retained-releases/index.json).
+# LIVE=1                       Also live-verify E2B template identity
+#                              (needs E2B_API_KEY or RELEASE_E2E_E2B_API_KEY).
+# CANDIDATE_SHA=<40-hex>       Optional candidate N SHA for the N != N-1 check.
+qualification-retained-release:
+	@if [ -z "$(RETAINED_RELEASE_ID)" ]; then \
+		echo "RETAINED_RELEASE_ID=<vX.Y.Z> is required, e.g. make qualification-retained-release RETAINED_RELEASE_ID=v0.3.38"; \
+		exit 2; \
+	fi
+	cd tests/release && pnpm install --silent && pnpm exec tsx src/cli/retained-release.ts validate \
+		--release-id $(RETAINED_RELEASE_ID) \
+		$(if $(filter 1,$(LIVE)),--live,) \
+		$(if $(CANDIDATE_SHA),--candidate-sha $(CANDIDATE_SHA),)
+
 qualification-candidate-handoff-smoke:
 	pnpm install --silent
 	env -u CARGO_BUILD_TARGET \

--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -94,9 +94,13 @@ across worlds. Compilation caches may accelerate the build, but a cache entry is
 not qualification evidence. Downstream jobs download the prepared artifact and
 verify its digest against the candidate manifest.
 
-Tier 4 additionally resolves the retained manifest for the last qualified
-production release, N-1. N-1 is not inferred by decrementing a patch version or
-rebuilding current source with an older version string.
+Tier 4 additionally resolves the retained-release receipt for the last
+qualified production release, N-1 — implemented as `RetainedReleaseReceiptV1`
+(`tests/release/src/artifacts/retained-release-set.ts`) with committed
+receipts under `tests/release/retained-releases/` (see that directory's
+README for the N-1 identity rules, the one-time v0.3.38 bootstrap exception,
+and the retention roots). N-1 is not inferred by decrementing a patch version
+or rebuilding current source with an older version string.
 
 Both manifests are versioned machine contracts. Each available artifact slot
 contains an immutable locator plus the digest/checksum needed to verify the

--- a/specs/developing/testing/tier-4-scenario-contract.md
+++ b/specs/developing/testing/tier-4-scenario-contract.md
@@ -55,8 +55,24 @@ upgrade world.
 
 ### N-1 means the last qualified production release
 
-N-1 is resolved from the retained manifest for the last production release
-qualified before N. It is never:
+N-1 is resolved from the retained-release receipt of the last production
+release qualified before N. Receipts are committed under
+`tests/release/retained-releases/` (append-only index + one immutable receipt
+per release; schema and validation in
+`tests/release/src/artifacts/retained-release-set.ts`), selected via
+`RELEASE_E2E_RETAINED_RELEASE_ID`, validated (shape, immutable/non-expiring
+locators, artifact-set digest recomputation, bootstrap policy) before any
+world side effect, and materialized with byte-hash verification on every use
+(`materialize-retained-release.ts`; `make qualification-retained-release`).
+
+One-time bootstrap exception (founder ruling 2026-07-16): production v0.3.38
+is retained as `bootstrap_unqualified` — explicitly not claiming historical
+qualification; evidence displays that state; the receipt's E2B `input_hash`
+is a disclosed-null historical gap; and its self-host target truthfully
+records `server-v0.3.35` (v0.3.38 shipped no server surface). Once any
+`qualified` receipt exists, selecting a bootstrap receipt fails closed.
+
+N-1 is never:
 
 - inferred by subtracting one patch version;
 - rebuilt from candidate source with an older version string;

--- a/tests/release/retained-releases/README.md
+++ b/tests/release/retained-releases/README.md
@@ -1,0 +1,93 @@
+# Retained Production Release Receipts
+
+This directory is the durable, immutable store of retained-release receipts:
+the exact production N-1 artifact identities Tier 4 update qualification
+starts from
+([`tier-4-scenario-contract.md`](../../../specs/developing/testing/tier-4-scenario-contract.md)
+"Artifact Identity"). Local runs and GitHub Actions read the identical
+committed receipt — same checkout, same bytes, same logical retained set.
+
+## Contents
+
+- `index.json` — append-only index of receipts. Each entry records the
+  release id, source SHA, qualification state, receipt path, and the SHA-256
+  of the exact receipt file bytes. Consumers reject a receipt whose bytes do
+  not match its index entry.
+- `v<X.Y.Z>.json` — one receipt per retained production release, conforming
+  to `RetainedReleaseReceiptV1`
+  (`tests/release/src/artifacts/retained-release-set.ts`).
+
+## Rules
+
+1. **Receipts are immutable.** Once indexed, a receipt file never changes.
+   Re-sealing the same release must reproduce identical bytes; differing
+   bytes are a hard failure, never an overwrite.
+2. **The index is append-only.** Entries are added when a release is
+   retained; they are removed only when a release leaves the retention set
+   defined below, in a reviewed PR.
+3. **Only immutable identities.** Locators embed the exact version, source
+   SHA, or content digest. Mutable aliases (`latest`, `production`,
+   `stable` as the terminal segment), expiring signed URLs, local paths, and
+   short-lived Actions artifacts are rejected by validation.
+4. **No secrets, no raw provider responses.** Receipts are public release
+   metadata plus hashes.
+
+## N-1 and the one-time bootstrap truth
+
+`N-1` means the retained receipt of the last production release **qualified
+through this platform** — never a decremented version string, a rebuild from
+older source, or whatever a rolling alias currently points at.
+
+The platform has a first-release paradox: no release could be marked
+`qualified` before Tier 4 could run, and Tier 4 could not run without a
+retained release. By founder ruling (2026-07-16), production **v0.3.38** is
+the one-time `bootstrap_unqualified` baseline:
+
+- The v0.3.38 receipt does **not** claim the release was historically
+  qualified; its `qualification_state` says so explicitly, it carries no
+  qualification evidence, and evidence derived from it displays that state.
+- Its E2B `input_hash` is `null` — E2B exposes no template input hash and no
+  code recorded one at release time. This is a disclosed unavailable
+  historical artifact, allowed only on the bootstrap receipt. `qualified`
+  receipts must carry a real input hash.
+- Its self-host target records `server-v0.3.35`: v0.3.38 was a hotfix that
+  did not ship the server surface, so production self-host truthfully remained
+  at 0.3.35.
+- Once any `qualified` receipt exists in the index, selecting a
+  `bootstrap_unqualified` receipt **fails closed**. The bootstrap exception
+  is one-time.
+
+## Retention roots
+
+A receipt in `index.json` is a garbage-collection **root**: every artifact it
+references (CDN desktop packages and signatures, the versioned updater
+snapshot, GitHub release assets, GHCR image digests, the E2B template build
+behind the recorded immutable source tag) must not be deleted while the
+receipt is indexed. At minimum the index retains:
+
+- the current production release's receipt, and
+- the immediately previous qualified production receipt until a later
+  production release completes its update qualification, and
+- any receipt referenced by an unresolved qualification incident.
+
+Deleting an artifact still referenced by an indexed receipt is a
+release-pipeline failure, surfaced by `make qualification-retained-release`
+(hash/identity validation fails closed before any world side effect).
+
+## Operating
+
+```bash
+# Validate + materialize (bytes verified on every use, cache never trusted):
+make qualification-retained-release RETAINED_RELEASE_ID=v0.3.38
+
+# Also live-verify E2B immutable identity (read-only metadata lookup):
+make qualification-retained-release RETAINED_RELEASE_ID=v0.3.38 LIVE=1
+
+# Select the baseline for T4-RUNTIME-1:
+RELEASE_E2E_RETAINED_RELEASE_ID=v0.3.38 make release-e2e LANE=sandbox SCENARIOS=T4-RUNTIME-1 ...
+```
+
+Receipts are created/sealed with
+`tests/release/src/cli/retained-release.ts seal`, which independently
+verifies every downloadable artifact's bytes and (with `--live`) the E2B
+immutable identity before writing anything.

--- a/tests/release/retained-releases/index.json
+++ b/tests/release/retained-releases/index.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kind": "proliferate.retained-release-index",
+  "receipts": [
+    {
+      "release_id": "v0.3.38",
+      "source_sha": "e61afc274593085e51870b24269f718a543b88b4",
+      "qualification_state": "bootstrap_unqualified",
+      "receipt_path": "v0.3.38.json",
+      "receipt_sha256": "1c4672ae2d18b024e7dbe890a5991ac7a6563768eae1009bb8974bbf48eef0d9"
+    }
+  ]
+}

--- a/tests/release/retained-releases/v0.3.38.json
+++ b/tests/release/retained-releases/v0.3.38.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "kind": "proliferate.retained-release",
+  "release": {
+    "release_id": "v0.3.38",
+    "release_tag": "proliferate-v0.3.38",
+    "source_sha": "e61afc274593085e51870b24269f718a543b88b4",
+    "published_at": "2026-07-17T01:07:21.493Z",
+    "qualification_state": "bootstrap_unqualified",
+    "qualification_evidence": null
+  },
+  "desktop": {
+    "version": "0.3.38",
+    "packages": [
+      {
+        "platform": "darwin-aarch64",
+        "immutable_locator": "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz",
+        "sha256": "bae2e0519ea75f2e88a5bead8007af4386d1952b9c26536ea2a9c140e6bc1bd5",
+        "signature_locator": "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig",
+        "sha256_signature": "9861f020f3580d4ea474b8a3383e7be92f27ea313933fd2476542d91adfb9793"
+      },
+      {
+        "platform": "darwin-x86_64",
+        "immutable_locator": "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz",
+        "sha256": "84b1b073298d36ac1432083c52dae24984a3524e269aead9cb981989a8e9c307",
+        "signature_locator": "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig",
+        "sha256_signature": "abd1eebdb37ac2a57e98e03541091f2e556d1ab0a238fee031b923721c47542a"
+      }
+    ],
+    "updater_pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZEMkRFQkU1RDRENDI4MkUKUldRdUtOVFU1ZXN0YlFBN2ZWUjZzcXpkMWpvL1VUdWpnNmF3Q1g4U0hHYnd4MVFmUTdvaERmY04K",
+    "embedded_anyharness_version": "0.3.38"
+  },
+  "managed_runtime": {
+    "template_family": "pablo-5391/proliferate-runtime-cloud",
+    "immutable_template_id": "y7dakz4fs16tbz8vb9zo",
+    "template_build_id": "661a9621-78db-4c55-84d1-281c21fb72dc",
+    "source_tag": "sha-e61afc274593",
+    "input_hash": null,
+    "anyharness_version": "0.3.38",
+    "worker_version": "0.3.38",
+    "supervisor_version": "0.3.38",
+    "harness_catalog_digest": "4720c40366a3f183688077442513f4167eaefdc3e934e16f1673e0d8377df0df",
+    "harness_registry_digest": "6a67fe6266294fb3d9589645a213cec971f4a3ff33e1c64415b72bc2c1884ca0"
+  },
+  "self_host": {
+    "version": "0.3.35",
+    "release_tag": "server-v0.3.35",
+    "deploy_bundle_locator": "https://github.com/proliferate-ai/proliferate/releases/download/server-v0.3.35/proliferate-deploy.tar.gz",
+    "deploy_bundle_sha256": "e8fc82e980cd0e71ab306cf3b8eba319f7e33f6c59e7aa48a5f22ba3cde83f8a",
+    "server_image_digest": "ghcr.io/proliferate-ai/proliferate-server@sha256:284a51aa3bdcab74b221fdc04f4d93ee757fe52c5ed2f9979a4477127955617d"
+  },
+  "artifact_set_digest": "b8aad5853c70f127664ed9a4828e3d3ae0dc2d207579b5574add13e808347a88"
+}

--- a/tests/release/src/artifacts/materialize-retained-release.test.ts
+++ b/tests/release/src/artifacts/materialize-retained-release.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  computeArtifactSetDigest,
+  type RetainedReleaseReceiptV1,
+} from "./retained-release-set.js";
+import {
+  downloadableRetainedArtifacts,
+  materializeRetainedRelease,
+} from "./materialize-retained-release.js";
+
+const SHA = "e61afc274593085e51870b24269f718a543b88b4";
+const BYTES: Record<string, string> = {
+  "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz": "pkg-aarch64",
+  "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig": "sig-aarch64",
+  "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz": "pkg-x64",
+  "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig": "sig-x64",
+  "https://github.example.com/releases/download/server-v0.3.35/proliferate-deploy.tar.gz": "bundle",
+};
+
+const sha = (text: string) => createHash("sha256").update(text).digest("hex");
+
+function receipt(): RetainedReleaseReceiptV1 {
+  const body: Omit<RetainedReleaseReceiptV1, "artifact_set_digest"> = {
+    schema_version: 1,
+    kind: "proliferate.retained-release",
+    release: {
+      release_id: "v0.3.38",
+      release_tag: "proliferate-v0.3.38",
+      source_sha: SHA,
+      published_at: "2026-07-17T01:07:21.493Z",
+      qualification_state: "bootstrap_unqualified",
+      qualification_evidence: null,
+    },
+    desktop: {
+      version: "0.3.38",
+      packages: [
+        {
+          platform: "darwin-aarch64",
+          immutable_locator:
+            "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz",
+          sha256: sha("pkg-aarch64"),
+          signature_locator:
+            "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig",
+          sha256_signature: sha("sig-aarch64"),
+        },
+        {
+          platform: "darwin-x86_64",
+          immutable_locator: "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz",
+          sha256: sha("pkg-x64"),
+          signature_locator:
+            "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig",
+          sha256_signature: sha("sig-x64"),
+        },
+      ],
+      updater_pubkey: "dW50cnVzdGVk",
+      embedded_anyharness_version: "0.3.38",
+    },
+    managed_runtime: {
+      template_family: "pablo-5391/proliferate-runtime-cloud",
+      immutable_template_id: "y7dakz4fs16tbz8vb9zo",
+      template_build_id: "661a9621-78db-4c55-84d1-281c21fb72dc",
+      source_tag: "sha-e61afc274593",
+      input_hash: null,
+      anyharness_version: "0.3.38",
+      worker_version: "0.3.38",
+      supervisor_version: "0.3.38",
+      harness_catalog_digest: sha("catalog"),
+      harness_registry_digest: sha("registry"),
+    },
+    self_host: {
+      version: "0.3.35",
+      release_tag: "server-v0.3.35",
+      deploy_bundle_locator:
+        "https://github.example.com/releases/download/server-v0.3.35/proliferate-deploy.tar.gz",
+      deploy_bundle_sha256: sha("bundle"),
+      server_image_digest: `ghcr.io/proliferate-ai/proliferate-server@sha256:${sha("image")}`,
+    },
+  };
+  return { ...body, artifact_set_digest: computeArtifactSetDigest(body) };
+}
+
+function fakeFetch(overrides: Record<string, string> = {}, log?: string[]): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    log?.push(url);
+    const bytes = overrides[url] ?? BYTES[url];
+    if (bytes === undefined) {
+      return new Response(null, { status: 404 });
+    }
+    return new Response(new TextEncoder().encode(bytes));
+  }) as typeof fetch;
+}
+
+test("downloadable set covers desktop packages+signatures and the self-host bundle; runtime is provider-side", () => {
+  const all = downloadableRetainedArtifacts(receipt(), ["desktop", "managed-runtime", "self-host"]);
+  assert.deepEqual(
+    all.map((entry) => entry.artifact).sort(),
+    [
+      "desktop/darwin-aarch64/package",
+      "desktop/darwin-aarch64/signature",
+      "desktop/darwin-x86_64/package",
+      "desktop/darwin-x86_64/signature",
+      "self-host/deploy-bundle",
+    ],
+  );
+  assert.equal(downloadableRetainedArtifacts(receipt(), ["managed-runtime"]).length, 0);
+});
+
+test("materializes, verifies, and caches artifact bytes", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "retained-mat-"));
+  try {
+    const log: string[] = [];
+    const first = await materializeRetainedRelease(receipt(), {
+      targets: ["desktop", "self-host"],
+      cacheDirectory: dir,
+      fetchImpl: fakeFetch({}, log),
+    });
+    assert.equal(first.length, 5);
+    assert.equal(log.length, 5);
+    for (const artifact of first) {
+      assert.equal(sha(await readFile(artifact.path, "utf8")), artifact.sha256);
+    }
+    // Cache hit: no network, but bytes are STILL hash-verified per use.
+    const secondLog: string[] = [];
+    const second = await materializeRetainedRelease(receipt(), {
+      targets: ["desktop", "self-host"],
+      cacheDirectory: dir,
+      fetchImpl: fakeFetch({}, secondLog),
+    });
+    assert.equal(secondLog.length, 0);
+    assert.deepEqual(
+      second.map((entry) => entry.sha256).sort(),
+      first.map((entry) => entry.sha256).sort(),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("package hash drift fails closed", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "retained-drift-"));
+  try {
+    await assert.rejects(
+      materializeRetainedRelease(receipt(), {
+        targets: ["desktop"],
+        cacheDirectory: dir,
+        fetchImpl: fakeFetch({
+          "https://cdn.example.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz":
+            "tampered-bytes",
+        }),
+      }),
+      /do not match the receipt SHA-256/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("missing artifact (HTTP error) fails closed", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "retained-missing-"));
+  try {
+    const notFoundFetch = (async () => new Response(null, { status: 404 })) as unknown as typeof fetch;
+    await assert.rejects(
+      materializeRetainedRelease(receipt(), {
+        targets: ["self-host"],
+        cacheDirectory: dir,
+        fetchImpl: notFoundFetch,
+      }),
+      /HTTP 404/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("cache corruption is detected and repaired by a fresh verified download", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "retained-corrupt-"));
+  try {
+    await materializeRetainedRelease(receipt(), {
+      targets: ["self-host"],
+      cacheDirectory: dir,
+      fetchImpl: fakeFetch(),
+    });
+    const [cacheFile] = await readdir(dir);
+    await writeFile(path.join(dir, cacheFile), "corrupted-on-disk");
+    const log: string[] = [];
+    const repaired = await materializeRetainedRelease(receipt(), {
+      targets: ["self-host"],
+      cacheDirectory: dir,
+      fetchImpl: fakeFetch({}, log),
+    });
+    assert.equal(log.length, 1, "corrupt cache must trigger a re-download, not a trusted read");
+    assert.equal(repaired[0].sha256, sha("bundle"));
+    assert.equal(sha(await readFile(repaired[0].path, "utf8")), sha("bundle"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("corrupt cache with an unreachable source fails closed rather than using stale bytes", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "retained-corrupt-offline-"));
+  try {
+    await materializeRetainedRelease(receipt(), {
+      targets: ["self-host"],
+      cacheDirectory: dir,
+      fetchImpl: fakeFetch(),
+    });
+    const [cacheFile] = await readdir(dir);
+    await writeFile(path.join(dir, cacheFile), "corrupted-on-disk");
+    await assert.rejects(
+      materializeRetainedRelease(receipt(), {
+        targets: ["self-host"],
+        cacheDirectory: dir,
+        fetchImpl: (async () => {
+          throw new Error("network down");
+        }) as unknown as typeof fetch,
+      }),
+      /could not be downloaded/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/artifacts/materialize-retained-release.ts
+++ b/tests/release/src/artifacts/materialize-retained-release.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  RetainedReleaseError,
+  type RetainedReleaseReceiptV1,
+  type RetainedTarget,
+} from "./retained-release-set.js";
+
+/**
+ * Materializes a validated retained-release receipt's downloadable artifacts
+ * into a run/cache directory, verifying SHA-256 on EVERY use — a cache hit is
+ * re-hashed before it is trusted, so a corrupted or tampered cache entry is a
+ * RetainedReleaseError, never silently launched bytes (frozen spec
+ * "Local and Actions behavior": a cache hit never bypasses validation).
+ *
+ * Local runs and GitHub Actions runs call this same code with the same
+ * receipt: only where the cache directory lives differs. An `oci` artifact
+ * (the self-host server image) and the E2B template are provider-side and are
+ * not byte-materialized here — their identities are validated by
+ * `validateRetainedReleaseReceiptShape` / `verifyRetainedReleaseLive`, and
+ * their consumers (docker, E2B provisioning) pin by digest/immutable id.
+ */
+
+export interface MaterializedRetainedArtifact {
+  /** Stable retained artifact id, e.g. `desktop/darwin-aarch64/package`. */
+  artifact: string;
+  sha256: string;
+  path: string;
+}
+
+export interface MaterializeRetainedReleaseOptions {
+  targets: readonly RetainedTarget[];
+  cacheDirectory: string;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+interface DownloadableArtifact {
+  artifact: string;
+  locator: string;
+  sha256: string;
+}
+
+/** The byte-downloadable artifact set for the selected targets. */
+export function downloadableRetainedArtifacts(
+  receipt: RetainedReleaseReceiptV1,
+  targets: readonly RetainedTarget[],
+): DownloadableArtifact[] {
+  const artifacts: DownloadableArtifact[] = [];
+  if (targets.includes("desktop")) {
+    for (const pkg of receipt.desktop.packages) {
+      artifacts.push({
+        artifact: `desktop/${pkg.platform}/package`,
+        locator: pkg.immutable_locator,
+        sha256: pkg.sha256,
+      });
+      artifacts.push({
+        artifact: `desktop/${pkg.platform}/signature`,
+        locator: pkg.signature_locator,
+        sha256: pkg.sha256_signature,
+      });
+    }
+  }
+  if (targets.includes("self-host")) {
+    artifacts.push({
+      artifact: "self-host/deploy-bundle",
+      locator: receipt.self_host.deploy_bundle_locator,
+      sha256: receipt.self_host.deploy_bundle_sha256,
+    });
+  }
+  // managed-runtime has no byte download: its retained identity is the
+  // immutable E2B template id/build id, consumed provider-side.
+  return artifacts;
+}
+
+function sha256OfBytes(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function sha256OfFile(filePath: string): Promise<string> {
+  return sha256OfBytes(await readFile(filePath));
+}
+
+/**
+ * Materializes one artifact: returns the verified cached copy if its bytes
+ * still hash correctly, otherwise downloads, verifies, and atomically
+ * installs into the cache. Every returned path has been hash-verified in
+ * this call.
+ */
+async function materializeOne(
+  entry: DownloadableArtifact,
+  cacheDirectory: string,
+  fetchImpl: typeof fetch,
+): Promise<MaterializedRetainedArtifact> {
+  // encodeURIComponent is injective on artifact ids (slashes encode to %2F),
+  // so distinct ids can never collide onto one cache file. The declared hash
+  // is part of the key so a receipt change can never alias stale bytes.
+  const cachePath = path.join(
+    cacheDirectory,
+    `${encodeURIComponent(entry.artifact)}-${entry.sha256.slice(0, 16)}`,
+  );
+  await mkdir(cacheDirectory, { recursive: true });
+
+  let cached = false;
+  try {
+    cached = (await stat(cachePath)).isFile();
+  } catch {
+    cached = false;
+  }
+  if (cached) {
+    const cachedSha = await sha256OfFile(cachePath);
+    if (cachedSha === entry.sha256) {
+      return { artifact: entry.artifact, sha256: cachedSha, path: cachePath };
+    }
+    // Corrupt cache entry: fall through to a fresh verified download rather
+    // than trusting or silently deleting ambiguous bytes.
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(entry.locator);
+  } catch (error) {
+    throw new RetainedReleaseError(
+      `Retained artifact "${entry.artifact}" could not be downloaded: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!response.ok) {
+    throw new RetainedReleaseError(
+      `Retained artifact "${entry.artifact}" download failed with HTTP ${response.status}.`,
+    );
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const actual = sha256OfBytes(bytes);
+  if (actual !== entry.sha256) {
+    throw new RetainedReleaseError(
+      `Retained artifact "${entry.artifact}" bytes do not match the receipt SHA-256 ` +
+        `(receipt ${entry.sha256}, downloaded ${actual}). Treat as a release/security incident.`,
+    );
+  }
+  const tempPath = `${cachePath}.tmp-${process.pid}`;
+  await writeFile(tempPath, bytes);
+  await rename(tempPath, cachePath);
+  return { artifact: entry.artifact, sha256: actual, path: cachePath };
+}
+
+/**
+ * Materializes every downloadable artifact for the selected targets. Fails
+ * closed on the first missing/mismatched artifact; a partial cache is left
+ * only with fully verified entries (installs are atomic).
+ */
+export async function materializeRetainedRelease(
+  receipt: RetainedReleaseReceiptV1,
+  options: MaterializeRetainedReleaseOptions,
+): Promise<MaterializedRetainedArtifact[]> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const artifacts = downloadableRetainedArtifacts(receipt, options.targets);
+  const materialized: MaterializedRetainedArtifact[] = [];
+  for (const entry of artifacts) {
+    materialized.push(await materializeOne(entry, options.cacheDirectory, fetchImpl));
+  }
+  return materialized;
+}

--- a/tests/release/src/artifacts/retained-release-set.test.ts
+++ b/tests/release/src/artifacts/retained-release-set.test.ts
@@ -1,0 +1,391 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  assertImmutableLocator,
+  computeArtifactSetDigest,
+  loadRetainedReleaseIndex,
+  loadRetainedReleaseReceipt,
+  qualifiedReceiptExists,
+  RetainedReleaseError,
+  toRetainedReleaseEvidence,
+  validateRetainedRelease,
+  validateRetainedReleaseReceiptShape,
+  verifyRetainedReleaseLive,
+  type RetainedReleaseReceiptV1,
+} from "./retained-release-set.js";
+
+const SHA = "e61afc274593085e51870b24269f718a543b88b4";
+const HEX64 = (seed: string) => createHash("sha256").update(seed).digest("hex");
+
+/** A complete valid receipt body (digest filled in by seal()). */
+function validBody(): Omit<RetainedReleaseReceiptV1, "artifact_set_digest"> {
+  return {
+    schema_version: 1,
+    kind: "proliferate.retained-release",
+    release: {
+      release_id: "v0.3.38",
+      release_tag: "proliferate-v0.3.38",
+      source_sha: SHA,
+      published_at: "2026-07-17T01:07:21.493Z",
+      qualification_state: "bootstrap_unqualified",
+      qualification_evidence: null,
+    },
+    desktop: {
+      version: "0.3.38",
+      packages: [
+        {
+          platform: "darwin-aarch64",
+          immutable_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz",
+          sha256: HEX64("aarch64"),
+          signature_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig",
+          sha256_signature: HEX64("aarch64.sig"),
+        },
+        {
+          platform: "darwin-x86_64",
+          immutable_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz",
+          sha256: HEX64("x64"),
+          signature_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig",
+          sha256_signature: HEX64("x64.sig"),
+        },
+      ],
+      updater_pubkey: "dW50cnVzdGVk",
+      embedded_anyharness_version: "0.3.38",
+    },
+    managed_runtime: {
+      template_family: "pablo-5391/proliferate-runtime-cloud",
+      immutable_template_id: "y7dakz4fs16tbz8vb9zo",
+      template_build_id: "661a9621-78db-4c55-84d1-281c21fb72dc",
+      source_tag: "sha-e61afc274593",
+      input_hash: null,
+      anyharness_version: "0.3.38",
+      worker_version: "0.3.38",
+      supervisor_version: "0.3.38",
+      harness_catalog_digest: HEX64("catalog"),
+      harness_registry_digest: HEX64("registry"),
+    },
+    self_host: {
+      version: "0.3.35",
+      release_tag: "server-v0.3.35",
+      deploy_bundle_locator:
+        "https://github.com/proliferate-ai/proliferate/releases/download/server-v0.3.35/proliferate-deploy.tar.gz",
+      deploy_bundle_sha256: HEX64("bundle"),
+      server_image_digest: `ghcr.io/proliferate-ai/proliferate-server@sha256:${HEX64("image")}`,
+    },
+  };
+}
+
+function seal(body: Omit<RetainedReleaseReceiptV1, "artifact_set_digest">): RetainedReleaseReceiptV1 {
+  return { ...body, artifact_set_digest: computeArtifactSetDigest(body) };
+}
+
+function mutated(
+  mutate: (receipt: RetainedReleaseReceiptV1) => void,
+  reseal = false,
+): RetainedReleaseReceiptV1 {
+  const receipt = seal(validBody());
+  mutate(receipt);
+  if (reseal) {
+    const { artifact_set_digest: _ignored, ...body } = receipt;
+    return seal(body);
+  }
+  return receipt;
+}
+
+test("accepts a complete valid receipt", () => {
+  const receipt = validateRetainedReleaseReceiptShape(seal(validBody()));
+  assert.equal(receipt.release.release_id, "v0.3.38");
+  assert.equal(receipt.managed_runtime.source_tag, "sha-e61afc274593");
+});
+
+test("rejects an unknown schema version", () => {
+  assert.throws(
+    () => validateRetainedReleaseReceiptShape(mutated((r) => ((r as { schema_version: number }).schema_version = 2), true)),
+    (error: unknown) => error instanceof RetainedReleaseError && /schema_version/.test((error as Error).message),
+  );
+});
+
+test("rejects each required target block missing independently", () => {
+  for (const key of ["desktop", "managed_runtime", "self_host", "release"] as const) {
+    const receipt = seal(validBody()) as unknown as Record<string, unknown>;
+    delete receipt[key];
+    assert.throws(
+      () => validateRetainedReleaseReceiptShape(receipt),
+      RetainedReleaseError,
+      `expected removal of ${key} to reject`,
+    );
+  }
+});
+
+test("rejects a missing supported desktop platform", () => {
+  assert.throws(
+    () => validateRetainedReleaseReceiptShape(mutated((r) => void r.desktop.packages.pop(), true)),
+    /missing supported platform/,
+  );
+});
+
+test("rejects undeclared fields", () => {
+  const receipt = seal(validBody()) as unknown as Record<string, unknown>;
+  receipt.rider = "smuggled";
+  assert.throws(() => validateRetainedReleaseReceiptShape(receipt), /undeclared field/);
+});
+
+test("rejects mutable-alias locators even though they currently resolve", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated(
+          (r) =>
+            (r.desktop.packages[0].immutable_locator =
+              "https://downloads.proliferate.com/desktop/stable/latest.json"),
+          true,
+        ),
+      ),
+    /mutable alias/,
+  );
+});
+
+test("rejects expiring presigned locators", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated(
+          (r) =>
+            (r.self_host.deploy_bundle_locator =
+              "https://bucket.s3.amazonaws.com/proliferate-deploy-0.3.35.tar.gz?X-Amz-Signature=abc&X-Amz-Expires=300"),
+          true,
+        ),
+      ),
+    /expiring/i,
+  );
+});
+
+test("rejects local filesystem paths in a persisted receipt", () => {
+  assert.throws(
+    () => assertImmutableLocator("/tmp/proliferate-deploy.tar.gz", "self_host.deploy_bundle", ["0.3.35"]),
+    /local filesystem path/,
+  );
+  assert.throws(
+    () => assertImmutableLocator("file:///tmp/x-0.3.35.tar.gz", "self_host.deploy_bundle", ["0.3.35"]),
+    /local filesystem path/,
+  );
+});
+
+test("rejects a locator with no content identity", () => {
+  assert.throws(
+    () => assertImmutableLocator("https://example.com/downloads/app.tar.gz", "desktop", ["0.3.38", "e61afc274593"]),
+    /no content identity/,
+  );
+});
+
+test("rejects a mutable-tag-only server image reference", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated((r) => (r.self_host.server_image_digest = "ghcr.io/proliferate-ai/proliferate-server:0.3.35"), true),
+      ),
+    /pinned by @sha256/,
+  );
+});
+
+test("rejects artifact-set digest drift", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated((r) => (r.managed_runtime.anyharness_version = "0.3.39"), false),
+      ),
+    /artifact_set_digest does not recompute/,
+  );
+});
+
+test("rejects a source tag inconsistent with the source SHA", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated((r) => (r.managed_runtime.source_tag = "sha-aaaaaaaaaaaa"), true),
+      ),
+    /does not match the release source SHA/,
+  );
+});
+
+test("rejects a null input hash on a qualified receipt, allows it on bootstrap", () => {
+  const qualified = mutated((r) => {
+    r.release.qualification_state = "qualified";
+    r.release.qualification_evidence = {
+      report_sha256: HEX64("report"),
+      immutable_locator: `https://qualification.example.com/evidence/v0.3.38/${HEX64("report")}.json`,
+    };
+  }, true);
+  assert.throws(
+    () => validateRetainedReleaseReceiptShape(qualified),
+    /input hash/,
+  );
+  // bootstrap with null input hash is the valid fixture itself
+  assert.equal(validateRetainedReleaseReceiptShape(seal(validBody())).managed_runtime.input_hash, null);
+});
+
+test("rejects qualification evidence on a bootstrap receipt (no retrofitted history)", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated((r) => {
+          r.release.qualification_evidence = {
+            report_sha256: HEX64("fake"),
+            immutable_locator: `https://example.com/evidence/v0.3.38/${HEX64("fake")}.json`,
+          };
+        }, true),
+      ),
+    /retrofit/,
+  );
+});
+
+test("requires evidence on a qualified receipt", () => {
+  assert.throws(
+    () =>
+      validateRetainedReleaseReceiptShape(
+        mutated((r) => {
+          r.release.qualification_state = "qualified";
+          r.managed_runtime.input_hash = HEX64("input");
+        }, true),
+      ),
+    /qualification_evidence/,
+  );
+});
+
+test("bootstrap policy: bootstrap receipt fails closed once a qualified receipt exists", () => {
+  const receipt = validateRetainedReleaseReceiptShape(seal(validBody()));
+  validateRetainedRelease(receipt, { requiredTargets: ["managed-runtime"], qualifiedReceiptExists: false });
+  assert.throws(
+    () =>
+      validateRetainedRelease(receipt, {
+        requiredTargets: ["managed-runtime"],
+        qualifiedReceiptExists: true,
+      }),
+    /bootstrap exception no longer applies/,
+  );
+});
+
+test("policy: N-1 must not equal candidate N", () => {
+  const receipt = validateRetainedReleaseReceiptShape(seal(validBody()));
+  assert.throws(
+    () =>
+      validateRetainedRelease(receipt, {
+        requiredTargets: ["desktop"],
+        currentCandidateSourceSha: SHA,
+        qualifiedReceiptExists: false,
+      }),
+    /same source SHA as candidate N/,
+  );
+});
+
+test("live verification detects template build and OCI digest drift", async () => {
+  const receipt = validateRetainedReleaseReceiptShape(seal(validBody()));
+  await verifyRetainedReleaseLive(receipt, {
+    resolveE2bTags: async () => [
+      { tag: "sha-e61afc274593", buildId: "661a9621-78db-4c55-84d1-281c21fb72dc" },
+      { tag: "production", buildId: "somewhere-else" },
+    ],
+  });
+  await assert.rejects(
+    verifyRetainedReleaseLive(receipt, {
+      resolveE2bTags: async () => [{ tag: "sha-e61afc274593", buildId: "different-build" }],
+    }),
+    /template build drift/,
+  );
+  await assert.rejects(
+    verifyRetainedReleaseLive(receipt, {
+      resolveE2bTags: async () => [],
+    }),
+    /no longer resolves/,
+  );
+  await assert.rejects(
+    verifyRetainedReleaseLive(receipt, {
+      resolveOciDigest: async () => `sha256:${HEX64("other-image")}`,
+    }),
+    /image digest drift/,
+  );
+});
+
+test("live verification detects component version/catalog drift", async () => {
+  const receipt = validateRetainedReleaseReceiptShape(seal(validBody()));
+  await assert.rejects(
+    verifyRetainedReleaseLive(receipt, {
+      expectedComponents: { anyharness_version: "0.1.0" },
+    }),
+    /component drift on managed_runtime.anyharness_version/,
+  );
+  await assert.rejects(
+    verifyRetainedReleaseLive(receipt, {
+      expectedComponents: { harness_catalog_digest: HEX64("other-catalog") },
+    }),
+    /component drift on managed_runtime.harness_catalog_digest/,
+  );
+});
+
+test("live verification detects E2B input-hash drift when a hash is recorded", async () => {
+  const receipt = validateRetainedReleaseReceiptShape(
+    mutated((r) => (r.managed_runtime.input_hash = HEX64("input")), true),
+  );
+  await assert.rejects(
+    verifyRetainedReleaseLive(receipt, {
+      resolveE2bInputHash: async () => HEX64("drifted-input"),
+    }),
+    /input hash drift/,
+  );
+});
+
+test("evidence projection is bounded to identities and hashes", () => {
+  const receipt = validateRetainedReleaseReceiptShape(seal(validBody()));
+  const evidence = toRetainedReleaseEvidence(receipt, HEX64("receipt-bytes"), ["desktop"], [
+    { artifact: "desktop/darwin-aarch64/package", digest: HEX64("aarch64") },
+  ]);
+  assert.deepEqual(Object.keys(evidence).sort(), [
+    "artifact_set_digest",
+    "kind",
+    "materialized_hashes",
+    "qualification_state",
+    "receipt_sha256",
+    "release_id",
+    "selected_targets",
+    "source_sha",
+  ]);
+  const serialized = JSON.stringify(evidence);
+  assert.ok(!serialized.includes("https://"), "evidence must not carry raw locators");
+  assert.ok(!serialized.includes("updater_pubkey"), "evidence must not embed receipt bodies");
+});
+
+test("index loads, round-trips, and drives qualifiedReceiptExists", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-index-"));
+  const indexPath = path.join(dir, "index.json");
+  const receipt = seal(validBody());
+  const receiptText = `${JSON.stringify(receipt, null, 2)}\n`;
+  writeFileSync(path.join(dir, "v0.3.38.json"), receiptText);
+  writeFileSync(
+    indexPath,
+    JSON.stringify({
+      schema_version: 1,
+      kind: "proliferate.retained-release-index",
+      receipts: [
+        {
+          release_id: "v0.3.38",
+          source_sha: SHA,
+          qualification_state: "bootstrap_unqualified",
+          receipt_path: "v0.3.38.json",
+          receipt_sha256: createHash("sha256").update(receiptText, "utf8").digest("hex"),
+        },
+      ],
+    }),
+  );
+  const index = loadRetainedReleaseIndex(indexPath);
+  assert.equal(qualifiedReceiptExists(index), false);
+  const loaded = loadRetainedReleaseReceipt(path.join(dir, "v0.3.38.json"));
+  assert.equal(loaded.receiptSha256, index.receipts[0].receipt_sha256);
+});

--- a/tests/release/src/artifacts/retained-release-set.test.ts
+++ b/tests/release/src/artifacts/retained-release-set.test.ts
@@ -7,8 +7,11 @@ import { test } from "node:test";
 
 import {
   assertImmutableLocator,
+  assertIndexReceiptsBound,
   computeArtifactSetDigest,
+  loadIndexedRetainedReceipt,
   loadRetainedReleaseIndex,
+  loadRetainedReleaseIndexOrInit,
   loadRetainedReleaseReceipt,
   qualifiedReceiptExists,
   RetainedReleaseError,
@@ -360,6 +363,107 @@ test("evidence projection is bounded to identities and hashes", () => {
   const serialized = JSON.stringify(evidence);
   assert.ok(!serialized.includes("https://"), "evidence must not carry raw locators");
   assert.ok(!serialized.includes("updater_pubkey"), "evidence must not embed receipt bodies");
+});
+
+test("RR-CONTROL-002: a malformed index fails closed, never an empty init", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-index-corrupt-"));
+  const indexPath = path.join(dir, "index.json");
+  writeFileSync(indexPath, "not json {");
+  assert.throws(() => loadRetainedReleaseIndex(indexPath), /not valid JSON/);
+  assert.throws(() => loadRetainedReleaseIndexOrInit(indexPath), /not valid JSON/);
+  writeFileSync(indexPath, JSON.stringify({ schema_version: 99, kind: "proliferate.retained-release-index", receipts: [] }));
+  assert.throws(() => loadRetainedReleaseIndexOrInit(indexPath), /Unsupported/);
+  // Only a genuinely ABSENT file initializes empty.
+  const absent = loadRetainedReleaseIndexOrInit(path.join(dir, "does-not-exist.json"));
+  assert.deepEqual(absent.receipts, []);
+});
+
+test("RR-CONTROL-005: duplicate release ids and traversal paths reject at index load", () => {
+  const entry = {
+    release_id: "v0.3.38",
+    source_sha: SHA,
+    qualification_state: "bootstrap_unqualified",
+    receipt_path: "v0.3.38.json",
+    receipt_sha256: HEX64("bytes"),
+  };
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-index-dup-"));
+  const indexPath = path.join(dir, "index.json");
+  writeFileSync(
+    indexPath,
+    JSON.stringify({ schema_version: 1, kind: "proliferate.retained-release-index", receipts: [entry, entry] }),
+  );
+  assert.throws(() => loadRetainedReleaseIndex(indexPath), /duplicate release_id/);
+  writeFileSync(
+    indexPath,
+    JSON.stringify({
+      schema_version: 1,
+      kind: "proliferate.retained-release-index",
+      receipts: [{ ...entry, receipt_path: "../escape/v0.3.38.json" }],
+    }),
+  );
+  assert.throws(() => loadRetainedReleaseIndex(indexPath), /must stay inside/);
+  writeFileSync(
+    indexPath,
+    JSON.stringify({
+      schema_version: 1,
+      kind: "proliferate.retained-release-index",
+      receipts: [{ ...entry, receipt_path: "/abs/v0.3.38.json" }],
+    }),
+  );
+  assert.throws(() => loadRetainedReleaseIndex(indexPath), /must stay inside/);
+});
+
+test("RR-CONTROL-005: index entry identity/state must match the loaded receipt", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-index-bind-"));
+  const indexPath = path.join(dir, "index.json");
+  const receipt = seal(validBody());
+  const receiptText = `${JSON.stringify(receipt, null, 2)}\n`;
+  writeFileSync(path.join(dir, "v0.3.38.json"), receiptText);
+  const receiptSha = createHash("sha256").update(receiptText, "utf8").digest("hex");
+  // Correct bytes, lying source_sha in the entry.
+  writeFileSync(
+    indexPath,
+    JSON.stringify({
+      schema_version: 1,
+      kind: "proliferate.retained-release-index",
+      receipts: [
+        {
+          release_id: "v0.3.38",
+          source_sha: "b".repeat(40),
+          qualification_state: "bootstrap_unqualified",
+          receipt_path: "v0.3.38.json",
+          receipt_sha256: receiptSha,
+        },
+      ],
+    }),
+  );
+  const lyingIndex = loadRetainedReleaseIndex(indexPath);
+  assert.throws(
+    () => loadIndexedRetainedReceipt(lyingIndex, indexPath, "v0.3.38"),
+    /does not match the receipt it points at/,
+  );
+  assert.throws(() => assertIndexReceiptsBound(lyingIndex, indexPath), /does not match the receipt/);
+  // Honest entry binds cleanly.
+  writeFileSync(
+    indexPath,
+    JSON.stringify({
+      schema_version: 1,
+      kind: "proliferate.retained-release-index",
+      receipts: [
+        {
+          release_id: "v0.3.38",
+          source_sha: SHA,
+          qualification_state: "bootstrap_unqualified",
+          receipt_path: "v0.3.38.json",
+          receipt_sha256: receiptSha,
+        },
+      ],
+    }),
+  );
+  const honest = loadRetainedReleaseIndex(indexPath);
+  assertIndexReceiptsBound(honest, indexPath);
+  const loaded = loadIndexedRetainedReceipt(honest, indexPath, "v0.3.38");
+  assert.equal(loaded.receipt.release.release_id, "v0.3.38");
 });
 
 test("index loads, round-trips, and drives qualifiedReceiptExists", () => {

--- a/tests/release/src/artifacts/retained-release-set.ts
+++ b/tests/release/src/artifacts/retained-release-set.ts
@@ -1,0 +1,818 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The retained-release receipt: the exact immutable production N-1 artifacts a
+ * Tier 4 update proof starts FROM (tier-4-scenario-contract.md "Artifact
+ * Identity"; frozen spec "Retain Exact Production Artifacts for Tier 4").
+ * The candidate side has `CandidateBuildMapV1` (build-map.ts); this is its
+ * retained-production counterpart.
+ *
+ * A receipt is produced at release time (or, for the one-time bootstrap
+ * release, reconstructed only after independently verifying every artifact —
+ * see cli/create-retained-release-receipt.ts) and committed under
+ * `tests/release/retained-releases/`. The repository is the durable immutable
+ * store for the receipt itself; the artifact BYTES stay in their durable
+ * stores (downloads CDN, GitHub release assets, GHCR, E2B) and are re-verified
+ * by hash on every materialization.
+ *
+ * The canonical release-manifest schema
+ * (specs/codebase/systems/engineering/delivery/release-manifest.schema.json)
+ * has no publisher today — nothing computes its `artifactSetDigest` or writes
+ * `release-manifest.json` (specs/developing/deploying/releases.md). Ownership
+ * therefore does not fit extending it; this receipt is the narrowly scoped
+ * qualification-owned contract, keyed by release tag + source SHA.
+ */
+
+export type RetainedQualificationState = "bootstrap_unqualified" | "qualified";
+
+export type RetainedTarget = "desktop" | "managed-runtime" | "self-host";
+
+export const RETAINED_TARGETS: readonly RetainedTarget[] = [
+  "desktop",
+  "managed-runtime",
+  "self-host",
+];
+
+/** Desktop platforms production actually publishes (release-desktop.yml). */
+export type RetainedDesktopPlatform = "darwin-aarch64" | "darwin-x86_64";
+
+export interface RetainedDesktopPackageV1 {
+  platform: RetainedDesktopPlatform;
+  /** Immutable HTTPS locator embedding the exact version (never `latest`). */
+  immutable_locator: string;
+  /** Lowercase 64-hex digest of the package bytes. */
+  sha256: string;
+  /** Locator of the Tauri updater signature (.sig) for this package. */
+  signature_locator: string;
+  sha256_signature: string;
+}
+
+export interface RetainedReleaseReceiptV1 {
+  schema_version: 1;
+  kind: "proliferate.retained-release";
+  release: {
+    /** Human-facing release id, e.g. `v0.3.38` — a lookup key, not identity. */
+    release_id: string;
+    /** The product tag, e.g. `proliferate-v0.3.38`. */
+    release_tag: string;
+    /** Lowercase 40-hex source SHA all product tags of this release point at. */
+    source_sha: string;
+    /** ISO-8601 publication instant (the versioned updater snapshot's pub_date). */
+    published_at: string;
+    qualification_state: RetainedQualificationState;
+    /**
+     * Required when `qualified`; forbidden when `bootstrap_unqualified` (the
+     * bootstrap release explicitly has no qualification evidence and must
+     * never be retrofitted with fake historical evidence).
+     */
+    qualification_evidence: {
+      report_sha256: string;
+      immutable_locator: string;
+    } | null;
+  };
+  desktop: {
+    version: string;
+    packages: RetainedDesktopPackageV1[];
+    /**
+     * The Tauri updater trust identity the retained app verifies updates with
+     * (minisign public key, base64 — non-secret, baked into the app).
+     */
+    updater_pubkey: string;
+    embedded_anyharness_version: string;
+  };
+  managed_runtime: {
+    /** E2B template family, e.g. `pablo-5391/proliferate-runtime-cloud`. */
+    template_family: string;
+    /** Immutable E2B template id. */
+    immutable_template_id: string;
+    /** Immutable E2B build id the mutable `production` alias resolved to. */
+    template_build_id: string;
+    /** Immutable source tag, `sha-<first 12 hex of source_sha>`. */
+    source_tag: string;
+    /**
+     * Complete template input hash. E2B exposes no input hash and no repo
+     * code has ever recorded one, so the bootstrap receipt truthfully carries
+     * null (disclosed unavailable historical artifact). Receipts in state
+     * `qualified` must carry a real hash — null fails validation.
+     */
+    input_hash: string | null;
+    anyharness_version: string;
+    worker_version: string;
+    supervisor_version: string;
+    /** SHA-256 of catalogs/agents/catalog.json at source_sha (native CLI + ACP pins). */
+    harness_catalog_digest: string;
+    /** SHA-256 of catalogs/agents/registry.json at source_sha (trusted registry). */
+    harness_registry_digest: string;
+  };
+  self_host: {
+    /**
+     * The self-host surface version actually in production for this release.
+     * May be older than release_id: self-host releases are surface-scoped
+     * (server-v* tags), and a hotfix that does not ship the server surface
+     * leaves production self-host at the prior server release.
+     */
+    version: string;
+    /** The server release tag the bundle belongs to, e.g. `server-v0.3.35`. */
+    release_tag: string;
+    deploy_bundle_locator: string;
+    deploy_bundle_sha256: string;
+    /** OCI reference pinned by digest, e.g. `ghcr.io/...@sha256:...`. */
+    server_image_digest: string;
+  };
+  /**
+   * SHA-256 of the canonical (recursively key-sorted, no-whitespace) JSON of
+   * the receipt with this field removed. Recomputed on every load.
+   */
+  artifact_set_digest: string;
+}
+
+/** The bounded projection allowed into aggregate qualification evidence. */
+export interface RetainedReleaseEvidenceV1 {
+  kind: "retained_release";
+  release_id: string;
+  source_sha: string;
+  qualification_state: RetainedQualificationState;
+  receipt_sha256: string;
+  artifact_set_digest: string;
+  selected_targets: string[];
+  materialized_hashes: Array<{
+    artifact: string;
+    digest: string;
+  }>;
+}
+
+/**
+ * Invalid receipt / policy / integrity input: consumers exit before any world
+ * side effect. Messages never embed raw receipt JSON, locator query strings,
+ * or provider responses.
+ */
+export class RetainedReleaseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RetainedReleaseError";
+  }
+}
+
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const RELEASE_ID_PATTERN = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+const SOURCE_TAG_PATTERN = /^sha-[0-9a-f]{12}$/;
+const OCI_DIGEST_REF_PATTERN = /^[a-z0-9.-]+\/[A-Za-z0-9._/-]+@sha256:[0-9a-f]{64}$/;
+const DESKTOP_PLATFORMS: readonly RetainedDesktopPlatform[] = [
+  "darwin-aarch64",
+  "darwin-x86_64",
+];
+// Query parameters that mark a presigned/expiring URL. An expiring locator can
+// never satisfy the retention promise, even while it still resolves.
+const EXPIRING_QUERY_PATTERN = /(^|[?&])(x-amz-[a-z-]+|signature|expires|token|sig|se|sp|sv)=/i;
+// Rolling aliases that are forbidden as the identifying final path segment.
+const MUTABLE_TERMINAL_SEGMENTS = new Set(["latest", "latest.json", "stable", "production", "staging"]);
+
+/**
+ * An immutable retained locator must be HTTPS (or an OCI digest reference),
+ * non-expiring, non-local, and must embed content identity — the exact
+ * version, the source sha12, or an @sha256 digest. A rolling alias may appear
+ * as an interior path segment (the CDN tree is `desktop/stable/<file>`), but
+ * never as the identifying terminal segment, and never as the only identity.
+ */
+export function assertImmutableLocator(
+  locator: string,
+  where: string,
+  identityTokens: readonly string[],
+): void {
+  if (typeof locator !== "string" || locator.trim().length === 0) {
+    throw new RetainedReleaseError(`${where} locator is missing.`);
+  }
+  if (OCI_DIGEST_REF_PATTERN.test(locator)) {
+    return; // digest-pinned OCI reference: immutable by construction.
+  }
+  if (locator.startsWith("file://") || locator.startsWith("/") || locator.startsWith("./") || locator.startsWith("~")) {
+    throw new RetainedReleaseError(
+      `${where} locator is a local filesystem path; a persisted receipt must use durable immutable locators.`,
+    );
+  }
+  let url: URL;
+  try {
+    url = new URL(locator);
+  } catch {
+    throw new RetainedReleaseError(`${where} locator is not a valid URL or OCI digest reference.`);
+  }
+  if (url.protocol !== "https:") {
+    throw new RetainedReleaseError(`${where} locator must be https (got ${url.protocol.replace(":", "")}).`);
+  }
+  if (EXPIRING_QUERY_PATTERN.test(url.search)) {
+    throw new RetainedReleaseError(
+      `${where} locator carries presigned/expiring query parameters; expiring URLs are forbidden in receipts.`,
+    );
+  }
+  const segments = url.pathname.split("/").filter((segment) => segment.length > 0);
+  const terminal = segments.at(-1)?.toLowerCase() ?? "";
+  if (MUTABLE_TERMINAL_SEGMENTS.has(terminal)) {
+    throw new RetainedReleaseError(
+      `${where} locator resolves a mutable alias ("${terminal}"); a rolling pointer cannot identify retained bytes even while it currently resolves.`,
+    );
+  }
+  const haystack = locator.toLowerCase();
+  const identified = identityTokens.some(
+    (token) => token.length > 0 && haystack.includes(token.toLowerCase()),
+  );
+  if (!identified) {
+    throw new RetainedReleaseError(
+      `${where} locator embeds no content identity (expected the exact version, source sha, or a digest).`,
+    );
+  }
+}
+
+/** Recursively key-sorted, whitespace-free JSON — the digest normalization. */
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function sha256OfText(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/** The artifact-set digest: canonical receipt content minus the digest field. */
+export function computeArtifactSetDigest(
+  receipt: Omit<RetainedReleaseReceiptV1, "artifact_set_digest">,
+): string {
+  const { release, desktop, managed_runtime, self_host, schema_version, kind } = receipt;
+  return sha256OfText(
+    canonicalJson({ schema_version, kind, release, desktop, managed_runtime, self_host }),
+  );
+}
+
+function rejectUnknownKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  where: string,
+): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length > 0) {
+    throw new RetainedReleaseError(
+      `Retained-release ${where} has undeclared field(s): ${unknown.join(", ")}.`,
+    );
+  }
+}
+
+function requireObject(value: unknown, where: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new RetainedReleaseError(`Retained-release ${where} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, where: string, pattern?: RegExp): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new RetainedReleaseError(`Retained-release ${where} is missing or empty.`);
+  }
+  if (pattern && !pattern.test(value)) {
+    throw new RetainedReleaseError(`Retained-release ${where} is malformed.`);
+  }
+  return value;
+}
+
+/**
+ * Strict structural validation of a parsed receipt, independent of the
+ * filesystem and providers. Unknown fields, unknown schema versions, missing
+ * targets, malformed identities, mutable/expiring/local locators, and an
+ * artifact-set digest that does not recompute all reject here — before any
+ * consumer side effect.
+ */
+export function validateRetainedReleaseReceiptShape(parsed: unknown): RetainedReleaseReceiptV1 {
+  const root = requireObject(parsed, "receipt");
+  rejectUnknownKeys(
+    root,
+    ["schema_version", "kind", "release", "desktop", "managed_runtime", "self_host", "artifact_set_digest"],
+    "receipt",
+  );
+  if (root.schema_version !== 1) {
+    throw new RetainedReleaseError("Unsupported retained-release receipt schema_version.");
+  }
+  if (root.kind !== "proliferate.retained-release") {
+    throw new RetainedReleaseError("Unsupported retained-release receipt kind.");
+  }
+
+  const releaseRaw = requireObject(root.release, "release");
+  rejectUnknownKeys(
+    releaseRaw,
+    ["release_id", "release_tag", "source_sha", "published_at", "qualification_state", "qualification_evidence"],
+    "release",
+  );
+  const releaseId = requireString(releaseRaw.release_id, "release.release_id", RELEASE_ID_PATTERN);
+  const releaseTag = requireString(releaseRaw.release_tag, "release.release_tag");
+  const sourceSha = requireString(releaseRaw.source_sha, "release.source_sha", FULL_SHA_PATTERN);
+  if (releaseTag !== `proliferate-${releaseId}`) {
+    throw new RetainedReleaseError(
+      `Retained-release release_tag "${releaseTag}" does not correspond to release_id "${releaseId}".`,
+    );
+  }
+  const publishedAt = requireString(releaseRaw.published_at, "release.published_at");
+  if (Number.isNaN(Date.parse(publishedAt))) {
+    throw new RetainedReleaseError("Retained-release release.published_at is not a valid instant.");
+  }
+  const state = releaseRaw.qualification_state;
+  if (state !== "bootstrap_unqualified" && state !== "qualified") {
+    throw new RetainedReleaseError("Retained-release release.qualification_state is unknown.");
+  }
+  let evidence: RetainedReleaseReceiptV1["release"]["qualification_evidence"] = null;
+  if (state === "qualified") {
+    const evidenceRaw = requireObject(
+      releaseRaw.qualification_evidence,
+      "release.qualification_evidence (required for a qualified receipt)",
+    );
+    rejectUnknownKeys(evidenceRaw, ["report_sha256", "immutable_locator"], "release.qualification_evidence");
+    const reportSha = requireString(
+      evidenceRaw.report_sha256,
+      "release.qualification_evidence.report_sha256",
+      SHA256_PATTERN,
+    );
+    const evidenceLocator = requireString(
+      evidenceRaw.immutable_locator,
+      "release.qualification_evidence.immutable_locator",
+    );
+    assertImmutableLocator(evidenceLocator, "release.qualification_evidence", [reportSha, releaseId, sourceSha.slice(0, 12)]);
+    evidence = { report_sha256: reportSha, immutable_locator: evidenceLocator };
+  } else if (releaseRaw.qualification_evidence != null) {
+    throw new RetainedReleaseError(
+      "A bootstrap_unqualified receipt must not carry qualification evidence; do not retrofit fake historical qualification.",
+    );
+  }
+
+  const releaseVersion = releaseId.slice(1);
+  const sha12 = sourceSha.slice(0, 12);
+
+  const desktopRaw = requireObject(root.desktop, "desktop");
+  rejectUnknownKeys(
+    desktopRaw,
+    ["version", "packages", "updater_pubkey", "embedded_anyharness_version"],
+    "desktop",
+  );
+  const desktopVersion = requireString(desktopRaw.version, "desktop.version", VERSION_PATTERN);
+  if (desktopVersion !== releaseVersion) {
+    throw new RetainedReleaseError(
+      `Retained-release desktop.version ${desktopVersion} does not match release ${releaseVersion}.`,
+    );
+  }
+  const updaterPubkey = requireString(desktopRaw.updater_pubkey, "desktop.updater_pubkey");
+  const embeddedAnyharness = requireString(
+    desktopRaw.embedded_anyharness_version,
+    "desktop.embedded_anyharness_version",
+    VERSION_PATTERN,
+  );
+  if (!Array.isArray(desktopRaw.packages) || desktopRaw.packages.length === 0) {
+    throw new RetainedReleaseError("Retained-release desktop.packages must be a non-empty array.");
+  }
+  const seenPlatforms = new Set<string>();
+  const packages = desktopRaw.packages.map((entry, index) => {
+    const pkg = requireObject(entry, `desktop.packages[${index}]`);
+    rejectUnknownKeys(
+      pkg,
+      ["platform", "immutable_locator", "sha256", "signature_locator", "sha256_signature"],
+      `desktop.packages[${index}]`,
+    );
+    const platform = pkg.platform;
+    if (typeof platform !== "string" || !DESKTOP_PLATFORMS.includes(platform as RetainedDesktopPlatform)) {
+      throw new RetainedReleaseError(`desktop.packages[${index}].platform is unsupported.`);
+    }
+    if (seenPlatforms.has(platform)) {
+      throw new RetainedReleaseError(`desktop.packages has duplicate platform "${platform}".`);
+    }
+    seenPlatforms.add(platform);
+    const locator = requireString(pkg.immutable_locator, `desktop.packages[${index}].immutable_locator`);
+    assertImmutableLocator(locator, `desktop.packages[${index}]`, [releaseVersion, sha12]);
+    const sha256 = requireString(pkg.sha256, `desktop.packages[${index}].sha256`, SHA256_PATTERN);
+    const signatureLocator = requireString(
+      pkg.signature_locator,
+      `desktop.packages[${index}].signature_locator`,
+    );
+    assertImmutableLocator(signatureLocator, `desktop.packages[${index}].signature`, [releaseVersion, sha12]);
+    const signatureSha = requireString(
+      pkg.sha256_signature,
+      `desktop.packages[${index}].sha256_signature`,
+      SHA256_PATTERN,
+    );
+    return {
+      platform: platform as RetainedDesktopPlatform,
+      immutable_locator: locator,
+      sha256,
+      signature_locator: signatureLocator,
+      sha256_signature: signatureSha,
+    };
+  });
+  for (const required of DESKTOP_PLATFORMS) {
+    if (!seenPlatforms.has(required)) {
+      throw new RetainedReleaseError(`desktop.packages is missing supported platform "${required}".`);
+    }
+  }
+
+  const runtimeRaw = requireObject(root.managed_runtime, "managed_runtime");
+  rejectUnknownKeys(
+    runtimeRaw,
+    [
+      "template_family",
+      "immutable_template_id",
+      "template_build_id",
+      "source_tag",
+      "input_hash",
+      "anyharness_version",
+      "worker_version",
+      "supervisor_version",
+      "harness_catalog_digest",
+      "harness_registry_digest",
+    ],
+    "managed_runtime",
+  );
+  const templateFamily = requireString(runtimeRaw.template_family, "managed_runtime.template_family");
+  const templateId = requireString(runtimeRaw.immutable_template_id, "managed_runtime.immutable_template_id");
+  const buildId = requireString(runtimeRaw.template_build_id, "managed_runtime.template_build_id");
+  const sourceTag = requireString(runtimeRaw.source_tag, "managed_runtime.source_tag", SOURCE_TAG_PATTERN);
+  if (sourceTag !== `sha-${sha12}`) {
+    throw new RetainedReleaseError(
+      `managed_runtime.source_tag "${sourceTag}" does not match the release source SHA (expected sha-${sha12}).`,
+    );
+  }
+  let inputHash: string | null = null;
+  if (runtimeRaw.input_hash !== null) {
+    inputHash = requireString(runtimeRaw.input_hash, "managed_runtime.input_hash", SHA256_PATTERN);
+  } else if (state === "qualified") {
+    throw new RetainedReleaseError(
+      "A qualified receipt must carry the complete E2B template input hash; null is allowed only for the disclosed bootstrap receipt.",
+    );
+  }
+  const anyharnessVersion = requireString(
+    runtimeRaw.anyharness_version,
+    "managed_runtime.anyharness_version",
+    VERSION_PATTERN,
+  );
+  const workerVersion = requireString(
+    runtimeRaw.worker_version,
+    "managed_runtime.worker_version",
+    VERSION_PATTERN,
+  );
+  const supervisorVersion = requireString(
+    runtimeRaw.supervisor_version,
+    "managed_runtime.supervisor_version",
+    VERSION_PATTERN,
+  );
+  const catalogDigest = requireString(
+    runtimeRaw.harness_catalog_digest,
+    "managed_runtime.harness_catalog_digest",
+    SHA256_PATTERN,
+  );
+  const registryDigest = requireString(
+    runtimeRaw.harness_registry_digest,
+    "managed_runtime.harness_registry_digest",
+    SHA256_PATTERN,
+  );
+
+  const selfHostRaw = requireObject(root.self_host, "self_host");
+  rejectUnknownKeys(
+    selfHostRaw,
+    ["version", "release_tag", "deploy_bundle_locator", "deploy_bundle_sha256", "server_image_digest"],
+    "self_host",
+  );
+  const selfHostVersion = requireString(selfHostRaw.version, "self_host.version", VERSION_PATTERN);
+  const selfHostTag = requireString(selfHostRaw.release_tag, "self_host.release_tag");
+  if (selfHostTag !== `server-v${selfHostVersion}`) {
+    throw new RetainedReleaseError(
+      `self_host.release_tag "${selfHostTag}" does not correspond to self_host.version "${selfHostVersion}".`,
+    );
+  }
+  const bundleLocator = requireString(selfHostRaw.deploy_bundle_locator, "self_host.deploy_bundle_locator");
+  assertImmutableLocator(bundleLocator, "self_host.deploy_bundle", [selfHostVersion, selfHostTag]);
+  const bundleSha = requireString(
+    selfHostRaw.deploy_bundle_sha256,
+    "self_host.deploy_bundle_sha256",
+    SHA256_PATTERN,
+  );
+  const imageDigest = requireString(selfHostRaw.server_image_digest, "self_host.server_image_digest");
+  if (!OCI_DIGEST_REF_PATTERN.test(imageDigest)) {
+    throw new RetainedReleaseError(
+      "self_host.server_image_digest must be an OCI reference pinned by @sha256 digest (a mutable tag alone cannot identify retained bytes).",
+    );
+  }
+
+  const declaredDigest = requireString(root.artifact_set_digest, "artifact_set_digest", SHA256_PATTERN);
+  const receipt: RetainedReleaseReceiptV1 = {
+    schema_version: 1,
+    kind: "proliferate.retained-release",
+    release: {
+      release_id: releaseId,
+      release_tag: releaseTag,
+      source_sha: sourceSha,
+      published_at: publishedAt,
+      qualification_state: state,
+      qualification_evidence: evidence,
+    },
+    desktop: {
+      version: desktopVersion,
+      packages,
+      updater_pubkey: updaterPubkey,
+      embedded_anyharness_version: embeddedAnyharness,
+    },
+    managed_runtime: {
+      template_family: templateFamily,
+      immutable_template_id: templateId,
+      template_build_id: buildId,
+      source_tag: sourceTag,
+      input_hash: inputHash,
+      anyharness_version: anyharnessVersion,
+      worker_version: workerVersion,
+      supervisor_version: supervisorVersion,
+      harness_catalog_digest: catalogDigest,
+      harness_registry_digest: registryDigest,
+    },
+    self_host: {
+      version: selfHostVersion,
+      release_tag: selfHostTag,
+      deploy_bundle_locator: bundleLocator,
+      deploy_bundle_sha256: bundleSha,
+      server_image_digest: imageDigest,
+    },
+    artifact_set_digest: declaredDigest,
+  };
+
+  const recomputed = computeArtifactSetDigest(receipt);
+  if (recomputed !== declaredDigest) {
+    throw new RetainedReleaseError(
+      `Retained-release artifact_set_digest does not recompute from normalized content ` +
+        `(declared ${declaredDigest}, recomputed ${recomputed}).`,
+    );
+  }
+
+  return receipt;
+}
+
+/** Policy inputs for selecting a retained release as the Tier 4 N-1. */
+export interface RetainedReleasePolicy {
+  /** Targets this run consumes; each must be completely present (all are, structurally). */
+  requiredTargets: readonly RetainedTarget[];
+  /**
+   * The candidate N source SHA. N-1 and N must not accidentally be the same
+   * release/artifact set.
+   */
+  currentCandidateSourceSha?: string;
+  /**
+   * True when any `qualified` production receipt exists (see the committed
+   * index). Once one exists, selecting a bootstrap receipt fails closed —
+   * the bootstrap exception is one-time by founder ruling.
+   */
+  qualifiedReceiptExists: boolean;
+}
+
+/**
+ * Policy validation, run after shape validation and before any world side
+ * effect (starting Desktop, E2B, EC2, or a candidate API).
+ */
+export function validateRetainedRelease(
+  receipt: RetainedReleaseReceiptV1,
+  policy: RetainedReleasePolicy,
+): void {
+  for (const target of policy.requiredTargets) {
+    if (!RETAINED_TARGETS.includes(target)) {
+      throw new RetainedReleaseError(`Unknown required retained target "${target}".`);
+    }
+  }
+  if (
+    receipt.release.qualification_state === "bootstrap_unqualified" &&
+    policy.qualifiedReceiptExists
+  ) {
+    throw new RetainedReleaseError(
+      `Retained release ${receipt.release.release_id} is bootstrap_unqualified, but a qualified production ` +
+        `receipt already exists; the one-time bootstrap exception no longer applies. Select the last ` +
+        `qualified production receipt.`,
+    );
+  }
+  if (
+    policy.currentCandidateSourceSha &&
+    policy.currentCandidateSourceSha === receipt.release.source_sha
+  ) {
+    throw new RetainedReleaseError(
+      `Retained N-1 release ${receipt.release.release_id} has the same source SHA as candidate N ` +
+        `(${receipt.release.source_sha}); an update proof from a release to itself proves nothing.`,
+    );
+  }
+}
+
+/**
+ * Loads, shape-validates, and digest-checks a receipt file. `receiptSha256`
+ * is the digest of the exact file bytes — the identity recorded in evidence.
+ */
+export function loadRetainedReleaseReceipt(receiptPath: string): {
+  receipt: RetainedReleaseReceiptV1;
+  receiptSha256: string;
+} {
+  let raw: string;
+  try {
+    raw = readFileSync(receiptPath, "utf8");
+  } catch (error) {
+    throw new RetainedReleaseError(
+      `Retained-release receipt is not readable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new RetainedReleaseError("Retained-release receipt is not valid JSON.");
+  }
+  return {
+    receipt: validateRetainedReleaseReceiptShape(parsed),
+    receiptSha256: sha256OfText(raw),
+  };
+}
+
+/** The committed append-only index of retained receipts (the retention roots). */
+export interface RetainedReleaseIndexV1 {
+  schema_version: 1;
+  kind: "proliferate.retained-release-index";
+  receipts: Array<{
+    release_id: string;
+    source_sha: string;
+    qualification_state: RetainedQualificationState;
+    /** Repository path of the receipt file, relative to the index directory. */
+    receipt_path: string;
+    /** SHA-256 of the exact receipt file bytes. */
+    receipt_sha256: string;
+  }>;
+}
+
+export const RETAINED_RELEASES_DIR = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "retained-releases",
+);
+export const RETAINED_RELEASE_INDEX_PATH = path.join(RETAINED_RELEASES_DIR, "index.json");
+
+export function loadRetainedReleaseIndex(
+  indexPath: string = RETAINED_RELEASE_INDEX_PATH,
+): RetainedReleaseIndexV1 {
+  let raw: string;
+  try {
+    raw = readFileSync(indexPath, "utf8");
+  } catch (error) {
+    throw new RetainedReleaseError(
+      `Retained-release index is not readable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new RetainedReleaseError("Retained-release index is not valid JSON.");
+  }
+  const root = requireObject(parsed, "index");
+  rejectUnknownKeys(root, ["schema_version", "kind", "receipts"], "index");
+  if (root.schema_version !== 1 || root.kind !== "proliferate.retained-release-index") {
+    throw new RetainedReleaseError("Unsupported retained-release index schema/kind.");
+  }
+  if (!Array.isArray(root.receipts)) {
+    throw new RetainedReleaseError("Retained-release index receipts must be an array.");
+  }
+  const receipts = root.receipts.map((entry, index) => {
+    const record = requireObject(entry, `index.receipts[${index}]`);
+    rejectUnknownKeys(
+      record,
+      ["release_id", "source_sha", "qualification_state", "receipt_path", "receipt_sha256"],
+      `index.receipts[${index}]`,
+    );
+    const state = record.qualification_state;
+    if (state !== "bootstrap_unqualified" && state !== "qualified") {
+      throw new RetainedReleaseError(`index.receipts[${index}].qualification_state is unknown.`);
+    }
+    return {
+      release_id: requireString(record.release_id, `index.receipts[${index}].release_id`, RELEASE_ID_PATTERN),
+      source_sha: requireString(record.source_sha, `index.receipts[${index}].source_sha`, FULL_SHA_PATTERN),
+      qualification_state: state as RetainedQualificationState,
+      receipt_path: requireString(record.receipt_path, `index.receipts[${index}].receipt_path`),
+      receipt_sha256: requireString(record.receipt_sha256, `index.receipts[${index}].receipt_sha256`, SHA256_PATTERN),
+    };
+  });
+  return { schema_version: 1, kind: "proliferate.retained-release-index", receipts };
+}
+
+export function qualifiedReceiptExists(index: RetainedReleaseIndexV1): boolean {
+  return index.receipts.some((entry) => entry.qualification_state === "qualified");
+}
+
+/** Optional live drift checks against provider metadata (read-only hooks). */
+export interface RetainedReleaseLiveChecks {
+  /** Resolves a template family's tags to `{ tag, buildId }` pairs (E2B read-only). */
+  resolveE2bTags?: (templateFamily: string) => Promise<Array<{ tag: string; buildId: string }>>;
+  /** Resolves an OCI reference (without digest) to its current digest for the recorded tag. */
+  resolveOciDigest?: (reference: string) => Promise<string>;
+  /** Resolves the provider's template input hash, when one exists. */
+  resolveE2bInputHash?: (templateFamily: string, buildId: string) => Promise<string | null>;
+  /** Expected component versions/digests observed inside the template. */
+  expectedComponents?: {
+    anyharness_version?: string;
+    worker_version?: string;
+    supervisor_version?: string;
+    harness_catalog_digest?: string;
+    harness_registry_digest?: string;
+  };
+}
+
+/**
+ * Verifies the receipt's provider identities against live read-only metadata.
+ * The receipt stays tied to its immutable ids: if the mutable `production`
+ * alias moved to a different build, that is promotion drift flagged
+ * separately by the caller — but the recorded immutable source tag must still
+ * resolve to the recorded build id, and observed component identities must
+ * agree with the receipt.
+ */
+export async function verifyRetainedReleaseLive(
+  receipt: RetainedReleaseReceiptV1,
+  checks: RetainedReleaseLiveChecks,
+): Promise<void> {
+  const runtime = receipt.managed_runtime;
+  if (checks.resolveE2bTags) {
+    const tags = await checks.resolveE2bTags(runtime.template_family);
+    const sourceTag = tags.find((entry) => entry.tag === runtime.source_tag);
+    if (!sourceTag) {
+      throw new RetainedReleaseError(
+        `E2B immutable source tag ${runtime.source_tag} no longer resolves on ${runtime.template_family}; ` +
+          `the retained template build cannot be identified.`,
+      );
+    }
+    if (sourceTag.buildId !== runtime.template_build_id) {
+      throw new RetainedReleaseError(
+        `E2B source tag ${runtime.source_tag} resolves to build ${sourceTag.buildId}, but the receipt ` +
+          `records ${runtime.template_build_id}; template build drift.`,
+      );
+    }
+  }
+  if (checks.resolveE2bInputHash && runtime.input_hash !== null) {
+    const observed = await checks.resolveE2bInputHash(runtime.template_family, runtime.template_build_id);
+    if (observed !== null && observed !== runtime.input_hash) {
+      throw new RetainedReleaseError(
+        `E2B template input hash drift (receipt ${runtime.input_hash}, provider ${observed}).`,
+      );
+    }
+  }
+  if (checks.resolveOciDigest) {
+    const [reference, declaredDigest] = receipt.self_host.server_image_digest.split("@");
+    const observed = await checks.resolveOciDigest(reference);
+    if (observed !== declaredDigest) {
+      throw new RetainedReleaseError(
+        `Self-host server image digest drift (receipt ${declaredDigest}, registry ${observed}).`,
+      );
+    }
+  }
+  const expected = checks.expectedComponents;
+  if (expected) {
+    const comparisons: Array<[string, string | undefined, string]> = [
+      ["anyharness_version", expected.anyharness_version, runtime.anyharness_version],
+      ["worker_version", expected.worker_version, runtime.worker_version],
+      ["supervisor_version", expected.supervisor_version, runtime.supervisor_version],
+      ["harness_catalog_digest", expected.harness_catalog_digest, runtime.harness_catalog_digest],
+      ["harness_registry_digest", expected.harness_registry_digest, runtime.harness_registry_digest],
+    ];
+    for (const [field, observed, declared] of comparisons) {
+      if (observed !== undefined && observed !== declared) {
+        throw new RetainedReleaseError(
+          `Retained component drift on managed_runtime.${field} (receipt ${declared}, observed ${observed}).`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The only projection of a retained release allowed into aggregate evidence:
+ * bounded identities and hashes. Never raw locator query strings, provider
+ * responses, credentials, or the full receipt body.
+ */
+export function toRetainedReleaseEvidence(
+  receipt: RetainedReleaseReceiptV1,
+  receiptSha256: string,
+  selectedTargets: readonly RetainedTarget[],
+  materializedHashes: Array<{ artifact: string; digest: string }>,
+): RetainedReleaseEvidenceV1 {
+  return {
+    kind: "retained_release",
+    release_id: receipt.release.release_id,
+    source_sha: receipt.release.source_sha,
+    qualification_state: receipt.release.qualification_state,
+    receipt_sha256: receiptSha256,
+    artifact_set_digest: receipt.artifact_set_digest,
+    selected_targets: [...selectedTargets],
+    materialized_hashes: materializedHashes.map((entry) => ({
+      artifact: entry.artifact,
+      digest: entry.digest,
+    })),
+  };
+}

--- a/tests/release/src/artifacts/retained-release-set.ts
+++ b/tests/release/src/artifacts/retained-release-set.ts
@@ -668,6 +668,32 @@ export function loadRetainedReleaseIndex(
       `Retained-release index is not readable: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+  return parseRetainedReleaseIndex(raw);
+}
+
+/**
+ * Like `loadRetainedReleaseIndex`, but a genuinely ABSENT index file (ENOENT
+ * — the supported first-seal initialization) yields an empty index. Every
+ * other failure — unreadable file, invalid JSON, unsupported schema, unsafe
+ * entries — still throws: converting those into an empty index would
+ * silently discard retention roots.
+ */
+export function loadRetainedReleaseIndexOrInit(indexPath: string): RetainedReleaseIndexV1 {
+  let raw: string;
+  try {
+    raw = readFileSync(indexPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { schema_version: 1, kind: "proliferate.retained-release-index", receipts: [] };
+    }
+    throw new RetainedReleaseError(
+      `Retained-release index is not readable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return parseRetainedReleaseIndex(raw);
+}
+
+function parseRetainedReleaseIndex(raw: string): RetainedReleaseIndexV1 {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -682,6 +708,7 @@ export function loadRetainedReleaseIndex(
   if (!Array.isArray(root.receipts)) {
     throw new RetainedReleaseError("Retained-release index receipts must be an array.");
   }
+  const seenIds = new Set<string>();
   const receipts = root.receipts.map((entry, index) => {
     const record = requireObject(entry, `index.receipts[${index}]`);
     rejectUnknownKeys(
@@ -693,19 +720,100 @@ export function loadRetainedReleaseIndex(
     if (state !== "bootstrap_unqualified" && state !== "qualified") {
       throw new RetainedReleaseError(`index.receipts[${index}].qualification_state is unknown.`);
     }
+    const releaseId = requireString(
+      record.release_id,
+      `index.receipts[${index}].release_id`,
+      RELEASE_ID_PATTERN,
+    );
+    // Duplicate ids would make bootstrap policy (qualifiedReceiptExists) and
+    // receipt selection ambiguous; reject rather than pick one.
+    if (seenIds.has(releaseId)) {
+      throw new RetainedReleaseError(`Retained-release index has duplicate release_id "${releaseId}".`);
+    }
+    seenIds.add(releaseId);
+    const receiptPath = requireString(record.receipt_path, `index.receipts[${index}].receipt_path`);
+    // Receipt paths are index-relative plain filenames: an absolute path or a
+    // traversal segment could resolve outside the retained-release directory.
+    if (
+      path.isAbsolute(receiptPath) ||
+      receiptPath.split(/[\\/]/).some((segment) => segment === ".." || segment === "")
+    ) {
+      throw new RetainedReleaseError(
+        `index.receipts[${index}].receipt_path must stay inside the retained-release directory.`,
+      );
+    }
     return {
-      release_id: requireString(record.release_id, `index.receipts[${index}].release_id`, RELEASE_ID_PATTERN),
+      release_id: releaseId,
       source_sha: requireString(record.source_sha, `index.receipts[${index}].source_sha`, FULL_SHA_PATTERN),
       qualification_state: state as RetainedQualificationState,
-      receipt_path: requireString(record.receipt_path, `index.receipts[${index}].receipt_path`),
+      receipt_path: receiptPath,
       receipt_sha256: requireString(record.receipt_sha256, `index.receipts[${index}].receipt_sha256`, SHA256_PATTERN),
     };
   });
   return { schema_version: 1, kind: "proliferate.retained-release-index", receipts };
 }
 
+/**
+ * Loads one indexed receipt with the full entry↔receipt binding: the receipt
+ * file's bytes must hash to the indexed hash AND the entry's identity fields
+ * (release_id, source_sha, qualification_state) must equal the loaded
+ * receipt's own. Policy (bootstrap one-time rule via qualifiedReceiptExists)
+ * must only ever be derived from an index whose entries are bound this way —
+ * a mislabeled entry could otherwise hide an existing qualified receipt and
+ * improperly keep the bootstrap exception alive.
+ */
+export function loadIndexedRetainedReceipt(
+  index: RetainedReleaseIndexV1,
+  indexPath: string,
+  releaseId: string,
+): { receipt: RetainedReleaseReceiptV1; receiptSha256: string } {
+  const entry = index.receipts.find((receipt) => receipt.release_id === releaseId);
+  if (!entry) {
+    throw new RetainedReleaseError(
+      `Retained release "${releaseId}" is not in the retained-release index; ` +
+        `known releases: ${index.receipts.map((receipt) => receipt.release_id).join(", ") || "(none)"}.`,
+    );
+  }
+  const receiptPath = path.join(path.dirname(indexPath), entry.receipt_path);
+  const { receipt, receiptSha256 } = loadRetainedReleaseReceipt(receiptPath);
+  if (receiptSha256 !== entry.receipt_sha256) {
+    throw new RetainedReleaseError(
+      `Retained receipt bytes for ${releaseId} do not match the index ` +
+        `(index ${entry.receipt_sha256}, file ${receiptSha256}).`,
+    );
+  }
+  if (
+    receipt.release.release_id !== entry.release_id ||
+    receipt.release.source_sha !== entry.source_sha ||
+    receipt.release.qualification_state !== entry.qualification_state
+  ) {
+    throw new RetainedReleaseError(
+      `Retained-release index entry for ${releaseId} does not match the receipt it points at ` +
+        `(index ${entry.release_id}/${entry.source_sha.slice(0, 12)}/${entry.qualification_state}, ` +
+        `receipt ${receipt.release.release_id}/${receipt.release.source_sha.slice(0, 12)}/` +
+        `${receipt.release.qualification_state}).`,
+    );
+  }
+  return { receipt, receiptSha256 };
+}
+
 export function qualifiedReceiptExists(index: RetainedReleaseIndexV1): boolean {
   return index.receipts.some((entry) => entry.qualification_state === "qualified");
+}
+
+/**
+ * Proves every index entry is bound to its receipt (bytes + identity/state)
+ * by loading each one. Required before deriving bootstrap policy from index
+ * metadata: `qualifiedReceiptExists` reads entry states without loading
+ * receipts, so an entry mislabeled `bootstrap_unqualified` could otherwise
+ * hide an existing qualified receipt and keep the one-time bootstrap
+ * exception alive. The retained set is small by design (current + previous
+ * qualified), so loading every receipt is cheap.
+ */
+export function assertIndexReceiptsBound(index: RetainedReleaseIndexV1, indexPath: string): void {
+  for (const entry of index.receipts) {
+    loadIndexedRetainedReceipt(index, indexPath, entry.release_id);
+  }
 }
 
 /** Optional live drift checks against provider metadata (read-only hooks). */

--- a/tests/release/src/cli/retained-release.test.ts
+++ b/tests/release/src/cli/retained-release.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  computeArtifactSetDigest,
+  type RetainedReleaseReceiptV1,
+} from "../artifacts/retained-release-set.js";
+
+/**
+ * Command-level regressions for the seal write-ordering invariants
+ * (RR-CONTROL-001/002): ALL preflight — existing-receipt immutability and
+ * index integrity — happens before ANY write or download, so every rejection
+ * below must leave the committed receipt and index byte-identical. The cases
+ * are hermetic precisely because preflight precedes network I/O: a correct
+ * implementation exits 2 without ever fetching an artifact.
+ */
+
+const CLI = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "retained-release.ts");
+const TSX = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "node_modules", ".bin", "tsx");
+
+const SHA = "e61afc274593085e51870b24269f718a543b88b4";
+const sha = (text: string) => createHash("sha256").update(text, "utf8").digest("hex");
+
+function receiptBody(anyharnessVersion = "0.3.38"): Omit<RetainedReleaseReceiptV1, "artifact_set_digest"> {
+  return {
+    schema_version: 1,
+    kind: "proliferate.retained-release",
+    release: {
+      release_id: "v0.3.38",
+      release_tag: "proliferate-v0.3.38",
+      source_sha: SHA,
+      published_at: "2026-07-17T01:07:21.493Z",
+      qualification_state: "bootstrap_unqualified",
+      qualification_evidence: null,
+    },
+    desktop: {
+      version: "0.3.38",
+      packages: [
+        {
+          platform: "darwin-aarch64",
+          immutable_locator:
+            "https://downloads.invalid.example/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz",
+          sha256: sha("a"),
+          signature_locator:
+            "https://downloads.invalid.example/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig",
+          sha256_signature: sha("b"),
+        },
+        {
+          platform: "darwin-x86_64",
+          immutable_locator:
+            "https://downloads.invalid.example/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz",
+          sha256: sha("c"),
+          signature_locator:
+            "https://downloads.invalid.example/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig",
+          sha256_signature: sha("d"),
+        },
+      ],
+      updater_pubkey: "dW50cnVzdGVk",
+      embedded_anyharness_version: "0.3.38",
+    },
+    managed_runtime: {
+      template_family: "pablo-5391/proliferate-runtime-cloud",
+      immutable_template_id: "y7dakz4fs16tbz8vb9zo",
+      template_build_id: "661a9621-78db-4c55-84d1-281c21fb72dc",
+      source_tag: "sha-e61afc274593",
+      input_hash: null,
+      anyharness_version: anyharnessVersion,
+      worker_version: "0.3.38",
+      supervisor_version: "0.3.38",
+      harness_catalog_digest: sha("catalog"),
+      harness_registry_digest: sha("registry"),
+    },
+    self_host: {
+      version: "0.3.35",
+      release_tag: "server-v0.3.35",
+      deploy_bundle_locator:
+        "https://github.invalid.example/releases/download/server-v0.3.35/proliferate-deploy.tar.gz",
+      deploy_bundle_sha256: sha("bundle"),
+      server_image_digest: `ghcr.io/proliferate-ai/proliferate-server@sha256:${sha("image")}`,
+    },
+  };
+}
+
+function sealReceipt(body: Omit<RetainedReleaseReceiptV1, "artifact_set_digest">): RetainedReleaseReceiptV1 {
+  return { ...body, artifact_set_digest: computeArtifactSetDigest(body) };
+}
+
+interface SealRun {
+  status: number;
+  stderr: string;
+}
+
+function runSeal(indexPath: string, draftPath: string): SealRun {
+  try {
+    execFileSync(TSX, [CLI, "seal", "--input", draftPath, "--index", indexPath], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stderr: "" };
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    return { status: failure.status ?? -1, stderr: failure.stderr ?? "" };
+  }
+}
+
+function seedStore(): { dir: string; indexPath: string; receiptPath: string } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-seal-cli-"));
+  const indexPath = path.join(dir, "index.json");
+  const receiptPath = path.join(dir, "v0.3.38.json");
+  const receipt = sealReceipt(receiptBody());
+  const receiptText = `${JSON.stringify(receipt, null, 2)}\n`;
+  writeFileSync(receiptPath, receiptText);
+  writeFileSync(
+    indexPath,
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        kind: "proliferate.retained-release-index",
+        receipts: [
+          {
+            release_id: "v0.3.38",
+            source_sha: SHA,
+            qualification_state: "bootstrap_unqualified",
+            receipt_path: "v0.3.38.json",
+            receipt_sha256: sha(receiptText),
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return { dir, indexPath, receiptPath };
+}
+
+test("RR-CONTROL-001: a differing reseal exits 2 and leaves receipt AND index byte-identical", () => {
+  const { dir, indexPath, receiptPath } = seedStore();
+  const receiptBefore = readFileSync(receiptPath, "utf8");
+  const indexBefore = readFileSync(indexPath, "utf8");
+
+  // A changed draft for the same release: different component version.
+  const draftPath = path.join(dir, "draft.json");
+  writeFileSync(draftPath, JSON.stringify(receiptBody("0.3.39")));
+
+  const result = runSeal(indexPath, draftPath);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /immutable once indexed/);
+  assert.match(result.stderr, /Nothing was written/);
+  assert.equal(readFileSync(receiptPath, "utf8"), receiptBefore, "receipt bytes must be untouched");
+  assert.equal(readFileSync(indexPath, "utf8"), indexBefore, "index bytes must be untouched");
+});
+
+test("RR-CONTROL-002: a corrupt index aborts seal before any write (no empty-index reinit)", () => {
+  const { dir, indexPath, receiptPath } = seedStore();
+  const receiptBefore = readFileSync(receiptPath, "utf8");
+  writeFileSync(indexPath, "not json {");
+
+  const draftPath = path.join(dir, "draft.json");
+  writeFileSync(draftPath, JSON.stringify(receiptBody()));
+
+  const result = runSeal(indexPath, draftPath);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /not valid JSON/);
+  assert.equal(readFileSync(indexPath, "utf8"), "not json {", "corrupt index must not be replaced");
+  assert.equal(readFileSync(receiptPath, "utf8"), receiptBefore, "receipt bytes must be untouched");
+});
+
+test("RR-CONTROL-002: an unsupported index schema aborts seal without writes", () => {
+  const { dir, indexPath } = seedStore();
+  writeFileSync(
+    indexPath,
+    JSON.stringify({ schema_version: 99, kind: "proliferate.retained-release-index", receipts: [] }),
+  );
+  const indexBefore = readFileSync(indexPath, "utf8");
+  const draftPath = path.join(dir, "draft.json");
+  writeFileSync(draftPath, JSON.stringify(receiptBody()));
+
+  const result = runSeal(indexPath, draftPath);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Unsupported/);
+  assert.equal(readFileSync(indexPath, "utf8"), indexBefore);
+});

--- a/tests/release/src/cli/retained-release.ts
+++ b/tests/release/src/cli/retained-release.ts
@@ -3,9 +3,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  assertIndexReceiptsBound,
   computeArtifactSetDigest,
+  loadIndexedRetainedReceipt,
   loadRetainedReleaseIndex,
-  loadRetainedReleaseReceipt,
+  loadRetainedReleaseIndexOrInit,
   qualifiedReceiptExists,
   RETAINED_RELEASE_INDEX_PATH,
   RetainedReleaseError,
@@ -15,7 +17,8 @@ import {
   validateRetainedRelease,
   validateRetainedReleaseReceiptShape,
   verifyRetainedReleaseLive,
-  type RetainedReleaseIndexV1,
+  type RetainedReleaseLiveChecks,
+  type RetainedReleaseReceiptV1,
   type RetainedTarget,
 } from "../artifacts/retained-release-set.js";
 import { materializeRetainedRelease } from "../artifacts/materialize-retained-release.js";
@@ -24,25 +27,32 @@ import { materializeRetainedRelease } from "../artifacts/materialize-retained-re
  * Retained-release receipt operator tool (frozen spec "Retain Exact
  * Production Artifacts for Tier 4"). Two commands:
  *
- *   seal --input <draft.json> --release-id <vX.Y.Z>
+ *   seal --input <draft.json> [--live]
  *     Takes a draft receipt (a complete receipt body whose artifact_set_digest
  *     may be absent/stale), computes the artifact-set digest over normalized
  *     content, re-validates the sealed shape, downloads and hash-verifies
  *     every downloadable artifact, optionally verifies live provider identity
- *     (--live: E2B source-tag -> build id), and only then writes the receipt
- *     and appends it to the committed index. For historical/bootstrap
- *     releases this is the "reconstruct only after independently verifying
- *     each retained artifact" path.
+ *     (--live: E2B source-tag -> build id AND the recorded OCI digest), and
+ *     only then writes the receipt and appends it to the committed index.
+ *     ALL preflight (including the immutability check against an existing
+ *     indexed receipt) happens before any byte is written: a differing reseal
+ *     leaves both the receipt and the index untouched. Only a genuinely
+ *     ABSENT index file initializes a new empty index; an unreadable or
+ *     corrupt index fails closed so retention roots can never be silently
+ *     discarded. For historical/bootstrap releases this is the "reconstruct
+ *     only after independently verifying each retained artifact" path.
  *
  *   validate --release-id <vX.Y.Z> [--targets a,b] [--candidate-sha <sha>] [--live]
- *     Loads the committed receipt via the index, runs shape + policy
- *     validation, materializes the selected targets into a cache with
- *     per-use hash verification, optionally live-verifies provider identity,
- *     and prints the bounded evidence projection. Exit 2 on any validation
- *     failure, before any world side effect.
+ *     Loads the committed receipt via the index (every entry bound to its
+ *     receipt's bytes AND identity/state before policy is derived), runs
+ *     shape + policy validation, materializes the selected targets into a
+ *     cache with per-use hash verification, optionally live-verifies provider
+ *     identity, and prints the bounded evidence projection. Exit 2 on any
+ *     validation failure, before any world side effect.
  *
- * Read-only toward providers: `--live` performs metadata lookups only. This
- * tool never promotes templates, rebuilds artifacts, or mutates aliases.
+ * Read-only toward providers: `--live` performs metadata lookups only (E2B
+ * template tags, container-registry manifest digests). This tool never
+ * promotes templates, rebuilds artifacts, or mutates aliases.
  */
 
 interface CliArgs {
@@ -121,6 +131,78 @@ async function e2bTagResolver(templateFamily: string): Promise<Array<{ tag: stri
   return tags.map((entry) => ({ tag: entry.tag, buildId: entry.buildId }));
 }
 
+/**
+ * Read-only OCI manifest-digest verification for `ghcr.io/...` references via
+ * the registry HTTP API (anonymous pull token for public images,
+ * GH_TOKEN/GITHUB_TOKEN for private ones). The receipt records
+ * `repo@sha256:...`; the registry is asked for that exact manifest — a
+ * registry that no longer serves it is drift/loss. Returns the digest the
+ * registry reports serving, which the caller compares to the recorded one.
+ */
+async function ociDigestResolver(reference: string, declaredDigest: string): Promise<string> {
+  const [registry, ...repoParts] = reference.split("/");
+  const repository = repoParts.join("/");
+  if (registry !== "ghcr.io" || repository.length === 0) {
+    throw new RetainedReleaseError(
+      `--live OCI verification supports ghcr.io references only (got "${registry}").`,
+    );
+  }
+  const token = await ghcrToken(repository);
+  const response = await fetch(`https://ghcr.io/v2/${repository}/manifests/${declaredDigest}`, {
+    method: "HEAD",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept:
+        "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, " +
+        "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json",
+    },
+  });
+  if (!response.ok) {
+    throw new RetainedReleaseError(
+      `--live OCI verification: ghcr.io no longer serves the recorded manifest for ${repository} ` +
+        `(HTTP ${response.status}); retained image drift or loss.`,
+    );
+  }
+  return response.headers.get("docker-content-digest") ?? "";
+}
+
+async function ghcrToken(repository: string): Promise<string> {
+  const response = await fetch(
+    `https://ghcr.io/token?scope=repository:${repository}:pull`,
+    process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+      ? {
+          headers: {
+            Authorization: `Basic ${Buffer.from(`x:${process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN}`).toString("base64")}`,
+          },
+        }
+      : undefined,
+  );
+  if (!response.ok) {
+    throw new RetainedReleaseError(`--live OCI verification: ghcr.io token request failed (HTTP ${response.status}).`);
+  }
+  const body = (await response.json()) as { token?: string };
+  if (!body.token) {
+    throw new RetainedReleaseError("--live OCI verification: ghcr.io returned no pull token.");
+  }
+  return body.token;
+}
+
+/**
+ * The full frozen `--live` check set (RR-CONTROL-004): E2B immutable
+ * source-tag -> build identity AND the recorded OCI manifest digest. Template
+ * COMPONENT identities (versions/catalog inside the image) require booting a
+ * sandbox from the template — a world side effect this read-only tool must
+ * not perform; they are asserted by the T4-RUNTIME-1 baseline against the
+ * same receipt (`expectedComponents`) when the live world runs.
+ */
+function liveChecks(receipt: RetainedReleaseReceiptV1): RetainedReleaseLiveChecks {
+  const declaredDigest = receipt.self_host.server_image_digest.split("@")[1] ?? "";
+  return {
+    resolveE2bTags: e2bTagResolver,
+    resolveOciDigest: (reference: string) => ociDigestResolver(reference, declaredDigest),
+  };
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
@@ -134,41 +216,41 @@ async function main(): Promise<void> {
       draft as unknown as Parameters<typeof computeArtifactSetDigest>[0],
     );
     const sealed = validateRetainedReleaseReceiptShape({ ...draft, artifact_set_digest: digest });
+    const receiptFileName = `${sealed.release.release_id}.json`;
+    const receiptPath = path.join(path.dirname(args.indexPath), receiptFileName);
+    const receiptText = `${JSON.stringify(sealed, null, 2)}\n`;
+    const receiptSha256 = sha256OfText(receiptText);
 
-    // Independent verification before the receipt is persisted: every
-    // downloadable artifact's bytes must hash to the declared digest.
+    // ALL preflight before ANY write (RR-CONTROL-001/002): only a genuinely
+    // absent index initializes empty; any other load failure aborts here. A
+    // release already indexed must reseal to identical bytes — a differing
+    // reseal aborts with the committed receipt and index untouched.
+    const index = loadRetainedReleaseIndexOrInit(args.indexPath);
+    const existing = index.receipts.find((entry) => entry.release_id === sealed.release.release_id);
+    if (existing && existing.receipt_sha256 !== receiptSha256) {
+      throw new RetainedReleaseError(
+        `Retained release ${sealed.release.release_id} is already indexed with different receipt bytes; ` +
+          `receipts are immutable once indexed. Nothing was written.`,
+      );
+    }
+    if (index.receipts.length > 0) {
+      assertIndexReceiptsBound(index, args.indexPath);
+    }
+
+    // Independent verification, still before persistence: every downloadable
+    // artifact's bytes must hash to the declared digest, and --live must prove
+    // provider identity (E2B build + OCI digest).
     const verifyDir = mkdtempSync(path.join(tmpdir(), "retained-seal-"));
     const materialized = await materializeRetainedRelease(sealed, {
       targets: ["desktop", "self-host"],
       cacheDirectory: verifyDir,
     });
     if (args.live) {
-      await verifyRetainedReleaseLive(sealed, { resolveE2bTags: e2bTagResolver });
+      await verifyRetainedReleaseLive(sealed, liveChecks(sealed));
     }
 
-    const receiptFileName = `${sealed.release.release_id}.json`;
-    const receiptPath = path.join(path.dirname(args.indexPath), receiptFileName);
-    const receiptText = `${JSON.stringify(sealed, null, 2)}\n`;
     writeFileSync(receiptPath, receiptText);
-    const receiptSha256 = sha256OfText(receiptText);
-
-    let index: RetainedReleaseIndexV1;
-    try {
-      index = loadRetainedReleaseIndex(args.indexPath);
-    } catch {
-      index = { schema_version: 1, kind: "proliferate.retained-release-index", receipts: [] };
-    }
-    // The index is append-only: re-sealing an existing release must produce
-    // identical bytes; differing bytes are a hard failure, not an overwrite.
-    const existing = index.receipts.find((entry) => entry.release_id === sealed.release.release_id);
-    if (existing) {
-      if (existing.receipt_sha256 !== receiptSha256) {
-        throw new RetainedReleaseError(
-          `Retained release ${sealed.release.release_id} is already indexed with different receipt bytes; ` +
-            `receipts are immutable once indexed.`,
-        );
-      }
-    } else {
+    if (!existing) {
       index.receipts.push({
         release_id: sealed.release.release_id,
         source_sha: sealed.release.source_sha,
@@ -194,32 +276,21 @@ async function main(): Promise<void> {
     throw new RetainedReleaseError("validate requires --release-id <vX.Y.Z>.");
   }
   const index = loadRetainedReleaseIndex(args.indexPath);
-  const entry = index.receipts.find((receipt) => receipt.release_id === args.releaseId);
-  if (!entry) {
-    throw new RetainedReleaseError(
-      `Retained release "${args.releaseId}" is not in the index at ${args.indexPath}.`,
-    );
-  }
-  const receiptPath = path.join(path.dirname(args.indexPath), entry.receipt_path);
-  const { receipt, receiptSha256 } = loadRetainedReleaseReceipt(receiptPath);
-  if (receiptSha256 !== entry.receipt_sha256) {
-    throw new RetainedReleaseError(
-      `Receipt bytes for ${args.releaseId} do not match the index ` +
-        `(index ${entry.receipt_sha256}, file ${receiptSha256}).`,
-    );
-  }
+  // Bind every entry before deriving bootstrap policy (RR-CONTROL-005).
+  assertIndexReceiptsBound(index, args.indexPath);
+  const { receipt, receiptSha256 } = loadIndexedRetainedReceipt(index, args.indexPath, args.releaseId);
   validateRetainedRelease(receipt, {
     requiredTargets: args.targets,
     currentCandidateSourceSha: args.candidateSha,
     qualifiedReceiptExists: qualifiedReceiptExists(index),
   });
+  if (args.live) {
+    await verifyRetainedReleaseLive(receipt, liveChecks(receipt));
+  }
   const materialized = await materializeRetainedRelease(receipt, {
     targets: args.targets,
     cacheDirectory: args.cacheDirectory,
   });
-  if (args.live) {
-    await verifyRetainedReleaseLive(receipt, { resolveE2bTags: e2bTagResolver });
-  }
   console.log(
     JSON.stringify(
       toRetainedReleaseEvidence(

--- a/tests/release/src/cli/retained-release.ts
+++ b/tests/release/src/cli/retained-release.ts
@@ -1,0 +1,242 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  computeArtifactSetDigest,
+  loadRetainedReleaseIndex,
+  loadRetainedReleaseReceipt,
+  qualifiedReceiptExists,
+  RETAINED_RELEASE_INDEX_PATH,
+  RetainedReleaseError,
+  RETAINED_TARGETS,
+  sha256OfText,
+  toRetainedReleaseEvidence,
+  validateRetainedRelease,
+  validateRetainedReleaseReceiptShape,
+  verifyRetainedReleaseLive,
+  type RetainedReleaseIndexV1,
+  type RetainedTarget,
+} from "../artifacts/retained-release-set.js";
+import { materializeRetainedRelease } from "../artifacts/materialize-retained-release.js";
+
+/**
+ * Retained-release receipt operator tool (frozen spec "Retain Exact
+ * Production Artifacts for Tier 4"). Two commands:
+ *
+ *   seal --input <draft.json> --release-id <vX.Y.Z>
+ *     Takes a draft receipt (a complete receipt body whose artifact_set_digest
+ *     may be absent/stale), computes the artifact-set digest over normalized
+ *     content, re-validates the sealed shape, downloads and hash-verifies
+ *     every downloadable artifact, optionally verifies live provider identity
+ *     (--live: E2B source-tag -> build id), and only then writes the receipt
+ *     and appends it to the committed index. For historical/bootstrap
+ *     releases this is the "reconstruct only after independently verifying
+ *     each retained artifact" path.
+ *
+ *   validate --release-id <vX.Y.Z> [--targets a,b] [--candidate-sha <sha>] [--live]
+ *     Loads the committed receipt via the index, runs shape + policy
+ *     validation, materializes the selected targets into a cache with
+ *     per-use hash verification, optionally live-verifies provider identity,
+ *     and prints the bounded evidence projection. Exit 2 on any validation
+ *     failure, before any world side effect.
+ *
+ * Read-only toward providers: `--live` performs metadata lookups only. This
+ * tool never promotes templates, rebuilds artifacts, or mutates aliases.
+ */
+
+interface CliArgs {
+  command: "seal" | "validate";
+  input?: string;
+  releaseId?: string;
+  targets: RetainedTarget[];
+  candidateSha?: string;
+  live: boolean;
+  cacheDirectory: string;
+  indexPath: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const [command, ...rest] = argv;
+  if (command !== "seal" && command !== "validate") {
+    throw new RetainedReleaseError(
+      "Usage: retained-release <seal|validate> [--input <draft.json>] [--release-id <vX.Y.Z>] " +
+        "[--targets desktop,managed-runtime,self-host] [--candidate-sha <sha>] [--live] " +
+        "[--cache-dir <dir>] [--index <path>]",
+    );
+  }
+  const args: CliArgs = {
+    command,
+    targets: [...RETAINED_TARGETS],
+    live: false,
+    cacheDirectory: path.join(
+      process.env.HOME ?? tmpdir(),
+      ".proliferate-local",
+      "qualification",
+      "retained-cache",
+    ),
+    indexPath: RETAINED_RELEASE_INDEX_PATH,
+  };
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    switch (arg) {
+      case "--input":
+        args.input = rest[++i];
+        break;
+      case "--release-id":
+        args.releaseId = rest[++i];
+        break;
+      case "--targets":
+        args.targets = (rest[++i] ?? "").split(",").map((entry) => entry.trim()) as RetainedTarget[];
+        break;
+      case "--candidate-sha":
+        args.candidateSha = rest[++i];
+        break;
+      case "--live":
+        args.live = true;
+        break;
+      case "--cache-dir":
+        args.cacheDirectory = rest[++i] ?? args.cacheDirectory;
+        break;
+      case "--index":
+        args.indexPath = rest[++i] ?? args.indexPath;
+        break;
+      default:
+        throw new RetainedReleaseError(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+async function e2bTagResolver(templateFamily: string): Promise<Array<{ tag: string; buildId: string }>> {
+  const apiKey = process.env.E2B_API_KEY ?? process.env.RELEASE_E2E_E2B_API_KEY;
+  if (!apiKey) {
+    throw new RetainedReleaseError(
+      "--live E2B verification needs E2B_API_KEY or RELEASE_E2E_E2B_API_KEY in the environment.",
+    );
+  }
+  const { Template } = await import("e2b");
+  const family = templateFamily.split("/").at(-1) ?? templateFamily;
+  const tags = (await Template.getTags(family, { apiKey })) as Array<{ tag: string; buildId: string }>;
+  return tags.map((entry) => ({ tag: entry.tag, buildId: entry.buildId }));
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.command === "seal") {
+    if (!args.input) {
+      throw new RetainedReleaseError("seal requires --input <draft.json>.");
+    }
+    const draft = JSON.parse(readFileSync(args.input, "utf8")) as Record<string, unknown>;
+    delete draft.artifact_set_digest;
+    const digest = computeArtifactSetDigest(
+      draft as unknown as Parameters<typeof computeArtifactSetDigest>[0],
+    );
+    const sealed = validateRetainedReleaseReceiptShape({ ...draft, artifact_set_digest: digest });
+
+    // Independent verification before the receipt is persisted: every
+    // downloadable artifact's bytes must hash to the declared digest.
+    const verifyDir = mkdtempSync(path.join(tmpdir(), "retained-seal-"));
+    const materialized = await materializeRetainedRelease(sealed, {
+      targets: ["desktop", "self-host"],
+      cacheDirectory: verifyDir,
+    });
+    if (args.live) {
+      await verifyRetainedReleaseLive(sealed, { resolveE2bTags: e2bTagResolver });
+    }
+
+    const receiptFileName = `${sealed.release.release_id}.json`;
+    const receiptPath = path.join(path.dirname(args.indexPath), receiptFileName);
+    const receiptText = `${JSON.stringify(sealed, null, 2)}\n`;
+    writeFileSync(receiptPath, receiptText);
+    const receiptSha256 = sha256OfText(receiptText);
+
+    let index: RetainedReleaseIndexV1;
+    try {
+      index = loadRetainedReleaseIndex(args.indexPath);
+    } catch {
+      index = { schema_version: 1, kind: "proliferate.retained-release-index", receipts: [] };
+    }
+    // The index is append-only: re-sealing an existing release must produce
+    // identical bytes; differing bytes are a hard failure, not an overwrite.
+    const existing = index.receipts.find((entry) => entry.release_id === sealed.release.release_id);
+    if (existing) {
+      if (existing.receipt_sha256 !== receiptSha256) {
+        throw new RetainedReleaseError(
+          `Retained release ${sealed.release.release_id} is already indexed with different receipt bytes; ` +
+            `receipts are immutable once indexed.`,
+        );
+      }
+    } else {
+      index.receipts.push({
+        release_id: sealed.release.release_id,
+        source_sha: sealed.release.source_sha,
+        qualification_state: sealed.release.qualification_state,
+        receipt_path: receiptFileName,
+        receipt_sha256: receiptSha256,
+      });
+      writeFileSync(args.indexPath, `${JSON.stringify(index, null, 2)}\n`);
+    }
+
+    console.log(
+      JSON.stringify(
+        toRetainedReleaseEvidence(sealed, receiptSha256, ["desktop", "managed-runtime", "self-host"],
+          materialized.map((entry) => ({ artifact: entry.artifact, digest: entry.sha256 }))),
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (!args.releaseId) {
+    throw new RetainedReleaseError("validate requires --release-id <vX.Y.Z>.");
+  }
+  const index = loadRetainedReleaseIndex(args.indexPath);
+  const entry = index.receipts.find((receipt) => receipt.release_id === args.releaseId);
+  if (!entry) {
+    throw new RetainedReleaseError(
+      `Retained release "${args.releaseId}" is not in the index at ${args.indexPath}.`,
+    );
+  }
+  const receiptPath = path.join(path.dirname(args.indexPath), entry.receipt_path);
+  const { receipt, receiptSha256 } = loadRetainedReleaseReceipt(receiptPath);
+  if (receiptSha256 !== entry.receipt_sha256) {
+    throw new RetainedReleaseError(
+      `Receipt bytes for ${args.releaseId} do not match the index ` +
+        `(index ${entry.receipt_sha256}, file ${receiptSha256}).`,
+    );
+  }
+  validateRetainedRelease(receipt, {
+    requiredTargets: args.targets,
+    currentCandidateSourceSha: args.candidateSha,
+    qualifiedReceiptExists: qualifiedReceiptExists(index),
+  });
+  const materialized = await materializeRetainedRelease(receipt, {
+    targets: args.targets,
+    cacheDirectory: args.cacheDirectory,
+  });
+  if (args.live) {
+    await verifyRetainedReleaseLive(receipt, { resolveE2bTags: e2bTagResolver });
+  }
+  console.log(
+    JSON.stringify(
+      toRetainedReleaseEvidence(
+        receipt,
+        receiptSha256,
+        args.targets,
+        materialized.map((item) => ({ artifact: item.artifact, digest: item.sha256 })),
+      ),
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error: unknown) => {
+  // Exit 2 = invalid invocation/receipt/artifact input, before any world side
+  // effect; the message never embeds raw receipt JSON or provider responses.
+  console.error(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(2);
+});

--- a/tests/release/src/config/env-manifest.ts
+++ b/tests/release/src/config/env-manifest.ts
@@ -315,31 +315,17 @@ export const ENV_MANIFEST: readonly EnvVarSpec[] = [
     lanes: ["sandbox"],
   },
   {
-    name: "RELEASE_E2E_RETAINED_TEMPLATE_ID",
+    name: "RELEASE_E2E_RETAINED_RELEASE_ID",
     description:
-      "Immutable provider (E2B) template id of the retained-production N-1 sandbox image that " +
-      "T4-RUNTIME-1 provisions its baseline from before updating to candidate N. 'Retained' means the " +
-      "exact template of the last release ACTUALLY qualified through this platform — never a decremented " +
-      "version or a rebuilt-from-source approximation. Absent (with RELEASE_E2E_RETAINED_MANIFEST) -> " +
-      "T4-RUNTIME-1 reports blocked rather than fabricating an N-1 (founder ruling 2026-07-16). No " +
-      "release has been qualified through the platform yet, so this is expected to be unset until one is.",
+      "Release id (e.g. `v0.3.38`) selecting a committed retained-release receipt from " +
+      "tests/release/retained-releases/index.json as the Tier 4 N-1 baseline. The receipt is " +
+      "schema-validated, digest-checked, and policy-checked (a bootstrap_unqualified receipt fails " +
+      "closed once any qualified receipt exists) before any world side effect; a named id that cannot " +
+      "be validated is an error, never a silent block. Absent -> T4-RUNTIME-1 reports blocked rather " +
+      "than fabricating an N-1.",
     whereItLives:
-      "Produced by the release-qualification pipeline when it retains the last green release's E2B " +
-      "template; supplied to an on-demand/nightly T4-RUNTIME-1 dispatch once such a template exists.",
-    secret: false,
-    lanes: ["sandbox"],
-  },
-  {
-    name: "RELEASE_E2E_RETAINED_MANIFEST",
-    description:
-      "The retained-production N-1 release component manifest (JSON) describing the versions and digests " +
-      "of the AnyHarness/Worker/Supervisor binaries and bundled catalog/registry baked into " +
-      "RELEASE_E2E_RETAINED_TEMPLATE_ID. T4-RUNTIME-1 parses it to assert baseline N-1 identities and to " +
-      "compute what a real N-1 -> N update must change. Absent (with RELEASE_E2E_RETAINED_TEMPLATE_ID) -> " +
-      "T4-RUNTIME-1 reports blocked. Not a credential (public release metadata).",
-    whereItLives:
-      "The retained release's published manifest, captured by the qualification pipeline alongside the " +
-      "retained template id; supplied verbatim to the T4-RUNTIME-1 dispatch.",
+      "Chosen by the operator/workflow from the committed retained-release index; the only current " +
+      "receipt is the founder-ruled one-time bootstrap_unqualified v0.3.38 baseline.",
     secret: false,
     lanes: ["sandbox"],
   },

--- a/tests/release/src/fixtures/retained-runtime-baseline.test.ts
+++ b/tests/release/src/fixtures/retained-runtime-baseline.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import type { EnvResolution } from "../config/env-resolution.js";
+import {
+  computeArtifactSetDigest,
+  RetainedReleaseError,
+  type RetainedReleaseReceiptV1,
+} from "../artifacts/retained-release-set.js";
+import {
+  RETAINED_RELEASE_ID_ENV,
+  resolveRetainedRuntimeBaseline,
+} from "./retained-runtime-baseline.js";
+
+const SHA = "e61afc274593085e51870b24269f718a543b88b4";
+const sha = (text: string) => createHash("sha256").update(text, "utf8").digest("hex");
+
+function fakeEnv(values: Record<string, string>): EnvResolution {
+  return { get: (name: string) => values[name] } as unknown as EnvResolution;
+}
+
+function sealedReceipt(
+  state: "bootstrap_unqualified" | "qualified" = "bootstrap_unqualified",
+): RetainedReleaseReceiptV1 {
+  const body: Omit<RetainedReleaseReceiptV1, "artifact_set_digest"> = {
+    schema_version: 1,
+    kind: "proliferate.retained-release",
+    release: {
+      release_id: "v0.3.38",
+      release_tag: "proliferate-v0.3.38",
+      source_sha: SHA,
+      published_at: "2026-07-17T01:07:21.493Z",
+      qualification_state: state,
+      qualification_evidence:
+        state === "qualified"
+          ? {
+              report_sha256: sha("report"),
+              immutable_locator: `https://qualification.example.com/evidence/v0.3.38/${sha("report")}.json`,
+            }
+          : null,
+    },
+    desktop: {
+      version: "0.3.38",
+      packages: [
+        {
+          platform: "darwin-aarch64",
+          immutable_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz",
+          sha256: sha("a"),
+          signature_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig",
+          sha256_signature: sha("b"),
+        },
+        {
+          platform: "darwin-x86_64",
+          immutable_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz",
+          sha256: sha("c"),
+          signature_locator:
+            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig",
+          sha256_signature: sha("d"),
+        },
+      ],
+      updater_pubkey: "dW50cnVzdGVk",
+      embedded_anyharness_version: "0.3.38",
+    },
+    managed_runtime: {
+      template_family: "pablo-5391/proliferate-runtime-cloud",
+      immutable_template_id: "y7dakz4fs16tbz8vb9zo",
+      template_build_id: "661a9621-78db-4c55-84d1-281c21fb72dc",
+      source_tag: "sha-e61afc274593",
+      input_hash: state === "qualified" ? sha("input") : null,
+      anyharness_version: "0.3.38",
+      worker_version: "0.3.38",
+      supervisor_version: "0.3.38",
+      harness_catalog_digest: sha("catalog"),
+      harness_registry_digest: sha("registry"),
+    },
+    self_host: {
+      version: "0.3.35",
+      release_tag: "server-v0.3.35",
+      deploy_bundle_locator:
+        "https://github.com/proliferate-ai/proliferate/releases/download/server-v0.3.35/proliferate-deploy.tar.gz",
+      deploy_bundle_sha256: sha("bundle"),
+      server_image_digest: `ghcr.io/proliferate-ai/proliferate-server@sha256:${sha("image")}`,
+    },
+  };
+  return { ...body, artifact_set_digest: computeArtifactSetDigest(body) };
+}
+
+function writeIndexDir(receipts: RetainedReleaseReceiptV1[]): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-baseline-"));
+  const entries = receipts.map((receipt) => {
+    const fileName = `${receipt.release.release_id}.json`;
+    const text = `${JSON.stringify(receipt, null, 2)}\n`;
+    writeFileSync(path.join(dir, fileName), text);
+    return {
+      release_id: receipt.release.release_id,
+      source_sha: receipt.release.source_sha,
+      qualification_state: receipt.release.qualification_state,
+      receipt_path: fileName,
+      receipt_sha256: sha(text),
+    };
+  });
+  writeFileSync(
+    path.join(dir, "index.json"),
+    JSON.stringify({ schema_version: 1, kind: "proliferate.retained-release-index", receipts: entries }),
+  );
+  return path.join(dir, "index.json");
+}
+
+test("returns null when no baseline input names anything (honest block)", () => {
+  assert.equal(resolveRetainedRuntimeBaseline(fakeEnv({})), null);
+});
+
+test("resolves a committed receipt by release id with full validation", () => {
+  const indexPath = writeIndexDir([sealedReceipt()]);
+  const baseline = resolveRetainedRuntimeBaseline(
+    fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }),
+    undefined,
+    { indexPath },
+  );
+  assert.ok(baseline);
+  assert.equal(baseline.templateId, "y7dakz4fs16tbz8vb9zo");
+  assert.equal(baseline.anyharnessReportedVersion, "0.3.38");
+  assert.equal(baseline.receipt?.release.qualification_state, "bootstrap_unqualified");
+  assert.ok(baseline.receiptSha256);
+  const manifest = JSON.parse(baseline.manifest) as Record<string, unknown>;
+  assert.equal(manifest.source_sha, SHA);
+  assert.equal(manifest.template_build_id, "661a9621-78db-4c55-84d1-281c21fb72dc");
+});
+
+test("a named release id that is not indexed is an error, never a silent block", () => {
+  const indexPath = writeIndexDir([sealedReceipt()]);
+  assert.throws(
+    () =>
+      resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v9.9.9" }), undefined, {
+        indexPath,
+      }),
+    RetainedReleaseError,
+  );
+});
+
+test("receipt bytes that do not match the index reject", () => {
+  const receipt = sealedReceipt();
+  const indexPath = writeIndexDir([receipt]);
+  // Rewrite the receipt file (still shape-valid) without updating the index.
+  writeFileSync(
+    path.join(path.dirname(indexPath), "v0.3.38.json"),
+    `${JSON.stringify(receipt)}\n`,
+  );
+  assert.throws(
+    () =>
+      resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
+        indexPath,
+      }),
+    /do not match the index/,
+  );
+});
+
+test("bootstrap receipt fails closed once any qualified receipt is indexed", () => {
+  const qualified = sealedReceipt("qualified");
+  qualified.release.release_id = "v0.4.0";
+  qualified.release.release_tag = "proliferate-v0.4.0";
+  const resealBody = { ...qualified } as Record<string, unknown>;
+  delete resealBody.artifact_set_digest;
+  qualified.artifact_set_digest = computeArtifactSetDigest(
+    resealBody as unknown as Omit<RetainedReleaseReceiptV1, "artifact_set_digest">,
+  );
+  // Its desktop version no longer matches v0.4.0, but the index-level policy
+  // check fires on the SELECTED receipt before its file is even loaded when
+  // selecting the bootstrap entry, so shape validity of the sibling does not
+  // matter for this assertion — keep the sibling only in the index.
+  const bootstrap = sealedReceipt();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-baseline-mixed-"));
+  const bootstrapText = `${JSON.stringify(bootstrap, null, 2)}\n`;
+  writeFileSync(path.join(dir, "v0.3.38.json"), bootstrapText);
+  writeFileSync(
+    path.join(dir, "index.json"),
+    JSON.stringify({
+      schema_version: 1,
+      kind: "proliferate.retained-release-index",
+      receipts: [
+        {
+          release_id: "v0.3.38",
+          source_sha: bootstrap.release.source_sha,
+          qualification_state: "bootstrap_unqualified",
+          receipt_path: "v0.3.38.json",
+          receipt_sha256: sha(bootstrapText),
+        },
+        {
+          release_id: "v0.4.0",
+          source_sha: "f".repeat(40),
+          qualification_state: "qualified",
+          receipt_path: "v0.4.0.json",
+          receipt_sha256: sha("placeholder"),
+        },
+      ],
+    }),
+  );
+  assert.throws(
+    () =>
+      resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
+        indexPath: path.join(dir, "index.json"),
+      }),
+    /bootstrap exception no longer applies/,
+  );
+});
+
+test("a blank release id resolves to null (honest block), whitespace-only included", () => {
+  assert.equal(resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "   " })), null);
+});
+
+test("honors the reported-version override for unstamped binaries (issue #1089)", () => {
+  const indexPath = writeIndexDir([sealedReceipt()]);
+  const overridden = resolveRetainedRuntimeBaseline(
+    fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }),
+    "0.1.0",
+    { indexPath },
+  );
+  assert.equal(overridden?.anyharnessReportedVersion, "0.1.0");
+  const blank = resolveRetainedRuntimeBaseline(
+    fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }),
+    "   ",
+    { indexPath },
+  );
+  assert.equal(blank?.anyharnessReportedVersion, "0.3.38");
+});

--- a/tests/release/src/fixtures/retained-runtime-baseline.test.ts
+++ b/tests/release/src/fixtures/retained-runtime-baseline.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -25,58 +25,60 @@ function fakeEnv(values: Record<string, string>): EnvResolution {
 
 function sealedReceipt(
   state: "bootstrap_unqualified" | "qualified" = "bootstrap_unqualified",
+  version = "0.3.38",
+  sourceSha = SHA,
 ): RetainedReleaseReceiptV1 {
   const body: Omit<RetainedReleaseReceiptV1, "artifact_set_digest"> = {
     schema_version: 1,
     kind: "proliferate.retained-release",
     release: {
-      release_id: "v0.3.38",
-      release_tag: "proliferate-v0.3.38",
-      source_sha: SHA,
+      release_id: `v${version}`,
+      release_tag: `proliferate-v${version}`,
+      source_sha: sourceSha,
       published_at: "2026-07-17T01:07:21.493Z",
       qualification_state: state,
       qualification_evidence:
         state === "qualified"
           ? {
               report_sha256: sha("report"),
-              immutable_locator: `https://qualification.example.com/evidence/v0.3.38/${sha("report")}.json`,
+              immutable_locator: `https://qualification.example.com/evidence/v${version}/${sha("report")}.json`,
             }
           : null,
     },
     desktop: {
-      version: "0.3.38",
+      version,
       packages: [
         {
           platform: "darwin-aarch64",
           immutable_locator:
-            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz",
+            `https://downloads.proliferate.com/desktop/stable/Proliferate_${version}_aarch64.app.tar.gz`,
           sha256: sha("a"),
           signature_locator:
-            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_aarch64.app.tar.gz.sig",
+            `https://downloads.proliferate.com/desktop/stable/Proliferate_${version}_aarch64.app.tar.gz.sig`,
           sha256_signature: sha("b"),
         },
         {
           platform: "darwin-x86_64",
           immutable_locator:
-            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz",
+            `https://downloads.proliferate.com/desktop/stable/Proliferate_${version}_x64.app.tar.gz`,
           sha256: sha("c"),
           signature_locator:
-            "https://downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_x64.app.tar.gz.sig",
+            `https://downloads.proliferate.com/desktop/stable/Proliferate_${version}_x64.app.tar.gz.sig`,
           sha256_signature: sha("d"),
         },
       ],
       updater_pubkey: "dW50cnVzdGVk",
-      embedded_anyharness_version: "0.3.38",
+      embedded_anyharness_version: version,
     },
     managed_runtime: {
       template_family: "pablo-5391/proliferate-runtime-cloud",
       immutable_template_id: "y7dakz4fs16tbz8vb9zo",
       template_build_id: "661a9621-78db-4c55-84d1-281c21fb72dc",
-      source_tag: "sha-e61afc274593",
+      source_tag: `sha-${sourceSha.slice(0, 12)}`,
       input_hash: state === "qualified" ? sha("input") : null,
-      anyharness_version: "0.3.38",
-      worker_version: "0.3.38",
-      supervisor_version: "0.3.38",
+      anyharness_version: version,
+      worker_version: version,
+      supervisor_version: version,
       harness_catalog_digest: sha("catalog"),
       harness_registry_digest: sha("registry"),
     },
@@ -117,12 +119,25 @@ test("returns null when no baseline input names anything (honest block)", () => 
   assert.equal(resolveRetainedRuntimeBaseline(fakeEnv({})), null);
 });
 
+const CANDIDATE_SHA = "f".repeat(40);
+
+test("a selected receipt without a candidate SHA fails closed (N-1 != N unenforceable)", () => {
+  const indexPath = writeIndexDir([sealedReceipt()]);
+  assert.throws(
+    () =>
+      resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
+        indexPath,
+      }),
+    /no candidate source SHA/,
+  );
+});
+
 test("resolves a committed receipt by release id with full validation", () => {
   const indexPath = writeIndexDir([sealedReceipt()]);
   const baseline = resolveRetainedRuntimeBaseline(
     fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }),
     undefined,
-    { indexPath },
+    { indexPath, currentCandidateSourceSha: CANDIDATE_SHA },
   );
   assert.ok(baseline);
   assert.equal(baseline.templateId, "y7dakz4fs16tbz8vb9zo");
@@ -140,6 +155,7 @@ test("a named release id that is not indexed is an error, never a silent block",
     () =>
       resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v9.9.9" }), undefined, {
         indexPath,
+        currentCandidateSourceSha: CANDIDATE_SHA,
       }),
     RetainedReleaseError,
   );
@@ -157,57 +173,69 @@ test("receipt bytes that do not match the index reject", () => {
     () =>
       resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
         indexPath,
+        currentCandidateSourceSha: CANDIDATE_SHA,
       }),
     /do not match the index/,
   );
 });
 
 test("bootstrap receipt fails closed once any qualified receipt is indexed", () => {
-  const qualified = sealedReceipt("qualified");
-  qualified.release.release_id = "v0.4.0";
-  qualified.release.release_tag = "proliferate-v0.4.0";
-  const resealBody = { ...qualified } as Record<string, unknown>;
-  delete resealBody.artifact_set_digest;
-  qualified.artifact_set_digest = computeArtifactSetDigest(
-    resealBody as unknown as Omit<RetainedReleaseReceiptV1, "artifact_set_digest">,
-  );
-  // Its desktop version no longer matches v0.4.0, but the index-level policy
-  // check fires on the SELECTED receipt before its file is even loaded when
-  // selecting the bootstrap entry, so shape validity of the sibling does not
-  // matter for this assertion — keep the sibling only in the index.
+  // Both receipts are fully valid and BOUND (bytes + identity/state) — the
+  // rejection must come from the bootstrap policy itself, not a binding error.
   const bootstrap = sealedReceipt();
-  const dir = mkdtempSync(path.join(os.tmpdir(), "retained-baseline-mixed-"));
-  const bootstrapText = `${JSON.stringify(bootstrap, null, 2)}\n`;
-  writeFileSync(path.join(dir, "v0.3.38.json"), bootstrapText);
-  writeFileSync(
-    path.join(dir, "index.json"),
-    JSON.stringify({
-      schema_version: 1,
-      kind: "proliferate.retained-release-index",
-      receipts: [
-        {
-          release_id: "v0.3.38",
-          source_sha: bootstrap.release.source_sha,
-          qualification_state: "bootstrap_unqualified",
-          receipt_path: "v0.3.38.json",
-          receipt_sha256: sha(bootstrapText),
-        },
-        {
-          release_id: "v0.4.0",
-          source_sha: "f".repeat(40),
-          qualification_state: "qualified",
-          receipt_path: "v0.4.0.json",
-          receipt_sha256: sha("placeholder"),
-        },
-      ],
-    }),
-  );
+  const qualified = sealedReceipt("qualified", "0.4.0", "a".repeat(40));
+  const indexPath = writeIndexDir([bootstrap, qualified]);
   assert.throws(
     () =>
       resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
-        indexPath: path.join(dir, "index.json"),
+        indexPath,
+        currentCandidateSourceSha: CANDIDATE_SHA,
       }),
     /bootstrap exception no longer applies/,
+  );
+  // The qualified receipt itself remains selectable.
+  const baseline = resolveRetainedRuntimeBaseline(
+    fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.4.0" }),
+    undefined,
+    { indexPath, currentCandidateSourceSha: CANDIDATE_SHA },
+  );
+  assert.equal(baseline?.receipt.release.qualification_state, "qualified");
+});
+
+test("RR-CONTROL-005: an index entry mislabeled bootstrap cannot hide a qualified receipt", () => {
+  // The v0.4.0 receipt IS qualified, but its index entry lies and says
+  // bootstrap_unqualified — which would keep the one-time bootstrap exception
+  // alive if policy were derived from unbound index metadata. Binding must
+  // reject before any policy decision.
+  const bootstrap = sealedReceipt();
+  const qualified = sealedReceipt("qualified", "0.4.0", "a".repeat(40));
+  const indexPath = writeIndexDir([bootstrap, qualified]);
+  const indexRaw = JSON.parse(readFileSync(indexPath, "utf8")) as {
+    receipts: Array<{ release_id: string; qualification_state: string }>;
+  };
+  const lied = indexRaw.receipts.map((entry) =>
+    entry.release_id === "v0.4.0" ? { ...entry, qualification_state: "bootstrap_unqualified" } : entry,
+  );
+  writeFileSync(indexPath, JSON.stringify({ ...indexRaw, receipts: lied }));
+  assert.throws(
+    () =>
+      resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
+        indexPath,
+        currentCandidateSourceSha: CANDIDATE_SHA,
+      }),
+    /does not match the receipt it points at/,
+  );
+});
+
+test("RR-CONTROL-003: retained N-1 equal to candidate N fails closed on the real resolver path", () => {
+  const indexPath = writeIndexDir([sealedReceipt()]);
+  assert.throws(
+    () =>
+      resolveRetainedRuntimeBaseline(fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }), undefined, {
+        indexPath,
+        currentCandidateSourceSha: SHA,
+      }),
+    /same source SHA as candidate N/,
   );
 });
 
@@ -220,13 +248,13 @@ test("honors the reported-version override for unstamped binaries (issue #1089)"
   const overridden = resolveRetainedRuntimeBaseline(
     fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }),
     "0.1.0",
-    { indexPath },
+    { indexPath, currentCandidateSourceSha: CANDIDATE_SHA },
   );
   assert.equal(overridden?.anyharnessReportedVersion, "0.1.0");
   const blank = resolveRetainedRuntimeBaseline(
     fakeEnv({ [RETAINED_RELEASE_ID_ENV]: "v0.3.38" }),
     "   ",
-    { indexPath },
+    { indexPath, currentCandidateSourceSha: CANDIDATE_SHA },
   );
   assert.equal(blank?.anyharnessReportedVersion, "0.3.38");
 });

--- a/tests/release/src/fixtures/retained-runtime-baseline.ts
+++ b/tests/release/src/fixtures/retained-runtime-baseline.ts
@@ -1,103 +1,126 @@
+import path from "node:path";
+
 import type { EnvResolution } from "../config/env-resolution.js";
+import {
+  loadRetainedReleaseIndex,
+  loadRetainedReleaseReceipt,
+  qualifiedReceiptExists,
+  RETAINED_RELEASE_INDEX_PATH,
+  RetainedReleaseError,
+  validateRetainedRelease,
+  type RetainedReleaseReceiptV1,
+} from "../artifacts/retained-release-set.js";
 
 /**
  * The immutable retained-production N-1 baseline a real T4-RUNTIME-1 update
- * proof updates FROM. "Retained" means the exact artifacts of the last release
- * actually qualified through this platform — never a decremented version or a
- * rebuilt-from-source approximation (tier-4-scenario-contract.md "Shared Tier 4
- * rules": "N-1 always means the last qualified production artifacts").
+ * proof updates FROM. "Retained" means the exact artifacts of the retained
+ * production release — never a decremented version or a rebuilt-from-source
+ * approximation (tier-4-scenario-contract.md "Artifact Identity").
  *
- * The mechanism that publishes and retains such a baseline does not exist yet
- * (release-worlds-and-fixtures.md defers the retained manifest as later work),
- * so `resolveRetainedRuntimeBaseline` returns null whenever the inputs are
- * absent and the scenario reports `blocked` rather than fabricating an N-1.
- * When the inputs ARE supplied, they name a real immutable E2B template and the
- * manifest describing its component versions/digests.
+ * Resolution is receipt-backed (replacing the former env-only assembly):
+ * `RELEASE_E2E_RETAINED_RELEASE_ID` selects a committed retained-release
+ * receipt (tests/release/retained-releases/) via the append-only index; the
+ * receipt is schema-validated, digest-checked, and policy-checked
+ * (bootstrap_unqualified fails closed once a qualified receipt exists) before
+ * any world side effect. Local runs and GitHub Actions resolve the identical
+ * committed receipt — the same logical retained set with no
+ * environment-specific representation. Absent a release id, the scenario
+ * reports `blocked` rather than fabricating an N-1.
  */
 export interface RetainedRuntimeBaseline {
   /** Immutable provider (E2B) template id of the retained N-1 sandbox image. */
   templateId: string;
   /**
-   * The retained release's component manifest, verbatim as supplied
-   * (JSON string). The live proof parses it for per-component version/digest;
-   * kept opaque here so this resolver stays a thin, secret-free input gate.
+   * The retained release's component manifest (JSON string): the receipt's
+   * managed_runtime block plus release identity. The live proof parses it for
+   * per-component version/digest.
    */
   manifest: string;
   /**
    * The version the retained AnyHarness binary ACTUALLY reports from
-   * `--version` / `/health`, not merely its release tag. The supervisor
-   * health-gate and worker `--version` probe assert an exact match to the
-   * requested version (R9R-001 / R9-008); a binary that is not version-stamped
-   * (issue #1089) can never converge, so the proof must compare against what is
-   * observably reported. Defaults to the template id's declared version when a
-   * dedicated override is not supplied.
+   * `--version` / `/health`, not merely its release tag (issue #1089: an
+   * unstamped binary can never converge, so the proof compares against what
+   * is observably reported). Defaults to the receipt's anyharness version
+   * when a dedicated override is not supplied.
    */
   anyharnessReportedVersion: string;
+  /** The full validated receipt backing this baseline. */
+  receipt: RetainedReleaseReceiptV1;
+  /** SHA-256 of the exact receipt file bytes (the evidence identity). */
+  receiptSha256: string;
 }
 
-export const RETAINED_TEMPLATE_ID_ENV = "RELEASE_E2E_RETAINED_TEMPLATE_ID";
-export const RETAINED_MANIFEST_ENV = "RELEASE_E2E_RETAINED_MANIFEST";
+export const RETAINED_RELEASE_ID_ENV = "RELEASE_E2E_RETAINED_RELEASE_ID";
 export const RETAINED_ANYHARNESS_REPORTED_VERSION_ENV =
   "RELEASE_E2E_RETAINED_ANYHARNESS_REPORTED_VERSION";
 
+/** Injectable index root and policy inputs so tests never depend on committed data. */
+export interface RetainedBaselineSource {
+  indexPath?: string;
+  /** The candidate N source SHA for the N-1 != N policy check, when known. */
+  currentCandidateSourceSha?: string;
+}
+
 /**
- * Resolve the retained N-1 baseline from the runner-resolved environment, or
- * null when the inputs are absent (the founder-ruled default until a real
- * qualified release is retained). Both the template id and the manifest must be
- * present and non-empty; a half-supplied baseline is treated as absent so a
- * partial environment blocks cleanly rather than running against an incoherent
- * N-1.
+ * Resolve the retained N-1 baseline, or null when no release id names one
+ * (the founder-ruled default until a retained release is selected — the
+ * scenario blocks honestly). A NAMED baseline that cannot be validated
+ * (unknown id, unreadable/invalid receipt, index digest mismatch,
+ * bootstrap-after-qualified, N-1 == N) throws RetainedReleaseError — an
+ * error, never a silent block, and never a fallback.
  *
- * The two gating inputs come from `env` — the runner's single env-resolution
- * authority (`ctx.env`), which the scenario feeds by declaring both names in
- * its `requiredEnv` (T4R-CONTROL-001). The optional reported-version override
- * is passed explicitly: it is not a gating requirement (the manifest supplies a
- * default), so it must not sit in `requiredEnv` — the scenario reads it through
- * the optional-var idiom and hands the raw value here, keeping this resolver
- * free of any second, undeclared env read.
+ * The release id comes from `env` — the runner's single env-resolution
+ * authority (`ctx.env`), fed by the scenario's `requiredEnv`
+ * (T4R-CONTROL-001). The optional reported-version override is passed
+ * explicitly: it is not a gating requirement (the receipt supplies a
+ * default), so it must not sit in `requiredEnv` — the scenario reads it
+ * through the optional-var idiom and hands the raw value here.
  */
 export function resolveRetainedRuntimeBaseline(
   env: EnvResolution,
   reportedVersionOverride?: string,
+  source: RetainedBaselineSource = {},
 ): RetainedRuntimeBaseline | null {
-  const templateId = env.get(RETAINED_TEMPLATE_ID_ENV)?.trim() ?? "";
-  const manifest = env.get(RETAINED_MANIFEST_ENV)?.trim() ?? "";
-  if (templateId.length === 0 || manifest.length === 0) {
+  const releaseId = env.get(RETAINED_RELEASE_ID_ENV)?.trim() ?? "";
+  if (releaseId.length === 0) {
     return null;
   }
+
+  const indexPath = source.indexPath ?? RETAINED_RELEASE_INDEX_PATH;
+  const index = loadRetainedReleaseIndex(indexPath);
+  const entry = index.receipts.find((receipt) => receipt.release_id === releaseId);
+  if (!entry) {
+    throw new RetainedReleaseError(
+      `Retained release "${releaseId}" is not in the retained-release index; ` +
+        `known releases: ${index.receipts.map((receipt) => receipt.release_id).join(", ") || "(none)"}.`,
+    );
+  }
+  const receiptPath = path.join(path.dirname(indexPath), entry.receipt_path);
+  const { receipt, receiptSha256 } = loadRetainedReleaseReceipt(receiptPath);
+  if (receiptSha256 !== entry.receipt_sha256) {
+    throw new RetainedReleaseError(
+      `Retained receipt bytes for ${releaseId} do not match the index ` +
+        `(index ${entry.receipt_sha256}, file ${receiptSha256}).`,
+    );
+  }
+  validateRetainedRelease(receipt, {
+    requiredTargets: ["managed-runtime"],
+    currentCandidateSourceSha: source.currentCandidateSourceSha,
+    qualifiedReceiptExists: qualifiedReceiptExists(index),
+  });
+
   const reportedOverride = reportedVersionOverride?.trim() ?? "";
   return {
-    templateId,
-    manifest,
+    templateId: receipt.managed_runtime.immutable_template_id,
+    manifest: JSON.stringify({
+      release_id: receipt.release.release_id,
+      source_sha: receipt.release.source_sha,
+      qualification_state: receipt.release.qualification_state,
+      ...receipt.managed_runtime,
+    }),
     anyharnessReportedVersion:
-      reportedOverride.length > 0 ? reportedOverride : deriveReportedVersion(manifest),
+      reportedOverride.length > 0 ? reportedOverride : receipt.managed_runtime.anyharness_version,
+    receipt,
+    receiptSha256,
   };
-}
-
-/**
- * Best-effort read of the AnyHarness version the manifest declares, used only
- * when no explicit reported-version override is given. Never throws: an
- * unparseable manifest yields an empty string, which the scenario asserts
- * against so a malformed baseline blocks rather than proceeding on a guess.
- */
-function deriveReportedVersion(manifest: string): string {
-  try {
-    const parsed: unknown = JSON.parse(manifest);
-    if (parsed && typeof parsed === "object") {
-      const record = parsed as Record<string, unknown>;
-      const anyharness = record.anyharness;
-      if (anyharness && typeof anyharness === "object") {
-        const version = (anyharness as Record<string, unknown>).version;
-        if (typeof version === "string") {
-          return version.trim();
-        }
-      }
-      if (typeof record.anyharnessVersion === "string") {
-        return record.anyharnessVersion.trim();
-      }
-    }
-  } catch {
-    return "";
-  }
-  return "";
 }

--- a/tests/release/src/fixtures/retained-runtime-baseline.ts
+++ b/tests/release/src/fixtures/retained-runtime-baseline.ts
@@ -1,9 +1,8 @@
-import path from "node:path";
-
 import type { EnvResolution } from "../config/env-resolution.js";
 import {
+  assertIndexReceiptsBound,
+  loadIndexedRetainedReceipt,
   loadRetainedReleaseIndex,
-  loadRetainedReleaseReceipt,
   qualifiedReceiptExists,
   RETAINED_RELEASE_INDEX_PATH,
   RetainedReleaseError,
@@ -57,7 +56,11 @@ export const RETAINED_ANYHARNESS_REPORTED_VERSION_ENV =
 /** Injectable index root and policy inputs so tests never depend on committed data. */
 export interface RetainedBaselineSource {
   indexPath?: string;
-  /** The candidate N source SHA for the N-1 != N policy check, when known. */
+  /**
+   * The candidate N source SHA for the N-1 != N policy check. Required
+   * whenever a release id is selected: a receipt-backed baseline without a
+   * known candidate identity fails closed (RR-CONTROL-003).
+   */
   currentCandidateSourceSha?: string;
 }
 
@@ -86,26 +89,27 @@ export function resolveRetainedRuntimeBaseline(
     return null;
   }
 
+  // A real update proof must know the candidate N it updates TO: without the
+  // candidate source SHA the N-1 != N invariant cannot be enforced, so a
+  // receipt-backed baseline fails closed rather than silently skipping it.
+  const candidateSha = source.currentCandidateSourceSha?.trim() ?? "";
+  if (candidateSha.length === 0) {
+    throw new RetainedReleaseError(
+      `Retained release "${releaseId}" was selected but no candidate source SHA was supplied; ` +
+        `the N-1 != N invariant cannot be enforced without it.`,
+    );
+  }
+
   const indexPath = source.indexPath ?? RETAINED_RELEASE_INDEX_PATH;
   const index = loadRetainedReleaseIndex(indexPath);
-  const entry = index.receipts.find((receipt) => receipt.release_id === releaseId);
-  if (!entry) {
-    throw new RetainedReleaseError(
-      `Retained release "${releaseId}" is not in the retained-release index; ` +
-        `known releases: ${index.receipts.map((receipt) => receipt.release_id).join(", ") || "(none)"}.`,
-    );
-  }
-  const receiptPath = path.join(path.dirname(indexPath), entry.receipt_path);
-  const { receipt, receiptSha256 } = loadRetainedReleaseReceipt(receiptPath);
-  if (receiptSha256 !== entry.receipt_sha256) {
-    throw new RetainedReleaseError(
-      `Retained receipt bytes for ${releaseId} do not match the index ` +
-        `(index ${entry.receipt_sha256}, file ${receiptSha256}).`,
-    );
-  }
+  // Bind EVERY entry (bytes + identity/state) before deriving bootstrap
+  // policy from index metadata: a mislabeled sibling entry could otherwise
+  // hide an existing qualified receipt (RR-CONTROL-005).
+  assertIndexReceiptsBound(index, indexPath);
+  const { receipt, receiptSha256 } = loadIndexedRetainedReceipt(index, indexPath, releaseId);
   validateRetainedRelease(receipt, {
     requiredTargets: ["managed-runtime"],
-    currentCandidateSourceSha: source.currentCandidateSourceSha,
+    currentCandidateSourceSha: candidateSha,
     qualifiedReceiptExists: qualifiedReceiptExists(index),
   });
 

--- a/tests/release/src/scenarios/upgrade/t4-runtime-1.test.ts
+++ b/tests/release/src/scenarios/upgrade/t4-runtime-1.test.ts
@@ -24,12 +24,12 @@ const EXEC_IDENTITY: RunIdentityV1 = {
 // cell's result. This is the T4R-CONTROL-001 regression surface: it proves
 // supplied retained inputs actually reach the scenario, which a hand-built
 // EnvResolution injected straight into run() cannot prove.
-async function runViaRunner(source: Record<string, string>) {
+async function runViaRunner(source: Record<string, string>, identity: RunIdentityV1 = EXEC_IDENTITY) {
   const cells = await buildPlannedCells([t4Runtime1], { desktop: "web", agents: ["all"] });
   const report = await executeSelectedCells({
     behavior: "diagnostic",
     execution: "real",
-    identity: EXEC_IDENTITY,
+    identity,
     inputs: { targetLane: "cloud", desktop: "web", agents: "all", scenarios: "all" },
     scenarios: [t4Runtime1],
     cells,
@@ -165,7 +165,7 @@ test("supervisor-owned runtime not confirmed blocks even with a retained receipt
   // Flag absent from ctx.env (not declared "1"): the confirmation gate fires.
   const env = fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" });
   await assert.rejects(
-    () => leaf().run(fakeCtx({ env })),
+    () => leaf().run(fakeCtx({ env, runIdentity: EXEC_IDENTITY })),
     (error: unknown) =>
       error instanceof ScenarioBlockedError &&
       /supervisor-owned runtime topology must be active/.test((error as Error).message),
@@ -175,9 +175,19 @@ test("supervisor-owned runtime not confirmed blocks even with a retained receipt
 test("retained receipt + flag on: live body not yet wired, blocks honestly (never a false green)", async () => {
   const env = envWithFlag({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" });
   await assert.rejects(
-    () => leaf().run(fakeCtx({ env })),
+    () => leaf().run(fakeCtx({ env, runIdentity: EXEC_IDENTITY })),
     (error: unknown) =>
       error instanceof ScenarioBlockedError && /live-proof body is not yet wired/.test((error as Error).message),
+  );
+});
+
+test("RR-CONTROL-003: a retained receipt without a run identity blocks (N-1 != N unenforceable)", async () => {
+  const env = envWithFlag({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" });
+  await assert.rejects(
+    () => leaf().run(fakeCtx({ env, runIdentity: null })),
+    (error: unknown) =>
+      error instanceof ScenarioBlockedError &&
+      /no resolved candidate source SHA/.test((error as Error).message),
   );
 });
 
@@ -194,8 +204,11 @@ test("resolver resolves the COMMITTED bootstrap receipt (the real repo data path
   // No injected index: this exercises the exact committed
   // tests/release/retained-releases/ data the runner will use, proving the
   // real v0.3.38 receipt validates end to end from a stock checkout.
+  const source = { currentCandidateSourceSha: "e".repeat(40) };
   const baseline = resolveRetainedRuntimeBaseline(
     fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" }),
+    undefined,
+    source,
   );
   assert.ok(baseline);
   assert.equal(baseline?.receipt.release.qualification_state, "bootstrap_unqualified");
@@ -204,6 +217,7 @@ test("resolver resolves the COMMITTED bootstrap receipt (the real repo data path
   const overridden = resolveRetainedRuntimeBaseline(
     fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" }),
     "0.1.0",
+    source,
   );
   assert.equal(overridden?.anyharnessReportedVersion, "0.1.0");
 });
@@ -214,6 +228,18 @@ test("resolver resolves the COMMITTED bootstrap receipt (the real repo data path
 // retained inputs actually reach ctx.env. No E2B, no flag activation, no
 // fabricated N-1 — every case still terminates blocked.
 // ---------------------------------------------------------------------------
+
+test("REGRESSION RR-CONTROL-003: retained N-1 == candidate N fails the cell through the real planner/runner path", async () => {
+  // Run identity whose source SHA equals the committed v0.3.38 receipt's
+  // source SHA: the resolver must fail closed (a red cell, never blocked as
+  // missing-input and never a fabricated proof from a release to itself).
+  const result = await runViaRunner(RETAINED_SOURCE, {
+    ...EXEC_IDENTITY,
+    source_sha: "e61afc274593085e51870b24269f718a543b88b4",
+  });
+  assert.equal(result.status, "failed");
+  assert.match(result.reason?.message ?? "", /same source SHA as candidate N/);
+});
 
 test("REGRESSION T4R-CONTROL-001: supplied retained inputs reach the scenario and advance to the terminal honest block", async () => {
   const result = await runViaRunner(RETAINED_SOURCE);

--- a/tests/release/src/scenarios/upgrade/t4-runtime-1.test.ts
+++ b/tests/release/src/scenarios/upgrade/t4-runtime-1.test.ts
@@ -45,8 +45,8 @@ async function runViaRunner(source: Record<string, string>) {
 
 const RETAINED_SOURCE = {
   RELEASE_E2E_SERVER_URL: "https://qualification.example/api",
-  RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-  RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
+  // The committed bootstrap receipt: the real repo data path, end to end.
+  RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38",
   RELEASE_E2E_SUPERVISOR_OWNED_RUNTIME: "1",
 } as const;
 
@@ -119,8 +119,7 @@ test("declares its gating inputs in requiredEnv so the runner surfaces them in c
   assert.deepEqual(
     [...t4Runtime1.requiredEnv].sort(),
     [
-      "RELEASE_E2E_RETAINED_MANIFEST",
-      "RELEASE_E2E_RETAINED_TEMPLATE_ID",
+      "RELEASE_E2E_RETAINED_RELEASE_ID",
       "RELEASE_E2E_SERVER_URL",
       "RELEASE_E2E_SUPERVISOR_OWNED_RUNTIME",
     ],
@@ -157,17 +156,14 @@ test("absent retained N-1 inputs block rather than fabricate an N-1", async () =
     () => leaf().run(fakeCtx({ env: envWithFlag() })),
     (error: unknown) =>
       error instanceof ScenarioBlockedError &&
-      /no retained-production N-1 template/.test((error as Error).message) &&
+      /no retained-production N-1 baseline selected/.test((error as Error).message) &&
       /Refusing to fabricate an N-1/.test((error as Error).message),
   );
 });
 
-test("supervisor-owned runtime not confirmed blocks even with retained inputs", async () => {
+test("supervisor-owned runtime not confirmed blocks even with a retained receipt", async () => {
   // Flag absent from ctx.env (not declared "1"): the confirmation gate fires.
-  const env = fakeEnv({
-    RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-    RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
-  });
+  const env = fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" });
   await assert.rejects(
     () => leaf().run(fakeCtx({ env })),
     (error: unknown) =>
@@ -176,11 +172,8 @@ test("supervisor-owned runtime not confirmed blocks even with retained inputs", 
   );
 });
 
-test("retained inputs + flag on: live body not yet wired, blocks honestly (never a false green)", async () => {
-  const env = envWithFlag({
-    RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-    RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
-  });
+test("retained receipt + flag on: live body not yet wired, blocks honestly (never a false green)", async () => {
+  const env = envWithFlag({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" });
   await assert.rejects(
     () => leaf().run(fakeCtx({ env })),
     (error: unknown) =>
@@ -188,79 +181,31 @@ test("retained inputs + flag on: live body not yet wired, blocks honestly (never
   );
 });
 
-test("resolver returns null when either retained input is missing", () => {
+test("resolver returns null when no release id is supplied", () => {
   assert.equal(resolveRetainedRuntimeBaseline(fakeEnv()), null);
-  assert.equal(
-    resolveRetainedRuntimeBaseline(fakeEnv({ RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_only" })),
-    null,
-  );
-  assert.equal(
-    resolveRetainedRuntimeBaseline(fakeEnv({ RELEASE_E2E_RETAINED_MANIFEST: "{}" })),
-    null,
-  );
   // Whitespace-only counts as absent.
   assert.equal(
-    resolveRetainedRuntimeBaseline(
-      fakeEnv({ RELEASE_E2E_RETAINED_TEMPLATE_ID: "   ", RELEASE_E2E_RETAINED_MANIFEST: "{}" }),
-    ),
+    resolveRetainedRuntimeBaseline(fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "   " })),
     null,
   );
 });
 
-test("resolver derives the reported version from the manifest, override wins", () => {
-  const derived = resolveRetainedRuntimeBaseline(
-    fakeEnv({
-      RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-      RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
-    }),
+test("resolver resolves the COMMITTED bootstrap receipt (the real repo data path)", () => {
+  // No injected index: this exercises the exact committed
+  // tests/release/retained-releases/ data the runner will use, proving the
+  // real v0.3.38 receipt validates end to end from a stock checkout.
+  const baseline = resolveRetainedRuntimeBaseline(
+    fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" }),
   );
-  assert.ok(derived);
-  assert.equal(derived?.templateId, "tmpl_retained_n1");
-  assert.equal(derived?.anyharnessReportedVersion, "0.3.11");
-
+  assert.ok(baseline);
+  assert.equal(baseline?.receipt.release.qualification_state, "bootstrap_unqualified");
+  assert.equal(baseline?.templateId, baseline?.receipt.managed_runtime.immutable_template_id);
+  // Override wins over the receipt's version (issue #1089 unstamped-binary case).
   const overridden = resolveRetainedRuntimeBaseline(
-    fakeEnv({
-      RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-      RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
-    }),
-    // The override is now an explicit argument, not an env read: it is optional
-    // (not a requiredEnv gate), so the scenario reads it via the optional-var
-    // idiom and hands it here (T4R-CONTROL-001).
+    fakeEnv({ RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38" }),
     "0.1.0",
   );
-  // The unstamped-binary case (issue #1089): reported truth differs from tag.
   assert.equal(overridden?.anyharnessReportedVersion, "0.1.0");
-
-  // A blank/whitespace override falls back to the manifest-derived version.
-  const blankOverride = resolveRetainedRuntimeBaseline(
-    fakeEnv({
-      RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-      RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
-    }),
-    "   ",
-  );
-  assert.equal(blankOverride?.anyharnessReportedVersion, "0.3.11");
-});
-
-test("resolver tolerates a flat anyharnessVersion field and an unparseable manifest", () => {
-  const flat = resolveRetainedRuntimeBaseline(
-    fakeEnv({
-      RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-      RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharnessVersion: "0.3.10" }),
-    }),
-  );
-  assert.equal(flat?.anyharnessReportedVersion, "0.3.10");
-
-  const garbage = resolveRetainedRuntimeBaseline(
-    fakeEnv({
-      RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-      RELEASE_E2E_RETAINED_MANIFEST: "not json {",
-    }),
-  );
-  // Non-null (both inputs present) but empty reported version, which the
-  // scenario asserts against so a malformed baseline blocks rather than guesses.
-  assert.ok(garbage);
-  assert.equal(garbage?.anyharnessReportedVersion, "");
 });
 
 // ---------------------------------------------------------------------------
@@ -291,17 +236,15 @@ test("REGRESSION T4R-CONTROL-001: absent retained inputs are surfaced as a missi
   });
   assert.equal(result.status, "blocked");
   assert.equal(result.reason?.code, "missing_requirement");
-  assert.match(result.reason!.message, /RELEASE_E2E_RETAINED_TEMPLATE_ID/);
-  assert.match(result.reason!.message, /RELEASE_E2E_RETAINED_MANIFEST/);
+  assert.match(result.reason!.message, /RELEASE_E2E_RETAINED_RELEASE_ID/);
 });
 
-test("REGRESSION T4R-CONTROL-001: retained inputs present but flag unset blocks as a missing requirement", async () => {
+test("REGRESSION T4R-CONTROL-001: retained receipt selected but flag unset blocks as a missing requirement", async () => {
   // The supervisor flag is now a declared requiredEnv gate too, so an absent flag
   // blocks at preflight rather than through a divergent process.env read.
   const result = await runViaRunner({
     RELEASE_E2E_SERVER_URL: "https://qualification.example/api",
-    RELEASE_E2E_RETAINED_TEMPLATE_ID: "tmpl_retained_n1",
-    RELEASE_E2E_RETAINED_MANIFEST: JSON.stringify({ anyharness: { version: "0.3.11" } }),
+    RELEASE_E2E_RETAINED_RELEASE_ID: "v0.3.38",
   });
   assert.equal(result.status, "blocked");
   assert.equal(result.reason?.code, "missing_requirement");

--- a/tests/release/src/scenarios/upgrade/t4-runtime-1.ts
+++ b/tests/release/src/scenarios/upgrade/t4-runtime-1.ts
@@ -128,9 +128,22 @@ async function runReal(ctx: ScenarioRunContext): Promise<void> {
   // NOT ctx.env: it is intentionally absent from requiredEnv, so ctx.env would
   // never surface it. It is handed to the resolver explicitly.
   const reportedVersionOverride = process.env[RETAINED_ANYHARNESS_REPORTED_VERSION_ENV];
+  // The runner's run identity carries the authoritative candidate N source
+  // SHA. The resolver enforces retained N-1 != candidate N and fails closed
+  // when the SHA cannot be established — a real T4 run must know what it
+  // updates TO (RR-CONTROL-003).
+  const candidateSourceSha = ctx.runIdentity?.source_sha?.trim() ?? "";
+  if (candidateSourceSha.length === 0 && (ctx.env.get(RETAINED_RELEASE_ID_ENV)?.trim() ?? "").length > 0) {
+    throw new ScenarioBlockedError(
+      "T4-RUNTIME-1: a retained release was selected but this run has no resolved candidate source SHA " +
+        "(run identity is absent), so the retained N-1 != candidate N invariant cannot be enforced. " +
+        "Run through the qualification runner so the run identity carries the candidate SHA.",
+    );
+  }
   const retained: RetainedRuntimeBaseline | null = resolveRetainedRuntimeBaseline(
     ctx.env,
     reportedVersionOverride,
+    { currentCandidateSourceSha: candidateSourceSha },
   );
   if (!retained) {
     throw new ScenarioBlockedError(

--- a/tests/release/src/scenarios/upgrade/t4-runtime-1.ts
+++ b/tests/release/src/scenarios/upgrade/t4-runtime-1.ts
@@ -4,8 +4,7 @@ import type { ScenarioDefinition, ScenarioRunContext } from "../types.js";
 import { ScenarioBlockedError } from "../types.js";
 import {
   RETAINED_ANYHARNESS_REPORTED_VERSION_ENV,
-  RETAINED_MANIFEST_ENV,
-  RETAINED_TEMPLATE_ID_ENV,
+  RETAINED_RELEASE_ID_ENV,
   resolveRetainedRuntimeBaseline,
   type RetainedRuntimeBaseline,
 } from "../../fixtures/retained-runtime-baseline.js";
@@ -28,24 +27,22 @@ import {
  * supervisor-owned update flow landed in #1223/#1241.
  *
  * WHY THIS SCENARIO CURRENTLY BLOCKS RATHER THAN RUNS (founder ruling
- * 2026-07-16, frozen spec "Prove Heartbeat-Driven Managed Runtime Update"):
- * a truthful N-1→N proof requires a REAL retained-production N-1 template and
- * manifest — the last artifacts actually qualified through this platform. No
- * release has been qualified through the platform yet, and no
- * retained-template resolution mechanism exists in the release harness
- * (release-worlds-and-fixtures.md defers it as "later work"). Rather than
- * fabricate an N-1 (a same-source second template labelled "N-1" would prove
- * nothing about a real cross-version update), this scenario is authored
- * complete and reports `blocked` until the retained baseline inputs
- * (RELEASE_E2E_RETAINED_TEMPLATE_ID + RELEASE_E2E_RETAINED_MANIFEST) are
- * supplied. When they are, `run()` continues into the real live proof. This
+ * 2026-07-16, frozen spec "Retain Exact Production Artifacts for Tier 4"):
+ * a truthful N-1→N proof requires a REAL retained-production N-1 baseline.
+ * The retained-release receipt mechanism now exists
+ * (tests/release/retained-releases/ + retained-release-set.ts): supplying
+ * RELEASE_E2E_RETAINED_RELEASE_ID selects a committed receipt, which is
+ * schema-, digest-, and policy-validated before `run()` continues into the
+ * real live proof. Rather than fabricate an N-1 (a same-source second
+ * template labelled "N-1" would prove nothing about a real cross-version
+ * update), this scenario reports `blocked` until a receipt is selected. This
  * keeps the gap visible (a blocked cell is reported, never silently passed)
  * without ever claiming a green it did not earn.
  *
  * Standing blockers this scenario reports honestly rather than faking:
  *   - --lane local has no managed-cloud world and no E2B sandbox -> blocked.
- *   - retained-production N-1 template/manifest inputs absent -> blocked
- *     (the founder-ruled default until a real N-1 exists).
+ *   - no retained release id selected -> blocked
+ *     (the founder-ruled default until a retained baseline is chosen).
  *   - the candidate API is not running with supervisor_owned_runtime -> blocked
  *     (a heartbeat would return the legacy direct-Worker topology, which
  *     contradicts the contract's "Worker writes the atomic mailbox request").
@@ -76,10 +73,15 @@ export const t4Runtime1: ScenarioDefinition = {
   // reported-version override is deliberately NOT here: it is optional (the
   // manifest supplies a default), and a required var would wrongly block when a
   // stamped binary needs no override.
+  // The receipt id is THE required baseline input: it names a committed,
+  // fully validated retained-release receipt. The legacy template/manifest
+  // pair is a deprecated diagnostic override and is deliberately NOT here —
+  // requiredEnv vars block the cell when absent, and the pair is an
+  // alternative, not a requirement; it is read through the optional-var idiom
+  // below (same as the reported-version override).
   requiredEnv: [
     "RELEASE_E2E_SERVER_URL",
-    RETAINED_TEMPLATE_ID_ENV,
-    RETAINED_MANIFEST_ENV,
+    RETAINED_RELEASE_ID_ENV,
     SUPERVISOR_OWNED_RUNTIME_ENV,
   ],
   plan: () => [
@@ -132,13 +134,12 @@ async function runReal(ctx: ScenarioRunContext): Promise<void> {
   );
   if (!retained) {
     throw new ScenarioBlockedError(
-      "T4-RUNTIME-1: no retained-production N-1 template/manifest available. A truthful N-1 -> N update " +
-        "proof requires the immutable E2B template and manifest of the last release actually qualified " +
-        "through this platform; none has been qualified yet, and the harness has no retained-template " +
-        "resolution mechanism (release-worlds-and-fixtures.md defers it as later work). Supply " +
-        "RELEASE_E2E_RETAINED_TEMPLATE_ID + RELEASE_E2E_RETAINED_MANIFEST to run the live proof. Refusing " +
-        "to fabricate an N-1 (a same-source second template proves nothing about a real cross-version " +
-        "update).",
+      "T4-RUNTIME-1: no retained-production N-1 baseline selected. A truthful N-1 -> N update proof " +
+        "requires the immutable retained artifacts of a real production release. Supply " +
+        `${RETAINED_RELEASE_ID_ENV} naming a committed retained-release receipt ` +
+        "(tests/release/retained-releases/index.json — the founder-ruled bootstrap_unqualified v0.3.38 " +
+        "baseline is the current entry). Refusing to fabricate an N-1 (a same-source second template " +
+        "proves nothing about a real cross-version update).",
     );
   }
 


### PR DESCRIPTION
## Summary

Implements the frozen "Retain Exact Production Artifacts for Tier 4" slice: a committed, immutable, machine-readable **retained-release receipt** giving Tier 4 update qualification the exact production N-1 artifacts for packaged Desktop, managed runtime/E2B, and self-host — consumable identically locally and in GitHub Actions, failing closed before any world side effect. Includes the sealed **v0.3.38 `bootstrap_unqualified`** receipt (founder ruling 2026-07-16). This PR does not run any N-1→N update and does not touch managed-runtime/Desktop/self-host update collectors.

- Base: `3e6e4fa901274e8126a83b35772b29867c23944e` (origin/main at start)
- Frozen spec: Vault "Retain Exact Production Artifacts for Tier 4" (rebaselined to this exact base, status frozen)

## What's here

| Piece | File |
|---|---|
| Receipt schema + validation + policy + live drift checks + evidence + index | `tests/release/src/artifacts/retained-release-set.ts` |
| Byte materializer (hash verified on EVERY use, cache never trusted) | `tests/release/src/artifacts/materialize-retained-release.ts` |
| Operator CLI: `seal` (verify-then-persist, append-only) / `validate` | `tests/release/src/cli/retained-release.ts` + `make qualification-retained-release` |
| Committed v0.3.38 bootstrap receipt + index + N-1/bootstrap/retention docs | `tests/release/retained-releases/` |
| Receipt-backed baseline resolution (replaces env-only assembly) | `tests/release/src/fixtures/retained-runtime-baseline.ts` |
| T4-RUNTIME-1 gates on `RELEASE_E2E_RETAINED_RELEASE_ID` | `tests/release/src/scenarios/upgrade/t4-runtime-1.ts` |
| Operating-truth updates | `specs/developing/testing/tier-4-scenario-contract.md`, `release-worlds-and-fixtures.md` |

## Key decisions (per spec discretion, disclosed)

1. **Own receipt, not release-manifest extension.** The canonical release-manifest schema has no publisher — nothing computes `artifactSetDigest` or writes `release-manifest.json` (`specs/developing/deploying/releases.md` states this). Ownership doesn't fit; the receipt references the release by tag + source SHA.
2. **Repo-committed receipts** (`tests/release/retained-releases/`, append-only index, immutable files, index-recorded byte hashes). Durable, immutable at any SHA, identical local/Actions consumption. Artifact bytes stay in their durable stores and are hash-verified per use.
3. **Legacy env pair removed.** `RELEASE_E2E_RETAINED_TEMPLATE_ID`/`RELEASE_E2E_RETAINED_MANIFEST` env-only assembly is replaced (no duplicate old/new path); the reported-version override (`RELEASE_E2E_RETAINED_ANYHARNESS_REPORTED_VERSION`, issue #1089) is retained.

## v0.3.38 artifact audit (all verified live, read-only)

- Tags `proliferate-v0.3.38` / `desktop-v0.3.38` / `runtime-v0.3.38` → source SHA `e61afc274593085e51870b24269f718a543b88b4`.
- **Desktop**: CDN `downloads.proliferate.com/desktop/stable/Proliferate_0.3.38_{aarch64,x64}.app.tar.gz` + `.sig` downloaded and hashed; immutable versioned snapshot `desktop/stable/0.3.38/latest.json` exists (publish refuses overwrite). Updater pubkey recorded from `tauri.conf.json`. Note: the `desktop-v0.3.38` GitHub release is a *draft* — the CDN is the durable source.
- **E2B**: production alias of `pablo-5391/proliferate-runtime-cloud` resolves to source tag `sha-e61afc274593` = build `661a9621-78db-4c55-84d1-281c21fb72dc` on template `y7dakz4fs16tbz8vb9zo` (verified via read-only `Template.getTags`; `--live` re-verifies at seal and validate time).
- **Runtime components**: versions 0.3.38 from the release-stamped tree; catalog/registry digests computed from `catalogs/agents/{catalog,registry}.json` at the source SHA.
- **Self-host**: **no `server-v0.3.38` exists** — v0.3.38 was a hotfix that didn't ship the server surface. Production self-host is truthfully `server-v0.3.35`: bundle `proliferate-deploy.tar.gz` (sha256 `e8fc82e9…`, matches the release's own SHA256SUMS) + GHCR `proliferate-server@sha256:284a51aa…`. Recorded at its real version rather than inventing a v0.3.38 self-host artifact.

### Unavailable historical artifacts (disclosed, not invented)

- **E2B template input hash**: E2B exposes none and no code recorded one at release time → `input_hash: null`, allowed *only* on the bootstrap receipt; `qualified` receipts reject null.
- **Windows/Linux desktop packages**: production publishes darwin-aarch64 + darwin-x86_64 only; the schema's platform set matches what production actually ships.

## Bootstrap policy

- v0.3.38 receipt carries `qualification_state: bootstrap_unqualified`, no qualification evidence (retrofitting evidence is a validation error), and evidence projections display the state.
- Once any `qualified` receipt is in the index, selecting a bootstrap receipt fails closed (tested).

## Tests (all in `tests/release`, 1098/1098 green; typecheck clean; `check_docs.py` green)

Complete valid receipt; each target block missing independently; unknown schema version; unknown fields; mutable-alias/expiring/local/no-identity locator rejections; mutable-tag-only OCI rejection; package hash drift; OCI digest drift; E2B template/build resolution + input-hash drift; component version/catalog drift; artifact-set digest drift; bootstrap transition (accept before, fail-closed after a qualified receipt); cache corruption (repair via verified re-download; fail closed offline); no side effects after failed validation (validation precedes materialization; runner preflight blocks the cell); local/Actions equivalence (same committed receipt, resolver exercised over the real committed repo data); evidence redaction/bounded identity (no locators, no receipt bodies).

## Live proof

- `seal --live`: downloaded + hash-verified all 4 Desktop artifacts and the self-host bundle from durable stores, live-verified E2B source-tag→build identity, then wrote receipt + index. Receipt sha256 `1c4672ae2d18b024e7dbe890a5991ac7a6563768eae1009bb8974bbf48eef0d9`, artifact-set digest `b8aad5853c70f127664ed9a4828e3d3ae0dc2d207579b5574add13e808347a88`.
- `validate --live` end-to-end run in flight at PR-open time (fresh ~1.2GB CDN downloads); result posted as a follow-up comment.

## Blockers / follow-ups

- Actions entrypoint intentionally deferred to the "Make qualification Actions independent and strict" slice (owns workflow YAML); local/Actions equivalence is proven at the loader layer (same committed receipt, same code).
- Release-time receipt production (sealing at promotion) is the natural follow-up once the release pipeline grows a manifest publisher; this PR's `seal` is the verified-reconstruction path the spec allows for bootstrap/historical releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
