### PR TITLE
fix(web): gate local agents and expected cancellation telemetry

### DIFF
--- a/apps/packages/product-client/src/app/AuthenticatedProductClient.tsx
+++ b/apps/packages/product-client/src/app/AuthenticatedProductClient.tsx
@@ -6,6 +6,7 @@ import { MaterializationHealthPassHost } from "#product/components/workspace/rep
 import { RepoSetupModalHost } from "#product/components/workspace/repo-setup/RepoSetupModalHost"
 import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
 import { AuthenticatedAppHost } from "#product/pages/AuthenticatedAppHost"
+import { CoworkThreadLaunchProvider } from "#product/providers/CoworkThreadLaunchProvider"
 
 /**
  * Internal, lazy-loaded authenticated product root.
@@ -18,13 +19,13 @@ import { AuthenticatedAppHost } from "#product/pages/AuthenticatedAppHost"
  */
 export default function AuthenticatedProductClient(): ReactElement {
   return (
-    <>
+    <CoworkThreadLaunchProvider>
       <AuthenticatedAppHost />
       <RepoSetupModalHost />
       <AddRepoFlowHost />
       <CloudRepoActionDialogHost />
       <WorkspaceAvailabilityActionHost />
       <MaterializationHealthPassHost />
-    </>
+    </CoworkThreadLaunchProvider>
   )
 }

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -116,19 +116,17 @@ vi.mock("#product/components/home/screen/HomeTargetPicker", () => ({
     screenMocks.targetPickerProps = props;
     return (
       <div data-testid="target-picker">
-        {props.coworkAvailable ? (
-          <button type="button" onClick={() => props.onSelectCowork()}>
-            Mock cowork
-          </button>
+        {props.desktopTargetsAvailable ? (
+          <>
+            <button type="button" onClick={() => props.onSelectCowork()}>Mock cowork</button>
+            <button type="button" onClick={() => props.onSelectRuntime("local")}>Mock local</button>
+            <button type="button" onClick={() => props.onSelectRuntime("ssh", "ssh-target-1")}>
+              Mock ssh
+            </button>
+          </>
         ) : null}
         <button type="button" onClick={() => props.onSelectRepository("/repo-b")}>
           Mock repo
-        </button>
-        <button type="button" onClick={() => props.onSelectRuntime("local")}>
-          Mock local
-        </button>
-        <button type="button" onClick={() => props.onSelectRuntime("ssh", "ssh-target-1")}>
-          Mock ssh
         </button>
         <button type="button" onClick={() => props.onSelectBranch("feature/sticky")}>
           Mock branch
@@ -302,7 +300,7 @@ describe("HomeNextScreen model availability notices", () => {
     submitPrompt("start cowork");
 
     expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "cowork" });
-    expect(screenMocks.targetPickerProps).toMatchObject({ coworkAvailable: true });
+    expect(screenMocks.targetPickerProps).toMatchObject({ desktopTargetsAvailable: true });
     expect(screenMocks.launch).toHaveBeenCalledWith(expect.objectContaining({
       text: "start cowork",
       target: { kind: "cowork" },
@@ -469,37 +467,66 @@ describe("HomeNextScreen target selection persistence", () => {
     });
   });
 
-  it("normalizes the default Cowork target to a repository target on Web", () => {
+  it("normalizes the default target to repository Cloud on Web", () => {
     screenMocks.productHost.desktop = null;
 
     render(<HomeNextScreen />);
 
-    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "repository" });
-    expect(screenMocks.targetPickerProps).toMatchObject({ coworkAvailable: false });
+    expect(screenMocks.homeNextStateArgs).toMatchObject({
+      desktopTargetsAvailable: false,
+      destination: "repository",
+      repoLaunchKind: "cloud",
+      selectedSshTargetId: null,
+    });
+    expect(screenMocks.targetPickerProps).toMatchObject({
+      desktopTargetsAvailable: false,
+      repoLaunchKind: "cloud",
+      selectedSshTargetId: null,
+    });
     expect(screen.queryByRole("button", { name: "Mock cowork" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Mock local" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Mock ssh" })).toBeNull();
   });
 
-  it("normalizes and rejects a persisted Cowork target on Web", async () => {
+  it("normalizes and rejects persisted Desktop targets on Web", async () => {
     screenMocks.productHost.desktop = null;
     memory.values.set(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY, {
       destination: "cowork",
       repositorySelection: { kind: "auto" },
-      repoLaunchKind: "worktree",
-      selectedSshTargetId: null,
+      repoLaunchKind: "ssh",
+      selectedSshTargetId: "ssh-target-1",
       baseBranchOverride: null,
     });
     await hydrateHomeNextTargetSelection(memory.context);
 
     render(<HomeNextScreen />);
 
-    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "repository" });
+    expect(screenMocks.homeNextStateArgs).toMatchObject({
+      destination: "repository",
+      repoLaunchKind: "cloud",
+      selectedSshTargetId: null,
+    });
     await act(async () => {
       screenMocks.targetPickerProps.onSelectCowork();
+      screenMocks.targetPickerProps.onSelectRuntime("local");
+      screenMocks.targetPickerProps.onSelectRuntime("worktree");
+      screenMocks.targetPickerProps.onSelectRuntime("ssh", "ssh-target-2");
+      screenMocks.targetPickerProps.onSelectRepository("/repo-b");
       await Promise.resolve();
     });
-    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "repository" });
+    expect(screenMocks.homeNextStateArgs).toMatchObject({
+      destination: "repository",
+      repositorySelection: { kind: "repository", sourceRoot: "/repo-b" },
+      repoLaunchKind: "cloud",
+      selectedSshTargetId: null,
+    });
     expect(memory.readJson(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY))
-      .toMatchObject({ destination: "repository" });
+      .toMatchObject({
+        destination: "repository",
+        repositorySelection: { kind: "repository", sourceRoot: "/repo-b" },
+        repoLaunchKind: "cloud",
+        selectedSshTargetId: null,
+      });
   });
 
   it("persists repository, branch, and runtime choices from the target picker", async () => {

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -60,11 +60,16 @@ const screenMocks = vi.hoisted(() => {
     targetPickerProps: null as any,
     leadingControlsProps: null as any,
     trailingControlsProps: null as any,
+    productHost: { desktop: {} as object | null },
   };
 });
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => screenMocks.navigate,
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => screenMocks.productHost,
 }));
 
 vi.mock("#product/hooks/home/derived/use-home-next-state", () => ({
@@ -111,9 +116,11 @@ vi.mock("#product/components/home/screen/HomeTargetPicker", () => ({
     screenMocks.targetPickerProps = props;
     return (
       <div data-testid="target-picker">
-        <button type="button" onClick={() => props.onSelectCowork()}>
-          Mock cowork
-        </button>
+        {props.coworkAvailable ? (
+          <button type="button" onClick={() => props.onSelectCowork()}>
+            Mock cowork
+          </button>
+        ) : null}
         <button type="button" onClick={() => props.onSelectRepository("/repo-b")}>
           Mock repo
         </button>
@@ -187,6 +194,7 @@ function installLocalStorageMock(options?: { throwOnSet?: boolean }) {
 }
 
 function resetHomeNext() {
+  screenMocks.productHost.desktop = {};
   screenMocks.homeNext.targetDisabledReason = null;
   screenMocks.homeNext.modelAvailabilityState = "launchable";
   screenMocks.homeNext.canLaunchTarget = true;
@@ -293,6 +301,8 @@ describe("HomeNextScreen model availability notices", () => {
   it("hands cowork prompts directly to launch without rendering a Home preview", () => {
     submitPrompt("start cowork");
 
+    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "cowork" });
+    expect(screenMocks.targetPickerProps).toMatchObject({ coworkAvailable: true });
     expect(screenMocks.launch).toHaveBeenCalledWith(expect.objectContaining({
       text: "start cowork",
       target: { kind: "cowork" },
@@ -457,6 +467,39 @@ describe("HomeNextScreen target selection persistence", () => {
       selectedSshTargetId: "ssh-target-1",
       baseBranchOverride: "feature/sticky",
     });
+  });
+
+  it("normalizes the default Cowork target to a repository target on Web", () => {
+    screenMocks.productHost.desktop = null;
+
+    render(<HomeNextScreen />);
+
+    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "repository" });
+    expect(screenMocks.targetPickerProps).toMatchObject({ coworkAvailable: false });
+    expect(screen.queryByRole("button", { name: "Mock cowork" })).toBeNull();
+  });
+
+  it("normalizes and rejects a persisted Cowork target on Web", async () => {
+    screenMocks.productHost.desktop = null;
+    memory.values.set(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY, {
+      destination: "cowork",
+      repositorySelection: { kind: "auto" },
+      repoLaunchKind: "worktree",
+      selectedSshTargetId: null,
+      baseBranchOverride: null,
+    });
+    await hydrateHomeNextTargetSelection(memory.context);
+
+    render(<HomeNextScreen />);
+
+    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "repository" });
+    await act(async () => {
+      screenMocks.targetPickerProps.onSelectCowork();
+      await Promise.resolve();
+    });
+    expect(screenMocks.homeNextStateArgs).toMatchObject({ destination: "repository" });
+    expect(memory.readJson(HOME_NEXT_TARGET_SELECTION_STORAGE_KEY))
+      .toMatchObject({ destination: "repository" });
   });
 
   it("persists repository, branch, and runtime choices from the target picker", async () => {

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -23,7 +23,7 @@ import { resolveHomeTargetLaunchKindForRepository } from "#product/lib/domain/ho
 
 export function HomeNextScreen() {
   const {
-    coworkAvailable,
+    desktopTargetsAvailable,
     destination,
     repositorySelection,
     repoLaunchKind,
@@ -43,6 +43,7 @@ export function HomeNextScreen() {
     dismissModelProbeCard,
   } = useHomeScreen();
   const homeNext = useHomeNextState({
+    desktopTargetsAvailable,
     destination,
     repositorySelection,
     repoLaunchKind,
@@ -88,6 +89,14 @@ export function HomeNextScreen() {
       setLaunchControlOverrides({});
     },
   });
+  const launchKindForRepository = (sourceRoot: string) =>
+    desktopTargetsAvailable
+      ? resolveHomeTargetLaunchKindForRepository({
+        currentLaunchKind: repoLaunchKind,
+        sourceRoot,
+        cloudActionBySourceRoot: homeNext.cloudRepoActionBySourceRoot,
+      })
+      : "cloud";
 
   const promptTarget = destination === "repository"
     ? homeNext.selectedRepository?.name?.trim()
@@ -141,21 +150,16 @@ export function HomeNextScreen() {
                           {promptTarget}
                         </Button>
                       )}
-                      coworkAvailable={coworkAvailable}
+                      coworkAvailable={desktopTargetsAvailable}
                       side="bottom"
                       destination={destination}
                       repositories={homeNext.repositories}
                       selectedRepository={homeNext.selectedRepository}
                       onSelectRepository={(sourceRoot) => {
-                        const launchKind = resolveHomeTargetLaunchKindForRepository({
-                          currentLaunchKind: repoLaunchKind,
-                          sourceRoot,
-                          cloudActionBySourceRoot: homeNext.cloudRepoActionBySourceRoot,
-                        });
                         patchTargetSelection({
                           destination: "repository",
                           repositorySelection: { kind: "repository", sourceRoot },
-                          repoLaunchKind: launchKind,
+                          repoLaunchKind: launchKindForRepository(sourceRoot),
                         });
                       }}
                       onSelectCowork={() => {
@@ -203,7 +207,7 @@ export function HomeNextScreen() {
             )}
             targetPickerSlot={(
               <HomeTargetPicker
-                coworkAvailable={coworkAvailable}
+                desktopTargetsAvailable={desktopTargetsAvailable}
                 destination={destination}
                 repoLaunchKind={repoLaunchKind}
                 repositories={homeNext.repositories}
@@ -219,18 +223,14 @@ export function HomeNextScreen() {
                   patchTargetSelection({ destination: "cowork" });
                 }}
                 onSelectRepository={(sourceRoot) => {
-                  const launchKind = resolveHomeTargetLaunchKindForRepository({
-                    currentLaunchKind: repoLaunchKind,
-                    sourceRoot,
-                    cloudActionBySourceRoot: homeNext.cloudRepoActionBySourceRoot,
-                  });
                   patchTargetSelection({
                     destination: "repository",
                     repositorySelection: { kind: "repository", sourceRoot },
-                    repoLaunchKind: launchKind,
+                    repoLaunchKind: launchKindForRepository(sourceRoot),
                   });
                 }}
                 onSelectRuntime={(launchKind, targetId = null) => {
+                  if (!desktopTargetsAvailable && launchKind !== "cloud") return;
                   patchTargetSelection({
                     repoLaunchKind: launchKind,
                     selectedSshTargetId: launchKind === "ssh" ? targetId : selectedSshTargetId,

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -23,6 +23,7 @@ import { resolveHomeTargetLaunchKindForRepository } from "#product/lib/domain/ho
 
 export function HomeNextScreen() {
   const {
+    coworkAvailable,
     destination,
     repositorySelection,
     repoLaunchKind,
@@ -140,6 +141,7 @@ export function HomeNextScreen() {
                           {promptTarget}
                         </Button>
                       )}
+                      coworkAvailable={coworkAvailable}
                       side="bottom"
                       destination={destination}
                       repositories={homeNext.repositories}
@@ -201,6 +203,7 @@ export function HomeNextScreen() {
             )}
             targetPickerSlot={(
               <HomeTargetPicker
+                coworkAvailable={coworkAvailable}
                 destination={destination}
                 repoLaunchKind={repoLaunchKind}
                 repositories={homeNext.repositories}

--- a/apps/packages/product-client/src/components/home/screen/HomeProjectMenu.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeProjectMenu.tsx
@@ -17,6 +17,7 @@ interface HomeProjectMenuProps {
   trigger: ReactElement<{
     onClick?: (...args: unknown[]) => void;
   }>;
+  coworkAvailable: boolean;
   destination: HomeNextDestination;
   repositories: SettingsRepositoryEntry[];
   selectedRepository: SettingsRepositoryEntry | null;
@@ -31,6 +32,7 @@ interface HomeProjectMenuProps {
  */
 export function HomeProjectMenu({
   trigger,
+  coworkAvailable,
   destination,
   repositories,
   selectedRepository,
@@ -91,16 +93,18 @@ export function HomeProjectMenu({
                 close();
               }}
             />
-            <PopoverMenuItem
-              icon={<X className="size-4" />}
-              label="Don't work in a project"
-              trailing={destination === "cowork" ? <Check className="size-4" /> : null}
-              onClick={() => {
-                onSelectCowork();
-                setSearchValue("");
-                close();
-              }}
-            />
+            {coworkAvailable ? (
+              <PopoverMenuItem
+                icon={<X className="size-4" />}
+                label="Don't work in a project"
+                trailing={destination === "cowork" ? <Check className="size-4" /> : null}
+                onClick={() => {
+                  onSelectCowork();
+                  setSearchValue("");
+                  close();
+                }}
+              />
+            ) : null}
           </div>
         </div>
       )}

--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
@@ -43,6 +43,7 @@ function renderPicker(overrides: Partial<Parameters<typeof HomeTargetPicker>[0]>
 
   render(
     <HomeTargetPicker
+      coworkAvailable={true}
       destination="repository"
       repoLaunchKind="worktree"
       repositories={[keystoneRepository, productRepository]}
@@ -135,6 +136,24 @@ describe("HomeTargetPicker", () => {
 
     expect(screen.getByRole("button", { name: /No project/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /No repository/i })).toBeNull();
+  });
+
+  it("offers the projectless Cowork target on Desktop", () => {
+    const callbacks = renderPicker();
+
+    fireEvent.click(screen.getByRole("button", { name: /Project: Keystone repository/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Don't work in a project" }));
+
+    expect(callbacks.onSelectCowork).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not offer the Desktop-only Cowork target on Web", () => {
+    const callbacks = renderPicker({ coworkAvailable: false });
+
+    fireEvent.click(screen.getByRole("button", { name: /Project: Keystone repository/i }));
+
+    expect(screen.queryByRole("button", { name: "Don't work in a project" })).toBeNull();
+    expect(callbacks.onSelectCowork).not.toHaveBeenCalled();
   });
 
   it("selects a base branch from the branch picker without changing runtime", () => {

--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
@@ -43,7 +43,7 @@ function renderPicker(overrides: Partial<Parameters<typeof HomeTargetPicker>[0]>
 
   render(
     <HomeTargetPicker
-      coworkAvailable={true}
+      desktopTargetsAvailable={true}
       destination="repository"
       repoLaunchKind="worktree"
       repositories={[keystoneRepository, productRepository]}
@@ -111,8 +111,10 @@ describe("HomeTargetPicker", () => {
     expect(callbacks.onSelectRuntime).toHaveBeenCalledWith("local");
   });
 
-  it("routes repository-access gates to cloud setup with precise copy", () => {
+  it("keeps Web cloud setup actionable while hiding Desktop runtime choices", () => {
     const callbacks = renderPicker({
+      desktopTargetsAvailable: false,
+      repoLaunchKind: "worktree",
       cloudActionBySourceRoot: {
         [keystoneRepository.sourceRoot]: {
           kind: "configure",
@@ -121,11 +123,13 @@ describe("HomeTargetPicker", () => {
       },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /New worktree/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Grant repository access/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Runtime: Grant repository access/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Grant repository access" }));
 
     expect(callbacks.onConfigureCloud).toHaveBeenCalledWith(keystoneRepository);
     expect(callbacks.onSelectRuntime).not.toHaveBeenCalledWith("cloud");
+    expect(screen.queryByRole("button", { name: /Work locally/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /New worktree/i })).toBeNull();
   });
 
   it("hides the runtime control for cowork starts", () => {
@@ -148,12 +152,34 @@ describe("HomeTargetPicker", () => {
   });
 
   it("does not offer the Desktop-only Cowork target on Web", () => {
-    const callbacks = renderPicker({ coworkAvailable: false });
+    const callbacks = renderPicker({ desktopTargetsAvailable: false });
 
     fireEvent.click(screen.getByRole("button", { name: /Project: Keystone repository/i }));
 
     expect(screen.queryByRole("button", { name: "Don't work in a project" })).toBeNull();
     expect(callbacks.onSelectCowork).not.toHaveBeenCalled();
+  });
+
+  it("normalizes forged Web runtime props and exposes only Cloud", () => {
+    const callbacks = renderPicker({
+      desktopTargetsAvailable: false,
+      repoLaunchKind: "worktree",
+      sshTargetsLoading: true,
+      sshTargetOptions: [{
+        id: "ssh-target-1",
+        label: "SSH server",
+        disabledReason: null,
+      } as never],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Runtime: Cloud" }));
+
+    expect(screen.getByRole("button", { name: "Cloud" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Work locally/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /New worktree/i })).toBeNull();
+    expect(screen.queryByText("Loading targets")).toBeNull();
+    expect(screen.queryByRole("button", { name: "SSH server" })).toBeNull();
+    expect(callbacks.onSelectRuntime).not.toHaveBeenCalled();
   });
 
   it("selects a base branch from the branch picker without changing runtime", () => {

--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.tsx
@@ -37,6 +37,7 @@ import {
 import { HomeProjectMenu } from "#product/components/home/screen/HomeProjectMenu";
 
 interface HomeTargetPickerProps {
+  coworkAvailable: boolean;
   destination: HomeNextDestination;
   repoLaunchKind: HomeNextRepoLaunchKind;
   repositories: SettingsRepositoryEntry[];
@@ -57,6 +58,7 @@ interface HomeTargetPickerProps {
 }
 
 export function HomeTargetPicker({
+  coworkAvailable,
   destination,
   repoLaunchKind,
   repositories,
@@ -123,6 +125,7 @@ export function HomeTargetPicker({
             aria-label={homeTargetProjectAriaLabel({ destination, selectedRepository })}
           />
         )}
+        coworkAvailable={coworkAvailable}
         destination={destination}
         repositories={repositories}
         selectedRepository={selectedRepository}

--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.tsx
@@ -37,7 +37,7 @@ import {
 import { HomeProjectMenu } from "#product/components/home/screen/HomeProjectMenu";
 
 interface HomeTargetPickerProps {
-  coworkAvailable: boolean;
+  desktopTargetsAvailable: boolean;
   destination: HomeNextDestination;
   repoLaunchKind: HomeNextRepoLaunchKind;
   repositories: SettingsRepositoryEntry[];
@@ -58,7 +58,7 @@ interface HomeTargetPickerProps {
 }
 
 export function HomeTargetPicker({
-  coworkAvailable,
+  desktopTargetsAvailable,
   destination,
   repoLaunchKind,
   repositories,
@@ -86,23 +86,28 @@ export function HomeTargetPicker({
   const selectedRepositoryCloudAction: CloudRepoActionState = selectedRepository
     ? cloudActionBySourceRoot[selectedRepository.sourceRoot] ?? { kind: "hidden", label: null }
     : { kind: "hidden", label: null };
-  const selectedSshTarget =
-    sshTargetOptions.find((target) => target.id === selectedSshTargetId) ?? null;
+  const effectiveRepoLaunchKind = desktopTargetsAvailable ? repoLaunchKind : "cloud";
+  const runtimeLaunchKinds: readonly HomeNextRepoLaunchKind[] = desktopTargetsAvailable
+    ? ["local", "worktree", "cloud"]
+    : ["cloud"];
+  const selectedSshTarget = desktopTargetsAvailable
+    ? sshTargetOptions.find((target) => target.id === selectedSshTargetId) ?? null
+    : null;
   const filteredSshTargetOptions = sshTargetOptions;
   const clearSearch = () => {
     setRuntimeSearchValue("");
   };
-  const runtimeLabel = repoLaunchKind === "ssh"
-    ? selectedSshTarget?.label ?? homeRepoLaunchKindLabel(repoLaunchKind)
-    : repoLaunchKind === "cloud"
+  const runtimeLabel = effectiveRepoLaunchKind === "ssh"
+    ? selectedSshTarget?.label ?? homeRepoLaunchKindLabel(effectiveRepoLaunchKind)
+    : effectiveRepoLaunchKind === "cloud"
     ? homeTargetRuntimeOptionLabel({
-      launchKind: repoLaunchKind,
+      launchKind: effectiveRepoLaunchKind,
       cloudAction: selectedRepositoryCloudAction,
     })
-    : homeRepoLaunchKindLabel(repoLaunchKind);
+    : homeRepoLaunchKindLabel(effectiveRepoLaunchKind);
   const runtimeButton = (
     <HomeTargetRowItem
-      icon={homeTargetLaunchKindIcon(repoLaunchKind, selectedSshTarget)}
+      icon={homeTargetLaunchKindIcon(effectiveRepoLaunchKind, selectedSshTarget)}
       value={destination === "cowork" ? "No repository" : runtimeLabel}
       disabled={!selectedRepository || destination === "cowork"}
       disclosure={!!selectedRepository && destination === "repository"}
@@ -125,7 +130,7 @@ export function HomeTargetPicker({
             aria-label={homeTargetProjectAriaLabel({ destination, selectedRepository })}
           />
         )}
-        coworkAvailable={coworkAvailable}
+        coworkAvailable={desktopTargetsAvailable}
         destination={destination}
         repositories={repositories}
         selectedRepository={selectedRepository}
@@ -145,8 +150,8 @@ export function HomeTargetPicker({
               className="max-h-[min(20rem,calc(100vh-1rem))]"
               bodyClassName="py-0"
             >
-              {(["local", "worktree", "cloud"] as const).map((launchKind) => {
-                const isSelected = repoLaunchKind === launchKind;
+              {runtimeLaunchKinds.map((launchKind) => {
+                const isSelected = effectiveRepoLaunchKind === launchKind;
                 const cloudConfigure =
                   launchKind === "cloud" && selectedRepositoryCloudAction.kind === "configure";
                 const cloudLoading =
@@ -177,14 +182,17 @@ export function HomeTargetPicker({
                   />
                 );
               })}
-              {sshTargetsLoading || filteredSshTargetOptions.length > 0 ? (
+              {desktopTargetsAvailable
+                && (sshTargetsLoading || filteredSshTargetOptions.length > 0) ? (
                 <div className={TARGET_PICKER_DIVIDER_CLASS} />
               ) : null}
-              {sshTargetsLoading ? (
+              {desktopTargetsAvailable && sshTargetsLoading ? (
                 <PickerEmptyRow label="Loading targets" />
-              ) : filteredSshTargetOptions.length > 0 ? (
+              ) : desktopTargetsAvailable && filteredSshTargetOptions.length > 0 ? (
                 filteredSshTargetOptions.map((target) => {
-                  const isSelected = repoLaunchKind === "ssh" && selectedSshTargetId === target.id;
+                  const isSelected =
+                    effectiveRepoLaunchKind === "ssh"
+                    && selectedSshTargetId === target.id;
                   return (
                     <TargetPickerMenuItem
                       key={`ssh:${target.id}`}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -121,8 +121,12 @@ vi.mock("#product/hooks/capabilities/derived/use-app-capabilities", () => ({
   useAppCapabilities: () => ({ managedCloudStatus: "disabled" }),
 }));
 
+const productHostState = vi.hoisted(() => ({
+  desktop: null as object | null,
+}));
+
 vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
-  useProductHost: () => ({ desktop: null }),
+  useProductHost: () => productHostState,
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/use-add-repo", () => ({
@@ -286,6 +290,7 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   releaseNoticeState.notice = null;
+  productHostState.desktop = null;
   workspaceUiState.sidebarOpen = true;
 });
 
@@ -296,6 +301,22 @@ function renderMainSidebar() {
     </MemoryRouter>,
   );
 }
+
+describe("MainSidebar host capabilities", () => {
+  it("omits Desktop-only Cowork threads on Web", () => {
+    renderMainSidebar();
+
+    expect(screen.queryByTestId("cowork-threads")).toBeNull();
+  });
+
+  it("shows Cowork threads when the Desktop bridge is available", () => {
+    productHostState.desktop = {};
+
+    renderMainSidebar();
+
+    expect(screen.getByTestId("cowork-threads")).not.toBeNull();
+  });
+});
 
 describe("MainSidebar support modal", () => {
   it("opens the feedback modal from Support", async () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -404,7 +404,7 @@ export const MainSidebar = memo(function MainSidebar() {
               onAddToThisMac={handleAddToThisMac}
             />
           </DebugProfiler>
-          <CoworkThreadsSection />
+          {isDesktopHost ? <CoworkThreadsSection /> : null}
         </ProductSidebarScrollableContent>
       </ProductSidebarBody>
       <ConfirmationDialog

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.test.tsx
@@ -27,8 +27,9 @@ vi.mock("#product/hooks/sessions/workflows/use-session-config-actions", () => ({
   }),
 }));
 
-vi.mock("#product/hooks/cowork/workflows/use-cowork-thread-workflow", () => ({
-  useCoworkThreadWorkflow: () => ({
+vi.mock("#product/providers/CoworkThreadLaunchProvider", () => ({
+  useCoworkThreadLaunchContext: () => ({
+    desktopTargetsAvailable: true,
     createThreadFromSelection: mocks.createThreadFromSelection,
   }),
 }));

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts
@@ -7,7 +7,7 @@ import {
   isWorkspaceDirectoryMissingError,
 } from "#product/lib/domain/sessions/creation/create-session-error";
 import { useSessionConfigActions } from "#product/hooks/sessions/workflows/use-session-config-actions";
-import { useCoworkThreadWorkflow } from "#product/hooks/cowork/workflows/use-cowork-thread-workflow";
+import { useCoworkThreadLaunchContext } from "#product/providers/CoworkThreadLaunchProvider";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
 import { useChatInputStore } from "#product/stores/chat/chat-input-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
@@ -56,7 +56,8 @@ export function useChatLaunchActions(options?: {
   const selectedWorkspace = workspaces.find((workspace) => workspace.id === selectedWorkspaceId);
   const { createEmptySessionWithResolvedConfig } = useSessionCreationActions();
   const { setActiveSessionConfigOption } = useSessionConfigActions();
-  const { createThreadFromSelection } = useCoworkThreadWorkflow();
+  const { desktopTargetsAvailable, createThreadFromSelection } =
+    useCoworkThreadLaunchContext();
   const {
     activeSessionId,
     currentLaunchIdentity,
@@ -110,6 +111,10 @@ export function useChatLaunchActions(options?: {
     persistLastUsedLaunchSelection(launchSelection);
 
     if (selectedWorkspace?.surface === "cowork") {
+      if (!desktopTargetsAvailable) {
+        showToast("Cowork threads are available in the Desktop app.", "info");
+        return;
+      }
       const latencyFlowId = startLatencyFlow({
         flowKind: "session_create",
         source: "model_selector",
@@ -167,6 +172,7 @@ export function useChatLaunchActions(options?: {
     createEmptySessionWithResolvedConfig,
     selectedWorkspace?.surface,
     selectedWorkspaceId,
+    desktopTargetsAvailable,
     setActiveSessionConfigOption,
     setWorkspaceArrivalEvent,
     showToast,

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx
@@ -58,23 +58,44 @@ const stateMocks = vi.hoisted(() => {
     isLoading: false,
   } as any;
 
-  return { model, repository, mode, computeTargets };
+  return {
+    model,
+    repository,
+    mode,
+    computeTargets,
+    modelArgs: null as any,
+    repositoryArgs: null as any,
+    modeArgs: null as any,
+    computeTargetArgs: null as any,
+  };
 });
 
 vi.mock("#product/hooks/home/derived/use-home-next-model-selection", () => ({
-  useHomeNextModelSelection: () => stateMocks.model,
+  useHomeNextModelSelection: (args: any) => {
+    stateMocks.modelArgs = args;
+    return stateMocks.model;
+  },
 }));
 
 vi.mock("#product/hooks/home/derived/use-home-next-repository-selection", () => ({
-  useHomeNextRepositorySelection: () => stateMocks.repository,
+  useHomeNextRepositorySelection: (args: any) => {
+    stateMocks.repositoryArgs = args;
+    return stateMocks.repository;
+  },
 }));
 
 vi.mock("#product/hooks/home/derived/use-home-next-mode-selection", () => ({
-  useHomeNextModeSelection: () => stateMocks.mode,
+  useHomeNextModeSelection: (args: any) => {
+    stateMocks.modeArgs = args;
+    return stateMocks.mode;
+  },
 }));
 
 vi.mock("#product/hooks/compute/derived/use-compute-target-options", () => ({
-  useComputeTargetOptions: () => stateMocks.computeTargets,
+  useComputeTargetOptions: (args: any) => {
+    stateMocks.computeTargetArgs = args;
+    return stateMocks.computeTargets;
+  },
 }));
 
 function resetMocks() {
@@ -106,16 +127,23 @@ function resetMocks() {
   stateMocks.repository.launchTarget = { kind: "local", sourceRoot: "/repo" };
   stateMocks.computeTargets.sshTargetOptions = [];
   stateMocks.computeTargets.isLoading = false;
+  stateMocks.modelArgs = null;
+  stateMocks.repositoryArgs = null;
+  stateMocks.modeArgs = null;
+  stateMocks.computeTargetArgs = null;
 }
 
 function renderHomeNextState({
+  desktopTargetsAvailable = true,
   destination = "cowork",
   repoLaunchKind = "local",
 }: {
+  desktopTargetsAvailable?: boolean;
   destination?: HomeNextDestination;
   repoLaunchKind?: HomeNextRepoLaunchKind;
 } = {}) {
   return renderHook(() => useHomeNextState({
+    desktopTargetsAvailable,
     destination,
     repositorySelection: { kind: "auto" },
     repoLaunchKind,
@@ -174,5 +202,48 @@ describe("useHomeNextState", () => {
     const noBranch = renderHomeNextState({ destination: "repository", repoLaunchKind: "worktree" });
     expect(noBranch.result.current.targetDisabledReason).toBe("Choose a base branch");
     noBranch.unmount();
+  });
+
+  it("forces the Web target model to repository Cloud and rejects local targets", () => {
+    stateMocks.computeTargets.sshTargetOptions = [{ id: "ssh-target-1" }];
+    stateMocks.computeTargets.isLoading = true;
+    const web = renderHomeNextState({
+      desktopTargetsAvailable: false,
+      destination: "cowork",
+      repoLaunchKind: "worktree",
+    });
+
+    expect(stateMocks.modelArgs).toMatchObject({ repoLaunchKind: "cloud" });
+    expect(stateMocks.repositoryArgs).toMatchObject({
+      destination: "repository",
+      repoLaunchKind: "cloud",
+    });
+    expect(stateMocks.modeArgs).toMatchObject({ destination: "repository" });
+    expect(stateMocks.computeTargetArgs).toEqual({ enabled: false });
+    expect(web.result.current.sshTargetOptions).toEqual([]);
+    expect(web.result.current.sshTargetsLoading).toBe(false);
+    expect(web.result.current.selectedSshTarget).toBeNull();
+    expect(web.result.current.launchTarget).toBeNull();
+    expect(web.result.current.canLaunchTarget).toBe(false);
+    web.unmount();
+  });
+
+  it("preserves a Cloud launch target in the Web target model", () => {
+    stateMocks.repository.launchTarget = {
+      kind: "cloud",
+      gitOwner: "owner",
+      gitRepoName: "repo",
+      baseBranch: "main",
+    };
+
+    const web = renderHomeNextState({
+      desktopTargetsAvailable: false,
+      destination: "repository",
+      repoLaunchKind: "cloud",
+    });
+
+    expect(web.result.current.launchTarget).toMatchObject({ kind: "cloud" });
+    expect(web.result.current.targetDisabledReason).toBeNull();
+    expect(web.result.current.canLaunchTarget).toBe(true);
   });
 });

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.ts
@@ -11,6 +11,7 @@ import { useHomeNextRepositorySelection } from "#product/hooks/home/derived/use-
 import { useComputeTargetOptions } from "#product/hooks/compute/derived/use-compute-target-options";
 
 interface UseHomeNextStateArgs {
+  desktopTargetsAvailable: boolean;
   destination: HomeNextDestination;
   repositorySelection: HomeNextRepositorySelection;
   repoLaunchKind: HomeNextRepoLaunchKind;
@@ -22,6 +23,7 @@ interface UseHomeNextStateArgs {
 
 // Owns read-only Home Next launch state composition. Does not own launch actions.
 export function useHomeNextState({
+  desktopTargetsAvailable,
   destination,
   repositorySelection,
   repoLaunchKind,
@@ -30,34 +32,44 @@ export function useHomeNextState({
   modeOverrideId,
   selectedSshTargetId = null,
 }: UseHomeNextStateArgs) {
-  const model = useHomeNextModelSelection({ modelSelectionOverride, repoLaunchKind });
+  const effectiveDestination = desktopTargetsAvailable ? destination : "repository";
+  const effectiveRepoLaunchKind = desktopTargetsAvailable ? repoLaunchKind : "cloud";
+  const model = useHomeNextModelSelection({
+    modelSelectionOverride,
+    repoLaunchKind: effectiveRepoLaunchKind,
+  });
   const repository = useHomeNextRepositorySelection({
-    destination,
+    destination: effectiveDestination,
     repositorySelection,
-    repoLaunchKind,
+    repoLaunchKind: effectiveRepoLaunchKind,
     baseBranchOverride,
   });
   const mode = useHomeNextModeSelection({
-    destination,
+    destination: effectiveDestination,
     modelSelection: model.effectiveModelSelection,
     modeOverrideId,
   });
   const computeTargets = useComputeTargetOptions({
-    enabled: destination === "repository",
+    enabled: desktopTargetsAvailable && effectiveDestination === "repository",
   });
-  const selectedSshTarget = computeTargets.sshTargetOptions.find((target) =>
+  const sshTargetOptions = desktopTargetsAvailable ? computeTargets.sshTargetOptions : [];
+  const selectedSshTarget = sshTargetOptions.find((target) =>
     target.id === selectedSshTargetId
   ) ?? null;
+  const launchTarget =
+    desktopTargetsAvailable || repository.launchTarget?.kind === "cloud"
+      ? repository.launchTarget
+      : null;
 
   const targetDisabledReason = useMemo(() => {
-    if (destination === "cowork") {
+    if (effectiveDestination === "cowork") {
       return null;
     }
     if (!repository.selectedRepository) {
       return "Choose a repository";
     }
 
-    if (repoLaunchKind === "local") {
+    if (effectiveRepoLaunchKind === "local") {
       return null;
     }
 
@@ -75,7 +87,7 @@ export function useHomeNextState({
       return "Choose a base branch";
     }
 
-    if (repoLaunchKind === "cloud") {
+    if (effectiveRepoLaunchKind === "cloud") {
       if (!repository.cloudActive) {
         return "Sign in to use cloud workspaces";
       }
@@ -93,7 +105,7 @@ export function useHomeNextState({
       }
     }
 
-    if (repoLaunchKind === "ssh") {
+    if (effectiveRepoLaunchKind === "ssh") {
       if (computeTargets.isLoading) {
         return "Loading SSH targets";
       }
@@ -109,12 +121,13 @@ export function useHomeNextState({
       return "SSH target launches are not wired yet";
     }
 
-    return repository.launchTarget ? null : "Choose where to launch";
+    return launchTarget ? null : "Choose where to launch";
   }, [
     computeTargets.isLoading,
     computeTargets.sshTargetOptions.length,
-    destination,
-    repoLaunchKind,
+    effectiveDestination,
+    effectiveRepoLaunchKind,
+    launchTarget,
     repository.branchOptions.length,
     repository.branchQuery.isError,
     repository.branchQuery.isLoading,
@@ -129,8 +142,9 @@ export function useHomeNextState({
 
   return {
     ...repository,
-    sshTargetOptions: computeTargets.sshTargetOptions,
-    sshTargetsLoading: computeTargets.isLoading,
+    launchTarget,
+    sshTargetOptions,
+    sshTargetsLoading: desktopTargetsAvailable && computeTargets.isLoading,
     selectedSshTarget,
     ...model,
     modeOptions: mode.modeOptions,
@@ -139,6 +153,6 @@ export function useHomeNextState({
     targetDisabledReason,
     canLaunchTarget:
       targetDisabledReason === null
-      && repository.launchTarget !== null,
+      && launchTarget !== null,
   };
 }

--- a/apps/packages/product-client/src/hooks/home/ui/use-home-next-target-selection-state.ts
+++ b/apps/packages/product-client/src/hooks/home/ui/use-home-next-target-selection-state.ts
@@ -99,13 +99,26 @@ export function normalizeHomeNextTargetSelectionState(
   };
 }
 
-function normalizeCoworkAvailability(
+function normalizeDesktopTargetAvailability(
   selection: HomeNextTargetSelectionState,
-  coworkAvailable: boolean,
+  desktopTargetsAvailable: boolean,
 ): HomeNextTargetSelectionState {
-  return !coworkAvailable && selection.destination === "cowork"
-    ? { ...selection, destination: "repository" }
-    : selection;
+  if (
+    desktopTargetsAvailable
+    || (
+      selection.destination === "repository"
+      && selection.repoLaunchKind === "cloud"
+      && selection.selectedSshTargetId === null
+    )
+  ) {
+    return selection;
+  }
+  return {
+    ...selection,
+    destination: "repository",
+    repoLaunchKind: "cloud",
+    selectedSshTargetId: null,
+  };
 }
 
 function persistTargetSelection(selection: HomeNextTargetSelectionState): void {
@@ -171,18 +184,21 @@ export function subscribeHomeNextTargetSelectionState(listener: () => void): () 
 }
 
 function useHomeNextTargetSelectionForHost() {
-  const coworkAvailable = useProductHost().desktop !== null;
+  const desktopTargetsAvailable = useProductHost().desktop !== null;
   const storedTargetSelection = useSyncExternalStore(
     subscribeHomeNextTargetSelectionState,
     readHomeNextTargetSelectionState,
     () => DEFAULT_HOME_NEXT_TARGET_SELECTION,
   );
   const targetSelection = useMemo(
-    () => normalizeCoworkAvailability(storedTargetSelection, coworkAvailable),
-    [coworkAvailable, storedTargetSelection],
+    () => normalizeDesktopTargetAvailability(
+      storedTargetSelection,
+      desktopTargetsAvailable,
+    ),
+    [desktopTargetsAvailable, storedTargetSelection],
   );
 
-  return { coworkAvailable, targetSelection };
+  return { desktopTargetsAvailable, targetSelection };
 }
 
 export function useHomeNextTargetSelectionSnapshot(): HomeNextTargetSelectionState {
@@ -190,22 +206,23 @@ export function useHomeNextTargetSelectionSnapshot(): HomeNextTargetSelectionSta
 }
 
 export function useHomeNextTargetSelectionState() {
-  const { coworkAvailable, targetSelection } = useHomeNextTargetSelectionForHost();
+  const { desktopTargetsAvailable, targetSelection } =
+    useHomeNextTargetSelectionForHost();
 
   const patchTargetSelection = useCallback((patch: HomeNextTargetSelectionPatch) => {
-    const next = normalizeCoworkAvailability(
+    const next = normalizeDesktopTargetAvailability(
       normalizeHomeNextTargetSelectionState({
         ...readHomeNextTargetSelectionState(),
         ...patch,
       }),
-      coworkAvailable,
+      desktopTargetsAvailable,
     );
     persistTargetSelection(next);
-  }, [coworkAvailable]);
+  }, [desktopTargetsAvailable]);
 
   return {
     ...targetSelection,
-    coworkAvailable,
+    desktopTargetsAvailable,
     patchTargetSelection,
     setDestination: useCallback(
       (destination: HomeNextDestination) => patchTargetSelection({ destination }),

--- a/apps/packages/product-client/src/hooks/home/ui/use-home-next-target-selection-state.ts
+++ b/apps/packages/product-client/src/hooks/home/ui/use-home-next-target-selection-state.ts
@@ -1,4 +1,5 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import type {
   HomeNextDestination,
   HomeNextRepoLaunchKind,
@@ -98,6 +99,15 @@ export function normalizeHomeNextTargetSelectionState(
   };
 }
 
+function normalizeCoworkAvailability(
+  selection: HomeNextTargetSelectionState,
+  coworkAvailable: boolean,
+): HomeNextTargetSelectionState {
+  return !coworkAvailable && selection.destination === "cowork"
+    ? { ...selection, destination: "repository" }
+    : selection;
+}
+
 function persistTargetSelection(selection: HomeNextTargetSelectionState): void {
   hasUserWritten = true;
   cachedHomeNextTargetSelection = selection;
@@ -160,27 +170,42 @@ export function subscribeHomeNextTargetSelectionState(listener: () => void): () 
   };
 }
 
-export function useHomeNextTargetSelectionSnapshot(): HomeNextTargetSelectionState {
-  return useSyncExternalStore(
+function useHomeNextTargetSelectionForHost() {
+  const coworkAvailable = useProductHost().desktop !== null;
+  const storedTargetSelection = useSyncExternalStore(
     subscribeHomeNextTargetSelectionState,
     readHomeNextTargetSelectionState,
     () => DEFAULT_HOME_NEXT_TARGET_SELECTION,
   );
+  const targetSelection = useMemo(
+    () => normalizeCoworkAvailability(storedTargetSelection, coworkAvailable),
+    [coworkAvailable, storedTargetSelection],
+  );
+
+  return { coworkAvailable, targetSelection };
+}
+
+export function useHomeNextTargetSelectionSnapshot(): HomeNextTargetSelectionState {
+  return useHomeNextTargetSelectionForHost().targetSelection;
 }
 
 export function useHomeNextTargetSelectionState() {
-  const targetSelection = useHomeNextTargetSelectionSnapshot();
+  const { coworkAvailable, targetSelection } = useHomeNextTargetSelectionForHost();
 
   const patchTargetSelection = useCallback((patch: HomeNextTargetSelectionPatch) => {
-    const next = normalizeHomeNextTargetSelectionState({
-      ...readHomeNextTargetSelectionState(),
-      ...patch,
-    });
+    const next = normalizeCoworkAvailability(
+      normalizeHomeNextTargetSelectionState({
+        ...readHomeNextTargetSelectionState(),
+        ...patch,
+      }),
+      coworkAvailable,
+    );
     persistTargetSelection(next);
-  }, []);
+  }, [coworkAvailable]);
 
   return {
     ...targetSelection,
+    coworkAvailable,
     patchTargetSelection,
     setDestination: useCallback(
       (destination: HomeNextDestination) => patchTargetSelection({ destination }),

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import type { ReactNode } from "react";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderableOutboxEntriesForTranscript } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
@@ -22,19 +23,25 @@ import { useSessionTranscriptStore } from "#product/stores/sessions/session-tran
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import { useDeferredHomeLaunchStore } from "#product/stores/home/deferred-home-launch-store";
 import { useHomeNextLaunch } from "#product/hooks/home/workflows/use-home-next-launch";
+import type { HomeLaunchTarget } from "#product/lib/domain/home/home-next-launch";
+import { CoworkThreadLaunchProvider } from "#product/providers/CoworkThreadLaunchProvider";
 
-const mocks = vi.hoisted(() => ({
-  createCloudWorkspaceAndEnterWithResult: vi.fn(),
-  createEmptySessionWithResolvedConfig: vi.fn(),
-  createLocalWorkspaceAndEnterWithResult: vi.fn(),
-  createSessionWithResolvedConfig: vi.fn(),
-  createThreadFromSelection: vi.fn(),
-  createWorktreeAndEnterWithResult: vi.fn(),
-  navigate: vi.fn(),
-  productHost: { desktop: {} as object | null },
-  selectWorkspace: vi.fn(),
-  showToast: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const createThreadFromSelection = vi.fn();
+  return {
+    createCloudWorkspaceAndEnterWithResult: vi.fn(),
+    createEmptySessionWithResolvedConfig: vi.fn(),
+    createLocalWorkspaceAndEnterWithResult: vi.fn(),
+    createSessionWithResolvedConfig: vi.fn(),
+    createThreadFromSelection,
+    createWorktreeAndEnterWithResult: vi.fn(),
+    navigate: vi.fn(),
+    productHost: { desktop: {} as object | null },
+    selectWorkspace: vi.fn(),
+    showToast: vi.fn(),
+    useCoworkThreadWorkflow: vi.fn(() => ({ createThreadFromSelection })),
+  };
+});
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
@@ -56,9 +63,7 @@ vi.mock("#product/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
 }));
 
 vi.mock("#product/hooks/cowork/workflows/use-cowork-thread-workflow", () => ({
-  useCoworkThreadWorkflow: () => ({
-    createThreadFromSelection: mocks.createThreadFromSelection,
-  }),
+  useCoworkThreadWorkflow: mocks.useCoworkThreadWorkflow,
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/use-workspace-entry-actions", () => ({
@@ -95,6 +100,14 @@ vi.mock("#product/hooks/sessions/workflows/use-session-interaction-resolution-ac
     revealMcpElicitationUrl: vi.fn(),
   }),
 }));
+
+function launchWrapper({ children }: { children: ReactNode }) {
+  return <CoworkThreadLaunchProvider>{children}</CoworkThreadLaunchProvider>;
+}
+
+function renderHomeNextLaunch() {
+  return renderHook(() => useHomeNextLaunch(), { wrapper: launchWrapper });
+}
 
 describe("useHomeNextLaunch", () => {
   beforeEach(() => {
@@ -144,7 +157,7 @@ describe("useHomeNextLaunch", () => {
       };
     });
 
-    const { result } = renderHook(() => useHomeNextLaunch());
+    const { result } = renderHomeNextLaunch();
     let succeeded = false;
     await act(async () => {
       succeeded = await result.current.launch({
@@ -178,7 +191,7 @@ describe("useHomeNextLaunch", () => {
 
   it("does not invoke the Desktop Cowork workflow from Web Home", async () => {
     mocks.productHost.desktop = null;
-    const { result } = renderHook(() => useHomeNextLaunch());
+    const { result } = renderHomeNextLaunch();
 
     let succeeded = true;
     await act(async () => {
@@ -193,6 +206,7 @@ describe("useHomeNextLaunch", () => {
 
     expect(succeeded).toBe(false);
     expect(result.current.isLaunching).toBe(false);
+    expect(mocks.useCoworkThreadWorkflow).not.toHaveBeenCalled();
     expect(mocks.createThreadFromSelection).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
     expect(useChatLaunchIntentStore.getState().activeIntent).toBeNull();
@@ -204,7 +218,7 @@ describe("useHomeNextLaunch", () => {
 
   it("still invokes the Cowork workflow from Desktop Home", async () => {
     mocks.createThreadFromSelection.mockResolvedValue(null);
-    const { result } = renderHook(() => useHomeNextLaunch());
+    const { result } = renderHomeNextLaunch();
 
     await act(async () => {
       await result.current.launch({
@@ -216,6 +230,82 @@ describe("useHomeNextLaunch", () => {
       });
     });
 
+    expect(mocks.useCoworkThreadWorkflow).toHaveBeenCalledTimes(1);
     expect(mocks.createThreadFromSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      label: "local",
+      target: { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null },
+    },
+    {
+      label: "worktree",
+      target: {
+        kind: "worktree",
+        repoRootId: "repo-root-1",
+        sourceWorkspaceId: null,
+        baseBranch: "main",
+        defaultBranch: "main",
+      },
+    },
+    {
+      label: "SSH",
+      target: { kind: "ssh" },
+    },
+  ])("rejects a forged $label launch before Web local workflows", async ({ target }) => {
+    mocks.productHost.desktop = null;
+    const { result } = renderHomeNextLaunch();
+
+    let succeeded = true;
+    await act(async () => {
+      succeeded = await result.current.launch({
+        text: "do not launch locally",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: target as HomeLaunchTarget,
+      });
+    });
+
+    expect(succeeded).toBe(false);
+    expect(mocks.useCoworkThreadWorkflow).not.toHaveBeenCalled();
+    expect(mocks.createLocalWorkspaceAndEnterWithResult).not.toHaveBeenCalled();
+    expect(mocks.createWorktreeAndEnterWithResult).not.toHaveBeenCalled();
+    expect(mocks.createCloudWorkspaceAndEnterWithResult).not.toHaveBeenCalled();
+    expect(useChatLaunchIntentStore.getState().activeIntent).toBeNull();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      "Local launch targets are available in the Desktop app.",
+      "info",
+    );
+  });
+
+  it("still invokes the Cloud workflow from Web Home", async () => {
+    mocks.productHost.desktop = null;
+    mocks.createCloudWorkspaceAndEnterWithResult.mockResolvedValue({
+      status: "interrupted",
+      failureMessage: "Expected test interruption",
+    });
+    const { result } = renderHomeNextLaunch();
+
+    await act(async () => {
+      await result.current.launch({
+        text: "launch in cloud",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: {
+          kind: "cloud",
+          gitOwner: "proliferate-ai",
+          gitRepoName: "proliferate",
+          baseBranch: "main",
+        },
+      });
+    });
+
+    expect(mocks.useCoworkThreadWorkflow).not.toHaveBeenCalled();
+    expect(mocks.createCloudWorkspaceAndEnterWithResult).toHaveBeenCalledTimes(1);
+    expect(mocks.createLocalWorkspaceAndEnterWithResult).not.toHaveBeenCalled();
+    expect(mocks.createWorktreeAndEnterWithResult).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
@@ -31,11 +31,22 @@ const mocks = vi.hoisted(() => ({
   createThreadFromSelection: vi.fn(),
   createWorktreeAndEnterWithResult: vi.fn(),
   navigate: vi.fn(),
+  productHost: { desktop: {} as object | null },
   selectWorkspace: vi.fn(),
+  showToast: vi.fn(),
 }));
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => mocks.productHost,
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof mocks.showToast }) => unknown) =>
+    selector({ show: mocks.showToast }),
 }));
 
 vi.mock("#product/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
@@ -88,6 +99,7 @@ vi.mock("#product/hooks/sessions/workflows/use-session-interaction-resolution-ac
 describe("useHomeNextLaunch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.productHost.desktop = {};
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
     useSessionIntentStore.getState().clear();
@@ -162,5 +174,48 @@ describe("useHomeNextLaunch", () => {
     expect(destinationPromptRows[0]?.text).toBe("build the projected destination");
     expect(mocks.createSessionWithResolvedConfig).not.toHaveBeenCalled();
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke the Desktop Cowork workflow from Web Home", async () => {
+    mocks.productHost.desktop = null;
+    const { result } = renderHook(() => useHomeNextLaunch());
+
+    let succeeded = true;
+    await act(async () => {
+      succeeded = await result.current.launch({
+        text: "start cowork on web",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: { kind: "cowork" },
+      });
+    });
+
+    expect(succeeded).toBe(false);
+    expect(result.current.isLaunching).toBe(false);
+    expect(mocks.createThreadFromSelection).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(useChatLaunchIntentStore.getState().activeIntent).toBeNull();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      "Cowork threads are available in the Desktop app.",
+      "info",
+    );
+  });
+
+  it("still invokes the Cowork workflow from Desktop Home", async () => {
+    mocks.createThreadFromSelection.mockResolvedValue(null);
+    const { result } = renderHook(() => useHomeNextLaunch());
+
+    await act(async () => {
+      await result.current.launch({
+        text: "start cowork on desktop",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: { kind: "cowork" },
+      });
+    });
+
+    expect(mocks.createThreadFromSelection).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
@@ -1,24 +1,19 @@
 import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useCreateCloudWorkspace } from "#product/hooks/cloud/workflows/use-create-cloud-workspace";
 import { useCoworkThreadWorkflow } from "#product/hooks/cowork/workflows/use-cowork-thread-workflow";
 import { useHomeNextLaunchPromptActions } from "#product/hooks/home/workflows/use-home-next-launch-prompt-actions";
 import { useWorkspaceEntryActions } from "#product/hooks/workspaces/workflows/use-workspace-entry-actions";
 import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
-import type {
-  HomeLaunchTarget,
-  HomeNextModelSelection,
-} from "#product/lib/domain/home/home-next-launch";
+import type { HomeLaunchTarget, HomeNextModelSelection } from "#product/lib/domain/home/home-next-launch";
 import {
   buildDeferredHomeLaunchId,
   useDeferredHomeLaunchStore,
 } from "#product/stores/home/deferred-home-launch-store";
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
-import {
-  failLatencyFlow,
-  startLatencyFlow,
-} from "#product/lib/infra/measurement/measurement-port";
+import { failLatencyFlow, startLatencyFlow } from "#product/lib/infra/measurement/measurement-port";
 import {
   buildHomePendingWorkspaceInitialSession,
   buildResolvedHomeLaunchControlValues,
@@ -38,6 +33,7 @@ interface HomeNextLaunchInput {
 
 // Owns the Home Next submit action. Does not own read-only selection state or deferred launch replay.
 export function useHomeNextLaunch() {
+  const coworkAvailable = useProductHost().desktop !== null;
   const navigate = useNavigate();
   const [isLaunching, setIsLaunching] = useState(false);
   const inFlightRef = useRef(false);
@@ -70,6 +66,10 @@ export function useHomeNextLaunch() {
   }: HomeNextLaunchInput): Promise<boolean> => {
     const prompt = text.trim();
     if (!prompt || inFlightRef.current) {
+      return false;
+    }
+    if (target.kind === "cowork" && !coworkAvailable) {
+      showToast("Cowork threads are available in the Desktop app.", "info");
       return false;
     }
 
@@ -382,6 +382,7 @@ export function useHomeNextLaunch() {
     createLocalWorkspaceAndEnterWithResult,
     createThreadFromSelection,
     createWorktreeAndEnterWithResult,
+    coworkAvailable,
     enqueueDeferredLaunch,
     failLaunchIntentIfActive,
     markLaunchIntentMaterialized,

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
@@ -1,8 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useCreateCloudWorkspace } from "#product/hooks/cloud/workflows/use-create-cloud-workspace";
-import { useCoworkThreadWorkflow } from "#product/hooks/cowork/workflows/use-cowork-thread-workflow";
 import { useHomeNextLaunchPromptActions } from "#product/hooks/home/workflows/use-home-next-launch-prompt-actions";
 import { useWorkspaceEntryActions } from "#product/hooks/workspaces/workflows/use-workspace-entry-actions";
 import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
@@ -14,6 +12,7 @@ import {
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
 import { failLatencyFlow, startLatencyFlow } from "#product/lib/infra/measurement/measurement-port";
+import { useCoworkThreadLaunchContext } from "#product/providers/CoworkThreadLaunchProvider";
 import {
   buildHomePendingWorkspaceInitialSession,
   buildResolvedHomeLaunchControlValues,
@@ -33,7 +32,6 @@ interface HomeNextLaunchInput {
 
 // Owns the Home Next submit action. Does not own read-only selection state or deferred launch replay.
 export function useHomeNextLaunch() {
-  const coworkAvailable = useProductHost().desktop !== null;
   const navigate = useNavigate();
   const [isLaunching, setIsLaunching] = useState(false);
   const inFlightRef = useRef(false);
@@ -44,7 +42,8 @@ export function useHomeNextLaunch() {
   const failLaunchIntentIfActive = useChatLaunchIntentStore((state) => state.failIfActive);
   const markLaunchIntentMaterialized =
     useChatLaunchIntentStore((state) => state.markMaterializedIfActive);
-  const { createThreadFromSelection } = useCoworkThreadWorkflow();
+  const { desktopTargetsAvailable, createThreadFromSelection } =
+    useCoworkThreadLaunchContext();
   const {
     promptExistingSession,
     promptProjectedOrCreateFreshSession,
@@ -68,8 +67,11 @@ export function useHomeNextLaunch() {
     if (!prompt || inFlightRef.current) {
       return false;
     }
-    if (target.kind === "cowork" && !coworkAvailable) {
-      showToast("Cowork threads are available in the Desktop app.", "info");
+    if (!desktopTargetsAvailable && target.kind !== "cloud") {
+      const message = target.kind === "cowork"
+        ? "Cowork threads are available in the Desktop app."
+        : "Local launch targets are available in the Desktop app.";
+      showToast(message, "info");
       return false;
     }
 
@@ -382,7 +384,7 @@ export function useHomeNextLaunch() {
     createLocalWorkspaceAndEnterWithResult,
     createThreadFromSelection,
     createWorktreeAndEnterWithResult,
-    coworkAvailable,
+    desktopTargetsAvailable,
     enqueueDeferredLaunch,
     failLaunchIntentIfActive,
     markLaunchIntentMaterialized,
@@ -392,8 +394,5 @@ export function useHomeNextLaunch() {
     showToast,
   ]);
 
-  return {
-    isLaunching,
-    launch,
-  };
+  return { isLaunching, launch };
 }

--- a/apps/packages/product-client/src/lib/access/cloud/health.test.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/health.test.ts
@@ -3,6 +3,9 @@ import {
   checkControlPlaneReachable,
   getLastKnownControlPlaneReachable,
 } from "#product/lib/access/cloud/health";
+import {
+  EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+} from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
 
 describe("control plane health", () => {
   afterEach(() => {
@@ -33,11 +36,13 @@ describe("control plane health", () => {
   it("times out a hung health request so boot can fall back", async () => {
     vi.useFakeTimers();
     let signal: AbortSignal | undefined;
+    let abortReason: unknown;
     const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
       signal = init?.signal ?? undefined;
       return new Promise<Response>((_resolve, reject) => {
         signal?.addEventListener("abort", () => {
-          reject(new DOMException("Aborted", "AbortError"));
+          abortReason = signal?.reason;
+          reject(abortReason);
         });
       });
     });
@@ -49,6 +54,9 @@ describe("control plane health", () => {
 
     await expect(reachable).resolves.toBe(false);
     expect(signal?.aborted).toBe(true);
+    expect(abortReason).toMatchObject({
+      name: EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+    });
     expect(getLastKnownControlPlaneReachable()).toBe(false);
   });
 });

--- a/apps/packages/product-client/src/lib/access/cloud/health.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/health.ts
@@ -5,6 +5,9 @@ import {
   startStartupTimer,
   summarizeStartupError,
 } from "#product/lib/infra/measurement/measurement-port";
+import {
+  createExpectedControlPlaneProbeTimeoutError,
+} from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
 
 let lastKnownControlPlaneReachable: boolean | null = null;
 const CONTROL_PLANE_HEALTH_TIMEOUT_MS = 2_500;
@@ -21,7 +24,7 @@ export async function checkControlPlaneReachable(apiBaseUrl: string): Promise<bo
     : null;
   const timeoutId = abortController
     ? globalThis.setTimeout(
-      () => abortController.abort(),
+      () => abortController.abort(createExpectedControlPlaneProbeTimeoutError()),
       CONTROL_PLANE_HEALTH_TIMEOUT_MS,
     )
     : null;

--- a/apps/packages/product-client/src/lib/access/cloud/server-capabilities.test.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/server-capabilities.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchServerCapabilities } from "#product/lib/access/cloud/server-capabilities";
+import {
+  EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+} from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
+
+describe("server capabilities", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("marks a hung metadata probe as an expected timeout", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    let abortReason: unknown;
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          abortReason = signal?.reason;
+          reject(abortReason);
+        });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const capabilities = fetchServerCapabilities("http://control-plane.test");
+
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    await expect(capabilities).resolves.toBeNull();
+    expect(signal?.aborted).toBe(true);
+    expect(abortReason).toMatchObject({
+      name: EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+    });
+  });
+});

--- a/apps/packages/product-client/src/lib/access/cloud/server-capabilities.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/server-capabilities.ts
@@ -3,6 +3,9 @@ import {
   parseServerCapabilities,
   type ServerCapabilityContract,
 } from "#product/lib/domain/capabilities/server-capability-contract";
+import {
+  createExpectedControlPlaneProbeTimeoutError,
+} from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
 
 const SERVER_CAPABILITIES_TIMEOUT_MS = 2_500;
 
@@ -20,7 +23,7 @@ export async function fetchServerCapabilities(
     typeof AbortController !== "undefined" ? new AbortController() : null;
   const timeoutId = abortController
     ? globalThis.setTimeout(
-        () => abortController.abort(),
+        () => abortController.abort(createExpectedControlPlaneProbeTimeoutError()),
         SERVER_CAPABILITIES_TIMEOUT_MS,
       )
     : null;

--- a/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
+++ b/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { useCoworkThreadWorkflow } from "#product/hooks/cowork/workflows/use-cowork-thread-workflow";
+
+type CreateCoworkThreadFromSelection = ReturnType<
+  typeof useCoworkThreadWorkflow
+>["createThreadFromSelection"];
+
+interface CoworkThreadLaunchContextValue {
+  desktopTargetsAvailable: boolean;
+  createThreadFromSelection: CreateCoworkThreadFromSelection;
+}
+
+const CoworkThreadLaunchContext = createContext<
+  CoworkThreadLaunchContextValue | undefined
+>(undefined);
+
+const unavailableCoworkThreadLaunch: CreateCoworkThreadFromSelection = async () => null;
+const WEB_COWORK_THREAD_LAUNCH_CONTEXT: CoworkThreadLaunchContextValue = {
+  desktopTargetsAvailable: false,
+  createThreadFromSelection: unavailableCoworkThreadLaunch,
+};
+
+export function CoworkThreadLaunchProvider({ children }: { children: ReactNode }) {
+  return useProductHost().desktop === null
+    ? (
+      <CoworkThreadLaunchContext.Provider value={WEB_COWORK_THREAD_LAUNCH_CONTEXT}>
+        {children}
+      </CoworkThreadLaunchContext.Provider>
+    )
+    : <DesktopCoworkThreadLaunchProvider>{children}</DesktopCoworkThreadLaunchProvider>;
+}
+
+function DesktopCoworkThreadLaunchProvider({ children }: { children: ReactNode }) {
+  const { createThreadFromSelection } = useCoworkThreadWorkflow();
+  const value = useMemo(
+    () => ({ desktopTargetsAvailable: true, createThreadFromSelection }),
+    [createThreadFromSelection],
+  );
+  return (
+    <CoworkThreadLaunchContext.Provider value={value}>
+      {children}
+    </CoworkThreadLaunchContext.Provider>
+  );
+}
+
+export function useCoworkThreadLaunchContext(): CoworkThreadLaunchContextValue {
+  const value = useContext(CoworkThreadLaunchContext);
+  if (!value) {
+    throw new Error(
+      "useCoworkThreadLaunchContext must be used inside CoworkThreadLaunchProvider",
+    );
+  }
+  return value;
+}

--- a/apps/packages/product-domain/package.json
+++ b/apps/packages/product-domain/package.json
@@ -231,6 +231,10 @@
       "types": "./dist/telemetry/scrub.d.ts",
       "import": "./dist/telemetry/scrub.js"
     },
+    "./telemetry/control-plane-probe-timeout": {
+      "types": "./dist/telemetry/control-plane-probe-timeout.d.ts",
+      "import": "./dist/telemetry/control-plane-probe-timeout.js"
+    },
     "./repos/repo-id": {
       "types": "./dist/repos/repo-id.d.ts",
       "import": "./dist/repos/repo-id.js"

--- a/apps/packages/product-domain/src/telemetry/control-plane-probe-timeout.ts
+++ b/apps/packages/product-domain/src/telemetry/control-plane-probe-timeout.ts
@@ -1,0 +1,21 @@
+export const EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME =
+  "ProliferateExpectedControlPlaneProbeTimeoutError";
+
+export function createExpectedControlPlaneProbeTimeoutError(): Error {
+  const error = new Error("Control plane probe timed out.");
+  error.name = EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME;
+  return error;
+}
+
+export function isExpectedControlPlaneProbeTimeoutError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  try {
+    return (error as { name?: unknown }).name
+      === EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/browser/telemetry/install-web-telemetry.ts
+++ b/apps/web/src/browser/telemetry/install-web-telemetry.ts
@@ -16,6 +16,7 @@ import {
 } from "@proliferate/product-domain/telemetry/scrub";
 
 import { webEnv } from "../../config/env";
+import { shouldDropExpectedWebSentryEvent } from "./sentry-event-filter";
 
 /**
  * The Web host's vendor-telemetry bootstrap: it initializes Sentry and PostHog
@@ -234,7 +235,13 @@ function scrubSentryEventPayload(event: MutableSentryEvent): MutableSentryEvent 
   return scrubbed;
 }
 
-function scrubSentryEvent(event: ErrorEvent): ErrorEvent | null {
+function scrubSentryEvent(
+  event: ErrorEvent,
+  hint: Parameters<NonNullable<SentryInitOptions["beforeSend"]>>[1],
+): ErrorEvent | null {
+  if (shouldDropExpectedWebSentryEvent(event, hint)) {
+    return null;
+  }
   return scrubSentryEventPayload(event as unknown as MutableSentryEvent) as unknown as ErrorEvent;
 }
 

--- a/apps/web/src/browser/telemetry/sentry-event-filter.test.ts
+++ b/apps/web/src/browser/telemetry/sentry-event-filter.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorEvent, EventHint, StackFrame } from "@sentry/react";
+import {
+  createExpectedControlPlaneProbeTimeoutError,
+  EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+} from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
+
+import { shouldDropExpectedWebSentryEvent } from "./sentry-event-filter";
+
+const UNHANDLED_REJECTION = {
+  handled: false,
+  type: "auto.browser.global_handlers.onunhandledrejection",
+} as const;
+
+function eventFor(
+  type: string,
+  value: string,
+  frames: StackFrame[] = [],
+): ErrorEvent {
+  return {
+    type: undefined,
+    exception: {
+      values: [{
+        mechanism: UNHANDLED_REJECTION,
+        stacktrace: { frames },
+        type,
+        value,
+      }],
+    },
+  };
+}
+
+const TANSTACK_OBSERVER_CANCEL_FRAMES: StackFrame[] = [
+  { function: "wL.setQueries" },
+  { function: "Object.batch" },
+  { function: "anonymous" },
+  { function: "bL.destroy" },
+  { function: "vL.removeObserver" },
+  { function: "Object.i [as cancel]" },
+  { function: "Object.onCancel" },
+];
+
+describe("shouldDropExpectedWebSentryEvent", () => {
+  it("drops source-marked control-plane probe timeouts", () => {
+    const serializedEvent = eventFor(
+      EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+      "Control plane probe timed out.",
+    );
+    const hintedEvent = eventFor("Error", "Control plane probe timed out.");
+    const hint = {
+      originalException: createExpectedControlPlaneProbeTimeoutError(),
+    } satisfies EventHint;
+
+    expect(shouldDropExpectedWebSentryEvent(hintedEvent, hint)).toBe(true);
+    expect(shouldDropExpectedWebSentryEvent(serializedEvent, {})).toBe(true);
+  });
+
+  it("drops the exact TanStack observer cancellation stack", () => {
+    const event = eventFor(
+      "AbortError",
+      "signal is aborted without reason",
+      TANSTACK_OBSERVER_CANCEL_FRAMES,
+    );
+
+    expect(shouldDropExpectedWebSentryEvent(event, {})).toBe(true);
+  });
+
+  it("preserves generic probe and PostHog AbortErrors", () => {
+    const genericProbe = eventFor("AbortError", "signal is aborted without reason", [
+      { function: "r" },
+    ]);
+    const postHogTimeout = eventFor("AbortError", "signal is aborted without reason", [
+      { function: "h.timeout" },
+    ]);
+
+    expect(shouldDropExpectedWebSentryEvent(genericProbe, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(postHogTimeout, {})).toBe(false);
+  });
+
+  it("preserves Cloud SDK SSE teardown and frame-less user aborts", () => {
+    const sseTeardown = eventFor("AbortError", "signal is aborted without reason", [
+      { function: "destroy_" },
+      { function: "close" },
+    ]);
+    const userAbort = eventFor("Error", "AbortError: The user aborted a request.");
+
+    expect(shouldDropExpectedWebSentryEvent(sseTeardown, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(userAbort, {})).toBe(false);
+  });
+
+  it("preserves handled errors and other failures with the same stack", () => {
+    const handled = eventFor(
+      "AbortError",
+      "signal is aborted without reason",
+      TANSTACK_OBSERVER_CANCEL_FRAMES,
+    );
+    handled.exception!.values![0].mechanism = {
+      handled: true,
+      type: "auto.browser.global_handlers.onunhandledrejection",
+    };
+    const typeError = eventFor(
+      "TypeError",
+      "Request failed",
+      TANSTACK_OBSERVER_CANCEL_FRAMES,
+    );
+    const handledProbeTimeout = eventFor(
+      EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+      "Control plane probe timed out.",
+    );
+    handledProbeTimeout.exception!.values![0].mechanism = {
+      handled: true,
+      type: "auto.browser.global_handlers.onunhandledrejection",
+    };
+
+    expect(shouldDropExpectedWebSentryEvent(handled, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(typeError, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(handledProbeTimeout, {})).toBe(false);
+  });
+
+  it("preserves mixed exception chains", () => {
+    const event = eventFor(
+      EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+      "Control plane probe timed out.",
+    );
+    event.exception!.values!.push({
+      mechanism: UNHANDLED_REJECTION,
+      type: "TypeError",
+      value: "Actionable failure",
+    });
+
+    expect(shouldDropExpectedWebSentryEvent(event, {
+      originalException: createExpectedControlPlaneProbeTimeoutError(),
+    })).toBe(false);
+  });
+});

--- a/apps/web/src/browser/telemetry/sentry-event-filter.ts
+++ b/apps/web/src/browser/telemetry/sentry-event-filter.ts
@@ -1,0 +1,90 @@
+import type { ErrorEvent, EventHint, Exception, StackFrame } from "@sentry/react";
+import {
+  EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
+  isExpectedControlPlaneProbeTimeoutError,
+} from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
+
+const UNHANDLED_REJECTION_MECHANISM =
+  "auto.browser.global_handlers.onunhandledrejection";
+
+type ExceptionWithRawStacktrace = Exception & {
+  raw_stacktrace?: { frames?: StackFrame[] };
+};
+
+function hasUnhandledRejectionMechanism(exception: Exception): boolean {
+  return exception.mechanism?.type === UNHANDLED_REJECTION_MECHANISM
+    && exception.mechanism.handled === false;
+}
+
+function frameMatchesMethod(frame: StackFrame, method: string): boolean {
+  const functionName = frame.function;
+  if (!functionName) {
+    return false;
+  }
+  if (method === "cancel") {
+    return functionName.endsWith("[as cancel]");
+  }
+  return functionName === method || functionName.endsWith(`.${method}`);
+}
+
+function findMethodAfter(
+  frames: StackFrame[],
+  method: string,
+  startIndex: number,
+): number {
+  return frames.findIndex((frame, index) => (
+    index >= startIndex && frameMatchesMethod(frame, method)
+  ));
+}
+
+function hasExpectedTanStackObserverCancellation(
+  exception: ExceptionWithRawStacktrace,
+): boolean {
+  if (
+    exception.type !== "AbortError"
+    || exception.value !== "signal is aborted without reason"
+  ) {
+    return false;
+  }
+
+  const frames = exception.raw_stacktrace?.frames ?? exception.stacktrace?.frames ?? [];
+  if (frames.length < 6) {
+    return false;
+  }
+
+  const setQueriesIndex = findMethodAfter(frames, "setQueries", 0);
+  const batchIndex = findMethodAfter(frames, "batch", setQueriesIndex + 1);
+  const tail = frames.slice(-4);
+
+  return setQueriesIndex >= 0
+    && batchIndex > setQueriesIndex
+    && frameMatchesMethod(tail[0], "destroy")
+    && frameMatchesMethod(tail[1], "removeObserver")
+    && frameMatchesMethod(tail[2], "cancel")
+    && frameMatchesMethod(tail[3], "onCancel");
+}
+
+/**
+ * Drops only source-marked control-plane timeouts and the exact TanStack
+ * observer teardown seen in hosted Web. Generic AbortErrors stay actionable.
+ */
+export function shouldDropExpectedWebSentryEvent(
+  event: ErrorEvent,
+  hint: EventHint,
+): boolean {
+  const exceptions = event.exception?.values as ExceptionWithRawStacktrace[] | undefined;
+  if (exceptions?.length !== 1) {
+    return false;
+  }
+
+  const exception = exceptions[0];
+  if (!hasUnhandledRejectionMechanism(exception)) {
+    return false;
+  }
+
+  const isMarkedProbeTimeout =
+    exception.type === EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME
+    || isExpectedControlPlaneProbeTimeoutError(hint.originalException);
+
+  return isMarkedProbeTimeout || hasExpectedTanStackObserverCancellation(exception);
+}


### PR DESCRIPTION
## Summary

- Gate the Cowork launch dependency behind a Desktop-only provider so hosted Web never mounts AnyHarness runtime/catalog/options/mutation hooks. Normalize Web Home selection, model, picker, and launch boundaries to repository Cloud; reject forged Cowork/local/worktree/SSH launches before intent creation. Desktop behavior is unchanged.
- Give owned control-plane probe timeouts a reserved error identity and drop only those unhandled rejections.
- Drop the exact TanStack observer-teardown AbortError stack while preserving generic, unrelated, handled, and mixed failures.

## Release note

Fixed hosted Web showing a Desktop-only Cowork action and reduced expected cancellation noise without hiding actionable failures.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/lib/access/cloud/health.test.ts src/lib/access/cloud/server-capabilities.test.ts src/components/workspace/shell/sidebar/MainSidebar.test.tsx`
- `pnpm --filter @proliferate/web exec vitest run src/browser/telemetry/sentry-event-filter.test.ts`
- `pnpm --filter @proliferate/product-client exec vitest run src/components/home/screen/HomeTargetPicker.test.tsx src/components/home/screen/HomeNextScreen.test.tsx src/hooks/home/derived/use-home-next-state.test.tsx src/hooks/home/workflows/use-home-next-launch.test.tsx src/hooks/chat/workflows/use-chat-launch-actions.test.tsx src/components/workspace/shell/sidebar/MainSidebar.test.tsx`
- `pnpm --filter @proliferate/product-client test`
- `pnpm web:typecheck`
- `pnpm web:build`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
