### PR TITLE
fix(anyharness): keep agent stderr out of Sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "url",
  "utoipa",
  "utoipa-axum",

--- a/anyharness/crates/anyharness-lib/Cargo.toml
+++ b/anyharness/crates/anyharness-lib/Cargo.toml
@@ -46,3 +46,4 @@ reqwest = { workspace = true, features = ["json"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tracing-subscriber.workspace = true

--- a/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
@@ -279,7 +279,7 @@ fn map_create_cowork_thread_error(error: CoworkCreateThreadError) -> ApiError {
                 super::sessions_errors::map_route_auth_error(&error)
             }
             crate::domains::sessions::runtime::CreateAndStartSessionError::StartFailed(error) => {
-                ApiError::internal(format!("ACP session start failed: {error}"))
+                super::sessions_errors::map_acp_session_start_error(error)
             }
             crate::domains::sessions::runtime::CreateAndStartSessionError::Internal(error) => {
                 ApiError::internal(error.to_string())

--- a/anyharness/crates/anyharness-lib/src/api/http/error.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/error.rs
@@ -139,17 +139,28 @@ impl ApiError {
 
     pub fn internal(detail: impl Into<String>) -> Self {
         let detail = detail.into();
+        Self::internal_with_safe_log(detail.clone(), detail)
+    }
+
+    /// Return an authenticated caller detail while logging only a separately
+    /// supplied telemetry-safe summary.
+    pub(super) fn internal_with_safe_log(
+        caller_detail: impl Into<String>,
+        telemetry_safe_detail: impl Into<String>,
+    ) -> Self {
+        let caller_detail = caller_detail.into();
+        let telemetry_safe_detail = telemetry_safe_detail.into();
         // tower_http only logs the status code on failure; this is the one
         // place every 500 passes through, so the detail must be logged here
         // or it survives only in the response body.
-        tracing::error!(detail = %detail, "internal API error");
+        tracing::error!(detail = %telemetry_safe_detail, "internal API error");
         Self(
             StatusCode::INTERNAL_SERVER_ERROR,
             ProblemDetails {
                 type_url: "about:blank".into(),
                 title: "Internal error".into(),
                 status: 500,
-                detail: Some(detail),
+                detail: Some(caller_detail),
                 instance: None,
                 code: None,
                 required_contexts: None,
@@ -170,6 +181,12 @@ impl ApiError {
     #[cfg(test)]
     pub(crate) fn code(&self) -> Option<&str> {
         self.1.code.as_deref()
+    }
+
+    /// RFC 7807 detail. Test/introspection accessor.
+    #[cfg(test)]
+    pub(crate) fn detail(&self) -> Option<&str> {
+        self.1.detail.as_deref()
     }
 }
 
@@ -206,5 +223,11 @@ mod tests {
             .required_contexts
             .is_none());
         assert!(ApiError::internal("y").1.required_contexts.is_none());
+    }
+
+    #[test]
+    fn internal_error_can_separate_caller_and_telemetry_details() {
+        let err = ApiError::internal_with_safe_log("caller diagnostic", "safe summary");
+        assert_eq!(err.1.detail.as_deref(), Some("caller diagnostic"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/error.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/error.rs
@@ -148,6 +148,16 @@ impl ApiError {
         caller_detail: impl Into<String>,
         telemetry_safe_detail: impl Into<String>,
     ) -> Self {
+        Self::internal_with_safe_log_and_code(caller_detail, telemetry_safe_detail, None)
+    }
+
+    /// Return an authenticated caller detail while logging only a separately
+    /// supplied telemetry-safe summary and exposing an optional stable code.
+    pub(super) fn internal_with_safe_log_and_code(
+        caller_detail: impl Into<String>,
+        telemetry_safe_detail: impl Into<String>,
+        code: Option<&str>,
+    ) -> Self {
         let caller_detail = caller_detail.into();
         let telemetry_safe_detail = telemetry_safe_detail.into();
         // tower_http only logs the status code on failure; this is the one
@@ -162,7 +172,7 @@ impl ApiError {
                 status: 500,
                 detail: Some(caller_detail),
                 instance: None,
-                code: None,
+                code: code.map(String::from),
                 required_contexts: None,
             },
         )
@@ -229,5 +239,17 @@ mod tests {
     fn internal_error_can_separate_caller_and_telemetry_details() {
         let err = ApiError::internal_with_safe_log("caller diagnostic", "safe summary");
         assert_eq!(err.1.detail.as_deref(), Some("caller diagnostic"));
+        assert!(err.1.code.is_none());
+    }
+
+    #[test]
+    fn internal_error_can_carry_a_telemetry_safe_code() {
+        let err = ApiError::internal_with_safe_log_and_code(
+            "caller diagnostic",
+            "safe summary",
+            Some("AGENT_STARTUP_FAILED"),
+        );
+        assert_eq!(err.1.detail.as_deref(), Some("caller diagnostic"));
+        assert_eq!(err.1.code.as_deref(), Some("AGENT_STARTUP_FAILED"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -2,25 +2,29 @@ use super::access::map_access_error;
 use super::error::ApiError;
 use crate::domains::agents::route_auth::RouteAuthError;
 use crate::domains::sessions::mcp_bindings::crypto::SessionMcpBindingsError;
+use crate::domains::sessions::model::AgentStartupExitError;
 use crate::domains::sessions::runtime::{
     CreateAndStartSessionError, EnsureLiveSessionError, ForkSessionError,
     PendingPromptMutationError, PendingPromptQueueError, ResolveInteractionError, SendPromptError,
     SessionLifecycleError, SetSessionConfigOptionError,
 };
 use crate::domains::sessions::service::{GetLiveConfigSnapshotError, UpdateSessionTitleError};
-use crate::live::sessions::AgentStartupExitError;
 
 fn map_internal_anyhow_error(
     error: anyhow::Error,
     telemetry_safe_detail: String,
     caller_prefix: &str,
 ) -> ApiError {
-    let caller_detail = error
-        .downcast_ref::<AgentStartupExitError>()
+    let startup_error = error.downcast_ref::<AgentStartupExitError>();
+    let caller_detail = startup_error
         .map(|error| format!("{caller_prefix}{}", error.caller_detail()))
         .unwrap_or_else(|| telemetry_safe_detail.clone());
 
-    ApiError::internal_with_safe_log(caller_detail, telemetry_safe_detail)
+    ApiError::internal_with_safe_log_and_code(
+        caller_detail,
+        telemetry_safe_detail,
+        startup_error.map(|_| AgentStartupExitError::CODE),
+    )
 }
 
 pub(super) fn map_acp_session_start_error(error: anyhow::Error) -> ApiError {
@@ -348,9 +352,9 @@ mod tests {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
+    use crate::domains::sessions::model::AgentStartupExitError;
     use crate::domains::sessions::runtime::{CreateAndStartSessionError, ResolveInteractionError};
     use crate::domains::workspaces::access_gate::WorkspaceAccessError;
-    use crate::live::sessions::AgentStartupExitError;
 
     #[test]
     fn pending_prompt_reorder_validation_maps_to_bad_request() {
@@ -414,6 +418,7 @@ mod tests {
                 "ACP session start failed: agent process exited during ACP startup (exit status: 1). Agent stderr:\nmissing binary"
             )
         );
+        assert_eq!(mapped.code(), Some("AGENT_STARTUP_FAILED"));
     }
 
     #[test]
@@ -436,6 +441,7 @@ mod tests {
                 "resume failed: agent process exited during ACP startup (exit status: 1). Agent stderr:\nmissing binary"
             )
         );
+        assert_eq!(mapped.code(), Some("AGENT_STARTUP_FAILED"));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -8,6 +8,25 @@ use crate::domains::sessions::runtime::{
     SessionLifecycleError, SetSessionConfigOptionError,
 };
 use crate::domains::sessions::service::{GetLiveConfigSnapshotError, UpdateSessionTitleError};
+use crate::live::sessions::AgentStartupExitError;
+
+fn map_internal_anyhow_error(
+    error: anyhow::Error,
+    telemetry_safe_detail: String,
+    caller_prefix: &str,
+) -> ApiError {
+    let caller_detail = error
+        .downcast_ref::<AgentStartupExitError>()
+        .map(|error| format!("{caller_prefix}{}", error.caller_detail()))
+        .unwrap_or_else(|| telemetry_safe_detail.clone());
+
+    ApiError::internal_with_safe_log(caller_detail, telemetry_safe_detail)
+}
+
+pub(super) fn map_acp_session_start_error(error: anyhow::Error) -> ApiError {
+    let telemetry_safe_detail = format!("ACP session start failed: {error}");
+    map_internal_anyhow_error(error, telemetry_safe_detail, "ACP session start failed: ")
+}
 
 pub(super) fn map_resolve_interaction_error(error: ResolveInteractionError) -> ApiError {
     match error {
@@ -116,10 +135,11 @@ pub(super) fn map_create_session_error(error: CreateAndStartSessionError) -> Api
             ApiError::internal(SessionMcpBindingsError::missing_data_key_detail())
         }
         CreateAndStartSessionError::RouteAuth(error) => map_route_auth_error(&error),
-        CreateAndStartSessionError::StartFailed(error) => {
-            ApiError::internal(format!("ACP session start failed: {error}"))
+        CreateAndStartSessionError::StartFailed(error) => map_acp_session_start_error(error),
+        CreateAndStartSessionError::Internal(error) => {
+            let telemetry_safe_detail = error.to_string();
+            map_internal_anyhow_error(error, telemetry_safe_detail, "")
         }
-        CreateAndStartSessionError::Internal(error) => ApiError::internal(error.to_string()),
     }
 }
 
@@ -168,7 +188,8 @@ pub(super) fn map_ensure_live_session_error(error: EnsureLiveSessionError) -> Ap
         }
         EnsureLiveSessionError::RouteAuth(error) => map_route_auth_error(&error),
         EnsureLiveSessionError::Internal(error) => {
-            ApiError::internal(format!("resume failed: {error}"))
+            let telemetry_safe_detail = format!("resume failed: {error}");
+            map_internal_anyhow_error(error, telemetry_safe_detail, "resume failed: ")
         }
     }
 }
@@ -186,7 +207,10 @@ pub(super) fn map_set_session_config_option_error(error: SetSessionConfigOptionE
             format!("workspace directory is missing: {path}"),
             "WORKSPACE_DIRECTORY_MISSING",
         ),
-        SetSessionConfigOptionError::Internal(error) => ApiError::internal(error.to_string()),
+        SetSessionConfigOptionError::Internal(error) => {
+            let telemetry_safe_detail = error.to_string();
+            map_internal_anyhow_error(error, telemetry_safe_detail, "")
+        }
     }
 }
 
@@ -204,7 +228,10 @@ pub(super) fn map_send_prompt_error(error: SendPromptError) -> ApiError {
         ),
         SendPromptError::InvalidPrompt(error) => ApiError::bad_request(error.detail, error.code),
         // {error:#} keeps the anyhow cause chain; to_string() would drop it.
-        SendPromptError::Internal(error) => ApiError::internal(format!("{error:#}")),
+        SendPromptError::Internal(error) => {
+            let telemetry_safe_detail = format!("{error:#}");
+            map_internal_anyhow_error(error, telemetry_safe_detail, "")
+        }
     }
 }
 
@@ -231,9 +258,13 @@ pub(super) fn map_fork_session_error(error: ForkSessionError) -> ApiError {
             ApiError::internal(SessionMcpBindingsError::missing_data_key_detail())
         }
         ForkSessionError::StartFailed { error, .. } => {
-            ApiError::internal(format!("fork child start failed: {error}"))
+            let telemetry_safe_detail = format!("fork child start failed: {error}");
+            map_internal_anyhow_error(error, telemetry_safe_detail, "fork child start failed: ")
         }
-        ForkSessionError::Internal(error) => ApiError::internal(error.to_string()),
+        ForkSessionError::Internal(error) => {
+            let telemetry_safe_detail = error.to_string();
+            map_internal_anyhow_error(error, telemetry_safe_detail, "")
+        }
     }
 }
 
@@ -319,6 +350,7 @@ mod tests {
 
     use crate::domains::sessions::runtime::{CreateAndStartSessionError, ResolveInteractionError};
     use crate::domains::workspaces::access_gate::WorkspaceAccessError;
+    use crate::live::sessions::AgentStartupExitError;
 
     #[test]
     fn pending_prompt_reorder_validation_maps_to_bad_request() {
@@ -362,6 +394,48 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn startup_stderr_detail_reaches_caller_through_safe_typed_error() {
+        let error = AgentStartupExitError::new(
+            "agent process exited during ACP startup (exit status: 1)".to_string(),
+            "agent process exited during ACP startup (exit status: 1). Agent stderr:\nmissing binary"
+                .to_string(),
+        );
+
+        let mapped = super::map_create_session_error(CreateAndStartSessionError::StartFailed(
+            anyhow::Error::new(error),
+        ));
+
+        assert_eq!(
+            mapped.detail(),
+            Some(
+                "ACP session start failed: agent process exited during ACP startup (exit status: 1). Agent stderr:\nmissing binary"
+            )
+        );
+    }
+
+    #[test]
+    fn resume_startup_stderr_detail_reaches_caller_through_safe_typed_error() {
+        use crate::domains::sessions::runtime::EnsureLiveSessionError;
+
+        let error = AgentStartupExitError::new(
+            "agent process exited during ACP startup (exit status: 1)".to_string(),
+            "agent process exited during ACP startup (exit status: 1). Agent stderr:\nmissing binary"
+                .to_string(),
+        );
+
+        let mapped = super::map_ensure_live_session_error(EnsureLiveSessionError::Internal(
+            anyhow::Error::new(error),
+        ));
+
+        assert_eq!(
+            mapped.detail(),
+            Some(
+                "resume failed: agent process exited during ACP startup (exit status: 1). Agent stderr:\nmissing binary"
+            )
+        );
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
@@ -1,7 +1,52 @@
+use std::fmt;
+
 use anyharness_contract::v1;
 
 use crate::domains::sessions::prompt::PromptPayload;
 use crate::origin::OriginContext;
+
+/// Startup failure whose ordinary formatting is safe for telemetry, while an
+/// authenticated API mapper may deliberately surface the bounded local stderr
+/// diagnostic to the caller that requested the session.
+#[derive(Clone)]
+pub(crate) struct AgentStartupExitError {
+    telemetry_safe_detail: String,
+    caller_detail: String,
+}
+
+impl AgentStartupExitError {
+    /// Stable RFC 7807 extension code used by clients to replace the caller
+    /// diagnostic before sending this error to telemetry.
+    pub(crate) const CODE: &'static str = "AGENT_STARTUP_FAILED";
+
+    pub(crate) fn new(telemetry_safe_detail: String, caller_detail: String) -> Self {
+        Self {
+            telemetry_safe_detail,
+            caller_detail,
+        }
+    }
+
+    pub(crate) fn caller_detail(&self) -> &str {
+        &self.caller_detail
+    }
+}
+
+impl fmt::Display for AgentStartupExitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.telemetry_safe_detail)
+    }
+}
+
+impl fmt::Debug for AgentStartupExitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AgentStartupExitError")
+            .field("telemetry_safe_detail", &self.telemetry_safe_detail)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::error::Error for AgentStartupExitError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionMcpBindingPolicy {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -30,6 +30,8 @@ use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
+use crate::live::sessions::AgentStartupExitError;
+use crate::observability::AGENT_STDERR_TRACING_TARGET;
 
 impl SessionActor {
     /// Spawns the agent process, establishes the ACP connection, starts the
@@ -171,15 +173,20 @@ impl SessionActor {
                 }
                 let error = agent_exited_during_startup_error(exit_status, &stderr_tail);
                 tracing::warn!(
+                    target: AGENT_STDERR_TRACING_TARGET,
                     session_id = %session_id,
                     workspace_id = %workspace_id,
                     agent_kind = %source_agent_kind,
-                    error = %error.to_string().replace('\n', " | "),
+                    error = %error.caller_detail().replace('\n', " | "),
                     elapsed_ms = startup_started.elapsed().as_millis(),
                     "[workspace-latency] session.actor.process_exited_during_startup"
                 );
-                let _ = ready_tx.send(Err(anyhow::anyhow!("{error}")));
-                return Err(error);
+                // Ordinary Display/Debug formatting is status-only, so generic
+                // actor and API logging cannot retransmit raw child output.
+                // The initiating authenticated API mapper can still opt into
+                // the bounded caller detail carried by this typed error.
+                let _ = ready_tx.send(Err(anyhow::Error::new(error.clone())));
+                return Err(anyhow::Error::new(error));
             }
         };
         let supports_native_close = init_response
@@ -388,20 +395,22 @@ impl SessionActor {
 fn agent_exited_during_startup_error(
     exit_status: std::io::Result<std::process::ExitStatus>,
     stderr_tail: &AgentStderrTail,
-) -> anyhow::Error {
+) -> AgentStartupExitError {
     let status = match exit_status {
         Ok(status) => status.to_string(),
         Err(error) => format!("wait failed: {error}"),
     };
     let tail = stderr_tail.snapshot();
-    if tail.is_empty() {
-        anyhow::anyhow!("agent process exited during ACP startup ({status})")
+    let telemetry_safe_detail = format!("agent process exited during ACP startup ({status})");
+    let caller_detail = if tail.is_empty() {
+        telemetry_safe_detail.clone()
     } else {
-        anyhow::anyhow!(
+        format!(
             "agent process exited during ACP startup ({status}). Agent stderr:\n{}",
             tail.join("\n")
         )
-    }
+    };
+    AgentStartupExitError::new(telemetry_safe_detail, caller_detail)
 }
 
 pub(in crate::live::sessions::actor) fn persist_session_action_capabilities(
@@ -541,6 +550,7 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("exited during ACP startup"));
         assert!(!message.contains("Agent stderr"));
+        assert_eq!(message, error.caller_detail());
     }
 
     #[test]
@@ -551,8 +561,13 @@ mod tests {
 
         let error = agent_exited_during_startup_error(Ok(exit_status), &tail);
         assert!(error
+            .caller_detail()
+            .contains("Failed to locate codex-acp binary"));
+        assert!(!error
             .to_string()
             .contains("Failed to locate codex-acp binary"));
+        assert!(error.caller_detail().contains("Agent stderr:"));
+        assert!(!format!("{error:?}").contains("Failed to locate codex-acp binary"));
     }
 
     fn init_meta(value: serde_json::Value) -> acp::schema::Meta {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -25,12 +25,10 @@ use crate::live::sessions::driver::native_session::{
 };
 use crate::live::sessions::driver::process::spawn_agent_process;
 use crate::live::sessions::driver::session_lifecycle::initialize_connection;
-use crate::live::sessions::driver::stderr::AgentStderrTail;
 use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
-use crate::live::sessions::AgentStartupExitError;
 use crate::observability::AGENT_STDERR_TRACING_TARGET;
 
 impl SessionActor {
@@ -171,7 +169,7 @@ impl SessionActor {
                     )
                     .await;
                 }
-                let error = agent_exited_during_startup_error(exit_status, &stderr_tail);
+                let error = stderr_tail.startup_exit_error(exit_status);
                 tracing::warn!(
                     target: AGENT_STDERR_TRACING_TARGET,
                     session_id = %session_id,
@@ -392,27 +390,6 @@ impl SessionActor {
     }
 }
 
-fn agent_exited_during_startup_error(
-    exit_status: std::io::Result<std::process::ExitStatus>,
-    stderr_tail: &AgentStderrTail,
-) -> AgentStartupExitError {
-    let status = match exit_status {
-        Ok(status) => status.to_string(),
-        Err(error) => format!("wait failed: {error}"),
-    };
-    let tail = stderr_tail.snapshot();
-    let telemetry_safe_detail = format!("agent process exited during ACP startup ({status})");
-    let caller_detail = if tail.is_empty() {
-        telemetry_safe_detail.clone()
-    } else {
-        format!(
-            "agent process exited during ACP startup ({status}). Agent stderr:\n{}",
-            tail.join("\n")
-        )
-    };
-    AgentStartupExitError::new(telemetry_safe_detail, caller_detail)
-}
-
 pub(in crate::live::sessions::actor) fn persist_session_action_capabilities(
     store: &dyn SessionStateDurable,
     session_id: &str,
@@ -539,36 +516,6 @@ fn loops_capability_from_init_meta(meta: Option<&acp::schema::Meta>) -> (bool, b
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::os::unix::process::ExitStatusExt;
-
-    #[test]
-    fn agent_exit_error_reports_status_without_stderr() {
-        let tail = AgentStderrTail::default();
-        let exit_status = std::process::ExitStatus::from_raw(0x100); // exit code 1
-
-        let error = agent_exited_during_startup_error(Ok(exit_status), &tail);
-        let message = error.to_string();
-        assert!(message.contains("exited during ACP startup"));
-        assert!(!message.contains("Agent stderr"));
-        assert_eq!(message, error.caller_detail());
-    }
-
-    #[test]
-    fn agent_exit_error_includes_stderr_tail() {
-        let tail = AgentStderrTail::default();
-        tail.push("Failed to locate codex-acp binary");
-        let exit_status = std::process::ExitStatus::from_raw(0x100);
-
-        let error = agent_exited_during_startup_error(Ok(exit_status), &tail);
-        assert!(error
-            .caller_detail()
-            .contains("Failed to locate codex-acp binary"));
-        assert!(!error
-            .to_string()
-            .contains("Failed to locate codex-acp binary"));
-        assert!(error.caller_detail().contains("Agent stderr:"));
-        assert!(!format!("{error:?}").contains("Failed to locate codex-acp binary"));
-    }
 
     fn init_meta(value: serde_json::Value) -> acp::schema::Meta {
         let serde_json::Value::Object(map) = value else {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, Mutex};
 
 use tokio::process::ChildStderr;
 
+use crate::observability::AGENT_STDERR_TRACING_TARGET;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::live::sessions) enum AgentStderrSeverity {
     Error,
@@ -10,8 +12,8 @@ pub(in crate::live::sessions) enum AgentStderrSeverity {
     Debug,
 }
 
-/// Retains the most recent agent stderr lines so startup failures can surface
-/// what the process said before it died.
+/// Retains the most recent agent stderr lines so local startup diagnostics can
+/// surface what the process said before it died.
 #[derive(Debug, Clone, Default)]
 pub(in crate::live::sessions) struct AgentStderrTail {
     lines: Arc<Mutex<VecDeque<String>>>,
@@ -117,6 +119,7 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
             match classify_agent_stderr_line(&line) {
                 AgentStderrSeverity::Error => {
                     tracing::error!(
+                        target: AGENT_STDERR_TRACING_TARGET,
                         session_id = %session_id,
                         agent = %agent_kind,
                         "[agent stderr] {line}"
@@ -124,6 +127,7 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
                 }
                 AgentStderrSeverity::Warn => {
                     tracing::warn!(
+                        target: AGENT_STDERR_TRACING_TARGET,
                         session_id = %session_id,
                         agent = %agent_kind,
                         "[agent stderr] {line}"
@@ -131,6 +135,7 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
                 }
                 AgentStderrSeverity::Debug => {
                     tracing::debug!(
+                        target: AGENT_STDERR_TRACING_TARGET,
                         session_id = %session_id,
                         agent = %agent_kind,
                         "[agent stderr] {line}"

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio::process::ChildStderr;
 
+use crate::live::sessions::AgentStartupExitError;
 use crate::observability::AGENT_STDERR_TRACING_TARGET;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -32,8 +33,29 @@ impl AgentStderrTail {
         lines.push_back(line.to_string());
     }
 
-    pub(in crate::live::sessions) fn snapshot(&self) -> Vec<String> {
+    fn snapshot(&self) -> Vec<String> {
         self.lock_lines().iter().cloned().collect()
+    }
+
+    pub(in crate::live::sessions) fn startup_exit_error(
+        &self,
+        exit_status: std::io::Result<std::process::ExitStatus>,
+    ) -> AgentStartupExitError {
+        let status = match exit_status {
+            Ok(status) => status.to_string(),
+            Err(error) => format!("wait failed: {error}"),
+        };
+        let tail = self.snapshot();
+        let telemetry_safe_detail = format!("agent process exited during ACP startup ({status})");
+        let caller_detail = if tail.is_empty() {
+            telemetry_safe_detail.clone()
+        } else {
+            format!(
+                "agent process exited during ACP startup ({status}). Agent stderr:\n{}",
+                tail.join("\n")
+            )
+        };
+        AgentStartupExitError::new(telemetry_safe_detail, caller_detail)
     }
 
     fn lock_lines(&self) -> std::sync::MutexGuard<'_, VecDeque<String>> {
@@ -150,6 +172,8 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
 
     #[test]
     fn sanitize_agent_stderr_line_strips_ansi_sequences() {
@@ -202,5 +226,36 @@ mod tests {
         assert_eq!(snapshot.len(), AgentStderrTail::MAX_LINES);
         assert_eq!(snapshot.first(), Some(&format!("line {evicted}")));
         assert_eq!(snapshot.last(), Some(&format!("line {}", total - 1)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_exit_error_reports_status_without_stderr() {
+        let tail = AgentStderrTail::default();
+        let exit_status = std::process::ExitStatus::from_raw(0x100); // exit code 1
+
+        let error = tail.startup_exit_error(Ok(exit_status));
+        let message = error.to_string();
+        assert!(message.contains("exited during ACP startup"));
+        assert!(!message.contains("Agent stderr"));
+        assert_eq!(message, error.caller_detail());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_exit_error_includes_stderr_tail_only_for_caller() {
+        let tail = AgentStderrTail::default();
+        tail.push("Failed to locate codex-acp binary");
+        let exit_status = std::process::ExitStatus::from_raw(0x100);
+
+        let error = tail.startup_exit_error(Ok(exit_status));
+        assert!(error
+            .caller_detail()
+            .contains("Failed to locate codex-acp binary"));
+        assert!(!error
+            .to_string()
+            .contains("Failed to locate codex-acp binary"));
+        assert!(error.caller_detail().contains("Agent stderr:"));
+        assert!(!format!("{error:?}").contains("Failed to locate codex-acp binary"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
+use std::io;
 use std::sync::{Arc, Mutex};
 
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 use tokio::process::ChildStderr;
 
 use crate::domains::sessions::model::AgentStartupExitError;
@@ -72,11 +74,16 @@ impl AgentStderrTail {
     }
 
     fn bounded_line(line: &str) -> String {
-        if line.len() <= Self::MAX_LINE_BYTES {
+        Self::bounded_line_with_truncation(line, line.len() > Self::MAX_LINE_BYTES)
+    }
+
+    fn bounded_line_with_truncation(line: &str, truncated: bool) -> String {
+        if !truncated && line.len() <= Self::MAX_LINE_BYTES {
             return line.to_string();
         }
 
-        let mut prefix_end = Self::MAX_LINE_BYTES - Self::TRUNCATED_SUFFIX.len();
+        let max_prefix_bytes = Self::MAX_LINE_BYTES - Self::TRUNCATED_SUFFIX.len();
+        let mut prefix_end = line.len().min(max_prefix_bytes);
         while !line.is_char_boundary(prefix_end) {
             prefix_end -= 1;
         }
@@ -85,6 +92,105 @@ impl AgentStderrTail {
         bounded.push_str(&line[..prefix_end]);
         bounded.push_str(Self::TRUNCATED_SUFFIX);
         bounded
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BoundedAgentStderrLine {
+    bytes: Vec<u8>,
+    truncated: bool,
+    terminated_by_newline: bool,
+}
+
+impl BoundedAgentStderrLine {
+    fn into_record(mut self) -> Option<AgentStderrRecord> {
+        // Match `AsyncBufReadExt::lines`: remove the CR from a complete CRLF
+        // line, but do not mistake a retained-prefix CR for the delimiter when
+        // the physical line was truncated.
+        if self.terminated_by_newline && !self.truncated && self.bytes.last() == Some(&b'\r') {
+            self.bytes.pop();
+        }
+
+        let decoded = String::from_utf8_lossy(&self.bytes);
+        let sanitized = sanitize_agent_stderr_line(&decoded);
+        if sanitized.is_empty() {
+            return None;
+        }
+
+        let line = AgentStderrTail::bounded_line_with_truncation(&sanitized, self.truncated);
+        let severity = classify_agent_stderr_line(&line);
+        Some(AgentStderrRecord { line, severity })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AgentStderrRecord {
+    line: String,
+    severity: AgentStderrSeverity,
+}
+
+/// Copies only a bounded prefix while consuming the complete physical line.
+/// This keeps newline-free child output from growing a `String` without bound
+/// while still draining the pipe so the child cannot block on stderr.
+async fn next_bounded_agent_stderr_line<R>(
+    reader: &mut R,
+) -> io::Result<Option<BoundedAgentStderrLine>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(AgentStderrTail::MAX_LINE_BYTES);
+    let mut truncated = false;
+
+    loop {
+        let (consumed, found_newline) = {
+            let available = reader.fill_buf().await?;
+            if available.is_empty() {
+                return if bytes.is_empty() && !truncated {
+                    Ok(None)
+                } else {
+                    Ok(Some(BoundedAgentStderrLine {
+                        bytes,
+                        truncated,
+                        terminated_by_newline: false,
+                    }))
+                };
+            }
+
+            let newline_index = available.iter().position(|byte| *byte == b'\n');
+            let content_bytes = newline_index.unwrap_or(available.len());
+            let remaining = AgentStderrTail::MAX_LINE_BYTES.saturating_sub(bytes.len());
+            let retained_bytes = content_bytes.min(remaining);
+            bytes.extend_from_slice(&available[..retained_bytes]);
+            truncated |= retained_bytes < content_bytes;
+
+            (
+                content_bytes + usize::from(newline_index.is_some()),
+                newline_index.is_some(),
+            )
+        };
+
+        reader.consume(consumed);
+        if found_newline {
+            return Ok(Some(BoundedAgentStderrLine {
+                bytes,
+                truncated,
+                terminated_by_newline: true,
+            }));
+        }
+    }
+}
+
+async fn next_agent_stderr_record<R>(reader: &mut R) -> io::Result<Option<AgentStderrRecord>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        let Some(line) = next_bounded_agent_stderr_line(reader).await? else {
+            return Ok(None);
+        };
+        if let Some(record) = line.into_record() {
+            return Ok(Some(record));
+        }
     }
 }
 
@@ -149,45 +255,44 @@ pub(in crate::live::sessions) fn spawn_agent_stderr_logger(
     let tail = AgentStderrTail::default();
     let tail_writer = tail.clone();
     let reader_task = tokio::task::spawn_local(async move {
-        use tokio::io::AsyncBufReadExt;
-        let reader = tokio::io::BufReader::new(stderr);
-        let mut lines = reader.lines();
-        while let Ok(Some(line)) = lines.next_line().await {
-            let line = sanitize_agent_stderr_line(&line);
-            if line.is_empty() {
-                continue;
-            }
-            tail_writer.push(&line);
-
-            match classify_agent_stderr_line(&line) {
-                AgentStderrSeverity::Error => {
-                    tracing::error!(
-                        target: AGENT_STDERR_TRACING_TARGET,
-                        session_id = %session_id,
-                        agent = %agent_kind,
-                        "[agent stderr] {line}"
-                    );
-                }
-                AgentStderrSeverity::Warn => {
-                    tracing::warn!(
-                        target: AGENT_STDERR_TRACING_TARGET,
-                        session_id = %session_id,
-                        agent = %agent_kind,
-                        "[agent stderr] {line}"
-                    );
-                }
-                AgentStderrSeverity::Debug => {
-                    tracing::debug!(
-                        target: AGENT_STDERR_TRACING_TARGET,
-                        session_id = %session_id,
-                        agent = %agent_kind,
-                        "[agent stderr] {line}"
-                    );
-                }
-            }
+        let mut reader =
+            tokio::io::BufReader::with_capacity(AgentStderrTail::MAX_LINE_BYTES, stderr);
+        while let Ok(Some(record)) = next_agent_stderr_record(&mut reader).await {
+            tail_writer.push(&record.line);
+            log_agent_stderr_record(&record, &session_id, &agent_kind);
         }
     });
     (tail, reader_task)
+}
+
+fn log_agent_stderr_record(record: &AgentStderrRecord, session_id: &str, agent_kind: &str) {
+    let line = &record.line;
+    match record.severity {
+        AgentStderrSeverity::Error => {
+            tracing::error!(
+                target: AGENT_STDERR_TRACING_TARGET,
+                session_id = %session_id,
+                agent = %agent_kind,
+                "[agent stderr] {line}"
+            );
+        }
+        AgentStderrSeverity::Warn => {
+            tracing::warn!(
+                target: AGENT_STDERR_TRACING_TARGET,
+                session_id = %session_id,
+                agent = %agent_kind,
+                "[agent stderr] {line}"
+            );
+        }
+        AgentStderrSeverity::Debug => {
+            tracing::debug!(
+                target: AGENT_STDERR_TRACING_TARGET,
+                session_id = %session_id,
+                agent = %agent_kind,
+                "[agent stderr] {line}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -195,6 +300,23 @@ mod tests {
     use super::*;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
+
+    #[derive(Clone)]
+    struct SharedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for SharedLogWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn sanitize_agent_stderr_line_strips_ansi_sequences() {
@@ -270,6 +392,90 @@ mod tests {
         assert!(snapshot[0].len() <= AgentStderrTail::MAX_LINE_BYTES);
         assert!(snapshot[0].ends_with(AgentStderrTail::TRUNCATED_SUFFIX));
         assert!(!snapshot[0].contains('\u{fffd}'));
+    }
+
+    #[tokio::test]
+    async fn giant_newline_free_write_is_bounded_before_retention_classification_and_logging() {
+        use tokio::io::AsyncWriteExt;
+
+        let (reader_io, mut writer) = tokio::io::duplex(64);
+        let giant_write = "🙂"
+            .repeat(AgentStderrTail::MAX_LINE_BYTES * 16)
+            .into_bytes();
+        let writer_task = tokio::spawn(async move {
+            writer.write_all(b"ERROR ").await.expect("write prefix");
+            writer
+                .write_all(&giant_write)
+                .await
+                .expect("write giant newline-free payload");
+            writer
+                .write_all(b"DO_NOT_RETAIN_OR_LOG\nWARN drain completed: \xff")
+                .await
+                .expect("write delimiter and lossy EOF line");
+            writer.shutdown().await.expect("close writer");
+        });
+
+        let mut reader = tokio::io::BufReader::with_capacity(64, reader_io);
+        let first = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            next_agent_stderr_record(&mut reader),
+        )
+        .await
+        .expect("giant line drain timed out")
+        .expect("read giant line")
+        .expect("giant line record");
+        assert_eq!(first.severity, AgentStderrSeverity::Error);
+        assert_eq!(first.line.len(), AgentStderrTail::MAX_LINE_BYTES);
+        assert!(first.line.ends_with(AgentStderrTail::TRUNCATED_SUFFIX));
+        assert!(!first.line.contains("DO_NOT_RETAIN_OR_LOG"));
+        assert!(!first.line.contains('\u{fffd}'));
+
+        let tail = AgentStderrTail::default();
+        tail.push(&first.line);
+        assert_eq!(tail.snapshot(), vec![first.line.clone()]);
+
+        let log_bytes = Arc::new(Mutex::new(Vec::new()));
+        let log_writer = Arc::clone(&log_bytes);
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(move || SharedLogWriter(Arc::clone(&log_writer)))
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            log_agent_stderr_record(&first, "session", "agent");
+        });
+        let logged = String::from_utf8(
+            log_bytes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+        )
+        .expect("formatted log is UTF-8");
+        assert!(logged.contains(&first.line));
+        assert!(!logged.contains("DO_NOT_RETAIN_OR_LOG"));
+
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            next_agent_stderr_record(&mut reader),
+        )
+        .await
+        .expect("lossy EOF line drain timed out")
+        .expect("read next line")
+        .expect("next line record");
+        assert_eq!(second.line, "WARN drain completed: �");
+        assert_eq!(second.severity, AgentStderrSeverity::Warn);
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            next_agent_stderr_record(&mut reader),
+        )
+        .await
+        .expect("EOF drain timed out")
+        .expect("read EOF")
+        .is_none());
+        tokio::time::timeout(std::time::Duration::from_secs(5), writer_task)
+            .await
+            .expect("writer task timed out")
+            .expect("writer task completed");
     }
 
     #[cfg(unix)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/stderr.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use tokio::process::ChildStderr;
 
-use crate::live::sessions::AgentStartupExitError;
+use crate::domains::sessions::model::AgentStartupExitError;
 use crate::observability::AGENT_STDERR_TRACING_TARGET;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,13 +24,18 @@ impl AgentStderrTail {
     /// Enough to capture a fatal error plus a few lines of context without
     /// bloating the startup error string shown to the user.
     const MAX_LINES: usize = 8;
+    /// A line-oriented reader can still receive one arbitrarily large line.
+    /// Capping each retained line also bounds the full caller detail because
+    /// the number of retained lines is fixed above.
+    const MAX_LINE_BYTES: usize = 1024;
+    const TRUNCATED_SUFFIX: &'static str = "…[truncated]";
 
     pub(in crate::live::sessions) fn push(&self, line: &str) {
         let mut lines = self.lock_lines();
         while lines.len() >= Self::MAX_LINES {
             lines.pop_front();
         }
-        lines.push_back(line.to_string());
+        lines.push_back(Self::bounded_line(line));
     }
 
     fn snapshot(&self) -> Vec<String> {
@@ -64,6 +69,22 @@ impl AgentStderrTail {
         self.lines
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn bounded_line(line: &str) -> String {
+        if line.len() <= Self::MAX_LINE_BYTES {
+            return line.to_string();
+        }
+
+        let mut prefix_end = Self::MAX_LINE_BYTES - Self::TRUNCATED_SUFFIX.len();
+        while !line.is_char_boundary(prefix_end) {
+            prefix_end -= 1;
+        }
+
+        let mut bounded = String::with_capacity(Self::MAX_LINE_BYTES);
+        bounded.push_str(&line[..prefix_end]);
+        bounded.push_str(Self::TRUNCATED_SUFFIX);
+        bounded
     }
 }
 
@@ -226,6 +247,29 @@ mod tests {
         assert_eq!(snapshot.len(), AgentStderrTail::MAX_LINES);
         assert_eq!(snapshot.first(), Some(&format!("line {evicted}")));
         assert_eq!(snapshot.last(), Some(&format!("line {}", total - 1)));
+    }
+
+    #[test]
+    fn agent_stderr_tail_bounds_one_giant_line() {
+        let tail = AgentStderrTail::default();
+        tail.push(&"x".repeat(AgentStderrTail::MAX_LINE_BYTES * 4));
+
+        let snapshot = tail.snapshot();
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].len(), AgentStderrTail::MAX_LINE_BYTES);
+        assert!(snapshot[0].ends_with(AgentStderrTail::TRUNCATED_SUFFIX));
+    }
+
+    #[test]
+    fn agent_stderr_tail_truncates_at_a_utf8_boundary() {
+        let tail = AgentStderrTail::default();
+        tail.push(&"🙂".repeat(AgentStderrTail::MAX_LINE_BYTES));
+
+        let snapshot = tail.snapshot();
+        assert_eq!(snapshot.len(), 1);
+        assert!(snapshot[0].len() <= AgentStderrTail::MAX_LINE_BYTES);
+        assert!(snapshot[0].ends_with(AgentStderrTail::TRUNCATED_SUFFIX));
+        assert!(!snapshot[0].contains('\u{fffd}'));
     }
 
     #[cfg(unix)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
@@ -21,5 +21,6 @@ pub use manager::LiveSessionManager;
 pub(crate) use manager::RevealMcpElicitationUrlError;
 #[cfg(test)]
 pub(crate) use manager::{ScriptedSessionEvent, ScriptedSessionSpec};
+pub(crate) use model::AgentStartupExitError;
 pub use model::SessionStartupStrategy;
 pub use rendezvous::broker::PermissionDecision;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
@@ -21,6 +21,5 @@ pub use manager::LiveSessionManager;
 pub(crate) use manager::RevealMcpElicitationUrlError;
 #[cfg(test)]
 pub(crate) use manager::{ScriptedSessionEvent, ScriptedSessionSpec};
-pub(crate) use model::AgentStartupExitError;
 pub use model::SessionStartupStrategy;
 pub use rendezvous::broker::PermissionDecision;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -33,7 +33,6 @@
 
 use std::any::Any;
 use std::collections::BTreeMap;
-use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -54,45 +53,6 @@ use crate::live::sessions::sink::SessionEventSink;
 // Re-exported: the normalized-payload vocabulary observers consume. The sink
 // module itself stays private to live; these shapes are part of the doorstep.
 pub use crate::live::sessions::sink::{AcpChunkPayload, AcpToolPayload, CompletedAssistantMessage};
-
-/// Startup failure whose ordinary formatting is safe for telemetry, while an
-/// authenticated API mapper may deliberately surface the bounded local stderr
-/// diagnostic to the caller that requested the session.
-#[derive(Clone)]
-pub(crate) struct AgentStartupExitError {
-    telemetry_safe_detail: String,
-    caller_detail: String,
-}
-
-impl AgentStartupExitError {
-    pub(crate) fn new(telemetry_safe_detail: String, caller_detail: String) -> Self {
-        Self {
-            telemetry_safe_detail,
-            caller_detail,
-        }
-    }
-
-    pub(crate) fn caller_detail(&self) -> &str {
-        &self.caller_detail
-    }
-}
-
-impl fmt::Display for AgentStartupExitError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.telemetry_safe_detail)
-    }
-}
-
-impl fmt::Debug for AgentStartupExitError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("AgentStartupExitError")
-            .field("telemetry_safe_detail", &self.telemetry_safe_detail)
-            .finish_non_exhaustive()
-    }
-}
-
-impl std::error::Error for AgentStartupExitError {}
 
 /// How the actor should establish the native agent session at startup.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -33,6 +33,7 @@
 
 use std::any::Any;
 use std::collections::BTreeMap;
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -53,6 +54,45 @@ use crate::live::sessions::sink::SessionEventSink;
 // Re-exported: the normalized-payload vocabulary observers consume. The sink
 // module itself stays private to live; these shapes are part of the doorstep.
 pub use crate::live::sessions::sink::{AcpChunkPayload, AcpToolPayload, CompletedAssistantMessage};
+
+/// Startup failure whose ordinary formatting is safe for telemetry, while an
+/// authenticated API mapper may deliberately surface the bounded local stderr
+/// diagnostic to the caller that requested the session.
+#[derive(Clone)]
+pub(crate) struct AgentStartupExitError {
+    telemetry_safe_detail: String,
+    caller_detail: String,
+}
+
+impl AgentStartupExitError {
+    pub(crate) fn new(telemetry_safe_detail: String, caller_detail: String) -> Self {
+        Self {
+            telemetry_safe_detail,
+            caller_detail,
+        }
+    }
+
+    pub(crate) fn caller_detail(&self) -> &str {
+        &self.caller_detail
+    }
+}
+
+impl fmt::Display for AgentStartupExitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.telemetry_safe_detail)
+    }
+}
+
+impl fmt::Debug for AgentStartupExitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AgentStartupExitError")
+            .field("telemetry_safe_detail", &self.telemetry_safe_detail)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::error::Error for AgentStartupExitError {}
 
 /// How the actor should establish the native agent session at startup.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/anyharness/crates/anyharness-lib/src/observability/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/observability/mod.rs
@@ -1,3 +1,8 @@
 pub mod latency;
 pub mod resource_pressure;
 pub mod transcript_phase;
+
+/// Agent-owned stderr may contain prompts, provider responses, or other raw
+/// child-process output. Keep the target stable so vendor telemetry can
+/// exclude it while console and file logging retain the local diagnostic.
+pub const AGENT_STDERR_TRACING_TARGET: &str = "anyharness.agent_stderr";

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyharness_lib::app::default_runtime_home;
+use anyharness_lib::{app::default_runtime_home, observability::AGENT_STDERR_TRACING_TARGET};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 use crate::{
@@ -49,6 +49,24 @@ fn sample_rate(key: &str, default: f32) -> f32 {
 
 fn env_filter_from_env() -> tracing_subscriber::EnvFilter {
     tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into())
+}
+
+fn sentry_event_filter_for_target(
+    target: &str,
+    default_filter: sentry_tracing::EventFilter,
+) -> sentry_tracing::EventFilter {
+    if target == AGENT_STDERR_TRACING_TARGET {
+        sentry_tracing::EventFilter::Ignore
+    } else {
+        default_filter
+    }
+}
+
+fn sentry_event_filter(metadata: &tracing::Metadata<'_>) -> sentry_tracing::EventFilter {
+    sentry_event_filter_for_target(
+        metadata.target(),
+        sentry_tracing::default_event_filter(metadata),
+    )
 }
 
 fn runtime_home_from_serve(args: &ServeArgs) -> PathBuf {
@@ -111,7 +129,7 @@ pub fn init(command: &Commands) -> TelemetryGuards {
 
     tracing_subscriber::registry()
         .with(console_layer)
-        .with(sentry_tracing::layer())
+        .with(sentry_tracing::layer().event_filter(sentry_event_filter))
         .with(file_sink.as_ref().map(|sink| {
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
@@ -200,12 +218,14 @@ fn sentry_scope_tags() -> Vec<(&'static str, String)> {
 mod tests {
     use super::{
         default_release, log_path_for_command, runtime_home_from_install, runtime_home_from_serve,
-        sentry_scope_tags, sentry_user_from_id, stamped_git_sha,
+        sentry_event_filter, sentry_event_filter_for_target, sentry_scope_tags,
+        sentry_user_from_id, stamped_git_sha,
     };
     use crate::{
         cli::Commands,
         commands::{install_agents::InstallAgentsArgs, serve::ServeArgs},
     };
+    use anyharness_lib::observability::AGENT_STDERR_TRACING_TARGET;
 
     #[test]
     fn tracing_error_reaches_the_sentry_client() {
@@ -217,7 +237,8 @@ mod tests {
         // `sentry-core` the layer uses; it fails (0 events) whenever the two
         // crates diverge again.
         use tracing_subscriber::layer::SubscriberExt;
-        let subscriber = tracing_subscriber::registry().with(sentry_tracing::layer());
+        let subscriber = tracing_subscriber::registry()
+            .with(sentry_tracing::layer().event_filter(sentry_event_filter));
         let events = sentry::test::with_captured_events(|| {
             tracing::subscriber::with_default(subscriber, || {
                 tracing::error!("sentry emission regression probe");
@@ -225,6 +246,42 @@ mod tests {
         });
         assert_eq!(events.len(), 1, "tracing ERROR must reach the Sentry client");
         assert_eq!(events[0].level, sentry::Level::Error);
+    }
+
+    #[test]
+    fn agent_stderr_stays_out_of_sentry_while_runtime_errors_remain_visible() {
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry()
+            .with(sentry_tracing::layer().event_filter(sentry_event_filter));
+        let events = sentry::test::with_captured_events(|| {
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::error!(
+                    target: AGENT_STDERR_TRACING_TARGET,
+                    "raw child-process stderr"
+                );
+                tracing::error!("ordinary runtime failure");
+            });
+        });
+
+        assert_eq!(events.len(), 1, "agent stderr must be ignored by Sentry");
+        assert_eq!(
+            events[0].message.as_deref(),
+            Some("ordinary runtime failure")
+        );
+    }
+
+    #[test]
+    fn agent_stderr_filter_ignores_every_sentry_signal_type() {
+        let all_signal_types = sentry_tracing::EventFilter::Event
+            | sentry_tracing::EventFilter::Breadcrumb
+            | sentry_tracing::EventFilter::Log;
+
+        let filter = sentry_event_filter_for_target(AGENT_STDERR_TRACING_TARGET, all_signal_types);
+
+        assert!(
+            filter.is_empty(),
+            "agent stderr must map to EventFilter::Ignore"
+        );
     }
 
     #[test]

--- a/anyharness/sdk/src/client/core.test.ts
+++ b/anyharness/sdk/src/client/core.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { AnyHarnessError, AnyHarnessTransport } from "./core.js";
+import {
+  AnyHarnessError,
+  AnyHarnessTransport,
+  toAnyHarnessTelemetryError,
+} from "./core.js";
 
 describe("AnyHarnessTransport problem details", () => {
   it("preserves valid RFC 7807 fields", async () => {
@@ -119,6 +123,73 @@ describe("AnyHarnessTransport problem details", () => {
       title: "Request failed",
       status: 500,
     });
+  });
+
+  it("keeps caller detail while producing a detached telemetry-safe error", async () => {
+    const rawTail = "provider stderr: token=caller-only-secret";
+    const error = await requestError(problemResponse({
+      type: "about:blank",
+      title: "Internal error",
+      status: 500,
+      detail: `ACP session start failed: ${rawTail}`,
+      code: "AGENT_STARTUP_FAILED",
+    }, 500));
+
+    const telemetryError = toAnyHarnessTelemetryError(error);
+
+    expect(error.message).toContain(rawTail);
+    expect(telemetryError).toBeInstanceOf(Error);
+    expect(telemetryError).not.toBe(error);
+    expect((telemetryError as Error).message).toBe(
+      "AnyHarness request failed (AGENT_STARTUP_FAILED)",
+    );
+    expect(telemetryError).toMatchObject({
+      name: "AnyHarnessError",
+      code: "AGENT_STARTUP_FAILED",
+      status: 500,
+    });
+    expect("problem" in (telemetryError as object)).toBe(false);
+    expect("cause" in (telemetryError as object)).toBe(false);
+    expect((telemetryError as Error).stack).not.toContain(rawTail);
+    expect(JSON.stringify(telemetryError)).not.toContain(rawTail);
+  });
+
+  it("does not trust an arbitrary problem code in telemetry", () => {
+    const rawCode = "provider output must not reach telemetry";
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Internal error",
+      status: 500,
+      detail: "caller-only detail",
+      code: rawCode,
+    });
+
+    const telemetryError = toAnyHarnessTelemetryError(error) as Error & { code?: string };
+
+    expect(telemetryError.message).toBe("AnyHarness request failed");
+    expect(telemetryError.code).toBeUndefined();
+    expect(telemetryError.stack).not.toContain(rawCode);
+    expect(JSON.stringify(telemetryError)).not.toContain(rawCode);
+  });
+
+  it("removes a wrapping cause chain when it contains an AnyHarness error", () => {
+    const rawTail = "provider stderr caller-only detail";
+    const cause = new AnyHarnessError({
+      type: "about:blank",
+      title: "Internal error",
+      status: 500,
+      detail: rawTail,
+      code: "AGENT_STARTUP_FAILED",
+    });
+    const wrapper = new Error("Failed to open chat", { cause });
+
+    const telemetryError = toAnyHarnessTelemetryError(wrapper);
+
+    expect(telemetryError).not.toBe(wrapper);
+    expect((telemetryError as Error).message).toContain("AGENT_STARTUP_FAILED");
+    expect("cause" in (telemetryError as object)).toBe(false);
+    expect((telemetryError as Error).stack).not.toContain(rawTail);
+    expect(JSON.stringify(telemetryError)).not.toContain(rawTail);
   });
 });
 

--- a/anyharness/sdk/src/client/core.ts
+++ b/anyharness/sdk/src/client/core.ts
@@ -177,6 +177,53 @@ export class AnyHarnessError extends Error {
   }
 }
 
+const TELEMETRY_SAFE_PROBLEM_CODE = /^[A-Z][A-Z0-9_]{0,63}$/;
+
+/**
+ * Replace an AnyHarness request error (or an Error wrapping one) with a
+ * detached telemetry representation. RFC 7807 `detail` remains available on
+ * the original error for caller-facing UI, but neither it nor the original
+ * cause chain can reach an exception transport through the returned value.
+ */
+export function toAnyHarnessTelemetryError(error: unknown): unknown {
+  const anyHarnessError = findAnyHarnessError(error);
+  if (!anyHarnessError) {
+    return error;
+  }
+
+  const rawCode = anyHarnessError.problem.code;
+  const code = typeof rawCode === "string" && TELEMETRY_SAFE_PROBLEM_CODE.test(rawCode)
+    ? rawCode
+    : null;
+  const safeError = new Error(
+    code
+      ? `AnyHarness request failed (${code})`
+      : "AnyHarness request failed",
+  ) as Error & { code?: string; status: number };
+  safeError.name = "AnyHarnessError";
+  safeError.status = anyHarnessError.problem.status;
+  if (code) {
+    safeError.code = code;
+  }
+  return safeError;
+}
+
+function findAnyHarnessError(error: unknown): AnyHarnessError | null {
+  let current = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current != null; depth += 1) {
+    if (current instanceof AnyHarnessError) {
+      return current;
+    }
+    if (!(current instanceof Error) || seen.has(current)) {
+      return null;
+    }
+    seen.add(current);
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return null;
+}
+
 export class AnyHarnessTransport {
   readonly baseUrl: string;
   readonly authToken?: string;

--- a/anyharness/sdk/src/index.ts
+++ b/anyharness/sdk/src/index.ts
@@ -3,6 +3,7 @@ export {
   AnyHarnessError,
   hashTimingScope,
   setAnyHarnessTimingObserver,
+  toAnyHarnessTelemetryError,
 } from "./client/core.js";
 export type {
   AnyHarnessClientOptions,

--- a/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.test.tsx
+++ b/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import { AnyHarnessError } from "@anyharness/sdk";
 
 import type { ProductTelemetry } from "@proliferate/product-client/host/product-host";
 import {
@@ -75,6 +76,38 @@ describe("useProductTelemetry", () => {
       routeId: "main",
     });
     expect(telemetry.getSupportContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps AnyHarness caller detail out of the explicit host capture", () => {
+    const telemetry = spyTelemetry();
+    const { result } = renderFacade(telemetry);
+    const rawTail = "provider stderr: caller-only-secret";
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Internal error",
+      status: 500,
+      detail: rawTail,
+      code: "AGENT_STARTUP_FAILED",
+    });
+
+    result.current.captureException(error, {
+      tags: { action: "create_session_with_resolved_config" },
+    });
+
+    const [capturedError, context] = vi.mocked(telemetry.captureException).mock.calls[0];
+    expect(error.message).toBe(rawTail);
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).not.toBe(error);
+    expect((capturedError as Error).message).toBe(
+      "AnyHarness request failed (AGENT_STARTUP_FAILED)",
+    );
+    expect("problem" in (capturedError as object)).toBe(false);
+    expect("cause" in (capturedError as object)).toBe(false);
+    expect((capturedError as Error).stack).not.toContain(rawTail);
+    expect(JSON.stringify(capturedError)).not.toContain(rawTail);
+    expect(context).toEqual({
+      tags: { action: "create_session_with_resolved_config" },
+    });
   });
 
   it("returns a stable adapter identity while the host is unchanged", () => {

--- a/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.ts
+++ b/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { toAnyHarnessTelemetryError } from "@anyharness/sdk";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import type {
   ErrorContext,
@@ -53,7 +54,7 @@ export function useProductTelemetry(): ProductTelemetryFacade {
         });
       },
       captureException(error, context) {
-        telemetry.captureException(error, context);
+        telemetry.captureException(toAnyHarnessTelemetryError(error), context);
       },
       setUser(user) {
         telemetry.setUser(user);

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx
@@ -172,11 +172,12 @@ describe("useWorkspaceActions local workspace creation", () => {
   });
 
   it("propagates create errors without resolving an existing workspace", async () => {
+    const sensitiveWorkspacePath = "/synthetic/telemetry/private-workspace";
     const error = new AnyHarnessError({
       type: "about:blank",
       title: "Bad request",
       status: 400,
-      detail: "a workspace record already exists for path: /Users/pablo/proliferate",
+      detail: `a workspace record already exists for path: ${sensitiveWorkspacePath}`,
       code: "WORKSPACE_CREATE_FAILED",
     });
     mocks.create.mockRejectedValueOnce(error);
@@ -185,14 +186,14 @@ describe("useWorkspaceActions local workspace creation", () => {
     let thrown: unknown = null;
     await act(async () => {
       try {
-        await result.current.createLocalWorkspace("/Users/pablo/proliferate");
+        await result.current.createLocalWorkspace(sensitiveWorkspacePath);
       } catch (caught) {
         thrown = caught;
       }
     });
 
     expect(thrown).toBe(error);
-    expect(error.message).toContain("/Users/pablo/proliferate");
+    expect(error.message).toContain(sensitiveWorkspacePath);
     expect(mocks.resolveFromPath).not.toHaveBeenCalled();
     expect(mocks.trackProductEvent).not.toHaveBeenCalled();
     expect(mocks.captureTelemetryException).toHaveBeenCalledTimes(1);
@@ -204,7 +205,7 @@ describe("useWorkspaceActions local workspace creation", () => {
     );
     expect("problem" in capturedError).toBe(false);
     expect("cause" in capturedError).toBe(false);
-    expect(capturedError.stack).not.toContain("/Users/pablo/proliferate");
+    expect(capturedError.stack).not.toContain(sensitiveWorkspacePath);
     expect(context).toEqual({
       tags: {
         action: "create_local_workspace",

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.test.tsx
@@ -192,9 +192,20 @@ describe("useWorkspaceActions local workspace creation", () => {
     });
 
     expect(thrown).toBe(error);
+    expect(error.message).toContain("/Users/pablo/proliferate");
     expect(mocks.resolveFromPath).not.toHaveBeenCalled();
     expect(mocks.trackProductEvent).not.toHaveBeenCalled();
-    expect(mocks.captureTelemetryException).toHaveBeenCalledWith(error, {
+    expect(mocks.captureTelemetryException).toHaveBeenCalledTimes(1);
+    const [capturedError, context] = mocks.captureTelemetryException.mock.calls[0];
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).not.toBe(error);
+    expect(capturedError.message).toBe(
+      "AnyHarness request failed (WORKSPACE_CREATE_FAILED)",
+    );
+    expect("problem" in capturedError).toBe(false);
+    expect("cause" in capturedError).toBe(false);
+    expect(capturedError.stack).not.toContain("/Users/pablo/proliferate");
+    expect(context).toEqual({
       tags: {
         action: "create_local_workspace",
         domain: "workspace",

--- a/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
@@ -98,12 +98,6 @@ describe("createAppQueryClient query telemetry", () => {
       "workspace_state_conflict",
     )],
     ["5xx request failure", new ProliferateClientError("Unavailable", 503)],
-    ["coded AnyHarness request failure", new AnyHarnessError({
-      type: "about:blank",
-      title: "Pull request lookup failed",
-      status: 400,
-      code: "HOSTING_PR_VIEW_FAILED",
-    })],
     ["network failure", new TypeError("Failed to fetch")],
     ["unknown programming failure", new Error("Invariant failed")],
     [
@@ -126,6 +120,88 @@ describe("createAppQueryClient query telemetry", () => {
       },
       extras: {
         query_hash: hashAppQueryKey(queryKey),
+      },
+    });
+  });
+
+  it("captures an AnyHarness 5xx without its caller-facing detail", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const rawTail = "provider stderr: caller-only-secret";
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Internal error",
+      status: 500,
+      detail: rawTail,
+      code: "AGENT_STARTUP_FAILED",
+    });
+    const queryKey = ["session", "create"];
+
+    await runFailingQuery(client, queryKey, error);
+
+    expect(error.message).toBe(rawTail);
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [capturedError, context] = captureException.mock.calls[0];
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).not.toBe(error);
+    expect(capturedError.message).toBe(
+      "AnyHarness request failed (AGENT_STARTUP_FAILED)",
+    );
+    expect("problem" in capturedError).toBe(false);
+    expect("cause" in capturedError).toBe(false);
+    expect(capturedError.stack).not.toContain(rawTail);
+    expect(JSON.stringify(capturedError)).not.toContain(rawTail);
+    expect(context).toEqual({
+      tags: {
+        action: "query_error",
+        domain: "react_query",
+      },
+      extras: {
+        query_hash: hashAppQueryKey(queryKey),
+      },
+    });
+  });
+
+  it("captures an AnyHarness mutation failure without its caller-facing detail", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const rawTail = "provider stderr: mutation-caller-only-secret";
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Internal error",
+      status: 500,
+      detail: rawTail,
+      code: "AGENT_STARTUP_FAILED",
+    });
+    const mutationKey = ["session", "create"];
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey,
+      mutationFn: async () => {
+        throw error;
+      },
+      retry: false,
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toBe(error);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [capturedError, context] = captureException.mock.calls[0];
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).not.toBe(error);
+    expect(capturedError.message).toBe(
+      "AnyHarness request failed (AGENT_STARTUP_FAILED)",
+    );
+    expect("problem" in capturedError).toBe(false);
+    expect("cause" in capturedError).toBe(false);
+    expect(capturedError.stack).not.toContain(rawTail);
+    expect(JSON.stringify(capturedError)).not.toContain(rawTail);
+    expect(context).toEqual({
+      tags: {
+        action: "mutation_error",
+        domain: "react_query",
+      },
+      extras: {
+        mutation_key: hashAppQueryKey(mutationKey),
       },
     });
   });

--- a/apps/packages/product-client/src/lib/infra/query/query-client.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.ts
@@ -4,6 +4,7 @@ import {
   QueryCache,
   QueryClient,
 } from "@tanstack/react-query";
+import { toAnyHarnessTelemetryError } from "@anyharness/sdk";
 import {
   isExpectedMutationTelemetryError,
   isExpectedQueryTelemetryError,
@@ -118,7 +119,7 @@ export function createAppQueryClient({
           return;
         }
 
-        captureException(error, {
+        captureException(toAnyHarnessTelemetryError(error), {
           tags: {
             action: "query_error",
             domain: "react_query",
@@ -139,7 +140,7 @@ export function createAppQueryClient({
         }
 
         const mutationKey = mutation.options.mutationKey;
-        captureException(error, {
+        captureException(toAnyHarnessTelemetryError(error), {
           tags: {
             action: "mutation_error",
             domain: "react_query",

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -65,5 +65,5 @@ apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 p
 anyharness/crates/anyharness-lib/src/api/router.rs 628 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs/cancel + local materialization operations + workflow-run-workspaces routes)
 anyharness/crates/anyharness-lib/src/app/mod.rs 647 AnyHarness app wiring (+session mutation admission purge/retention wiring, +goal/loop/activity/feed services, +two-phase workflow-run and workflow-workspace wiring, +local materialization service wiring)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam)
-anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 686 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
+anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 648 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations

--- a/specs/codebase/systems/engineering/observability/sentry.md
+++ b/specs/codebase/systems/engineering/observability/sentry.md
@@ -74,6 +74,14 @@ authorization headers, tokens, secrets, environment values, or provider
 responses. Correlation identifiers are diagnostic metadata, not permission to
 copy user content into Sentry.
 
+AnyHarness marks direct child-agent stderr events with a dedicated tracing
+target that the Sentry layer ignores while console/file logging remains
+available locally. The exclusion applies to Sentry events, breadcrumbs, and
+structured logs. A startup failure writes its bounded stderr tail to that
+excluded local diagnostic and carries it in a typed error for the initiating
+authenticated API response; ordinary error formatting and API telemetry use a
+status-only summary. Raw provider output is not a safe Sentry grouping key.
+
 Two exact, bounded fields are deliberately preserved through the scrubbers
 because they are deployment identity, not a raw process-environment map:
 

--- a/specs/codebase/systems/engineering/observability/sentry.md
+++ b/specs/codebase/systems/engineering/observability/sentry.md
@@ -77,10 +77,17 @@ copy user content into Sentry.
 AnyHarness marks direct child-agent stderr events with a dedicated tracing
 target that the Sentry layer ignores while console/file logging remains
 available locally. The exclusion applies to Sentry events, breadcrumbs, and
-structured logs. A startup failure writes its bounded stderr tail to that
-excluded local diagnostic and carries it in a typed error for the initiating
-authenticated API response; ordinary error formatting and API telemetry use a
-status-only summary. Raw provider output is not a safe Sentry grouping key.
+structured logs. A startup failure retains at most eight lines and 1,024 UTF-8
+bytes per line, writes that bounded tail to the excluded local diagnostic, and
+carries it in a domain-owned typed error for the initiating authenticated API
+response. Ordinary error formatting and API telemetry use a status-only
+summary. The response also carries the stable `AGENT_STARTUP_FAILED` code;
+`@anyharness/sdk` uses that structured problem to create a detached telemetry
+error whose message and metadata derive only from a validated code and HTTP
+status, with no original problem or cause chain. ProductClient applies that
+projection both at its explicit exception facade and its global React Query
+capture boundary while preserving the original detail for UI.
+Raw provider output is not a safe Sentry grouping key or exception message.
 
 Two exact, bounded fields are deliberately preserved through the scrubbers
 because they are deployment identity, not a raw process-environment map:


### PR DESCRIPTION
## Summary

- Exclude direct child-agent stderr from every AnyHarness Sentry signal type through a dedicated tracing target while preserving console/file diagnostics.
- Carry startup exit diagnostics through a domain-owned typed error with the stable `AGENT_STARTUP_FAILED` code, status-only `Display`/`Debug`, and an eight-line, 1,024-byte-per-line UTF-8-safe caller tail.
- Preserve bounded UI detail while `@anyharness/sdk` creates a detached telemetry error and ProductClient applies it at both explicit exception and React Query query/mutation capture boundaries.
- Keep the startup diagnostic beside the stderr driver and remove the API-to-live runtime ownership violation without increasing any size allowlist.

## Release note

Section: Fix
Title: Safer agent startup diagnostics
Description: Agent startup failures now preserve useful local diagnostics without sending raw child-process output to telemetry.
Group: agent-stderr-telemetry

## Production evidence

- Exact-event triage of a Claude runtime event found only a generic multiline opener, with no model, OpenAI-compatible gateway, or LiteLLM signature. The underlying Claude condition remains unknown because the event captured only the first physical stderr line.
- A separate exact Sentry group combines nine pre-fix local `gpt-5.6-sol` rejections with eight unrelated stderr messages under one fingerprint. The route-selection defect had already been fixed; this PR fixes the shared stderr telemetry/grouping defect.
- The two production rows have distinct Sentry groups, agents, releases, and exact-event identities, so they are intentionally not deduplicated.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] Fix relationships are linked through the tracker API. No tracker, report, user, or support identifiers, raw logs, credentials, private source data, or telemetry identities appear in this PR.

## Verification

- `CARGO_BUILD_JOBS=1 cargo test -q -p anyharness-lib 'live::sessions::driver::stderr::tests::' -- --nocapture` (11 passed)
- `CARGO_BUILD_JOBS=1 cargo test -q -p anyharness-lib 'stderr_detail_reaches_caller' -- --nocapture` (2 passed)
- `CARGO_BUILD_JOBS=1 cargo test -q -p anyharness-lib 'api::http::error::tests::internal_error_can_' -- --nocapture` (2 passed)
- `CARGO_BUILD_JOBS=1 cargo test -p anyharness 'telemetry::tests::' -- --nocapture` (11 passed)
- `pnpm --filter @anyharness/sdk build`
- `pnpm --filter @anyharness/sdk test` (15 files, 99 tests passed)
- `pnpm --filter @proliferate/product-client build`
- `pnpm --filter @proliferate/product-client test` (556 files, 3,299 tests passed)
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --filter @proliferate/product-client exec vitest run src/hooks/workspaces/workflows/use-workspace-actions.test.tsx` (1 file, 3 tests passed; frozen lockfile unchanged)
- `python3 scripts/check_anyharness_boundaries.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_docs.py`
- `git diff --check`
- Independent privacy, boundary, and bounded-reader reviews: no blockers.
- Intentional dependency delta: `anyharness-lib` adds `tracing-subscriber` as a test-only dev dependency to capture the logging boundary; `Cargo.lock` adds only that dependency edge.
- Repository-wide `cargo fmt --all -- --check` still reports pre-existing formatting drift in untouched files.