### PR TITLE
fix(product): classify expected auth control states

### DIFF
--- a/apps/desktop/src/lib/integrations/auth/proliferate-auth-transport.ts
+++ b/apps/desktop/src/lib/integrations/auth/proliferate-auth-transport.ts
@@ -6,6 +6,7 @@ import { buildProliferateApiUrl } from "@/lib/infra/proliferate-api"
 // `AuthRequestError` class (instanceof-stable) and one `isAbortError` predicate.
 export {
   AuthRequestError,
+  InteractiveAuthTimeoutError,
   isDefinitiveAuthRejection,
   fetchAuthResponse,
   delay,

--- a/apps/desktop/src/lib/integrations/auth/proliferate-auth.ts
+++ b/apps/desktop/src/lib/integrations/auth/proliferate-auth.ts
@@ -17,6 +17,7 @@ import {
   fetchAuthResponse,
   isAbortError,
   isDefinitiveAuthRejection,
+  InteractiveAuthTimeoutError,
   parseAuthError,
 } from "./proliferate-auth-transport"
 import {
@@ -247,9 +248,8 @@ export async function pollGitHubDesktopSession(
     throw lastError
   }
 
-  throw new AuthRequestError(
+  throw new InteractiveAuthTimeoutError(
     options.timeoutMessage ?? "Sign-in timed out. Finish the browser flow and try again.",
-    408,
   )
 }
 

--- a/apps/packages/product-client/src/components/auth/AuthShell.test.tsx
+++ b/apps/packages/product-client/src/components/auth/AuthShell.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  githubCatch: vi.fn(),
+  githubSignIn: vi.fn(),
+  ssoCatch: vi.fn(),
+  ssoSignIn: vi.fn(),
+}));
+
+vi.mock("#product/hooks/auth/workflows/use-github-sign-in", () => ({
+  useGitHubSignIn: () => ({
+    signIn: mocks.githubSignIn,
+    submitting: false,
+    error: null,
+    signInAvailable: true,
+    signInChecking: false,
+    signInUnavailableDescription: "",
+    cancelSignIn: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock("#product/hooks/auth/workflows/use-sso-sign-in", () => ({
+  useSsoSignIn: () => ({
+    signIn: mocks.ssoSignIn,
+    submitting: false,
+    error: null,
+    signInAvailable: true,
+    signInChecking: false,
+    signInUnavailableDescription: "",
+    displayName: "Acme",
+    cancelSignIn: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock("#product/hooks/auth/workflows/use-password-sign-in", () => ({
+  usePasswordSignIn: () => ({
+    signIn: vi.fn(async () => {}),
+    submitting: false,
+    error: null,
+    signInAvailable: false,
+  }),
+}));
+
+vi.mock("#product/components/auth/AuthScreenLayout", () => ({
+  AuthScreenLayout: (props: {
+    onGitHubSignIn: () => void;
+    onSsoSignIn: () => void;
+  }) => (
+    <>
+      <button onClick={props.onGitHubSignIn}>GitHub</button>
+      <button onClick={props.onSsoSignIn}>SSO</button>
+    </>
+  ),
+}));
+
+import { AuthShell } from "./AuthShell";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.githubSignIn.mockReturnValue({
+    catch: mocks.githubCatch,
+  } as unknown as Promise<void>);
+  mocks.ssoSignIn.mockReturnValue({
+    catch: mocks.ssoCatch,
+  } as unknown as Promise<void>);
+});
+
+describe("AuthShell", () => {
+  it("consumes GitHub and SSO rejections after their hooks surface the error", () => {
+    render(<AuthShell mode="auth" markComplete />);
+
+    fireEvent.click(screen.getByRole("button", { name: "GitHub" }));
+    fireEvent.click(screen.getByRole("button", { name: "SSO" }));
+
+    expect(mocks.githubCatch).toHaveBeenCalledOnce();
+    expect(mocks.ssoCatch).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/packages/product-client/src/components/auth/AuthShell.tsx
+++ b/apps/packages/product-client/src/components/auth/AuthShell.tsx
@@ -62,10 +62,14 @@ export function AuthShell({ mode, markComplete, onMarkResolved }: AuthShellProps
       passwordSignInAvailable={passwordSignInAvailable}
       passwordSubmitting={passwordSubmitting}
       onGitHubSignIn={() => {
-        void signIn();
+        void signIn().catch(() => {
+          // error is already surfaced via the hook's `error` state
+        });
       }}
       onSsoSignIn={() => {
-        void signInWithSso();
+        void signInWithSso().catch(() => {
+          // error is already surfaced via the hook's `error` state
+        });
       }}
       onPasswordSignIn={(email, password) => {
         void signInWithPassword(email, password).catch(() => {

--- a/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.test.ts
+++ b/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthRequestError } from "#product/lib/access/cloud/auth-transport";
+import {
+  makeTestProductHost,
+  productHostWrapper,
+} from "#product/test/product-host-test-utils";
+import { useAuditedAuth } from "./use-audited-auth";
+
+afterEach(cleanup);
+
+function harness(error: Error) {
+  const captureException = vi.fn();
+  const track = vi.fn();
+  const host = makeTestProductHost({
+    auth: {
+      startLogin: vi.fn(async () => {
+        throw error;
+      }),
+    },
+    overrides: {
+      telemetry: {
+        track,
+        captureException,
+        setUser: vi.fn(),
+        setTag: vi.fn(),
+        routeChanged: vi.fn(),
+        getSupportContext: () => ({ clientReleaseId: "desktop@test" }),
+        getAnonymousInstallId: async () => null,
+      },
+    },
+  });
+  return {
+    captureException,
+    track,
+    ...renderHook(() => useAuditedAuth(), {
+      wrapper: productHostWrapper(host),
+    }),
+  };
+}
+
+describe("useAuditedAuth", () => {
+  it("tracks an interactive timeout without capturing it as an exception", async () => {
+    const error = new AuthRequestError("Sign-in timed out.", 408);
+    const { result, captureException, track } = harness(error);
+
+    await act(async () => {
+      await expect(
+        result.current.startLogin({ kind: "github" }),
+      ).rejects.toBe(error);
+    });
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith({
+      name: "auth_sign_in_failed",
+      properties: {
+        failure_kind: "configuration_error",
+        provider: "github",
+      },
+    });
+  });
+
+  it("continues capturing non-control auth failures", async () => {
+    const error = new AuthRequestError("Cloud unavailable.", 503);
+    const { result, captureException } = harness(error);
+
+    await act(async () => {
+      await expect(
+        result.current.startLogin({ kind: "github" }),
+      ).rejects.toBe(error);
+    });
+
+    expect(captureException).toHaveBeenCalledWith(error, {
+      tags: { action: "sign_in", domain: "auth", provider: "github" },
+    });
+  });
+});

--- a/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.test.ts
+++ b/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.test.ts
@@ -2,7 +2,10 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AuthRequestError } from "#product/lib/access/cloud/auth-transport";
+import {
+  AuthRequestError,
+  InteractiveAuthTimeoutError,
+} from "#product/lib/access/cloud/auth-transport";
 import {
   makeTestProductHost,
   productHostWrapper,
@@ -43,7 +46,7 @@ function harness(error: Error) {
 
 describe("useAuditedAuth", () => {
   it("tracks an interactive timeout without capturing it as an exception", async () => {
-    const error = new AuthRequestError("Sign-in timed out.", 408);
+    const error = new InteractiveAuthTimeoutError("Sign-in timed out.");
     const { result, captureException, track } = harness(error);
 
     await act(async () => {
@@ -59,6 +62,21 @@ describe("useAuditedAuth", () => {
         failure_kind: "configuration_error",
         provider: "github",
       },
+    });
+  });
+
+  it("captures an unbranded HTTP 408 response", async () => {
+    const error = new AuthRequestError("Upstream request timed out.", 408);
+    const { result, captureException } = harness(error);
+
+    await act(async () => {
+      await expect(
+        result.current.startLogin({ kind: "github" }),
+      ).rejects.toBe(error);
+    });
+
+    expect(captureException).toHaveBeenCalledWith(error, {
+      tags: { action: "sign_in", domain: "auth", provider: "github" },
     });
   });
 

--- a/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.ts
+++ b/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.ts
@@ -16,7 +16,7 @@ import {
   isTelemetryHandled,
 } from "#product/lib/domain/telemetry/errors";
 import {
-  AuthRequestError,
+  InteractiveAuthTimeoutError,
   isAbortError,
 } from "#product/lib/access/cloud/auth-transport";
 
@@ -41,7 +41,7 @@ function captureActionForRequest(request: LoginRequest): string {
 }
 
 function isExpectedAuthControlState(error: unknown): boolean {
-  return error instanceof AuthRequestError && error.status === 408;
+  return error instanceof InteractiveAuthTimeoutError;
 }
 
 export interface AuditedAuth {

--- a/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.ts
+++ b/apps/packages/product-client/src/hooks/auth/facade/use-audited-auth.ts
@@ -15,7 +15,10 @@ import {
   isLoginNotAttempted,
   isTelemetryHandled,
 } from "#product/lib/domain/telemetry/errors";
-import { isAbortError } from "#product/lib/access/cloud/auth-transport";
+import {
+  AuthRequestError,
+  isAbortError,
+} from "#product/lib/access/cloud/auth-transport";
 
 /**
  * The failure-side `provider` a login request classifies to. On success the
@@ -37,6 +40,10 @@ function captureActionForRequest(request: LoginRequest): string {
   return request.kind === "google" ? "link_provider" : "sign_in";
 }
 
+function isExpectedAuthControlState(error: unknown): boolean {
+  return error instanceof AuthRequestError && error.status === 408;
+}
+
 export interface AuditedAuth {
   startLogin: (request: LoginRequest) => Promise<ProductLoginOutcome>;
   logout: () => Promise<ProductLogoutOutcome>;
@@ -53,7 +60,8 @@ export interface AuditedAuth {
  * - success → `auth_signed_in {provider, source}` / `auth_signed_out {provider}`
  *   from the normalized host outcome;
  * - non-abort, transport-attempted failure → `captureException` (skipped when
- *   the error is already telemetry-handled) then `auth_sign_in_failed
+ *   the error is already telemetry-handled or is an intentional interactive
+ *   timeout) then `auth_sign_in_failed
  *   {failure_kind, provider}`;
  * - abort → re-thrown with no emission;
  * - a host pre-transport rejection (unsupported method / unresolved
@@ -81,7 +89,7 @@ export function useAuditedAuth(): AuditedAuth {
           throw error;
         }
         const provider = failureProviderForRequest(request);
-        if (!isTelemetryHandled(error)) {
+        if (!isTelemetryHandled(error) && !isExpectedAuthControlState(error)) {
           telemetry.captureException(error, {
             tags: {
               action: captureActionForRequest(request),

--- a/apps/packages/product-client/src/lib/access/cloud/auth-transport.ts
+++ b/apps/packages/product-client/src/lib/access/cloud/auth-transport.ts
@@ -22,6 +22,16 @@ export class AuthRequestError extends Error {
   }
 }
 
+/** The local interactive poll reached its deadline without a provider callback.
+ * Unlike an HTTP 408 returned by the server or a proxy, this is an expected
+ * rendered control state and is intentionally excluded from exception capture. */
+export class InteractiveAuthTimeoutError extends AuthRequestError {
+  constructor(message: string) {
+    super(message, 408);
+    this.name = "InteractiveAuthTimeoutError";
+  }
+}
+
 // True only when the server definitively rejected the credentials. Network
 // failures are normalized to AuthRequestError(503) by normalizeTransportError,
 // so an instanceof check alone would treat offline launches as sign-outs.

--- a/apps/web/src/browser/auth/web-auth-transport.test.ts
+++ b/apps/web/src/browser/auth/web-auth-transport.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./web-auth-transport";
 
 vi.mock("../../lib/access/cloud/auth/web-auth-flow", () => ({
+  SSO_SLUG_UNAVAILABLE_CODE: "sso_slug_unavailable",
   startWebAuthFlow: vi.fn(async () => {}),
   startWebSsoFlow: vi.fn(async () => {}),
   startWebSsoFlowForSlug: vi.fn(async () => {}),
@@ -110,6 +111,18 @@ describe("createWebAuthOperations", () => {
     void ops.startLogin({ kind: "sso", slug: "acme" });
     await Promise.resolve();
     expect(flowMock.startWebSsoFlowForSlug).toHaveBeenCalledWith("acme");
+  });
+
+  it("marks an unavailable slug as not attempted", async () => {
+    flowMock.startWebSsoFlowForSlug.mockRejectedValueOnce(
+      Object.assign(new Error("SSO is unavailable."), {
+        code: "sso_slug_unavailable",
+      }),
+    );
+    const { ops } = makeOps();
+
+    await expect(ops.startLogin({ kind: "sso", slug: "missing" }))
+      .rejects.toSatisfy(isLoginNotAttempted);
   });
 
   it("rejects password/apple as not-attempted so no failure event is emitted", async () => {

--- a/apps/web/src/browser/auth/web-auth-transport.ts
+++ b/apps/web/src/browser/auth/web-auth-transport.ts
@@ -11,6 +11,7 @@ import { markLoginNotAttempted } from "@proliferate/product-client/internal/lib/
 
 import {
   completeWebAuthFlow,
+  SSO_SLUG_UNAVAILABLE_CODE,
   startWebAuthFlow,
   startWebSsoFlow,
   startWebSsoFlowForSlug,
@@ -125,7 +126,16 @@ export function createWebAuthOperations(
       }
       case "sso": {
         if (request.slug) {
-          await startWebSsoFlowForSlug(request.slug);
+          try {
+            await startWebSsoFlowForSlug(request.slug);
+          } catch (error) {
+            if (webAuthFlowErrorCode(error) === SSO_SLUG_UNAVAILABLE_CODE) {
+              throw markLoginNotAttempted(
+                error instanceof Error ? error : new Error("SSO is unavailable."),
+              );
+            }
+            throw error;
+          }
         } else {
           await startWebSsoFlow({
             email: request.email,

--- a/apps/web/src/lib/access/cloud/auth/web-auth-flow.ts
+++ b/apps/web/src/lib/access/cloud/auth/web-auth-flow.ts
@@ -134,6 +134,7 @@ export async function startWebSsoFlow(input: {
 // generic answer, so we surface one generic message either way.
 const SSO_SLUG_UNAVAILABLE_MESSAGE =
   "We could not find single sign-on for that workspace. Check the sign-in link your admin shared.";
+export const SSO_SLUG_UNAVAILABLE_CODE = "sso_slug_unavailable";
 
 export async function startWebSsoFlowForSlug(slug: string): Promise<void> {
   const trimmed = slug.trim();
@@ -143,7 +144,10 @@ export async function startWebSsoFlowForSlug(slug: string): Promise<void> {
   const client = createWebCloudClient(webEnv.apiBaseUrl, null);
   const discovery = await discoverSso({ slug: trimmed }, client);
   if (!discovery.enabled || !discovery.organizationId) {
-    throw new Error(SSO_SLUG_UNAVAILABLE_MESSAGE);
+    throw new WebAuthFlowError(
+      SSO_SLUG_UNAVAILABLE_MESSAGE,
+      SSO_SLUG_UNAVAILABLE_CODE,
+    );
   }
   await startWebSsoFlow({
     organizationId: discovery.organizationId,

--- a/specs/codebase/structures/frontend/guides/telemetry.md
+++ b/specs/codebase/structures/frontend/guides/telemetry.md
@@ -75,6 +75,11 @@ session replay, and telemetry-related provider and hook ownership.
   handler does not apply this query disposition rule; it separately leaves only
   explicitly coded repository-selection validation states to their owning
   mutation workflow. Other mutation failures remain reportable.
+- Auth workflows treat only `AbortError`, the explicitly branded local
+  interactive poll timeout, and an explicitly coded unavailable SSO slug as
+  typed, rendered control states. Generic HTTP 4xx responses (including an
+  unbranded 408), network failures, security failures, and unknown errors remain
+  reportable.
 - Sentry tags must stay low-cardinality. Prefer stable keys such as `domain`,
   `action`, `provider`, `workspace_kind`, and `route`.
 - Put high-cardinality or diagnostic values in scrubbed extras, not tags.


### PR DESCRIPTION
## Summary

- consume surfaced GitHub and SSO sign-in rejections at the persistent auth shell so user cancellation cannot become an unhandled promise
- brand only the locally generated interactive poll deadline so it remains in the typed failure metric without exception capture; unbranded HTTP 408 responses remain reportable
- mark an unavailable Web SSO workspace slug as a typed pre-transport rejection
- document the narrow auth control-state telemetry rule

## Verification

- pnpm --config.minimum-release-age=0 --filter @proliferate/product-client build
- pnpm --config.minimum-release-age=0 --filter proliferate exec tsc --noEmit
- pnpm --config.minimum-release-age=0 --filter @proliferate/web typecheck
- pnpm --config.minimum-release-age=0 --filter @proliferate/product-client exec vitest run src/components/auth/AuthShell.test.tsx src/hooks/auth/facade/use-audited-auth.test.ts (4 passed)
- pnpm --config.minimum-release-age=0 --filter @proliferate/web exec vitest run src/browser/auth/web-auth-transport.test.ts (15 passed)
- pnpm --config.minimum-release-age=0 --filter proliferate exec vitest run src/lib/integrations/auth/proliferate-auth-transport.test.ts (3 passed)
- python3 scripts/check_docs.py
- git diff --check

Accepted review findings R1321-1 and R1321-2 are resolved at the current head; root re-review is clean at the current head.

## Tracker

The fixing relationships are linked through the production tracker; no private tracker identifiers or telemetry identities are included here.
