### PR TITLE
fix(deploy): enforce hosted Redis deployment contract

### DIFF
--- a/.github/workflows/_deploy-server.yml
+++ b/.github/workflows/_deploy-server.yml
@@ -34,7 +34,6 @@ jobs:
       image_uri: ${{ steps.image.outputs.image_uri }}
       task_definition_arn: ${{ steps.task.outputs.task_definition_arn }}
     env:
-      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
       AWS_DEPLOY_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
       ECR_SERVER_REPOSITORY: ${{ vars.ECR_SERVER_REPOSITORY || 'proliferate-server' }}
       ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
@@ -92,7 +91,19 @@ jobs:
         with:
           ref: ${{ inputs.git_sha }}
 
+      # GitHub variables are not automatically redacted. Mask every externally
+      # configured AWS identifier before validation or an action can report it.
+      - name: Mask hosted AWS identifiers
+        run: |
+          set -euo pipefail
+          for identifier in "$AWS_DEPLOY_ROLE_ARN" "$SUPPORT_FEED_SECRET_ARN"; do
+            if [ -n "$identifier" ]; then
+              echo "::add-mask::${identifier}"
+            fi
+          done
+
       - name: Validate server deploy config
+        id: hosted_contract
         run: |
           set -euo pipefail
           : "${AWS_DEPLOY_ROLE_ARN:?Set AWS_DEPLOY_ROLE_ARN on the GitHub environment.}"
@@ -103,6 +114,65 @@ jobs:
           : "${WEB_URL:?Set WEB_URL on the GitHub environment.}"
           : "${E2B_TEMPLATE_REF:?Set E2B_TEMPLATE_REF on the GitHub environment.}"
           : "${SUPPORT_FEED_SECRET_ARN:?Set SUPPORT_FEED_SECRET_ARN on the GitHub environment.}"
+
+          contract_fields="$(
+            jq -er --arg environment "$DEPLOY_ENVIRONMENT" '
+              . as $contract
+              | [
+                  .environments
+                  | to_entries[]
+                  | select(.value.workflow_names | index($environment))
+                ] as $matches
+              | if ($matches | length) != 1 then
+                  error("environment must match exactly one hosted contract")
+                else
+                  [
+                    $contract.aws_account_id,
+                    $contract.aws_region,
+                    $matches[0].value.secret_name,
+                    $matches[0].value.background_redis_reference_service,
+                    $matches[0].value.background_redis_reference_name,
+                    $matches[0].value.deploy_role_name,
+                    $matches[0].value.execution_role_name
+                  ]
+                  | @tsv
+                end
+            ' server/deploy/hosted-redis-contract.json 2>/dev/null
+          )" || {
+            echo "Unable to resolve the checked-in hosted server environment contract." >&2
+            exit 1
+          }
+          IFS=$'\t' read -r \
+            expected_account_id aws_region redis_secret_name \
+            background_redis_reference_service background_redis_reference_name \
+            expected_role_name expected_execution_role_name \
+            <<< "$contract_fields"
+
+          if [[ ! "$expected_account_id" =~ ^[0-9]{12}$ \
+              || ! "$aws_region" =~ ^[a-z]{2}-[a-z0-9-]+-[0-9]+$ \
+              || ! "$redis_secret_name" =~ ^[A-Za-z0-9/_+=.@-]+$ \
+              || ! "$background_redis_reference_service" =~ ^(secretsmanager|ssm)$ \
+              || ! "$background_redis_reference_name" =~ ^[A-Za-z0-9/_+=.@-]+$ \
+              || ! "$expected_role_name" =~ ^[A-Za-z0-9_+=,.@-]+$ \
+              || ! "$expected_execution_role_name" =~ ^[A-Za-z0-9_+=,.@-]+$ ]]; then
+            echo "The checked-in hosted server environment contract is malformed." >&2
+            exit 1
+          fi
+          expected_role_arn="arn:aws:iam::${expected_account_id}:role/${expected_role_name}"
+          if [ "$AWS_DEPLOY_ROLE_ARN" != "$expected_role_arn" ]; then
+            echo "Hosted server deploy role does not match the checked-in account/environment contract." >&2
+            exit 1
+          fi
+          {
+            echo "AWS_REGION=${aws_region}"
+            echo "EXPECTED_AWS_ACCOUNT_ID=${expected_account_id}"
+            echo "EXPECTED_ECS_EXECUTION_ROLE_NAME=${expected_execution_role_name}"
+            echo "EXPECTED_BACKGROUND_REDIS_SERVICE=${background_redis_reference_service}"
+            echo "EXPECTED_BACKGROUND_REDIS_NAME=${background_redis_reference_name}"
+            echo "REDBEAT_REDIS_SECRET_NAME=${redis_secret_name}"
+          } >> "$GITHUB_ENV"
+          echo "aws_region=${aws_region}" >> "$GITHUB_OUTPUT"
+
           if [ "$SUPPORT_TRACKER_ENABLED" = "true" ]; then
             : "${SUPPORT_GITHUB_APP_ID:?Set SUPPORT_GITHUB_APP_ID when support tracker is enabled.}"
             : "${SUPPORT_GITHUB_APP_INSTALLATION_ID:?Set SUPPORT_GITHUB_APP_INSTALLATION_ID when support tracker is enabled.}"
@@ -131,7 +201,21 @@ jobs:
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ steps.hosted_contract.outputs.aws_region }}
+          mask-aws-account-id: true
+
+      - name: Verify AWS deployment identity
+        run: |
+          set -euo pipefail
+          actual_account="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)" || {
+            echo "Unable to verify the hosted server AWS identity." >&2
+            exit 1
+          }
+          if [ "$actual_account" != "$EXPECTED_AWS_ACCOUNT_ID" ]; then
+            echo "Hosted server AWS identity does not match the checked-in account contract." >&2
+            exit 1
+          fi
+          echo "Hosted server AWS identity verified."
 
       # Prove the environment's support-feed secret is reachable and carries the
       # supportFeedToken field before any ECS mutation, without resolving the
@@ -144,11 +228,12 @@ jobs:
               --secret-id "$SUPPORT_FEED_SECRET_ARN" \
               --query SecretString \
               --output text \
+              2>/dev/null \
             | jq -e 'type == "object" and (has("supportFeedToken"))
                      and (.supportFeedToken | type == "string")
                      and (.supportFeedToken | length > 0)' \
-              >/dev/null; then
-            echo "Support feed secret ${SUPPORT_FEED_SECRET_ARN} is missing, inaccessible, or has no supportFeedToken field." >&2
+              >/dev/null 2>/dev/null; then
+            echo "The support feed secret is missing, inaccessible, or malformed." >&2
             exit 1
           fi
           echo "Support feed secret reference verified (field present; value not read)."
@@ -232,23 +317,197 @@ jobs:
           echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
           echo "Pinning task definitions to immutable ${image_ref}"
 
-      - name: Render ECS task definition
-        id: task
+      # Run this value-bearing preflight only after every third-party action's
+      # main phase. Their post-job hooks run later, so the first-party task-
+      # definition transactions below delete every identifier-bearing artifact
+      # before exit.
+      # The masked base ARN is a step output consumed explicitly by the first-party
+      # render step; it never enters the job-wide environment.
+      - name: Verify API Redis secret reference
+        id: redis_secret
+        env:
+          REDIS_PREFLIGHT_TIMEOUT_SECONDS: "20"
         run: |
           set -euo pipefail
+          case "$REDIS_PREFLIGHT_TIMEOUT_SECONDS" in
+            ''|*[!0-9]*|0)
+              echo "The API Redis DNS timeout guard is misconfigured." >&2
+              exit 1
+              ;;
+          esac
+          if ! command -v timeout >/dev/null 2>&1; then
+            echo "The API Redis DNS timeout guard is unavailable." >&2
+            exit 1
+          fi
+
+          redis_preflight_status=0
+          REDBEAT_REDIS_SECRET_ARN="$(
+            aws secretsmanager get-secret-value \
+              --secret-id "$REDBEAT_REDIS_SECRET_NAME" \
+              --output json \
+              2>/dev/null \
+            | timeout --signal=TERM --kill-after=2s \
+                "${REDIS_PREFLIGHT_TIMEOUT_SECONDS}s" python3 -c '
+          import ipaddress
+          import json
+          import os
+          import re
+          import socket
+          import sys
+          from urllib.parse import unquote, urlsplit
+
+          try:
+              response = json.load(sys.stdin)
+              arn = response.get("ARN")
+              secret_string = response.get("SecretString")
+              expected_region = re.escape(os.environ.get("AWS_REGION", ""))
+              expected_account = re.escape(os.environ.get("EXPECTED_AWS_ACCOUNT_ID", ""))
+              expected_secret = re.escape(os.environ.get("REDBEAT_REDIS_SECRET_NAME", ""))
+              expected_arn = re.compile(
+                  rf"arn:aws:secretsmanager:{expected_region}:"
+                  rf"{expected_account}:secret:{expected_secret}-[A-Za-z0-9]{{6}}"
+              )
+              if not isinstance(arn, str) or expected_arn.fullmatch(arn) is None:
+                  raise ValueError
+              if not isinstance(secret_string, str):
+                  raise ValueError
+              payload = json.loads(secret_string)
+              value = payload.get("REDBEAT_REDIS_URL")
+              if not isinstance(value, str) or value != value.strip():
+                  raise ValueError
+              parsed = urlsplit(value)
+              host = parsed.hostname
+              _ = parsed.port  # Force validation of an optional explicit port.
+              if parsed.scheme not in {"redis", "rediss"} or not host:
+                  raise ValueError
+              normalized_host = unquote(host).rstrip(".").lower()
+              if normalized_host == "localhost" or normalized_host.endswith(".localhost"):
+                  raise ValueError
+              try:
+                  address = ipaddress.ip_address(normalized_host)
+              except ValueError:
+                  try:
+                      address = ipaddress.ip_address(socket.inet_aton(normalized_host))
+                  except OSError:
+                      address = None
+              if address is not None and (address.is_loopback or address.is_unspecified):
+                  raise ValueError
+
+              try:
+                  answers = socket.getaddrinfo(
+                      normalized_host,
+                      parsed.port or 6379,
+                      type=socket.SOCK_STREAM,
+                  )
+              except OSError as exc:
+                  raise ValueError from exc
+              if not answers:
+                  raise ValueError
+              for answer in answers:
+                  resolved_host = answer[4][0].split("%", 1)[0]
+                  resolved_address = ipaddress.ip_address(resolved_host)
+                  if resolved_address.is_loopback or resolved_address.is_unspecified:
+                      raise ValueError
+              print(arn)
+          except Exception:
+              raise SystemExit(1)
+          ' 2>/dev/null
+          )" || redis_preflight_status=$?
+          case "$redis_preflight_status" in
+            0) ;;
+            124|137)
+              echo "API Redis endpoint validation timed out before non-loopback DNS safety could be established." >&2
+              exit 1
+              ;;
+            125|126|127)
+              echo "The API Redis DNS timeout guard failed." >&2
+              exit 1
+              ;;
+            *)
+              echo "The API Redis secret is missing, inaccessible, or has no valid non-loopback REDBEAT_REDIS_URL field." >&2
+              exit 1
+              ;;
+          esac
+          if [ -z "$REDBEAT_REDIS_SECRET_ARN" ]; then
+            echo "The API Redis secret is missing, inaccessible, or has no valid non-loopback REDBEAT_REDIS_URL field." >&2
+            exit 1
+          fi
+          echo "::add-mask::${REDBEAT_REDIS_SECRET_ARN}"
+          echo "secret_arn=${REDBEAT_REDIS_SECRET_ARN}" >> "$GITHUB_OUTPUT"
+          echo "API Redis secret reference verified (value not printed or retained)."
+
+      - name: Render ECS task definition
+        id: task
+        env:
+          REDBEAT_REDIS_SECRET_ARN: ${{ steps.redis_secret.outputs.secret_arn }}
+        run: |
+          set -euo pipefail
+
+          # HOSTED_REDIS_SCRATCH_BEGIN
+          # Third-party actions register post-job hooks. Keep every file that can
+          # carry the Redis identifier in a private directory, and remove each
+          # one before this first-party step exits on success or failure.
+          : "${RUNNER_TEMP:?RUNNER_TEMP is required for private render scratch space.}"
+          umask 077
+          render_dir="$(mktemp -d "${RUNNER_TEMP}/hosted-redis-render.XXXXXX")"
+          task_definition_raw="${render_dir}/task-definition.raw.json"
+          env_updates_file="${render_dir}/env-updates.json"
+          secret_updates_file="${render_dir}/secret-updates.json"
+          merge_program_file="${render_dir}/merge-task.jq"
+          assert_program_file="${render_dir}/assert-task.jq"
+          task_definition_rendered="${render_dir}/task-definition.json"
+          cleanup_render_files() {
+            rm -f -- \
+              "$task_definition_raw" \
+              "$env_updates_file" \
+              "$secret_updates_file" \
+              "$merge_program_file" \
+              "$assert_program_file" \
+              "$task_definition_rendered"
+            rmdir "$render_dir" 2>/dev/null || true
+          }
+          trap cleanup_render_files EXIT
+          # HOSTED_REDIS_SCRATCH_END
+
+          # HOSTED_EXECUTION_ROLE_VERIFY_BEGIN
+          # Fetch and verify the exact live definition cloned below. This binds
+          # Terraform's configured execution role to the ECS surface without a
+          # second-fetch race between verification and registration.
           task_definition_arn="$(
             aws ecs describe-services \
               --cluster "$ECS_CLUSTER" \
               --services "$ECS_SERVER_SERVICE" \
               --query 'services[0].taskDefinition' \
-              --output text
-          )"
-          test "$task_definition_arn" != "None"
-
-          aws ecs describe-task-definition \
-            --task-definition "$task_definition_arn" \
-            --query taskDefinition \
-            > task-definition.raw.json
+              --output text \
+              2>/dev/null
+          )" || {
+            echo "Unable to verify the hosted server task execution role." >&2
+            exit 1
+          }
+          expected_task_prefix="arn:aws:ecs:${AWS_REGION}:${EXPECTED_AWS_ACCOUNT_ID}:task-definition/"
+          if [[ "$task_definition_arn" != "${expected_task_prefix}"?* ]]; then
+            echo "Unable to verify the hosted server task execution role." >&2
+            exit 1
+          fi
+          if ! aws ecs describe-task-definition \
+              --task-definition "$task_definition_arn" \
+              --query taskDefinition \
+              --output json \
+              > "$task_definition_raw" \
+              2>/dev/null; then
+            echo "Unable to verify the hosted server task execution role." >&2
+            exit 1
+          fi
+          expected_execution_role_arn="arn:aws:iam::${EXPECTED_AWS_ACCOUNT_ID}:role/${EXPECTED_ECS_EXECUTION_ROLE_NAME}"
+          if ! jq -e --arg expected "$expected_execution_role_arn" \
+              '.executionRoleArn == $expected' \
+              "$task_definition_raw" \
+              >/dev/null 2>/dev/null; then
+            echo "Unable to verify the hosted server task execution role." >&2
+            exit 1
+          fi
+          echo "Hosted server task execution role verified."
+          # HOSTED_EXECUTION_ROLE_VERIFY_END
 
           support_github_private_key_parameter="$SUPPORT_GITHUB_APP_PRIVATE_KEY_PARAMETER_NAME"
           if [ -z "$support_github_private_key_parameter" ] && [ "$SUPPORT_TRACKER_ENABLED" = "true" ]; then
@@ -354,21 +613,25 @@ jobs:
               {"name":"SUPPORT_LINEAR_PROJECT_ID","value":$support_linear_project_id},
               {"name":"SUPPORT_LINEAR_LABEL_IDS","value":$support_linear_label_ids},
               {"name":"SUPPORT_LINEAR_PRIVATE_DETAILS_LABEL_ID","value":$support_linear_private_details_label_id}
-            ]' > env-updates.json
+            ]' > "$env_updates_file"
 
-          # The support-feed bearer token is always projected as exactly one ECS
-          # secret referencing the environment's supportFeedToken field. It is
-          # listed first and unconditionally; the render/assert jq below strips
-          # any inherited plaintext duplicate and rejects a missing/duplicated
-          # reference before registration.
+          # Hosted dependencies are authored as exact ECS field projections.
+          # Listing them unconditionally makes merge_secrets replace inherited
+          # manual/stale references; the assertion below proves the final refs.
+          # HOSTED_SECRET_UPDATES_BEGIN
           jq -n \
             --arg support_feed_secret_arn "$SUPPORT_FEED_SECRET_ARN" \
