### PR TITLE
fix(product): classify local Git prerequisite states

### DIFF
--- a/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli.rs
+++ b/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli.rs
@@ -309,7 +309,9 @@ fn parse_review_decision(decision: Option<&str>) -> PullRequestReviewDecision {
 }
 
 fn classify_gh_failure(stderr: String) -> GhError {
-    if stderr.contains("auth") || stderr.contains("login") || stderr.contains("logged") {
+    if stderr.contains("no git remotes found") {
+        GhError::UnsupportedRemote("repository has no git remotes configured".to_string())
+    } else if stderr.contains("auth") || stderr.contains("login") || stderr.contains("logged") {
         GhError::AuthRequired(stderr)
     } else {
         GhError::CommandFailed(stderr)
@@ -338,10 +340,7 @@ pub fn get_current_pr(cwd: &Path) -> Result<Option<PullRequestSummary>, GhError>
         {
             return Ok(None);
         }
-        if stderr.contains("auth") || stderr.contains("login") {
-            return Err(GhError::AuthRequired(stderr));
-        }
-        return Err(GhError::CommandFailed(stderr));
+        return Err(classify_gh_failure(stderr));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli.rs
+++ b/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli.rs
@@ -318,6 +318,16 @@ fn classify_gh_failure(stderr: String) -> GhError {
     }
 }
 
+fn validate_create_pr_output(success: bool, stderr: &[u8]) -> Result<(), GhError> {
+    if success {
+        Ok(())
+    } else {
+        Err(classify_gh_failure(
+            String::from_utf8_lossy(stderr).into_owned(),
+        ))
+    }
+}
+
 pub fn get_current_pr(cwd: &Path) -> Result<Option<PullRequestSummary>, GhError> {
     check_gh_installed()?;
 
@@ -410,13 +420,7 @@ pub fn create_pr(
         .output()
         .map_err(|_| GhError::NotInstalled)?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        if stderr.contains("auth") || stderr.contains("login") {
-            return Err(GhError::AuthRequired(stderr));
-        }
-        return Err(GhError::CommandFailed(stderr));
-    }
+    validate_create_pr_output(output.status.success(), &output.stderr)?;
 
     match get_current_pr(cwd)? {
         Some(pr) => Ok(pr),

--- a/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli_tests.rs
@@ -268,3 +268,27 @@ fn classifies_gh_failures() {
         GhError::CommandFailed(_)
     ));
 }
+
+#[test]
+fn maps_create_pr_command_failures_through_shared_classifier() {
+    assert!(validate_create_pr_output(true, b"ignored stderr").is_ok());
+
+    let missing_remote = validate_create_pr_output(false, b"no git remotes found")
+        .expect_err("missing remote should fail");
+    assert!(matches!(
+        missing_remote,
+        GhError::UnsupportedRemote(message)
+            if message == "repository has no git remotes configured"
+    ));
+
+    let logged_out = validate_create_pr_output(false, b"not logged into any GitHub hosts")
+        .expect_err("logged-out CLI should fail");
+    assert!(matches!(logged_out, GhError::AuthRequired(_)));
+
+    let generic = validate_create_pr_output(false, b"GraphQL: rate limited")
+        .expect_err("generic CLI failure should fail");
+    assert!(matches!(
+        generic,
+        GhError::CommandFailed(message) if message == "GraphQL: rate limited"
+    ));
+}

--- a/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli_tests.rs
@@ -249,6 +249,12 @@ fn reduces_pr_view_check_rollup_contexts() {
 
 #[test]
 fn classifies_gh_failures() {
+    let missing_remote = classify_gh_failure("no git remotes found".into());
+    assert!(matches!(
+        missing_remote,
+        GhError::UnsupportedRemote(message)
+            if message == "repository has no git remotes configured"
+    ));
     assert!(matches!(
         classify_gh_failure("To get started with GitHub CLI, please run: gh auth login".into()),
         GhError::AuthRequired(_)

--- a/apps/packages/product-client/src/lib/domain/telemetry/failures.test.ts
+++ b/apps/packages/product-client/src/lib/domain/telemetry/failures.test.ts
@@ -3,6 +3,7 @@ import { ProliferateClientError } from "@proliferate/cloud-sdk";
 import { describe, expect, it } from "vitest";
 import {
   classifyTelemetryFailure,
+  isExpectedMutationTelemetryError,
   isExpectedQueryTelemetryError,
 } from "#product/lib/domain/telemetry/failures";
 
@@ -153,5 +154,41 @@ describe("query telemetry failure classification", () => {
     });
 
     expect(isExpectedQueryTelemetryError(error)).toBe(false);
+  });
+});
+
+describe("mutation telemetry failure classification", () => {
+  it.each([
+    "REPO_ROOT_NOT_GIT_REPO",
+    "REPO_ROOT_WORKTREE_UNSUPPORTED",
+    "REPO_WORKSPACE_NOT_GIT_REPO",
+    "REPO_WORKSPACE_WORKTREE_UNSUPPORTED",
+  ])("treats typed repository validation %s as expected", (code) => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Repository selection rejected",
+      status: 400,
+      code,
+    });
+
+    expect(isExpectedMutationTelemetryError(error)).toBe(true);
+  });
+
+  it.each([
+    new ProliferateClientError("Bad Request", 400),
+    new AnyHarnessError({
+      type: "about:blank",
+      title: "Repository lookup failed",
+      status: 400,
+      code: "REPO_ROOT_RESOLVE_FAILED",
+    }),
+    new AnyHarnessError({
+      type: "about:blank",
+      title: "Repository validation crashed",
+      status: 503,
+      code: "REPO_ROOT_NOT_GIT_REPO",
+    }),
+  ])("keeps non-validation mutation failure %s reportable", (error) => {
+    expect(isExpectedMutationTelemetryError(error)).toBe(false);
   });
 });

