### PR TITLE
fix(integrations): enforce Slack OAuth scope ceiling

### DIFF
--- a/server/proliferate/integrations/integration_oauth/models.py
+++ b/server/proliferate/integrations/integration_oauth/models.py
@@ -35,4 +35,6 @@ class TokenResponse:
     access_token: str
     refresh_token: str | None
     expires_at: datetime | None
-    scopes: tuple[str, ...]
+    # ``None`` means the provider omitted scope metadata. An explicit empty
+    # value remains ``()`` so exact policies can distinguish the two cases.
+    scopes: tuple[str, ...] | None

--- a/server/proliferate/integrations/integration_oauth/tokens.py
+++ b/server/proliferate/integrations/integration_oauth/tokens.py
@@ -1,11 +1,35 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import httpx
 
 from proliferate.integrations.integration_oauth.errors import IntegrationOAuthProviderError
 from proliferate.integrations.integration_oauth.models import TokenResponse
+
+_SCOPE_SEPARATOR_RE = re.compile(r"[\s,]+")
+
+
+def _granted_scopes(payload: dict[str, Any]) -> tuple[str, ...] | None:
+    """Read standard or Slack user-token scope metadata from a token payload."""
+    raw_scope: object | None = payload.get("scope") if "scope" in payload else None
+    if "scope" not in payload:
+        authed_user = payload.get("authed_user")
+        if isinstance(authed_user, dict) and "scope" in authed_user:
+            raw_scope = authed_user.get("scope")
+        else:
+            return None
+    if not isinstance(raw_scope, str):
+        return ()
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for scope in _SCOPE_SEPARATOR_RE.split(raw_scope.strip()):
+        if scope and scope not in seen:
+            normalized.append(scope)
+            seen.add(scope)
+    return tuple(normalized)
 
 
 async def exchange_token(
@@ -112,10 +136,9 @@ async def _token_request(
         if isinstance(expires_in, int)
         else None
     )
-    scope = payload.get("scope")
     return TokenResponse(
         access_token=str(payload["access_token"]),
         refresh_token=payload.get("refresh_token"),
         expires_at=expires_at,
-        scopes=tuple(str(scope).split()) if scope else (),
+        scopes=_granted_scopes(payload),
     )

--- a/server/proliferate/server/cloud/integrations/access.py
+++ b/server/proliferate/server/cloud/integrations/access.py
@@ -34,6 +34,12 @@ from proliferate.server.cloud.integrations.config import (
     parse_definition_config,
     render_mcp_url,
 )
+from proliferate.server.cloud.integrations.oauth.scope_policy import (
+    OAuthScopePolicyError,
+    normalize_oauth_scopes,
+    resolve_refreshed_oauth_scopes,
+    validate_stored_oauth_scopes,
+)
 from proliferate.utils.crypto import decrypt_json, decrypt_text, encrypt_json
 from proliferate.utils.time import utcnow
 
@@ -199,6 +205,21 @@ def _parse_expires_at(raw: object) -> datetime | None:
     return value
 
 
+def _bundle_scopes(bundle: dict[str, Any]) -> tuple[str, ...]:
+    raw = bundle.get("scopes")
+    if isinstance(raw, str | list | tuple):
+        return normalize_oauth_scopes(raw)
+    return ()
+
+
+def _scope_policy_reauth() -> CloudApiError:
+    return CloudApiError(
+        "integration_reauth_required",
+        "Integration requires re-authentication.",
+        status_code=401,
+    )
+
+
 # --------------------------------------------------------------------------- #
 # OAuth token refresh
 # --------------------------------------------------------------------------- #
@@ -208,6 +229,7 @@ async def _refresh_oauth_bundle(
     *,
     account: IntegrationAccountRecord,
     bundle: dict[str, Any],
+    cfg: IntegrationConfig,
 ) -> tuple[str, datetime | None]:
     """Refresh the access token in ``bundle`` and persist the new credential.
 
@@ -273,7 +295,15 @@ async def _refresh_oauth_bundle(
         )
     new_refresh = token.refresh_token or refresh_value
     expires_at = _parse_expires_at(token.expires_at)
-    scopes = token.scopes or bundle.get("scopes", [])
+    try:
+        scopes = resolve_refreshed_oauth_scopes(
+            reported_scopes=token.scopes,
+            stored_scopes=_bundle_scopes(bundle),
+            configured_scopes=cfg.oauth_scopes,
+            scope_policy=cfg.oauth_scope_policy,
+        )
+    except OAuthScopePolicyError as exc:
+        raise _scope_policy_reauth() from exc
 
     new_bundle = {
         **bundle,
@@ -364,6 +394,14 @@ async def _oauth_access(
     settings: dict[str, Any],
 ) -> ProviderAccess:
     bundle = _decode_bundle(account)
+    try:
+        validate_stored_oauth_scopes(
+            stored_scopes=_bundle_scopes(bundle),
+            configured_scopes=cfg.oauth_scopes,
+            scope_policy=cfg.oauth_scope_policy,
+        )
+    except OAuthScopePolicyError as exc:
+        raise _scope_policy_reauth() from exc
     access_token = bundle.get("accessToken")
     expires_at = _parse_expires_at(bundle.get("expiresAt"))
     now = utcnow()
@@ -373,7 +411,7 @@ async def _oauth_access(
         resolved_expiry = expires_at
     else:
         resolved_token, resolved_expiry = await _refresh_oauth_bundle(
-            account=account, bundle=bundle
+            account=account, bundle=bundle, cfg=cfg
         )
 
     # Expose bundle string fields (plus the resolved access token) as secrets so

--- a/server/proliferate/server/cloud/integrations/config.py
+++ b/server/proliferate/server/cloud/integrations/config.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast, get_args
 
 Transport = Literal["http", "stdio"]
+OAuthScopePolicy = Literal["provider", "exact"]
 SettingKind = Literal["string", "boolean", "select", "url"]
 ArgKind = Literal["static", "workspace_path", "secret", "setting"]
 EnvKind = Literal["static", "secret", "setting"]
@@ -136,6 +137,7 @@ class IntegrationConfig:
     display_url: str = ""
     oauth_scopes: tuple[str, ...] = ()
     oauth_scopes_required: bool = False
+    oauth_scope_policy: OAuthScopePolicy = "provider"
     headers: tuple[HeaderTemplate, ...] = ()
     query: tuple[QueryTemplate, ...] = ()
     secret_fields: tuple[SecretField, ...] = ()
@@ -212,6 +214,7 @@ def serialize_definition_config(cfg: IntegrationConfig) -> str:
         "displayUrl": cfg.display_url,
         "oauthScopes": list(cfg.oauth_scopes),
         "oauthScopesRequired": cfg.oauth_scopes_required,
+        "oauthScopePolicy": cfg.oauth_scope_policy,
         "headers": [_header_to_json(h) for h in cfg.headers],
         "query": [_query_to_json(q) for q in cfg.query],
         "secretFields": [_secret_field_to_json(f) for f in cfg.secret_fields],
@@ -296,6 +299,13 @@ def _env_kind_from_json(raw: object) -> EnvKind:
     return cast(EnvKind, kind)
 
 
+def _oauth_scope_policy_from_json(raw: object) -> OAuthScopePolicy:
+    policy = str(raw)
+    if policy not in get_args(OAuthScopePolicy):
+        raise IntegrationConfigError(f"unsupported OAuth scope policy: {policy!r}")
+    return cast(OAuthScopePolicy, policy)
+
+
 def _setting_field_from_json(raw: dict[str, Any]) -> SettingField:
     options = tuple(
         SettingOption(value=str(o["value"]), label=str(o["label"])) for o in raw.get("options", ())
@@ -346,6 +356,7 @@ def parse_definition_config(config_json_str: str) -> IntegrationConfig:
         display_url=str(raw.get("displayUrl", "")),
         oauth_scopes=tuple(str(scope) for scope in raw.get("oauthScopes", ())),
         oauth_scopes_required=bool(raw.get("oauthScopesRequired", False)),
+        oauth_scope_policy=_oauth_scope_policy_from_json(raw.get("oauthScopePolicy", "provider")),
         headers=tuple(_header_from_json(h) for h in raw.get("headers", ())),
         query=tuple(_query_from_json(q) for q in raw.get("query", ())),
         secret_fields=tuple(_secret_field_from_json(f) for f in raw.get("secretFields", ())),

--- a/server/proliferate/server/cloud/integrations/oauth/scope_policy.py
+++ b/server/proliferate/server/cloud/integrations/oauth/scope_policy.py
@@ -1,0 +1,154 @@
+"""Pure OAuth scope-policy rules for hosted integration accounts."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+_SCOPE_SEPARATOR_RE = re.compile(r"[\s,]+")
+
+
+class OAuthScopePolicyError(ValueError):
+    """A provider scope response violated the configured integration policy."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def normalize_oauth_scopes(raw: str | Iterable[object] | None) -> tuple[str, ...]:
+    """Normalize comma/space-delimited scopes, preserving first-seen order."""
+    if raw is None:
+        return ()
+    values: Iterable[object] = (raw,) if isinstance(raw, str) else raw
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for scope in _SCOPE_SEPARATOR_RE.split(str(value).strip()):
+            if scope and scope not in seen:
+                normalized.append(scope)
+                seen.add(scope)
+    return tuple(normalized)
+
+
+def resolve_requested_oauth_scope(
+    *,
+    challenged_scope: str | None,
+    configured_scopes: tuple[str, ...],
+    scopes_required: bool,
+    scope_policy: str,
+) -> str | None:
+    """Resolve the authorization scope without letting exact policies widen."""
+    if scope_policy == "exact":
+        configured = normalize_oauth_scopes(configured_scopes)
+        challenge = normalize_oauth_scopes(challenged_scope)
+        if not configured:
+            if scopes_required:
+                raise OAuthScopePolicyError(
+                    "missing_oauth_scope",
+                    "This integration requires OAuth scopes, but none were configured.",
+                )
+            return None
+        unexpected = set(challenge) - set(configured)
+        if unexpected:
+            raise OAuthScopePolicyError(
+                "oauth_scope_escalation",
+                "OAuth provider requested scopes outside the configured ceiling.",
+            )
+        return " ".join(configured)
+
+    challenge_value = (challenged_scope or "").strip()
+    if challenge_value:
+        return challenge_value
+    configured_value = " ".join(scope.strip() for scope in configured_scopes if scope.strip())
+    if configured_value:
+        return configured_value
+    if scopes_required:
+        raise OAuthScopePolicyError(
+            "missing_oauth_scope",
+            "This integration requires OAuth scopes, but none were provided.",
+        )
+    return None
+
+
+def validate_callback_oauth_scopes(
+    *,
+    granted_scopes: tuple[str, ...] | None,
+    requested_scopes: tuple[str, ...],
+    configured_scopes: tuple[str, ...],
+    scope_policy: str,
+) -> tuple[str, ...]:
+    """Validate a token grant before credentials become usable."""
+    granted = normalize_oauth_scopes(granted_scopes)
+    if scope_policy != "exact":
+        return granted
+
+    configured = normalize_oauth_scopes(configured_scopes)
+    requested = normalize_oauth_scopes(requested_scopes)
+    if (
+        granted_scopes is None
+        or set(requested) != set(configured)
+        or set(granted) != set(configured)
+    ):
+        raise OAuthScopePolicyError(
+            "oauth_scope_mismatch",
+            "OAuth provider did not grant the exact configured scopes.",
+        )
+    return configured
+
+
+def validate_stored_oauth_scopes(
+    *,
+    stored_scopes: tuple[str, ...],
+    configured_scopes: tuple[str, ...],
+    scope_policy: str,
+) -> tuple[str, ...]:
+    """Reject credentials known to exceed an exact scope ceiling.
+
+    Empty or partial legacy metadata remains usable: it cannot prove excess
+    privilege and existing read-only Slack accounts must keep search working.
+    """
+    stored = normalize_oauth_scopes(stored_scopes)
+    if scope_policy == "exact":
+        configured = normalize_oauth_scopes(configured_scopes)
+        stored_set = set(stored)
+        if stored_set - set(configured):
+            raise OAuthScopePolicyError(
+                "oauth_scope_mismatch",
+                "Stored OAuth scopes exceed the configured ceiling.",
+            )
+        return tuple(scope for scope in configured if scope in stored_set)
+    return stored
+
+
+def resolve_refreshed_oauth_scopes(
+    *,
+    reported_scopes: tuple[str, ...] | None,
+    stored_scopes: tuple[str, ...],
+    configured_scopes: tuple[str, ...],
+    scope_policy: str,
+) -> tuple[str, ...]:
+    """Resolve refresh scopes, distinguishing omission from an empty grant."""
+    stored = validate_stored_oauth_scopes(
+        stored_scopes=stored_scopes,
+        configured_scopes=configured_scopes,
+        scope_policy=scope_policy,
+    )
+    if reported_scopes is None:
+        return stored
+
+    reported = normalize_oauth_scopes(reported_scopes)
+    if scope_policy != "exact":
+        # Preserve the former provider-directed refresh behavior, which used
+        # the stored scopes whenever the refreshed value was falsey.
+        return reported or stored
+
+    configured = normalize_oauth_scopes(configured_scopes)
+    reported_set = set(reported)
+    if not reported or reported_set - set(configured):
+        raise OAuthScopePolicyError(
+            "oauth_scope_mismatch",
+            "OAuth provider returned an invalid scope set for the configured ceiling.",
+        )
+    return tuple(scope for scope in configured if scope in reported_set)

--- a/server/proliferate/server/cloud/integrations/oauth/service.py
+++ b/server/proliferate/server/cloud/integrations/oauth/service.py
@@ -26,7 +26,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings as app_settings
 from proliferate.db.store.integrations.accounts import set_account_credentials
-from proliferate.db.store.integrations.definitions import IntegrationDefinitionRecord
+from proliferate.db.store.integrations.definitions import (
+    IntegrationDefinitionRecord,
+    get_definition,
+)
 from proliferate.db.store.integrations.oauth_clients import (
     delete_oauth_client,
     get_oauth_client,
@@ -54,6 +57,13 @@ from proliferate.integrations.integration_oauth import (
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integrations.config import parse_definition_config, render_mcp_url
 from proliferate.server.cloud.integrations.oauth.clients import resolve_oauth_client
+from proliferate.server.cloud.integrations.oauth.scope_policy import (
+    OAuthScopePolicyError,
+    validate_callback_oauth_scopes,
+)
+from proliferate.server.cloud.integrations.oauth.scope_policy import (
+    resolve_requested_oauth_scope as resolve_scope_policy,
+)
 from proliferate.utils.crypto import decrypt_text, encrypt_json, encrypt_text
 
 # Callback path appended to the API base URL for the shared OAuth callback.
@@ -129,25 +139,28 @@ def _resolve_requested_oauth_scope(
     challenged_scope: str | None,
     configured_scopes: tuple[str, ...],
     scopes_required: bool,
+    scope_policy: str = "provider",
 ) -> str | None:
-    challenge = (challenged_scope or "").strip()
-    if challenge:
-        return challenge
-
-    configured = " ".join(scope.strip() for scope in configured_scopes if scope.strip())
-    if configured:
-        return configured
-
-    if scopes_required:
-        raise IntegrationOAuthProviderError(
-            "missing_oauth_scope",
-            "This integration requires OAuth scopes, but none were provided.",
+    try:
+        return resolve_scope_policy(
+            challenged_scope=challenged_scope,
+            configured_scopes=configured_scopes,
+            scopes_required=scopes_required,
+            scope_policy=scope_policy,
         )
-    return None
+    except OAuthScopePolicyError as exc:
+        raise IntegrationOAuthProviderError(exc.code, exc.message) from exc
 
 
 def _requested_scopes_json(requested_scope: str | None) -> str:
     return json.dumps(requested_scope.split() if requested_scope else [])
+
+
+def _parse_requested_scopes(requested_scopes_json: str) -> tuple[str, ...]:
+    raw = json.loads(requested_scopes_json)
+    if not isinstance(raw, list) or not all(isinstance(scope, str) for scope in raw):
+        raise ValueError("OAuth flow has invalid requested scope metadata.")
+    return tuple(raw)
 
 
 def _should_drop_cached_oauth_client_on_token_error(error_code: str) -> bool:
@@ -293,6 +306,7 @@ async def start_oauth_flow(
             challenged_scope=protected.challenged_scope,
             configured_scopes=config.oauth_scopes,
             scopes_required=config.oauth_scopes_required,
+            scope_policy=config.oauth_scope_policy,
         )
         issuer = protected.authorization_servers[0]
         auth_metadata = await discover_authorization_server_metadata(issuer)
@@ -443,6 +457,16 @@ async def complete_oauth_callback(
         failed = await fail_oauth_flow(db, flow_id=flow.id, failure_code="account_missing") or flow
         return _callback_result(failed, ok=False, status="failed")
 
+    definition = await get_definition(db, flow.definition_id)
+    try:
+        if definition is None:
+            raise ValueError("OAuth flow definition is missing.")
+        config = parse_definition_config(definition.config_json)
+        requested_scopes = _parse_requested_scopes(flow.requested_scopes)
+    except (json.JSONDecodeError, ValueError):
+        failed = await fail_oauth_flow(db, flow_id=flow.id, failure_code="invalid_flow") or flow
+        return _callback_result(failed, ok=False, status="failed")
+
     oauth_client = await get_oauth_client(
         db,
         issuer=flow.issuer or "",
@@ -474,6 +498,17 @@ async def complete_oauth_callback(
         failed = await fail_oauth_flow(db, flow_id=flow.id, failure_code=exc.code) or flow
         return _callback_result(failed, ok=False, status="failed")
 
+    try:
+        granted_scopes = validate_callback_oauth_scopes(
+            granted_scopes=token.scopes,
+            requested_scopes=requested_scopes,
+            configured_scopes=config.oauth_scopes,
+            scope_policy=config.oauth_scope_policy,
+        )
+    except OAuthScopePolicyError as exc:
+        failed = await fail_oauth_flow(db, flow_id=flow.id, failure_code=exc.code) or flow
+        return _callback_result(failed, ok=False, status="failed")
+
     await set_account_credentials(
         db,
         account_id=flow.account_id,
@@ -485,7 +520,7 @@ async def complete_oauth_callback(
                 access_token=token.access_token,
                 refresh_token=token.refresh_token,
                 expires_at=token.expires_at,
-                scopes=token.scopes,
+                scopes=granted_scopes,
                 token_endpoint=flow.token_endpoint,
                 redirect_uri=flow.redirect_uri,
             )

--- a/server/proliferate/server/cloud/integrations/seeds.py
+++ b/server/proliferate/server/cloud/integrations/seeds.py
@@ -292,6 +292,7 @@ SEED_DEFINITIONS: tuple[SeedDefinition, ...] = (
                 "search:read.users",
             ),
             oauth_scopes_required=True,
+            oauth_scope_policy="exact",
             headers=(_oauth_bearer_header(),),
         ),
     ),

--- a/server/tests/integration/test_cloud_integrations_api.py
+++ b/server/tests/integration/test_cloud_integrations_api.py
@@ -347,6 +347,36 @@ class TestAuthenticateIntegration:
         assert persisted_flow is not None
         assert json.loads(persisted_flow.requested_scopes) == list(expected_scopes)
 
+    @pytest.mark.asyncio
+    async def test_authenticate_slack_rejects_scope_challenge_above_ceiling(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        auth = await _authed_user(client, db_session, prefix="int-oauth-slack-escalation")
+        await _seed_definitions(db_session)
+        definition_id = await _definition_id(db_session, "slack")
+
+        async def _fake_protected(server_url: str) -> ProtectedResourceMetadata:
+            assert server_url == "https://mcp.slack.com/mcp"
+            return ProtectedResourceMetadata(
+                authorization_servers=("https://auth.example.com",),
+                resource="https://mcp.slack.com/mcp",
+                challenged_scope="search:read.public chat:write",
+            )
+
+        monkeypatch.setattr(oauth_service, "discover_protected_resource_metadata", _fake_protected)
+
+        response = await client.post(
+            "/v1/cloud/integrations/authentications",
+            headers=auth.headers,
+            json={"definitionId": definition_id, "authKind": "oauth2"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "oauth_scope_escalation"
+
 
 class TestRemoveAccount:
     @pytest.mark.asyncio

--- a/server/tests/integration/test_integration_oauth_scope_policy.py
+++ b/server/tests/integration/test_integration_oauth_scope_policy.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import uuid
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.integrations.integration_oauth.models import (
+    AuthorizationServerMetadata,
+    ProtectedResourceMetadata,
+    TokenResponse,
+)
+from proliferate.server.cloud.integrations.oauth import clients as oauth_clients
+from proliferate.server.cloud.integrations.oauth import service as oauth_service
+from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
+from proliferate.utils.crypto import decrypt_json
+from tests.e2e.cloud.helpers.auth import create_user_and_login
+from tests.e2e.cloud.helpers.github import seed_linked_github_account
+from tests.e2e.cloud.helpers.shared import AuthSession
+
+SLACK_SCOPES = (
+    "search:read.public",
+    "search:read.private",
+    "search:read.im",
+    "search:read.mpim",
+    "search:read.files",
+    "search:read.users",
+)
+
+
+async def _start_slack_flow(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[AuthSession, dict[str, object], str]:
+    prefix = f"oauth-scope-{uuid.uuid4().hex}"
+    auth = await create_user_and_login(client, db_session, email_prefix=prefix)
+    await seed_linked_github_account(
+        db_session,
+        user_id=auth.user_id,
+        access_token=f"gh-{prefix}",
+    )
+    await sync_seed_definitions(db_session)
+    await db_session.commit()
+    definition = await definitions_store.get_seed_by_namespace(db_session, "slack")
+    assert definition is not None
+
+    monkeypatch.setattr(oauth_clients.app_settings, "cloud_mcp_slack_enabled", True)
+    monkeypatch.setattr(oauth_clients.app_settings, "cloud_mcp_slack_client_id", "slack-client")
+    monkeypatch.setattr(
+        oauth_clients.app_settings,
+        "cloud_mcp_slack_client_secret",
+        "slack-client-secret",
+    )
+    monkeypatch.setattr(
+        oauth_clients.app_settings,
+        "cloud_mcp_slack_token_endpoint_auth_method",
+        "client_secret_post",
+    )
+
+    async def _protected(_server_url: str) -> ProtectedResourceMetadata:
+        return ProtectedResourceMetadata(
+            authorization_servers=("https://slack.com",),
+            resource="https://mcp.slack.com/mcp",
+            challenged_scope=None,
+        )
+
+    async def _auth_metadata(issuer: str) -> AuthorizationServerMetadata:
+        return AuthorizationServerMetadata(
+            issuer=issuer,
+            authorization_endpoint="https://slack.com/oauth/v2_user/authorize",
+            token_endpoint="https://slack.com/api/oauth.v2.user.access",
+            registration_endpoint=None,
+            token_endpoint_auth_methods_supported=("client_secret_post",),
+        )
+
+    monkeypatch.setattr(oauth_service, "discover_protected_resource_metadata", _protected)
+    monkeypatch.setattr(oauth_service, "discover_authorization_server_metadata", _auth_metadata)
+
+    response = await client.post(
+        "/v1/cloud/integrations/authentications",
+        headers=auth.headers,
+        json={"definitionId": str(definition.id), "authKind": "oauth2"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    state = parse_qs(urlsplit(body["authorizationUrl"]).query)["state"][0]
+    return auth, body, state
+
+
+@pytest.mark.asyncio
+async def test_slack_http_callback_persists_only_exact_scope_grant(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth, started, state = await _start_slack_flow(client, db_session, monkeypatch)
+
+    async def _exchange_token(**_kwargs: object) -> TokenResponse:
+        return TokenResponse(
+            access_token="access-token",
+            refresh_token="refresh-token",
+            expires_at=None,
+            scopes=tuple(reversed(SLACK_SCOPES)),
+        )
+
+    monkeypatch.setattr(oauth_service, "exchange_token", _exchange_token)
+
+    callback = await client.get(
+        "/v1/cloud/integrations/oauth/callback",
+        params={"state": state, "code": "authorization-code"},
+    )
+    assert callback.status_code == 200
+
+    flow = await client.get(
+        f"/v1/cloud/integrations/oauth/flows/{started['oauthFlowId']}",
+        headers=auth.headers,
+    )
+    assert flow.status_code == 200
+    assert flow.json()["status"] == "completed"
+
+    await db_session.rollback()
+    account = await accounts_store.get_account(
+        db_session, uuid.UUID(str(started["account"]["accountId"]))
+    )
+    assert account is not None
+    assert account.status == "ready"
+    assert account.credential_ciphertext is not None
+    assert decrypt_json(account.credential_ciphertext)["scopes"] == list(SLACK_SCOPES)
+
+
+@pytest.mark.parametrize(
+    "granted_scopes",
+    [None, (), SLACK_SCOPES[:-1], (*SLACK_SCOPES, "chat:write")],
+)
+@pytest.mark.asyncio
+async def test_slack_http_callback_rejects_invalid_scope_grant(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    granted_scopes: tuple[str, ...] | None,
+) -> None:
+    auth, started, state = await _start_slack_flow(client, db_session, monkeypatch)
+
+    async def _exchange_token(**_kwargs: object) -> TokenResponse:
+        return TokenResponse(
+            access_token="access-token",
+            refresh_token="refresh-token",
+            expires_at=None,
+            scopes=granted_scopes,
+        )
+
+    monkeypatch.setattr(oauth_service, "exchange_token", _exchange_token)
+
+    callback = await client.get(
+        "/v1/cloud/integrations/oauth/callback",
+        params={"state": state, "code": "authorization-code"},
+    )
+    assert callback.status_code == 200
+
+    flow = await client.get(
+        f"/v1/cloud/integrations/oauth/flows/{started['oauthFlowId']}",
+        headers=auth.headers,
+    )
+    assert flow.status_code == 200
+    assert flow.json()["status"] == "failed"
+    assert flow.json()["failureCode"] == "oauth_scope_mismatch"
+
+    await db_session.rollback()
+    account = await accounts_store.get_account(
+        db_session, uuid.UUID(str(started["account"]["accountId"]))
+    )
+    assert account is not None
+    assert account.status == "setup_required"
+    assert account.credential_ciphertext is None

--- a/server/tests/integration/test_integration_provider_access.py
+++ b/server/tests/integration/test_integration_provider_access.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.models.auth import User
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.integrations.integration_oauth.models import TokenResponse
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations import access as integration_access
 from proliferate.server.cloud.integrations.access import ensure_provider_access
 from proliferate.server.cloud.integrations.config import (
     IntegrationConfig,
@@ -15,7 +20,16 @@ from proliferate.server.cloud.integrations.config import (
     serialize_definition_config,
 )
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
-from proliferate.utils.crypto import encrypt_json
+from proliferate.utils.crypto import decrypt_json, encrypt_json
+
+SLACK_SCOPES = (
+    "search:read.public",
+    "search:read.private",
+    "search:read.im",
+    "search:read.mpim",
+    "search:read.files",
+    "search:read.users",
+)
 
 
 @pytest.mark.asyncio
@@ -161,6 +175,214 @@ async def test_oauth_access_uses_unexpired_access_token(db_session: AsyncSession
         db_session, account_record=account, definition_record=definition
     )
     assert access.headers.get("Authorization") == "Bearer linear-access-token"
+
+
+@pytest.mark.asyncio
+async def test_slack_access_keeps_legacy_empty_scope_metadata_usable(
+    db_session: AsyncSession,
+) -> None:
+    bundle = {
+        "issuer": "https://slack.com",
+        "resource": "https://mcp.slack.com/mcp",
+        "clientId": "slack-client",
+        "accessToken": "slack-access-token",
+        "refreshToken": "slack-refresh-token",
+        "expiresAt": None,
+        "scopes": [],
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
+    }
+    definition, account = await _account_for(
+        db_session,
+        namespace="slack",
+        auth_kind="oauth2",
+        credential_ciphertext=encrypt_json(bundle),
+        credential_format="oauth-bundle-v1",
+    )
+
+    access = await ensure_provider_access(
+        db_session, account_record=account, definition_record=definition
+    )
+
+    assert access.headers.get("Authorization") == "Bearer slack-access-token"
+
+
+@pytest.mark.asyncio
+async def test_slack_refresh_preserves_scopes_when_provider_omits_them(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = {
+        "issuer": "https://slack.com",
+        "resource": "https://mcp.slack.com/mcp",
+        "clientId": "slack-client",
+        "accessToken": "expired-access-token",
+        "refreshToken": "slack-refresh-token",
+        "expiresAt": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+        "scopes": list(SLACK_SCOPES),
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
+    }
+    definition, account = await _account_for(
+        db_session,
+        namespace="slack",
+        auth_kind="oauth2",
+        credential_ciphertext=encrypt_json(bundle),
+        credential_format="oauth-bundle-v1",
+    )
+
+    async def _refresh_token(**_kwargs: object) -> TokenResponse:
+        return TokenResponse(
+            access_token="replacement-access-token",
+            refresh_token=None,
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            scopes=None,
+        )
+
+    monkeypatch.setattr(integration_access, "refresh_token", _refresh_token)
+
+    access = await ensure_provider_access(
+        db_session, account_record=account, definition_record=definition
+    )
+
+    assert access.headers.get("Authorization") == "Bearer replacement-access-token"
+    await db_session.rollback()
+    refreshed = await accounts_store.get_account(db_session, account.id)
+    assert refreshed is not None
+    assert refreshed.credential_ciphertext is not None
+    refreshed_bundle = decrypt_json(refreshed.credential_ciphertext)
+    assert refreshed_bundle["scopes"] == list(SLACK_SCOPES)
+    assert refreshed_bundle["accessToken"] == "replacement-access-token"
+
+
+@pytest.mark.asyncio
+async def test_slack_refresh_accepts_nonempty_scope_subset_below_ceiling(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = {
+        "issuer": "https://slack.com",
+        "resource": "https://mcp.slack.com/mcp",
+        "clientId": "slack-client",
+        "accessToken": "expired-access-token",
+        "refreshToken": "slack-refresh-token",
+        "expiresAt": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+        "scopes": list(SLACK_SCOPES),
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
+    }
+    definition, account = await _account_for(
+        db_session,
+        namespace="slack",
+        auth_kind="oauth2",
+        credential_ciphertext=encrypt_json(bundle),
+        credential_format="oauth-bundle-v1",
+    )
+
+    async def _refresh_token(**_kwargs: object) -> TokenResponse:
+        return TokenResponse(
+            access_token="subset-access-token",
+            refresh_token=None,
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            scopes=("search:read.private", "search:read.public"),
+        )
+
+    monkeypatch.setattr(integration_access, "refresh_token", _refresh_token)
+
+    access = await ensure_provider_access(
+        db_session, account_record=account, definition_record=definition
+    )
+
+    assert access.headers.get("Authorization") == "Bearer subset-access-token"
+    await db_session.rollback()
+    refreshed = await accounts_store.get_account(db_session, account.id)
+    assert refreshed is not None
+    assert refreshed.credential_ciphertext is not None
+    refreshed_bundle = decrypt_json(refreshed.credential_ciphertext)
+    assert refreshed_bundle["scopes"] == ["search:read.public", "search:read.private"]
+
+
+@pytest.mark.asyncio
+async def test_slack_refresh_rejects_reported_scope_above_ceiling_without_persisting(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = {
+        "issuer": "https://slack.com",
+        "resource": "https://mcp.slack.com/mcp",
+        "clientId": "slack-client",
+        "accessToken": "expired-access-token",
+        "refreshToken": "slack-refresh-token",
+        "expiresAt": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+        "scopes": list(SLACK_SCOPES),
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
+    }
+    definition, account = await _account_for(
+        db_session,
+        namespace="slack",
+        auth_kind="oauth2",
+        credential_ciphertext=encrypt_json(bundle),
+        credential_format="oauth-bundle-v1",
+    )
+    original_ciphertext = account.credential_ciphertext
+    original_auth_version = account.auth_version
+
+    async def _refresh_token(**_kwargs: object) -> TokenResponse:
+        return TokenResponse(
+            access_token="over-scoped-access-token",
+            refresh_token="rotated-refresh-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            scopes=(*SLACK_SCOPES, "chat:write"),
+        )
+
+    monkeypatch.setattr(integration_access, "refresh_token", _refresh_token)
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await ensure_provider_access(
+            db_session, account_record=account, definition_record=definition
+        )
+
+    assert exc_info.value.code == "integration_reauth_required"
+    await db_session.rollback()
+    unchanged = await accounts_store.get_account(db_session, account.id)
+    assert unchanged is not None
+    assert unchanged.credential_ciphertext == original_ciphertext
+    assert unchanged.auth_version == original_auth_version
+
+
+@pytest.mark.asyncio
+async def test_slack_access_rejects_known_stored_scope_above_ceiling(
+    db_session: AsyncSession,
+) -> None:
+    bundle = {
+        "issuer": "https://slack.com",
+        "resource": "https://mcp.slack.com/mcp",
+        "clientId": "slack-client",
+        "accessToken": "over-scoped-access-token",
+        "refreshToken": "slack-refresh-token",
+        "expiresAt": None,
+        "scopes": [*SLACK_SCOPES, "chat:write"],
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
+    }
+    definition, account = await _account_for(
+        db_session,
+        namespace="slack",
+        auth_kind="oauth2",
+        credential_ciphertext=encrypt_json(bundle),
+        credential_format="oauth-bundle-v1",
+    )
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await ensure_provider_access(
+            db_session, account_record=account, definition_record=definition
+        )
+
+    assert exc_info.value.code == "integration_reauth_required"
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_cloud_integration_oauth.py
+++ b/server/tests/unit/test_cloud_integration_oauth.py
@@ -55,6 +55,29 @@ def test_oauth_scope_uses_configured_fallback_once() -> None:
     assert _authorization_scope(requested_scope) == ["search:read.public search:read.private"]
 
 
+def test_exact_oauth_scope_uses_configured_ceiling_for_subset_challenge() -> None:
+    requested_scope = _resolve_requested_oauth_scope(
+        challenged_scope="search:read.public",
+        configured_scopes=("search:read.public", "search:read.private"),
+        scopes_required=True,
+        scope_policy="exact",
+    )
+
+    assert requested_scope == "search:read.public search:read.private"
+
+
+def test_exact_oauth_scope_rejects_provider_escalation() -> None:
+    with pytest.raises(IntegrationOAuthProviderError) as exc_info:
+        _resolve_requested_oauth_scope(
+            challenged_scope="search:read.public chat:write",
+            configured_scopes=("search:read.public", "search:read.private"),
+            scopes_required=True,
+            scope_policy="exact",
+        )
+
+    assert exc_info.value.code == "oauth_scope_escalation"
+
+
 def test_oauth_scope_remains_optional_for_generic_providers() -> None:
     requested_scope = _resolve_requested_oauth_scope(
         challenged_scope=None,

--- a/server/tests/unit/test_cloud_integration_oauth_scope_policy.py
+++ b/server/tests/unit/test_cloud_integration_oauth_scope_policy.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+
+from proliferate.server.cloud.integrations.oauth.scope_policy import (
+    OAuthScopePolicyError,
+    resolve_refreshed_oauth_scopes,
+    validate_callback_oauth_scopes,
+    validate_stored_oauth_scopes,
+)
+
+CONFIGURED = ("search:read.public", "search:read.private")
+
+
+def test_exact_callback_accepts_same_scope_set_in_provider_order() -> None:
+    assert (
+        validate_callback_oauth_scopes(
+            granted_scopes=("search:read.private", "search:read.public"),
+            requested_scopes=CONFIGURED,
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+        == CONFIGURED
+    )
+
+
+@pytest.mark.parametrize(
+    "granted_scopes",
+    [None, (), ("search:read.public",), (*CONFIGURED, "chat:write")],
+)
+def test_exact_callback_rejects_missing_partial_or_extra_grant(
+    granted_scopes: tuple[str, ...] | None,
+) -> None:
+    with pytest.raises(OAuthScopePolicyError) as exc_info:
+        validate_callback_oauth_scopes(
+            granted_scopes=granted_scopes,
+            requested_scopes=CONFIGURED,
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+
+    assert exc_info.value.code == "oauth_scope_mismatch"
+
+
+def test_exact_callback_rejects_configuration_change_during_flow() -> None:
+    with pytest.raises(OAuthScopePolicyError, match="exact configured scopes"):
+        validate_callback_oauth_scopes(
+            granted_scopes=CONFIGURED,
+            requested_scopes=("search:read.public",),
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+
+
+def test_refresh_omission_preserves_legacy_empty_scope_metadata() -> None:
+    assert (
+        resolve_refreshed_oauth_scopes(
+            reported_scopes=None,
+            stored_scopes=(),
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+        == ()
+    )
+
+
+def test_refresh_omission_preserves_known_scope_metadata() -> None:
+    assert (
+        resolve_refreshed_oauth_scopes(
+            reported_scopes=None,
+            stored_scopes=CONFIGURED,
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+        == CONFIGURED
+    )
+
+
+@pytest.mark.parametrize(
+    "reported_scopes",
+    [(), (*CONFIGURED, "chat:write")],
+)
+def test_exact_refresh_rejects_empty_or_scope_above_ceiling(
+    reported_scopes: tuple[str, ...],
+) -> None:
+    with pytest.raises(OAuthScopePolicyError) as exc_info:
+        resolve_refreshed_oauth_scopes(
+            reported_scopes=reported_scopes,
+            stored_scopes=CONFIGURED,
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+
+    assert exc_info.value.code == "oauth_scope_mismatch"
+
+
+def test_exact_refresh_accepts_nonempty_subset_in_canonical_order() -> None:
+    assert resolve_refreshed_oauth_scopes(
+        reported_scopes=("search:read.private",),
+        stored_scopes=CONFIGURED,
+        configured_scopes=CONFIGURED,
+        scope_policy="exact",
+    ) == ("search:read.private",)
+
+
+def test_exact_access_rejects_known_stored_scope_outside_ceiling() -> None:
+    with pytest.raises(OAuthScopePolicyError) as exc_info:
+        validate_stored_oauth_scopes(
+            stored_scopes=(*CONFIGURED, "chat:write"),
+            configured_scopes=CONFIGURED,
+            scope_policy="exact",
+        )
+
+    assert exc_info.value.code == "oauth_scope_mismatch"
+
+
+def test_provider_policy_preserves_existing_scope_behavior() -> None:
+    assert validate_callback_oauth_scopes(
+        granted_scopes=("provider:write",),
+        requested_scopes=("provider:read",),
+        configured_scopes=("configured:read",),
+        scope_policy="provider",
+    ) == ("provider:write",)
+    assert resolve_refreshed_oauth_scopes(
+        reported_scopes=None,
+        stored_scopes=("provider:write",),
+        configured_scopes=("configured:read",),
+        scope_policy="provider",
+    ) == ("provider:write",)
+    assert resolve_refreshed_oauth_scopes(
+        reported_scopes=(),
+        stored_scopes=("provider:write",),
+        configured_scopes=("configured:read",),
+        scope_policy="provider",
+    ) == ("provider:write",)

--- a/server/tests/unit/test_integration_config.py
+++ b/server/tests/unit/test_integration_config.py
@@ -57,10 +57,21 @@ def test_slack_seed_has_exact_required_oauth_scopes() -> None:
 
     assert slack.config.oauth_scopes == expected_scopes
     assert slack.config.oauth_scopes_required is True
+    assert slack.config.oauth_scope_policy == "exact"
 
     reparsed = parse_definition_config(serialize_definition_config(slack.config))
     assert reparsed.oauth_scopes == expected_scopes
     assert reparsed.oauth_scopes_required is True
+    assert reparsed.oauth_scope_policy == "exact"
+
+
+def test_parse_rejects_unknown_oauth_scope_policy() -> None:
+    with pytest.raises(IntegrationConfigError, match="unsupported OAuth scope policy"):
+        parse_definition_config('{"oauthScopePolicy":"provider-controlled"}')
+
+
+def test_legacy_config_defaults_to_provider_scope_policy() -> None:
+    assert parse_definition_config("{}").oauth_scope_policy == "provider"
 
 
 def test_parse_rejects_malformed_config() -> None:

--- a/server/tests/unit/test_integration_oauth_tokens.py
+++ b/server/tests/unit/test_integration_oauth_tokens.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from proliferate.integrations.integration_oauth.tokens import _granted_scopes
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"scope": "one two"}, ("one", "two")),
+        ({"scope": "one,two"}, ("one", "two")),
+        ({"scope": "one, two one"}, ("one", "two")),
+        (
+            {"authed_user": {"scope": "search:read.public,search:read.private"}},
+            ("search:read.public", "search:read.private"),
+        ),
+        ({"scope": "top", "authed_user": {"scope": "nested"}}, ("top",)),
+        ({"scope": ""}, ()),
+        ({"authed_user": {"scope": ""}}, ()),
+        ({}, None),
+    ],
+)
+def test_granted_scopes_normalizes_standard_and_slack_payloads(
+    payload: dict[str, object], expected: tuple[str, ...] | None
+) -> None:
+    assert _granted_scopes(payload) == expected

--- a/specs/codebase/platforms/product/integrations.md
+++ b/specs/codebase/platforms/product/integrations.md
@@ -54,6 +54,34 @@ Raw OAuth and MCP protocol clients live under
 [`server/proliferate/integrations/`](../../../../server/proliferate/integrations/)
 and do not own product persistence.
 
+### OAuth scope integrity
+
+Definition config chooses either the default provider-directed OAuth scope
+behavior or an exact scope policy. Slack uses the exact policy with this
+read/search-only ceiling:
+
+```text
+search:read.public
+search:read.private
+search:read.im
+search:read.mpim
+search:read.files
+search:read.users
+```
+
+For an exact policy, an authorization challenge may omit scopes or name a
+subset, but it cannot add a scope; Cloud always requests the canonical
+configured set. The callback must report that same set before credentials can
+become ready. Token parsing accepts standard top-level scope metadata and
+Slack's nested user-token scope metadata with comma or whitespace separators.
+
+A refresh response that omits scope metadata preserves the stored value. An
+explicit non-empty refresh grant may be a subset but cannot exceed the ceiling;
+an explicit empty grant or known stored scope outside the ceiling requires
+reauthentication. Legacy Slack bundles with empty scope metadata remain usable
+for existing search behavior. This scope ceiling does not authorize outbound
+Slack tools; gateway tool authorization is a separate boundary.
+
 ## Runtime Worker Identity
 
 [`db/models/cloud/runtime_workers.py`](../../../../server/proliferate/db/models/cloud/runtime_workers.py)
@@ -214,6 +242,9 @@ and [`runtime_workers/api.py`](../../../../server/proliferate/server/cloud/runti
 - OAuth refresh and provider access errors are product errors owned by the
   integrations service; tool-level provider errors are returned to the agent
   without leaking credentials.
+- An exact-policy challenge cannot exceed the ceiling, a callback grant must
+  equal the requested set, and an explicit refresh grant must be non-empty and
+  remain within the ceiling; failures store no replacement credentials.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- add a backwards-compatible OAuth scope policy and make the canonical Slack seed an exact six-scope read/search ceiling
- reject provider challenge escalation, require exact callback grants before credential persistence, and keep refresh grants within the ceiling
- parse Slack `authed_user.scope` plus comma/whitespace scope formats while preserving legacy read-only accounts with empty scope metadata
- keep `chat:write`, Slack outbound tools, live OAuth, and real messages explicitly out of scope

This is the first mergeable prerequisite for confirmed Slack sends. The reviewed follow-up sequence is: fail-closed Slack tool policy; durable one-time actions and product-authenticated approval API; product approval UI; atomic consume-before-delivery; then a separate `chat:write` activation PR.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `JWT_SECRET=... CLOUD_SECRET_KEY=... uv run pytest -q <focused OAuth + gateway files>` — 74 passed
- `uv run ruff check proliferate/ tests/`
- `uv run ruff format --check proliferate/ tests/`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_server_boundaries.py`
- `python3 -m unittest scripts/test_check_docs.py`
- `python3 scripts/check_docs.py`
- independent review round 2: SCOPE-001 and SCOPE-002 resolved; no remaining findings
- no Docker, Rust build, live Slack mutation, installation, OAuth, schedule, or message send performed