+            --arg redis_secret_arn "$REDBEAT_REDIS_SECRET_ARN" \
             --arg support_github_private_key_parameter "$support_github_private_key_parameter" \
             --arg support_linear_api_key_parameter "$support_linear_api_key_parameter" \
             '[
               {
                 "name":"SUPPORT_FEED_BEARER_TOKEN",
                 "valueFrom":($support_feed_secret_arn + ":supportFeedToken::")
+              },
+              {
+                "name":"REDBEAT_REDIS_URL",
+                "valueFrom":($redis_secret_arn + ":REDBEAT_REDIS_URL::")
               },
               (
                 if $support_github_private_key_parameter == "" then empty else
@@ -386,18 +649,19 @@ jobs:
                 }
                 end
               )
-            ]' > secret-updates.json
+            ]' > "$secret_updates_file"
+          # HOSTED_SECRET_UPDATES_END
 
           # The render (MERGE_JQ) and fail-closed check (ASSERT_JQ) are pure
           # JSON->JSON programs with no AWS dependency. They are written to files
-          # verbatim so server/tests/integration/test_support_feed.py can extract
-          # and exercise the exact logic that runs here. Keep the heredoc
+          # verbatim so server/tests/integration/test_support_feed_deploy_render.py
+          # can extract and exercise the exact logic that runs here. Keep the heredoc
           # sentinels (MERGE_JQ / ASSERT_JQ) stable; the test greps for them.
-          cat > merge-task.jq <<'MERGE_JQ'
+          cat > "$merge_program_file" <<'MERGE_JQ'
           def merge_environment($updates):
             (.environment // []) as $current
             | ($updates[0] | map(.name)) as $updated_names
-            | ["SUPPORT_GITHUB_APP_PRIVATE_KEY", "SUPPORT_LINEAR_API_KEY", "SUPPORT_FEED_BEARER_TOKEN"] as $secret_names
+            | ["SUPPORT_GITHUB_APP_PRIVATE_KEY", "SUPPORT_LINEAR_API_KEY", "SUPPORT_FEED_BEARER_TOKEN", "REDBEAT_REDIS_URL"] as $secret_names
             # Stale runtime-identity overrides the server never re-authors. The
             # task definition is merged from the previous revision, so dropping
             # our own assignments is not enough: any inherited copy must be
@@ -436,9 +700,11 @@ jobs:
             )
           MERGE_JQ
 
-          cat > assert-task.jq <<'ASSERT_JQ'
+          cat > "$assert_program_file" <<'ASSERT_JQ'
           def feed_secrets($c): [ $c.secrets[]? | select(.name == "SUPPORT_FEED_BEARER_TOKEN") ];
           def feed_plain($c): [ $c.environment[]? | select(.name == "SUPPORT_FEED_BEARER_TOKEN") ];
+          def redis_secrets($c): [ $c.secrets[]? | select(.name == "REDBEAT_REDIS_URL") ];
+          def redis_plain($c): [ $c.environment[]? | select(.name == "REDBEAT_REDIS_URL") ];
           def forbidden_names: ["SERVER_VERSION", "ANYHARNESS_VERSION", "ANYHARNESS_GIT_SHA", "E2B_TEMPLATE_VERSION", "CLOUD_RUNTIME_SENTRY_RELEASE", "CLOUD_TARGET_SENTRY_RELEASE", "E2B_RUNTIME_SENTRY_RELEASE"];
           def stale_vars($c): [ $c.environment[]? | select(.name as $n | forbidden_names | index($n)) ];
           def strict_identity($c): [ $c.environment[]? | select(.name == "PROLIFERATE_REQUIRE_RELEASE_IDENTITY" and .value == "1") ];
@@ -451,6 +717,8 @@ jobs:
           | (feed_plain($c)) as $plain
           | (stale_vars($c)) as $stale
           | (strict_identity($c)) as $strict
+          | (redis_secrets($c)) as $redis_secrets
+          | (redis_plain($c)) as $redis_plain
           | if ($secrets | length) != 1 then
               error("expected exactly one SUPPORT_FEED_BEARER_TOKEN ECS secret, found \($secrets | length)")
             elif ($plain | length) != 0 then
@@ -463,23 +731,31 @@ jobs:
               error("stale runtime-identity variables must not remain: \($stale | map(.name) | join(", "))")
             elif ($strict | length) != 1 then
               error("PROLIFERATE_REQUIRE_RELEASE_IDENTITY=1 must be set for strict hosted release identity")
+            elif ($redis_secrets | length) != 1 then
+              error("expected exactly one REDBEAT_REDIS_URL ECS secret, found \($redis_secrets | length)")
+            elif ($redis_plain | length) != 0 then
+              error("REDBEAT_REDIS_URL must not be present as a plaintext environment entry")
+            elif (($redis_secrets[0].valueFrom // "") != $redis_value_from) then
+              error("REDBEAT_REDIS_URL must match the environment-owned Secrets Manager field reference")
             else empty end
           ASSERT_JQ
 
           jq \
             --arg container "$ECS_SERVER_CONTAINER_NAME" \
             --arg image "${{ steps.digest.outputs.image_ref }}" \
-            --slurpfile updates env-updates.json \
-            --slurpfile secret_updates secret-updates.json \
-            -f merge-task.jq \
-            task-definition.raw.json > task-definition.json
+            --slurpfile updates "$env_updates_file" \
+            --slurpfile secret_updates "$secret_updates_file" \
+            -f "$merge_program_file" \
+            "$task_definition_raw" > "$task_definition_rendered"
 
           # Fail closed before register-task-definition: exactly one secret-backed
-          # SUPPORT_FEED_BEARER_TOKEN, no plaintext duplicate, correct field ref.
+          # SUPPORT_FEED_BEARER_TOKEN and REDBEAT_REDIS_URL, no plaintext
+          # duplicates, and valid AWS secret references.
           jq \
             --arg container "$ECS_SERVER_CONTAINER_NAME" \
-            -f assert-task.jq \
-            task-definition.json > /dev/null
+            --arg redis_value_from "${REDBEAT_REDIS_SECRET_ARN}:REDBEAT_REDIS_URL::" \
+            -f "$assert_program_file" \
+            "$task_definition_rendered" > /dev/null
 
           # Fail closed unless the server container is pinned to an IMMUTABLE
           # digest (`repo@sha256:...`), never a mutable tag. A mutable tag could be
@@ -488,7 +764,7 @@ jobs:
           server_image="$(
             jq -r --arg container "$ECS_SERVER_CONTAINER_NAME" \
               'first(.containerDefinitions[] | select(.name == $container) | .image)' \
-              task-definition.json
+              "$task_definition_rendered"
           )"
           case "$server_image" in
             *@sha256:*) ;;
@@ -500,10 +776,14 @@ jobs:
 
           new_task_definition_arn="$(
             aws ecs register-task-definition \
-              --cli-input-json file://task-definition.json \
+              --cli-input-json "file://${task_definition_rendered}" \
               --query 'taskDefinition.taskDefinitionArn' \
-              --output text
-          )"
+              --output text \
+              2>/dev/null
+          )" || {
+            echo "Unable to register the verified hosted server task definition." >&2
+            exit 1
+          }
           echo "task_definition_arn=$new_task_definition_arn" >> "$GITHUB_OUTPUT"
 
       - name: Run Alembic migrations
@@ -599,6 +879,30 @@ jobs:
         if: ${{ env.ECS_WORKER_SERVICE != '' && env.ECS_BEAT_SERVICE != '' }}
         run: |
           set -euo pipefail
+          # HOSTED_BACKGROUND_SCRATCH_BEGIN
+          # Re-imaging preserves the full task definition, including secret
+          # identifiers. Keep both definitions private and remove them before
+          # any third-party post-job action can run.
+          : "${RUNNER_TEMP:?RUNNER_TEMP is required for private background scratch space.}"
+          umask 077
+          background_render_dir="$(mktemp -d "${RUNNER_TEMP}/hosted-background-render.XXXXXX")"
+          worker_task_raw="${background_render_dir}/worker.raw.json"
+          worker_task_rendered="${background_render_dir}/worker.json"
+          beat_task_raw="${background_render_dir}/beat.raw.json"
+          beat_task_rendered="${background_render_dir}/beat.json"
+          background_assert_program="${background_render_dir}/assert-task.jq"
+          cleanup_background_task_files() {
+            rm -f -- \
+              "$worker_task_raw" \
+              "$worker_task_rendered" \
+              "$beat_task_raw" \
+              "$beat_task_rendered" \
+              "$background_assert_program"
+            rmdir "$background_render_dir" 2>/dev/null || true
+          }
+          trap cleanup_background_task_files EXIT
+          # HOSTED_BACKGROUND_SCRATCH_END
+
           # Re-image a celery service in place: take its current task definition,
           # swap only the container image to the candidate, register, and roll.
           # Environment/secrets are Terraform-owned and left intact. The candidate
@@ -613,22 +917,80 @@ jobs:
               exit 1
               ;;
           esac
+          expected_background_execution_role="arn:aws:iam::${EXPECTED_AWS_ACCOUNT_ID}:role/${EXPECTED_ECS_EXECUTION_ROLE_NAME}"
+          case "$EXPECTED_BACKGROUND_REDIS_SERVICE" in
+            secretsmanager)
+              expected_background_redis_prefix="arn:aws:secretsmanager:${AWS_REGION}:${EXPECTED_AWS_ACCOUNT_ID}:secret:${EXPECTED_BACKGROUND_REDIS_NAME}-"
+              expected_background_redis_exact=""
+              ;;
+            ssm)
+              background_parameter_name="${EXPECTED_BACKGROUND_REDIS_NAME#/}"
+              if [ -z "$background_parameter_name" ]; then
+                echo "The hosted background Redis contract is malformed." >&2
+                exit 1
+              fi
+              expected_background_redis_prefix=""
+              expected_background_redis_exact="arn:aws:ssm:${AWS_REGION}:${EXPECTED_AWS_ACCOUNT_ID}:parameter/${background_parameter_name}"
+              ;;
+            *)
+              echo "The hosted background Redis contract is malformed." >&2
+              exit 1
+              ;;
+          esac
+          cat > "$background_assert_program" <<'BACKGROUND_ASSERT_JQ'
+          def redis_secrets($container):
+            [$container.secrets[]? | select(.name == "REDBEAT_REDIS_URL")];
+          def redis_plain($container):
+            [$container.environment[]? | select(.name == "REDBEAT_REDIS_URL")];
+          def allowed_redis_reference($value):
+            if $redis_exact != "" then
+              $value == $redis_exact
+            else
+              ($value | startswith($redis_prefix))
+              and (($value | ltrimstr($redis_prefix)) | test("^[A-Za-z0-9]{6}$"))
+            end;
+
+          ([.containerDefinitions[] | select(.name == $container)]) as $matches
+          | if ($matches | length) != 1 then false
+            else
+              $matches[0] as $target
+              | (redis_secrets($target)) as $redis
+              | (redis_plain($target)) as $plain
+              | (
+                  .executionRoleArn == $execution_role
+                  and ($redis | length) == 1
+                  and ($plain | length) == 0
+                  and allowed_redis_reference(($redis[0].valueFrom // ""))
+                )
+            end
+          BACKGROUND_ASSERT_JQ
+
           roll_service() {
-            service="$1"; container="$2"
+            service="$1"; container="$2"; task_raw="$3"; task_rendered="$4"
             current_arn="$(
               aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$service" \
-                --query 'services[0].taskDefinition' --output text
-            )"
-            test "$current_arn" != "None"
-            aws ecs describe-task-definition --task-definition "$current_arn" \
-              --query taskDefinition > "td-${container}.raw.json"
+                --query 'services[0].taskDefinition' --output text \
+                2>/dev/null
+            )" || {
+              echo "Unable to verify the hosted background task definition." >&2
+              return 1
+            }
+            if [ "$current_arn" = "None" ]; then
+              echo "Unable to verify the hosted background task definition." >&2
+              return 1
+            fi
+            if ! aws ecs describe-task-definition --task-definition "$current_arn" \
+                --query taskDefinition > "$task_raw" 2>/dev/null; then
+              echo "Unable to verify the hosted background task definition." >&2
+              return 1
+            fi
             # Fail closed if the named container does not match exactly one
             # definition: a wrong ECS_*_CONTAINER_NAME would otherwise rewrite
             # nothing, register the OLD image, and still report success.
             match_count="$(
               jq --arg container "$container" \
                 '[.containerDefinitions[] | select(.name == $container)] | length' \
-                "td-${container}.raw.json"
+                "$task_raw"
             )"
             if [ "$match_count" != "1" ]; then
               echo "Expected exactly one '${container}' container in ${service}'s task definition, found ${match_count}." >&2
@@ -642,39 +1004,71 @@ jobs:
               | .containerDefinitions |= map(
                   if .name == $container then .image = $image else . end
                 )
-            ' "td-${container}.raw.json" > "td-${container}.json"
+            ' "$task_raw" > "$task_rendered"
+            # The re-image path preserves secrets, so validate the exact
+            # account/region/environment-bound execution role and the one
+            # allowed direct Redis secret projection on the rendered document
+            # before registration. Any plaintext, duplicate, field selector,
+            # sibling secret, or role mismatch fails closed.
+            if ! jq -e \
+                --arg container "$container" \
+                --arg execution_role "$expected_background_execution_role" \
+                --arg redis_prefix "$expected_background_redis_prefix" \
+                --arg redis_exact "$expected_background_redis_exact" \
+                -f "$background_assert_program" \
+                "$task_rendered" \
+                >/dev/null 2>/dev/null; then
+              echo "Background task definition violates the hosted execution-role/Redis contract." >&2
+              return 1
+            fi
             # Assert the rewritten definition carries the candidate image on the
             # named container before registration.
             rewritten_image="$(
               jq -r --arg container "$container" \
                 'first(.containerDefinitions[] | select(.name == $container) | .image)' \
-                "td-${container}.json"
+                "$task_rendered"
             )"
             if [ "$rewritten_image" != "$candidate_image" ]; then
               echo "Container '${container}' image is '${rewritten_image}', expected candidate '${candidate_image}'." >&2
               exit 1
             fi
             new_arn="$(
-              aws ecs register-task-definition --cli-input-json "file://td-${container}.json" \
-                --query 'taskDefinition.taskDefinitionArn' --output text
-            )"
+              aws ecs register-task-definition --cli-input-json "file://${task_rendered}" \
+                --query 'taskDefinition.taskDefinitionArn' --output text \
+                2>/dev/null
+            )" || {
+              echo "Unable to register the verified hosted background task definition." >&2
+              return 1
+            }
             # Confirm the REGISTERED revision (not just the local file) carries the
             # candidate image on exactly the named container.
             registered_image="$(
               aws ecs describe-task-definition --task-definition "$new_arn" \
                 --query "taskDefinition.containerDefinitions[?name=='${container}'].image | [0]" \
-                --output text
-            )"
+                --output text \
+                2>/dev/null
+            )" || {
+              echo "Unable to verify the registered hosted background task definition." >&2
+              return 1
+            }
             if [ "$registered_image" != "$candidate_image" ]; then
-              echo "Registered ${service} task def ${new_arn} carries image '${registered_image}', expected '${candidate_image}'." >&2
+              echo "Registered ${service} task definition does not carry the candidate image." >&2
               exit 1
             fi
-            aws ecs update-service --cluster "$ECS_CLUSTER" --service "$service" \
-              --task-definition "$new_arn" --force-new-deployment > /dev/null
+            if ! aws ecs update-service --cluster "$ECS_CLUSTER" --service "$service" \
+                --task-definition "$new_arn" --force-new-deployment \
+                >/dev/null 2>/dev/null; then
+              echo "Unable to roll the verified hosted background task definition." >&2
+              return 1
+            fi
             echo "$new_arn"
           }
