### PR TITLE
chore(agents): update managed coding-agent harnesses

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
@@ -23,14 +23,17 @@ fn draft_catalog_parses_with_expected_shape() {
 
     let claude = &catalog.agents[0];
     assert_eq!(claude.kind, "claude");
-    assert_eq!(claude.harness.agent_process.version, "0.44.0");
+    assert_eq!(
+        claude.harness.agent_process.version,
+        "0.59.0-proliferate.1"
+    );
     assert_eq!(
         claude
             .harness
             .native
             .as_ref()
             .map(|pin| pin.version.as_str()),
-        Some("2.1.181")
+        Some("2.1.212")
     );
     assert_eq!(
         claude

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
@@ -48,10 +48,10 @@ fn pins_surface_catalog_harness_versions() {
     let catalog = draft_catalog();
 
     let claude = catalog.pins("claude").expect("claude pins");
-    assert_eq!(claude.agent_process.version, "0.44.0");
+    assert_eq!(claude.agent_process.version, "0.59.0-proliferate.1");
     assert_eq!(
         claude.native.as_ref().map(|pin| pin.version.as_str()),
-        Some("2.1.181")
+        Some("2.1.212")
     );
 
     // Cursor has no native pin; unknown kinds have no pins at all.
@@ -114,9 +114,7 @@ fn models_intersect_availability_with_active_contexts() {
             "default",
             "opus[1m]",
             "sonnet",
-            "sonnet[1m]",
             "haiku",
-            "opus",
             "claude-fable-5",
             "claude-opus-4-8"
         ]
@@ -127,9 +125,9 @@ fn models_intersect_availability_with_active_contexts() {
             "default",
             "sonnet",
             "haiku",
-            "opus",
             "claude-fable-5",
-            "claude-opus-4-8"
+            "claude-opus-4-8",
+            "opus"
         ]
     );
     // No matching context, no models; unknown kind, no models.
@@ -151,6 +149,7 @@ fn baseline_counts_as_a_context_when_active() {
         vec![
             "opencode/big-pickle",
             "opencode/deepseek-v4-flash-free",
+            "opencode/hy3-free",
             "opencode/mimo-v2.5-free",
             "opencode/nemotron-3-ultra-free",
             "opencode/north-mini-code-free"
@@ -174,9 +173,9 @@ fn visible_models_are_the_default_visible_subset_of_available() {
             "default",
             "sonnet",
             "haiku",
-            "opus",
             "claude-fable-5",
-            "claude-opus-4-8"
+            "claude-opus-4-8",
+            "opus"
         ]
     );
 }
@@ -314,19 +313,19 @@ fn validate_launch_availability_beats_visibility() {
 fn validate_launch_rejects_gated_and_unknown_models() {
     let catalog = draft_catalog();
 
-    // sonnet[1m] is api-only: gated under oauth, with the unlock condition.
+    // opus[1m] is api-only: gated under oauth, with the unlock condition.
     let gated = catalog
         .validate_launch(
             "claude",
             &contexts(&["anthropic-oauth"]),
-            Some("sonnet[1m]"),
+            Some("opus[1m]"),
             None,
         )
         .expect_err("api-only model must be gated under oauth");
     assert_eq!(
         gated,
         SelectionUnsupported::ModelGated {
-            model_id: "sonnet[1m]".into(),
+            model_id: "opus[1m]".into(),
             required_contexts: vec!["anthropic-api".into()],
         }
     );

--- a/anyharness/crates/anyharness/src/commands/catalog_probe.rs
+++ b/anyharness/crates/anyharness/src/commands/catalog_probe.rs
@@ -246,10 +246,10 @@ fn auth_env_for_context(
             }
             Ok(env)
         }
-        // OpenCode resolves credentials from env vars AND its own config/auth
-        // storage (XDG dirs), so every opencode context isolates those dirs —
-        // otherwise machine-local opencode.jsonc / auth.json would pollute the
-        // auth attribution.
+        // OpenCode resolves credentials from env vars, XDG config/auth storage,
+        // and provider SDK defaults below HOME (for example ~/.aws). Isolate all
+        // of those roots so machine-local provider state cannot pollute auth
+        // attribution.
         (AgentKind::OpenCode, "baseline") => opencode_isolation_env(auth_context, isolation_dirs),
         (AgentKind::OpenCode, "anthropic-api") => {
             let mut env = opencode_isolation_env(auth_context, isolation_dirs)?;
@@ -344,13 +344,35 @@ wire_api = "responses"
             "cursor-agent ignores CURSOR_API_KEY for ACP sessions; run `cursor-agent login` \
              on this machine and use --auth-context cursor-login instead"
         ),
-        // Grok (xAI Grok Build) speaks ACP natively and authenticates from
-        // XAI_API_KEY. Isolate HOME so machine-local ~/.grok config (default
-        // model, cached login) cannot pollute observed values.
+        // Grok (xAI Grok Build) speaks ACP natively. Isolate HOME so
+        // machine-local config cannot pollute observed values, then inject one
+        // explicit API key or copy the selected logged-in auth file.
         (AgentKind::Grok, "xai-api") => {
-            let key = secrets.require("XAI_API_KEY")?;
             let mut env = isolation_env(auth_context, &[("HOME", "home")], isolation_dirs)?;
-            env.insert("XAI_API_KEY".to_string(), key);
+            if let Some(key) = secrets.get("XAI_API_KEY") {
+                env.insert("XAI_API_KEY".to_string(), key);
+            } else if let Some(key) = secrets.get("GROK_API_KEY") {
+                env.insert("GROK_API_KEY".to_string(), key);
+            } else {
+                let source = std::env::var("PROBE_GROK_AUTH_JSON").unwrap_or_else(|_| {
+                    format!(
+                        "{}/.grok/auth.json",
+                        std::env::var("HOME").unwrap_or_default()
+                    )
+                });
+                if !std::path::Path::new(&source).is_file() {
+                    bail!(
+                        "xai-api requires XAI_API_KEY, GROK_API_KEY, or a logged-in Grok \
+                         auth.json; not found at {source}"
+                    );
+                }
+                let isolated_home =
+                    std::path::Path::new(env.get("HOME").expect("grok isolation home"));
+                let grok_dir = isolated_home.join(".grok");
+                std::fs::create_dir_all(&grok_dir)?;
+                std::fs::copy(&source, grok_dir.join("auth.json"))
+                    .with_context(|| format!("failed to copy {source}"))?;
+            }
             Ok(env)
         }
         _ => bail!(
@@ -384,6 +406,8 @@ const CREDENTIAL_ENV_VARS: &[&str] = &[
     "AWS_SECRET_ACCESS_KEY",
     "AWS_SESSION_TOKEN",
     "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
 ];
 
 /// Region for bedrock auth contexts; model availability is region-dependent
@@ -413,6 +437,10 @@ impl ProbeSecrets {
             .get(key)
             .cloned()
             .ok_or_else(|| anyhow!("this auth context requires {key} in the environment"))
+    }
+
+    fn get(&self, key: &str) -> Option<String> {
+        self.values.get(key).cloned()
     }
 }
 
@@ -450,6 +478,7 @@ fn opencode_isolation_env(
     isolation_env(
         auth_context,
         &[
+            ("HOME", "home"),
             ("XDG_CONFIG_HOME", "config"),
             ("XDG_DATA_HOME", "data"),
             ("XDG_CACHE_HOME", "cache"),
@@ -480,4 +509,46 @@ fn isolation_env(
         env.insert(var.to_string(), path.to_string_lossy().into_owned());
     }
     Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_isolation_covers_home_and_all_xdg_roots() {
+        let mut isolation_dirs = IsolationDirs::default();
+        let env = opencode_isolation_env("baseline", &mut isolation_dirs).unwrap();
+        let base = isolation_dirs.0[0].clone();
+
+        for key in [
+            "HOME",
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_STATE_HOME",
+        ] {
+            assert!(std::path::Path::new(&env[key]).is_dir(), "missing {key}");
+        }
+
+        drop(isolation_dirs);
+        assert!(!base.exists(), "probe isolation must be removed on drop");
+    }
+
+    #[test]
+    fn grok_context_accepts_the_alternate_api_key_name() {
+        let secrets = ProbeSecrets {
+            values: BTreeMap::from([("GROK_API_KEY".to_string(), "test-key".to_string())]),
+        };
+        let mut isolation_dirs = IsolationDirs::default();
+
+        let env = auth_env_for_context(&secrets, &AgentKind::Grok, "xai-api", &mut isolation_dirs)
+            .unwrap();
+
+        assert_eq!(
+            env.get("GROK_API_KEY").map(String::as_str),
+            Some("test-key")
+        );
+        assert!(!env.contains_key("XAI_API_KEY"));
+    }
 }

--- a/anyharness/tests/src/harness/local-agent-launchers.ts
+++ b/anyharness/tests/src/harness/local-agent-launchers.ts
@@ -70,7 +70,8 @@ function resolveCodexLauncher(): { program: string; args: string[]; cwd: string 
 function ensureCodexNpmLauncher(): { program: string; args: string[]; cwd: string } {
   const installRoot = process.env.ANYHARNESS_TEST_CODEX_NPM_ROOT?.trim() || CODEX_NPM_INSTALL_ROOT;
   const packageSpec =
-    process.env.ANYHARNESS_TEST_CODEX_NPM_SPEC?.trim() || "@proliferateai/codex-acp@0.11.8";
+    process.env.ANYHARNESS_TEST_CODEX_NPM_SPEC?.trim() ||
+    "@proliferate-ai/codex-acp@0.18.2-proliferate.1";
   const forceInstall = process.env.ANYHARNESS_TEST_FORCE_AGENT_INSTALL === "1";
   const binaryPath = join(installRoot, "node_modules", ".bin", "codex-acp");
 

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-14.1",
+  "catalogVersion": "2026-07-17.4",
   "probedAgainst": {
-    "registryVersion": "2026-07-14.1"
+    "registryVersion": "2026-07-17.1"
   },
-  "generatedAt": "2026-07-11T00:36:38.653Z",
+  "generatedAt": "2026-07-17T05:35:36.826Z",
   "defaultAgentKind": "claude",
   "agents": [
     {
@@ -12,30 +12,30 @@
       "displayName": "Claude",
       "harness": {
         "agentProcess": {
-          "version": "0.44.0",
+          "version": "0.59.0-proliferate.1",
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
-            "gitRef": "d933c614497b88eb86200920003ab82d220252ca",
+            "gitRef": "6addb0f1694cff90cd64b7cf99ddab6f129aaeb2",
             "executableRelpath": "node_modules/.bin/claude-agent-acp"
           }
         },
         "native": {
-          "version": "2.1.181",
+          "version": "2.1.212",
           "source": {
             "kind": "binary",
             "targets": {
               "macos_arm64": {
-                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.181/darwin-arm64/claude",
-                "sha256": "c4d833b04606cef9b6eab3ad255ed2e1448f87dea2bc00ff5acf77b57df6e94d"
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.212/darwin-arm64/claude",
+                "sha256": "09ecba2ab2df9b6ee5b0695e26f65dea60fb3b6af3d3542ee09f466838d1e574"
               },
               "macos_x64": {
-                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.181/darwin-x64/claude",
-                "sha256": "353798bcdc49a52a666645370e1c48a84fe837d93bf9d954c19338dca7260ddd"
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.212/darwin-x64/claude",
+                "sha256": "7681a0634c89fa4474e53c0c794e992944aebf3409a7a2b87ea9f9b0194ea341"
               },
               "linux_x64": {
-                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.181/linux-x64/claude",
-                "sha256": "35ffd4e9d9a86395d0ba4e05f8b23bf098bfeab95e97deacd6537909d1324e9c"
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.212/linux-x64/claude",
+                "sha256": "044a88cf3a5180776617fd3da1238dcbf9141ddec449a39cf7d2af1ac78e684e"
               }
             }
           }
@@ -127,21 +127,18 @@
             }
           },
           {
-            "key": "fast_mode",
+            "key": "fast",
             "values": [
-              "off",
-              "on"
-            ],
-            "mapping": {
-              "liveConfigId": "fast_mode"
-            }
+              "on",
+              "off"
+            ]
           }
         ],
         "models": [
           {
             "id": "default",
-            "displayName": "Default 4.5",
-            "description": "Use the default model (currently Sonnet 4.5)",
+            "displayName": "Default 4.8",
+            "description": "Use the default model (currently Opus 4.8)",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -172,10 +169,10 @@
                 ],
                 "observedValue": "default"
               },
-              "fast_mode": {
+              "fast": {
                 "values": [
-                  "off",
-                  "on"
+                  "on",
+                  "off"
                 ],
                 "observedValue": "off"
               }
@@ -193,7 +190,7 @@
           },
           {
             "id": "opus[1m]",
-            "displayName": "Opus 4.8 (1M context)",
+            "displayName": "Opus 4.8",
             "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
             "availability": {
               "anyOf": [
@@ -224,10 +221,10 @@
                 ],
                 "observedValue": "default"
               },
-              "fast_mode": {
+              "fast": {
                 "values": [
-                  "off",
-                  "on"
+                  "on",
+                  "off"
                 ],
                 "observedValue": "off"
               }
@@ -243,128 +240,8 @@
           },
           {
             "id": "sonnet",
-            "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
-            "availability": {
-              "anyOf": [
-                "anthropic-api",
-                "anthropic-oauth"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "auto",
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              },
-              "effort": {
-                "values": [
-                  "default",
-                  "low",
-                  "medium",
-                  "high",
-                  "max"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.anthropic-api",
-                "claude.anthropic-oauth"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "sonnet[1m]",
-            "displayName": "Sonnet 4.6 (1M context)",
-            "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "auto",
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              },
-              "effort": {
-                "values": [
-                  "default",
-                  "low",
-                  "medium",
-                  "high",
-                  "max"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "haiku",
-            "displayName": "Haiku 4.5",
-            "description": "Haiku 4.5 · Fastest for quick answers",
-            "availability": {
-              "anyOf": [
-                "anthropic-api",
-                "anthropic-oauth"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.anthropic-api",
-                "claude.anthropic-oauth",
-                "claude.bedrock"
-              ],
-              "observedInAllContexts": true,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opus",
-            "displayName": "Opus 4.6",
-            "description": "Opus 4.6 · Legacy",
+            "displayName": "Sonnet",
+            "description": "Sonnet 5 · Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -394,13 +271,39 @@
                   "max"
                 ],
                 "observedValue": "default"
-              },
-              "fast_mode": {
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.anthropic-api",
+                "claude.anthropic-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "haiku",
+            "displayName": "Haiku 4.5",
+            "description": "Haiku 4.5 · Fastest for quick answers",
+            "availability": {
+              "anyOf": [
+                "anthropic-api",
+                "anthropic-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
                 "values": [
-                  "off",
-                  "on"
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
                 ],
-                "observedValue": "off"
+                "observedValue": "default"
               }
             },
             "status": "active",
@@ -446,13 +349,6 @@
                   "max"
                 ],
                 "observedValue": "default"
-              },
-              "fast_mode": {
-                "values": [
-                  "off",
-                  "on"
-                ],
-                "observedValue": "off"
               }
             },
             "status": "active",
@@ -498,10 +394,10 @@
                 ],
                 "observedValue": "default"
               },
-              "fast_mode": {
+              "fast": {
                 "values": [
-                  "off",
-                  "on"
+                  "on",
+                  "off"
                 ],
                 "observedValue": "off"
               }
@@ -517,9 +413,145 @@
             }
           },
           {
+            "id": "opus",
+            "displayName": "Opus 4.8",
+            "description": "Opus 4.8 · Best for everyday, complex tasks",
+            "availability": {
+              "anyOf": [
+                "anthropic-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              },
+              "fast": {
+                "values": [
+                  "on",
+                  "off"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.anthropic-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-fable-5",
+            "displayName": "Fable 5",
+            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-sonnet-5",
+            "displayName": "Sonnet 5",
+            "description": "Sonnet 5 · Efficient for routine tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "us.anthropic.claude-sonnet-4-6",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "description": "Sonnet 4.6 · Previous Sonnet version",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -599,48 +631,6 @@
             }
           },
           {
-            "id": "us.anthropic.claude-fable-5",
-            "displayName": "Fable 5",
-            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
-            "availability": {
-              "anyOf": [
-                "bedrock"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              },
-              "effort": {
-                "values": [
-                  "default",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh",
-                  "max"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.bedrock"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "displayName": "Opus 4.1",
             "description": "Opus 4.1 · Legacy",
@@ -684,6 +674,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -726,6 +717,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -768,6 +760,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -810,6 +803,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -825,6 +819,47 @@
                   "medium",
                   "high",
                   "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-6-v1",
+            "displayName": "Opus 4.6",
+            "description": "Opus 4.6 · Legacy",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
                   "max"
                 ],
                 "observedValue": "default"
@@ -892,6 +927,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -1133,9 +1169,9 @@
           "gateway": "claude-sonnet-4-5"
         },
         "observedDefaults": {
-          "anthropic-api": "opus",
-          "anthropic-oauth": "opus",
-          "bedrock": "us.anthropic.claude-opus-4-8"
+          "anthropic-api": "default",
+          "anthropic-oauth": "default",
+          "bedrock": "default"
         },
         "gatewayPolicy": {
           "providers": [
@@ -1154,11 +1190,27 @@
           ]
         }
       },
+      "settings": [
+        {
+          "key": "chrome",
+          "type": "boolean",
+          "label": "Use Claude Code with Chrome",
+          "description": "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
+          "default": false,
+          "surfaces": [
+            "local"
+          ],
+          "mapping": {
+            "kind": "cli_flag",
+            "flag": "--chrome"
+          }
+        }
+      ],
       "provenance": {
-        "probedAt": "2026-06-18T02:52:37.457623+00:00",
+        "probedAt": "2026-07-17T05:34:23.802840+00:00",
         "attestation": {
           "name": "@agentclientprotocol/claude-agent-acp",
-          "version": "0.44.0",
+          "version": "0.59.0-proliferate.1",
           "title": "Claude Agent"
         },
         "runs": [
@@ -1175,56 +1227,40 @@
             "snapshotPath": "generated/claude.bedrock.probe.json"
           }
         ]
-      },
-      "settings": [
-        {
-          "key": "chrome",
-          "type": "boolean",
-          "label": "Use Claude Code with Chrome",
-          "description": "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
-          "default": false,
-          "surfaces": [
-            "local"
-          ],
-          "mapping": {
-            "kind": "cli_flag",
-            "flag": "--chrome"
-          }
-        }
-      ]
+      }
     },
     {
       "kind": "codex",
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.18.1-proliferate.1",
+          "version": "0.18.2-proliferate.1",
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "938065e69331d91df0de3bbf1dcaae6e6dc6e2eb",
+            "gitRef": "8a6ce248c07417b0b5b84056164996ad7080d03f",
             "packageSubdir": "npm",
             "executableRelpath": "node_modules/.bin/codex-acp"
           }
         },
         "native": {
-          "version": "rust-v0.144.1",
+          "version": "rust-v0.144.5",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-aarch64-apple-darwin.tar.gz",
-                "sha256": "88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-aarch64-apple-darwin.tar.gz",
+                "sha256": "a5b77d2fb393f201777809425ab28d9beb65ee0c0b2bf792f09eaf8ef1151592",
                 "expectedBinary": "codex-aarch64-apple-darwin"
               },
               "macos_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-apple-darwin.tar.gz",
-                "sha256": "0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-apple-darwin.tar.gz",
+                "sha256": "ff5c894a9ffa6d97c225c8d3c869c7ef7573dcbd0cf9b762ecfb9fa96dbb7d88",
                 "expectedBinary": "codex-x86_64-apple-darwin"
               },
               "linux_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-unknown-linux-musl.tar.gz",
-                "sha256": "84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-unknown-linux-musl.tar.gz",
+                "sha256": "b6bea13bedf493232f6717714c45e783788c695cedcf37c344f73afc97b1ec9f",
                 "expectedBinary": "codex-x86_64-unknown-linux-musl"
               }
             },
@@ -2000,7 +2036,7 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
               }
             },
             "status": "active",
@@ -2127,10 +2163,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-07-11T00:36:25.416008+00:00",
+        "probedAt": "2026-07-17T05:35:01.459582+00:00",
         "attestation": {
           "name": "codex-acp",
-          "version": "0.18.1-proliferate.1",
+          "version": "0.18.2-proliferate.1",
           "title": "Codex"
         },
         "runs": [
@@ -2154,23 +2190,23 @@
       "displayName": "Cursor",
       "harness": {
         "agentProcess": {
-          "version": "2026.06.15",
+          "version": "2026.07.09",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://downloads.cursor.com/lab/2026.06.15-18-00-12-6f5a2cf/darwin/arm64/agent-cli-package.tar.gz",
-                "sha256": "49ed840e3ab46a129968907dbfef06e459eefb2fca1c4fec538eb560e1b59bac",
+                "url": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/arm64/agent-cli-package.tar.gz",
+                "sha256": "009ee857d49f17c10e5035e33884eb258d1f3839c1d52bdb35f35a117369dfde",
                 "expectedBinary": "./dist-package/cursor-agent"
               },
               "macos_x64": {
-                "url": "https://downloads.cursor.com/lab/2026.06.15-18-00-12-6f5a2cf/darwin/x64/agent-cli-package.tar.gz",
-                "sha256": "6eb89fbd79374aac8145ea2f19793cfa3f6138d74af1d45d4fe299c644642a74",
+                "url": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/x64/agent-cli-package.tar.gz",
+                "sha256": "066c499f6ec43734254337c493aeec5aabb4a6ae6d6df7da214fa86ceda9e45d",
                 "expectedBinary": "./dist-package/cursor-agent"
               },
               "linux_x64": {
-                "url": "https://downloads.cursor.com/lab/2026.06.15-18-00-12-6f5a2cf/linux/x64/agent-cli-package.tar.gz",
-                "sha256": "33b22b0c4fd0397a89fc1b908e4536bb0a8fb09daff97acf519fbec76569ccb3",
+                "url": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/linux/x64/agent-cli-package.tar.gz",
+                "sha256": "c7c1f32249cedb99cc20cd4eed1f9308dc2299a78c283bbc6efd6d658cd4977e",
                 "expectedBinary": "./dist-package/cursor-agent"
               }
             },
@@ -2197,6 +2233,7 @@
         }
       ],
       "session": {
+        "supportsGoals": false,
         "controls": [
           {
             "key": "model",
@@ -2218,6 +2255,14 @@
               "createField": "modeId",
               "liveConfigId": "mode"
             }
+          },
+          {
+            "key": "effort",
+            "values": [
+              "high",
+              "medium",
+              "xhigh"
+            ]
           },
           {
             "key": "fast",
@@ -2242,17 +2287,10 @@
             ]
           },
           {
-            "key": "effort",
-            "values": [
-              "high",
-              "medium",
-              "xhigh"
-            ]
-          },
-          {
             "key": "reasoning",
             "values": [
-              "medium"
+              "medium",
+              "high"
             ]
           }
         ],
@@ -2285,6 +2323,47 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "default[]"
+              ]
+            }
+          },
+          {
+            "id": "grok-4.5",
+            "displayName": "Grok-4.5",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "effort": {
+                "values": [
+                  "high"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "true"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "grok-4.5[effort=high,fast=true]"
               ]
             }
           },
@@ -2376,6 +2455,52 @@
             }
           },
           {
+            "id": "gpt-5.6-sol",
+            "displayName": "GPT-5.6-Sol",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "context": {
+                "values": [
+                  "272k"
+                ]
+              },
+              "reasoning": {
+                "values": [
+                  "medium"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "false"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]"
+              ]
+            }
+          },
+          {
             "id": "gpt-5.5",
             "displayName": "GPT-5.5",
             "availability": {
@@ -2418,6 +2543,144 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.5[context=272k,reasoning=medium,fast=false]"
+              ]
+            }
+          },
+          {
+            "id": "claude-fable-5",
+            "displayName": "Claude Fable 5",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "thinking": {
+                "values": [
+                  "true"
+                ]
+              },
+              "context": {
+                "values": [
+                  "300k"
+                ]
+              },
+              "effort": {
+                "values": [
+                  "high"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "claude-fable-5[thinking=true,context=300k,effort=high]"
+              ]
+            }
+          },
+          {
+            "id": "claude-sonnet-5",
+            "displayName": "Claude-Sonnet-5",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "thinking": {
+                "values": [
+                  "true"
+                ]
+              },
+              "context": {
+                "values": [
+                  "300k"
+                ]
+              },
+              "effort": {
+                "values": [
+                  "high"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "claude-sonnet-5[thinking=true,context=300k,effort=high]"
+              ]
+            }
+          },
+          {
+            "id": "gpt-5.6-terra",
+            "displayName": "GPT-5.6-Terra",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "context": {
+                "values": [
+                  "272k"
+                ]
+              },
+              "reasoning": {
+                "values": [
+                  "medium"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "false"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "gpt-5.6-terra[context=272k,reasoning=medium,fast=false]"
               ]
             }
           },
