### PR TITLE
fix(product-client): recover ready workspace chats

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
@@ -72,6 +72,30 @@ describe("TranscriptPendingPromptRow", () => {
     expect(actions.retryPrompt).toHaveBeenCalledWith("prompt-1");
   });
 
+  it("shows an actionable retry when projected session launch requires login", () => {
+    const actions = {
+      retryPrompt: vi.fn(),
+      dismissPrompt: vi.fn(),
+    };
+    render(
+      <TranscriptPendingPromptRow
+        activeSessionId="client-session:claude:1"
+        rowIndex={0}
+        prompt={createOptimisticPendingPrompt("Run after login", "prompt-1", NOW)}
+        outboxEntry={failedOutboxEntry(
+          "agent 'claude' is not ready (status: LoginRequired)",
+        )}
+        optimisticTrailingStatus={null}
+        outboxActions={actions}
+      />,
+    );
+
+    expect(screen.getByText(/LoginRequired/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(actions.retryPrompt).toHaveBeenCalledWith("prompt-1");
+  });
+
   it("shows the delivery error and retry for unconfirmed dispatches", () => {
     const actions = {
       retryPrompt: vi.fn(),

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts
@@ -10,13 +10,10 @@ import {
 } from "#product/lib/domain/chat/composer/chat-input";
 import { isWorkspaceDirectoryMissing } from "#product/lib/domain/workspaces/availability";
 import { missingCheckoutCopy } from "#product/copy/workspaces/workspace-availability-copy";
-import { launchSelectionIsAvailable } from "#product/lib/domain/chat/models/launch-selection-defaults";
-import { getProviderDisplayName } from "#product/lib/domain/agents/provider-display";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useConfiguredLaunchReadiness } from "#product/hooks/chat/derived/use-configured-launch-readiness";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
-import { useActiveSessionLaunchState } from "#product/hooks/chat/derived/use-active-session-config-state";
 
 export type ChatAvailabilityState = ChatInputAvailabilityState;
 
@@ -41,7 +38,6 @@ export function useChatAvailabilityState(options?: {
   const { data: workspaceCollections } = useWorkspaces();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
   const configuredLaunch = useConfiguredLaunchReadiness();
-  const { currentLaunchIdentity } = useActiveSessionLaunchState();
 
   const selectedCloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
   const selectedLocalWorkspace = selectedCloudWorkspaceId === null
@@ -66,18 +62,6 @@ export function useChatAvailabilityState(options?: {
     selectedCloudRuntimePhase: selectedCloudRuntime.state?.phase ?? null,
     selectedCloudRuntimeActionBlockReason: selectedCloudRuntime.state?.actionBlockReason ?? null,
     activeSessionId,
-    activeSessionLaunchDisabledReason:
-      activeSessionId
-      && currentLaunchIdentity
-      && !launchSelectionIsAvailable(
-        configuredLaunch.launchCatalog.launchAgents,
-        currentLaunchIdentity,
-      )
-        ? `${
-          getProviderDisplayName(currentLaunchIdentity.kind)
-          ?? currentLaunchIdentity.kind
-        } isn't ready on this target. Open a new chat with a ready agent.`
-        : null,
     isConfiguredLaunchLoading: configuredLaunch.isLoading,
     hasReadyConfiguredLaunch: configuredLaunch.isReady,
     configuredLaunchDisabledReason: configuredLaunch.disabledReason,
@@ -89,8 +73,6 @@ export function useChatAvailabilityState(options?: {
     configuredLaunch.disabledReason,
     configuredLaunch.isLoading,
     configuredLaunch.isReady,
-    configuredLaunch.launchCatalog.launchAgents,
-    currentLaunchIdentity,
     pendingWorkspaceEntry,
     primaryPendingInteractionKind,
     selectedCloudRuntime.state?.actionBlockReason,

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSelectedCloudRuntimeRehydration } from "#product/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration";
+import type { SelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const mocks = vi.hoisted(() => ({
+  bootstrapWorkspace: vi.fn(),
+  materializePendingWorkspaceSessions: vi.fn(),
+  materializeReadyWorkspaceProjectedSessions: vi.fn(),
+  withFreshCloudSandboxGatewayAccessToken: vi.fn(async <T,>(connectionInfo: T) => connectionInfo),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-bootstrap-actions", () => ({
+  useWorkspaceBootstrapActions: () => ({
+    bootstrapWorkspace: mocks.bootstrapWorkspace,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-pending-workspace-session-materialization", () => ({
+  usePendingWorkspaceSessionMaterialization: () =>
+    mocks.materializePendingWorkspaceSessions,
+  useReadyWorkspaceProjectedSessionMaterialization: () =>
+    mocks.materializeReadyWorkspaceProjectedSessions,
+}));
+
+vi.mock("#product/hooks/workspaces/lifecycle/workspace-bootstrap-memory", () => ({
+  hasWorkspaceBootstrappedInSession: () => true,
+}));
+
+vi.mock("#product/lib/access/cloud/cloud-sandbox-gateway", () => ({
+  withFreshCloudSandboxGatewayAccessToken:
+    mocks.withFreshCloudSandboxGatewayAccessToken,
+}));
+
+vi.mock("#product/lib/infra/measurement/measurement-port", () => ({
+  logLatency: vi.fn(),
+  startLatencyTimer: vi.fn(() => 0),
+}));
+
+describe("useSelectedCloudRuntimeRehydration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.getState().clearSelection();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("recovers an unmaterialized projected root session in an already-ready workspace", async () => {
+    useSessionSelectionStore.setState({
+      selectedLogicalWorkspaceId: "cloud:workspace-real",
+      selectedWorkspaceId: "workspace-real",
+      pendingWorkspaceEntry: null,
+      activeSessionId: "client-session:claude:1",
+    });
+    putSessionRecord({
+      ...createEmptySessionRecord("client-session:claude:1", "claude", {
+        workspaceId: "workspace-real",
+        materializedSessionId: null,
+        modelId: "opus",
+        requestedModelId: "opus",
+        sessionRelationship: { kind: "root" },
+      }),
+      status: "errored",
+      transcriptHydrated: true,
+    });
+
+    renderHook(() => useSelectedCloudRuntimeRehydration(readyCloudRuntime()));
+
+    await waitFor(() => {
+      expect(mocks.materializeReadyWorkspaceProjectedSessions).toHaveBeenCalledWith(
+        "workspace-real",
+        { eventPrefix: "workspace.cloud_runtime_rehydration" },
+      );
+    });
+    expect(mocks.bootstrapWorkspace).not.toHaveBeenCalled();
+    expect(mocks.materializePendingWorkspaceSessions).not.toHaveBeenCalled();
+  });
+});
+
+function readyCloudRuntime(): SelectedCloudRuntimeState {
+  return {
+    workspaceId: "workspace-real",
+    cloudWorkspaceId: "workspace-real",
+    state: {
+      phase: "ready",
+      variant: "warm",
+      tone: "pending",
+      title: null,
+      subtitle: null,
+      actionBlockReason: null,
+      preserveVisibleContent: false,
+      showRetry: false,
+      showClaim: false,
+    },
+    connectionInfo: {
+      runtimeUrl: "https://runtime.invalid",
+      accessToken: "test-token",
+      anyharnessWorkspaceId: "anyharness-workspace-1",
+    } as SelectedCloudRuntimeState["connectionInfo"],
+    retry: null,
+    claim: null,
+    claimPending: false,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
@@ -12,6 +12,9 @@ import { hasWorkspaceBootstrappedInSession } from "#product/hooks/workspaces/lif
 import type { SelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { withFreshCloudSandboxGatewayAccessToken } from "#product/lib/access/cloud/cloud-sandbox-gateway";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  isProjectedSessionMaterializationCandidate,
+} from "#product/lib/domain/sessions/creation/projected-session-materialization";
 
 export function useSelectedCloudRuntimeRehydration(
   selectedCloudRuntime: SelectedCloudRuntimeState,
@@ -34,9 +37,7 @@ export function useSelectedCloudRuntimeRehydration(
     return (state.sessionIdsByWorkspaceId[workspaceId] ?? [])
       .filter((sessionId) => {
         const entry = state.entriesById[sessionId];
-        return !!entry
-          && !entry.materializedSessionId
-          && entry.sessionRelationship.kind === "pending";
+        return entry ? isProjectedSessionMaterializationCandidate(entry) : false;
       })
       .join("|");
   });
@@ -81,7 +82,12 @@ export function useSelectedCloudRuntimeRehydration(
       return;
     }
 
-    if (!shouldRehydrateOnReadyRef.current && isBootstrapped && !hasAwaitingPendingWorkspaceEntry) {
+    if (
+      !shouldRehydrateOnReadyRef.current
+      && isBootstrapped
+      && !hasAwaitingPendingWorkspaceEntry
+      && !hasUnmaterializedProjectedSessions
+    ) {
       return;
     }
 

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
@@ -82,15 +82,6 @@ export function useSelectedCloudRuntimeRehydration(
       return;
     }
 
-    if (
-      !shouldRehydrateOnReadyRef.current
-      && isBootstrapped
-      && !hasAwaitingPendingWorkspaceEntry
-      && !hasUnmaterializedProjectedSessions
-    ) {
-      return;
-    }
-
     shouldRehydrateOnReadyRef.current = false;
 
     let cancelled = false;

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx
@@ -88,6 +88,7 @@ describe("usePendingWorkspaceSessionMaterialization", () => {
       modelId: "opus",
       modeId: "default",
       hasAttemptedPrompt: true,
+      sessionRelationship: { kind: "root" },
     }));
 
     const materializeReadyWorkspaceProjectedSessions =

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.ts
@@ -13,6 +13,9 @@ import type {
   CreateEmptySessionWithResolvedConfigOptions,
 } from "#product/hooks/sessions/workflows/session-creation-types";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
+import {
+  isProjectedSessionMaterializationCandidate,
+} from "#product/lib/domain/sessions/creation/projected-session-materialization";
 
 interface PendingWorkspaceSessionMaterializationOptions {
   eventPrefix?: string;
@@ -157,10 +160,7 @@ export function useReadyWorkspaceProjectedSessionMaterialization() {
   ): PendingWorkspaceSessionMaterializationResult => {
     const eventPrefix = options?.eventPrefix ?? "workspace.ready_projected_session";
     const projectedSessions = Object.values(getWorkspaceSessionRecords(workspaceId))
-      .filter((session) =>
-        !session.materializedSessionId
-        && session.sessionRelationship.kind === "pending"
-      );
+      .filter(isProjectedSessionMaterializationCandidate);
     const projectedSessionIds = projectedSessions.map((session) => session.sessionId);
 
     let materializationStartCount = 0;

--- a/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts
@@ -120,10 +120,6 @@ describe("resolveChatInputAvailability", () => {
       selectedCloudRuntimePhase: "ready",
       selectedCloudRuntimeActionBlockReason: null,
       activeSessionId: "client-session:claude:1",
-      ...{
-        activeSessionLaunchDisabledReason:
-          "Claude isn't ready on this target. Open a new chat with a ready agent.",
-      },
       isConfiguredLaunchLoading: false,
       hasReadyConfiguredLaunch: false,
       configuredLaunchDisabledReason: "agent 'claude' is not ready (status: LoginRequired)",

--- a/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.test.ts
@@ -110,6 +110,77 @@ describe("resolveChatInputAvailability", () => {
     });
   });
 
+  it("keeps a ready workspace composer queueable when its projected session launch fails", () => {
+    expect(resolveChatInputAvailability({
+      selectedWorkspaceId: "cloud:workspace-1",
+      isCloudWorkspaceSelected: true,
+      connectionState: "healthy",
+      selectedCloudWorkspaceStatus: "ready",
+      selectedCloudWorkspaceActionBlockReason: null,
+      selectedCloudRuntimePhase: "ready",
+      selectedCloudRuntimeActionBlockReason: null,
+      activeSessionId: "client-session:claude:1",
+      ...{
+        activeSessionLaunchDisabledReason:
+          "Claude isn't ready on this target. Open a new chat with a ready agent.",
+      },
+      isConfiguredLaunchLoading: false,
+      hasReadyConfiguredLaunch: false,
+      configuredLaunchDisabledReason: "agent 'claude' is not ready (status: LoginRequired)",
+      pendingWorkspaceEntry: null,
+    })).toEqual({
+      isDisabled: false,
+      disabledReason: null,
+      sendBlockedReason: null,
+      areRuntimeControlsDisabled: false,
+      selectedWorkspaceKind: "cloud",
+    });
+  });
+
+  it("still blocks a new session when no configured launch is ready", () => {
+    expect(resolveChatInputAvailability({
+      selectedWorkspaceId: "cloud:workspace-1",
+      isCloudWorkspaceSelected: true,
+      connectionState: "healthy",
+      selectedCloudWorkspaceStatus: "ready",
+      selectedCloudWorkspaceActionBlockReason: null,
+      selectedCloudRuntimePhase: "ready",
+      selectedCloudRuntimeActionBlockReason: null,
+      activeSessionId: null,
+      isConfiguredLaunchLoading: false,
+      hasReadyConfiguredLaunch: false,
+      configuredLaunchDisabledReason: "Choose a ready agent.",
+      pendingWorkspaceEntry: null,
+    })).toMatchObject({
+      isDisabled: true,
+      disabledReason: "Choose a ready agent.",
+      sendBlockedReason: null,
+      areRuntimeControlsDisabled: false,
+    });
+  });
+
+  it("still blocks an existing session while its cloud workspace is provisioning", () => {
+    expect(resolveChatInputAvailability({
+      selectedWorkspaceId: "cloud:workspace-1",
+      isCloudWorkspaceSelected: true,
+      connectionState: "healthy",
+      selectedCloudWorkspaceStatus: "materializing",
+      selectedCloudWorkspaceActionBlockReason: null,
+      selectedCloudRuntimePhase: null,
+      selectedCloudRuntimeActionBlockReason: null,
+      activeSessionId: "client-session:claude:1",
+      isConfiguredLaunchLoading: false,
+      hasReadyConfiguredLaunch: true,
+      configuredLaunchDisabledReason: null,
+      pendingWorkspaceEntry: null,
+    })).toMatchObject({
+      isDisabled: true,
+      disabledReason: "Cloud workspace is still preparing.",
+      sendBlockedReason: null,
+      areRuntimeControlsDisabled: true,
+    });
+  });
+
   it("keeps pending approval, user-input, and MCP elicitation as chat blockers", () => {
     const base = {
       selectedWorkspaceId: "workspace-1",

--- a/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/chat-input.ts
@@ -12,7 +12,6 @@ interface ChatInputAvailabilityArgs {
   selectedCloudRuntimePhase: "ready" | "resuming" | "failed" | "claim_required" | null;
   selectedCloudRuntimeActionBlockReason: string | null;
   activeSessionId: string | null;
-  activeSessionLaunchDisabledReason?: string | null;
   isConfiguredLaunchLoading: boolean;
   hasReadyConfiguredLaunch: boolean;
   configuredLaunchDisabledReason: string | null;
@@ -83,7 +82,6 @@ export function resolveChatInputAvailability({
   selectedCloudRuntimePhase,
   selectedCloudRuntimeActionBlockReason,
   activeSessionId,
-  activeSessionLaunchDisabledReason = null,
   isConfiguredLaunchLoading,
   hasReadyConfiguredLaunch,
   configuredLaunchDisabledReason,
@@ -185,16 +183,6 @@ export function resolveChatInputAvailability({
     return {
       isDisabled: true,
       disabledReason: configuredLaunchDisabledReason ?? "Your chosen default agent is not ready yet.",
-      sendBlockedReason: null,
-      areRuntimeControlsDisabled: false,
-      selectedWorkspaceKind,
-    };
-  }
-
-  if (activeSessionId && activeSessionLaunchDisabledReason) {
-    return {
-      isDisabled: true,
-      disabledReason: activeSessionLaunchDisabledReason,
       sendBlockedReason: null,
       areRuntimeControlsDisabled: false,
       selectedWorkspaceKind,

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/projected-session-materialization.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/projected-session-materialization.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  isProjectedSessionMaterializationCandidate,
+} from "#product/lib/domain/sessions/creation/projected-session-materialization";
+import {
+  createDirectoryEntry,
+} from "#product/lib/domain/sessions/directory/directory-entry";
+import type {
+  SessionRelationship,
+} from "#product/lib/domain/sessions/directory/relationship";
+
+describe("isProjectedSessionMaterializationCandidate", () => {
+  it.each<SessionRelationship>([
+    { kind: "root" },
+    { kind: "pending" },
+  ])("accepts an unmaterialized $kind session", (sessionRelationship) => {
+    expect(isProjectedSessionMaterializationCandidate(session({
+      materializedSessionId: null,
+      sessionRelationship,
+    }))).toBe(true);
+  });
+
+  it("rejects a materialized root session", () => {
+    expect(isProjectedSessionMaterializationCandidate(session({
+      materializedSessionId: "runtime-session-1",
+      sessionRelationship: { kind: "root" },
+    }))).toBe(false);
+  });
+
+  it.each<SessionRelationship>([
+    { kind: "subagent_child", parentSessionId: "parent-1" },
+    { kind: "cowork_child", parentSessionId: "parent-1" },
+    { kind: "review_child", parentSessionId: "parent-1" },
+    { kind: "linked_child", parentSessionId: "parent-1" },
+  ])("leaves an unmaterialized $kind session to its parent flow", (sessionRelationship) => {
+    expect(isProjectedSessionMaterializationCandidate(session({
+      materializedSessionId: null,
+      sessionRelationship,
+    }))).toBe(false);
+  });
+});
+
+function session(input: {
+  materializedSessionId: string | null;
+  sessionRelationship: SessionRelationship;
+}) {
+  return createDirectoryEntry({
+    sessionId: "client-session-1",
+    workspaceId: "workspace-1",
+    agentKind: "claude",
+    ...input,
+  });
+}

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/projected-session-materialization.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/projected-session-materialization.ts
@@ -1,0 +1,16 @@
+import type { SessionDirectoryEntry } from "#product/lib/domain/sessions/directory/directory-entry";
+
+/**
+ * A client-owned root session may exist before AnyHarness assigns its runtime
+ * session id. `pending` is retained for older/pre-classification records, but
+ * child sessions are materialized by their owning parent-session flow.
+ */
+export function isProjectedSessionMaterializationCandidate(
+  session: SessionDirectoryEntry,
+): boolean {
+  return session.materializedSessionId === null
+    && (
+      session.sessionRelationship.kind === "root"
+      || session.sessionRelationship.kind === "pending"
+    );
+}


### PR DESCRIPTION
## Summary

- Recover unmaterialized projected root sessions when an already-bootstrapped cloud workspace is ready.
- Keep an existing-session composer writable and queueable when its launch identity is unavailable, while retaining provisioning, runtime, pending-interaction, and new-session launch blockers.
- Preserve transcript-level launch failures with the existing Retry/Dismiss recovery path.
- Supersedes #1231. This replacement was reconstructed on current `origin/main`; it does not transplant the conflicting historical head.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship or private source data applies to this PR.

## Reproduction and root cause

A cloud workspace can reach Ready while its projected client-owned root session remains unmaterialized after a launch error such as `LoginRequired`. Current ready-workspace recovery filters only `sessionRelationship.kind === "pending"`, even though projected roots are classified as `"root"`. A second already-bootstrapped guard then exits before recovery. Separately, composer availability treats the active session's missing launch-catalog identity as a chat-wide blocker.

The fix centralizes the recovery predicate as unmaterialized `root` or legacy/pre-classification `pending`, leaving all child relationships to their parent-owned flows. That same predicate drives lifecycle detection and materialization. The bootstrapped guard is bypassed only when such a candidate exists. Existing sessions no longer consume new-launch catalog readiness as composer availability; new-session launches still do.

## Verification

- `pnpm --config.minimumReleaseAge=0 --filter @proliferate/product-client build`
- `cd apps/packages/product-client && pnpm --config.minimumReleaseAge=0 exec tsc -p tsconfig.json --noEmit`
- `cd apps/packages/product-client && pnpm --config.minimumReleaseAge=0 exec vitest run src/lib/domain/sessions/creation/projected-session-materialization.test.ts src/lib/domain/chat/composer/chat-input.test.ts src/hooks/workspaces/workflows/use-pending-workspace-session-materialization.test.tsx src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.test.tsx src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx`
  - 5 files passed, 29 tests passed.
- `python3 scripts/check_frontend_boundaries.py`

## Assumptions and residual risk

- No branch deployment was created, so post-fix proof is deterministic state/lifecycle/component coverage rather than a hosted browser pass.
- Agent authentication remains a session-level failure. Retry can succeed only after the agent becomes ready; until then the queued prompt remains visible and recoverable in the transcript.
- The current pending-shell/composer docs still contain pre-ProductClient `apps/desktop` paths, while the ProductClient package doc's “foundation only” wording conflicts with the completed unification record. This PR does not broaden into that documentation cleanup because the governing projected-session behavior is already unambiguous and this change restores it.