--- a/apps/packages/product-client/src/lib/domain/telemetry/failures.ts
+++ b/apps/packages/product-client/src/lib/domain/telemetry/failures.ts
@@ -12,6 +12,13 @@ const EXPECTED_ANYHARNESS_HOSTING_AVAILABILITY_CODES = new Set([
   "HOSTING_REMOTE_UNSUPPORTED",
 ]);
 
+const EXPECTED_ANYHARNESS_REPOSITORY_VALIDATION_CODES = new Set([
+  "REPO_ROOT_NOT_GIT_REPO",
+  "REPO_ROOT_WORKTREE_UNSUPPORTED",
+  "REPO_WORKSPACE_NOT_GIT_REPO",
+  "REPO_WORKSPACE_WORKTREE_UNSUPPORTED",
+]);
+
 const EXPECTED_GITHUB_APP_STATE_CODES = new Set([
   "github_app_authorization_required",
   "github_app_authorization_expired",
@@ -142,4 +149,20 @@ export function isExpectedQueryTelemetryError(error: unknown): boolean {
       EXPECTED_ANYHARNESS_HOSTING_AVAILABILITY_CODES.has(code)
       || EXPECTED_GITHUB_APP_STATE_CODES.has(code)
     );
+}
+
+/**
+ * Returns true only for typed repository-selection validation states that the
+ * owning mutation workflow already renders to the user. Other mutation
+ * failures remain reportable, including generic 4xx responses.
+ */
+export function isExpectedMutationTelemetryError(error: unknown): boolean {
+  const status = errorStatus(error);
+  if (status !== null && status >= 500) {
+    return false;
+  }
+
+  const code = errorCode(error);
+  return code !== null
+    && EXPECTED_ANYHARNESS_REPOSITORY_VALIDATION_CODES.has(code);
 }

--- a/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createAppQueryClient,
   hashAppQueryKey,
+  shouldCaptureAppMutationError,
   shouldCaptureAppQueryError,
 } from "#product/lib/infra/query/query-client";
 
@@ -177,5 +178,33 @@ describe("createAppQueryClient query telemetry", () => {
         mutation_key: hashAppQueryKey(mutationKey),
       },
     });
+  });
+
+  it.each([
+    "REPO_ROOT_NOT_GIT_REPO",
+    "REPO_ROOT_WORKTREE_UNSUPPORTED",
+    "REPO_WORKSPACE_NOT_GIT_REPO",
+    "REPO_WORKSPACE_WORKTREE_UNSUPPORTED",
+  ])("does not capture expected repository mutation validation %s", async (code) => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Repository selection rejected",
+      status: 400,
+      code,
+    });
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey: ["resolve-repository"],
+      mutationFn: async () => {
+        throw error;
+      },
+      retry: false,
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toBe(error);
+
+    expect(shouldCaptureAppMutationError(error)).toBe(false);
+    expect(captureException).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/lib/infra/query/query-client.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.ts
@@ -4,7 +4,10 @@ import {
   QueryCache,
   QueryClient,
 } from "@tanstack/react-query";