-          worker_arn="$(roll_service "$ECS_WORKER_SERVICE" "$ECS_WORKER_CONTAINER_NAME")"
-          beat_arn="$(roll_service "$ECS_BEAT_SERVICE" "$ECS_BEAT_CONTAINER_NAME")"
+          worker_arn="$(roll_service \
+            "$ECS_WORKER_SERVICE" "$ECS_WORKER_CONTAINER_NAME" \
+            "$worker_task_raw" "$worker_task_rendered")"
+          beat_arn="$(roll_service \
+            "$ECS_BEAT_SERVICE" "$ECS_BEAT_CONTAINER_NAME" \
+            "$beat_task_raw" "$beat_task_rendered")"
           {
             echo "worker_task_definition_arn=$worker_arn"
             echo "beat_task_definition_arn=$beat_arn"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,18 @@ jobs:
       - name: Terraform test (background plane fail-closed)
         run: terraform -chdir=server/infra test
 
+      # The live hosted identities intentionally do not share state with the
+      # bootstrap root above. Validate and test the child IAM ownership root
+      # independently; no credentials, backend, plan, or apply are used here.
+      - name: Terraform init (hosted Redis, no backend)
+        run: terraform -chdir=server/infra/hosted-redis init -backend=false -input=false
+
+      - name: Terraform validate (hosted Redis)
+        run: terraform -chdir=server/infra/hosted-redis validate
+
+      - name: Terraform test (hosted Redis least privilege)
+        run: terraform -chdir=server/infra/hosted-redis test
+
   ci-cd-config:
     name: CI/CD config checks
     runs-on: ubuntu-latest

--- a/server/deploy/hosted-redis-contract.json
+++ b/server/deploy/hosted-redis-contract.json
@@ -1,0 +1,22 @@
+{
+  "aws_account_id": "157466816238",
+  "aws_region": "us-east-1",
+  "environments": {
+    "staging": {
+      "workflow_names": ["staging", "Staging"],
+      "secret_name": "proliferate/staging/server-app",
+      "background_redis_reference_service": "secretsmanager",
+      "background_redis_reference_name": "proliferate/staging/background/redbeat-redis-url",
+      "deploy_role_name": "proliferate-staging-github-actions-deploy",
+      "execution_role_name": "proliferate-staging-ecs-execution"
+    },
+    "production": {
+      "workflow_names": ["production", "Production"],
+      "secret_name": "proliferate/prod/server-app",
+      "background_redis_reference_service": "secretsmanager",
+      "background_redis_reference_name": "proliferate/production/background/redbeat-redis-url",
+      "deploy_role_name": "proliferate-prod-github-actions-deploy",
+      "execution_role_name": "proliferate-prod-ecs-execution"
+    }
+  }
+}

--- a/server/infra/hosted-redis/README.md
+++ b/server/infra/hosted-redis/README.md
@@ -1,0 +1,79 @@
+# Hosted server Redis ownership
+
+This isolated Terraform root is the durable owner of one exact Redis
+secret-read child policy on each hosted deploy role and ECS execution role. It
+does not own the roles, secrets, secret values, task definitions, or services.
+
+`server/deploy/hosted-redis-contract.json` is the single account-, region-, and
+environment-bound contract consumed by this root and the server deploy
+workflow. Each managed policy contains one `Allow`, one
+`secretsmanager:GetSecretValue` action, and one exact resolved `server-app`
+secret ARN.
+
+The contract also names the allowed direct Redis secret or Parameter Store
+reference for the optional worker/Beat re-image check. That background source
+and its grants are not read or managed by this isolated root. The gated
+definitions in `server/infra/background.tf` describe a future background
+deployment surface; this contract does not assert ownership of the current
+live background source or grants.
+
+The roles also carry pre-existing policies for other task-start secrets. Some
+bundle the Redis record with other exact or name-scoped resources and are not
+owned here. Adoption adds a dedicated exact policy but does not make the
+role's total effective permissions least-privilege; narrowing those shared
+legacy policies requires their independently identified owner and is outside
+this root.
+
+## One-time non-destructive adoption
+
+The two deploy-role policies predated this root. `imports.tf` made their
+adoption explicit. The two dedicated execution-role policies were created by
+the initial adoption. Never rebuild this state with an unsaved or unverified
+first plan.
+
+The first saved plan is acceptable only when the sanitizer reports exactly two
+imports, two creates, zero updates, and zero deletes:
+
+```bash
+(
+  set -euo pipefail
+  terraform -chdir=server/infra/hosted-redis init
+  terraform -chdir=server/infra/hosted-redis plan \
+    -out=hosted-redis.tfplan >/dev/null 2>/dev/null
+  terraform -chdir=server/infra/hosted-redis show \
+    -json hosted-redis.tfplan 2>/dev/null \
+    | python3 server/infra/hosted-redis/check_adoption_plan.py adoption
+  terraform -chdir=server/infra/hosted-redis apply \
+    hosted-redis.tfplan >/dev/null 2>/dev/null
+)
+```
+
+The subshell's fail-fast and pipeline settings make apply conditional on both
+`terraform show` and the sanitizer succeeding. Do not print, commit, or retain
+a binary/JSON plan as a receipt; plan data contains infrastructure identifiers.
+Record only the sanitizer's counts.
+
+Normal operation and every post-apply check use a saved plan plus the
+steady-state sanitizer:
+
+```bash
+(
+  set -euo pipefail
+  terraform -chdir=server/infra/hosted-redis plan \
+    -out=hosted-redis-steady.tfplan >/dev/null 2>/dev/null
+  terraform -chdir=server/infra/hosted-redis show \
+    -json hosted-redis-steady.tfplan 2>/dev/null \
+    | python3 server/infra/hosted-redis/check_adoption_plan.py steady-state
+)
+```
+
+The steady-state result must be zero changes and zero drift. Remove both local
+plan files after the review.
+
+## Ownership transfer
+
+Both resource types use `prevent_destroy`; there is intentionally no
+`terraform destroy` rollback. A future de-adoption is an ownership transfer:
+first land and prove an equivalent owner, then use a separately reviewed
+state-only removal for the imported policies. Never delete a pre-existing
+deploy policy or a production dependency as a shortcut for reverting state.

--- a/server/infra/hosted-redis/check_adoption_plan.py
+++ b/server/infra/hosted-redis/check_adoption_plan.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Validate hosted Redis Terraform plans without printing plan contents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+CONTRACT_PATH = Path(__file__).resolve().parents[2] / "deploy/hosted-redis-contract.json"
+ENVIRONMENTS = ("production", "staging")
+POLICY_NAME = "api-redis-secret-read"
+EXPECTED_CHECKS = {
+    "check.aws_account_binding",
+    "check.secret_identity_binding",
+}
+MANAGED_VALUE_FIELDS = ("name", "policy", "role")
+
+
+def _address(kind: str, environment: str) -> str:
+    return f'aws_iam_role_policy.{kind}_secret_read["{environment}"]'
+
+
+def _load_contract() -> dict[str, object]:
+    try:
+        contract = json.loads(CONTRACT_PATH.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("hosted contract is unavailable") from error
+    if not isinstance(contract, dict):
+        raise ValueError("hosted contract must be an object")
+
+    account_id = contract.get("aws_account_id")
+    region = contract.get("aws_region")
+    environments = contract.get("environments")
+    if not isinstance(account_id, str) or re.fullmatch(r"[0-9]{12}", account_id) is None:
+        raise ValueError("hosted account is malformed")
+    if not isinstance(region, str) or re.fullmatch(r"[a-z]{2}-[a-z0-9-]+-[0-9]+", region) is None:
+        raise ValueError("hosted region is malformed")
+    if not isinstance(environments, dict) or set(environments) != set(ENVIRONMENTS):
+        raise ValueError("hosted environment set differs from the adoption contract")
+
+    for environment in ENVIRONMENTS:
+        values = environments.get(environment)
+        if not isinstance(values, dict):
+            raise ValueError("hosted environment must be an object")
+        secret_name = values.get("secret_name")
+        background_redis_service = values.get("background_redis_reference_service")
+        background_redis_name = values.get("background_redis_reference_name")
+        deploy_role = values.get("deploy_role_name")
+        execution_role = values.get("execution_role_name")
+        if background_redis_service not in {"secretsmanager", "ssm"}:
+            raise ValueError("hosted background Redis service is malformed")
+        for managed_secret_name in (secret_name, background_redis_name):
+            if (
+                not isinstance(managed_secret_name, str)
+                or re.fullmatch(r"[A-Za-z0-9/_+=.@-]+", managed_secret_name) is None
+            ):
+                raise ValueError("hosted secret name is malformed")
+        for role in (deploy_role, execution_role):
+            if not isinstance(role, str) or re.fullmatch(r"[A-Za-z0-9_+=,.@-]+", role) is None:
+                raise ValueError("hosted role name is malformed")
+    return contract
+
+
+def _expected(
+    phase: str, contract: dict[str, object]
+) -> dict[str, tuple[list[str], bool, str, str]]:
+    environments = contract["environments"]
+    assert isinstance(environments, dict)
+    expected: dict[str, tuple[list[str], bool, str, str]] = {}
+    for environment in ENVIRONMENTS:
+        values = environments[environment]
+        assert isinstance(values, dict)
+        deploy_role = values["deploy_role_name"]
+        execution_role = values["execution_role_name"]
+        assert isinstance(deploy_role, str)
+        assert isinstance(execution_role, str)
+        expected[_address("deploy", environment)] = (
+            ["no-op"],
+            phase == "adoption",
+            environment,
+            deploy_role,
+        )
+        expected[_address("execution", environment)] = (
+            ["create"] if phase == "adoption" else ["no-op"],
+            False,
+            environment,
+            execution_role,
+        )
+    return expected
+
+
+def _contains_unknown(value: object) -> bool:
+    if value is None or value is False:
+        return False
+    if value is True:
+        return True
+    if isinstance(value, dict):
+        return any(_contains_unknown(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_unknown(child) for child in value)
+    return True
+
+
+def _secret_pattern(contract: dict[str, object], environment: str) -> re.Pattern[str]:
+    account_id = contract["aws_account_id"]
+    region = contract["aws_region"]
+    environments = contract["environments"]
+    assert isinstance(account_id, str)
+    assert isinstance(region, str)
+    assert isinstance(environments, dict)
+    values = environments[environment]
+    assert isinstance(values, dict)
+    secret_name = values["secret_name"]
+    assert isinstance(secret_name, str)
+    return re.compile(
+        rf"arn:aws:secretsmanager:{re.escape(region)}:{re.escape(account_id)}:"
+        rf"secret:{re.escape(secret_name)}-[A-Za-z0-9]{{6}}"
+    )
+
+
+def _validate_policy_values(
+    values: object,
+    *,
+    contract: dict[str, object],
+    environment: str,
+    expected_role: str,
+) -> str:
+    if not isinstance(values, dict):
+        raise ValueError("managed policy values are missing")
+    if values.get("name") != POLICY_NAME or values.get("role") != expected_role:
+        raise ValueError("managed policy identity differs from the hosted contract")
+    policy_text = values.get("policy")
+    if not isinstance(policy_text, str):
+        raise ValueError("managed policy document is missing")
+    try:
+        policy = json.loads(policy_text)
+    except json.JSONDecodeError as error:
+        raise ValueError("managed policy document is malformed") from error
+    if not isinstance(policy, dict):
+        raise ValueError("managed policy document must be an object")
+
+    if set(policy) != {"Version", "Statement"} or policy.get("Version") != "2012-10-17":
+        raise ValueError("managed policy envelope differs from the hosted contract")
+    statements = policy.get("Statement")
+    if not isinstance(statements, list) or len(statements) != 1:
+        raise ValueError("managed policy must contain one statement")
+    statement = statements[0]
+    if not isinstance(statement, dict):
+        raise ValueError("managed policy statement is malformed")
+    if set(statement) != {"Sid", "Effect", "Action", "Resource"}:
+        raise ValueError("managed policy statement differs from the hosted contract")
+    if statement.get("Sid") != "ReadApiRedisSecret" or statement.get("Effect") != "Allow":
+        raise ValueError("managed policy statement differs from the hosted contract")
+
+    # AWS normalizes singleton IAM Action/Resource arrays to scalar strings on
+    # read. Accept only those two semantically identical encodings; multiple or
+    # non-string values remain rejected.
+    actions = statement.get("Action")
+    if isinstance(actions, list) and len(actions) == 1:
+        actions = actions[0]
+    if actions != "secretsmanager:GetSecretValue":
+        raise ValueError("managed policy permissions differ from the hosted contract")
+    resources = statement.get("Resource")
+    if isinstance(resources, list) and len(resources) == 1:
+        resources = resources[0]
+    if not isinstance(resources, str):
+        raise ValueError("managed policy must contain one resource")
+    secret_arn = resources
+    if _secret_pattern(contract, environment).fullmatch(secret_arn) is None:
+        raise ValueError("managed policy secret differs from the hosted contract")
+    return secret_arn
+
+
+def _validate_checks(plan: dict[str, object]) -> None:
+    checks = plan.get("checks")
+    if not isinstance(checks, list):
+        raise ValueError("Terraform checks are missing")
+    seen: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            raise ValueError("Terraform check is malformed")
+        address = check.get("address")
+        if not isinstance(address, dict) or not isinstance(address.get("to_display"), str):
+            raise ValueError("Terraform check address is malformed")
+        display = address["to_display"]
+        if display in seen:
+            raise ValueError("duplicate Terraform check is present")
+        seen.add(display)
+        if check.get("status") != "pass":
+            raise ValueError("Terraform check did not pass")
+        instances = check.get("instances", [])
+        if not isinstance(instances, list) or any(
+            not isinstance(instance, dict) or instance.get("status") != "pass"
+            for instance in instances
+        ):
+            raise ValueError("Terraform check instance did not pass")
+    if not EXPECTED_CHECKS.issubset(seen):
+        raise ValueError("required Terraform checks are missing")
+
+
+def validate(plan: object, phase: str) -> str:
+    if not isinstance(plan, dict):
+        raise ValueError("plan must be an object")
+    format_version = plan.get("format_version")
+    if not isinstance(format_version, str) or format_version.split(".", 1)[0] != "1":
+        raise ValueError("unsupported plan format")
+
+    contract = _load_contract()
+    _validate_checks(plan)
+
+    changes = plan.get("resource_changes")
+    if not isinstance(changes, list):
+        raise ValueError("resource changes are missing")
+    managed: dict[str, dict[str, object]] = {}
+    for resource in changes:
+        if not isinstance(resource, dict):
+            raise ValueError("resource change is malformed")
+        if resource.get("mode") != "managed":
+            continue
+        address = resource.get("address")
+        if not isinstance(address, str):
+            raise ValueError("managed resource address is malformed")
+        if address in managed:
+            raise ValueError("duplicate managed resource is present")
+        if resource.get("deposed") is not None:
+            raise ValueError("deposed managed resource is present")
+        managed[address] = resource
+
+    expected = _expected(phase, contract)
+    if set(managed) != set(expected):
+        raise ValueError("managed resource set differs from the adoption contract")
+
+    resolved_secret_arns: dict[str, str] = {}
+    for address, (
+        expected_actions,
+        must_import,
+        environment,
+        expected_role,
+    ) in expected.items():
+        change = managed[address].get("change")
+        if not isinstance(change, dict) or change.get("actions") != expected_actions:
+            raise ValueError("managed action differs from the adoption contract")
+
+        importing = change.get("importing")
+        if must_import:
+            expected_import = {"id": f"{expected_role}:{POLICY_NAME}"}
+            if importing != expected_import:
+                raise ValueError("deploy policy import differs from the hosted contract")
+        elif importing is not None:
+            raise ValueError("unexpected import is present")
+
+        after_unknown = change.get("after_unknown", {})
+        if not isinstance(after_unknown, dict) or any(
+            _contains_unknown(after_unknown.get(field)) for field in MANAGED_VALUE_FIELDS
+        ):
+            raise ValueError("managed policy identity remains unknown")
+
+        after_secret_arn = _validate_policy_values(
+            change.get("after"),
+            contract=contract,
+            environment=environment,
+            expected_role=expected_role,
+        )
+        if expected_actions == ["no-op"]:
+            before_secret_arn = _validate_policy_values(
+                change.get("before"),
+                contract=contract,
+                environment=environment,
+                expected_role=expected_role,
+            )
+            if before_secret_arn != after_secret_arn:
+                raise ValueError("managed policy secret changes during adoption")
+        elif change.get("before") is not None:
+            raise ValueError("created policy unexpectedly has prior state")
+
+        prior_secret_arn = resolved_secret_arns.setdefault(environment, after_secret_arn)
+        if prior_secret_arn != after_secret_arn:
+            raise ValueError("environment policies resolve different secrets")
+
+    drift = plan.get("resource_drift", [])
+    if not isinstance(drift, list) or drift:
+        raise ValueError("resource drift is present")
+
+    if phase == "adoption":
+        return "Hosted Redis adoption plan accepted: imports=2 creates=2 updates=0 deletes=0"
+    return "Hosted Redis steady-state plan accepted: changes=0 drift=0"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phase", choices=("adoption", "steady-state"))
+    args = parser.parse_args()
+    try:
+        plan = json.load(sys.stdin)
+        print(validate(plan, args.phase))
+        return 0
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+        print("Hosted Redis plan rejected; plan details withheld.", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/infra/hosted-redis/imports.tf
+++ b/server/infra/hosted-redis/imports.tf
@@ -1,0 +1,10 @@
+# The two deploy-role policies already exist with the exact desired document.
+# Configuration-driven imports make adoption visible in the saved plan instead
+# of blind-upserting a same-named inline policy. Execution-role policies are not
+# imported: the adoption plan must show those two instances as creates.
+import {
+  for_each = local.environments
+
+  to = aws_iam_role_policy.deploy_secret_read[each.key]
+  id = "${each.value.deploy_role_name}:api-redis-secret-read"
+}

--- a/server/infra/hosted-redis/main.tf
+++ b/server/infra/hosted-redis/main.tf
@@ -1,0 +1,119 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # This root owns only the hosted server Redis binding. Keeping its state
+  # separate prevents the legacy bootstrap root in server/infra/main.tf from
+  # claiming or replacing the current staging/production ECS services.
+  backend "s3" {
+    bucket  = "proliferate-terraform-state"
+    key     = "server/hosted-redis/terraform.tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}
+
+locals {
+  contract       = jsondecode(file("${path.module}/../../deploy/hosted-redis-contract.json"))
+  aws_account_id = local.contract.aws_account_id
+  aws_region     = local.contract.aws_region
+
+  # This isolated root consumes the same checked-in environment contract as
+  # the deploy workflow and does not claim any other deployment surface.
+  environments = local.contract.environments
+}
+
+provider "aws" {
+  region              = local.aws_region
+  allowed_account_ids = [local.aws_account_id]
+}
+
+data "aws_caller_identity" "current" {}
+
+check "aws_account_binding" {
+  assert {
+    condition     = data.aws_caller_identity.current.account_id == local.aws_account_id
+    error_message = "The hosted Redis root may run only in its bound AWS account."
+  }
+}
+
+data "aws_secretsmanager_secret" "server_app" {
+  for_each = local.environments
+  name     = each.value.secret_name
+}
+
+data "aws_iam_role" "deploy" {
+  for_each = local.environments
+  name     = each.value.deploy_role_name
+}
+
+data "aws_iam_role" "execution" {
+  for_each = local.environments
+  name     = each.value.execution_role_name
+}
+
+check "secret_identity_binding" {
+  assert {
+    condition = alltrue([
+      for environment, contract in local.environments :
+      can(regex(
+        "^arn:aws:secretsmanager:${local.aws_region}:${local.aws_account_id}:secret:${contract.secret_name}-[A-Za-z0-9]{6}$",
+        data.aws_secretsmanager_secret.server_app[environment].arn,
+      ))
+    ])
+    error_message = "Each hosted environment must resolve its exact account-, region-, and name-bound server-app secret."
+  }
+}
+
+# The deploy role reads the JSON record only for the value-safe preflight. The
+# policy has one action and one exact secret ARN; it cannot enumerate secrets or
+# read the other environment's record.
+resource "aws_iam_role_policy" "deploy_secret_read" {
+  for_each = local.environments
+  name     = "api-redis-secret-read"
+  role     = data.aws_iam_role.deploy[each.key].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "ReadApiRedisSecret"
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = [data.aws_secretsmanager_secret.server_app[each.key].arn]
+    }]
+  })
+
+  # These policies predate this root and are adopted by imports.tf. Never let a
+  # destroy or resource removal turn state de-adoption into a live deletion.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ECS resolves REDBEAT_REDIS_URL from the same record when a task starts. This
+# child policy owns only that read grant; the existing role remains data-owned.
+resource "aws_iam_role_policy" "execution_secret_read" {
+  for_each = local.environments
+  name     = "api-redis-secret-read"
+  role     = data.aws_iam_role.execution[each.key].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "ReadApiRedisSecret"
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = [data.aws_secretsmanager_secret.server_app[each.key].arn]
+    }]
+  })
+
+  # Redis is a production dependency. Removal requires a separately reviewed
+  # ownership transfer, never an incidental destroy of this isolated root.
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/server/infra/hosted-redis/tests/contract.tftest.hcl
+++ b/server/infra/hosted-redis/tests/contract.tftest.hcl
@@ -1,0 +1,117 @@
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "157466816238"
+    }
+  }
+}
+
+# Configuration-driven deploy-policy imports are exercised by the real-account
+# adoption plan. Mock providers cannot execute imports, so override only those
+# two instances while retaining their configured policy values for assertions.
+override_resource {
+  target = aws_iam_role_policy.deploy_secret_read["staging"]
+}
+
+override_resource {
+  target = aws_iam_role_policy.deploy_secret_read["production"]
+}
+
+run "least_privilege_environment_bindings" {
+  command = plan
+
+  override_data {
+    target = data.aws_secretsmanager_secret.server_app["staging"]
+    values = {
+      arn  = "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/staging/server-app-Ab12Cd"
+      name = "proliferate/staging/server-app"
+    }
+  }
+
+  override_data {
+    target = data.aws_secretsmanager_secret.server_app["production"]
+    values = {
+      arn  = "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app-Ef34Gh"
+      name = "proliferate/prod/server-app"
+    }
+  }
+
+  assert {
+    condition     = toset(keys(local.environments)) == toset(["staging", "production"])
+    error_message = "Only the two hosted server environments may be managed."
+  }
+
+  assert {
+    condition = (
+      local.aws_account_id == "157466816238"
+      && local.aws_region == "us-east-1"
+      && toset(local.environments.staging.workflow_names) == toset(["staging", "Staging"])
+      && toset(local.environments.production.workflow_names) == toset(["production", "Production"])
+      && local.environments.staging.background_redis_reference_service == "secretsmanager"
+      && local.environments.staging.background_redis_reference_name == "proliferate/staging/background/redbeat-redis-url"
+      && local.environments.production.background_redis_reference_service == "secretsmanager"
+      && local.environments.production.background_redis_reference_name == "proliferate/production/background/redbeat-redis-url"
+    )
+    error_message = "Terraform must consume the exact workflow account/region/environment aliases."
+  }
+
+  assert {
+    condition = alltrue([
+      for environment in keys(local.environments) :
+      length(jsondecode(aws_iam_role_policy.deploy_secret_read[environment].policy).Statement) == 1
+    ])
+    error_message = "Every deploy policy must contain exactly one statement."
+  }
+
+  assert {
+    condition = alltrue([
+      for environment in keys(local.environments) :
+      jsondecode(aws_iam_role_policy.deploy_secret_read[environment].policy).Statement[0].Action == ["secretsmanager:GetSecretValue"]
+      && jsondecode(aws_iam_role_policy.deploy_secret_read[environment].policy).Statement[0].Sid == "ReadApiRedisSecret"
+    ])
+    error_message = "Deploy roles may receive only GetSecretValue."
+  }
+
+  assert {
+    condition = alltrue([
+      for environment in keys(local.environments) :
+      jsondecode(aws_iam_role_policy.deploy_secret_read[environment].policy).Statement[0].Resource == [data.aws_secretsmanager_secret.server_app[environment].arn]
+    ])
+    error_message = "Deploy policies must target exactly their environment secret."
+  }
+
+  assert {
+    condition = alltrue([
+      for environment in keys(local.environments) :
+      jsondecode(aws_iam_role_policy.execution_secret_read[environment].policy).Statement[0] == jsondecode(aws_iam_role_policy.deploy_secret_read[environment].policy).Statement[0]
+    ])
+    error_message = "Execution and deploy roles must receive the same exact-secret read grant."
+  }
+}
+
+run "wrong_account_fails_closed" {
+  command = plan
+
+  override_data {
+    target = data.aws_caller_identity.current
+    values = {
+      account_id = "111122223333"
+    }
+  }
+
+  override_data {
+    target = data.aws_secretsmanager_secret.server_app["staging"]
+    values = {
+      arn = "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/staging/server-app-Ab12Cd"
+    }
+  }
+
+  override_data {
+    target = data.aws_secretsmanager_secret.server_app["production"]
+    values = {
+      arn = "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app-Ef34Gh"
+    }
+  }
+
+  expect_failures = [check.aws_account_binding]
+}