@@ -2560,42 +2823,6 @@
             }
           },
           {
-            "id": "grok-build-0.1",
-            "displayName": "Grok Build 0.1",
-            "availability": {
-              "anyOf": [
-                "cursor-login"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "agent",
-                  "plan",
-                  "ask"
-                ],
-                "observedValue": "agent"
-              },
-              "context": {
-                "values": [
-                  "200k"
-                ]
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "cursor.cursor-login"
-              ],
-              "observedInAllContexts": true,
-              "viaTrialOnly": false,
-              "variantIds": [
-                "grok-build-0.1[context=200k]"
-              ]
-            }
-          },
-          {
             "id": "gpt-5.4",
             "displayName": "GPT-5.4",
             "availability": {
@@ -2673,11 +2900,6 @@
                 "values": [
                   "high"
                 ]
-              },
-              "fast": {
-                "values": [
-                  "false"
-                ]
               }
             },
             "status": "active",
@@ -2688,7 +2910,7 @@
               "observedInAllContexts": true,
               "viaTrialOnly": false,
               "variantIds": [
-                "claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]"
+                "claude-opus-4-6[thinking=true,context=200k,effort=high]"
               ]
             }
           },
@@ -2766,6 +2988,52 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.2[reasoning=medium,fast=false]"
+              ]
+            }
+          },
+          {
+            "id": "gpt-5.6-luna",
+            "displayName": "GPT-5.6-Luna",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "context": {
+                "values": [
+                  "272k"
+                ]
+              },
+              "reasoning": {
+                "values": [
+                  "medium"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "false"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "gpt-5.6-luna[context=272k,reasoning=medium,fast=false]"
               ]
             }
           },
@@ -2905,42 +3173,6 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "claude-haiku-4-5[thinking=true]"
-              ]
-            }
-          },
-          {
-            "id": "grok-4.3",
-            "displayName": "Grok 4.3",
-            "availability": {
-              "anyOf": [
-                "cursor-login"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "agent",
-                  "plan",
-                  "ask"
-                ],
-                "observedValue": "agent"
-              },
-              "context": {
-                "values": [
-                  "200k"
-                ]
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "cursor.cursor-login"
-              ],
-              "observedInAllContexts": true,
-              "viaTrialOnly": false,
-              "variantIds": [
-                "grok-4.3[context=200k]"
               ]
             }
           },
