### PR TITLE
fix(server): allow Web environment GitHub returns

### DIFF
--- a/server/proliferate/server/cloud/github_app/service.py
+++ b/server/proliferate/server/cloud/github_app/service.py
@@ -58,6 +58,7 @@ _WEB_RETURN_PATHS = frozenset(
     {
         "/settings",
         "/settings/account",
+        "/settings/environments",
         "/settings/organization",
         "/settings/organizations",
     }

--- a/server/tests/unit/test_github_app_service.py
+++ b/server/tests/unit/test_github_app_service.py
@@ -456,6 +456,29 @@ async def test_create_github_app_installation_url_allows_desktop_environment_ret
     )
 
 
+@pytest.mark.asyncio
+async def test_create_github_app_installation_url_allows_web_environment_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(service.settings, "cloud_secret_key", "test-secret")
+    monkeypatch.setattr(service.settings, "github_app_slug", "proliferate-dev")
+    monkeypatch.setattr(service.settings, "frontend_base_url", "https://app.example.test")
+    org_user = _OrgUser(actor_user_id=uuid.uuid4(), organization_id=uuid.uuid4())
+
+    response = await service.create_github_app_installation_url(
+        object(),
+        org_user=org_user,
+        return_to=(
+            "https://app.example.test/settings/environments"
+            "?source=github_app_installation_callback"
+        ),
+    )
+
+    assert response.installation_url.startswith(
+        "https://github.com/apps/proliferate-dev/installations/new?state="
+    )
+
+
 # --- Repo authority error-to-status/action mapping (frozen PR 1 contract) -----
 #
 # The authority endpoint may only recommend an action that can actually repair


### PR DESCRIPTION
## Summary

- allow the hosted Web settings environment route as a same-origin GitHub App callback target
- cover the Web installation-start contract alongside the existing Desktop environment return

## Root cause and impact

Hosted Web builds the GitHub App setup return URL at `/settings/environments`, but the server allowlist omitted that routed path. The server therefore rejected a valid same-origin setup request before redirecting to GitHub. The allowlist remains exact-origin, exact-path, and fragment-free.

## Verification

- `DEBUG=true uv run --extra dev pytest -q tests/unit/test_github_app_service.py tests/unit/test_github_app_callback_return.py` (17 passed)
- `uv run --extra dev ruff check proliferate/server/cloud/github_app/service.py tests/unit/test_github_app_service.py`
- `git diff --check`

## Tracker

The fixing relationship is linked through the production tracker; no private tracker identifiers or telemetry identities are included here.