--- a/server/tests/helpers/hosted_redis_deploy.py
+++ b/server/tests/helpers/hosted_redis_deploy.py
@@ -1,0 +1,169 @@
+"""Helpers for exercising the embedded hosted Redis deploy preflight."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+EXPECTED_AWS_ACCOUNT_ID = "157466816238"
+APP_SECRET_ARN = (
+    "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app-Ab12Cd"
+)
+
+
+def marked_shell(run_script: str, marker: str) -> str:
+    """Extract one non-empty marker-delimited shell fragment with diagnostics."""
+
+    start_token = f"# {marker}_BEGIN\n"
+    end_token = f"\n# {marker}_END"
+    start_count = run_script.count(start_token)
+    end_count = run_script.count(end_token)
+    if start_count != 1 or end_count != 1:
+        raise AssertionError(
+            f"{marker} requires exactly one begin and end marker; "
+            f"found begin={start_count}, end={end_count}"
+        )
+    start = run_script.index(start_token) + len(start_token)
+    end = run_script.index(end_token)
+    if end < start:
+        raise AssertionError(f"{marker} end marker must follow its begin marker")
+    body = run_script[start:end]
+    if not body.strip():
+        raise AssertionError(f"{marker} delimits an empty shell fragment")
+    return body
+
+
+def _write_dns_override(tmp_path: Path) -> None:
+    """Install deterministic getaddrinfo results for the embedded validator."""
+
+    (tmp_path / "sitecustomize.py").write_text(
+        """import ipaddress
+import os
+import socket
+import time
+
+
+def _answer(address, port, sock_type):
+    parsed = ipaddress.ip_address(address.split("%", 1)[0])
+    family = socket.AF_INET6 if parsed.version == 6 else socket.AF_INET
+    sockaddr = (address, port, 0, 0) if parsed.version == 6 else (address, port)
+    return (family, sock_type or socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+
+
+def _getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+    del family, proto, flags
+    answers = {
+        "cache.internal": ["10.20.30.40"],
+        "loopback.alias": ["127.0.0.1"],
+        "unspecified.alias": ["0.0.0.0"],
+        "mixed.alias": ["10.20.30.40", "127.0.0.1"],
+        "scoped-loopback.alias": ["::1%lo0"],
+    }
+    if host == "timeout.alias":
+        time.sleep(float(os.environ.get("FAKE_DNS_DELAY_SECONDS", "30")))
+        return [_answer("10.20.30.40", port, type)]
+    if host == "unresolved.alias":
+        raise socket.gaierror("synthetic resolution failure")
+    if host in answers:
+        return [_answer(address, port, type) for address in answers[host]]
+    try:
+        ipaddress.ip_address(host.split("%", 1)[0])
+    except ValueError as exc:
+        raise socket.gaierror("unexpected synthetic hostname") from exc
+    return [_answer(host, port, type)]
+
+
+socket.getaddrinfo = _getaddrinfo
+"""
+    )
+
+
+def _ensure_timeout_command(tmp_path: Path) -> None:
+    """Provide the workflow's GNU-timeout interface on non-GNU dev hosts."""
+
+    if shutil.which("timeout") is not None:
+        return
+    timeout = tmp_path / "timeout"
+    timeout.write_text(
+        """#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+args = sys.argv[1:]
+if len(args) < 4 or args[0] != "--signal=TERM" or not args[1].startswith("--kill-after="):
+    raise SystemExit(125)
+try:
+    kill_after = float(args[1].split("=", 1)[1].removesuffix("s"))
+    duration = float(args[2].removesuffix("s"))
+except ValueError:
+    raise SystemExit(125) from None
+process = subprocess.Popen(args[3:])
+try:
+    raise SystemExit(process.wait(timeout=duration))
+except subprocess.TimeoutExpired:
+    process.terminate()
+    try:
+        process.wait(timeout=kill_after)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+    raise SystemExit(124) from None
+"""
+    )
+    timeout.chmod(0o755)
+
+
+def run_redis_preflight(
+    tmp_path: Path,
+    run_script: str,
+    *,
+    redis_url: str,
+    secret_arn: str = APP_SECRET_ARN,
+    aws_stderr: str = "",
+    aws_exit: int = 0,
+    dns_timeout_seconds: int = 20,
+    dns_delay_seconds: int = 30,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the exact workflow body against deterministic DNS and fake AWS."""
+
+    _write_dns_override(tmp_path)
+    _ensure_timeout_command(tmp_path)
+    fake_aws = tmp_path / "aws"
+    fake_aws.write_text(
+        "#!/bin/sh\n"
+        "printf '%s' \"$FAKE_AWS_STDERR\" >&2\n"
+        'if [ "$FAKE_AWS_EXIT" -ne 0 ]; then exit "$FAKE_AWS_EXIT"; fi\n'
+        "printf '%s\\n' \"$FAKE_AWS_RESPONSE\"\n"
+    )
+    fake_aws.chmod(0o755)
+    script = tmp_path / "preflight.sh"
+    script.write_text(run_script)
+    github_output = tmp_path / "github-output"
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "PYTHONPATH": str(tmp_path),
+        "FAKE_AWS_STDERR": aws_stderr,
+        "FAKE_AWS_EXIT": str(aws_exit),
+        "FAKE_AWS_RESPONSE": json.dumps(
+            {
+                "ARN": secret_arn,
+                "SecretString": json.dumps({"REDBEAT_REDIS_URL": redis_url}),
+            }
+        ),
+        "AWS_REGION": "us-east-1",
+        "EXPECTED_AWS_ACCOUNT_ID": EXPECTED_AWS_ACCOUNT_ID,
+        "REDBEAT_REDIS_SECRET_NAME": "proliferate/prod/server-app",
+        "REDIS_PREFLIGHT_TIMEOUT_SECONDS": str(dns_timeout_seconds),
+        "FAKE_DNS_DELAY_SECONDS": str(dns_delay_seconds),
+        "GITHUB_OUTPUT": str(github_output),
+    }
+    result = subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True, env=env, timeout=10
+    )
+    written_output = github_output.read_text() if github_output.exists() else ""
+    return result, written_output

--- a/server/tests/integration/test_support_feed_deploy_render.py
+++ b/server/tests/integration/test_support_feed_deploy_render.py
@@ -1,22 +1,24 @@
-"""Deploy-time task-render contract tests for the private support feed.
+"""Deploy-time task-render contracts for secret-backed hosted dependencies.
 
 The render (MERGE_JQ) and fail-closed check (ASSERT_JQ) are pure jq programs
 embedded verbatim in `.github/workflows/_deploy-server.yml`. We extract and run
 them with real jq over synthetic task JSON; no AWS call and no secret value is
 involved. Split from ``test_support_feed.py`` solely to satisfy the repo-shape
-600-line source cap (``scripts/check_max_lines.py``); the tests are relocated
-unchanged.
+600-line source cap (``scripts/check_max_lines.py``); this module now owns the
+shared hosted-secret render contracts.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
+from tests.helpers.hosted_redis_deploy import APP_SECRET_ARN, marked_shell, run_redis_preflight
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DEPLOY_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "_deploy-server.yml"
@@ -25,6 +27,12 @@ _PROD_FEED_ARN = (
     "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/support-feed-NoKayy"
 )
 _FEED_VALUE_FROM = f"{_PROD_FEED_ARN}:supportFeedToken::"
+_APP_SECRET_ARN = APP_SECRET_ARN
+_REDIS_VALUE_FROM = f"{_APP_SECRET_ARN}:REDBEAT_REDIS_URL::"
+_STALE_REDIS_VALUE_FROM = (
+    "arn:aws:secretsmanager:us-east-1:157466816238:"
+    "secret:stale-server-app-Zz99Yy:REDBEAT_REDIS_URL::"
+)
 # Distinct ARNs used only to build synthetic prior/duplicate task states.
 _STALE_VALUE_FROM = "arn:aws:secretsmanager:us-east-1:1:secret:stale:supportFeedToken::"
 _OTHER_VALUE_FROM = "arn:aws:secretsmanager:us-east-1:1:secret:other:supportFeedToken::"
@@ -54,6 +62,34 @@ def _render_jq_programs() -> tuple[str, str]:
     steps = workflow["jobs"]["deploy"]["steps"]
     run_script = next(s["run"] for s in steps if s.get("name") == "Render ECS task definition")
     return _extract_heredoc(run_script, "MERGE_JQ"), _extract_heredoc(run_script, "ASSERT_JQ")
+
+
+def _secret_updates_from_workflow(tmp_path: Path) -> list[dict]:
+    """Execute the exact secret-update authoring fragment from the workflow."""
+
+    workflow = yaml.safe_load(_DEPLOY_WORKFLOW.read_text())
+    steps = workflow["jobs"]["deploy"]["steps"]
+    run_script = next(s["run"] for s in steps if s.get("name") == "Render ECS task definition")
+    fragment = marked_shell(run_script, "HOSTED_SECRET_UPDATES")
+    script = tmp_path / "author-secrets.sh"
+    script.write_text("set -euo pipefail\n" + fragment + "\n")
+    env = {
+        **os.environ,
+        "SUPPORT_FEED_SECRET_ARN": _PROD_FEED_ARN,
+        "REDBEAT_REDIS_SECRET_ARN": _APP_SECRET_ARN,
+        "secret_updates_file": str(tmp_path / "secret-updates.json"),
+        "support_github_private_key_parameter": "",
+        "support_linear_api_key_parameter": "/proliferate/prod/support/linear-api-key",
+    }
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads((tmp_path / "secret-updates.json").read_text())
 
 
 def _run_jq(
@@ -119,7 +155,17 @@ def _merge(
 
 def _assert_task(final_task: dict, tmp_path: Path) -> subprocess.CompletedProcess[str]:
     _, assert_program = _render_jq_programs()
-    return _run_jq(assert_program, final_task, tmp_path, "--arg", "container", _CONTAINER)
+    return _run_jq(
+        assert_program,
+        final_task,
+        tmp_path,
+        "--arg",
+        "container",
+        _CONTAINER,
+        "--arg",
+        "redis_value_from",
+        _REDIS_VALUE_FROM,
+    )
 
 
 def _server_container(task: dict) -> dict:
@@ -127,11 +173,185 @@ def _server_container(task: dict) -> dict:
     return container
 
 
+def test_deploy_preflights_environment_owned_redis_field_before_render() -> None:
+    workflow = yaml.safe_load(_DEPLOY_WORKFLOW.read_text())
+    steps = workflow["jobs"]["deploy"]["steps"]
+    names = [step.get("name", "") for step in steps]
+    preflight = next(
+        step for step in steps if step.get("name") == "Verify API Redis secret reference"
+    )
+    run = str(preflight["run"])
+
+    assert names.index("Verify API Redis secret reference") < names.index(
+        "Render ECS task definition"
+    )
+    assert '--secret-id "$REDBEAT_REDIS_SECRET_NAME"' in run
+    assert 'response.get("ARN")' in run
+    assert 'response.get("SecretString")' in run
+    assert 'payload.get("REDBEAT_REDIS_URL")' in run
+    assert "urlsplit" in run
+    assert "unquote(host)" in run
+    assert "ipaddress.ip_address" in run
+    assert "address.is_loopback" in run
+    assert "socket.inet_aton" in run
+    assert "socket.getaddrinfo" in run
+    assert "resolved_address.is_loopback" in run
+    assert "value not printed or retained" in run
+
+
+def _redis_preflight_run() -> str:
+    workflow = yaml.safe_load(_DEPLOY_WORKFLOW.read_text())
+    return str(
+        next(
+            step
+            for step in workflow["jobs"]["deploy"]["steps"]
+            if step.get("name") == "Verify API Redis secret reference"
+        )["run"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("redis_url", "accepted"),
+    [
+        pytest.param("rediss://cache.internal:6379/0", True, id="managed-endpoint"),
+        pytest.param("rediss://loopback.alias:6379/0", False, id="dns-loopback"),
+        pytest.param("rediss://unspecified.alias:6379/0", False, id="dns-unspecified"),
+        pytest.param("rediss://mixed.alias:6379/0", False, id="dns-mixed-answer"),
+        pytest.param("rediss://scoped-loopback.alias:6379/0", False, id="dns-scoped-ipv6"),
+        pytest.param("rediss://unresolved.alias:6379/0", False, id="dns-unresolved"),
+        pytest.param("redis://localhost:6379/0", False, id="localhost"),
+        pytest.param("redis://localhost", False, id="localhost-no-boundary"),
+        pytest.param("redis://foo.localhost:6379/0", False, id="localhost-subdomain"),
+        pytest.param("redis://local%68ost:6379/0", False, id="encoded-localhost"),
+        pytest.param("redis://127.42.0.1:6379/0", False, id="ipv4-loopback-range"),
+        pytest.param("redis://%31%32%37.0.0.1:6379/0", False, id="encoded-ipv4-loopback"),
+        pytest.param("redis://127.0.0.1", False, id="ipv4-loopback-no-boundary"),
+        pytest.param("redis://127.1:6379/0", False, id="ipv4-loopback-shorthand"),
+        pytest.param("redis://[::1]:6379/0", False, id="ipv6-loopback"),
+        pytest.param(
+            "redis://[0:0:0:0:0:0:0:1]:6379/0",
+            False,
+            id="ipv6-loopback-expanded",
+        ),
+        pytest.param("redis://0.0.0.0", False, id="unspecified-address"),
+        pytest.param(
+            "redis://user:synthetic-password@127.0.0.1:6379/0",
+            False,
+            id="credentialed-loopback",
+        ),
+        pytest.param(
+            "redis://user:synthetic-password@localhost:6379/0", False, id="auth-localhost"
+        ),
+        pytest.param("redis://", False, id="hostless"),
+        pytest.param("redis:///tmp/redis.sock", False, id="unix-socket-url"),
+        pytest.param("not-a-redis-url", False, id="invalid-scheme"),
+    ],
+)
+def test_deploy_redis_preflight_is_value_safe_and_rejects_loopback(
+    redis_url: str,
+    accepted: bool,
+    tmp_path: Path,
+) -> None:
+    result, written_output = run_redis_preflight(
+        tmp_path, _redis_preflight_run(), redis_url=redis_url
+    )
+
+    assert (result.returncode == 0) is accepted
+    assert redis_url not in result.stdout
+    assert redis_url not in result.stderr
+    if accepted:
+        assert written_output == f"secret_arn={_APP_SECRET_ARN}\n"
+    else:
+        assert written_output == ""
+
+
+@pytest.mark.parametrize(
+    "secret_arn",
+    [
+        "arn:aws:secretsmanager:us-west-2:157466816238:secret:proliferate/prod/server-app-Ab12Cd",
+        "arn:aws:secretsmanager:us-east-1:111122223333:secret:proliferate/prod/server-app-Ab12Cd",
+        "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/staging/server-app-Ab12Cd",
+        "arn:aws:secretsmanager:us-east-1:157466816238:secret:proliferate/prod/server-app",
+    ],
+)
+def test_deploy_redis_preflight_rejects_wrong_secret_identity(
+    secret_arn: str, tmp_path: Path
+) -> None:
+    result, written_output = run_redis_preflight(
+        tmp_path,
+        _redis_preflight_run(),
+        redis_url="rediss://cache.internal:6379/0",
+        secret_arn=secret_arn,
+    )
+
+    assert result.returncode != 0
+    assert secret_arn not in result.stdout
+    assert secret_arn not in result.stderr
+    assert written_output == ""
+
+
+@pytest.mark.parametrize(("aws_exit", "accepted"), [(0, True), (55, False)])
+def test_deploy_redis_preflight_suppresses_aws_stderr(
+    aws_exit: int, accepted: bool, tmp_path: Path
+) -> None:
+    leaked = (
+        "synthetic aws error arn:aws:secretsmanager:us-east-1:111122223333:secret:hidden "
+        "redis://user:password@leaked.internal:6379/0"
+    )
+    result, _ = run_redis_preflight(
+        tmp_path,
+        _redis_preflight_run(),
+        redis_url="rediss://cache.internal:6379/0",
+        aws_stderr=leaked,
+        aws_exit=aws_exit,
+    )
+
+    assert (result.returncode == 0) is accepted
+    assert leaked not in result.stdout
+    assert leaked not in result.stderr
+    assert "password" not in result.stdout
+    assert "password" not in result.stderr
+
+
+def test_support_feed_preflight_suppresses_aws_identifiers(tmp_path: Path) -> None:
+    workflow = yaml.safe_load(_DEPLOY_WORKFLOW.read_text())
+    steps = workflow["jobs"]["deploy"]["steps"]
+    run = str(
+        next(step for step in steps if step.get("name") == "Verify support feed secret reference")[
+            "run"
+        ]
+    )
+    fake_aws = tmp_path / "aws"
+    leaked_arn = "arn:aws:secretsmanager:us-east-1:111122223333:secret:hidden-Ab12Cd"
+    fake_aws.write_text("#!/bin/sh\nprintf '%s\\n' \"$LEAKED_AWS_ERROR\" >&2\nexit 44\n")
+    fake_aws.chmod(0o755)
+    script = tmp_path / "support-preflight.sh"
+    script.write_text(run)
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "SUPPORT_FEED_SECRET_ARN": leaked_arn,
+            "LEAKED_AWS_ERROR": f"access denied for {leaked_arn}",
+        },
+    )
+
+    assert result.returncode != 0
+    assert leaked_arn not in result.stdout
+    assert leaked_arn not in result.stderr
+    assert (
+        result.stderr.strip() == "The support feed secret is missing, inaccessible, or malformed."
+    )
+
+
 @_requires_jq
-def test_render_projects_single_feed_secret_and_strips_inherited_plaintext(tmp_path: Path) -> None:
-    # The live task inherits both a stale feed secret and a leaked plaintext
-    # SUPPORT_FEED_BEARER_TOKEN. The render must dedupe to one secret and drop
-    # the plaintext entry.
+def test_render_authors_hosted_secrets_and_strips_inherited_plaintext(tmp_path: Path) -> None:
+    # The live task inherits stale secret references and leaked plaintext
+    # entries. The render must replace both owned refs, dedupe them, and drop
+    # every plaintext copy.
     raw_task = {
         "taskDefinitionArn": "arn:aws:ecs:us-east-1:1:task-definition/proliferate-prod-server:5",
         "revision": 5,
@@ -148,6 +368,7 @@ def test_render_projects_single_feed_secret_and_strips_inherited_plaintext(tmp_p
                 "environment": [
                     {"name": "API_URL", "value": "old"},
                     {"name": "SUPPORT_FEED_BEARER_TOKEN", "value": "LEAKED-PLAINTEXT"},
+                    {"name": "REDBEAT_REDIS_URL", "value": "redis://plaintext.invalid/0"},
                     # Stale runtime-identity overrides inherited from the prior
                     # task revision; the merge must strip them.
                     {"name": "ANYHARNESS_GIT_SHA", "value": "deadbeefcafe"},
@@ -162,19 +383,14 @@ def test_render_projects_single_feed_secret_and_strips_inherited_plaintext(tmp_p
                         "name": "SUPPORT_FEED_BEARER_TOKEN",
                         "valueFrom": _STALE_VALUE_FROM,
                     },
+                    {"name": "REDBEAT_REDIS_URL", "valueFrom": _STALE_REDIS_VALUE_FROM},
                     {"name": "OTHER", "valueFrom": "keepme"},
                 ],
             },
             {"name": "sidecar", "image": "s"},
         ],
     }
-    secret_updates = [
-        {"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM},
-        {
-            "name": "SUPPORT_LINEAR_API_KEY",
-            "valueFrom": "/proliferate/prod/support/linear-api-key",
-        },
-    ]
+    secret_updates = _secret_updates_from_workflow(tmp_path)
 
     final = _merge(raw_task, secret_updates, tmp_path)
     container = _server_container(final)
@@ -182,6 +398,10 @@ def test_render_projects_single_feed_secret_and_strips_inherited_plaintext(tmp_p
     feed_secrets = [s for s in container["secrets"] if s["name"] == "SUPPORT_FEED_BEARER_TOKEN"]
     assert feed_secrets == [{"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM}]
     assert [e for e in container["environment"] if e["name"] == "SUPPORT_FEED_BEARER_TOKEN"] == []
+    assert [s for s in container["secrets"] if s["name"] == "REDBEAT_REDIS_URL"] == [
+        {"name": "REDBEAT_REDIS_URL", "valueFrom": _REDIS_VALUE_FROM}
+    ]
+    assert [e for e in container["environment"] if e["name"] == "REDBEAT_REDIS_URL"] == []
     # A non-feed inherited secret survives.
     assert any(s["name"] == "OTHER" for s in container["secrets"])
     # Every inherited stale runtime-identity override is stripped.
@@ -212,7 +432,10 @@ def test_render_assert_passes_on_well_formed_task(tmp_path: Path) -> None:
                     {"name": "API_URL", "value": "x"},
                     {"name": "PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "value": "1"},
                 ],
-                "secrets": [{"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM}],
+                "secrets": [
+                    {"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM},
+                    {"name": "REDBEAT_REDIS_URL", "valueFrom": _REDIS_VALUE_FROM},
+                ],
             }
         ]
     }
@@ -303,5 +526,72 @@ def test_render_assert_passes_on_well_formed_task(tmp_path: Path) -> None:
 def test_render_assert_fails_closed(container: dict, expected_reason: str, tmp_path: Path) -> None:
     task = {"containerDefinitions": [container]}
     result = _assert_task(task, tmp_path)
+    assert result.returncode != 0
+    assert expected_reason in result.stderr
+
+
+@_requires_jq
+@pytest.mark.parametrize(
+    ("redis_environment", "redis_secrets", "expected_reason"),
+    [
+        pytest.param([], [], "expected exactly one REDBEAT_REDIS_URL", id="missing-secret"),
+        pytest.param(
+            [{"name": "REDBEAT_REDIS_URL", "value": "redis://plaintext.invalid/0"}],
+            [{"name": "REDBEAT_REDIS_URL", "valueFrom": _REDIS_VALUE_FROM}],
+            "must not be present as a plaintext environment entry",
+            id="plaintext-duplicate",
+        ),
+        pytest.param(
+            [],
+            [
+                {"name": "REDBEAT_REDIS_URL", "valueFrom": _REDIS_VALUE_FROM},
+                {
+                    "name": "REDBEAT_REDIS_URL",
+                    "valueFrom": (
+                        "arn:aws:secretsmanager:us-east-1:1:secret:other:REDBEAT_REDIS_URL::"
+                    ),
+                },
+            ],
+            "expected exactly one REDBEAT_REDIS_URL",
+            id="duplicate-secret",
+        ),
+        pytest.param(
+            [],
+            [{"name": "REDBEAT_REDIS_URL", "valueFrom": "/ssm/redis-url"}],
+            "must match the environment-owned Secrets Manager field reference",
+            id="unowned-reference",
+        ),
+        pytest.param(
+            [],
+            [{"name": "REDBEAT_REDIS_URL", "valueFrom": _APP_SECRET_ARN}],
+            "must match the environment-owned Secrets Manager field reference",
+            id="missing-field-projection",
+        ),
+    ],
+)
+def test_render_assert_requires_secret_backed_redis_url(
+    redis_environment: list[dict],
+    redis_secrets: list[dict],
+    expected_reason: str,
+    tmp_path: Path,
+) -> None:
+    task = {
+        "containerDefinitions": [
+            {
+                "name": _CONTAINER,
+                "environment": [
+                    {"name": "PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "value": "1"},
+                    *redis_environment,
+                ],
+                "secrets": [
+                    {"name": "SUPPORT_FEED_BEARER_TOKEN", "valueFrom": _FEED_VALUE_FROM},
+                    *redis_secrets,
+                ],
+            }
+        ]
+    }
+
+    result = _assert_task(task, tmp_path)
+
     assert result.returncode != 0
     assert expected_reason in result.stderr

--- a/server/tests/unit/test_background_deploy_definitions.py
+++ b/server/tests/unit/test_background_deploy_definitions.py
@@ -208,8 +208,16 @@ def _run_validate_config(tmp_path: Path, env: dict[str, str]) -> subprocess.Comp
     body = str(_deploy_steps()["Validate server deploy config"]["run"])
     script = tmp_path / "validate.sh"
     script.write_text(body)
+    github_env = tmp_path / "github-env"
+    github_output = tmp_path / "github-output"
     base_env = {
-        "AWS_DEPLOY_ROLE_ARN": "role",
+        "PATH": os.environ.get("PATH", ""),
+        "AWS_DEPLOY_ROLE_ARN": (
+            "arn:aws:iam::157466816238:role/proliferate-staging-github-actions-deploy"
+        ),
+        "DEPLOY_ENVIRONMENT": "staging",
+        "GITHUB_ENV": str(github_env),
+        "GITHUB_OUTPUT": str(github_output),
         "ECS_CLUSTER": "cluster",
         "ECS_SERVER_SERVICE": "server",
         "API_URL": "https://api",
@@ -231,7 +239,100 @@ def _run_validate_config(tmp_path: Path, env: dict[str, str]) -> subprocess.Comp
         capture_output=True,
         text=True,
         env=base_env,
+        cwd=REPO_ROOT,
     )
+
+
+@pytest.mark.parametrize(
+    (
+        "environment",
+        "role_name",
+        "expected_execution_role_name",
+        "expected_secret_name",
+        "expected_background_secret_name",
+    ),
+    [
+        (
+            "staging",
+            "proliferate-staging-github-actions-deploy",
+            "proliferate-staging-ecs-execution",
+            "proliferate/staging/server-app",
+            "proliferate/staging/background/redbeat-redis-url",
+        ),
+        (
+            "Production",
+            "proliferate-prod-github-actions-deploy",
+            "proliferate-prod-ecs-execution",
+            "proliferate/prod/server-app",
+            "proliferate/production/background/redbeat-redis-url",
+        ),
+        (
+            "production",
+            "proliferate-prod-github-actions-deploy",
+            "proliferate-prod-ecs-execution",
+            "proliferate/prod/server-app",
+            "proliferate/production/background/redbeat-redis-url",
+        ),
+    ],
+)
+def test_validate_config_exports_checked_in_redis_owner(
+    environment: str,
+    role_name: str,
+    expected_execution_role_name: str,
+    expected_secret_name: str,
+    expected_background_secret_name: str,
+    tmp_path: Path,
+) -> None:
+    result = _run_validate_config(
+        tmp_path,
+        {
+            "DEPLOY_ENVIRONMENT": environment,
+            "AWS_DEPLOY_ROLE_ARN": f"arn:aws:iam::157466816238:role/{role_name}",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "github-env").read_text() == (
+        "AWS_REGION=us-east-1\n"
+        "EXPECTED_AWS_ACCOUNT_ID=157466816238\n"
+        f"EXPECTED_ECS_EXECUTION_ROLE_NAME={expected_execution_role_name}\n"
+        "EXPECTED_BACKGROUND_REDIS_SERVICE=secretsmanager\n"
+        f"EXPECTED_BACKGROUND_REDIS_NAME={expected_background_secret_name}\n"
+        f"REDBEAT_REDIS_SECRET_NAME={expected_secret_name}\n"
+    )
+    assert (tmp_path / "github-output").read_text() == "aws_region=us-east-1\n"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"DEPLOY_ENVIRONMENT": "development"},
+        {
+            "AWS_DEPLOY_ROLE_ARN": (
+                "arn:aws:iam::111122223333:role/proliferate-staging-github-actions-deploy"
+            )
+        },
+        {
+            "DEPLOY_ENVIRONMENT": "production",
+            "AWS_DEPLOY_ROLE_ARN": (
+                "arn:aws:iam::157466816238:role/proliferate-staging-github-actions-deploy"
+            ),
+        },
+        {"AWS_DEPLOY_ROLE_ARN": "not-an-arn"},
+    ],
+)
+def test_validate_config_rejects_unbound_hosted_identity(
+    overrides: dict[str, str], tmp_path: Path
+) -> None:
+    result = _run_validate_config(tmp_path, overrides)
+
+    assert result.returncode != 0
+    assert "REDBEAT_REDIS_SECRET_NAME=" not in (
+        (tmp_path / "github-env").read_text() if (tmp_path / "github-env").exists() else ""
+    )
+    combined = result.stdout + result.stderr
+    for value in overrides.values():
+        assert value not in combined
 
 
 def test_validate_config_rejects_partial_background_plane(tmp_path: Path) -> None:
@@ -413,7 +514,13 @@ def _run_candidate_proof(
         "CANDIDATE_PROOF_TIMEOUT_SECONDS": timeout_seconds,
         "CANDIDATE_PROOF_POLL_SECONDS": "1",
     }
-    return subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env)
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
 
 
 @_requires_jq

--- a/server/tests/unit/test_hosted_background_deploy_identity.py
+++ b/server/tests/unit/test_hosted_background_deploy_identity.py
@@ -1,0 +1,232 @@
+"""Fail-closed identity contracts for hosted worker/Beat task registration."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "_deploy-server.yml"
+CONTRACT_PATH = REPO_ROOT / "server" / "deploy" / "hosted-redis-contract.json"
+CONTRACT = json.loads(CONTRACT_PATH.read_text())
+ACCOUNT = CONTRACT["aws_account_id"]
+REGION = CONTRACT["aws_region"]
+STAGING = CONTRACT["environments"]["staging"]
+EXECUTION_ROLE = f"arn:aws:iam::{ACCOUNT}:role/{STAGING['execution_role_name']}"
+REDIS_PREFIX = (
+    f"arn:aws:secretsmanager:{REGION}:{ACCOUNT}:secret:"
+    f"{STAGING['background_redis_reference_name']}-"
+)
+REDIS_ARN = f"{REDIS_PREFIX}Ab12Cd"
+SSM_NAME = "/proliferate/staging/background/redbeat-redis-url"
+SSM_ARN = f"arn:aws:ssm:{REGION}:{ACCOUNT}:parameter{SSM_NAME}"
+
+requires_jq = pytest.mark.skipif(shutil.which("jq") is None, reason="jq is required")
+
+
+def _steps() -> dict[str, dict[str, object]]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    return {step.get("name", ""): step for step in workflow["jobs"]["deploy"]["steps"]}
+
+
+def _extract_heredoc(run_script: str, tag: str) -> str:
+    opener = f"<<'{tag}'\n"
+    start = run_script.index(opener) + len(opener)
+    end = run_script.index(f"\n{tag}\n", start)
+    return run_script[start:end]
+
+
+def _task(container: str) -> dict[str, object]:
+    return {
+        "family": f"synthetic-{container}",
+        "executionRoleArn": EXECUTION_ROLE,
+        "containerDefinitions": [
+            {
+                "name": container,
+                "image": "example.invalid/server@sha256:abc",
+                "environment": [],
+                "secrets": [{"name": "REDBEAT_REDIS_URL", "valueFrom": REDIS_ARN}],
+            }
+        ],
+    }
+
+
+def _run_assertion(
+    task: dict[str, object],
+    container: str,
+    tmp_path: Path,
+    *,
+    redis_prefix: str = REDIS_PREFIX,
+    redis_exact: str = "",
+) -> subprocess.CompletedProcess[str]:
+    background = str(_steps()["Deploy worker and Beat from candidate image"]["run"])
+    program = tmp_path / "background-assert.jq"
+    document = tmp_path / "task.json"
+    program.write_text(_extract_heredoc(background, "BACKGROUND_ASSERT_JQ"))
+    document.write_text(json.dumps(task))
+    return subprocess.run(
+        [
+            "jq",
+            "-e",
+            "--arg",
+            "container",
+            container,
+            "--arg",
+            "execution_role",
+            EXECUTION_ROLE,
+            "--arg",
+            "redis_prefix",
+            redis_prefix,
+            "--arg",
+            "redis_exact",
+            redis_exact,
+            "-f",
+            str(program),
+            str(document),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("container", ["worker", "beat"])
+@requires_jq
+def test_worker_and_beat_accept_exact_execution_role_and_redis_secret(
+    container: str, tmp_path: Path
+) -> None:
+    result = _run_assertion(_task(container), container, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("container", ["worker", "beat"])
+@requires_jq
+def test_worker_and_beat_accept_exact_ssm_parameter_reference(
+    container: str, tmp_path: Path
+) -> None:
+    task = _task(container)
+    task["containerDefinitions"][0]["secrets"][0]["valueFrom"] = SSM_ARN
+
+    result = _run_assertion(task, container, tmp_path, redis_prefix="", redis_exact=SSM_ARN)
+
+    assert result.returncode == 0, result.stderr
+
+
+def _wrong_role(task: dict[str, object], container: str) -> None:
+    del container
+    task["executionRoleArn"] = EXECUTION_ROLE.replace("staging", "production")
+
+
+def _wrong_account(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["secrets"][0]["valueFrom"] = REDIS_ARN.replace(
+        ACCOUNT, "111122223333"
+    )
+
+
+def _wrong_region(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["secrets"][0]["valueFrom"] = REDIS_ARN.replace(
+        REGION, "us-west-2"
+    )
+
+
+def _wrong_secret(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["secrets"][0]["valueFrom"] = REDIS_ARN.replace(
+        "staging/background", "production/background"
+    )
+
+
+def _field_projection(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["secrets"][0]["valueFrom"] += ":REDBEAT_REDIS_URL::"
+
+
+def _duplicate_secret(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["secrets"].append(
+        {"name": "REDBEAT_REDIS_URL", "valueFrom": REDIS_ARN}
+    )
+
+
+def _plaintext_duplicate(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["environment"].append(
+        {"name": "REDBEAT_REDIS_URL", "value": "redis://127.0.0.1:6379"}
+    )
+
+
+def _missing_secret(task: dict[str, object], container: str) -> None:
+    task["containerDefinitions"][0]["secrets"] = []
+
+
+@pytest.mark.parametrize("container", ["worker", "beat"])
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _wrong_role,
+        _wrong_account,
+        _wrong_region,
+        _wrong_secret,
+        _field_projection,
+        _duplicate_secret,
+        _plaintext_duplicate,
+        _missing_secret,
+    ],
+    ids=[
+        "wrong-role",
+        "wrong-account",
+        "wrong-region",
+        "wrong-secret",
+        "field-projection",
+        "duplicate-secret",
+        "plaintext-duplicate",
+        "missing-secret",
+    ],
+)
+@requires_jq
+def test_worker_and_beat_reject_identity_or_projection_mismatch(
+    container: str,
+    mutate: Callable[[dict[str, object], str], None],
+    tmp_path: Path,
+) -> None:
+    task = _task(container)
+    mutate(task, container)
+
+    result = _run_assertion(task, container, tmp_path)
+
+    assert result.returncode != 0
+
+
+def test_background_registration_uses_the_checked_in_contract_before_aws_mutation() -> None:
+    steps = _steps()
+    validation = str(steps["Validate server deploy config"]["run"])
+    background = str(steps["Deploy worker and Beat from candidate image"]["run"])
+
+    assert "background_redis_reference_service" in validation
+    assert "background_redis_reference_name" in validation
+    assert "EXPECTED_BACKGROUND_REDIS_SERVICE" in validation
+    assert "EXPECTED_BACKGROUND_REDIS_NAME" in validation
+    assert "secretsmanager)" in background
+    assert "ssm)" in background
+    assert "expected_background_execution_role" in background
+    assert "expected_background_redis_prefix" in background
+    assert background.index("BACKGROUND_ASSERT_JQ") < background.index(
+        "aws ecs register-task-definition"
+    )
+    assert '"$task_rendered"' in background
+    assert "td-${container}" not in background
+
+
+def test_managed_background_secret_names_match_the_deploy_contract() -> None:
+    background_terraform = (REPO_ROOT / "server" / "infra" / "background.tf").read_text()
+
+    assert 'name  = "proliferate/${var.environment}/background/redbeat-redis-url"' in (
+        background_terraform
+    )
+    for environment, values in CONTRACT["environments"].items():
+        assert values["background_redis_reference_service"] == "secretsmanager"
+        assert values["background_redis_reference_name"] == (
+            f"proliferate/{environment}/background/redbeat-redis-url"
+        )

--- a/server/tests/unit/test_hosted_deploy_identity.py
+++ b/server/tests/unit/test_hosted_deploy_identity.py
@@ -1,0 +1,357 @@
+"""Account-identity and log-redaction contracts for hosted server deploys."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.helpers.hosted_redis_deploy import marked_shell, run_redis_preflight
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEPLOY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "_deploy-server.yml"
+
+
+def _deploy_steps() -> dict[str, dict[str, object]]:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    return {step.get("name", ""): step for step in workflow["jobs"]["deploy"]["steps"]}
+
+
+@pytest.mark.parametrize(
+    ("run_script", "diagnostic"),
+    [
+        ("# BLOCK_BEGIN\nbody\n", "found begin=1, end=0"),
+        (
+            "# BLOCK_BEGIN\nbody\n# BLOCK_END\n# BLOCK_END",
+            "found begin=1, end=2",
+        ),
+        (
+            "prefix\n# BLOCK_END\n# BLOCK_BEGIN\nbody",
+            "end marker must follow its begin marker",
+        ),
+        ("# BLOCK_BEGIN\n\n# BLOCK_END", "delimits an empty shell fragment"),
+    ],
+)
+def test_marked_shell_rejects_ambiguous_or_empty_boundaries(
+    run_script: str, diagnostic: str
+) -> None:
+    with pytest.raises(AssertionError) as exc_info:
+        marked_shell(run_script, "BLOCK")
+
+    assert diagnostic in str(exc_info.value)
+
+
+def test_deploy_masks_account_and_external_aws_identifiers() -> None:
+    steps = _deploy_steps()
+    mask_run = str(steps["Mask hosted AWS identifiers"]["run"])
+    configure = steps["Configure AWS credentials"]
+
+    assert "AWS_DEPLOY_ROLE_ARN" in mask_run
+    assert "SUPPORT_FEED_SECRET_ARN" in mask_run
+    assert "::add-mask::" in mask_run
+    assert configure["with"]["mask-aws-account-id"] is True
+
+
+def test_workflow_and_terraform_consume_one_hosted_contract() -> None:
+    steps = _deploy_steps()
+    validation = str(steps["Validate server deploy config"]["run"])
+    terraform = (REPO_ROOT / "server" / "infra" / "hosted-redis" / "main.tf").read_text()
+    imports = (REPO_ROOT / "server" / "infra" / "hosted-redis" / "imports.tf").read_text()
+    contract_path = "server/deploy/hosted-redis-contract.json"
+
+    assert contract_path in validation
+    assert "execution_role_name" in validation
+    assert "../../deploy/hosted-redis-contract.json" in terraform
+    assert "for_each = local.environments" in imports
+    assert "to = aws_iam_role_policy.deploy_secret_read[each.key]" in imports
+    assert 'id = "${each.value.deploy_role_name}:api-redis-secret-read"' in imports
+    assert terraform.count("prevent_destroy = true") == 2
+    assert "sensitive(jsonencode" not in terraform
+    assert steps["Configure AWS credentials"]["with"]["aws-region"] == (
+        "${{ steps.hosted_contract.outputs.aws_region }}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("actual_account", "accepted"),
+    [("157466816238", True), ("111122223333", False)],
+)
+def test_deploy_verifies_assumed_aws_account(
+    actual_account: str, accepted: bool, tmp_path: Path
+) -> None:
+    body = str(_deploy_steps()["Verify AWS deployment identity"]["run"])
+    fake_aws = tmp_path / "aws"
+    fake_aws.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$ACTUAL_ACCOUNT\"\n"
+        "printf '%s\\n' \"$AWS_ERROR_SENTINEL\" >&2\n"
+    )
+    fake_aws.chmod(0o755)
+    script = tmp_path / "verify-account.sh"
+    script.write_text(body)
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}",
+            "ACTUAL_ACCOUNT": actual_account,
+            "EXPECTED_AWS_ACCOUNT_ID": "157466816238",
+            "AWS_ERROR_SENTINEL": "synthetic role/resource ARN must stay hidden",
+        },
+    )
+
+    assert (result.returncode == 0) is accepted
+    assert "synthetic role/resource ARN" not in result.stdout
+    assert "synthetic role/resource ARN" not in result.stderr
+
+
+def test_redis_identifier_is_step_scoped_after_third_party_action_main_steps() -> None:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    steps = workflow["jobs"]["deploy"]["steps"]
+    names = [step.get("name", "") for step in steps]
+    redis = next(step for step in steps if step.get("name") == "Verify API Redis secret reference")
+    render = next(step for step in steps if step.get("name") == "Render ECS task definition")
+
+    redis_index = names.index("Verify API Redis secret reference")
+    action_indexes = [index for index, step in enumerate(steps) if "uses" in step]
+    assert action_indexes
+    assert max(action_indexes) < redis_index
+    assert redis["id"] == "redis_secret"
+    assert "GITHUB_OUTPUT" in str(redis["run"])
+    assert "GITHUB_ENV" not in str(redis["run"])
+    assert render["env"]["REDBEAT_REDIS_SECRET_ARN"] == (
+        "${{ steps.redis_secret.outputs.secret_arn }}"
+    )
+    assert "REDBEAT_REDIS_SECRET_ARN" not in workflow["jobs"]["deploy"].get("env", {})
+    render_run = str(render["run"])
+    assert "trap cleanup_render_files EXIT" in render_run
+    assert "${RUNNER_TEMP}/hosted-redis-render.XXXXXX" in render_run
+    assert "Third-party actions register post-job hooks" in render_run
+
+
+def test_api_redis_dns_preflight_has_an_external_hard_timeout() -> None:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    redis = _deploy_steps()["Verify API Redis secret reference"]
+    run = str(redis["run"])
+
+    assert workflow["jobs"]["deploy"]["runs-on"] == "ubuntu-latest"
+    assert redis["env"]["REDIS_PREFLIGHT_TIMEOUT_SECONDS"] == "20"
+    assert "timeout --signal=TERM --kill-after=2s" in run
+    assert "124|137)" in run
+    assert "125|126|127)" in run
+    assert "socket.setdefaulttimeout" not in run
+
+
+def test_api_redis_dns_timeout_is_bounded_and_sanitized(tmp_path: Path) -> None:
+    redis_url = "rediss://timeout.alias:6379/0"
+    started = time.monotonic()
+    result, written_output = run_redis_preflight(
+        tmp_path,
+        str(_deploy_steps()["Verify API Redis secret reference"]["run"]),
+        redis_url=redis_url,
+        dns_timeout_seconds=1,
+        dns_delay_seconds=30,
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode != 0
+    assert elapsed < 4
+    assert result.stderr.strip() == (
+        "API Redis endpoint validation timed out before non-loopback DNS safety "
+        "could be established."
+    )
+    assert redis_url not in result.stdout + result.stderr
+    assert "timeout.alias" not in result.stdout + result.stderr
+    assert "arn:aws" not in result.stdout + result.stderr
+    assert written_output == ""
+
+
+@pytest.mark.parametrize(
+    ("task_definition", "execution_role", "aws_fails", "accepted"),
+    [
+        ("expected", "expected", False, True),
+        ("wrong-account", "expected", False, False),
+        ("wrong-region", "expected", False, False),
+        ("expected", "wrong", False, False),
+        ("expected", "missing", False, False),
+        ("expected", "expected", True, False),
+    ],
+)
+def test_deploy_verifies_exact_live_execution_role(
+    task_definition: str,
+    execution_role: str,
+    aws_fails: bool,
+    accepted: bool,
+    tmp_path: Path,
+) -> None:
+    steps = _deploy_steps()
+    render = str(steps["Render ECS task definition"]["run"])
+    body = "\n".join(
+        [
+            marked_shell(render, "HOSTED_REDIS_SCRATCH"),
+            marked_shell(render, "HOSTED_EXECUTION_ROLE_VERIFY"),
+        ]
+    )
+    expected_task = "arn:aws:ecs:us-east-1:157466816238:task-definition/proliferate-server:7"
+    task_definitions = {
+        "expected": expected_task,
+        "wrong-account": expected_task.replace("157466816238", "111122223333"),
+        "wrong-region": expected_task.replace("us-east-1", "us-west-2"),
+    }
+    expected_role = "arn:aws:iam::157466816238:role/proliferate-staging-ecs-execution"
+    execution_roles = {
+        "expected": expected_role,
+        "wrong": expected_role.replace("staging", "production"),
+        "missing": None,
+    }
+    fake_aws = tmp_path / "aws"
+    fake_aws.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'echo "$AWS_ERROR_SENTINEL" >&2\n'
+        'if [[ "$*" == *"ecs describe-services"* ]]; then\n'
+        "  printf '%s\\n' \"$TASK_DEFINITION_ARN\"\n"
+        'elif [[ "$*" == *"ecs describe-task-definition"* ]]; then\n'
+        '  if [ "$AWS_FAILS" = true ]; then exit 1; fi\n'
+        "  printf '%s\\n' \"$TASK_DEFINITION_JSON\"\n"
+        "else\n"
+        "  exit 2\n"
+        "fi\n"
+    )
+    fake_aws.chmod(0o755)
+    script = tmp_path / "verify-execution-role.sh"
+    script.write_text(body)
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={
+            "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}",
+            "AWS_ERROR_SENTINEL": "synthetic provider ARN must stay hidden",
+            "AWS_FAILS": str(aws_fails).lower(),
+            "AWS_REGION": "us-east-1",
+            "ECS_CLUSTER": "cluster",
+            "ECS_SERVER_SERVICE": "service",
+            "EXPECTED_AWS_ACCOUNT_ID": "157466816238",
+            "EXPECTED_ECS_EXECUTION_ROLE_NAME": "proliferate-staging-ecs-execution",
+            "RUNNER_TEMP": str(tmp_path),
+            "TASK_DEFINITION_ARN": task_definitions[task_definition],
+            "TASK_DEFINITION_JSON": json.dumps(
+                {"executionRoleArn": execution_roles[execution_role]}
+                if execution_roles[execution_role] is not None
+                else {}
+            ),
+        },
+    )
+
+    assert (result.returncode == 0) is accepted
+    combined = result.stdout + result.stderr
+    assert "synthetic provider ARN" not in combined
+    assert expected_task not in combined
+    assert expected_role not in combined
+    assert not list(tmp_path.glob("hosted-redis-render.*"))
+
+
+def test_render_scratch_cleanup_removes_every_identifier_bearing_file(
+    tmp_path: Path,
+) -> None:
+    render = str(_deploy_steps()["Render ECS task definition"]["run"])
+    setup = marked_shell(render, "HOSTED_REDIS_SCRATCH")
+    receipt = tmp_path / "scratch-path"
+    script = tmp_path / "exercise-cleanup.sh"
+    script.write_text(
+        "set -euo pipefail\n"
+        + setup
+        + "\n"
+        + 'printf \'%s\\n\' "$render_dir" > "$SCRATCH_PATH_RECEIPT"\n'
+        + "for artifact in \\\n"
+        + '  "$task_definition_raw" \\\n'
+        + '  "$env_updates_file" \\\n'
+        + '  "$secret_updates_file" \\\n'
+        + '  "$merge_program_file" \\\n'
+        + '  "$assert_program_file" \\\n'
+        + '  "$task_definition_rendered"; do\n'
+        + "  printf '%s\\n' 'synthetic-secret-identifier' > \"$artifact\"\n"
+        + "done\n"
+        + "exit 23\n"
+    )
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "RUNNER_TEMP": str(tmp_path),
+            "SCRATCH_PATH_RECEIPT": str(receipt),
+        },
+    )
+
+    assert result.returncode == 23
+    scratch_dir = Path(receipt.read_text().strip())
+    assert not scratch_dir.exists()
+    assert "synthetic-secret-identifier" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("exit_code", [0, 29], ids=["success", "failure"])
+def test_background_scratch_cleanup_removes_redis_bearing_task_definitions(
+    exit_code: int,
+    tmp_path: Path,
+) -> None:
+    background = str(_deploy_steps()["Deploy worker and Beat from candidate image"]["run"])
+    setup = marked_shell(background, "HOSTED_BACKGROUND_SCRATCH")
+    receipt = tmp_path / "background-scratch-path"
+    script = tmp_path / "exercise-background-cleanup.sh"
+    script.write_text(
+        "set -euo pipefail\n"
+        + setup
+        + "\n"
+        + 'printf \'%s\\n\' "$background_render_dir" > "$SCRATCH_PATH_RECEIPT"\n'
+        + "for artifact in \\\n"
+        + '  "$worker_task_raw" \\\n'
+        + '  "$worker_task_rendered" \\\n'
+        + '  "$beat_task_raw" \\\n'
+        + '  "$beat_task_rendered" \\\n'
+        + '  "$background_assert_program"; do\n'
+        + "  printf '%s\\n' "
+        + '\'{"secrets":[{"name":"REDBEAT_REDIS_URL",'
+        + '"valueFrom":"synthetic-secret-identifier"}]}\' > "$artifact"\n'
+        + "done\n"
+        + f"exit {exit_code}\n"
+    )
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "RUNNER_TEMP": str(tmp_path),
+            "SCRATCH_PATH_RECEIPT": str(receipt),
+        },
+    )
+
+    assert result.returncode == exit_code
+    scratch_dir = Path(receipt.read_text().strip())
+    assert not scratch_dir.exists()
+    assert "synthetic-secret-identifier" not in result.stdout + result.stderr
+    assert "td-${container}" not in background
+
+
+def test_verified_task_definition_is_the_one_rendered() -> None:
+    workflow = yaml.safe_load(DEPLOY_WORKFLOW_PATH.read_text())
+    steps = workflow["jobs"]["deploy"]["steps"]
+    render = next(step for step in steps if step.get("name") == "Render ECS task definition")
+    render_run = str(render["run"])
+
+    assert not any(step.get("name") == "Verify ECS task execution role" for step in steps)
+    assert render_run.count("describe-task-definition") == 1
+    assert render_run.index("# HOSTED_EXECUTION_ROLE_VERIFY_BEGIN") < render_run.index(
+        '--slurpfile updates "$env_updates_file"'
+    )
+    assert render_run.count('"$task_definition_raw"') >= 3

--- a/server/tests/unit/test_hosted_redis_adoption_plan.py
+++ b/server/tests/unit/test_hosted_redis_adoption_plan.py
@@ -1,0 +1,282 @@
+"""Safe plan-shape checks for the hosted Redis Terraform adoption."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKER = REPO_ROOT / "server" / "infra" / "hosted-redis" / "check_adoption_plan.py"
+README = REPO_ROOT / "server" / "infra" / "hosted-redis" / "README.md"
+CONTRACT = json.loads((REPO_ROOT / "server" / "deploy" / "hosted-redis-contract.json").read_text())
+ENVIRONMENTS = ("production", "staging")
+POLICY_NAME = "api-redis-secret-read"
+
+
+def _secret_arn(environment: str) -> str:
+    suffix = "Ab12Cd" if environment == "staging" else "Ef34Gh"
+    values = CONTRACT["environments"][environment]
+    return (
+        f"arn:aws:secretsmanager:{CONTRACT['aws_region']}:"
+        f"{CONTRACT['aws_account_id']}:secret:{values['secret_name']}-{suffix}"
+    )
+
+
+def _policy(environment: str) -> str:
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "ReadApiRedisSecret",
+                    "Effect": "Allow",
+                    "Action": ["secretsmanager:GetSecretValue"],
+                    "Resource": [_secret_arn(environment)],
+                }
+            ],
+        },
+        separators=(",", ":"),
+    )
+
+
+def _values(environment: str, kind: str) -> dict[str, object]:
+    role = CONTRACT["environments"][environment][f"{kind}_role_name"]
+    return {
+        "id": f"{role}:{POLICY_NAME}",
+        "name": POLICY_NAME,
+        "policy": _policy(environment),
+        "role": role,
+    }
+
+
+def _change(environment: str, kind: str, phase: str) -> dict[str, object]:
+    creates = phase == "adoption" and kind == "execution"
+    values = _values(environment, kind)
+    change: dict[str, object] = {
+        "actions": ["create"] if creates else ["no-op"],
+        "before": None if creates else copy.deepcopy(values),
+        "after": copy.deepcopy(values),
+        "after_unknown": {"id": True} if creates else {},
+    }
+    if phase == "adoption" and kind == "deploy":
+        role = CONTRACT["environments"][environment]["deploy_role_name"]
+        change["importing"] = {"id": f"{role}:{POLICY_NAME}"}
+    return {
+        "address": f'aws_iam_role_policy.{kind}_secret_read["{environment}"]',
+        "mode": "managed",
+        "change": change,
+    }
+
+
+def _check(name: str, status: str = "pass") -> dict[str, object]:
+    return {
+        "address": {"to_display": f"check.{name}"},
+        "status": status,
+        "instances": [{"status": status}],
+    }
+
+
+def _plan(phase: str) -> dict[str, object]:
+    changes = [
+        _change(environment, kind, phase)
+        for environment in ENVIRONMENTS
+        for kind in ("deploy", "execution")
+    ]
+    changes.append(
+        {
+            "address": "data.aws_caller_identity.current",
+            "mode": "data",
+            "change": {"actions": ["read"]},
+        }
+    )
+    return {
+        "format_version": "1.2",
+        "resource_changes": changes,
+        "resource_drift": [],
+        "checks": [
+            _check("aws_account_binding"),
+            _check("secret_identity_binding"),
+        ],
+    }
+
+
+def _managed(plan: dict[str, object], address_fragment: str) -> dict[str, object]:
+    changes = plan["resource_changes"]
+    assert isinstance(changes, list)
+    return next(
+        change
+        for change in changes
+        if isinstance(change, dict) and address_fragment in str(change.get("address"))
+    )
+
+
+def _run(plan: dict[str, object], phase: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(CHECKER), phase],
+        input=json.dumps(plan),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _wrong_import(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "deploy_secret_read")
+    resource["change"]["importing"]["id"] = "wrong-role:api-redis-secret-read"
+
+
+def _wrong_role(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "execution_secret_read")
+    resource["change"]["after"]["role"] = "wrong-execution-role"
+
+
+def _wildcard_policy(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "execution_secret_read")
+    resource["change"]["after"]["policy"] = json.dumps(
+        {"Version": "2012-10-17", "Statement": [{"Action": "*", "Resource": "*"}]}
+    )
+
+
+def _failed_check(plan: dict[str, object]) -> None:
+    plan["checks"][0]["status"] = "fail"
+
+
+def _unknown_policy(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "execution_secret_read")
+    resource["change"]["after_unknown"]["policy"] = True
+
+
+def _duplicate_managed(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "deploy_secret_read")
+    plan["resource_changes"].append(copy.deepcopy(resource))
+
+
+def _deposed_managed(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "deploy_secret_read")
+    resource["deposed"] = "synthetic-deposed-key"
+
+
+def _extra_managed(plan: dict[str, object]) -> None:
+    resource = copy.deepcopy(_managed(plan, "deploy_secret_read"))
+    resource["address"] = "aws_iam_role_policy.unexpected"
+    plan["resource_changes"].append(resource)
+
+
+def _wrong_account_secret(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "execution_secret_read")
+    policy = json.loads(resource["change"]["after"]["policy"])
+    policy["Statement"][0]["Resource"][0] = policy["Statement"][0]["Resource"][0].replace(
+        CONTRACT["aws_account_id"], "111122223333"
+    )
+    resource["change"]["after"]["policy"] = json.dumps(policy)
+
+
+def _wrong_region_secret(plan: dict[str, object]) -> None:
+    resource = _managed(plan, "execution_secret_read")
+    policy = json.loads(resource["change"]["after"]["policy"])
+    policy["Statement"][0]["Resource"][0] = policy["Statement"][0]["Resource"][0].replace(
+        CONTRACT["aws_region"], "us-west-2"
+    )
+    resource["change"]["after"]["policy"] = json.dumps(policy)
+
+
+def test_accepts_exact_contract_bound_adoption_and_steady_state() -> None:
+    adoption = _run(_plan("adoption"), "adoption")
+    steady = _run(_plan("steady-state"), "steady-state")
+
+    assert adoption.returncode == 0, adoption.stderr
+    assert adoption.stdout == (
+        "Hosted Redis adoption plan accepted: imports=2 creates=2 updates=0 deletes=0\n"
+    )
+    assert steady.returncode == 0, steady.stderr
+    assert steady.stdout == "Hosted Redis steady-state plan accepted: changes=0 drift=0\n"
+
+
+def test_accepts_aws_normalized_singleton_action_and_resource() -> None:
+    plan = _plan("steady-state")
+    for resource in plan["resource_changes"]:
+        if not isinstance(resource, dict) or resource.get("mode") != "managed":
+            continue
+        change = resource["change"]
+        for side in ("before", "after"):
+            policy = json.loads(change[side]["policy"])
+            statement = policy["Statement"][0]
+            statement["Action"] = statement["Action"][0]
+            statement["Resource"] = statement["Resource"][0]
+            change[side]["policy"] = json.dumps(policy)
+
+    result = _run(plan, "steady-state")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "Hosted Redis steady-state plan accepted: changes=0 drift=0\n"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _wrong_import,
+        _wrong_role,
+        _wildcard_policy,
+        _failed_check,
+        _unknown_policy,
+        _duplicate_managed,
+        _deposed_managed,
+        _extra_managed,
+        _wrong_account_secret,
+        _wrong_region_secret,
+    ],
+    ids=[
+        "wrong-import-id",
+        "wrong-role",
+        "wildcard-policy",
+        "failed-check",
+        "unknown-policy",
+        "duplicate-managed",
+        "deposed-managed",
+        "extra-managed",
+        "wrong-account-secret",
+        "wrong-region-secret",
+    ],
+)
+def test_rejects_unsafe_adoption_without_leaking_plan(
+    mutate: Callable[[dict[str, object]], None],
+) -> None:
+    plan = _plan("adoption")
+    mutate(plan)
+    plan["sensitive_sentinel"] = "synthetic role/resource ARN must stay hidden"
+
+    result = _run(plan, "adoption")
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert result.stderr == "Hosted Redis plan rejected; plan details withheld.\n"
+    assert "synthetic role/resource ARN" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("status", ["fail", "unknown", "error"])
+def test_rejects_every_nonpassing_check_status(status: str) -> None:
+    plan = _plan("steady-state")
+    plan["checks"][1]["instances"][0]["status"] = status
+
+    assert _run(plan, "steady-state").returncode != 0
+
+
+def test_runbook_gates_apply_and_suppresses_plan_diagnostics() -> None:
+    runbook = README.read_text()
+    adoption_block = runbook.split("```bash", 1)[1].split("```", 1)[0]
+    steady_block = runbook.split("```bash", 2)[2].split("```", 1)[0]
+    adoption_commands = " ".join(adoption_block.replace("\\\n", " ").split())
+    steady_commands = " ".join(steady_block.replace("\\\n", " ").split())
+
+    assert adoption_block.strip().startswith("(\n  set -euo pipefail")
+    assert "check_adoption_plan.py adoption" in adoption_commands
+    assert adoption_commands.index("check_adoption_plan.py adoption") < adoption_commands.index(
+        " apply hosted-redis.tfplan"
+    )
+    assert "show -json hosted-redis.tfplan 2>/dev/null" in adoption_commands
+    assert "show -json hosted-redis-steady.tfplan 2>/dev/null" in steady_commands
+    assert steady_block.strip().startswith("(\n  set -euo pipefail")

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -86,7 +86,11 @@ alone. When neither is configured, the workflow deploys the API exactly as
 before. The re-image step also asserts that exactly one container matches each
 configured name and that the registered task definition carries the candidate
 image, so a mistyped container name fails closed instead of rolling the old
-image.
+image. Before either worker or Beat task definition is registered, the same
+checked-in hosted contract must match its execution role and its one direct
+`REDBEAT_REDIS_URL` reference by source service, account, region, and
+environment-owned name; duplicate, plaintext, field-projected, or
+sibling-environment references fail closed.
 
 `server/infra/background.tf` (Amazon MQ RabbitMQ broker, ElastiCache Serverless
 Valkey scheduler store, and the worker/Beat ECS services, task definitions,
@@ -104,6 +108,32 @@ definitions. `background_services_enabled = true` fails at Terraform plan time
 under a mocked provider) unless either the managed broker/store stage is enabled
 or both external endpoint secret ARNs are supplied, so the services can never be
 created without a reachable broker/store.
+
+The hosted API also uses Redis for cross-process Cloud materialization and
+GitHub-refresh leases, independently of whether worker and Beat services are
+enabled. `server/infra/hosted-redis/` is the isolated durable owner for
+the environment-specific deploy-role and ECS-execution-role child grants. Its
+one-time non-destructive adoption imported the two pre-existing deploy policies
+and created the two dedicated execution policies only after an exact saved-plan
+shape check; it never removes the roles' other pre-existing secret grants.
+`server/deploy/hosted-redis-contract.json` is the single machine-readable map
+consumed by both that Terraform root and the workflow; it binds the current
+hosted account, region, workflow environment aliases, stable server-app secret
+names, optional background Redis reference identities, and existing role names without
+claiming ownership of the live ECS services or background secrets. The server
+deploy resolves the generated secret ARN only after
+assuming the exact environment role, preflights a valid DNS-resolved non-loopback
+`REDBEAT_REDIS_URL`, authors that exact field projection on the API task, removes
+inherited plaintext or stale references, and fails before task registration
+when any identity or dependency check fails. It also proves the live task
+definition uses the contract's account/environment execution role before
+cloning that same definition. The resolved base secret ARN is kept out of the
+job-wide environment and is produced only after every third-party action's main
+phase. Because those actions can register post-job hooks, the first-party render
+and background re-image transactions keep all identifier-bearing task JSON in
+private temporary directories and remove it on every exit before those hooks
+run. The loopback default remains a local-development convenience, not hosted
+configuration.
 
 The plane's telemetry distinguishes two age/latency signals:
 `OutboxOldestDuePendingAgeSeconds` measures a row's pre-publish wait in Postgres
@@ -174,7 +204,7 @@ gate.
 | `_deploy-e2b.yml` | Reusable only | Build and/or promote one immutable E2B template into a rolling environment tag; the smoke proves the three runtime binaries report the canonical version and carry the stamped source SHA before the rolling tag moves. |
 | `_deploy-litellm.yml` | Reusable only | Build and roll the LiteLLM ECS service when its environment switch is enabled. |
 | `_deploy-mobile.yml` | Reusable only | Run the selected EAS build and optional submit lane when enabled. |
-| `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, conditionally roll the Celery worker and Beat before the API, roll the API, and verify health. API, worker, and Beat are all pinned to the one candidate image by its **immutable `repo@sha256:` digest** (resolved from the build/push output), never a mutable tag, so all three planes run the byte-identical image and a later tag move cannot change what a rolled service runs. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, and preserves the support-feed secret, all asserted before registration. |
+| `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, conditionally roll the Celery worker and Beat before the API, roll the API, and verify health. API, worker, and Beat are all pinned to the one candidate image by its **immutable `repo@sha256:` digest** (resolved from the build/push output), never a mutable tag, so all three planes run the byte-identical image and a later tag move cannot change what a rolled service runs. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, preserves the support-feed secret, and explicitly authors the API's checked-in environment-bound Redis field reference after account, region, secret-identity, and DNS-safe value preflights, all asserted before registration. |
 | `_deploy-web.yml` | Reusable only | Deploy and verify the selected Vercel web surface. |
 | `_deploy-workers.yml` | Reusable only | Report the disabled Worker lane, or fail if enabled before a canonical deploy exists. |
 

--- a/specs/developing/deploying/hosted.md
+++ b/specs/developing/deploying/hosted.md
@@ -81,6 +81,27 @@ see [Releases](releases.md).
 
 ## Surface Notes
 
+- The server lane derives the stable staging/production server-app secret name
+  from `server/deploy/hosted-redis-contract.json`; it does not accept a Redis
+  secret ARN from a GitHub Environment variable. The workflow and the isolated
+  `server/infra/hosted-redis/` Terraform root consume that same file. Terraform
+  owns the four dedicated exact-secret child policies. Its one-time
+  configuration-driven adoption imported the two pre-existing deploy policies
+  and created the two missing ECS execution policies only after the saved plan
+  proved two imports, two creates, and no other managed change. It does not
+  remove pre-existing bundled secret grants. The workflow
+  binds the expected account, region, deploy role, live task execution role, and
+  secret identity; suppresses provider errors; rejects literal or DNS-resolved
+  loopback/unspecified Redis endpoints; and authors the exact field projection
+  on every API task revision. If the optional background plane is configured,
+  worker and Beat registration also fails closed unless each task carries the
+  contract execution role and exactly one environment-owned direct Secrets
+  Manager or Parameter Store Redis reference, with no plaintext or
+  field-projected duplicate. The resolved base
+  ARN remains step-scoped and is
+  obtained after every third-party action's main phase. The first-party render
+  and background re-image steps remove their private identifier-bearing scratch
+  files on every exit before those actions' post-job hooks execute.
 - Worker deployment is a no-op while `WORKERS_DEPLOY_ENABLED=false`. Enabling
   it before a canonical service and command exist deliberately fails.
 - The nightly and hotfix coordinators have no LiteLLM job. Deploy an exact

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -96,7 +96,7 @@
 - name: REDBEAT_REDIS_URL
   secret: true
   default: "redis://127.0.0.1:6379/0"
-  description: Redis URL for redbeat scheduler metadata; not a Celery broker
+  description: Redis URL for RedBeat scheduler metadata and shared cross-process leases, including Cloud materialization; hosted deployments require a secret-backed non-loopback endpoint, and Redis is not the Celery broker
   tags: [local-dev, self-hosted, production]
 
 - name: REDBEAT_KEY_PREFIX

--- a/specs/developing/reference/environment-sources.md
+++ b/specs/developing/reference/environment-sources.md
@@ -71,16 +71,56 @@ launch-stack wrapper.
 
 ## Hosted Server
 
-Terraform provisions the baseline ECS task definition. The hosted deploy
-workflow then reads the live service definition, renders the next revision's
-runtime environment, and registers that revision. Most current sensitive
-inputs are written as ordinary task-definition environment entries. Only
-values explicitly configured in the ECS `secrets` collection are resolved from
-SSM. Do not infer universal secret-manager storage from a variable's secret
-classification.
+The reusable hosted deploy workflow reads the live ECS service definition,
+renders the next revision's runtime environment, and registers that revision.
+GitHub Environment variables remain inputs for the surfaces documented by the
+workflow, and the live service supplies the prior task shape. The workflow
+explicitly overwrites its owned runtime fields. `server/infra/main.tf` is a
+bootstrap definition whose resource identities are not the current
+staging/production service identities; do not infer current hosted state from
+that module without an explicit import/reconciliation.
+
+Most current sensitive inputs are written as ordinary task-definition
+environment entries. Only values explicitly configured in the ECS `secrets`
+collection are resolved by ECS from their named SSM Parameter Store or Secrets
+Manager source. Do not infer universal secret-manager storage from a variable's
+secret classification.
 
 Hosted workflow inputs and deployment procedures are owned by
 [`../deploying/hosted.md`](../deploying/hosted.md).
+
+The hosted API consumes Redis for Cloud materialization and GitHub-refresh
+leases even when the optional worker/Beat plane is disabled. The durable owner
+for this binding is the isolated `server/infra/hosted-redis/`
+Terraform root, not the bootstrap root or a manually entered GitHub variable.
+Both the root and the deploy workflow consume
+`server/deploy/hosted-redis-contract.json`, the single machine-readable owner
+for the AWS account, region, workflow aliases, stable secret names, and existing
+role names. The one-time adoption imported the two existing deploy child
+policies and created the two missing execution child policies only after a
+saved plan showed exactly that non-destructive shape. The root does not own the
+roles, secrets, ECS services, secret values, or other pre-existing role
+policies.
+
+Each environment entry also selects the only direct background Redis reference
+service and name that the optional worker/Beat re-image path accepts. The
+workflow verifies the rendered task's exact contract execution role and an
+account-, region-, service-, and name-bound `REDBEAT_REDIS_URL` reference before
+registration. A future external endpoint rebind must first update this
+checked-in identity in the same reviewed change; a GitHub Environment variable
+cannot override it.
+
+After selecting one exact workflow alias from that contract and assuming its
+role, the deploy verifies the live task definition's exact execution role,
+resolves and masks the generated base ARN after every third-party action's main
+phase, and passes it only to the first-party render step. Because those actions'
+post-job hooks run later, the API render and background re-image transactions
+keep identifier-bearing task JSON in private temporary directories and delete it
+on every exit before the hooks execute. The deploy verifies the ARN's
+account/region/environment identity, parses the JSON `REDBEAT_REDIS_URL` without
+logging it, rejects literal and DNS-resolved loopback or unspecified addresses,
+authors the exact ECS field projection, and removes inherited plaintext or stale
+references. The server's loopback default is not a hosted source.
 
 ## Frontend, Mobile, and Desktop Native Builds
 


### PR DESCRIPTION
## Summary

- Add one checked-in hosted Redis contract consumed by both the reusable server deployment workflow and an isolated Terraform root, binding staging and production to their AWS account, region, existing deploy/execution roles, and stable API/background Redis reference names.
- Verify the assumed deploy identity and the live task definition's exact execution role before cloning that same task document; resolve and mask the API Redis secret identifier only after third-party action main phases, reject literal or DNS-resolved loopback/unspecified endpoints, and author exactly one ECS field projection.
- Bound API endpoint validation with an external TERM/KILL watchdog on the pinned Linux runner. Timeout and guard failures are distinct and sanitized; stable workflow sentinels make the exact secret-authoring fragment testable without prose or whitespace anchors.
- Fail closed before every supported API, worker, or Beat registration unless the task uses the contract execution role and exact allowed Redis mapping. Background re-images preserve only the named direct Secrets Manager or Parameter Store reference and reject missing, duplicate, plaintext, field-projected, cross-account, cross-region, or sibling identities; this PR does not claim ownership of that live background source or its grants.
- Keep Redis identifiers out of the job-wide environment and confine API plus worker/Beat task-definition files to private temporary transactions that clean up on success or failure before third-party post-job hooks run.
- Durably own only four exact `secretsmanager:GetSecretValue` child policies for the API secret. Existing broader execution-role grants remain unchanged and outside this root, so this PR does not claim role-wide least privilege.

## Sanitized rollout receipt

- The historical saved adoption plan showed `imports=2 creates=2 updates=0 deletes=0`. Before apply, the producing Terraform root and live targets were separately verified to bind the provider, roles, and exact secret policies to the checked-in account/region/environment contract.
- The saved plan was applied with Terraform output suppressed; no task definition, ECS service, secret, or legacy policy was changed.
- The contract-bound plan gate was hardened after that adoption. Its adversarial tests now reject wrong identities, broader permissions, failed checks, unknowns, and drift; a fresh live read-only saved plan passed the hardened gate with `changes=0 drift=0`. The deleted historical plan was not replayed through the later gate.
- Terraform state contains exactly the four dedicated policy addresses. In both hosted environments, each dedicated deploy/execution child policy allows its target API secret and implicitly denies the sibling environment. Current API task definitions match the contract execution role and exact Redis field projection.
- Pre-existing broader execution grants remain untouched. The obsolete GitHub Environment Redis-ARN variables were removed only after in-memory equality checks and are absent in both environments; the checked-in contract plus Terraform state are the durable source of truth for the API Redis policies.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Terraform 1.9.8 (official checksum verified): `fmt -check`, `init -backend=false`, `validate`, and `test`; fresh live read-only steady plan accepted with `changes=0 drift=0`
- Focused server deploy suites: 128 passed
- `actionlint` plus `bash -n` for all 17 reusable-workflow shell blocks
- Focused `ruff check` and `ruff format --check`
- `python3 scripts/check_docs.py` (218 Markdown files)
- `python3 scripts/check_max_lines.py`
- `git diff --check`