-import { isExpectedQueryTelemetryError } from "#product/lib/domain/telemetry/failures";
+import {
+  isExpectedMutationTelemetryError,
+  isExpectedQueryTelemetryError,
+} from "#product/lib/domain/telemetry/failures";
 
 /**
  * The narrow exception-capture dependency the query cache reports through. The
@@ -98,6 +101,10 @@ export function shouldCaptureAppQueryError(error: unknown): boolean {
   return !isCancelledError(error) && !isExpectedQueryTelemetryError(error);
 }
 
+export function shouldCaptureAppMutationError(error: unknown): boolean {
+  return !isExpectedMutationTelemetryError(error);
+}
+
 export function createAppQueryClient({
   captureException,
 }: AppQueryClientDeps): QueryClient {
@@ -124,7 +131,10 @@ export function createAppQueryClient({
     }),
     mutationCache: new MutationCache({
       onError: (error, _variables, _context, mutation) => {
-        if (mutation.meta?.telemetryHandled) {
+        if (
+          mutation.meta?.telemetryHandled
+          || !shouldCaptureAppMutationError(error)
+        ) {
           return;
         }
 

--- a/specs/codebase/structures/frontend/guides/telemetry.md
+++ b/specs/codebase/structures/frontend/guides/telemetry.md
@@ -72,7 +72,9 @@ session replay, and telemetry-related provider and hook ownership.
   gates, and explicitly coded GitHub App or AnyHarness availability states in
   React Query without sending them as exceptions. Generic 4xx responses remain
   reportable, as do request, network, and unknown failures. The global mutation
-  handler does not apply this query disposition rule.
+  handler does not apply this query disposition rule; it separately leaves only
+  explicitly coded repository-selection validation states to their owning
+  mutation workflow. Other mutation failures remain reportable.
 - Sentry tags must stay low-cardinality. Prefer stable keys such as `domain`,
   `action`, `provider`, `workspace_kind`, and `route`.
 - Put high-cardinality or diagnostic values in scrubbed extras, not tags.


### PR DESCRIPTION
## Summary

- Treat only the four typed repository-selection validation codes as caller-owned mutation states, while retaining telemetry for generic 4xx, 5xx, network, and unknown failures.
- Route both current-PR lookup and PR creation through shared GitHub CLI failure classification, mapping the exact `no git remotes found` condition to the existing unsupported-remote availability state.
- Document the mutation telemetry boundary and add focused regression coverage.

## Release note

Section: Fix
Title: Clearer local Git prerequisite handling
Description: Local repository setup and pull request checks now handle expected Git prerequisites without reporting unexpected failures.
Group: local-git-prerequisites

## Production evidence

- Tracker #1398 occurred on Desktop 0.3.38 after PR #1268 had shipped. The add-repository workflow rendered the expected validation state, but the global mutation cache also reported it.
- Tracker #1367 is a heterogeneous Sentry group; two exact occurrences on Desktop 0.3.30 were the no-remotes state. The current-PR adapter converted that expected local prerequisite into a generic PR-view failure, and the PR-create path duplicated the same incomplete classification. PR #1268 only normalized malformed RFC Problem Details and did not change this valid typed error.
- Tracker #1391 contains expected missing-`gh` availability events from Desktop 0.3.30. PR #1270 already filters that typed query state beginning with Desktop 0.3.31, so this PR adds no separate #1391 behavior.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] Fix relationships are linked through the tracker API for #1398 and #1367; #1391 is linked to its existing fixing PR #1270. No raw logs, user identities, repository identities, credentials, or private source data appear in this PR.

## Verification

- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/telemetry/failures.test.ts src/lib/infra/query/query-client.test.ts` (62 passed)
- `CARGO_BUILD_JOBS=2 cargo test -p anyharness-lib adapters::hosting::github_cli::github_cli_tests -- --nocapture` (9 passed)
- `rustfmt --edition 2021 --check anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli.rs anyharness/crates/anyharness-lib/src/adapters/hosting/github_cli_tests.rs`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
