### PR TITLE
fix(web): classify expected lifecycle cancellations

### DIFF
--- a/anyharness/sdk/src/streams/__tests__/sessions.test.ts
+++ b/anyharness/sdk/src/streams/__tests__/sessions.test.ts
@@ -134,6 +134,77 @@ describe("streamSession", () => {
     expect(globalThis.fetch).toHaveBeenCalledOnce();
   });
 
+  it("forwards an explicit close reason to the stream abort signal", async () => {
+    let observedReason: unknown;
+    let resolveAborted: (() => void) | undefined;
+    const aborted = new Promise<void>((resolve) => {
+      resolveAborted = resolve;
+    });
+    const onError = vi.fn();
+
+    globalThis.fetch = vi.fn((_input, init) => new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) {
+        reject(new Error("Expected a stream abort signal"));
+        return;
+      }
+      signal.addEventListener("abort", () => {
+        observedReason = signal.reason;
+        resolveAborted?.();
+        reject(signal.reason);
+      }, { once: true });
+    })) as typeof fetch;
+
+    const reason = new Error("expected stale close");
+    const handle = streamSession({
+      baseUrl: "http://runtime.test",
+      sessionId: "s1",
+      onEvent: () => undefined,
+      onError,
+    });
+    handle.close(reason);
+    await aborted;
+    await Promise.resolve();
+
+    expect(observedReason).toBe(reason);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("keeps the platform AbortError for ordinary stream closes", async () => {
+    let observedReason: unknown;
+    let resolveAborted: (() => void) | undefined;
+    const aborted = new Promise<void>((resolve) => {
+      resolveAborted = resolve;
+    });
+    const onError = vi.fn();
+
+    globalThis.fetch = vi.fn((_input, init) => new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) {
+        reject(new Error("Expected a stream abort signal"));
+        return;
+      }
+      signal.addEventListener("abort", () => {
+        observedReason = signal.reason;
+        resolveAborted?.();
+        reject(signal.reason);
+      }, { once: true });
+    })) as typeof fetch;
+
+    const handle = streamSession({
+      baseUrl: "http://runtime.test",
+      sessionId: "s1",
+      onEvent: () => undefined,
+      onError,
+    });
+    handle.close();
+    await aborted;
+    await Promise.resolve();
+
+    expect(observedReason).toMatchObject({ name: "AbortError" });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("emits sanitized stream timing events", async () => {
     const timingEvents: AnyHarnessTimingEvent[] = [];
     setAnyHarnessTimingObserver((event) => timingEvents.push(event));

--- a/anyharness/sdk/src/streams/sessions.ts
+++ b/anyharness/sdk/src/streams/sessions.ts
@@ -26,7 +26,7 @@ export interface SessionStreamOptions {
 }
 
 export interface SessionStreamHandle {
-  close: () => void;
+  close: (reason?: unknown) => void;
 }
 
 export function streamSession(options: SessionStreamOptions): SessionStreamHandle {
@@ -199,7 +199,7 @@ export function streamSession(options: SessionStreamOptions): SessionStreamHandl
   })();
 
   return {
-    close: () => controller.abort(),
+    close: (reason?: unknown) => controller.abort(reason),
   };
 }
 

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-open.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-open.ts
@@ -26,7 +26,10 @@ import {
   isCurrentStreamHandle,
   shouldReconnectStream,
 } from "#product/hooks/sessions/lifecycle/session-runtime-helpers";
