### PR TITLE
docs(local): document native services and WSL2 setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,15 @@ For full-stack local development, use named profiles:
 
 ```bash
 make server-install
-make setup PROFILE=main
+make setup PROFILE=<name>
 make build # first clean worktree, or after generated/Rust/frontend artifacts change
 make dev-list
-make run PROFILE=main
+make run PROFILE=<name>
 ```
+
+Give every worktree its own profile name. To reuse an existing Postgres or
+Redis service, or to develop from Windows through WSL2, follow the
+[local-development procedure](./specs/developing/local/README.md).
 
 ## Pull Requests
 

--- a/specs/developing/local/README.md
+++ b/specs/developing/local/README.md
@@ -45,6 +45,71 @@ It reserves a Mobile Web port but does not start Expo. It also does not start
 Celery workers or the optional Stripe, LiteLLM, tunnel, native-Mobile, or SSO
 flows unless their focused command or flag is used.
 
+## Existing Postgres And Redis
+
+By default, `setup` starts or reuses the repository's Docker Postgres service,
+and `run` starts or reuses the Docker Postgres and Redis services. To use
+services already running on the same host instead, select the existing-service
+paths on every command that touches them:
+
+```bash
+make setup PROFILE=<name> USE_EXISTING_POSTGRES=1
+make build # if this worktree needs artifacts
+make run PROFILE=<name> USE_EXISTING_POSTGRES=1 USE_EXISTING_REDIS=1
+```
+
+The existing-Postgres path requires `psql` on `PATH`. Its default login role is
+`proliferate`. Create that dedicated local role once from a PostgreSQL
+administrator account, choosing a local password at the prompt:
+
+```bash
+createuser --createdb --pwprompt proliferate
+```
+
+On Ubuntu and WSL, the administrator invocation is commonly
+`sudo -u postgres createuser --createdb --pwprompt proliferate`. The role needs
+`LOGIN`, `CREATEDB`, and normal `CONNECT` access to the `postgres` maintenance
+database; it does not need `SUPERUSER`, `CREATEROLE`, or `BYPASSRLS`. The
+repository's local-only password default is `localdev`. If you choose another
+password or role, provide `LOCAL_PGPASSWORD` and `LOCAL_PGUSER` in the
+environment for both `setup` and `run`, and do not commit them.
+
+Let `setup` create `proliferate_dev_<normalized_name>` so the login role owns
+the database. If that database already exists, the login role must own the
+database and its migration-managed objects; setup checks existence but does
+not repair ownership.
+
+The default endpoints are local Postgres on port `5432` and local Redis on port
+`6379`. Override a nondefault Postgres endpoint with the `LOCAL_PG*` Make
+variables. For a nondefault Redis endpoint, keep `LOCAL_REDIS_HOST` and
+`LOCAL_REDIS_PORT` aligned with the server's `REDBEAT_REDIS_URL`; the readiness
+checks only prove that the configured TCP ports accept connections.
+
+## Windows And WSL2
+
+On Windows, run the Linux development workflow inside WSL2 and keep the
+checkout in the WSL filesystem, such as `~/proliferate`, rather than under
+`/mnt/c`. If you use the existing-service path above, the documented defaults
+assume Postgres and Redis run inside the same WSL distribution. Windows-hosted
+services may need endpoint overrides under NAT networking; mirrored networking
+can make Windows-host loopback reachable instead. Either path needs separate
+endpoint, authentication, and firewall verification, which this procedure does
+not qualify.
+
+WSL normally makes services bound to WSL loopback reachable from Windows
+through `localhost`. That depends on the active WSL networking configuration,
+VPN or enterprise policy, and the corresponding Windows-side ports being free.
+Use `make dev-list` inside WSL to identify the profile's allocated ports, then
+verify `http://localhost:<allocated-port>` from Windows for the service you
+need.
+
+Normal host-only development should not require `netsh portproxy`, Windows
+Firewall, or Hyper-V firewall exceptions. Only consider those for intentional
+LAN access after following
+[Microsoft's WSL networking guidance](https://learn.microsoft.com/en-us/windows/wsl/networking).
+The standard Proliferate launcher binds services to `127.0.0.1`; LAN exposure
+is not qualified by this procedure.
+
 ## Profile State And Environment
 
 The important profile-owned paths are:


### PR DESCRIPTION
## Summary

- Put existing Postgres/Redis and Windows/WSL2 guidance in the canonical local-development procedure, with a discoverability link from `CONTRIBUTING.md`.
- Replace shared `PROFILE=main` examples with the per-worktree `PROFILE=<name>` placeholder.
- Document the minimum PostgreSQL role contract (`LOGIN`, `CREATEDB`, and normal maintenance-database access) without a fixed-password or `SUPERUSER` role-creation example.
- Keep WSL localhost forwarding conditional on networking and host state, and keep portproxy/firewall changes out of the standard loopback-only path.

This lets contributors reuse native services without Docker while preserving profile isolation and avoiding unnecessary database or Windows networking privilege.

## Attribution

Supersedes #1140 by @Rahul-Ganesan, preserving the original native-service and WSL2 documentation contribution while updating it for current main.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- `python3 scripts/check_docs.py` — passed (219 Markdown files)
- `git diff --check` — passed
- `make --no-print-directory -n server-db-ready USE_EXISTING_POSTGRES=1 LOCAL_PGHOST=127.0.0.1 LOCAL_PGPORT=5432` — selected the native TCP probe, with no Docker command
- `make --no-print-directory -n server-redis-ready USE_EXISTING_REDIS=1 LOCAL_REDIS_HOST=127.0.0.1 LOCAL_REDIS_PORT=6379` — selected the native TCP probe, with no Docker command
- `make --no-print-directory -n setup PROFILE=docs-native-services USE_EXISTING_POSTGRES=1 LOCAL_PGHOST=127.0.0.1 LOCAL_PGPORT=5432` — selected profile setup plus `ensure-db`, with no Docker command
- `createuser --help` — confirmed `--createdb` adds database creation while login defaults on and superuser/createrole/bypass-RLS default off
- Independent read-only accuracy and security review — no remaining actionable findings after corrections
