### PR TITLE
fix(server): release gateway transaction before proxying

### DIFF
--- a/server/proliferate/server/cloud/gateway/api.py
+++ b/server/proliferate/server/cloud/gateway/api.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Request, WebSocket, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_product_user
+from proliferate.db import session_ops
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.integrations.sentry import clear_server_sentry_user
@@ -36,6 +37,10 @@ async def proxy_cloud_sandbox_anyharness_http(
     user: User = Depends(current_product_user),
 ) -> object:
     access = await ensure_cloud_sandbox_gateway_access(db, user)
+    # The upstream response may stream indefinitely. End the shared auth/access
+    # transaction before entering that transport lifetime so it cannot pin a
+    # pool checkout or transaction-scoped sandbox locks.
+    await session_ops.commit_session(db)
     return await proxy_http_to_anyharness(
         request,
         upstream_base_url=access.upstream_base_url,
@@ -64,6 +69,9 @@ async def proxy_cloud_sandbox_anyharness_websocket(
         except GatewayWebSocketAuthError:
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return
+        # WebSocket dependencies remain alive until the socket closes. Release
+        # the completed auth/access transaction before starting the proxy pump.
+        await session_ops.commit_session(db)
         await proxy_websocket_to_anyharness(
             websocket,
             upstream_base_url=access.upstream_base_url,

--- a/server/tests/unit/test_cloud_sandbox_gateway_transaction_lifetime.py
+++ b/server/tests/unit/test_cloud_sandbox_gateway_transaction_lifetime.py
@@ -1,0 +1,112 @@
+"""Transaction lifetime guarantees for long-lived cloud sandbox proxies."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from fastapi import Request, WebSocket
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from proliferate.db.models.auth import User
+from proliferate.server.cloud.gateway import api as gateway_api
+
+
+@pytest.mark.asyncio
+async def test_http_gateway_commits_access_before_starting_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    db = cast(AsyncSession, object())
+    user = cast(User, object())
+    request = cast(Request, object())
+
+    async def _access(actual_db: object, actual_user: object) -> object:
+        assert actual_db is db
+        assert actual_user is user
+        events.append("access")
+        return SimpleNamespace(upstream_base_url="http://up", upstream_token="token")
+
+    async def _commit(actual_db: object) -> None:
+        assert actual_db is db
+        events.append("commit")
+
+    async def _proxy(actual_request: object, **_kwargs: object) -> Response:
+        assert actual_request is request
+        assert events == ["access", "commit"]
+        events.append("stream")
+        return Response()
+
+    monkeypatch.setattr(gateway_api, "ensure_cloud_sandbox_gateway_access", _access)
+    monkeypatch.setattr(gateway_api.session_ops, "commit_session", _commit)
+    monkeypatch.setattr(gateway_api, "proxy_http_to_anyharness", _proxy)
+
+    await gateway_api.proxy_cloud_sandbox_anyharness_http(
+        "v1/sessions/session-id/stream",
+        request,
+        db,
+        user,
+    )
+
+    assert events == ["access", "commit", "stream"]
+
+
+@pytest.mark.asyncio
+async def test_websocket_gateway_commits_access_before_starting_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    db = cast(AsyncSession, object())
+    user = cast(User, object())
+    websocket = cast(WebSocket, object())
+
+    async def _authenticate(actual_db: object, token: object) -> object:
+        assert actual_db is db
+        assert token == "product-token"
+        events.append("authenticate")
+        return user
+
+    async def _access(actual_db: object, actual_user: object) -> object:
+        assert actual_db is db
+        assert actual_user is user
+        events.append("access")
+        return SimpleNamespace(upstream_base_url="http://up", upstream_token="token")
+
+    async def _commit(actual_db: object) -> None:
+        assert actual_db is db
+        events.append("commit")
+
+    async def _proxy(actual_websocket: object, **_kwargs: object) -> None:
+        assert actual_websocket is websocket
+        assert events == ["authenticate", "access", "commit"]
+        events.append("proxy")
+
+    monkeypatch.setattr(
+        gateway_api,
+        "authenticate_product_user_for_gateway_websocket",
+        _authenticate,
+    )
+    monkeypatch.setattr(gateway_api, "ensure_cloud_sandbox_gateway_access", _access)
+    monkeypatch.setattr(gateway_api.session_ops, "commit_session", _commit)
+    monkeypatch.setattr(gateway_api, "proxy_websocket_to_anyharness", _proxy)
+    monkeypatch.setattr(
+        gateway_api,
+        "product_token_from_websocket",
+        lambda _websocket: "product-token",
+    )
+    monkeypatch.setattr(
+        gateway_api,
+        "accepted_gateway_websocket_subprotocol",
+        lambda _websocket: None,
+    )
+    monkeypatch.setattr(gateway_api, "clear_server_sentry_user", lambda: None)
+
+    await gateway_api.proxy_cloud_sandbox_anyharness_websocket(
+        websocket,
+        "v1/terminals/terminal-id/ws",
+        db,
+    )
+
+    assert events == ["authenticate", "access", "commit", "proxy"]

--- a/server/tests/unit/test_cloud_sandbox_gateway_ws_sentry.py
+++ b/server/tests/unit/test_cloud_sandbox_gateway_ws_sentry.py
@@ -49,6 +49,14 @@ def _fake_websocket() -> WebSocket:
     return cast(WebSocket, websocket)
 
 
+def _fake_session() -> AsyncSession:
+    class _FakeSession:
+        async def commit(self) -> None:
+            return None
+
+    return cast(AsyncSession, _FakeSession())
+
+
 @pytest.mark.asyncio
 async def test_ws_route_clears_sentry_user_after_proxying(
     monkeypatch: pytest.MonkeyPatch, fake_sdk: _FakeSentrySdk
@@ -77,7 +85,7 @@ async def test_ws_route_clears_sentry_user_after_proxying(
     monkeypatch.setattr(gateway_api, "accepted_gateway_websocket_subprotocol", lambda _ws: None)
 
     await gateway_api.proxy_cloud_sandbox_anyharness_websocket(
-        _fake_websocket(), "some/path", cast(AsyncSession, object())
+        _fake_websocket(), "some/path", _fake_session()
     )
 
     assert proxied == [True]
@@ -110,7 +118,7 @@ async def test_ws_route_clears_sentry_user_when_proxy_raises(
 
     with pytest.raises(RuntimeError):
         await gateway_api.proxy_cloud_sandbox_anyharness_websocket(
-            _fake_websocket(), "some/path", cast(AsyncSession, object())
+            _fake_websocket(), "some/path", _fake_session()
         )
 
     assert fake_sdk.user is None
@@ -130,7 +138,7 @@ async def test_ws_route_clears_sentry_user_on_auth_failure(
     monkeypatch.setattr(gateway_api, "product_token_from_websocket", lambda _ws: "token")
 
     await gateway_api.proxy_cloud_sandbox_anyharness_websocket(
-        _fake_websocket(), "some/path", cast(AsyncSession, object())
+        _fake_websocket(), "some/path", _fake_session()
     )
 
     assert fake_sdk.user is None

--- a/specs/codebase/platforms/product/sandbox-provisioning.md
+++ b/specs/codebase/platforms/product/sandbox-provisioning.md
@@ -60,6 +60,10 @@ HTTP/WS /v1/gateway/cloud-sandbox/anyharness/{path...}
 loads and decrypts runtime access from the caller's active `cloud_sandbox`.
 [`gateway/proxy.py`](../../../../server/proliferate/server/cloud/gateway/proxy.py)
 then proxies HTTP or WebSocket traffic to AnyHarness with the sandbox bearer.
+The gateway finishes the shared authentication/access transaction before it
+enters HTTP response streaming or the WebSocket pump. Long-lived proxy
+connections must not retain a database-pool checkout or transaction-scoped
+sandbox locks.
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary

- End the shared gateway authentication/access transaction before starting an HTTP response stream or WebSocket pump, so long-lived transports do not retain a database-pool checkout or transaction-scoped locks.
- Add route-ordering regression coverage for both transports, keep WebSocket Sentry teardown coverage working, and document the gateway lifetime contract.
- Root cause: the request-scoped database dependency previously lived for the full proxy connection, allowing concurrent long-lived gateway traffic to exhaust each API process pool. Bounded background work was a downstream victim/amplifier; this change does not increase pool capacity.

## Release note

Section: Fix
Title: Keep long-running cloud sandbox sessions reliable
Description: Long-running cloud sandbox sessions no longer consume server capacity and cause intermittent errors.
Group: cloud-sandbox-reliability

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `cd server && uv run pytest -q tests/unit/test_cloud_sandbox_gateway_access.py tests/unit/test_cloud_sandbox_gateway_proxy.py tests/unit/test_cloud_sandbox_gateway_service.py tests/unit/test_cloud_sandbox_gateway_transaction_lifetime.py tests/unit/test_cloud_sandbox_gateway_ws_sentry.py` (18 passed)
- `cd server && uv run ruff check proliferate/server/cloud/gateway/api.py tests/unit/test_cloud_sandbox_gateway_transaction_lifetime.py tests/unit/test_cloud_sandbox_gateway_ws_sentry.py`
- `cd server && uv run ruff format --check proliferate/server/cloud/gateway/api.py tests/unit/test_cloud_sandbox_gateway_transaction_lifetime.py tests/unit/test_cloud_sandbox_gateway_ws_sentry.py`
- `python3 scripts/check_server_boundaries.py`
- `python3 scripts/check_docs.py`
