### PR TITLE
fix(product): separate desktop transport failures

### DIFF
--- a/apps/packages/product-client/src/hooks/access/cloud/use-cloud-billing.test.tsx
+++ b/apps/packages/product-client/src/hooks/access/cloud/use-cloud-billing.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  getCloudBillingPlan: vi.fn(),
+}));
+
+vi.mock("@proliferate/cloud-sdk/client/billing", () => ({
+  createBillingPortalSession: vi.fn(),
+  createCloudCheckoutSession: vi.fn(),
+  createRefillCheckoutSession: vi.fn(),
+  getCloudBillingPlan: mocks.getCloudBillingPlan,
+  updateOverageSettings: vi.fn(),
+}));
+
+vi.mock("#product/hooks/telemetry/facade/use-product-telemetry", () => ({
+  useProductTelemetry: () => ({ captureException: mocks.captureException }),
+}));
+
+import { useCloudBillingQuery } from "#product/hooks/access/cloud/use-cloud-billing";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useCloudBillingQuery", () => {
+  it("preserves transport failures and fingerprints them by operation", async () => {
+    const error = new TypeError("Load failed");
+    mocks.getCloudBillingPlan.mockRejectedValue(error);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useCloudBillingQuery(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(mocks.captureException).toHaveBeenCalledWith(error, {
+      tags: {
+        action: "fetch_billing_plan",
+        domain: "cloud_billing",
+        route: "settings",
+      },
+      fingerprint: ["{{ default }}", "fetch_billing_plan"],
+    });
+  });
+});

--- a/apps/packages/product-client/src/hooks/access/cloud/use-cloud-billing.ts
+++ b/apps/packages/product-client/src/hooks/access/cloud/use-cloud-billing.ts
@@ -145,6 +145,7 @@ export function useCloudBillingQuery(
             domain: "cloud_billing",
             route: "settings",
           },
+          fingerprint: ["{{ default }}", "fetch_billing_plan"],
         });
         throw error;
       }

--- a/apps/packages/product-client/src/lib/workflows/cloud/ensure-desktop-worker.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/cloud/ensure-desktop-worker.test.ts
@@ -68,6 +68,13 @@ describe("ensureDesktopWorker", () => {
     await expect(ensureDesktopWorker(null, worker, { onFailure, captureException })).resolves.toBe(false);
 
     expect(tauriMocks.ensureDesktopDispatchWorker).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledWith(error, {
+      tags: {
+        action: "ensure-desktop-worker",
+        domain: "cloud",
+      },
+      fingerprint: ["{{ default }}", "ensure-desktop-worker"],
+    });
     expect(onFailure).toHaveBeenCalledWith(error);
   });
 

--- a/apps/packages/product-client/src/lib/workflows/cloud/ensure-desktop-worker.ts
+++ b/apps/packages/product-client/src/lib/workflows/cloud/ensure-desktop-worker.ts
@@ -61,6 +61,7 @@ export function ensureDesktopWorker(
           action: "ensure-desktop-worker",
           domain: "cloud",
         },