-import { createFlushAwareSessionStreamHandle } from "#product/hooks/sessions/lifecycle/session-stream-handle";
+import {
+  closeStaleSessionStreamHandle,
+  createFlushAwareSessionStreamHandle,
+} from "#product/hooks/sessions/lifecycle/session-stream-handle";
 import { createSessionStreamRefreshController } from "#product/hooks/sessions/lifecycle/session-stream-connection-refresh";
 import { scheduleSessionStreamReconnect } from "#product/hooks/sessions/lifecycle/session-stream-connection-reconnect";
 import type {
@@ -155,7 +158,7 @@ export async function openSessionStreamConnection({
     onHandle: (nextHandle) => {
       if (!isStillCurrent()) {
         logDevSessionRuntimeEvent(sessionId, "stream_handle_ignored_not_current", {});
-        nextHandle.close();
+        closeStaleSessionStreamHandle(nextHandle);
         return;
       }
       const flushAwareHandle = createFlushAwareSessionStreamHandle(

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-handle.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-handle.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionStreamHandle } from "@anyharness/sdk";
+import { isExpectedSessionStreamStaleCloseError } from "@proliferate/product-domain/telemetry/session-stream-stale-close";
+
+import { closeStaleSessionStreamHandle } from "#product/hooks/sessions/lifecycle/session-stream-handle";
+
+describe("closeStaleSessionStreamHandle", () => {
+  it("marks only the ownership boundary for stale connection cleanup", () => {
+    const close = vi.fn();
+    const handle: SessionStreamHandle = { close };
+
+    closeStaleSessionStreamHandle(handle);
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(isExpectedSessionStreamStaleCloseError(close.mock.calls[0]?.[0])).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-handle.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-handle.ts
@@ -1,6 +1,11 @@
 import type { SessionStreamHandle } from "@anyharness/sdk";
+import { createExpectedSessionStreamStaleCloseError } from "@proliferate/product-domain/telemetry/session-stream-stale-close";
 import type { FlushAwareSessionStreamHandle } from "#product/lib/workflows/sessions/session-runtime";
 import type { SessionStreamFlushController } from "#product/hooks/sessions/lifecycle/use-session-stream-flush";
+
+export function closeStaleSessionStreamHandle(handle: SessionStreamHandle): void {
+  handle.close(createExpectedSessionStreamStaleCloseError());
+}
 
 export function createFlushAwareSessionStreamHandle(
   handle: SessionStreamHandle,

--- a/apps/packages/product-domain/package.json
+++ b/apps/packages/product-domain/package.json
@@ -243,6 +243,10 @@
       "types": "./dist/telemetry/control-plane-probe-timeout.d.ts",
       "import": "./dist/telemetry/control-plane-probe-timeout.js"
     },
+    "./telemetry/session-stream-stale-close": {
+      "types": "./dist/telemetry/session-stream-stale-close.d.ts",
+      "import": "./dist/telemetry/session-stream-stale-close.js"
+    },
     "./repos/repo-id": {
       "types": "./dist/repos/repo-id.d.ts",
       "import": "./dist/repos/repo-id.js"

--- a/apps/packages/product-domain/src/telemetry/session-stream-stale-close.ts
+++ b/apps/packages/product-domain/src/telemetry/session-stream-stale-close.ts
@@ -1,0 +1,21 @@
+export const EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME =
+  "ProliferateExpectedSessionStreamStaleCloseError";
+
+export function createExpectedSessionStreamStaleCloseError(): Error {
+  const error = new Error("Stale session stream connection closed.");
+  error.name = EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME;
+  return error;
+}
+
+export function isExpectedSessionStreamStaleCloseError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  try {
+    return (error as { name?: unknown }).name
+      === EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/browser/telemetry/sentry-event-filter.test.ts
+++ b/apps/web/src/browser/telemetry/sentry-event-filter.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { ErrorEvent, EventHint, StackFrame } from "@sentry/react";
+import type { ErrorEvent, EventHint, Exception, StackFrame } from "@sentry/react";
 import {
   createExpectedControlPlaneProbeTimeoutError,
   EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
 } from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
+import {
+  createExpectedSessionStreamStaleCloseError,
+  EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME,
+} from "@proliferate/product-domain/telemetry/session-stream-stale-close";
 
 import { shouldDropExpectedWebSentryEvent } from "./sentry-event-filter";
 
@@ -17,27 +21,87 @@ function eventFor(
   value: string,
   frames: StackFrame[] = [],
 ): ErrorEvent {
+  const exception: Exception & { raw_stacktrace: { frames: StackFrame[] } } = {
+    mechanism: UNHANDLED_REJECTION,
+    raw_stacktrace: { frames },
+    type,
+    value,
+  };
   return {
     type: undefined,
     exception: {
-      values: [{
-        mechanism: UNHANDLED_REJECTION,
-        stacktrace: { frames },
-        type,
-        value,
-      }],
+      values: [exception],
     },
   };
 }
 
-const TANSTACK_OBSERVER_CANCEL_FRAMES: StackFrame[] = [
-  { function: "wL.setQueries" },
-  { function: "Object.batch" },
-  { function: "anonymous" },
-  { function: "bL.destroy" },
-  { function: "vL.removeObserver" },
-  { function: "Object.i [as cancel]" },
-  { function: "Object.onCancel" },
+function eventForProcessedStack(
+  type: string,
+  value: string,
+  frames: StackFrame[],
+): ErrorEvent {
+  const event = eventFor(type, value, frames);
+  const exception = event.exception!.values![0] as Exception & {
+    raw_stacktrace?: { frames: StackFrame[] };
+  };
+  delete exception.raw_stacktrace;
+  exception.stacktrace = { frames };
+  return event;
+}
+
+const TANSTACK_CANCELLATION_STACKS: { name: string; frames: StackFrame[] }[] = [
+  {
+    name: "queries observer teardown",
+    frames: [
+      { function: "wL.setQueries" },
+      { function: "Object.batch" },
+      { function: "anonymous" },
+      { function: "bL.destroy" },
+      { function: "vL.removeObserver" },
+      { function: "Object.i [as cancel]" },
+      { function: "Object.onCancel" },
+    ],
+  },
+  {
+    name: "observer options query replacement",
+    frames: [
+      { function: "bL.setOptions" },
+      { function: "bL.#updateQuery" },
+      { function: "vL.removeObserver" },
+      { function: "Object.i [as cancel]" },
+      { function: "Object.onCancel" },
+    ],
+  },
+  {
+    name: "terminal catalog refetch",
+    frames: [
+      { function: "bL.refetch" },
+      { function: "bL.fetch" },
+      { function: "vL.fetch" },
+      { function: "vL.cancel" },
+      { function: "Object.i [as cancel]" },
+      { function: "Object.onCancel" },
+    ],
+  },
+  {
+    name: "stream-side-effect invalidation refetch",
+    frames: [
+      { function: "qL.invalidateQueries" },
+      { function: "Object.batch" },
+      { function: "qL.refetchQueries" },
+      { function: "Object.batch" },
+      { function: "vL.fetch" },
+      { function: "vL.cancel" },
+      { function: "Object.i [as cancel]" },
+      { function: "Object.onCancel" },
+    ],
+  },
+];
+
+const STALE_SESSION_STREAM_CLOSE_FRAMES: StackFrame[] = [
+  { function: "openSessionStream" },
+  { function: "Object.onHandle" },
+  { function: "Object.close" },
 ];
 
 describe("shouldDropExpectedWebSentryEvent", () => {
@@ -55,14 +119,39 @@ describe("shouldDropExpectedWebSentryEvent", () => {
     expect(shouldDropExpectedWebSentryEvent(serializedEvent, {})).toBe(true);
   });
 
-  it("drops the exact TanStack observer cancellation stack", () => {
-    const event = eventFor(
+  it.each(TANSTACK_CANCELLATION_STACKS)("drops the exact $name raw stack", ({ frames }) => {
+    const event = eventFor("AbortError", "signal is aborted without reason", frames);
+
+    expect(shouldDropExpectedWebSentryEvent(event, {})).toBe(true);
+  });
+
+  it("keeps the browser stacktrace fallback for the original observer teardown", () => {
+    const event = eventForProcessedStack(
       "AbortError",
       "signal is aborted without reason",
-      TANSTACK_OBSERVER_CANCEL_FRAMES,
+      TANSTACK_CANCELLATION_STACKS[0]!.frames,
     );
 
     expect(shouldDropExpectedWebSentryEvent(event, {})).toBe(true);
+  });
+
+  it("drops source-marked stale session stream closes", () => {
+    const serializedEvent = eventFor(
+      EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME,
+      "Stale session stream connection closed.",
+      STALE_SESSION_STREAM_CLOSE_FRAMES,
+    );
+    const hintedEvent = eventFor(
+      "Error",
+      "Stale session stream connection closed.",
+      STALE_SESSION_STREAM_CLOSE_FRAMES,
+    );
+    const hint = {
+      originalException: createExpectedSessionStreamStaleCloseError(),
+    } satisfies EventHint;
+
+    expect(shouldDropExpectedWebSentryEvent(serializedEvent, {})).toBe(true);
+    expect(shouldDropExpectedWebSentryEvent(hintedEvent, hint)).toBe(true);
   });
 
   it("preserves generic probe and PostHog AbortErrors", () => {
@@ -88,11 +177,95 @@ describe("shouldDropExpectedWebSentryEvent", () => {
     expect(shouldDropExpectedWebSentryEvent(userAbort, {})).toBe(false);
   });
 
+  it("preserves same-named methods without a complete cancellation chain", () => {
+    const incompleteStacks: StackFrame[][] = [
+      TANSTACK_CANCELLATION_STACKS[0]!.frames.slice(1),
+      TANSTACK_CANCELLATION_STACKS[0]!.frames.filter(
+        (frame) => frame.function !== "Object.batch",
+      ),
+      TANSTACK_CANCELLATION_STACKS[0]!.frames.filter(
+        (frame) => frame.function !== "bL.destroy",
+      ),
+      TANSTACK_CANCELLATION_STACKS[1]!.frames.filter(
+        (frame) => frame.function !== "bL.setOptions",
+      ),
+      TANSTACK_CANCELLATION_STACKS[1]!.frames.filter(
+        (frame) => frame.function !== "vL.removeObserver",
+      ),
+      TANSTACK_CANCELLATION_STACKS[2]!.frames.filter(
+        (frame) => !frame.function?.endsWith(".fetch"),
+      ),
+      TANSTACK_CANCELLATION_STACKS[2]!.frames.filter(
+        (frame) => frame.function !== "vL.cancel",
+      ),
+      TANSTACK_CANCELLATION_STACKS[3]!.frames.filter(
+        (frame) => frame.function !== "qL.invalidateQueries",
+      ),
+      TANSTACK_CANCELLATION_STACKS[3]!.frames.filter(
+        (frame) => frame.function !== "qL.refetchQueries",
+      ),
+      TANSTACK_CANCELLATION_STACKS[3]!.frames.filter(
+        (frame) => frame.function !== "vL.cancel",
+      ),
+      [
+        ...TANSTACK_CANCELLATION_STACKS[3]!.frames,
+        { function: "transportFailure" },
+      ],
+      [
+        { function: "qL.refetchQueries" },
+        { function: "qL.invalidateQueries" },
+        { function: "vL.cancel" },
+        { function: "Object.i [as cancel]" },
+        { function: "Object.onCancel" },
+      ],
+      ...TANSTACK_CANCELLATION_STACKS.map(({ frames }) => frames.filter(
+        (frame) => frame.function !== "Object.i [as cancel]",
+      )),
+      ...TANSTACK_CANCELLATION_STACKS.map(({ frames }) => frames.filter(
+        (frame) => frame.function !== "Object.onCancel",
+      )),
+    ];
+
+    for (const frames of incompleteStacks) {
+      expect(shouldDropExpectedWebSentryEvent(eventFor(
+        "AbortError",
+        "signal is aborted without reason",
+        frames,
+      ), {})).toBe(false);
+    }
+  });
+
+  it("preserves real transport failures", () => {
+    const failedFetch = eventFor("TypeError", "Failed to fetch", [
+      { function: "fetch" },
+      { function: "request" },
+    ]);
+    const unmarkedStreamAbort = eventFor(
+      "AbortError",
+      "signal is aborted without reason",
+      STALE_SESSION_STREAM_CLOSE_FRAMES,
+    );
+    const refetchTransportAbort = eventFor(
+      "AbortError",
+      "signal is aborted without reason",
+      [
+        { function: "bL.refetch" },
+        { function: "bL.fetch" },
+        { function: "globalThis.fetch" },
+        { function: "request" },
+      ],
+    );
+
+    expect(shouldDropExpectedWebSentryEvent(failedFetch, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(unmarkedStreamAbort, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(refetchTransportAbort, {})).toBe(false);
+  });
+
   it("preserves handled errors and other failures with the same stack", () => {
     const handled = eventFor(
       "AbortError",
       "signal is aborted without reason",
-      TANSTACK_OBSERVER_CANCEL_FRAMES,
+      TANSTACK_CANCELLATION_STACKS[0]!.frames,
     );
     handled.exception!.values![0].mechanism = {
       handled: true,
@@ -101,7 +274,12 @@ describe("shouldDropExpectedWebSentryEvent", () => {
     const typeError = eventFor(
       "TypeError",
       "Request failed",
-      TANSTACK_OBSERVER_CANCEL_FRAMES,
+      TANSTACK_CANCELLATION_STACKS[0]!.frames,
+    );
+    const differentlyWordedAbort = eventFor(
+      "AbortError",
+      "The operation was aborted.",
+      TANSTACK_CANCELLATION_STACKS[0]!.frames,
     );
     const handledProbeTimeout = eventFor(
       EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
@@ -114,6 +292,7 @@ describe("shouldDropExpectedWebSentryEvent", () => {
 
     expect(shouldDropExpectedWebSentryEvent(handled, {})).toBe(false);
     expect(shouldDropExpectedWebSentryEvent(typeError, {})).toBe(false);
+    expect(shouldDropExpectedWebSentryEvent(differentlyWordedAbort, {})).toBe(false);
     expect(shouldDropExpectedWebSentryEvent(handledProbeTimeout, {})).toBe(false);
   });
 

--- a/apps/web/src/browser/telemetry/sentry-event-filter.ts
+++ b/apps/web/src/browser/telemetry/sentry-event-filter.ts
@@ -3,6 +3,10 @@ import {
   EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME,
   isExpectedControlPlaneProbeTimeoutError,
 } from "@proliferate/product-domain/telemetry/control-plane-probe-timeout";
+import {
+  EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME,
+  isExpectedSessionStreamStaleCloseError,
+} from "@proliferate/product-domain/telemetry/session-stream-stale-close";
 
 const UNHANDLED_REJECTION_MECHANISM =
   "auto.browser.global_handlers.onunhandledrejection";
@@ -21,23 +25,90 @@ function frameMatchesMethod(frame: StackFrame, method: string): boolean {
   if (!functionName) {
     return false;
   }
-  if (method === "cancel") {
-    return functionName.endsWith("[as cancel]");
-  }
   return functionName === method || functionName.endsWith(`.${method}`);
 }
 
-function findMethodAfter(
-  frames: StackFrame[],
-  method: string,
-  startIndex: number,
-): number {
-  return frames.findIndex((frame, index) => (
-    index >= startIndex && frameMatchesMethod(frame, method)
-  ));
+function frameMatchesRetryerCancel(frame: StackFrame): boolean {
+  return frame.function?.endsWith("[as cancel]") ?? false;
 }
 
-function hasExpectedTanStackObserverCancellation(
+type FramePredicate = (frame: StackFrame) => boolean;
+
+function hasOrderedFrameChain(
+  frames: StackFrame[],
+  predicates: FramePredicate[],
+): boolean {
+  let predicateIndex = 0;
+  for (const frame of frames) {
+    if (predicates[predicateIndex]?.(frame)) {
+      predicateIndex += 1;
+    }
+  }
+  return predicateIndex === predicates.length;
+}
+
+function hasExactFrameTail(
+  frames: StackFrame[],
+  predicates: FramePredicate[],
+): boolean {
+  if (frames.length < predicates.length) {
+    return false;
+  }
+  const tail = frames.slice(-predicates.length);
+  return predicates.every((predicate, index) => predicate(tail[index]));
+}
+
+const method = (name: string): FramePredicate =>
+  (frame) => frameMatchesMethod(frame, name);
+
+function hasExpectedQueriesObserverDestroyCancellation(
+  frames: StackFrame[],
+): boolean {
+  return hasOrderedFrameChain(frames, [method("setQueries"), method("batch")])
+    && hasExactFrameTail(frames, [
+      method("destroy"),
+      method("removeObserver"),
+      frameMatchesRetryerCancel,
+      method("onCancel"),
+    ]);
+}
+
+function hasExpectedObserverSetOptionsCancellation(
+  frames: StackFrame[],
+): boolean {
+  return hasOrderedFrameChain(frames, [method("setOptions"), method("removeObserver")])
+    && hasExactFrameTail(frames, [
+      method("removeObserver"),
+      frameMatchesRetryerCancel,
+      method("onCancel"),
+    ]);
+}
+
+function hasExpectedObserverRefetchCancellation(
+  frames: StackFrame[],
+): boolean {
+  return hasOrderedFrameChain(frames, [method("refetch"), method("fetch")])
+    && hasExactFrameTail(frames, [
+      method("cancel"),
+      frameMatchesRetryerCancel,
+      method("onCancel"),
+    ]);
+}
+
+function hasExpectedInvalidationRefetchCancellation(
+  frames: StackFrame[],
+): boolean {
+  return hasOrderedFrameChain(frames, [
+    method("invalidateQueries"),
+    method("refetchQueries"),
+  ]) && hasExactFrameTail(frames, [
+    method("cancel"),
+    frameMatchesRetryerCancel,
+    method("onCancel"),
+  ]);
+}
+
+function hasExpectedTanStackCancellation(
   exception: ExceptionWithRawStacktrace,
 ): boolean {
   if (
@@ -48,25 +119,15 @@ function hasExpectedTanStackObserverCancellation(
   }
 
   const frames = exception.raw_stacktrace?.frames ?? exception.stacktrace?.frames ?? [];
-  if (frames.length < 6) {
-    return false;
-  }
-
-  const setQueriesIndex = findMethodAfter(frames, "setQueries", 0);
-  const batchIndex = findMethodAfter(frames, "batch", setQueriesIndex + 1);
-  const tail = frames.slice(-4);
-
-  return setQueriesIndex >= 0
-    && batchIndex > setQueriesIndex
-    && frameMatchesMethod(tail[0], "destroy")
-    && frameMatchesMethod(tail[1], "removeObserver")
-    && frameMatchesMethod(tail[2], "cancel")
-    && frameMatchesMethod(tail[3], "onCancel");
+  return hasExpectedQueriesObserverDestroyCancellation(frames)
+    || hasExpectedObserverSetOptionsCancellation(frames)
+    || hasExpectedObserverRefetchCancellation(frames)
+    || hasExpectedInvalidationRefetchCancellation(frames);
 }
 
 /**
- * Drops only source-marked control-plane timeouts and the exact TanStack
- * observer teardown seen in hosted Web. Generic AbortErrors stay actionable.
+ * Drops only source-marked lifecycle cancellations and exact TanStack
+ * cancellation chains seen in hosted Web. Generic AbortErrors stay actionable.
  */
 export function shouldDropExpectedWebSentryEvent(
   event: ErrorEvent,
@@ -85,6 +146,11 @@ export function shouldDropExpectedWebSentryEvent(
   const isMarkedProbeTimeout =
     exception.type === EXPECTED_CONTROL_PLANE_PROBE_TIMEOUT_ERROR_NAME
     || isExpectedControlPlaneProbeTimeoutError(hint.originalException);
+  const isMarkedStaleSessionStreamClose =
+    exception.type === EXPECTED_SESSION_STREAM_STALE_CLOSE_ERROR_NAME
+    || isExpectedSessionStreamStaleCloseError(hint.originalException);
 
-  return isMarkedProbeTimeout || hasExpectedTanStackObserverCancellation(exception);
+  return isMarkedProbeTimeout
+    || isMarkedStaleSessionStreamClose
+    || hasExpectedTanStackCancellation(exception);
 }


### PR DESCRIPTION
## Summary

- classify only the proven TanStack lifecycle-cancellation stacks for query observer teardown, option replacement, explicit refetch, and invalidation refetch
- source-mark only the stale AnyHarness session-stream handle close while preserving ordinary close behavior
- keep generic AbortErrors, handled or mixed events, incomplete method chains, and transport failures reportable
- follow up on #1310 without widening its generic AbortError suppression

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] Tracker relationships are intentionally reserved for the coordinating root task. No tracker, report, user, support IDs, or private source data appear in this PR.

## Verification

- `pnpm --filter @anyharness/sdk exec vitest run src/streams/__tests__/sessions.test.ts --maxWorkers=1` (6 passed)
- `pnpm --filter @proliferate/product-client exec vitest run src/hooks/sessions/lifecycle/session-stream-handle.test.ts --maxWorkers=1` (1 passed)
- `pnpm --filter @proliferate/web exec vitest run src/browser/telemetry/sentry-event-filter.test.ts --maxWorkers=1` (13 passed)
- `pnpm --filter @anyharness/sdk typecheck`
- `pnpm --filter @anyharness/sdk typecheck:contracts`
- `pnpm --filter @proliferate/product-domain typecheck`
- `pnpm --filter @proliferate/product-client typecheck`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_anyharness_boundaries.py`
- `git diff --check`
- full remote checks are delegated to CI because the host resource ceiling precluded redundant workspace-wide local suites