@@ -3305,8 +3537,8 @@
             }
           },
           {
-            "id": "kimi-k2.5",
-            "displayName": "Kimi K2.5",
+            "id": "kimi-k2.7-code",
+            "displayName": "Kimi-K2.7-Code",
             "availability": {
               "anyOf": [
                 "cursor-login"
@@ -3331,13 +3563,13 @@
               "observedInAllContexts": true,
               "viaTrialOnly": false,
               "variantIds": [
-                "kimi-k2.5[]"
+                "kimi-k2.7-code[]"
               ]
             }
           },
           {
-            "id": "claude-fable-5",
-            "displayName": "Claude Fable 5",
+            "id": "glm-5.2",
+            "displayName": "GLM-5.2",
             "availability": {
               "anyOf": [
                 "cursor-login"
@@ -3353,17 +3585,7 @@
                 ],
                 "observedValue": "agent"
               },
-              "thinking": {
-                "values": [
-                  "true"
-                ]
-              },
-              "context": {
-                "values": [
-                  "300k"
-                ]
-              },
-              "effort": {
+              "reasoning": {
                 "values": [
                   "high"
                 ]
@@ -3377,7 +3599,7 @@
               "observedInAllContexts": true,
               "viaTrialOnly": false,
               "variantIds": [
-                "claude-fable-5[thinking=true,context=300k,effort=high]"
+                "glm-5.2[reasoning=high]"
               ]
             }
           }
@@ -3386,11 +3608,11 @@
           "cursor-login": "default"
         },
         "observedDefaults": {
-          "cursor-login": "gemini-3.1-pro[]"
+          "cursor-login": "glm-5.2[reasoning=high]"
         }
       },
       "provenance": {
-        "probedAt": "2026-06-18T02:53:09.426103+00:00",
+        "probedAt": "2026-07-17T05:35:36.678732+00:00",
         "attestation": null,
         "runs": [
           {
@@ -3405,11 +3627,11 @@
       "displayName": "Grok",
       "harness": {
         "agentProcess": {
-          "version": "0.2.55",
+          "version": "0.2.102",
           "source": {
             "kind": "npm",
-            "package": "@xai-official/grok@0.2.55",
-            "sha256": "sha512-I5v0ePk1Q/yQmLLkpCprzySaTQC1DvvN/rrzrbhaqCBptbBkEkwwpXZKhg1VyLqHczDUnwjmSIH/kSmLLjSc0g==",
+            "package": "@xai-official/grok@0.2.102",
+            "sha256": "sha512-Q8BdegoBOCvLq5cDDYiomZd3Dnxwwv72TbQ60B5HNpOJP4AoJpTarNuB+BGNUZ1/6U7rw14xZrRtxLrkkv3nHA==",
             "args": [
               "agent",
               "stdio"
@@ -3445,6 +3667,7 @@
         }
       ],
       "session": {
+        "supportsGoals": false,
         "controls": [
           {
             "key": "model",
@@ -3516,6 +3739,25 @@
           {
             "id": "grok-4.3",
             "displayName": "Grok 4.3",
+            "availability": {
+              "anyOf": [
+                "xai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {},
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "grok.xai-api"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "grok-4.5",
+            "displayName": "Grok-4.5",
             "availability": {
               "anyOf": [
                 "xai-api"
@@ -3609,14 +3851,14 @@
             }
           },
           {
-            "id": "grok-imagine-video-1.5-preview",
-            "displayName": "Grok Imagine Video 1.5 Preview",
+            "id": "grok-imagine-video-1.5",
+            "displayName": "Grok-Imagine-Video-1.5",
             "availability": {
               "anyOf": [
                 "xai-api"
               ]
             },
-            "defaultVisible": false,
+            "defaultVisible": true,
             "controls": {},
             "status": "active",
             "provenance": {
@@ -3696,7 +3938,7 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-16T06:46:29.757670+00:00",
+        "probedAt": "2026-07-17T05:35:08.879897+00:00",
         "attestation": null,
         "runs": [
           {
@@ -3711,23 +3953,23 @@
       "displayName": "OpenCode",
       "harness": {
         "agentProcess": {
-          "version": "1.17.7",
+          "version": "1.18.3",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-arm64.zip",
-                "sha256": "7a63aeb5a15b29da2681ac2b8c74d4cb3a64fa13b61198a3c7dc771243c23972",
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip",
+                "sha256": "946f62b155638b911144b7bef520ee4a6442f696297907873463bca3524e40ef",
                 "expectedBinary": "./opencode"
               },
               "macos_x64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-x64.zip",
-                "sha256": "4953e7c3c8db8c623ea726d8ecb6657ba04806b7b4d906c078fc072fb172cfe0",
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-x64.zip",
+                "sha256": "4ea147867ba19e4ec03559df557811f1674f40788aea4d10326dc563b7667c6d",
                 "expectedBinary": "./opencode"
               },
               "linux_x64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-linux-x64.tar.gz",
-                "sha256": "60fe5a92dc9af64ec079348fedde17e12da6a867efe7e8353be8038480607924",
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-x64.tar.gz",
+                "sha256": "60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583",
                 "expectedBinary": "./opencode"
               }
             },
@@ -3809,6 +4051,7 @@
         }
       ],
       "session": {
+        "supportsGoals": false,
         "controls": [
           {
             "key": "model",
@@ -3882,33 +4125,6 @@
             }
           },
           {
-            "id": "anthropic/claude-3-5-haiku-latest",
-            "displayName": "Anthropic/Claude Haiku 3.5 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "anthropic/claude-haiku-4-5-20251001",
             "displayName": "Anthropic/Claude Haiku 4.5",
             "availability": {
@@ -3945,145 +4161,6 @@
           {
             "id": "anthropic/claude-haiku-4-5",
             "displayName": "Anthropic/Claude Haiku 4.5 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-20250514",
-            "displayName": "Anthropic/Claude Opus 4",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh",
-                  "max"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-0",
-            "displayName": "Anthropic/Claude Opus 4 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-1-20250805",
-            "displayName": "Anthropic/Claude Opus 4.1",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-1",
-            "displayName": "Anthropic/Claude Opus 4.1 (latest)",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -4406,74 +4483,6 @@
             }
           },
           {
-            "id": "anthropic/claude-sonnet-4-20250514",
-            "displayName": "Anthropic/Claude Sonnet 4",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-sonnet-4-0",
-            "displayName": "Anthropic/Claude Sonnet 4 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "anthropic/claude-sonnet-4-5-20250929",
             "displayName": "Anthropic/Claude Sonnet 4.5",
             "availability": {
@@ -4578,6 +4587,43 @@
             }
           },
           {
+            "id": "anthropic/claude-sonnet-5",
+            "displayName": "Anthropic/Claude Sonnet 5",
+            "availability": {
+              "anyOf": [
+                "anthropic-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.anthropic-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "opencode/big-pickle",
             "displayName": "OpenCode Zen/Big Pickle",
             "availability": {
@@ -4628,13 +4674,46 @@
             "controls": {
               "effort": {
                 "values": [
-                  "low",
-                  "medium",
                   "high",
                   "max"
                 ],
-                "observedValue": "low"
+                "observedValue": "high"
               },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.anthropic-api",
+                "opencode.baseline",
+                "opencode.gemini-api",
+                "opencode.openai-api",
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/hy3-free",
+            "displayName": "OpenCode Zen/Hy3 Free",
+            "availability": {
+              "anyOf": [
+                "anthropic-api",
+                "baseline",
+                "gemini-api",
+                "openai-api",
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
               "mode": {
                 "values": [
                   "build",
@@ -4670,14 +4749,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -4713,14 +4784,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -5157,10 +5220,12 @@
             "controls": {
               "effort": {
                 "values": [
+                  "minimal",
                   "low",
+                  "medium",
                   "high"
                 ],
-                "observedValue": "low"
+                "observedValue": "minimal"
               },
               "mode": {
                 "values": [
@@ -5191,11 +5256,40 @@
             "controls": {
               "effort": {
                 "values": [
+                  "minimal",
                   "low",
+                  "medium",
                   "high"
                 ],
-                "observedValue": "low"
+                "observedValue": "minimal"
               },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.gemini-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "google/gemini-omni-flash-preview",
+            "displayName": "Google/Gemini Omni Flash Preview",
+            "availability": {
+              "anyOf": [
+                "gemini-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
               "mode": {
                 "values": [
                   "build",
@@ -5282,74 +5376,6 @@
             }
           },
           {
-            "id": "google/gemma-4-E2B-it",
-            "displayName": "Google/Gemma 4 E2B IT",
-            "availability": {
-              "anyOf": [
-                "gemini-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.gemini-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "google/gemma-4-E4B-it",
-            "displayName": "Google/Gemma 4 E4B IT",
-            "availability": {
-              "anyOf": [
-                "gemini-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.gemini-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "google/gemini-2.5-flash-image",
             "displayName": "Google/Nano Banana",
             "availability": {
@@ -5359,13 +5385,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -5427,12 +5446,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "high"
-                ],
-                "observedValue": "high"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -6697,6 +6710,462 @@
             }
           },
           {
+            "id": "openai/gpt-5.6",
+            "displayName": "OpenAI/GPT-5.6",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-fast",
+            "displayName": "OpenAI/GPT-5.6 Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-luna",
+            "displayName": "OpenAI/GPT-5.6 Luna",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-luna-fast",
+            "displayName": "OpenAI/GPT-5.6 Luna Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-luna-pro",
+            "displayName": "OpenAI/GPT-5.6 Luna Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-pro",
+            "displayName": "OpenAI/GPT-5.6 Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-sol",
+            "displayName": "OpenAI/GPT-5.6 Sol",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-sol-fast",
+            "displayName": "OpenAI/GPT-5.6 Sol Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-sol-pro",
+            "displayName": "OpenAI/GPT-5.6 Sol Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-terra",
+            "displayName": "OpenAI/GPT-5.6 Terra",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-terra-fast",
+            "displayName": "OpenAI/GPT-5.6 Terra Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-terra-pro",
+            "displayName": "OpenAI/GPT-5.6 Terra Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "openai/gpt-image-1",
             "displayName": "OpenAI/gpt-image-1",
             "availability": {
@@ -6760,6 +7229,70 @@
             },
             "defaultVisible": true,
             "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-image-2",
+            "displayName": "OpenAI/gpt-image-2",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-realtime-2.1",
+            "displayName": "OpenAI/GPT-Realtime-2.1",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "minimal"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -7135,8 +7668,8 @@
             }
           },
           {
-            "id": "opencode-go/deepseek-v4-flash",
-            "displayName": "OpenCode Go/DeepSeek V4 Flash",
+            "id": "opencode/claude-fable-5",
+            "displayName": "OpenCode Zen/Claude Fable 5",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -7149,366 +7682,11 @@
                   "low",
                   "medium",
                   "high",
+                  "xhigh",
                   "max"
                 ],
                 "observedValue": "low"
               },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/deepseek-v4-pro",
-            "displayName": "OpenCode Go/DeepSeek V4 Pro",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high",
-                  "max"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/glm-5.1",
-            "displayName": "OpenCode Go/GLM-5.1",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/glm-5.2",
-            "displayName": "OpenCode Go/GLM-5.2",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/kimi-k2.6",
-            "displayName": "OpenCode Go/Kimi K2.6",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/kimi-k2.7-code",
-            "displayName": "OpenCode Go/Kimi K2.7 Code",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/mimo-v2.5",
-            "displayName": "OpenCode Go/MiMo V2.5",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/mimo-v2.5-pro",
-            "displayName": "OpenCode Go/MiMo V2.5 Pro",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/minimax-m2.7",
-            "displayName": "OpenCode Go/MiniMax M2.7",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/minimax-m3",
-            "displayName": "OpenCode Go/MiniMax M3 3 (3x usage)",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "none",
-                  "thinking"
-                ],
-                "observedValue": "none"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/qwen3.6-plus",
-            "displayName": "OpenCode Go/Qwen3.6 Plus",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/qwen3.7-max",
-            "displayName": "OpenCode Go/Qwen3.7 Max",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/qwen3.7-plus",
-            "displayName": "OpenCode Go/Qwen3.7 Plus",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
               "mode": {
                 "values": [
                   "build",
@@ -7844,8 +8022,8 @@
             }
           },
           {
-            "id": "opencode/deepseek-v4-flash",
-            "displayName": "OpenCode Zen/DeepSeek V4 Flash",
+            "id": "opencode/claude-sonnet-5",
+            "displayName": "OpenCode Zen/Claude Sonnet 5",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -7858,9 +8036,44 @@
                   "low",
                   "medium",
                   "high",
+                  "xhigh",
                   "max"
                 ],
                 "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/deepseek-v4-flash",
+            "displayName": "OpenCode Zen/DeepSeek V4 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
               },
               "mode": {
                 "values": [
@@ -7891,12 +8104,10 @@
             "controls": {
               "effort": {
                 "values": [
-                  "low",
-                  "medium",
                   "high",
                   "max"
                 ],
-                "observedValue": "low"
+                "observedValue": "high"
               },
               "mode": {
                 "values": [
@@ -8059,6 +8270,40 @@
             },
             "defaultVisible": true,
             "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/glm-5.2",
+            "displayName": "OpenCode Zen/GLM-5.2",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -8447,13 +8692,12 @@
             "controls": {
               "effort": {
                 "values": [
-                  "none",
                   "low",
                   "medium",
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "none"
+                "observedValue": "low"
               },
               "mode": {
                 "values": [
@@ -8691,6 +8935,155 @@
             }
           },
           {
+            "id": "opencode/gpt-5.6-luna",
+            "displayName": "OpenCode Zen/GPT-5.6 Luna",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.6-sol",
+            "displayName": "OpenCode Zen/GPT-5.6 Sol",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.6-terra",
+            "displayName": "OpenCode Zen/GPT-5.6 Terra",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/grok-4.5",
+            "displayName": "OpenCode Zen/Grok 4.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "opencode/grok-build-0.1",
             "displayName": "OpenCode Zen/Grok Build 0.1",
             "availability": {
@@ -8772,8 +9165,35 @@
             }
           },
           {
+            "id": "opencode/kimi-k2.7-code",
+            "displayName": "OpenCode Zen/Kimi K2.7 Code",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "opencode/minimax-m2.5",
-            "displayName": "OpenCode Zen/MiniMax M2.5",
+            "displayName": "OpenCode Zen/MiniMax-M2.5",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -8800,7 +9220,34 @@
           },
           {
             "id": "opencode/minimax-m2.7",
-            "displayName": "OpenCode Zen/MiniMax M2.7",
+            "displayName": "OpenCode Zen/MiniMax-M2.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/minimax-m3",
+            "displayName": "OpenCode Zen/MiniMax-M3 3",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -8835,6 +9282,13 @@
             },
             "defaultVisible": true,
             "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -8862,6 +9316,413 @@
             },
             "defaultVisible": true,
             "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/deepseek-v4-flash",
+            "displayName": "OpenCode Go/DeepSeek V4 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/deepseek-v4-pro",
+            "displayName": "OpenCode Go/DeepSeek V4 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/glm-5.1",
+            "displayName": "OpenCode Go/GLM-5.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/glm-5.2",
+            "displayName": "OpenCode Go/GLM-5.2",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/kimi-k2.6",
+            "displayName": "OpenCode Go/Kimi K2.6",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/kimi-k2.7-code",
+            "displayName": "OpenCode Go/Kimi K2.7 Code",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/mimo-v2.5",
+            "displayName": "OpenCode Go/MiMo V2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/mimo-v2.5-pro",
+            "displayName": "OpenCode Go/MiMo V2.5 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m2.7",
+            "displayName": "OpenCode Go/MiniMax-M2.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m3",
+            "displayName": "OpenCode Go/MiniMax-M3 3",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "thinking"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.6-plus",
+            "displayName": "OpenCode Go/Qwen3.6 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.7-max",
+            "displayName": "OpenCode Go/Qwen3.7 Max",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.7-plus",
+            "displayName": "OpenCode Go/Qwen3.7 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -9009,10 +9870,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-18T02:52:36.735929+00:00",
+        "probedAt": "2026-07-17T05:35:02.916500+00:00",
         "attestation": {
           "name": "OpenCode",
-          "version": "1.17.7",
+          "version": "1.18.3",
           "title": null
         },
         "runs": [

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "registryVersion": "2026-07-14.1",
-  "generatedAt": "2026-05-31T00:00:00Z",
+  "registryVersion": "2026-07-17.1",
+  "generatedAt": "2026-07-17T03:08:00Z",
   "agents": [
     {
       "kind": "claude",
@@ -25,7 +25,7 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#d933c614497b88eb86200920003ab82d220252ca",
+          "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#6addb0f1694cff90cd64b7cf99ddab6f129aaeb2",
           "packageSubdir": null,
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/claude-agent-acp"
@@ -133,7 +133,7 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/codex-acp.git#938065e69331d91df0de3bbf1dcaae6e6dc6e2eb",
+          "package": "git+https://github.com/proliferate-ai/codex-acp.git#8a6ce248c07417b0b5b84056164996ad7080d03f",
           "packageSubdir": "npm",
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/codex-acp"

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -99,16 +99,21 @@ function readCompleteProbeState() {
     if (!candidateAgent?.harness?.agentProcess?.source) {
       throw new Error(`${agent}: resolved candidate has no fenced agent-process source`);
     }
-    const attestationVersions = agentSnapshots.map((snapshot) => {
-      const version = snapshot.attestation?.version;
-      if (typeof version !== "string" || !version.trim()) {
-        throw new Error(
-          `${agent}.${snapshot.authContext}: successful probe is missing agent-process attestation version`,
-        );
-      }
-      return version;
-    });
+    const attestationVersions = agentSnapshots
+      .map((snapshot) => snapshot.attestation?.version)
+      .filter((version) => typeof version === "string" && version.trim());
     const observedVersions = new Set(attestationVersions);
+    const sourceKind = candidateAgent.harness.agentProcess.source.kind;
+    const mayUseFencedPinAttestation = sourceKind === "archive" || sourceKind === "npm";
+    if (attestationVersions.length !== agentSnapshots.length && !(
+      attestationVersions.length === 0 && mayUseFencedPinAttestation
+    )) {
+      const missingSnapshot = agentSnapshots.find((snapshot) => !snapshot.attestation?.version);
+      throw new Error(
+        `${agent}.${missingSnapshot?.authContext ?? "unknown"}: successful probe is missing ` +
+        "agent-process attestation version",
+      );
+    }
     if (observedVersions.size > 1 || (
       observedVersions.size === 1 &&
       !observedVersions.has(candidateAgent.harness.agentProcess.version)

--- a/scripts/agent-catalog/build-catalog.test.mjs
+++ b/scripts/agent-catalog/build-catalog.test.mjs
@@ -191,6 +191,34 @@ test("complete probes reject missing agent-process attestation versions", () => 
   });
 });
 
+test("complete probes accept a missing process attestation for an immutable archive pin", () => {
+  withFixture((root) => {
+    alignProbeVersions(root);
+    writeCompleteState(root, ["opencode"]);
+    const generated = join(root, "scripts", "agent-catalog", "generated");
+    for (const name of readdirSync(generated).filter((name) => name.startsWith("opencode."))) {
+      const snapshotPath = join(generated, name);
+      const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8"));
+      snapshot.attestation = null;
+      writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+    }
+
+    const script = join(root, "scripts", "agent-catalog", "build-catalog.mjs");
+    execFileSync(process.execPath, [script, "--require-complete-probe"]);
+
+    const candidate = JSON.parse(
+      readFileSync(join(root, "catalogs", "agents", "catalog.json"), "utf8"),
+    );
+    const draft = JSON.parse(
+      readFileSync(join(root, "scripts", "agent-catalog", "catalog.draft.json"), "utf8"),
+    );
+    assert.equal(
+      draft.agents.find((agent) => agent.kind === "opencode").harness.agentProcess.version,
+      candidate.agents.find((agent) => agent.kind === "opencode").harness.agentProcess.version,
+    );
+  });
+});
+
 test("complete probes reject missing native CLI versions for native pins", () => {
   withFixture((root) => {
     alignProbeVersions(root);

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-14.1",
+  "catalogVersion": "2026-07-17.4",
   "probedAgainst": {
-    "registryVersion": "2026-07-14.1"
+    "registryVersion": "2026-07-17.1"
   },
-  "generatedAt": "2026-07-11T00:36:38.653Z",
+  "generatedAt": "2026-07-17T05:35:36.826Z",
   "defaultAgentKind": "claude",
   "agents": [
     {
@@ -12,30 +12,30 @@
       "displayName": "Claude",
       "harness": {
         "agentProcess": {
-          "version": "0.44.0",
+          "version": "0.59.0-proliferate.1",
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
-            "gitRef": "d933c614497b88eb86200920003ab82d220252ca",
+            "gitRef": "6addb0f1694cff90cd64b7cf99ddab6f129aaeb2",
             "executableRelpath": "node_modules/.bin/claude-agent-acp"
           }
         },
         "native": {
-          "version": "2.1.181",
+          "version": "2.1.212",
           "source": {
             "kind": "binary",
             "targets": {
               "macos_arm64": {
-                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.181/darwin-arm64/claude",
-                "sha256": "c4d833b04606cef9b6eab3ad255ed2e1448f87dea2bc00ff5acf77b57df6e94d"
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.212/darwin-arm64/claude",
+                "sha256": "09ecba2ab2df9b6ee5b0695e26f65dea60fb3b6af3d3542ee09f466838d1e574"
               },
               "macos_x64": {
-                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.181/darwin-x64/claude",
-                "sha256": "353798bcdc49a52a666645370e1c48a84fe837d93bf9d954c19338dca7260ddd"
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.212/darwin-x64/claude",
+                "sha256": "7681a0634c89fa4474e53c0c794e992944aebf3409a7a2b87ea9f9b0194ea341"
               },
               "linux_x64": {
-                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.181/linux-x64/claude",
-                "sha256": "35ffd4e9d9a86395d0ba4e05f8b23bf098bfeab95e97deacd6537909d1324e9c"
+                "url": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.212/linux-x64/claude",
+                "sha256": "044a88cf3a5180776617fd3da1238dcbf9141ddec449a39cf7d2af1ac78e684e"
               }
             }
           }
@@ -127,21 +127,18 @@
             }
           },
           {
-            "key": "fast_mode",
+            "key": "fast",
             "values": [
-              "off",
-              "on"
-            ],
-            "mapping": {
-              "liveConfigId": "fast_mode"
-            }
+              "on",
+              "off"
+            ]
           }
         ],
         "models": [
           {
             "id": "default",
-            "displayName": "Default 4.5",
-            "description": "Use the default model (currently Sonnet 4.5)",
+            "displayName": "Default 4.8",
+            "description": "Use the default model (currently Opus 4.8)",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -172,10 +169,10 @@
                 ],
                 "observedValue": "default"
               },
-              "fast_mode": {
+              "fast": {
                 "values": [
-                  "off",
-                  "on"
+                  "on",
+                  "off"
                 ],
                 "observedValue": "off"
               }
@@ -193,7 +190,7 @@
           },
           {
             "id": "opus[1m]",
-            "displayName": "Opus 4.8 (1M context)",
+            "displayName": "Opus 4.8",
             "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
             "availability": {
               "anyOf": [
@@ -224,10 +221,10 @@
                 ],
                 "observedValue": "default"
               },
-              "fast_mode": {
+              "fast": {
                 "values": [
-                  "off",
-                  "on"
+                  "on",
+                  "off"
                 ],
                 "observedValue": "off"
               }
@@ -243,128 +240,8 @@
           },
           {
             "id": "sonnet",
-            "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
-            "availability": {
-              "anyOf": [
-                "anthropic-api",
-                "anthropic-oauth"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "auto",
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              },
-              "effort": {
-                "values": [
-                  "default",
-                  "low",
-                  "medium",
-                  "high",
-                  "max"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.anthropic-api",
-                "claude.anthropic-oauth"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "sonnet[1m]",
-            "displayName": "Sonnet 4.6 (1M context)",
-            "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "auto",
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              },
-              "effort": {
-                "values": [
-                  "default",
-                  "low",
-                  "medium",
-                  "high",
-                  "max"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "haiku",
-            "displayName": "Haiku 4.5",
-            "description": "Haiku 4.5 · Fastest for quick answers",
-            "availability": {
-              "anyOf": [
-                "anthropic-api",
-                "anthropic-oauth"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.anthropic-api",
-                "claude.anthropic-oauth",
-                "claude.bedrock"
-              ],
-              "observedInAllContexts": true,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opus",
-            "displayName": "Opus 4.6",
-            "description": "Opus 4.6 · Legacy",
+            "displayName": "Sonnet",
+            "description": "Sonnet 5 · Efficient for routine tasks",
             "availability": {
               "anyOf": [
                 "anthropic-api",
@@ -394,13 +271,39 @@
                   "max"
                 ],
                 "observedValue": "default"
-              },
-              "fast_mode": {
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.anthropic-api",
+                "claude.anthropic-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "haiku",
+            "displayName": "Haiku 4.5",
+            "description": "Haiku 4.5 · Fastest for quick answers",
+            "availability": {
+              "anyOf": [
+                "anthropic-api",
+                "anthropic-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
                 "values": [
-                  "off",
-                  "on"
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
                 ],
-                "observedValue": "off"
+                "observedValue": "default"
               }
             },
             "status": "active",
@@ -446,13 +349,6 @@
                   "max"
                 ],
                 "observedValue": "default"
-              },
-              "fast_mode": {
-                "values": [
-                  "off",
-                  "on"
-                ],
-                "observedValue": "off"
               }
             },
             "status": "active",
@@ -498,10 +394,10 @@
                 ],
                 "observedValue": "default"
               },
-              "fast_mode": {
+              "fast": {
                 "values": [
-                  "off",
-                  "on"
+                  "on",
+                  "off"
                 ],
                 "observedValue": "off"
               }
@@ -517,9 +413,145 @@
             }
           },
           {
+            "id": "opus",
+            "displayName": "Opus 4.8",
+            "description": "Opus 4.8 · Best for everyday, complex tasks",
+            "availability": {
+              "anyOf": [
+                "anthropic-oauth"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              },
+              "fast": {
+                "values": [
+                  "on",
+                  "off"
+                ],
+                "observedValue": "off"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.anthropic-oauth"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-fable-5",
+            "displayName": "Fable 5",
+            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-sonnet-5",
+            "displayName": "Sonnet 5",
+            "description": "Sonnet 5 · Efficient for routine tasks",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "auto",
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "us.anthropic.claude-sonnet-4-6",
             "displayName": "Sonnet 4.6",
-            "description": "Sonnet 4.6 · Efficient for routine tasks",
+            "description": "Sonnet 4.6 · Previous Sonnet version",
             "availability": {
               "anyOf": [
                 "bedrock"
@@ -599,48 +631,6 @@
             }
           },
           {
-            "id": "us.anthropic.claude-fable-5",
-            "displayName": "Fable 5",
-            "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
-            "availability": {
-              "anyOf": [
-                "bedrock"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "default",
-                  "acceptEdits",
-                  "plan",
-                  "dontAsk",
-                  "bypassPermissions"
-                ],
-                "observedValue": "default"
-              },
-              "effort": {
-                "values": [
-                  "default",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh",
-                  "max"
-                ],
-                "observedValue": "default"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "claude.bedrock"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
             "displayName": "Opus 4.1",
             "description": "Opus 4.1 · Legacy",
@@ -684,6 +674,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -726,6 +717,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -768,6 +760,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -810,6 +803,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -825,6 +819,47 @@
                   "medium",
                   "high",
                   "xhigh",
+                  "max"
+                ],
+                "observedValue": "default"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "claude.bedrock"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "us.anthropic.claude-opus-4-6-v1",
+            "displayName": "Opus 4.6",
+            "description": "Opus 4.6 · Legacy",
+            "availability": {
+              "anyOf": [
+                "bedrock"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "default",
+                  "acceptEdits",
+                  "plan",
+                  "dontAsk",
+                  "bypassPermissions"
+                ],
+                "observedValue": "default"
+              },
+              "effort": {
+                "values": [
+                  "default",
+                  "low",
+                  "medium",
+                  "high",
                   "max"
                 ],
                 "observedValue": "default"
@@ -892,6 +927,7 @@
             "controls": {
               "mode": {
                 "values": [
+                  "auto",
                   "default",
                   "acceptEdits",
                   "plan",
@@ -1133,9 +1169,9 @@
           "gateway": "claude-sonnet-4-5"
         },
         "observedDefaults": {
-          "anthropic-api": "opus",
-          "anthropic-oauth": "opus",
-          "bedrock": "us.anthropic.claude-opus-4-8"
+          "anthropic-api": "default",
+          "anthropic-oauth": "default",
+          "bedrock": "default"
         },
         "gatewayPolicy": {
           "providers": [
@@ -1154,11 +1190,27 @@
           ]
         }
       },
+      "settings": [
+        {
+          "key": "chrome",
+          "type": "boolean",
+          "label": "Use Claude Code with Chrome",
+          "description": "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
+          "default": false,
+          "surfaces": [
+            "local"
+          ],
+          "mapping": {
+            "kind": "cli_flag",
+            "flag": "--chrome"
+          }
+        }
+      ],
       "provenance": {
-        "probedAt": "2026-06-18T02:52:37.457623+00:00",
+        "probedAt": "2026-07-17T05:34:23.802840+00:00",
         "attestation": {
           "name": "@agentclientprotocol/claude-agent-acp",
-          "version": "0.44.0",
+          "version": "0.59.0-proliferate.1",
           "title": "Claude Agent"
         },
         "runs": [
@@ -1175,56 +1227,40 @@
             "snapshotPath": "generated/claude.bedrock.probe.json"
           }
         ]
-      },
-      "settings": [
-        {
-          "key": "chrome",
-          "type": "boolean",
-          "label": "Use Claude Code with Chrome",
-          "description": "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
-          "default": false,
-          "surfaces": [
-            "local"
-          ],
-          "mapping": {
-            "kind": "cli_flag",
-            "flag": "--chrome"
-          }
-        }
-      ]
+      }
     },
     {
       "kind": "codex",
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.18.1-proliferate.1",
+          "version": "0.18.2-proliferate.1",
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "938065e69331d91df0de3bbf1dcaae6e6dc6e2eb",
+            "gitRef": "8a6ce248c07417b0b5b84056164996ad7080d03f",
             "packageSubdir": "npm",
             "executableRelpath": "node_modules/.bin/codex-acp"
           }
         },
         "native": {
-          "version": "rust-v0.144.1",
+          "version": "rust-v0.144.5",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-aarch64-apple-darwin.tar.gz",
-                "sha256": "88e72ac8bd30815f7d18e62dac333dc20ce3ad1cba94be1649a1977dd9bfdbb8",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-aarch64-apple-darwin.tar.gz",
+                "sha256": "a5b77d2fb393f201777809425ab28d9beb65ee0c0b2bf792f09eaf8ef1151592",
                 "expectedBinary": "codex-aarch64-apple-darwin"
               },
               "macos_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-apple-darwin.tar.gz",
-                "sha256": "0ea72d21c794504342d5fe0d5d057b0221c0a42f4bdf4a48b95af243af2b0c0e",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-apple-darwin.tar.gz",
+                "sha256": "ff5c894a9ffa6d97c225c8d3c869c7ef7573dcbd0cf9b762ecfb9fa96dbb7d88",
                 "expectedBinary": "codex-x86_64-apple-darwin"
               },
               "linux_x64": {
-                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.1/codex-x86_64-unknown-linux-musl.tar.gz",
-                "sha256": "84091ae20c65fcc7d4120db97d1bd57d7ff8df9c7609fb781c78c2ebbd4f5a28",
+                "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-unknown-linux-musl.tar.gz",
+                "sha256": "b6bea13bedf493232f6717714c45e783788c695cedcf37c344f73afc97b1ec9f",
                 "expectedBinary": "codex-x86_64-unknown-linux-musl"
               }
             },
@@ -2000,7 +2036,7 @@
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "medium"
+                "observedValue": "low"
               }
             },
             "status": "active",
@@ -2127,10 +2163,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-07-11T00:36:25.416008+00:00",
+        "probedAt": "2026-07-17T05:35:01.459582+00:00",
         "attestation": {
           "name": "codex-acp",
-          "version": "0.18.1-proliferate.1",
+          "version": "0.18.2-proliferate.1",
           "title": "Codex"
         },
         "runs": [
@@ -2154,23 +2190,23 @@
       "displayName": "Cursor",
       "harness": {
         "agentProcess": {
-          "version": "2026.06.15",
+          "version": "2026.07.09",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://downloads.cursor.com/lab/2026.06.15-18-00-12-6f5a2cf/darwin/arm64/agent-cli-package.tar.gz",
-                "sha256": "49ed840e3ab46a129968907dbfef06e459eefb2fca1c4fec538eb560e1b59bac",
+                "url": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/arm64/agent-cli-package.tar.gz",
+                "sha256": "009ee857d49f17c10e5035e33884eb258d1f3839c1d52bdb35f35a117369dfde",
                 "expectedBinary": "./dist-package/cursor-agent"
               },
               "macos_x64": {
-                "url": "https://downloads.cursor.com/lab/2026.06.15-18-00-12-6f5a2cf/darwin/x64/agent-cli-package.tar.gz",
-                "sha256": "6eb89fbd79374aac8145ea2f19793cfa3f6138d74af1d45d4fe299c644642a74",
+                "url": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/x64/agent-cli-package.tar.gz",
+                "sha256": "066c499f6ec43734254337c493aeec5aabb4a6ae6d6df7da214fa86ceda9e45d",
                 "expectedBinary": "./dist-package/cursor-agent"
               },
               "linux_x64": {
-                "url": "https://downloads.cursor.com/lab/2026.06.15-18-00-12-6f5a2cf/linux/x64/agent-cli-package.tar.gz",
-                "sha256": "33b22b0c4fd0397a89fc1b908e4536bb0a8fb09daff97acf519fbec76569ccb3",
+                "url": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/linux/x64/agent-cli-package.tar.gz",
+                "sha256": "c7c1f32249cedb99cc20cd4eed1f9308dc2299a78c283bbc6efd6d658cd4977e",
                 "expectedBinary": "./dist-package/cursor-agent"
               }
             },
@@ -2197,6 +2233,7 @@
         }
       ],
       "session": {
+        "supportsGoals": false,
         "controls": [
           {
             "key": "model",
@@ -2218,6 +2255,14 @@
               "createField": "modeId",
               "liveConfigId": "mode"
             }
+          },
+          {
+            "key": "effort",
+            "values": [
+              "high",
+              "medium",
+              "xhigh"
+            ]
           },
           {
             "key": "fast",
@@ -2242,17 +2287,10 @@
             ]
           },
           {
-            "key": "effort",
-            "values": [
-              "high",
-              "medium",
-              "xhigh"
-            ]
-          },
-          {
             "key": "reasoning",
             "values": [
-              "medium"
+              "medium",
+              "high"
             ]
           }
         ],
@@ -2285,6 +2323,47 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "default[]"
+              ]
+            }
+          },
+          {
+            "id": "grok-4.5",
+            "displayName": "Grok-4.5",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "effort": {
+                "values": [
+                  "high"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "true"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "grok-4.5[effort=high,fast=true]"
               ]
             }
           },
@@ -2376,6 +2455,52 @@
             }
           },
           {
+            "id": "gpt-5.6-sol",
+            "displayName": "GPT-5.6-Sol",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "context": {
+                "values": [
+                  "272k"
+                ]
+              },
+              "reasoning": {
+                "values": [
+                  "medium"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "false"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]"
+              ]
+            }
+          },
+          {
             "id": "gpt-5.5",
             "displayName": "GPT-5.5",
             "availability": {
@@ -2418,6 +2543,144 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.5[context=272k,reasoning=medium,fast=false]"
+              ]
+            }
+          },
+          {
+            "id": "claude-fable-5",
+            "displayName": "Claude Fable 5",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "thinking": {
+                "values": [
+                  "true"
+                ]
+              },
+              "context": {
+                "values": [
+                  "300k"
+                ]
+              },
+              "effort": {
+                "values": [
+                  "high"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "claude-fable-5[thinking=true,context=300k,effort=high]"
+              ]
+            }
+          },
+          {
+            "id": "claude-sonnet-5",
+            "displayName": "Claude-Sonnet-5",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "thinking": {
+                "values": [
+                  "true"
+                ]
+              },
+              "context": {
+                "values": [
+                  "300k"
+                ]
+              },
+              "effort": {
+                "values": [
+                  "high"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "claude-sonnet-5[thinking=true,context=300k,effort=high]"
+              ]
+            }
+          },
+          {
+            "id": "gpt-5.6-terra",
+            "displayName": "GPT-5.6-Terra",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "context": {
+                "values": [
+                  "272k"
+                ]
+              },
+              "reasoning": {
+                "values": [
+                  "medium"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "false"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "gpt-5.6-terra[context=272k,reasoning=medium,fast=false]"
               ]
             }
           },
@@ -2560,42 +2823,6 @@
             }
           },
           {
-            "id": "grok-build-0.1",
-            "displayName": "Grok Build 0.1",
-            "availability": {
-              "anyOf": [
-                "cursor-login"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "agent",
-                  "plan",
-                  "ask"
-                ],
-                "observedValue": "agent"
-              },
-              "context": {
-                "values": [
-                  "200k"
-                ]
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "cursor.cursor-login"
-              ],
-              "observedInAllContexts": true,
-              "viaTrialOnly": false,
-              "variantIds": [
-                "grok-build-0.1[context=200k]"
-              ]
-            }
-          },
-          {
             "id": "gpt-5.4",
             "displayName": "GPT-5.4",
             "availability": {
@@ -2673,11 +2900,6 @@
                 "values": [
                   "high"
                 ]
-              },
-              "fast": {
-                "values": [
-                  "false"
-                ]
               }
             },
             "status": "active",
@@ -2688,7 +2910,7 @@
               "observedInAllContexts": true,
               "viaTrialOnly": false,
               "variantIds": [
-                "claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]"
+                "claude-opus-4-6[thinking=true,context=200k,effort=high]"
               ]
             }
           },
@@ -2766,6 +2988,52 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "gpt-5.2[reasoning=medium,fast=false]"
+              ]
+            }
+          },
+          {
+            "id": "gpt-5.6-luna",
+            "displayName": "GPT-5.6-Luna",
+            "availability": {
+              "anyOf": [
+                "cursor-login"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "agent",
+                  "plan",
+                  "ask"
+                ],
+                "observedValue": "agent"
+              },
+              "context": {
+                "values": [
+                  "272k"
+                ]
+              },
+              "reasoning": {
+                "values": [
+                  "medium"
+                ]
+              },
+              "fast": {
+                "values": [
+                  "false"
+                ]
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "cursor.cursor-login"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false,
+              "variantIds": [
+                "gpt-5.6-luna[context=272k,reasoning=medium,fast=false]"
               ]
             }
           },
@@ -2905,42 +3173,6 @@
               "viaTrialOnly": false,
               "variantIds": [
                 "claude-haiku-4-5[thinking=true]"
-              ]
-            }
-          },
-          {
-            "id": "grok-4.3",
-            "displayName": "Grok 4.3",
-            "availability": {
-              "anyOf": [
-                "cursor-login"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "agent",
-                  "plan",
-                  "ask"
-                ],
-                "observedValue": "agent"
-              },
-              "context": {
-                "values": [
-                  "200k"
-                ]
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "cursor.cursor-login"
-              ],
-              "observedInAllContexts": true,
-              "viaTrialOnly": false,
-              "variantIds": [
-                "grok-4.3[context=200k]"
               ]
             }
           },
@@ -3305,8 +3537,8 @@
             }
           },
           {
-            "id": "kimi-k2.5",
-            "displayName": "Kimi K2.5",
+            "id": "kimi-k2.7-code",
+            "displayName": "Kimi-K2.7-Code",
             "availability": {
               "anyOf": [
                 "cursor-login"
@@ -3331,13 +3563,13 @@
               "observedInAllContexts": true,
               "viaTrialOnly": false,
               "variantIds": [
-                "kimi-k2.5[]"
+                "kimi-k2.7-code[]"
               ]
             }
           },
           {
-            "id": "claude-fable-5",
-            "displayName": "Claude Fable 5",
+            "id": "glm-5.2",
+            "displayName": "GLM-5.2",
             "availability": {
               "anyOf": [
                 "cursor-login"
@@ -3353,17 +3585,7 @@
                 ],
                 "observedValue": "agent"
               },
-              "thinking": {
-                "values": [
-                  "true"
-                ]
-              },
-              "context": {
-                "values": [
-                  "300k"
-                ]
-              },
-              "effort": {
+              "reasoning": {
                 "values": [
                   "high"
                 ]
@@ -3377,7 +3599,7 @@
               "observedInAllContexts": true,
               "viaTrialOnly": false,
               "variantIds": [
-                "claude-fable-5[thinking=true,context=300k,effort=high]"
+                "glm-5.2[reasoning=high]"
               ]
             }
           }
@@ -3386,11 +3608,11 @@
           "cursor-login": "default"
         },
         "observedDefaults": {
-          "cursor-login": "gemini-3.1-pro[]"
+          "cursor-login": "glm-5.2[reasoning=high]"
         }
       },
       "provenance": {
-        "probedAt": "2026-06-18T02:53:09.426103+00:00",
+        "probedAt": "2026-07-17T05:35:36.678732+00:00",
         "attestation": null,
         "runs": [
           {
@@ -3405,11 +3627,11 @@
       "displayName": "Grok",
       "harness": {
         "agentProcess": {
-          "version": "0.2.55",
+          "version": "0.2.102",
           "source": {
             "kind": "npm",
-            "package": "@xai-official/grok@0.2.55",
-            "sha256": "sha512-I5v0ePk1Q/yQmLLkpCprzySaTQC1DvvN/rrzrbhaqCBptbBkEkwwpXZKhg1VyLqHczDUnwjmSIH/kSmLLjSc0g==",
+            "package": "@xai-official/grok@0.2.102",
+            "sha256": "sha512-Q8BdegoBOCvLq5cDDYiomZd3Dnxwwv72TbQ60B5HNpOJP4AoJpTarNuB+BGNUZ1/6U7rw14xZrRtxLrkkv3nHA==",
             "args": [
               "agent",
               "stdio"
@@ -3445,6 +3667,7 @@
         }
       ],
       "session": {
+        "supportsGoals": false,
         "controls": [
           {
             "key": "model",
@@ -3516,6 +3739,25 @@
           {
             "id": "grok-4.3",
             "displayName": "Grok 4.3",
+            "availability": {
+              "anyOf": [
+                "xai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {},
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "grok.xai-api"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "grok-4.5",
+            "displayName": "Grok-4.5",
             "availability": {
               "anyOf": [
                 "xai-api"
@@ -3609,14 +3851,14 @@
             }
           },
           {
-            "id": "grok-imagine-video-1.5-preview",
-            "displayName": "Grok Imagine Video 1.5 Preview",
+            "id": "grok-imagine-video-1.5",
+            "displayName": "Grok-Imagine-Video-1.5",
             "availability": {
               "anyOf": [
                 "xai-api"
               ]
             },
-            "defaultVisible": false,
+            "defaultVisible": true,
             "controls": {},
             "status": "active",
             "provenance": {
@@ -3696,7 +3938,7 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-16T06:46:29.757670+00:00",
+        "probedAt": "2026-07-17T05:35:08.879897+00:00",
         "attestation": null,
         "runs": [
           {
@@ -3711,23 +3953,23 @@
       "displayName": "OpenCode",
       "harness": {
         "agentProcess": {
-          "version": "1.17.7",
+          "version": "1.18.3",
           "source": {
             "kind": "archive",
             "targets": {
               "macos_arm64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-arm64.zip",
-                "sha256": "7a63aeb5a15b29da2681ac2b8c74d4cb3a64fa13b61198a3c7dc771243c23972",
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip",
+                "sha256": "946f62b155638b911144b7bef520ee4a6442f696297907873463bca3524e40ef",
                 "expectedBinary": "./opencode"
               },
               "macos_x64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-darwin-x64.zip",
-                "sha256": "4953e7c3c8db8c623ea726d8ecb6657ba04806b7b4d906c078fc072fb172cfe0",
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-x64.zip",
+                "sha256": "4ea147867ba19e4ec03559df557811f1674f40788aea4d10326dc563b7667c6d",
                 "expectedBinary": "./opencode"
               },
               "linux_x64": {
-                "url": "https://github.com/anomalyco/opencode/releases/download/v1.17.7/opencode-linux-x64.tar.gz",
-                "sha256": "60fe5a92dc9af64ec079348fedde17e12da6a867efe7e8353be8038480607924",
+                "url": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-x64.tar.gz",
+                "sha256": "60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583",
                 "expectedBinary": "./opencode"
               }
             },
@@ -3809,6 +4051,7 @@
         }
       ],
       "session": {
+        "supportsGoals": false,
         "controls": [
           {
             "key": "model",
@@ -3882,33 +4125,6 @@
             }
           },
           {
-            "id": "anthropic/claude-3-5-haiku-latest",
-            "displayName": "Anthropic/Claude Haiku 3.5 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "anthropic/claude-haiku-4-5-20251001",
             "displayName": "Anthropic/Claude Haiku 4.5",
             "availability": {
@@ -3945,145 +4161,6 @@
           {
             "id": "anthropic/claude-haiku-4-5",
             "displayName": "Anthropic/Claude Haiku 4.5 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-20250514",
-            "displayName": "Anthropic/Claude Opus 4",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh",
-                  "max"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-0",
-            "displayName": "Anthropic/Claude Opus 4 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-1-20250805",
-            "displayName": "Anthropic/Claude Opus 4.1",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-opus-4-1",
-            "displayName": "Anthropic/Claude Opus 4.1 (latest)",
             "availability": {
               "anyOf": [
                 "anthropic-api"
@@ -4406,74 +4483,6 @@
             }
           },
           {
-            "id": "anthropic/claude-sonnet-4-20250514",
-            "displayName": "Anthropic/Claude Sonnet 4",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "anthropic/claude-sonnet-4-0",
-            "displayName": "Anthropic/Claude Sonnet 4 (latest)",
-            "availability": {
-              "anyOf": [
-                "anthropic-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.anthropic-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "anthropic/claude-sonnet-4-5-20250929",
             "displayName": "Anthropic/Claude Sonnet 4.5",
             "availability": {
@@ -4578,6 +4587,43 @@
             }
           },
           {
+            "id": "anthropic/claude-sonnet-5",
+            "displayName": "Anthropic/Claude Sonnet 5",
+            "availability": {
+              "anyOf": [
+                "anthropic-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.anthropic-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "opencode/big-pickle",
             "displayName": "OpenCode Zen/Big Pickle",
             "availability": {
@@ -4628,13 +4674,46 @@
             "controls": {
               "effort": {
                 "values": [
-                  "low",
-                  "medium",
                   "high",
                   "max"
                 ],
-                "observedValue": "low"
+                "observedValue": "high"
               },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.anthropic-api",
+                "opencode.baseline",
+                "opencode.gemini-api",
+                "opencode.openai-api",
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": true,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/hy3-free",
+            "displayName": "OpenCode Zen/Hy3 Free",
+            "availability": {
+              "anyOf": [
+                "anthropic-api",
+                "baseline",
+                "gemini-api",
+                "openai-api",
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
               "mode": {
                 "values": [
                   "build",
@@ -4670,14 +4749,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -4713,14 +4784,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -5157,10 +5220,12 @@
             "controls": {
               "effort": {
                 "values": [
+                  "minimal",
                   "low",
+                  "medium",
                   "high"
                 ],
-                "observedValue": "low"
+                "observedValue": "minimal"
               },
               "mode": {
                 "values": [
@@ -5191,11 +5256,40 @@
             "controls": {
               "effort": {
                 "values": [
+                  "minimal",
                   "low",
+                  "medium",
                   "high"
                 ],
-                "observedValue": "low"
+                "observedValue": "minimal"
               },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.gemini-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "google/gemini-omni-flash-preview",
+            "displayName": "Google/Gemini Omni Flash Preview",
+            "availability": {
+              "anyOf": [
+                "gemini-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
               "mode": {
                 "values": [
                   "build",
@@ -5282,74 +5376,6 @@
             }
           },
           {
-            "id": "google/gemma-4-E2B-it",
-            "displayName": "Google/Gemma 4 E2B IT",
-            "availability": {
-              "anyOf": [
-                "gemini-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.gemini-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "google/gemma-4-E4B-it",
-            "displayName": "Google/Gemma 4 E4B IT",
-            "availability": {
-              "anyOf": [
-                "gemini-api"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.gemini-api"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
             "id": "google/gemini-2.5-flash-image",
             "displayName": "Google/Nano Banana",
             "availability": {
@@ -5359,13 +5385,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "high",
-                  "max"
-                ],
-                "observedValue": "high"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -5427,12 +5446,6 @@
             },
             "defaultVisible": true,
             "controls": {
-              "effort": {
-                "values": [
-                  "high"
-                ],
-                "observedValue": "high"
-              },
               "mode": {
                 "values": [
                   "build",
@@ -6697,6 +6710,462 @@
             }
           },
           {
+            "id": "openai/gpt-5.6",
+            "displayName": "OpenAI/GPT-5.6",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-fast",
+            "displayName": "OpenAI/GPT-5.6 Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-luna",
+            "displayName": "OpenAI/GPT-5.6 Luna",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-luna-fast",
+            "displayName": "OpenAI/GPT-5.6 Luna Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-luna-pro",
+            "displayName": "OpenAI/GPT-5.6 Luna Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-pro",
+            "displayName": "OpenAI/GPT-5.6 Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-sol",
+            "displayName": "OpenAI/GPT-5.6 Sol",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-sol-fast",
+            "displayName": "OpenAI/GPT-5.6 Sol Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-sol-pro",
+            "displayName": "OpenAI/GPT-5.6 Sol Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-terra",
+            "displayName": "OpenAI/GPT-5.6 Terra",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-terra-fast",
+            "displayName": "OpenAI/GPT-5.6 Terra Fast",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-5.6-terra-pro",
+            "displayName": "OpenAI/GPT-5.6 Terra Pro",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "openai/gpt-image-1",
             "displayName": "OpenAI/gpt-image-1",
             "availability": {
@@ -6760,6 +7229,70 @@
             },
             "defaultVisible": true,
             "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-image-2",
+            "displayName": "OpenAI/gpt-image-2",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.openai-api"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "openai/gpt-realtime-2.1",
+            "displayName": "OpenAI/GPT-Realtime-2.1",
+            "availability": {
+              "anyOf": [
+                "openai-api"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ],
+                "observedValue": "minimal"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -7135,8 +7668,8 @@
             }
           },
           {
-            "id": "opencode-go/deepseek-v4-flash",
-            "displayName": "OpenCode Go/DeepSeek V4 Flash",
+            "id": "opencode/claude-fable-5",
+            "displayName": "OpenCode Zen/Claude Fable 5",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -7149,366 +7682,11 @@
                   "low",
                   "medium",
                   "high",
+                  "xhigh",
                   "max"
                 ],
                 "observedValue": "low"
               },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/deepseek-v4-pro",
-            "displayName": "OpenCode Go/DeepSeek V4 Pro",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high",
-                  "max"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/glm-5.1",
-            "displayName": "OpenCode Go/GLM-5.1",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/glm-5.2",
-            "displayName": "OpenCode Go/GLM-5.2",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/kimi-k2.6",
-            "displayName": "OpenCode Go/Kimi K2.6",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/kimi-k2.7-code",
-            "displayName": "OpenCode Go/Kimi K2.7 Code",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/mimo-v2.5",
-            "displayName": "OpenCode Go/MiMo V2.5",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/mimo-v2.5-pro",
-            "displayName": "OpenCode Go/MiMo V2.5 Pro",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
-                "observedValue": "low"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/minimax-m2.7",
-            "displayName": "OpenCode Go/MiniMax M2.7",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/minimax-m3",
-            "displayName": "OpenCode Go/MiniMax M3 3 (3x usage)",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "effort": {
-                "values": [
-                  "none",
-                  "thinking"
-                ],
-                "observedValue": "none"
-              },
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/qwen3.6-plus",
-            "displayName": "OpenCode Go/Qwen3.6 Plus",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/qwen3.7-max",
-            "displayName": "OpenCode Go/Qwen3.7 Max",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
-              "mode": {
-                "values": [
-                  "build",
-                  "plan"
-                ],
-                "observedValue": "build"
-              }
-            },
-            "status": "active",
-            "provenance": {
-              "observedIn": [
-                "opencode.opencode-zen"
-              ],
-              "observedInAllContexts": false,
-              "viaTrialOnly": false
-            }
-          },
-          {
-            "id": "opencode-go/qwen3.7-plus",
-            "displayName": "OpenCode Go/Qwen3.7 Plus",
-            "availability": {
-              "anyOf": [
-                "opencode-zen"
-              ]
-            },
-            "defaultVisible": true,
-            "controls": {
               "mode": {
                 "values": [
                   "build",
@@ -7844,8 +8022,8 @@
             }
           },
           {
-            "id": "opencode/deepseek-v4-flash",
-            "displayName": "OpenCode Zen/DeepSeek V4 Flash",
+            "id": "opencode/claude-sonnet-5",
+            "displayName": "OpenCode Zen/Claude Sonnet 5",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -7858,9 +8036,44 @@
                   "low",
                   "medium",
                   "high",
+                  "xhigh",
                   "max"
                 ],
                 "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/deepseek-v4-flash",
+            "displayName": "OpenCode Zen/DeepSeek V4 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
               },
               "mode": {
                 "values": [
@@ -7891,12 +8104,10 @@
             "controls": {
               "effort": {
                 "values": [
-                  "low",
-                  "medium",
                   "high",
                   "max"
                 ],
-                "observedValue": "low"
+                "observedValue": "high"
               },
               "mode": {
                 "values": [
@@ -8059,6 +8270,40 @@
             },
             "defaultVisible": true,
             "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/glm-5.2",
+            "displayName": "OpenCode Zen/GLM-5.2",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -8447,13 +8692,12 @@
             "controls": {
               "effort": {
                 "values": [
-                  "none",
                   "low",
                   "medium",
                   "high",
                   "xhigh"
                 ],
-                "observedValue": "none"
+                "observedValue": "low"
               },
               "mode": {
                 "values": [
@@ -8691,6 +8935,155 @@
             }
           },
           {
+            "id": "opencode/gpt-5.6-luna",
+            "displayName": "OpenCode Zen/GPT-5.6 Luna",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.6-sol",
+            "displayName": "OpenCode Zen/GPT-5.6 Sol",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/gpt-5.6-terra",
+            "displayName": "OpenCode Zen/GPT-5.6 Terra",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/grok-4.5",
+            "displayName": "OpenCode Zen/Grok 4.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "observedValue": "low"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "opencode/grok-build-0.1",
             "displayName": "OpenCode Zen/Grok Build 0.1",
             "availability": {
@@ -8772,8 +9165,35 @@
             }
           },
           {
+            "id": "opencode/kimi-k2.7-code",
+            "displayName": "OpenCode Zen/Kimi K2.7 Code",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
             "id": "opencode/minimax-m2.5",
-            "displayName": "OpenCode Zen/MiniMax M2.5",
+            "displayName": "OpenCode Zen/MiniMax-M2.5",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -8800,7 +9220,34 @@
           },
           {
             "id": "opencode/minimax-m2.7",
-            "displayName": "OpenCode Zen/MiniMax M2.7",
+            "displayName": "OpenCode Zen/MiniMax-M2.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode/minimax-m3",
+            "displayName": "OpenCode Zen/MiniMax-M3 3",
             "availability": {
               "anyOf": [
                 "opencode-zen"
@@ -8835,6 +9282,13 @@
             },
             "defaultVisible": true,
             "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -8862,6 +9316,413 @@
             },
             "defaultVisible": true,
             "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/deepseek-v4-flash",
+            "displayName": "OpenCode Go/DeepSeek V4 Flash",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/deepseek-v4-pro",
+            "displayName": "OpenCode Go/DeepSeek V4 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/glm-5.1",
+            "displayName": "OpenCode Go/GLM-5.1",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/glm-5.2",
+            "displayName": "OpenCode Go/GLM-5.2",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/kimi-k2.6",
+            "displayName": "OpenCode Go/Kimi K2.6",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/kimi-k2.7-code",
+            "displayName": "OpenCode Go/Kimi K2.7 Code",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/mimo-v2.5",
+            "displayName": "OpenCode Go/MiMo V2.5",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/mimo-v2.5-pro",
+            "displayName": "OpenCode Go/MiMo V2.5 Pro",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m2.7",
+            "displayName": "OpenCode Go/MiniMax-M2.7",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/minimax-m3",
+            "displayName": "OpenCode Go/MiniMax-M3 3",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "none",
+                  "thinking"
+                ],
+                "observedValue": "none"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.6-plus",
+            "displayName": "OpenCode Go/Qwen3.6 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.7-max",
+            "displayName": "OpenCode Go/Qwen3.7 Max",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
+              "mode": {
+                "values": [
+                  "build",
+                  "plan"
+                ],
+                "observedValue": "build"
+              }
+            },
+            "status": "active",
+            "provenance": {
+              "observedIn": [
+                "opencode.opencode-zen"
+              ],
+              "observedInAllContexts": false,
+              "viaTrialOnly": false
+            }
+          },
+          {
+            "id": "opencode-go/qwen3.7-plus",
+            "displayName": "OpenCode Go/Qwen3.7 Plus",
+            "availability": {
+              "anyOf": [
+                "opencode-zen"
+              ]
+            },
+            "defaultVisible": true,
+            "controls": {
+              "effort": {
+                "values": [
+                  "high",
+                  "max"
+                ],
+                "observedValue": "high"
+              },
               "mode": {
                 "values": [
                   "build",
@@ -9009,10 +9870,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-06-18T02:52:36.735929+00:00",
+        "probedAt": "2026-07-17T05:35:02.916500+00:00",
         "attestation": {
           "name": "OpenCode",
-          "version": "1.17.7",
+          "version": "1.18.3",
           "title": null
         },
         "runs": [

--- a/scripts/agent-catalog/generated/claude.anthropic-api.probe.json
+++ b/scripts/agent-catalog/generated/claude.anthropic-api.probe.json
@@ -1,21 +1,22 @@
 {
-  "probedAt": "2026-06-18T02:52:36.082085+00:00",
+  "probedAt": "2026-07-17T05:32:48.831389+00:00",
   "agentKind": "claude",
   "authContext": "anthropic-api",
   "attestation": {
     "name": "@agentclientprotocol/claude-agent-acp",
-    "version": "0.44.0",
+    "version": "0.59.0-proliferate.1",
     "title": "Claude Agent"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/claude/native/claude",
+    "version": "2.1.212 (Claude Code)"
   },
   "trials": [
     {
       "modelId": "claude-fable-5",
       "accepted": true,
+      "name": "Fable",
       "configOptions": [
         {
           "category": "mode",
@@ -31,7 +32,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -59,7 +60,7 @@
         },
         {
           "category": "model",
-          "currentValue": "opus",
+          "currentValue": "claude-fable-5",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
@@ -71,28 +72,23 @@
             },
             {
               "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
-              "name": "Opus (1M context)",
+              "name": "Opus",
               "value": "opus[1m]"
             },
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
-              "name": "Sonnet",
-              "value": "sonnet"
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+              "name": "Fable",
+              "value": "claude-fable-5"
             },
             {
-              "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
-              "name": "Sonnet (1M context)",
-              "value": "sonnet[1m]"
+              "description": "Sonnet 5 · Efficient for routine tasks · $3/$15 per Mtok",
+              "name": "Sonnet",
+              "value": "sonnet"
             },
             {
               "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
               "name": "Haiku",
               "value": "haiku"
-            },
-            {
-              "description": "Opus 4.8 · Best for everyday, complex tasks",
-              "name": "Opus",
-              "value": "opus"
             }
           ],
           "type": "select"
@@ -127,24 +123,6 @@
             {
               "name": "Max",
               "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "_fast_mode",
-          "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
-          "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
-            {
-              "name": "On",
-              "value": "on"
             }
           ],
           "type": "select"
@@ -169,7 +147,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -197,7 +175,7 @@
         },
         {
           "category": "model",
-          "currentValue": "opus",
+          "currentValue": "opus[1m]",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
@@ -209,28 +187,18 @@
             },
             {
               "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
-              "name": "Opus (1M context)",
+              "name": "Opus",
               "value": "opus[1m]"
             },
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
+              "description": "Sonnet 5 · Efficient for routine tasks · $3/$15 per Mtok",
               "name": "Sonnet",
               "value": "sonnet"
-            },
-            {
-              "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
-              "name": "Sonnet (1M context)",
-              "value": "sonnet[1m]"
             },
             {
               "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
               "name": "Haiku",
               "value": "haiku"
-            },
-            {
-              "description": "Opus 4.8 · Best for everyday, complex tasks",
-              "name": "Opus",
-              "value": "opus"
             }
           ],
           "type": "select"
@@ -270,19 +238,19 @@
           "type": "select"
         },
         {
-          "category": "_fast_mode",
+          "category": "model_config",
           "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
+          "description": "Faster responses on supported models",
+          "id": "fast",
+          "name": "Fast mode",
           "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
             {
               "name": "On",
               "value": "on"
+            },
+            {
+              "name": "Off",
+              "value": "off"
             }
           ],
           "type": "select"
@@ -302,7 +270,7 @@
       {
         "description": "Standard behavior, prompts for dangerous operations",
         "id": "default",
-        "name": "Default"
+        "name": "Manual"
       },
       {
         "description": "Auto-accept file edit operations",
@@ -342,7 +310,7 @@
         },
         {
           "description": "Standard behavior, prompts for dangerous operations",
-          "name": "Default",
+          "name": "Manual",
           "value": "default"
         },
         {
@@ -370,7 +338,7 @@
     },
     {
       "category": "model",
-      "currentValue": "opus",
+      "currentValue": "default",
       "description": "AI model to use",
       "id": "model",
       "name": "Model",
@@ -382,28 +350,18 @@
         },
         {
           "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
-          "name": "Opus (1M context)",
+          "name": "Opus",
           "value": "opus[1m]"
         },
         {
-          "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
+          "description": "Sonnet 5 · Efficient for routine tasks · $3/$15 per Mtok",
           "name": "Sonnet",
           "value": "sonnet"
-        },
-        {
-          "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
-          "name": "Sonnet (1M context)",
-          "value": "sonnet[1m]"
         },
         {
           "description": "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
           "name": "Haiku",
           "value": "haiku"
-        },
-        {
-          "description": "Opus 4.8 · Best for everyday, complex tasks",
-          "name": "Opus",
-          "value": "opus"
         }
       ],
       "type": "select"
@@ -443,19 +401,19 @@
       "type": "select"
     },
     {
-      "category": "_fast_mode",
+      "category": "model_config",
       "currentValue": "off",
-      "description": "Favor faster responses",
-      "id": "fast_mode",
-      "name": "Fast Mode",
+      "description": "Faster responses on supported models",
+      "id": "fast",
+      "name": "Fast mode",
       "options": [
-        {
-          "name": "Off",
-          "value": "off"
-        },
         {
           "name": "On",
           "value": "on"
+        },
+        {
+          "name": "Off",
+          "value": "off"
         }
       ],
       "type": "select"
@@ -481,7 +439,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -552,19 +510,19 @@
           "type": "select"
         },
         {
-          "category": "_fast_mode",
+          "category": "model_config",
           "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
+          "description": "Faster responses on supported models",
+          "id": "fast",
+          "name": "Fast mode",
           "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
             {
               "name": "On",
               "value": "on"
+            },
+            {
+              "name": "Off",
+              "value": "off"
             }
           ],
           "type": "select"
@@ -573,7 +531,7 @@
     },
     {
       "modelId": "opus[1m]",
-      "name": "Opus (1M context)",
+      "name": "Opus",
       "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok",
       "configOptions": [
         {
@@ -590,7 +548,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -661,19 +619,19 @@
           "type": "select"
         },
         {
-          "category": "_fast_mode",
+          "category": "model_config",
           "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
+          "description": "Faster responses on supported models",
+          "id": "fast",
+          "name": "Fast mode",
           "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
             {
               "name": "On",
               "value": "on"
+            },
+            {
+              "name": "Off",
+              "value": "off"
             }
           ],
           "type": "select"
@@ -683,7 +641,7 @@
     {
       "modelId": "sonnet",
       "name": "Sonnet",
-      "description": "Sonnet 4.6 · Efficient for routine tasks · $3/$15 per Mtok",
+      "description": "Sonnet 5 · Efficient for routine tasks · $3/$15 per Mtok",
       "configOptions": [
         {
           "category": "mode",
@@ -699,7 +657,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -759,91 +717,8 @@
               "value": "high"
             },
             {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "sonnet[1m]",
-      "name": "Sonnet (1M context)",
-      "description": "Sonnet 4.6 for long sessions · $3/$15 per Mtok",
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "default",
-          "description": "Session permission mode",
-          "id": "mode",
-          "name": "Mode",
-          "options": [
-            {
-              "description": "Use a model classifier to approve/deny permission prompts",
-              "name": "Auto",
-              "value": "auto"
-            },
-            {
-              "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "description": "Auto-accept file edit operations",
-              "name": "Accept Edits",
-              "value": "acceptEdits"
-            },
-            {
-              "description": "Planning mode, no actual tool execution",
-              "name": "Plan Mode",
-              "value": "plan"
-            },
-            {
-              "description": "Don't prompt for permissions, deny if not pre-approved",
-              "name": "Don't Ask",
-              "value": "dontAsk"
-            },
-            {
-              "description": "Bypass all permission checks",
-              "name": "Bypass Permissions",
-              "value": "bypassPermissions"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "sonnet[1m]",
-          "description": "AI model to use",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "default",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
+              "name": "Xhigh",
+              "value": "xhigh"
             },
             {
               "name": "Max",
@@ -868,7 +743,7 @@
           "options": [
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -903,115 +778,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        }
-      ]
-    },
-    {
-      "modelId": "opus",
-      "name": "Opus",
-      "description": "Opus 4.8 · Best for everyday, complex tasks",
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "default",
-          "description": "Session permission mode",
-          "id": "mode",
-          "name": "Mode",
-          "options": [
-            {
-              "description": "Use a model classifier to approve/deny permission prompts",
-              "name": "Auto",
-              "value": "auto"
-            },
-            {
-              "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "description": "Auto-accept file edit operations",
-              "name": "Accept Edits",
-              "value": "acceptEdits"
-            },
-            {
-              "description": "Planning mode, no actual tool execution",
-              "name": "Plan Mode",
-              "value": "plan"
-            },
-            {
-              "description": "Don't prompt for permissions, deny if not pre-approved",
-              "name": "Don't Ask",
-              "value": "dontAsk"
-            },
-            {
-              "description": "Bypass all permission checks",
-              "name": "Bypass Permissions",
-              "value": "bypassPermissions"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "opus",
-          "description": "AI model to use",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "default",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "_fast_mode",
-          "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
-          "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
-            {
-              "name": "On",
-              "value": "on"
-            }
-          ],
-          "type": "select"
         }
       ]
     }

--- a/scripts/agent-catalog/generated/claude.anthropic-oauth.probe.json
+++ b/scripts/agent-catalog/generated/claude.anthropic-oauth.probe.json
@@ -1,21 +1,22 @@
 {
-  "probedAt": "2026-06-18T02:52:36.222593+00:00",
+  "probedAt": "2026-07-17T05:32:49.472793+00:00",
   "agentKind": "claude",
   "authContext": "anthropic-oauth",
   "attestation": {
     "name": "@agentclientprotocol/claude-agent-acp",
-    "version": "0.44.0",
+    "version": "0.59.0-proliferate.1",
     "title": "Claude Agent"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/claude/native/claude",
+    "version": "2.1.212 (Claude Code)"
   },
   "trials": [
     {
       "modelId": "claude-fable-5",
       "accepted": true,
+      "name": "Fable",
       "configOptions": [
         {
           "category": "mode",
@@ -31,7 +32,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -59,20 +60,25 @@
         },
         {
           "category": "model",
-          "currentValue": "opus",
+          "currentValue": "claude-fable-5",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
           "options": [
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "description": "Sonnet 5 · Efficient for routine tasks",
               "name": "Default (recommended)",
               "value": "default"
             },
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "description": "Sonnet 5 · Efficient for routine tasks",
               "name": "Sonnet",
               "value": "sonnet"
+            },
+            {
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+              "name": "Fable",
+              "value": "claude-fable-5"
             },
             {
               "description": "Opus 4.8 · Best for everyday, complex tasks",
@@ -117,24 +123,6 @@
             {
               "name": "Max",
               "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "_fast_mode",
-          "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
-          "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
-            {
-              "name": "On",
-              "value": "on"
             }
           ],
           "type": "select"
@@ -159,7 +147,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -193,12 +181,12 @@
           "name": "Model",
           "options": [
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "description": "Sonnet 5 · Efficient for routine tasks",
               "name": "Default (recommended)",
               "value": "default"
             },
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "description": "Sonnet 5 · Efficient for routine tasks",
               "name": "Sonnet",
               "value": "sonnet"
             },
@@ -250,19 +238,19 @@
           "type": "select"
         },
         {
-          "category": "_fast_mode",
+          "category": "model_config",
           "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
+          "description": "Faster responses on supported models",
+          "id": "fast",
+          "name": "Fast mode",
           "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
             {
               "name": "On",
               "value": "on"
+            },
+            {
+              "name": "Off",
+              "value": "off"
             }
           ],
           "type": "select"
@@ -282,7 +270,7 @@
       {
         "description": "Standard behavior, prompts for dangerous operations",
         "id": "default",
-        "name": "Default"
+        "name": "Manual"
       },
       {
         "description": "Auto-accept file edit operations",
@@ -322,7 +310,7 @@
         },
         {
           "description": "Standard behavior, prompts for dangerous operations",
-          "name": "Default",
+          "name": "Manual",
           "value": "default"
         },
         {
@@ -350,18 +338,18 @@
     },
     {
       "category": "model",
-      "currentValue": "opus",
+      "currentValue": "default",
       "description": "AI model to use",
       "id": "model",
       "name": "Model",
       "options": [
         {
-          "description": "Sonnet 4.6 · Efficient for routine tasks",
+          "description": "Sonnet 5 · Efficient for routine tasks",
           "name": "Default (recommended)",
           "value": "default"
         },
         {
-          "description": "Sonnet 4.6 · Efficient for routine tasks",
+          "description": "Sonnet 5 · Efficient for routine tasks",
           "name": "Sonnet",
           "value": "sonnet"
         },
@@ -411,31 +399,13 @@
         }
       ],
       "type": "select"
-    },
-    {
-      "category": "_fast_mode",
-      "currentValue": "off",
-      "description": "Favor faster responses",
-      "id": "fast_mode",
-      "name": "Fast Mode",
-      "options": [
-        {
-          "name": "Off",
-          "value": "off"
-        },
-        {
-          "name": "On",
-          "value": "on"
-        }
-      ],
-      "type": "select"
     }
   ],
   "models": [
     {
       "modelId": "default",
       "name": "Default (recommended)",
-      "description": "Sonnet 4.6 · Efficient for routine tasks",
+      "description": "Sonnet 5 · Efficient for routine tasks",
       "configOptions": [
         {
           "category": "mode",
@@ -451,7 +421,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -511,6 +481,10 @@
               "value": "high"
             },
             {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
               "name": "Max",
               "value": "max"
             }
@@ -522,7 +496,7 @@
     {
       "modelId": "sonnet",
       "name": "Sonnet",
-      "description": "Sonnet 4.6 · Efficient for routine tasks",
+      "description": "Sonnet 5 · Efficient for routine tasks",
       "configOptions": [
         {
           "category": "mode",
@@ -538,7 +512,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -598,6 +572,10 @@
               "value": "high"
             },
             {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
               "name": "Max",
               "value": "max"
             }
@@ -625,7 +603,7 @@
             },
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -696,19 +674,19 @@
           "type": "select"
         },
         {
-          "category": "_fast_mode",
+          "category": "model_config",
           "currentValue": "off",
-          "description": "Favor faster responses",
-          "id": "fast_mode",
-          "name": "Fast Mode",
+          "description": "Faster responses on supported models",
+          "id": "fast",
+          "name": "Fast mode",
           "options": [
-            {
-              "name": "Off",
-              "value": "off"
-            },
             {
               "name": "On",
               "value": "on"
+            },
+            {
+              "name": "Off",
+              "value": "off"
             }
           ],
           "type": "select"
@@ -729,7 +707,7 @@
           "options": [
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {

--- a/scripts/agent-catalog/generated/claude.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/claude.bedrock.probe.json
@@ -1,21 +1,22 @@
 {
-  "probedAt": "2026-06-18T02:52:37.457623+00:00",
+  "probedAt": "2026-07-17T05:34:23.802840+00:00",
   "agentKind": "claude",
   "authContext": "bedrock",
   "attestation": {
     "name": "@agentclientprotocol/claude-agent-acp",
-    "version": "0.44.0",
+    "version": "0.59.0-proliferate.1",
     "title": "Claude Agent"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
+    "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/claude/native/claude",
+    "version": "2.1.212 (Claude Code)"
   },
   "trials": [
     {
       "modelId": "global.anthropic.claude-fable-5",
       "accepted": true,
+      "name": "Fable",
       "configOptions": [
         {
           "category": "mode",
@@ -25,8 +26,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -54,30 +60,35 @@
         },
         {
           "category": "model",
-          "currentValue": "us.anthropic.claude-opus-4-8",
+          "currentValue": "global.anthropic.claude-fable-5",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
           "options": [
             {
-              "description": "Use the default model (currently Sonnet 4.5)",
+              "description": "Use the default model (currently Opus 4.8)",
               "name": "Default",
               "value": "default"
             },
             {
-              "description": "Sonnet 4.6 · Efficient for routine tasks",
+              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
+              "name": "Fable",
+              "value": "global.anthropic.claude-fable-5"
+            },
+            {
+              "description": "Sonnet 5 · Efficient for routine tasks",
               "name": "Sonnet",
+              "value": "us.anthropic.claude-sonnet-5"
+            },
+            {
+              "description": "Sonnet 4.6 · Previous Sonnet version",
+              "name": "Sonnet 4.6",
               "value": "us.anthropic.claude-sonnet-4-6"
             },
             {
               "description": "Sonnet 4.6 for long sessions",
-              "name": "Sonnet (1M context)",
+              "name": "Sonnet 4.6 (1M context)",
               "value": "us.anthropic.claude-sonnet-4-6[1m]"
-            },
-            {
-              "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
-              "name": "Fable",
-              "value": "us.anthropic.claude-fable-5"
             },
             {
               "description": "Opus 4.1 · Legacy",
@@ -107,7 +118,7 @@
             {
               "description": "Opus 4.6 · Legacy",
               "name": "Opus 4.6",
-              "value": "opus"
+              "value": "us.anthropic.claude-opus-4-6-v1"
             },
             {
               "description": "Opus 4.6 for long sessions",
@@ -161,7 +172,6 @@
     {
       "modelId": "us.anthropic.claude-opus-4-8",
       "accepted": true,
-      "name": "Opus",
       "configOptions": [
         {
           "category": "mode",
@@ -171,8 +181,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -200,25 +215,15 @@
         },
         {
           "category": "model",
-          "currentValue": "us.anthropic.claude-opus-4-8",
+          "currentValue": "opus",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
           "options": [
             {
-              "description": "Use the default model (currently Sonnet 4.5)",
+              "description": "Use the default model (currently Opus 4.8)",
               "name": "Default",
               "value": "default"
-            },
-            {
-              "description": "Sonnet 4.6 · Efficient for routine tasks",
-              "name": "Sonnet",
-              "value": "us.anthropic.claude-sonnet-4-6"
-            },
-            {
-              "description": "Sonnet 4.6 for long sessions",
-              "name": "Sonnet (1M context)",
-              "value": "us.anthropic.claude-sonnet-4-6[1m]"
             },
             {
               "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
@@ -226,39 +231,24 @@
               "value": "us.anthropic.claude-fable-5"
             },
             {
-              "description": "Opus 4.1 · Legacy",
-              "name": "Opus 4.1",
-              "value": "us.anthropic.claude-opus-4-1-20250805-v1:0"
+              "description": "Sonnet 5 · Efficient for routine tasks",
+              "name": "Sonnet",
+              "value": "us.anthropic.claude-sonnet-5"
             },
             {
-              "description": "Opus 4.8 · Best for everyday, complex tasks",
-              "name": "Opus",
-              "value": "us.anthropic.claude-opus-4-8"
+              "description": "Sonnet 4.6 · Previous Sonnet version",
+              "name": "Sonnet 4.6",
+              "value": "us.anthropic.claude-sonnet-4-6"
             },
             {
-              "description": "Opus 4.8 for long sessions",
-              "name": "Opus (1M context)",
-              "value": "us.anthropic.claude-opus-4-8[1m]"
+              "description": "Sonnet 4.6 for long sessions",
+              "name": "Sonnet 4.6 (1M context)",
+              "value": "us.anthropic.claude-sonnet-4-6[1m]"
             },
             {
-              "description": "Opus 4.7 · Legacy",
-              "name": "Opus 4.7",
-              "value": "us.anthropic.claude-opus-4-7"
-            },
-            {
-              "description": "Opus 4.7 for long sessions",
-              "name": "Opus 4.7 (1M context)",
-              "value": "us.anthropic.claude-opus-4-7[1m]"
-            },
-            {
-              "description": "Opus 4.6 · Legacy",
-              "name": "Opus 4.6",
+              "description": "Custom Opus model",
+              "name": "us.anthropic.claude-opus-4-8",
               "value": "opus"
-            },
-            {
-              "description": "Opus 4.6 for long sessions",
-              "name": "Opus 4.6 (1M context)",
-              "value": "us.anthropic.claude-opus-4-6-v1[1m]"
             },
             {
               "description": "Haiku 4.5 · Fastest for quick answers",
@@ -310,9 +300,14 @@
   "modes": {
     "availableModes": [
       {
+        "description": "Use a model classifier to approve/deny permission prompts",
+        "id": "auto",
+        "name": "Auto"
+      },
+      {
         "description": "Standard behavior, prompts for dangerous operations",
         "id": "default",
-        "name": "Default"
+        "name": "Manual"
       },
       {
         "description": "Auto-accept file edit operations",
@@ -346,8 +341,13 @@
       "name": "Mode",
       "options": [
         {
+          "description": "Use a model classifier to approve/deny permission prompts",
+          "name": "Auto",
+          "value": "auto"
+        },
+        {
           "description": "Standard behavior, prompts for dangerous operations",
-          "name": "Default",
+          "name": "Manual",
           "value": "default"
         },
         {
@@ -375,30 +375,35 @@
     },
     {
       "category": "model",
-      "currentValue": "us.anthropic.claude-opus-4-8",
+      "currentValue": "default",
       "description": "AI model to use",
       "id": "model",
       "name": "Model",
       "options": [
         {
-          "description": "Use the default model (currently Sonnet 4.5)",
+          "description": "Use the default model (currently Opus 4.8)",
           "name": "Default",
           "value": "default"
-        },
-        {
-          "description": "Sonnet 4.6 · Efficient for routine tasks",
-          "name": "Sonnet",
-          "value": "us.anthropic.claude-sonnet-4-6"
-        },
-        {
-          "description": "Sonnet 4.6 for long sessions",
-          "name": "Sonnet (1M context)",
-          "value": "us.anthropic.claude-sonnet-4-6[1m]"
         },
         {
           "description": "Fable 5 · Most capable for your hardest and longest-running tasks",
           "name": "Fable",
           "value": "us.anthropic.claude-fable-5"
+        },
+        {
+          "description": "Sonnet 5 · Efficient for routine tasks",
+          "name": "Sonnet",
+          "value": "us.anthropic.claude-sonnet-5"
+        },
+        {
+          "description": "Sonnet 4.6 · Previous Sonnet version",
+          "name": "Sonnet 4.6",
+          "value": "us.anthropic.claude-sonnet-4-6"
+        },
+        {
+          "description": "Sonnet 4.6 for long sessions",
+          "name": "Sonnet 4.6 (1M context)",
+          "value": "us.anthropic.claude-sonnet-4-6[1m]"
         },
         {
           "description": "Opus 4.1 · Legacy",
@@ -428,7 +433,7 @@
         {
           "description": "Opus 4.6 · Legacy",
           "name": "Opus 4.6",
-          "value": "opus"
+          "value": "us.anthropic.claude-opus-4-6-v1"
         },
         {
           "description": "Opus 4.6 for long sessions",
@@ -482,7 +487,7 @@
     {
       "modelId": "default",
       "name": "Default",
-      "description": "Use the default model (currently Sonnet 4.5)",
+      "description": "Use the default model (currently Opus 4.8)",
       "configOptions": [
         {
           "category": "mode",
@@ -492,8 +497,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -522,58 +532,6 @@
         {
           "category": "model",
           "currentValue": "default",
-          "description": "AI model to use",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        }
-      ]
-    },
-    {
-      "modelId": "us.anthropic.claude-sonnet-4-6",
-      "name": "Sonnet",
-      "description": "Sonnet 4.6 · Efficient for routine tasks",
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "default",
-          "description": "Session permission mode",
-          "id": "mode",
-          "name": "Mode",
-          "options": [
-            {
-              "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "description": "Auto-accept file edit operations",
-              "name": "Accept Edits",
-              "value": "acceptEdits"
-            },
-            {
-              "description": "Planning mode, no actual tool execution",
-              "name": "Plan Mode",
-              "value": "plan"
-            },
-            {
-              "description": "Don't prompt for permissions, deny if not pre-approved",
-              "name": "Don't Ask",
-              "value": "dontAsk"
-            },
-            {
-              "description": "Bypass all permission checks",
-              "name": "Bypass Permissions",
-              "value": "bypassPermissions"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "us.anthropic.claude-sonnet-4-6",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
@@ -605,86 +563,8 @@
               "value": "high"
             },
             {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "us.anthropic.claude-sonnet-4-6[1m]",
-      "name": "Sonnet (1M context)",
-      "description": "Sonnet 4.6 for long sessions",
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "default",
-          "description": "Session permission mode",
-          "id": "mode",
-          "name": "Mode",
-          "options": [
-            {
-              "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "description": "Auto-accept file edit operations",
-              "name": "Accept Edits",
-              "value": "acceptEdits"
-            },
-            {
-              "description": "Planning mode, no actual tool execution",
-              "name": "Plan Mode",
-              "value": "plan"
-            },
-            {
-              "description": "Don't prompt for permissions, deny if not pre-approved",
-              "name": "Don't Ask",
-              "value": "dontAsk"
-            },
-            {
-              "description": "Bypass all permission checks",
-              "name": "Bypass Permissions",
-              "value": "bypassPermissions"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "us.anthropic.claude-sonnet-4-6[1m]",
-          "description": "AI model to use",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "default",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Default",
-              "value": "default"
-            },
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
+              "name": "Xhigh",
+              "value": "xhigh"
             },
             {
               "name": "Max",
@@ -708,8 +588,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -782,6 +667,261 @@
       ]
     },
     {
+      "modelId": "us.anthropic.claude-sonnet-5",
+      "name": "Sonnet",
+      "description": "Sonnet 5 · Efficient for routine tasks",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Manual",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-sonnet-5",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "default",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-sonnet-4-6",
+      "name": "Sonnet 4.6",
+      "description": "Sonnet 4.6 · Previous Sonnet version",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Manual",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-sonnet-4-6",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "default",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "us.anthropic.claude-sonnet-4-6[1m]",
+      "name": "Sonnet 4.6 (1M context)",
+      "description": "Sonnet 4.6 for long sessions",
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "default",
+          "description": "Session permission mode",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Standard behavior, prompts for dangerous operations",
+              "name": "Manual",
+              "value": "default"
+            },
+            {
+              "description": "Auto-accept file edit operations",
+              "name": "Accept Edits",
+              "value": "acceptEdits"
+            },
+            {
+              "description": "Planning mode, no actual tool execution",
+              "name": "Plan Mode",
+              "value": "plan"
+            },
+            {
+              "description": "Don't prompt for permissions, deny if not pre-approved",
+              "name": "Don't Ask",
+              "value": "dontAsk"
+            },
+            {
+              "description": "Bypass all permission checks",
+              "name": "Bypass Permissions",
+              "value": "bypassPermissions"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "us.anthropic.claude-sonnet-4-6[1m]",
+          "description": "AI model to use",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "default",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Default",
+              "value": "default"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
       "modelId": "us.anthropic.claude-opus-4-1-20250805-v1:0",
       "name": "Opus 4.1",
       "description": "Opus 4.1 · Legacy",
@@ -795,7 +935,7 @@
           "options": [
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -846,8 +986,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -932,8 +1077,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -1018,8 +1168,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -1104,8 +1259,13 @@
           "name": "Mode",
           "options": [
             {
+              "description": "Use a model classifier to approve/deny permission prompts",
+              "name": "Auto",
+              "value": "auto"
+            },
+            {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -1178,7 +1338,7 @@
       ]
     },
     {
-      "modelId": "opus",
+      "modelId": "us.anthropic.claude-opus-4-6-v1",
       "name": "Opus 4.6",
       "description": "Opus 4.6 · Legacy",
       "configOptions": [
@@ -1191,7 +1351,7 @@
           "options": [
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -1219,7 +1379,7 @@
         },
         {
           "category": "model",
-          "currentValue": "opus",
+          "currentValue": "us.anthropic.claude-opus-4-6-v1",
           "description": "AI model to use",
           "id": "model",
           "name": "Model",
@@ -1273,7 +1433,7 @@
           "options": [
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {
@@ -1355,7 +1515,7 @@
           "options": [
             {
               "description": "Standard behavior, prompts for dangerous operations",
-              "name": "Default",
+              "name": "Manual",
               "value": "default"
             },
             {

--- a/scripts/agent-catalog/generated/codex.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/codex.bedrock.probe.json
@@ -1,16 +1,16 @@
 {
-  "probedAt": "2026-07-11T00:36:25.132627+00:00",
+  "probedAt": "2026-07-17T05:35:01.459582+00:00",
   "agentKind": "codex",
   "authContext": "bedrock",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.17.0-proliferate.1",
+    "version": "0.18.2-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
     "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
-    "version": "codex-cli 0.144.1"
+    "version": "codex-cli 0.144.5"
   },
   "trials": [],
   "currentModelId": null,

--- a/scripts/agent-catalog/generated/codex.openai-api.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-api.probe.json
@@ -1,16 +1,16 @@
 {
-  "probedAt": "2026-07-11T00:36:25.133691+00:00",
+  "probedAt": "2026-07-17T05:35:00.330612+00:00",
   "agentKind": "codex",
   "authContext": "openai-api",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.17.0-proliferate.1",
+    "version": "0.18.2-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
     "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
-    "version": "codex-cli 0.144.1"
+    "version": "codex-cli 0.144.5"
   },
   "trials": [],
   "currentModelId": null,

--- a/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
@@ -1,16 +1,16 @@
 {
-  "probedAt": "2026-07-11T00:36:25.416008+00:00",
+  "probedAt": "2026-07-17T05:35:01.238029+00:00",
   "agentKind": "codex",
   "authContext": "openai-oauth",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.17.0-proliferate.1",
+    "version": "0.18.2-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",
   "nativeCli": {
     "path": "/Users/pablohansen/.proliferate-local/anyharness/agents/codex/native/codex",
-    "version": "codex-cli 0.144.1"
+    "version": "codex-cli 0.144.5"
   },
   "trials": [],
   "currentModelId": null,
@@ -128,7 +128,7 @@
     },
     {
       "category": "thought_level",
-      "currentValue": "medium",
+      "currentValue": "low",
       "description": "Choose how much reasoning effort the model should use",
       "id": "reasoning_effort",
       "name": "Reasoning Effort",
@@ -250,7 +250,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -372,7 +372,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -494,7 +494,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -611,7 +611,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -723,7 +723,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -835,7 +835,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",
@@ -927,7 +927,7 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "medium",
+          "currentValue": "low",
           "description": "Choose how much reasoning effort the model should use",
           "id": "reasoning_effort",
           "name": "Reasoning Effort",

--- a/scripts/agent-catalog/generated/cursor.cursor-login.probe.json
+++ b/scripts/agent-catalog/generated/cursor.cursor-login.probe.json
@@ -1,13 +1,10 @@
 {
-  "probedAt": "2026-06-18T02:53:09.426103+00:00",
+  "probedAt": "2026-07-17T05:35:36.678732+00:00",
   "agentKind": "cursor",
   "authContext": "cursor-login",
   "attestation": null,
   "modelSource": "modelConfigOption",
-  "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
-  },
+  "nativeCli": null,
   "trials": [],
   "currentModelId": null,
   "currentModeId": "agent",
@@ -59,7 +56,7 @@
     },
     {
       "category": "model",
-      "currentValue": "gemini-3.1-pro[]",
+      "currentValue": "glm-5.2[reasoning=high]",
       "description": "Controls which model variant is used for responses",
       "id": "model",
       "name": "Model",
@@ -67,6 +64,10 @@
         {
           "name": "Auto",
           "value": "default[]"
+        },
+        {
+          "name": "grok-4.5",
+          "value": "grok-4.5[effort=high,fast=true]"
         },
         {
           "name": "composer-2.5",
@@ -77,8 +78,24 @@
           "value": "claude-opus-4-8[thinking=true,context=300k,effort=high,fast=false]"
         },
         {
+          "name": "gpt-5.6-sol",
+          "value": "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]"
+        },
+        {
           "name": "gpt-5.5",
           "value": "gpt-5.5[context=272k,reasoning=medium,fast=false]"
+        },
+        {
+          "name": "claude-fable-5",
+          "value": "claude-fable-5[thinking=true,context=300k,effort=high]"
+        },
+        {
+          "name": "claude-sonnet-5",
+          "value": "claude-sonnet-5[thinking=true,context=300k,effort=high]"
+        },
+        {
+          "name": "gpt-5.6-terra",
+          "value": "gpt-5.6-terra[context=272k,reasoning=medium,fast=false]"
         },
         {
           "name": "claude-sonnet-4-6",
@@ -93,16 +110,12 @@
           "value": "claude-opus-4-7[thinking=true,context=300k,effort=xhigh,fast=false]"
         },
         {
-          "name": "grok-build-0.1",
-          "value": "grok-build-0.1[context=200k]"
-        },
-        {
           "name": "gpt-5.4",
           "value": "gpt-5.4[context=272k,reasoning=medium,fast=false]"
         },
         {
           "name": "claude-opus-4-6",
-          "value": "claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]"
+          "value": "claude-opus-4-6[thinking=true,context=200k,effort=high]"
         },
         {
           "name": "claude-opus-4-5",
@@ -111,6 +124,10 @@
         {
           "name": "gpt-5.2",
           "value": "gpt-5.2[reasoning=medium,fast=false]"
+        },
+        {
+          "name": "gpt-5.6-luna",
+          "value": "gpt-5.6-luna[context=272k,reasoning=medium,fast=false]"
         },
         {
           "name": "gemini-3.1-pro",
@@ -127,10 +144,6 @@
         {
           "name": "claude-haiku-4-5",
           "value": "claude-haiku-4-5[thinking=true]"
-        },
-        {
-          "name": "grok-4.3",
-          "value": "grok-4.3[context=200k]"
         },
         {
           "name": "claude-sonnet-4-5",
@@ -173,12 +186,12 @@
           "value": "gemini-2.5-flash[]"
         },
         {
-          "name": "kimi-k2.5",
-          "value": "kimi-k2.5[]"
+          "name": "kimi-k2.7-code",
+          "value": "kimi-k2.7-code[]"
         },
         {
-          "name": "claude-fable-5",
-          "value": "claude-fable-5[thinking=true,context=300k,effort=high]"
+          "name": "glm-5.2",
+          "value": "glm-5.2[reasoning=high]"
         }
       ],
       "type": "select"
@@ -218,6 +231,48 @@
         {
           "category": "model",
           "currentValue": "default[]",
+          "description": "Controls which model variant is used for responses",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
+      "modelId": "grok-4.5[effort=high,fast=true]",
+      "name": "grok-4.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "agent",
+          "description": "Controls how the agent executes tasks",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Full agent capabilities with tool access",
+              "name": "Agent",
+              "value": "agent"
+            },
+            {
+              "description": "Read-only mode for planning and designing before implementation",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Q&A mode - no edits or command execution",
+              "name": "Ask",
+              "value": "ask"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "grok-4.5[effort=high,fast=true]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",
@@ -312,6 +367,48 @@
       ]
     },
     {
+      "modelId": "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]",
+      "name": "gpt-5.6-sol",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "agent",
+          "description": "Controls how the agent executes tasks",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Full agent capabilities with tool access",
+              "name": "Agent",
+              "value": "agent"
+            },
+            {
+              "description": "Read-only mode for planning and designing before implementation",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Q&A mode - no edits or command execution",
+              "name": "Ask",
+              "value": "ask"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-sol[context=272k,reasoning=medium,fast=false]",
+          "description": "Controls which model variant is used for responses",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
       "modelId": "gpt-5.5[context=272k,reasoning=medium,fast=false]",
       "name": "gpt-5.5",
       "description": null,
@@ -344,6 +441,132 @@
         {
           "category": "model",
           "currentValue": "gpt-5.5[context=272k,reasoning=medium,fast=false]",
+          "description": "Controls which model variant is used for responses",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
+      "modelId": "claude-fable-5[thinking=true,context=300k,effort=high]",
+      "name": "claude-fable-5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "agent",
+          "description": "Controls how the agent executes tasks",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Full agent capabilities with tool access",
+              "name": "Agent",
+              "value": "agent"
+            },
+            {
+              "description": "Read-only mode for planning and designing before implementation",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Q&A mode - no edits or command execution",
+              "name": "Ask",
+              "value": "ask"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "claude-fable-5[thinking=true,context=300k,effort=high]",
+          "description": "Controls which model variant is used for responses",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
+      "modelId": "claude-sonnet-5[thinking=true,context=300k,effort=high]",
+      "name": "claude-sonnet-5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "agent",
+          "description": "Controls how the agent executes tasks",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Full agent capabilities with tool access",
+              "name": "Agent",
+              "value": "agent"
+            },
+            {
+              "description": "Read-only mode for planning and designing before implementation",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Q&A mode - no edits or command execution",
+              "name": "Ask",
+              "value": "ask"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "claude-sonnet-5[thinking=true,context=300k,effort=high]",
+          "description": "Controls which model variant is used for responses",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
+      "modelId": "gpt-5.6-terra[context=272k,reasoning=medium,fast=false]",
+      "name": "gpt-5.6-terra",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "agent",
+          "description": "Controls how the agent executes tasks",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Full agent capabilities with tool access",
+              "name": "Agent",
+              "value": "agent"
+            },
+            {
+              "description": "Read-only mode for planning and designing before implementation",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Q&A mode - no edits or command execution",
+              "name": "Ask",
+              "value": "ask"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-terra[context=272k,reasoning=medium,fast=false]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",
@@ -480,48 +703,6 @@
       ]
     },
     {
-      "modelId": "grok-build-0.1[context=200k]",
-      "name": "grok-build-0.1",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "agent",
-          "description": "Controls how the agent executes tasks",
-          "id": "mode",
-          "name": "Mode",
-          "options": [
-            {
-              "description": "Full agent capabilities with tool access",
-              "name": "Agent",
-              "value": "agent"
-            },
-            {
-              "description": "Read-only mode for planning and designing before implementation",
-              "name": "Plan",
-              "value": "plan"
-            },
-            {
-              "description": "Q&A mode - no edits or command execution",
-              "name": "Ask",
-              "value": "ask"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "grok-build-0.1[context=200k]",
-          "description": "Controls which model variant is used for responses",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        }
-      ]
-    },
-    {
       "modelId": "gpt-5.4[context=272k,reasoning=medium,fast=false]",
       "name": "gpt-5.4",
       "description": null,
@@ -564,7 +745,7 @@
       ]
     },
     {
-      "modelId": "claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]",
+      "modelId": "claude-opus-4-6[thinking=true,context=200k,effort=high]",
       "name": "claude-opus-4-6",
       "description": null,
       "configOptions": [
@@ -595,7 +776,7 @@
         },
         {
           "category": "model",
-          "currentValue": "claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]",
+          "currentValue": "claude-opus-4-6[thinking=true,context=200k,effort=high]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",
@@ -680,6 +861,48 @@
         {
           "category": "model",
           "currentValue": "gpt-5.2[reasoning=medium,fast=false]",
+          "description": "Controls which model variant is used for responses",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        }
+      ]
+    },
+    {
+      "modelId": "gpt-5.6-luna[context=272k,reasoning=medium,fast=false]",
+      "name": "gpt-5.6-luna",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "mode",
+          "currentValue": "agent",
+          "description": "Controls how the agent executes tasks",
+          "id": "mode",
+          "name": "Mode",
+          "options": [
+            {
+              "description": "Full agent capabilities with tool access",
+              "name": "Agent",
+              "value": "agent"
+            },
+            {
+              "description": "Read-only mode for planning and designing before implementation",
+              "name": "Plan",
+              "value": "plan"
+            },
+            {
+              "description": "Q&A mode - no edits or command execution",
+              "name": "Ask",
+              "value": "ask"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "model",
+          "currentValue": "gpt-5.6-luna[context=272k,reasoning=medium,fast=false]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",
@@ -848,48 +1071,6 @@
         {
           "category": "model",
           "currentValue": "claude-haiku-4-5[thinking=true]",
-          "description": "Controls which model variant is used for responses",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        }
-      ]
-    },
-    {
-      "modelId": "grok-4.3[context=200k]",
-      "name": "grok-4.3",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "mode",
-          "currentValue": "agent",
-          "description": "Controls how the agent executes tasks",
-          "id": "mode",
-          "name": "Mode",
-          "options": [
-            {
-              "description": "Full agent capabilities with tool access",
-              "name": "Agent",
-              "value": "agent"
-            },
-            {
-              "description": "Read-only mode for planning and designing before implementation",
-              "name": "Plan",
-              "value": "plan"
-            },
-            {
-              "description": "Q&A mode - no edits or command execution",
-              "name": "Ask",
-              "value": "ask"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "model",
-          "currentValue": "grok-4.3[context=200k]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",
@@ -1320,8 +1501,8 @@
       ]
     },
     {
-      "modelId": "kimi-k2.5[]",
-      "name": "kimi-k2.5",
+      "modelId": "kimi-k2.7-code[]",
+      "name": "kimi-k2.7-code",
       "description": null,
       "configOptions": [
         {
@@ -1351,7 +1532,7 @@
         },
         {
           "category": "model",
-          "currentValue": "kimi-k2.5[]",
+          "currentValue": "kimi-k2.7-code[]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",
@@ -1362,8 +1543,8 @@
       ]
     },
     {
-      "modelId": "claude-fable-5[thinking=true,context=300k,effort=high]",
-      "name": "claude-fable-5",
+      "modelId": "glm-5.2[reasoning=high]",
+      "name": "glm-5.2",
       "description": null,
       "configOptions": [
         {
@@ -1393,7 +1574,7 @@
         },
         {
           "category": "model",
-          "currentValue": "claude-fable-5[thinking=true,context=300k,effort=high]",
+          "currentValue": "glm-5.2[reasoning=high]",
           "description": "Controls which model variant is used for responses",
           "id": "model",
           "name": "Model",

--- a/scripts/agent-catalog/generated/grok.xai-api.probe.json
+++ b/scripts/agent-catalog/generated/grok.xai-api.probe.json
@@ -1,5 +1,5 @@
 {
-  "probedAt": "2026-06-16T06:46:29.757670+00:00",
+  "probedAt": "2026-07-17T05:35:08.879897+00:00",
   "agentKind": "grok",
   "authContext": "xai-api",
   "attestation": null,
@@ -36,6 +36,12 @@
       "configOptions": null
     },
     {
+      "modelId": "grok-4.5",
+      "name": "grok-4.5",
+      "description": null,
+      "configOptions": null
+    },
+    {
       "modelId": "grok-build-0.1",
       "name": "grok-build-0.1",
       "description": null,
@@ -60,8 +66,8 @@
       "configOptions": null
     },
     {
-      "modelId": "grok-imagine-video-1.5-preview",
-      "name": "grok-imagine-video-1.5-preview",
+      "modelId": "grok-imagine-video-1.5",
+      "name": "grok-imagine-video-1.5",
       "description": null,
       "configOptions": null
     }

--- a/scripts/agent-catalog/generated/opencode.anthropic-api.probe.json
+++ b/scripts/agent-catalog/generated/opencode.anthropic-api.probe.json
@@ -1,17 +1,14 @@
 {
-  "probedAt": "2026-06-18T02:52:36.413747+00:00",
+  "probedAt": "2026-07-17T05:35:02.859027+00:00",
   "agentKind": "opencode",
   "authContext": "anthropic-api",
   "attestation": {
     "name": "OpenCode",
-    "version": "1.17.7",
+    "version": "1.18.3",
     "title": null
   },
   "modelSource": "modelConfigOption",
-  "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
-  },
+  "nativeCli": null,
   "trials": [],
   "currentModelId": null,
   "currentModeId": null,
@@ -28,32 +25,12 @@
           "value": "anthropic/claude-fable-5"
         },
         {
-          "name": "Anthropic/Claude Haiku 3.5 (latest)",
-          "value": "anthropic/claude-3-5-haiku-latest"
-        },
-        {
           "name": "Anthropic/Claude Haiku 4.5",
           "value": "anthropic/claude-haiku-4-5-20251001"
         },
         {
           "name": "Anthropic/Claude Haiku 4.5 (latest)",
           "value": "anthropic/claude-haiku-4-5"
-        },
-        {
-          "name": "Anthropic/Claude Opus 4",
-          "value": "anthropic/claude-opus-4-20250514"
-        },
-        {
-          "name": "Anthropic/Claude Opus 4 (latest)",
-          "value": "anthropic/claude-opus-4-0"
-        },
-        {
-          "name": "Anthropic/Claude Opus 4.1",
-          "value": "anthropic/claude-opus-4-1-20250805"
-        },
-        {
-          "name": "Anthropic/Claude Opus 4.1 (latest)",
-          "value": "anthropic/claude-opus-4-1"
         },
         {
           "name": "Anthropic/Claude Opus 4.5",
@@ -88,14 +65,6 @@
           "value": "anthropic/claude-opus-4-8-fast"
         },
         {
-          "name": "Anthropic/Claude Sonnet 4",
-          "value": "anthropic/claude-sonnet-4-20250514"
-        },
-        {
-          "name": "Anthropic/Claude Sonnet 4 (latest)",
-          "value": "anthropic/claude-sonnet-4-0"
-        },
-        {
           "name": "Anthropic/Claude Sonnet 4.5",
           "value": "anthropic/claude-sonnet-4-5-20250929"
         },
@@ -108,12 +77,20 @@
           "value": "anthropic/claude-sonnet-4-6"
         },
         {
+          "name": "Anthropic/Claude Sonnet 5",
+          "value": "anthropic/claude-sonnet-5"
+        },
+        {
           "name": "OpenCode Zen/Big Pickle",
           "value": "opencode/big-pickle"
         },
         {
           "name": "OpenCode Zen/DeepSeek V4 Flash Free",
           "value": "opencode/deepseek-v4-flash-free"
+        },
+        {
+          "name": "OpenCode Zen/Hy3 Free",
+          "value": "opencode/hy3-free"
         },
         {
           "name": "OpenCode Zen/MiMo V2.5 Free",
@@ -217,41 +194,6 @@
       ]
     },
     {
-      "modelId": "anthropic/claude-3-5-haiku-latest",
-      "name": "Anthropic/Claude Haiku 3.5 (latest)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-3-5-haiku-latest",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
       "modelId": "anthropic/claude-haiku-4-5-20251001",
       "name": "Anthropic/Claude Haiku 4.5",
       "description": null,
@@ -312,230 +254,6 @@
         {
           "category": "model",
           "currentValue": "anthropic/claude-haiku-4-5",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "anthropic/claude-opus-4-20250514",
-      "name": "Anthropic/Claude Opus 4",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-opus-4-20250514",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Xhigh",
-              "value": "xhigh"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "anthropic/claude-opus-4-0",
-      "name": "Anthropic/Claude Opus 4 (latest)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-opus-4-0",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "anthropic/claude-opus-4-1-20250805",
-      "name": "Anthropic/Claude Opus 4.1",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-opus-4-1-20250805",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "anthropic/claude-opus-4-1",
-      "name": "Anthropic/Claude Opus 4.1 (latest)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-opus-4-1",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -1078,112 +796,6 @@
       ]
     },
     {
-      "modelId": "anthropic/claude-sonnet-4-20250514",
-      "name": "Anthropic/Claude Sonnet 4",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-sonnet-4-20250514",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "anthropic/claude-sonnet-4-0",
-      "name": "Anthropic/Claude Sonnet 4 (latest)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "anthropic/claude-sonnet-4-0",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
       "modelId": "anthropic/claude-sonnet-4-5-20250929",
       "name": "Anthropic/Claude Sonnet 4.5",
       "description": null,
@@ -1351,6 +963,71 @@
       ]
     },
     {
+      "modelId": "anthropic/claude-sonnet-5",
+      "name": "Anthropic/Claude Sonnet 5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "anthropic/claude-sonnet-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
       "modelId": "opencode/big-pickle",
       "name": "OpenCode Zen/Big Pickle",
       "description": null,
@@ -1401,19 +1078,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "high",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
             {
               "name": "High",
               "value": "high"
@@ -1424,6 +1093,41 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/hy3-free",
+      "name": "OpenCode Zen/Hy3 Free",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/hy3-free",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -1461,28 +1165,6 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -1516,28 +1198,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",

--- a/scripts/agent-catalog/generated/opencode.baseline.probe.json
+++ b/scripts/agent-catalog/generated/opencode.baseline.probe.json
@@ -1,17 +1,14 @@
 {
-  "probedAt": "2026-06-18T02:52:35.899018+00:00",
+  "probedAt": "2026-07-17T05:35:02.847962+00:00",
   "agentKind": "opencode",
   "authContext": "baseline",
   "attestation": {
     "name": "OpenCode",
-    "version": "1.17.7",
+    "version": "1.18.3",
     "title": null
   },
   "modelSource": "modelConfigOption",
-  "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
-  },
+  "nativeCli": null,
   "trials": [],
   "currentModelId": null,
   "currentModeId": null,
@@ -30,6 +27,10 @@
         {
           "name": "OpenCode Zen/DeepSeek V4 Flash Free",
           "value": "opencode/deepseek-v4-flash-free"
+        },
+        {
+          "name": "OpenCode Zen/Hy3 Free",
+          "value": "opencode/hy3-free"
         },
         {
           "name": "OpenCode Zen/MiMo V2.5 Free",
@@ -118,19 +119,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "high",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
             {
               "name": "High",
               "value": "high"
@@ -141,6 +134,41 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/hy3-free",
+      "name": "OpenCode Zen/Hy3 Free",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/hy3-free",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -178,28 +206,6 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -233,28 +239,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",

--- a/scripts/agent-catalog/generated/opencode.gemini-api.probe.json
+++ b/scripts/agent-catalog/generated/opencode.gemini-api.probe.json
@@ -1,17 +1,14 @@
 {
-  "probedAt": "2026-06-18T02:52:36.465671+00:00",
+  "probedAt": "2026-07-17T05:35:02.869666+00:00",
   "agentKind": "opencode",
   "authContext": "gemini-api",
   "attestation": {
     "name": "OpenCode",
-    "version": "1.17.7",
+    "version": "1.18.3",
     "title": null
   },
   "modelSource": "modelConfigOption",
-  "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
-  },
+  "nativeCli": null,
   "trials": [],
   "currentModelId": null,
   "currentModeId": null,
@@ -76,20 +73,16 @@
           "value": "google/gemini-flash-lite-latest"
         },
         {
+          "name": "Google/Gemini Omni Flash Preview",
+          "value": "google/gemini-omni-flash-preview"
+        },
+        {
           "name": "Google/Gemma 4 26B A4B IT",
           "value": "google/gemma-4-26b-a4b-it"
         },
         {
           "name": "Google/Gemma 4 31B IT",
           "value": "google/gemma-4-31b-it"
-        },
-        {
-          "name": "Google/Gemma 4 E2B IT",
-          "value": "google/gemma-4-E2B-it"
-        },
-        {
-          "name": "Google/Gemma 4 E4B IT",
-          "value": "google/gemma-4-E4B-it"
         },
         {
           "name": "Google/Nano Banana",
@@ -110,6 +103,10 @@
         {
           "name": "OpenCode Zen/DeepSeek V4 Flash Free",
           "value": "opencode/deepseek-v4-flash-free"
+        },
+        {
+          "name": "OpenCode Zen/Hy3 Free",
+          "value": "opencode/hy3-free"
         },
         {
           "name": "OpenCode Zen/MiMo V2.5 Free",
@@ -724,14 +721,22 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "minimal",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
             {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
               "name": "Low",
               "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
             },
             {
               "name": "High",
@@ -777,14 +782,22 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "minimal",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
             {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
               "name": "Low",
               "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
             },
             {
               "name": "High",
@@ -792,6 +805,41 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "google/gemini-omni-flash-preview",
+      "name": "Google/Gemini Omni Flash Preview",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "google/gemini-omni-flash-preview",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -921,112 +969,6 @@
       ]
     },
     {
-      "modelId": "google/gemma-4-E2B-it",
-      "name": "Google/Gemma 4 E2B IT",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "google/gemma-4-E2B-it",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "google/gemma-4-E4B-it",
-      "name": "Google/Gemma 4 E4B IT",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "google/gemma-4-E4B-it",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
       "modelId": "google/gemini-2.5-flash-image",
       "name": "Google/Nano Banana",
       "description": null,
@@ -1039,24 +981,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",
@@ -1147,20 +1071,6 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "high",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -1232,19 +1142,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "high",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
             {
               "name": "High",
               "value": "high"
@@ -1255,6 +1157,41 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/hy3-free",
+      "name": "OpenCode Zen/Hy3 Free",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/hy3-free",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -1292,28 +1229,6 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -1347,28 +1262,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",

--- a/scripts/agent-catalog/generated/opencode.openai-api.probe.json
+++ b/scripts/agent-catalog/generated/opencode.openai-api.probe.json
@@ -1,17 +1,14 @@
 {
-  "probedAt": "2026-06-18T02:52:36.604875+00:00",
+  "probedAt": "2026-07-17T05:35:02.916500+00:00",
   "agentKind": "opencode",
   "authContext": "openai-api",
   "attestation": {
     "name": "OpenCode",
-    "version": "1.17.7",
+    "version": "1.18.3",
     "title": null
   },
   "modelSource": "modelConfigOption",
-  "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
-  },
+  "nativeCli": null,
   "trials": [],
   "currentModelId": null,
   "currentModeId": null,
@@ -176,6 +173,54 @@
           "value": "openai/gpt-5.5-pro"
         },
         {
+          "name": "OpenAI/GPT-5.6",
+          "value": "openai/gpt-5.6"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Fast",
+          "value": "openai/gpt-5.6-fast"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Luna",
+          "value": "openai/gpt-5.6-luna"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Luna Fast",
+          "value": "openai/gpt-5.6-luna-fast"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Luna Pro",
+          "value": "openai/gpt-5.6-luna-pro"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Pro",
+          "value": "openai/gpt-5.6-pro"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Sol",
+          "value": "openai/gpt-5.6-sol"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Sol Fast",
+          "value": "openai/gpt-5.6-sol-fast"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Sol Pro",
+          "value": "openai/gpt-5.6-sol-pro"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Terra",
+          "value": "openai/gpt-5.6-terra"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Terra Fast",
+          "value": "openai/gpt-5.6-terra-fast"
+        },
+        {
+          "name": "OpenAI/GPT-5.6 Terra Pro",
+          "value": "openai/gpt-5.6-terra-pro"
+        },
+        {
           "name": "OpenAI/gpt-image-1",
           "value": "openai/gpt-image-1"
         },
@@ -186,6 +231,14 @@
         {
           "name": "OpenAI/gpt-image-1.5",
           "value": "openai/gpt-image-1.5"
+        },
+        {
+          "name": "OpenAI/gpt-image-2",
+          "value": "openai/gpt-image-2"
+        },
+        {
+          "name": "OpenAI/GPT-Realtime-2.1",
+          "value": "openai/gpt-realtime-2.1"
         },
         {
           "name": "OpenAI/o1",
@@ -238,6 +291,10 @@
         {
           "name": "OpenCode Zen/DeepSeek V4 Flash Free",
           "value": "opencode/deepseek-v4-flash-free"
+        },
+        {
+          "name": "OpenCode Zen/Hy3 Free",
+          "value": "opencode/hy3-free"
         },
         {
           "name": "OpenCode Zen/MiMo V2.5 Free",
@@ -2236,6 +2293,834 @@
       ]
     },
     {
+      "modelId": "openai/gpt-5.6",
+      "name": "OpenAI/GPT-5.6",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-fast",
+      "name": "OpenAI/GPT-5.6 Fast",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-fast",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-luna",
+      "name": "OpenAI/GPT-5.6 Luna",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-luna",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-luna-fast",
+      "name": "OpenAI/GPT-5.6 Luna Fast",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-luna-fast",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-luna-pro",
+      "name": "OpenAI/GPT-5.6 Luna Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-luna-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-pro",
+      "name": "OpenAI/GPT-5.6 Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-sol",
+      "name": "OpenAI/GPT-5.6 Sol",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-sol",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-sol-fast",
+      "name": "OpenAI/GPT-5.6 Sol Fast",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-sol-fast",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-sol-pro",
+      "name": "OpenAI/GPT-5.6 Sol Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-sol-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-terra",
+      "name": "OpenAI/GPT-5.6 Terra",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-terra",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-terra-fast",
+      "name": "OpenAI/GPT-5.6 Terra Fast",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-terra-fast",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-5.6-terra-pro",
+      "name": "OpenAI/GPT-5.6 Terra Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-5.6-terra-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
       "modelId": "openai/gpt-image-1",
       "name": "OpenAI/gpt-image-1",
       "description": null,
@@ -2318,6 +3203,106 @@
           "options": [],
           "type": "select",
           "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-image-2",
+      "name": "OpenAI/gpt-image-2",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-image-2",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "openai/gpt-realtime-2.1",
+      "name": "OpenAI/GPT-Realtime-2.1",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "openai/gpt-realtime-2.1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "minimal",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Minimal",
+              "value": "minimal"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            }
+          ],
+          "type": "select"
         },
         {
           "category": "mode",
@@ -2936,19 +3921,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "high",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
             {
               "name": "High",
               "value": "high"
@@ -2959,6 +3936,41 @@
             }
           ],
           "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/hy3-free",
+      "name": "OpenCode Zen/Hy3 Free",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/hy3-free",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
         },
         {
           "category": "mode",
@@ -2996,28 +4008,6 @@
           "valuesElided": true
         },
         {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -3051,28 +4041,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",

--- a/scripts/agent-catalog/generated/opencode.opencode-zen.probe.json
+++ b/scripts/agent-catalog/generated/opencode.opencode-zen.probe.json
@@ -1,17 +1,14 @@
 {
-  "probedAt": "2026-06-18T02:52:36.735929+00:00",
+  "probedAt": "2026-07-17T05:35:02.905116+00:00",
   "agentKind": "opencode",
   "authContext": "opencode-zen",
   "attestation": {
     "name": "OpenCode",
-    "version": "1.17.7",
+    "version": "1.18.3",
     "title": null
   },
   "modelSource": "modelConfigOption",
-  "nativeCli": {
-    "path": "/Users/pablohansen/.proliferate/anyharness/agents/claude/native/claude",
-    "version": "2.1.177 (Claude Code)"
-  },
+  "nativeCli": null,
   "trials": [],
   "currentModelId": null,
   "currentModeId": null,
@@ -24,60 +21,12 @@
       "name": "Model",
       "options": [
         {
-          "name": "OpenCode Go/DeepSeek V4 Flash",
-          "value": "opencode-go/deepseek-v4-flash"
-        },
-        {
-          "name": "OpenCode Go/DeepSeek V4 Pro",
-          "value": "opencode-go/deepseek-v4-pro"
-        },
-        {
-          "name": "OpenCode Go/GLM-5.1",
-          "value": "opencode-go/glm-5.1"
-        },
-        {
-          "name": "OpenCode Go/GLM-5.2",
-          "value": "opencode-go/glm-5.2"
-        },
-        {
-          "name": "OpenCode Go/Kimi K2.6",
-          "value": "opencode-go/kimi-k2.6"
-        },
-        {
-          "name": "OpenCode Go/Kimi K2.7 Code",
-          "value": "opencode-go/kimi-k2.7-code"
-        },
-        {
-          "name": "OpenCode Go/MiMo V2.5",
-          "value": "opencode-go/mimo-v2.5"
-        },
-        {
-          "name": "OpenCode Go/MiMo V2.5 Pro",
-          "value": "opencode-go/mimo-v2.5-pro"
-        },
-        {
-          "name": "OpenCode Go/MiniMax M2.7",
-          "value": "opencode-go/minimax-m2.7"
-        },
-        {
-          "name": "OpenCode Go/MiniMax M3 (3x usage)",
-          "value": "opencode-go/minimax-m3"
-        },
-        {
-          "name": "OpenCode Go/Qwen3.6 Plus",
-          "value": "opencode-go/qwen3.6-plus"
-        },
-        {
-          "name": "OpenCode Go/Qwen3.7 Max",
-          "value": "opencode-go/qwen3.7-max"
-        },
-        {
-          "name": "OpenCode Go/Qwen3.7 Plus",
-          "value": "opencode-go/qwen3.7-plus"
-        },
-        {
           "name": "OpenCode Zen/Big Pickle",
           "value": "opencode/big-pickle"
+        },
+        {
+          "name": "OpenCode Zen/Claude Fable 5",
+          "value": "opencode/claude-fable-5"
         },
         {
           "name": "OpenCode Zen/Claude Haiku 4.5",
@@ -116,6 +65,10 @@
           "value": "opencode/claude-sonnet-4-6"
         },
         {
+          "name": "OpenCode Zen/Claude Sonnet 5",
+          "value": "opencode/claude-sonnet-5"
+        },
+        {
           "name": "OpenCode Zen/DeepSeek V4 Flash",
           "value": "opencode/deepseek-v4-flash"
         },
@@ -146,6 +99,10 @@
         {
           "name": "OpenCode Zen/GLM-5.1",
           "value": "opencode/glm-5.1"
+        },
+        {
+          "name": "OpenCode Zen/GLM-5.2",
+          "value": "opencode/glm-5.2"
         },
         {
           "name": "OpenCode Zen/GPT-5",
@@ -216,8 +173,28 @@
           "value": "opencode/gpt-5.5-pro"
         },
         {
+          "name": "OpenCode Zen/GPT-5.6 Luna",
+          "value": "opencode/gpt-5.6-luna"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.6 Sol",
+          "value": "opencode/gpt-5.6-sol"
+        },
+        {
+          "name": "OpenCode Zen/GPT-5.6 Terra",
+          "value": "opencode/gpt-5.6-terra"
+        },
+        {
+          "name": "OpenCode Zen/Grok 4.5",
+          "value": "opencode/grok-4.5"
+        },
+        {
           "name": "OpenCode Zen/Grok Build 0.1",
           "value": "opencode/grok-build-0.1"
+        },
+        {
+          "name": "OpenCode Zen/Hy3 Free",
+          "value": "opencode/hy3-free"
         },
         {
           "name": "OpenCode Zen/Kimi K2.5",
@@ -228,16 +205,24 @@
           "value": "opencode/kimi-k2.6"
         },
         {
+          "name": "OpenCode Zen/Kimi K2.7 Code",
+          "value": "opencode/kimi-k2.7-code"
+        },
+        {
           "name": "OpenCode Zen/MiMo V2.5 Free",
           "value": "opencode/mimo-v2.5-free"
         },
         {
-          "name": "OpenCode Zen/MiniMax M2.5",
+          "name": "OpenCode Zen/MiniMax-M2.5",
           "value": "opencode/minimax-m2.5"
         },
         {
-          "name": "OpenCode Zen/MiniMax M2.7",
+          "name": "OpenCode Zen/MiniMax-M2.7",
           "value": "opencode/minimax-m2.7"
+        },
+        {
+          "name": "OpenCode Zen/MiniMax-M3",
+          "value": "opencode/minimax-m3"
         },
         {
           "name": "OpenCode Zen/Nemotron 3 Ultra Free",
@@ -254,6 +239,58 @@
         {
           "name": "OpenCode Zen/Qwen3.6 Plus",
           "value": "opencode/qwen3.6-plus"
+        },
+        {
+          "name": "OpenCode Go/DeepSeek V4 Flash",
+          "value": "opencode-go/deepseek-v4-flash"
+        },
+        {
+          "name": "OpenCode Go/DeepSeek V4 Pro",
+          "value": "opencode-go/deepseek-v4-pro"
+        },
+        {
+          "name": "OpenCode Go/GLM-5.1",
+          "value": "opencode-go/glm-5.1"
+        },
+        {
+          "name": "OpenCode Go/GLM-5.2",
+          "value": "opencode-go/glm-5.2"
+        },
+        {
+          "name": "OpenCode Go/Kimi K2.6",
+          "value": "opencode-go/kimi-k2.6"
+        },
+        {
+          "name": "OpenCode Go/Kimi K2.7 Code",
+          "value": "opencode-go/kimi-k2.7-code"
+        },
+        {
+          "name": "OpenCode Go/MiMo V2.5",
+          "value": "opencode-go/mimo-v2.5"
+        },
+        {
+          "name": "OpenCode Go/MiMo V2.5 Pro",
+          "value": "opencode-go/mimo-v2.5-pro"
+        },
+        {
+          "name": "OpenCode Go/MiniMax-M2.7",
+          "value": "opencode-go/minimax-m2.7"
+        },
+        {
+          "name": "OpenCode Go/MiniMax-M3",
+          "value": "opencode-go/minimax-m3"
+        },
+        {
+          "name": "OpenCode Go/Qwen3.6 Plus",
+          "value": "opencode-go/qwen3.6-plus"
+        },
+        {
+          "name": "OpenCode Go/Qwen3.7 Max",
+          "value": "opencode-go/qwen3.7-max"
+        },
+        {
+          "name": "OpenCode Go/Qwen3.7 Plus",
+          "value": "opencode-go/qwen3.7-plus"
         }
       ],
       "type": "select"
@@ -280,575 +317,6 @@
   ],
   "models": [
     {
-      "modelId": "opencode-go/deepseek-v4-flash",
-      "name": "OpenCode Go/DeepSeek V4 Flash",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/deepseek-v4-flash",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/deepseek-v4-pro",
-      "name": "OpenCode Go/DeepSeek V4 Pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/deepseek-v4-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            },
-            {
-              "name": "Max",
-              "value": "max"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/glm-5.1",
-      "name": "OpenCode Go/GLM-5.1",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/glm-5.1",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/glm-5.2",
-      "name": "OpenCode Go/GLM-5.2",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/glm-5.2",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/kimi-k2.6",
-      "name": "OpenCode Go/Kimi K2.6",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/kimi-k2.6",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/kimi-k2.7-code",
-      "name": "OpenCode Go/Kimi K2.7 Code",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/kimi-k2.7-code",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/mimo-v2.5",
-      "name": "OpenCode Go/MiMo V2.5",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/mimo-v2.5",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/mimo-v2.5-pro",
-      "name": "OpenCode Go/MiMo V2.5 Pro",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/mimo-v2.5-pro",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/minimax-m2.7",
-      "name": "OpenCode Go/MiniMax M2.7",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/minimax-m2.7",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/minimax-m3",
-      "name": "OpenCode Go/MiniMax M3 (3x usage)",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/minimax-m3",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "none",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
-            {
-              "name": "Thinking",
-              "value": "thinking"
-            }
-          ],
-          "type": "select"
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/qwen3.6-plus",
-      "name": "OpenCode Go/Qwen3.6 Plus",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/qwen3.6-plus",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/qwen3.7-max",
-      "name": "OpenCode Go/Qwen3.7 Max",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/qwen3.7-max",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
-      "modelId": "opencode-go/qwen3.7-plus",
-      "name": "OpenCode Go/Qwen3.7 Plus",
-      "description": null,
-      "configOptions": [
-        {
-          "category": "model",
-          "currentValue": "opencode-go/qwen3.7-plus",
-          "id": "model",
-          "name": "Model",
-          "options": [],
-          "type": "select",
-          "valuesElided": true
-        },
-        {
-          "category": "mode",
-          "currentValue": "build",
-          "id": "mode",
-          "name": "Session Mode",
-          "options": [
-            {
-              "description": "The default agent. Executes tools based on configured permissions.",
-              "name": "build",
-              "value": "build"
-            },
-            {
-              "description": "Plan mode. Disallows all edit tools.",
-              "name": "plan",
-              "value": "plan"
-            }
-          ],
-          "type": "select"
-        }
-      ]
-    },
-    {
       "modelId": "opencode/big-pickle",
       "name": "OpenCode Zen/Big Pickle",
       "description": null,
@@ -861,6 +329,71 @@
           "options": [],
           "type": "select",
           "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/claude-fable-5",
+      "name": "OpenCode Zen/Claude Fable 5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/claude-fable-5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
         },
         {
           "category": "mode",
@@ -1405,13 +938,13 @@
       ]
     },
     {
-      "modelId": "opencode/deepseek-v4-flash",
-      "name": "OpenCode Zen/DeepSeek V4 Flash",
+      "modelId": "opencode/claude-sonnet-5",
+      "name": "OpenCode Zen/Claude Sonnet 5",
       "description": null,
       "configOptions": [
         {
           "category": "model",
-          "currentValue": "opencode/deepseek-v4-flash",
+          "currentValue": "opencode/claude-sonnet-5",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -1433,6 +966,63 @@
               "name": "Medium",
               "value": "medium"
             },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/deepseek-v4-flash",
+      "name": "OpenCode Zen/DeepSeek V4 Flash",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/deepseek-v4-flash",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
             {
               "name": "High",
               "value": "high"
@@ -1481,19 +1071,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "high",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
             {
               "name": "High",
               "value": "high"
@@ -1542,19 +1124,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "low",
+          "currentValue": "high",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
             {
               "name": "High",
               "value": "high"
@@ -1814,6 +1388,59 @@
           "options": [],
           "type": "select",
           "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/glm-5.2",
+      "name": "OpenCode Zen/GLM-5.2",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/glm-5.2",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
         },
         {
           "category": "mode",
@@ -2458,15 +2085,11 @@
         },
         {
           "category": "thought_level",
-          "currentValue": "none",
+          "currentValue": "low",
           "description": "Available effort levels for this model",
           "id": "effort",
           "name": "Effort",
           "options": [
-            {
-              "name": "None",
-              "value": "none"
-            },
             {
               "name": "Low",
               "value": "low"
@@ -2882,6 +2505,270 @@
       ]
     },
     {
+      "modelId": "opencode/gpt-5.6-luna",
+      "name": "OpenCode Zen/GPT-5.6 Luna",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.6-luna",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.6-sol",
+      "name": "OpenCode Zen/GPT-5.6 Sol",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.6-sol",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/gpt-5.6-terra",
+      "name": "OpenCode Zen/GPT-5.6 Terra",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/gpt-5.6-terra",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Xhigh",
+              "value": "xhigh"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/grok-4.5",
+      "name": "OpenCode Zen/Grok 4.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/grok-4.5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "low",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Medium",
+              "value": "medium"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
       "modelId": "opencode/grok-build-0.1",
       "name": "OpenCode Zen/Grok Build 0.1",
       "description": null,
@@ -2889,6 +2776,41 @@
         {
           "category": "model",
           "currentValue": "opencode/grok-build-0.1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/hy3-free",
+      "name": "OpenCode Zen/Hy3 Free",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/hy3-free",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -2987,6 +2909,41 @@
       ]
     },
     {
+      "modelId": "opencode/kimi-k2.7-code",
+      "name": "OpenCode Zen/Kimi K2.7 Code",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/kimi-k2.7-code",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
       "modelId": "opencode/mimo-v2.5-free",
       "name": "OpenCode Zen/MiMo V2.5 Free",
       "description": null,
@@ -2999,28 +2956,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",
@@ -3045,7 +2980,7 @@
     },
     {
       "modelId": "opencode/minimax-m2.5",
-      "name": "OpenCode Zen/MiniMax M2.5",
+      "name": "OpenCode Zen/MiniMax-M2.5",
       "description": null,
       "configOptions": [
         {
@@ -3080,12 +3015,47 @@
     },
     {
       "modelId": "opencode/minimax-m2.7",
-      "name": "OpenCode Zen/MiniMax M2.7",
+      "name": "OpenCode Zen/MiniMax-M2.7",
       "description": null,
       "configOptions": [
         {
           "category": "model",
           "currentValue": "opencode/minimax-m2.7",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode/minimax-m3",
+      "name": "OpenCode Zen/MiniMax-M3",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode/minimax-m3",
           "id": "model",
           "name": "Model",
           "options": [],
@@ -3126,28 +3096,6 @@
           "options": [],
           "type": "select",
           "valuesElided": true
-        },
-        {
-          "category": "thought_level",
-          "currentValue": "low",
-          "description": "Available effort levels for this model",
-          "id": "effort",
-          "name": "Effort",
-          "options": [
-            {
-              "name": "Low",
-              "value": "low"
-            },
-            {
-              "name": "Medium",
-              "value": "medium"
-            },
-            {
-              "name": "High",
-              "value": "high"
-            }
-          ],
-          "type": "select"
         },
         {
           "category": "mode",
@@ -3238,6 +3186,24 @@
           "valuesElided": true
         },
         {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
           "category": "mode",
           "currentValue": "build",
           "id": "mode",
@@ -3271,6 +3237,605 @@
           "options": [],
           "type": "select",
           "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/deepseek-v4-flash",
+      "name": "OpenCode Go/DeepSeek V4 Flash",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/deepseek-v4-flash",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/deepseek-v4-pro",
+      "name": "OpenCode Go/DeepSeek V4 Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/deepseek-v4-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/glm-5.1",
+      "name": "OpenCode Go/GLM-5.1",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/glm-5.1",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/glm-5.2",
+      "name": "OpenCode Go/GLM-5.2",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/glm-5.2",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/kimi-k2.6",
+      "name": "OpenCode Go/Kimi K2.6",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/kimi-k2.6",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/kimi-k2.7-code",
+      "name": "OpenCode Go/Kimi K2.7 Code",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/kimi-k2.7-code",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/mimo-v2.5",
+      "name": "OpenCode Go/MiMo V2.5",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/mimo-v2.5",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/mimo-v2.5-pro",
+      "name": "OpenCode Go/MiMo V2.5 Pro",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/mimo-v2.5-pro",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/minimax-m2.7",
+      "name": "OpenCode Go/MiniMax-M2.7",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/minimax-m2.7",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/minimax-m3",
+      "name": "OpenCode Go/MiniMax-M3",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/minimax-m3",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "none",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "None",
+              "value": "none"
+            },
+            {
+              "name": "Thinking",
+              "value": "thinking"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/qwen3.6-plus",
+      "name": "OpenCode Go/Qwen3.6 Plus",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/qwen3.6-plus",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/qwen3.7-max",
+      "name": "OpenCode Go/Qwen3.7 Max",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/qwen3.7-max",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
+        },
+        {
+          "category": "mode",
+          "currentValue": "build",
+          "id": "mode",
+          "name": "Session Mode",
+          "options": [
+            {
+              "description": "The default agent. Executes tools based on configured permissions.",
+              "name": "build",
+              "value": "build"
+            },
+            {
+              "description": "Plan mode. Disallows all edit tools.",
+              "name": "plan",
+              "value": "plan"
+            }
+          ],
+          "type": "select"
+        }
+      ]
+    },
+    {
+      "modelId": "opencode-go/qwen3.7-plus",
+      "name": "OpenCode Go/Qwen3.7 Plus",
+      "description": null,
+      "configOptions": [
+        {
+          "category": "model",
+          "currentValue": "opencode-go/qwen3.7-plus",
+          "id": "model",
+          "name": "Model",
+          "options": [],
+          "type": "select",
+          "valuesElided": true
+        },
+        {
+          "category": "thought_level",
+          "currentValue": "high",
+          "description": "Available effort levels for this model",
+          "id": "effort",
+          "name": "Effort",
+          "options": [
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Max",
+              "value": "max"
+            }
+          ],
+          "type": "select"
         },
         {
           "category": "mode",

--- a/scripts/agent-catalog/resolve-pins.mjs
+++ b/scripts/agent-catalog/resolve-pins.mjs
@@ -52,6 +52,7 @@ const registryByKind = new Map(registry.agents.map((a) => [a.kind, a]));
 // `--reuse-from` reference, e.g. the previously-shipped lockfile) for unchanged
 // URLs, so re-runs and draft→bundled promotion don't re-download every artifact.
 const knownSha = new Map();
+const checksumManifestCache = new Map();
 const collectShas = (doc) => {
   for (const agent of doc.agents ?? []) {
     for (const pin of [agent.harness?.native, agent.harness?.agentProcess]) {
@@ -124,12 +125,13 @@ async function resolveNative(kind, install) {
       const url = install.binaryUrlTemplate
         .replaceAll("{version}", version)
         .replaceAll("{platform}", vendor);
-      targets[platKey] = { url, sha256: await shaFor(url) };
+      targets[platKey] = { url, sha256: await shaForDirectBinary(url, version, vendor) };
     }
     return { version, source: { kind: "binary", targets } };
   }
   if (install.kind === "tarball_release") {
-    const version = await githubLatestTag(install.versionedUrlTemplate);
+    const release = await githubLatestRelease(install.versionedUrlTemplate);
+    const version = release.tag_name;
     const targets = {};
     for (const [platKey, target] of Object.entries(install.platformMap)) {
       if (!platforms.has(platKey)) continue;
@@ -137,7 +139,14 @@ async function resolveNative(kind, install) {
         .replaceAll("{version}", version)
         .replaceAll("{target}", target);
       const expectedBinary = install.expectedBinaryTemplate.replaceAll("{target}", target);
-      targets[platKey] = { url, sha256: await shaFor(url), expectedBinary };
+      const publishedDigest = release.assets
+        ?.find((asset) => asset.browser_download_url === url)
+        ?.digest?.replace(/^sha256:/, "");
+      targets[platKey] = {
+        url,
+        sha256: await shaForPublished(url, publishedDigest),
+        expectedBinary,
+      };
     }
     // A native CLI is invoked by the adapter, not directly — no ACP launch args.
     return { version, source: { kind: "archive", targets, args: [] } };
@@ -189,7 +198,7 @@ async function resolveAgentProcess(kind, install, currentVersion) {
         if (!ourKey || !platforms.has(ourKey)) continue; // platform we do not ship
         targets[ourKey] = {
           url: target.archive,
-          sha256: await shaFor(target.archive),
+          sha256: await shaForPublished(target.archive, target.sha256),
           expectedBinary: target.cmd,
         };
         if (target.args) args = target.args; // ACP-mode args (consistent across platforms)
@@ -228,16 +237,15 @@ function npmIntegrity(pkg) {
   return out.stdout.trim() || null;
 }
 
-async function githubLatestTag(versionedUrlTemplate) {
+async function githubLatestRelease(versionedUrlTemplate) {
   // versionedUrlTemplate looks like
   //   https://github.com/<owner>/<repo>/releases/download/{version}/...
   const m = versionedUrlTemplate.match(/github\.com\/([^/]+)\/([^/]+)\/releases/);
   if (!m) throw new Error(`cannot derive GitHub repo from ${versionedUrlTemplate}`);
   const [, owner, repo] = m;
-  const rel = await fetchJson(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
+  return fetchJson(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
     headers: { "User-Agent": "proliferate-resolve-pins", Accept: "application/vnd.github+json" },
   });
-  return rel.tag_name;
 }
 
 async function shaFor(url) {
@@ -251,6 +259,44 @@ async function shaFor(url) {
   const digest = hash.digest("hex");
   process.stdout.write(`${digest.slice(0, 12)}…\n`);
   return digest;
+}
+
+async function shaForPublished(url, publishedDigest) {
+  if (knownSha.has(url)) return knownSha.get(url);
+  if (noDownload) return "";
+  if (/^[a-f0-9]{64}$/i.test(publishedDigest ?? "")) {
+    console.log(`   ✓ checksum published for ${url}`);
+    return publishedDigest.toLowerCase();
+  }
+  return shaFor(url);
+}
+
+async function shaForDirectBinary(url, version, vendorPlatform) {
+  if (knownSha.has(url)) return knownSha.get(url);
+  if (noDownload) return "";
+
+  // Claude Code's direct-binary channel publishes a versioned manifest beside
+  // its per-platform directories. Prefer that provider checksum so a catalog
+  // refresh does not download every ~250 MB binary merely to rediscover the
+  // digest. Other direct-binary layouts keep the existing download-and-hash
+  // behavior as a fail-safe.
+  const manifestUrl = new URL("../manifest.json", url).toString();
+  try {
+    let manifestPromise = checksumManifestCache.get(manifestUrl);
+    if (!manifestPromise) {
+      manifestPromise = fetchJson(manifestUrl);
+      checksumManifestCache.set(manifestUrl, manifestPromise);
+    }
+    const manifest = await manifestPromise;
+    const checksum = manifest?.platforms?.[vendorPlatform]?.checksum;
+    if (manifest?.version === version && /^[a-f0-9]{64}$/i.test(checksum ?? "")) {
+      console.log(`   ✓ ${vendorPlatform} checksum from ${manifestUrl}`);
+      return checksum.toLowerCase();
+    }
+  } catch {
+    checksumManifestCache.delete(manifestUrl);
+  }
+  return shaFor(url);
 }
 
 async function fetchText(url) {

--- a/scripts/agent-catalog/resolve-pins.test.mjs
+++ b/scripts/agent-catalog/resolve-pins.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const sourceDir = dirname(fileURLToPath(import.meta.url));
+const resolver = join(sourceDir, "resolve-pins.mjs");
+
+test("direct binaries use a matching versioned checksum manifest", async () => {
+  const root = mkdtempSync(join(tmpdir(), "resolve-agent-pins-"));
+  const requests = [];
+  const checksum = "a".repeat(64);
+  const server = createServer((request, response) => {
+    requests.push(request.url);
+    if (request.url === "/latest") {
+      response.end("9.9.9\n");
+      return;
+    }
+    if (request.url === "/9.9.9/manifest.json") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        version: "9.9.9",
+        platforms: { "darwin-arm64": { checksum } },
+      }));
+      return;
+    }
+    response.statusCode = 500;
+    response.end("binary should not be downloaded");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  const catalogPath = join(root, "catalog.json");
+  const registryPath = join(root, "registry.json");
+  writeFileSync(catalogPath, JSON.stringify({
+    agents: [{
+      kind: "claude",
+      harness: {
+        native: { version: "1.0.0", source: { kind: "binary", targets: {} } },
+        agentProcess: { version: "0.44.0" },
+      },
+    }],
+  }));
+  writeFileSync(registryPath, JSON.stringify({
+    agents: [{
+      kind: "claude",
+      native: {
+        install: {
+          kind: "direct_binary",
+          latestVersionUrl: `http://127.0.0.1:${port}/latest`,
+          binaryUrlTemplate: `http://127.0.0.1:${port}/{version}/{platform}/claude`,
+          platformMap: { macos_arm64: "darwin-arm64" },
+        },
+      },
+      agentProcess: {
+        install: {
+          kind: "managed_npm_package",
+          package: "git+https://example.test/claude-agent-acp.git#abc123",
+          executableRelpath: "node_modules/.bin/claude-agent-acp",
+        },
+      },
+    }],
+  }));
+
+  try {
+    const result = await run(process.execPath, [
+      resolver,
+      "--agent", "claude",
+      "--platforms", "macos_arm64",
+      "--catalog", catalogPath,
+      "--registry", registryPath,
+    ]);
+    assert.equal(result.code, 0, result.stderr);
+    const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+    assert.equal(catalog.agents[0].harness.native.version, "9.9.9");
+    assert.equal(
+      catalog.agents[0].harness.native.source.targets.macos_arm64.sha256,
+      checksum,
+    );
+    assert.deepEqual(requests, ["/latest", "/9.9.9/manifest.json"]);
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("registry-backed archives use the registry's published checksum", async () => {
+  const root = mkdtempSync(join(tmpdir(), "resolve-registry-pins-"));
+  const requests = [];
+  const checksum = "b".repeat(64);
+  const server = createServer((request, response) => {
+    requests.push(request.url);
+    if (request.url === "/registry.json") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        agents: [{
+          id: "opencode",
+          version: "2.3.4",
+          distribution: {
+            binary: {
+              "darwin-aarch64": {
+                archive: `http://127.0.0.1:${server.address().port}/opencode.zip`,
+                cmd: "./opencode",
+                args: ["acp"],
+                sha256: checksum,
+              },
+            },
+          },
+        }],
+      }));
+      return;
+    }
+    response.statusCode = 500;
+    response.end("archive should not be downloaded");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  const catalogPath = join(root, "catalog.json");
+  const registryPath = join(root, "registry.json");
+  writeFileSync(catalogPath, JSON.stringify({
+    agents: [{ kind: "opencode", harness: { agentProcess: { version: "1.0.0" } } }],
+  }));
+  writeFileSync(registryPath, JSON.stringify({
+    agents: [{
+      kind: "opencode",
+      agentProcess: { install: { kind: "registry_backed", registryId: "opencode" } },
+    }],
+  }));
+
+  try {
+    const result = await run(process.execPath, [
+      resolver,
+      "--agent", "opencode",
+      "--platforms", "macos_arm64",
+      "--catalog", catalogPath,
+      "--registry", registryPath,
+    ], { ANYHARNESS_ACP_REGISTRY_URL: `http://127.0.0.1:${port}/registry.json` });
+    assert.equal(result.code, 0, result.stderr);
+    const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+    assert.equal(catalog.agents[0].harness.agentProcess.version, "2.3.4");
+    assert.equal(
+      catalog.agents[0].harness.agentProcess.source.targets.macos_arm64.sha256,
+      checksum,
+    );
+    assert.deepEqual(requests, ["/registry.json"]);
+  } finally {
+    server.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function run(command, args, extraEnv = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      encoding: "utf8",
+      env: { ...process.env, ...extraEnv },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}

--- a/scripts/agent-catalog/run-probes.sh
+++ b/scripts/agent-catalog/run-probes.sh
@@ -157,6 +157,9 @@ need_env() { [ -n "${!1:-}" ]; }
 codex_oauth_path() {
   printf '%s' "${PROBE_CODEX_OAUTH_AUTH_JSON:-$HOME/.codex/auth.json}"
 }
+grok_auth_path() {
+  printf '%s' "${PROBE_GROK_AUTH_JSON:-$HOME/.grok/auth.json}"
+}
 context_available() {
   case "$1" in
     claude.anthropic-api|opencode.anthropic-api) need_env ANTHROPIC_API_KEY ;;
@@ -167,7 +170,7 @@ context_available() {
     opencode.baseline) return 0 ;;
     opencode.gemini-api) need_env GEMINI_API_KEY ;;
     opencode.opencode-zen) need_env OPENCODE_API_KEY ;;
-    grok.xai-api) need_env XAI_API_KEY ;;
+    grok.xai-api) need_env XAI_API_KEY || need_env GROK_API_KEY || [ -f "$(grok_auth_path)" ] ;;
     cursor.cursor-login) return 0 ;;
     *) return 1 ;;
   esac
@@ -181,7 +184,7 @@ context_requirement() {
     codex.openai-oauth) echo "PROBE_CODEX_OAUTH_AUTH_JSON (a readable codex auth.json)" ;;
     opencode.gemini-api) echo "GEMINI_API_KEY" ;;
     opencode.opencode-zen) echo "OPENCODE_API_KEY" ;;
-    grok.xai-api) echo "XAI_API_KEY" ;;
+    grok.xai-api) echo "XAI_API_KEY, GROK_API_KEY, or PROBE_GROK_AUTH_JSON (a readable Grok auth.json)" ;;
     cursor.cursor-login) echo "a working machine-local cursor-agent login" ;;
     *) echo "no credential" ;;
   esac
@@ -260,6 +263,7 @@ pids=()
 labels=()
 logs=()
 ids=()
+failures=0
 
 probe() { # probe <agent> <context> [extra args...]
   local agent="$1" context="$2" timeout log snapshot; shift 2
@@ -283,6 +287,32 @@ skip() {
   printf 'skipped=%s\n' "$1" >> "$STATE"
 }
 
+wait_for_probes() {
+  local i code
+  [ "${#pids[@]}" -gt 0 ] || return
+  echo "── waiting on ${#pids[@]} probes"
+  for i in "${!pids[@]}"; do
+    if wait "${pids[$i]}"; then
+      echo "✓ ${labels[$i]}"
+      printf 'passed=%s\n' "${ids[$i]}" >> "$STATE"
+    else
+      code=$?
+      if [ "$code" -eq 124 ]; then
+        echo "✗ ${labels[$i]} TIMED OUT"
+      else
+        echo "✗ ${labels[$i]} FAILED — $(tail -1 "${logs[$i]}" 2>/dev/null | cut -c1-160)"
+      fi
+      echo "  log: ${logs[$i]}"
+      printf 'failed=%s\n' "${ids[$i]}" >> "$STATE"
+      failures=$((failures + 1))
+    fi
+  done
+  pids=()
+  labels=()
+  logs=()
+  ids=()
+}
+
 CLAUDE_TRIALS=(--trial-model claude-fable-5 --trial-model claude-opus-4-8)
 BEDROCK_TRIALS=(--trial-model global.anthropic.claude-fable-5 --trial-model us.anthropic.claude-opus-4-8)
 
@@ -302,20 +332,24 @@ if agent_selected claude; then
   else
     skip claude.bedrock "$(context_requirement claude.bedrock)"
   fi
+  wait_for_probes
 fi
 if agent_selected codex; then
   if context_available codex.openai-api; then
     probe codex openai-api
+    wait_for_probes
   else
     skip codex.openai-api "$(context_requirement codex.openai-api)"
   fi
   if context_available codex.openai-oauth; then
     probe codex openai-oauth
+    wait_for_probes
   else
     skip codex.openai-oauth "$(context_requirement codex.openai-oauth)"
   fi
   if context_available codex.bedrock; then
     probe codex bedrock
+    wait_for_probes
   else
     skip codex.bedrock "$(context_requirement codex.bedrock)"
   fi
@@ -342,6 +376,7 @@ if agent_selected opencode; then
   else
     skip opencode.opencode-zen "$(context_requirement opencode.opencode-zen)"
   fi
+  wait_for_probes
 fi
 if agent_selected grok; then
   if context_available grok.xai-api; then
@@ -349,29 +384,12 @@ if agent_selected grok; then
   else
     skip grok.xai-api "$(context_requirement grok.xai-api)"
   fi
+  wait_for_probes
 fi
 if agent_selected cursor; then
   probe cursor cursor-login --model-switch-timeout-secs 5
+  wait_for_probes
 fi
-
-echo "── waiting on ${#pids[@]} probes"
-failures=0
-for i in "${!pids[@]}"; do
-  if wait "${pids[$i]}"; then
-    echo "✓ ${labels[$i]}"
-    printf 'passed=%s\n' "${ids[$i]}" >> "$STATE"
-  else
-    code=$?
-    if [ "$code" -eq 124 ]; then
-      echo "✗ ${labels[$i]} TIMED OUT"
-    else
-      echo "✗ ${labels[$i]} FAILED — $(tail -1 "${logs[$i]}" 2>/dev/null | cut -c1-160)"
-    fi
-    echo "  log: ${logs[$i]}"
-    printf 'failed=%s\n' "${ids[$i]}" >> "$STATE"
-    failures=$((failures + 1))
-  fi
-done
 
 if [ "$failures" -eq 0 ] && [ "${#missing[@]}" -eq 0 ]; then
   printf 'complete=true\n' >> "$STATE"

--- a/scripts/agent-catalog/run-probes.test.mjs
+++ b/scripts/agent-catalog/run-probes.test.mjs
@@ -58,6 +58,18 @@ test("a Codex-only run requires every Codex context and no unrelated credentials
   assert.ok(stateValues(result.state, "retained").includes("cursor.cursor-login"));
 });
 
+test("Codex auth contexts are serialized to bound engine startup memory", () => {
+  const script = readFileSync(sourceScript, "utf8");
+
+  for (const context of ["openai-api", "openai-oauth", "bedrock"]) {
+    assert.match(
+      script,
+      new RegExp(`probe codex ${context}\\n\\s+wait_for_probes`),
+      `${context} must finish before another Codex engine starts`,
+    );
+  }
+});
+
 test("CATALOG_PROBE_AGENTS accepts a comma-separated focused selection", () => {
   const result = runPreflight([], { CATALOG_PROBE_AGENTS: "codex,grok" });
 
@@ -81,6 +93,16 @@ test("a credential-complete focused run selects its active agent on Bash 3.2", (
   assert.notEqual(result.status, 0);
   assert.deepEqual(stateValues(result.state, "agent"), ["codex"]);
   assert.doesNotMatch(result.stderr, /active_agents\[@\]: unbound variable/);
+});
+
+test("a Grok-only run accepts an explicit logged-in auth file", () => {
+  const result = runPreflight(["--agent", "grok"], {
+    PROBE_GROK_AUTH_JSON: sourceScript,
+  });
+
+  assert.notEqual(result.status, 2, result.stderr);
+  assert.deepEqual(stateValues(result.state, "agent"), ["grok"]);
+  assert.deepEqual(stateValues(result.state, "required"), ["grok.xai-api"]);
 });
 
 test("agent selections reject unknown names before changing probe state", () => {

--- a/scripts/validate-agent-catalog.mjs
+++ b/scripts/validate-agent-catalog.mjs
@@ -251,6 +251,79 @@ function validateRegistryPairing(catalog, registry) {
   }
 }
 
+function versionCore(value) {
+  return typeof value === "string"
+    ? value.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0]
+    : undefined;
+}
+
+function validateSnapshotEvidence(catalog) {
+  for (const agent of catalog.agents ?? []) {
+    const processVersion = agent.harness?.agentProcess?.version;
+    const processSourceKind = agent.harness?.agentProcess?.source?.kind;
+    const immutableUnattestedSource = processSourceKind === "archive" || processSourceKind === "npm";
+    const nativeVersion = versionCore(agent.harness?.native?.version);
+    const runs = agent.provenance?.runs;
+
+    if (!Array.isArray(runs) || runs.length === 0) {
+      fail(`${agent.kind}: provenance.runs must contain committed probe evidence`);
+      continue;
+    }
+
+    for (const run of runs) {
+      const snapshotPath = run?.snapshotPath;
+      if (typeof snapshotPath !== "string" || !snapshotPath.trim()) {
+        fail(`${agent.kind}: provenance run '${run?.id}' has no snapshotPath`);
+        continue;
+      }
+      const absoluteSnapshotPath = path.resolve("scripts/agent-catalog", snapshotPath);
+      if (!fs.existsSync(absoluteSnapshotPath)) {
+        fail(`${agent.kind}: probe snapshot '${snapshotPath}' does not exist`);
+        continue;
+      }
+
+      let snapshot;
+      try {
+        snapshot = JSON.parse(fs.readFileSync(absoluteSnapshotPath, "utf8"));
+      } catch (error) {
+        fail(`${agent.kind}: probe snapshot '${snapshotPath}' is invalid JSON: ${error.message}`);
+        continue;
+      }
+
+      if (snapshot.agentKind !== agent.kind) {
+        fail(
+          `${agent.kind}: probe snapshot '${snapshotPath}' declares agentKind '${snapshot.agentKind}'`,
+        );
+      }
+
+      const attestedVersion = snapshot.attestation?.version;
+      if (typeof attestedVersion === "string" && attestedVersion.trim()) {
+        if (attestedVersion !== processVersion) {
+          fail(
+            `${agent.kind}: probe snapshot '${snapshotPath}' attests process version ` +
+            `'${attestedVersion}', expected '${processVersion}'`,
+          );
+        }
+      } else if (!immutableUnattestedSource) {
+        fail(
+          `${agent.kind}: probe snapshot '${snapshotPath}' lacks process attestation for ` +
+          `${processSourceKind ?? "unknown"} source`,
+        );
+      }
+
+      if (nativeVersion) {
+        const observedNativeVersion = versionCore(snapshot.nativeCli?.version);
+        if (observedNativeVersion !== nativeVersion) {
+          fail(
+            `${agent.kind}: probe snapshot '${snapshotPath}' reports native version ` +
+            `'${snapshot.nativeCli?.version ?? "missing"}', expected '${agent.harness.native.version}'`,
+          );
+        }
+      }
+    }
+  }
+}
+
 const catalogRaw = fs.readFileSync(CATALOG_PATH, "utf8");
 const draftRaw = fs.readFileSync(DRAFT_PATH, "utf8");
 if (catalogRaw !== draftRaw) {
@@ -260,6 +333,7 @@ const catalog = JSON.parse(catalogRaw);
 const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8"));
 validateCatalog(catalog);
 validateRegistryPairing(catalog, registry);
+validateSnapshotEvidence(catalog);
 
 if (errors.length > 0) {
   for (const message of errors) console.error(`agent catalog validation failed: ${message}`);

--- a/scripts/validate-agent-catalog.test.mjs
+++ b/scripts/validate-agent-catalog.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const validatorPath = fileURLToPath(new URL("./validate-agent-catalog.mjs", import.meta.url));
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "agent-catalog-validator-"));
+  mkdirSync(path.join(root, "catalogs/agents"), { recursive: true });
+  mkdirSync(path.join(root, "scripts/agent-catalog/generated"), { recursive: true });
+
+  const catalog = {
+    schemaVersion: 2,
+    catalogVersion: "test.1",
+    probedAgainst: { registryVersion: "registry.1" },
+    defaultAgentKind: "claude",
+    agents: [{
+      kind: "claude",
+      displayName: "Claude",
+      harness: {
+        agentProcess: {
+          version: "0.59.0-proliferate.1",
+          source: { kind: "git" },
+        },
+        native: { version: "2.1.212" },
+      },
+      authContexts: [{ id: "anthropic-api", authSlotId: "anthropic" }],
+      session: {
+        models: [{
+          id: "default",
+          displayName: "Default",
+          status: "active",
+          defaultVisible: true,
+          availability: { anyOf: ["anthropic-api"] },
+        }],
+        defaults: { "anthropic-api": "default" },
+      },
+      provenance: {
+        runs: [{
+          id: "claude.anthropic-api",
+          snapshotPath: "generated/claude.anthropic-api.probe.json",
+        }],
+      },
+    }],
+  };
+  const registry = {
+    registryVersion: "registry.1",
+    agents: [{ kind: "claude" }],
+  };
+  const snapshot = {
+    agentKind: "claude",
+    authContext: "anthropic-api",
+    nativeCli: { version: "2.1.212 (Claude Code)" },
+    attestation: { version: "0.59.0-proliferate.1" },
+  };
+
+  writeFileSync(path.join(root, "catalogs/agents/catalog.json"), JSON.stringify(catalog));
+  writeFileSync(path.join(root, "scripts/agent-catalog/catalog.draft.json"), JSON.stringify(catalog));
+  writeFileSync(path.join(root, "catalogs/agents/registry.json"), JSON.stringify(registry));
+  const snapshotPath = path.join(
+    root,
+    "scripts/agent-catalog/generated/claude.anthropic-api.probe.json",
+  );
+  writeFileSync(snapshotPath, JSON.stringify(snapshot));
+  return { root, snapshot, snapshotPath };
+}
+
+test("accepts probe evidence matching the catalog lockfile", () => {
+  const { root } = fixture();
+  try {
+    const output = execFileSync(process.execPath, [validatorPath], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.match(output, /agent catalog OK: test\.1/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects stale adapter attestation in committed probe evidence", () => {
+  const { root, snapshot, snapshotPath } = fixture();
+  try {
+    snapshot.attestation.version = "0.44.0";
+    writeFileSync(snapshotPath, JSON.stringify(snapshot));
+    assert.throws(
+      () => execFileSync(process.execPath, [validatorPath], { cwd: root, encoding: "utf8" }),
+      /attests process version '0\.44\.0', expected '0\.59\.0-proliferate\.1'/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/server/tests/integration/test_workflow_definitions_api.py
+++ b/server/tests/integration/test_workflow_definitions_api.py
@@ -333,7 +333,7 @@ async def test_optional_nested_fields_remain_omitted_and_blank_description_norma
             "workflow_catalog_selection_unavailable",
         ),
         (
-            {"agentKind": "claude", "modelId": "sonnet", "effort": "xhigh"},
+            {"agentKind": "claude", "modelId": "sonnet", "effort": "ultra"},
             None,
             "stages.0.harnessConfig.effort",
             "workflow_catalog_selection_unavailable",

--- a/specs/codebase/platforms/product/agent-catalog-readiness.md
+++ b/specs/codebase/platforms/product/agent-catalog-readiness.md
@@ -151,7 +151,6 @@ The supported AnyHarness agent input schemas are:
 
 ```text
 catalogs/agents/catalog.json          # the lockfile (probe-generated, source-pinned)
-catalogs/agents/schema.json
 catalogs/agents/registry.json         # trusted method/auth/launch + discovery config
 catalogs/agents/registry.schema.json
 ```
@@ -188,8 +187,11 @@ registry. It boots from the bundled `AgentCatalogDocument` and
 `AgentRegistryDocument`. Cloud convergence may replace only the active catalog:
 the worker compares `catalogVersion`, fetches the server-owned document, and
 submits it to the runtime's validated catalog-apply endpoint. A successful
-activation persists the active catalog and starts installed-only reconcile.
-The trusted registry remains the compiled/bundled method boundary throughout.
+activation replaces the process-local active catalog and starts installed-only
+reconcile. The replacement is not persisted: after a runtime restart the
+bundled catalog is active until the Worker fetches and reapplies newer
+control-plane truth. The trusted registry remains the compiled/bundled method
+boundary throughout.
 
 Dynamic model refresh is a separate `model_registry/**` concern and stores
 target-local snapshots in SQLite; it must not rewrite the active agent catalog
@@ -215,9 +217,13 @@ pinned npm/git specifier — produced by the probe (`resolve-pins.mjs`). Install
 consumes the catalog pin, materializes EXACTLY that, and verifies the
 **sha256 before use**.
 
-The sha256 is the trust anchor. A url living in the catalog cannot fetch
-unintended bytes: a mismatch hard-fails the install and leaves nothing on disk.
-This is what permits resolved download URLs to live in the (bundled, versioned,
+The sha256 is the trust anchor. A url living in the catalog cannot activate
+unintended bytes: a mismatch hard-fails the install. Direct binaries and native
+archives verify in staging before replacing their current executable.
+Registry-backed whole-tree archives currently remove the prior extracted tree
+before downloading and verifying the replacement, so a failed Cursor/OpenCode
+update can leave that managed role unavailable until retry. This is what
+permits resolved download URLs to live in the (bundled, versioned,
 build-signed) catalog rather than the registry — the integrity check, not the
 file's location, is the security boundary. The registry still owns auth,
 launch, and the install method; it is never consulted for *which bytes* once a
@@ -270,14 +276,68 @@ make catalog-update CATALOG_PROBE_AGENTS=cursor \
   CATALOG_PROBE_ARGS=--include-cursor
 ```
 
+Probe contexts run with isolated harness homes and an allowlisted credential
+surface. In particular, the OpenCode baseline context gets an isolated `HOME`
+and XDG directories and scrubs AWS credential and region variables so a
+developer's `~/.aws` state cannot silently expand the supposedly unauthenticated
+model inventory.
+
 `--allow-partial` is diagnostic only; the same mode is available as
 `ALLOW_PARTIAL=1`. The complete-probe gate refuses to promote its output, and
 `catalog-pin` refuses an incomplete local probe state.
+
+The producer uses provider-published SHA-256 values when the versioned source
+publishes them (Claude's release manifest, GitHub release-asset digests, and
+ACP registry archive checksums) and otherwise downloads and hashes each shipped
+target. Installation still downloads the selected target and verifies those
+catalog bytes before activation.
+
+`catalog-update` is not a read-only repository operation. Its debug AnyHarness
+binary reconciles selected agents in the operator's default development runtime
+home (`~/.proliferate-local/anyharness`) before probing, and it does not roll
+those installed artifacts back when the checked-in catalog backup is restored.
+Selected harness families are probed one at a time. Auth contexts inside one
+family normally run concurrently, but Codex contexts are serialized because
+parallel Codex engine startup can exhaust constrained operator memory and make
+otherwise healthy probes miss the authoritative deadline.
 
 `catalogVersion` changes with catalog content. `registryVersion` changes with
 registry content, and `probedAgainst.registryVersion` must pair the promoted
 catalog with that registry version. CI enforces those version bumps and exact
 draft/bundled equality.
+
+## Runtime Disk Reconciliation
+
+Managed artifacts live below the selected AnyHarness runtime home:
+
+```text
+<runtime-home>/agents/<kind>/.install.lock
+<runtime-home>/agents/<kind>/native/
+<runtime-home>/agents/<kind>/agent_process/
+<runtime-home>/agents/<kind>/install-manifest.json
+```
+
+The default development home is `~/.proliferate-local/anyharness`; the default
+release home is `~/.proliferate/anyharness`. An agent-scoped install lock
+serializes reconciliation. The manifest records each role's resolved version
+or immutable Git ref, source kind, installed launcher path, launcher/binary
+SHA-256, and installation time.
+
+Reconciliation first compares the active catalog pin and the installed
+manifest, then verifies the recorded launcher or binary checksum. A missing
+manifest role, pin/source mismatch, missing executable, or checksum mismatch
+reinstalls that role. The checksum covers the executable or managed launcher,
+not every file in an extracted adapter tree. npm and Git packages are installed
+into the live managed prefix; they do not currently use a directory-level
+atomic swap or rollback. Manifest replacement uses a temporary file and rename,
+but a manifest write failure is best-effort and causes a later reconciliation
+to retry.
+
+Runtime startup hydrates a pending release seed and then performs
+installed-only reconciliation. It updates managed agents that already have
+installed state, but it does not install every missing catalog agent merely
+because the runtime started. Missing-agent installation remains an explicit
+setup/install operation.
 
 ## Source Shape
 

--- a/specs/codebase/structures/anyharness/harnesses/claude.md
+++ b/specs/codebase/structures/anyharness/harnesses/claude.md
@@ -68,22 +68,17 @@ metadata or raw tool input/output blobs.
 ## Permission Mode Launch Guard
 
 The managed `claude-agent-acp` adapter validates
-`permissions.defaultMode` from Claude settings before creating a session. The
-current managed adapter accepts `default`, `acceptEdits`, `plan`, `dontAsk`,
-and `bypassPermissions`; it does not accept `auto`.
+`permissions.defaultMode` from Claude settings before creating a session. It
+accepts `default`, `acceptEdits`, `plan`, `dontAsk`, `bypassPermissions`, and
+`auto`. `auto` is model-dependent: the adapter advertises it only when the
+resolved Claude model reports auto-mode support and clamps a stale `auto`
+default back to `default` when the active model does not support it.
 
-AnyHarness must not advertise `auto` as a Claude create-session mode until the
-managed adapter supports it. Gateway-backed Claude launches set a
-runtime-owned `CLAUDE_CONFIG_DIR` so hosted sessions do not inherit a user's
-global Claude settings default that the adapter cannot start with.
-
-Older user-owned managed Claude adapters can predate adapter support for
-`auto`. Readiness treats a managed npm package whose installed metadata does
-not match the bundled package spec as `install_required`, so the visible setup
-flow and startup reconcile can refresh the adapter. If an adapter still reaches
-session creation and fails on `permissions.defaultMode: auto`, the start error
-must include a repair hint to update/reinstall Claude setup or change the
-unsupported global Claude setting.
+Gateway-backed Claude launches set a runtime-owned `CLAUDE_CONFIG_DIR` so
+hosted sessions do not inherit unrelated user-global Claude configuration.
+Readiness treats a managed package whose installed source metadata does not
+match the bundled Git pin as `install_required`, so setup and startup reconcile
+can refresh older adapters before launch.
 
 ## Restart Semantics
 

--- a/specs/codebase/structures/anyharness/harnesses/codex.md
+++ b/specs/codebase/structures/anyharness/harnesses/codex.md
@@ -1,13 +1,18 @@
 # Codex Harness
 
-AnyHarness installs the Codex ACP wrapper from the published npm package line,
-not by building the Rust repo at runtime.
+AnyHarness installs the Proliferate Codex ACP fork from the exact Git commit in
+the agent registry. The managed npm installer checks out that immutable source,
+selects its `npm/` package subdirectory, and resolves the wrapper executable
+from `node_modules/.bin/codex-acp`.
 
-- Agent-process package: `@proliferateai/codex-acp@0.11.8`
-- Install strategy: plain `ManagedNpmPackage` with `package_subdir = None` and
-  `source_build_binary_name = None`
-- Runtime expectation: the npm package already contains the prebuilt platform
-  binaries that the wrapper needs
+- Agent-process line: `@proliferate-ai/codex-acp@0.18.2-proliferate.1`
+- Install strategy: Git-backed `ManagedNpmPackage` with
+  `package_subdir = "npm"`
+- Runtime expectation: the wrapper's matching optional platform package is
+  published before the registry commit is promoted
+- Engine relationship: the adapter embeds the Codex core it serves over ACP;
+  the separately pinned native Codex CLI is used for native auth/readiness and
+  must be updated and probed alongside the embedded core
 
 The Codex ACP session config surface also exposes `fast_mode` as a live control.
 That maps to Codex `service_tier = fast` for the current session, but it is not


### PR DESCRIPTION
## Summary

- update every supported managed coding harness to the latest upstream version resolved on 2026-07-17
- port and pin the current Proliferate Claude and Codex ACP adapters, including their GoalPort/LoopPort behavior
- regenerate the authoritative catalog from successful live probes across all required auth contexts
- use provider-published checksums when available and reject stale committed probe evidence
- serialize Codex probe contexts on constrained machines and isolate OpenCode from ambient HOME/XDG/AWS provider state
- document the exact runtime disk reconciliation, replacement, rollback, persistence, and startup behavior

## Versions

| Harness | Agent process | Native CLI |
| --- | --- | --- |
| Claude | 0.59.0-proliferate.1 | 2.1.212 |
| Codex | 0.18.2-proliferate.1 | rust-v0.144.5 |
| Cursor | 2026.07.09 | n/a |
| Grok | 0.2.102 | n/a |
| OpenCode | 1.18.3 | n/a |

Catalog version: 2026-07-17.4.

## Adapter releases

- Claude adapter: https://github.com/proliferate-ai/claude-agent-acp/pull/27
- Codex adapter port: https://github.com/proliferate-ai/codex-acp/pull/16
- Codex release hardening: https://github.com/proliferate-ai/codex-acp/pull/17
- Codex release: https://github.com/proliferate-ai/codex-acp/releases/tag/v0.18.2-proliferate.1

## Live proof

The authoritative catalog-update flow installed the exact pins into the default development runtime home and passed every configured context:

- Claude: anthropic-api, anthropic-oauth, bedrock
- Codex: openai-api, openai-oauth, bedrock
- OpenCode: baseline, anthropic-api, openai-api, gemini-api, opencode-zen
- Grok: xai-api
- Cursor: cursor-login

The promoted catalog and draft are byte-identical, all target checksums are valid SHA-256 values, and a count-only scan found no exact local credentials or credential-shaped strings in the changed repository paths.

## Tests

- 273 AnyHarness agent-domain Rust tests
- 2 catalog-probe isolation/auth Rust tests
- 23 agent-catalog Node tests
- agent catalog validation
- documentation integrity validation
- 26 server catalog and worker-convergence tests

## Operational follow-up

The scheduled catalog-probe workflow has no repository-level provider credentials and its recent daily runs fail at preflight. This PR does not copy operator credentials into GitHub; a separate operations issue will track provisioning scoped Actions secrets.