+        fingerprint: ["{{ default }}", "ensure-desktop-worker"],
       });
       try {
         deps.onFailure(error);

--- a/apps/packages/product-client/src/providers/ProductProviderRoot.test.tsx
+++ b/apps/packages/product-client/src/providers/ProductProviderRoot.test.tsx
@@ -77,16 +77,17 @@ describe("ProductProviderRoot", () => {
       </ProductProviderRoot>,
     );
 
-    expect(mocks.runtimeProps.at(-1)?.runtimeUrl).toBeNull();
+    expect(mocks.runtimeProps[mocks.runtimeProps.length - 1]?.runtimeUrl).toBeNull();
 
     act(() => {
       useHarnessConnectionStore.setState({ connectionState: "healthy" });
     });
-    expect(mocks.runtimeProps.at(-1)?.runtimeUrl).toBe("http://127.0.0.1:9001");
+    expect(mocks.runtimeProps[mocks.runtimeProps.length - 1]?.runtimeUrl)
+      .toBe("http://127.0.0.1:9001");
 
     act(() => {
       useHarnessConnectionStore.setState({ connectionState: "failed" });
     });
-    expect(mocks.runtimeProps.at(-1)?.runtimeUrl).toBeNull();
+    expect(mocks.runtimeProps[mocks.runtimeProps.length - 1]?.runtimeUrl).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/providers/ProductProviderRoot.test.tsx
+++ b/apps/packages/product-client/src/providers/ProductProviderRoot.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runtimeProps: [] as Array<{ runtimeUrl: string | null }>,
+  resolveConnection: vi.fn(),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  AnyHarnessRuntime: ({
+    children,
+    runtimeUrl,
+  }: {
+    children: ReactNode;
+    runtimeUrl: string | null;
+  }) => {
+    mocks.runtimeProps.push({ runtimeUrl });
+    return children;
+  },
+  AnyHarnessWorkspace: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    desktop: null,
+    cloud: { client: null },
+    deployment: { apiBaseUrl: "https://api.example.test" },
+    auth: { state: { status: "anonymous", methods: [] } },
+  }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-resolve-workspace-connection", () => ({
+  useResolveWorkspaceConnection: () => mocks.resolveConnection,
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary", () => ({
+  useCloudWorkspaceMaterializationCacheBoundary: () => {},
+}));
+
+vi.mock("#product/providers/TelemetryProvider", () => ({
+  TelemetryProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ProductProviderRoot } from "#product/providers/ProductProviderRoot";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+beforeEach(() => {
+  mocks.runtimeProps.length = 0;
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "http://127.0.0.1:9001",
+    connectionState: "connecting",
+    error: null,
+  });
+  useSessionSelectionStore.setState({
+    selectedWorkspaceId: null,
+    selectedLogicalWorkspaceId: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProductProviderRoot", () => {
+  it("publishes the local runtime to runtime-level SDK queries only while it is healthy", () => {
+    render(
+      <ProductProviderRoot>
+        <div />
+      </ProductProviderRoot>,
+    );
+
+    expect(mocks.runtimeProps.at(-1)?.runtimeUrl).toBeNull();
+
+    act(() => {
+      useHarnessConnectionStore.setState({ connectionState: "healthy" });
+    });
+    expect(mocks.runtimeProps.at(-1)?.runtimeUrl).toBe("http://127.0.0.1:9001");
+
+    act(() => {
+      useHarnessConnectionStore.setState({ connectionState: "failed" });
+    });
+    expect(mocks.runtimeProps.at(-1)?.runtimeUrl).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/providers/ProductProviderRoot.tsx
+++ b/apps/packages/product-client/src/providers/ProductProviderRoot.tsx
@@ -44,6 +44,8 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
     authStatus === "loading" ? "bootstrapping" : authStatus;
   const location = useLocation();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
+  const runtimeConnectionState = useHarnessConnectionStore((state) => state.connectionState);
+  const readyRuntimeUrl = runtimeConnectionState === "healthy" ? runtimeUrl : "";
   const cacheScopeKey = useMemo(() => buildAnyHarnessCacheScopeKey({
     apiBaseUrl,
     authStatus: cacheAuthStatus,
@@ -67,7 +69,7 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
   });
 
   return (
-    <AnyHarnessRuntime runtimeUrl={runtimeUrl || null} cacheScopeKey={cacheScopeKey}>
+    <AnyHarnessRuntime runtimeUrl={readyRuntimeUrl || null} cacheScopeKey={cacheScopeKey}>
       <CloudWorkspaceMaterializationCacheBoundary>
         <AnyHarnessWorkspace
           workspaceId={providerWorkspaceId}


### PR DESCRIPTION
## Summary

- Keep runtime-level AnyHarness SDK queries idle until the Desktop local runtime reports healthy, preventing startup unavailability from becoming query-error telemetry.
- Preserve real hosted transport failures while adding default-plus-operation fingerprints so billing-plan and desktop-worker enrollment failures no longer collapse into one future group.
- Cover the provider state transitions and both explicit telemetry capture paths with focused tests.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Focused ProductClient Vitest run: 3 files, 7 tests passed.
- Shared Packages CI: ProductClient 559 files / 3,326 tests passed; workflow surface 9 tests passed.
- Full pull-request matrix: 23 checks passed on head 7d23ad286, including Web/Desktop builds, CodeQL, intent tests, self-host smoke, Vercel, and Cargo.