### PR TITLE
fix(product-client): prevent replaced sessions from resurfacing

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   committedReplacedSessionTombstonesForWorkspace,
+  filterReplacedSessionTombstones,
+  hydrateCommittedReplacedSessionTombstones,
   isReplacedSessionTombstoned,
   resetReplacedSessionTombstonesForTests,
 } from "#product/hooks/sessions/workflows/session-replacement-tombstones";
@@ -9,6 +11,11 @@ import {
 } from "#product/hooks/sessions/workflows/session-replacement-dismissals";
 import { scheduleCreatedRuntimeSessionCleanup } from "#product/hooks/sessions/workflows/session-created-runtime-cleanup";
 import { materializeSessionCreation } from "#product/hooks/sessions/workflows/session-creation-materialization";
+import {
+  beginEmptySessionReplacement,
+  type EmptySessionReplacementTransaction,
+} from "#product/hooks/sessions/workflows/use-empty-session-replacement-cleanup";
+import { reconcileReplacedSessionTombstones } from "#product/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache";
 import {
   createEmptySessionRecord,
   getSessionRecord,
@@ -28,7 +35,26 @@ const mocks = vi.hoisted(() => ({
   dismissSession: vi.fn(() => new Promise<void>(() => undefined)),
   resolveDesktopRuntimeUrlForWorkspace: vi.fn(async () => "http://runtime.test"),
   writeTombstones: vi.fn(() => true),
+  actualShouldDiscardSupersededSessionCreation: null as null | ((
+    sessionId: string,
+  ) => Promise<boolean>),
+  shouldDiscardSupersededSessionCreationOverride: null as null | ((
+    sessionId: string,
+  ) => Promise<boolean>),
 }));
+
+vi.mock("#product/hooks/sessions/workflows/session-creation-supersession", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#product/hooks/sessions/workflows/session-creation-supersession")>();
+  mocks.actualShouldDiscardSupersededSessionCreation =
+    actual.shouldDiscardSupersededSessionCreation;
+  return {
+    ...actual,
+    shouldDiscardSupersededSessionCreation: (sessionId: string) => (
+      mocks.shouldDiscardSupersededSessionCreationOverride?.(sessionId)
+      ?? actual.shouldDiscardSupersededSessionCreation(sessionId)
+    ),
+  };
+});
 
 vi.mock("#product/lib/access/anyharness/sessions", async (importOriginal) => ({
   ...await importOriginal<typeof import("#product/lib/access/anyharness/sessions")>(),
@@ -74,6 +100,7 @@ beforeEach(() => {
   mocks.applySessionLaunchDefaults.mockReset();
   mocks.createSession.mockReset();
   mocks.resolveDesktopRuntimeUrlForWorkspace.mockClear();
+  mocks.shouldDiscardSupersededSessionCreationOverride = null;
   resetReplacedSessionTombstonesForTests();
   resetSessionReplacementDismissalsForTests();
   resetSessionCreationSupersessionForTests();
@@ -97,6 +124,27 @@ describe("created runtime cleanup", () => {
       .toEqual(["runtime-created"]);
     expect(isReplacedSessionTombstoned("workspace-1", "runtime-created")).toBe(true);
     expect(isReplacedSessionTombstoned("workspace-1", "client-created")).toBe(true);
+  });
+
+  it("retires the runtime when persistence fails but dismissal confirms absence", async () => {
+    mocks.writeTombstones.mockReturnValue(false);
+    mocks.dismissSession.mockResolvedValue();
+
+    await expect(scheduleCreatedRuntimeSessionCleanup({
+      connection: {} as never,
+      workspaceId: "workspace-1",
+      runtimeSessionId: "runtime-created",
+      clientSessionId: "client-created",
+      captureException: vi.fn(),
+    })).resolves.toBe(true);
+
+    expect(mocks.dismissSession).toHaveBeenCalledOnce();
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([]);
+    expect(isReplacedSessionTombstoned("workspace-1", "runtime-created"))
+      .toBe(true);
+    expect(isReplacedSessionTombstoned("workspace-1", "client-created"))
+      .toBe(true);
   });
 
   it("releases suppression when neither persistence nor dismissal can retire the runtime", async () => {
@@ -296,7 +344,229 @@ describe("created runtime cleanup", () => {
     defaultsGate.resolve({ session: runtimeSession, liveConfig: null });
     unregister();
   });
+
+  it("cleans a late runtime without publishing it when replacement wins the final-check race", async () => {
+    const pendingSessionId = "pending-tail-race";
+    const projectedRecord = createEmptySessionRecord(pendingSessionId, "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "gpt-5",
+    });
+    const runtimeSession = {
+      id: "runtime-tail-race",
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+    };
+    putSessionRecord(projectedRecord);
+    const createGate = deferred<typeof runtimeSession>();
+    mocks.createSession.mockReturnValueOnce(createGate.promise);
+    mocks.applySessionLaunchDefaults.mockResolvedValue({
+      session: runtimeSession,
+      liveConfig: null,
+    });
+    const closeSessionSlotStream = vi.fn();
+    const removeWorkspaceSessionRecord = vi.fn();
+    const replacementDismiss = vi.fn(async () => undefined);
+    let replacement: EmptySessionReplacementTransaction | null = null;
+    injectReplacementAfterFinalCheckpoint(() => {
+      replacement = beginEmptySessionReplacement(
+        pendingSessionId,
+        "workspace-1",
+        {
+          closeSessionSlotStream,
+          removeWorkspaceSessionRecord,
+          dismissSessionMutation: { mutateAsync: replacementDismiss } as never,
+          captureException: vi.fn(),
+        },
+      );
+    });
+    const trackProductEvent = vi.fn();
+    const upsertWorkspaceSessionRecord = vi.fn();
+    const unregister = registerSessionCreation(pendingSessionId);
+
+    const materialization = materializeSessionCreation({
+      trackProductEvent,
+      captureException: vi.fn(),
+      ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
+      existingProjectedRecord: projectedRecord,
+      frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      localRuntime: null,
+      cloudClient: null,
+      options: {
+        text: "",
+        agentKind: "codex",
+        modelId: "gpt-5",
+        workspaceId: "workspace-1",
+      },
+      pendingSessionId,
+      resolvedModeId: null,
+      upsertWorkspaceSessionRecord,
+      workspaceId: "workspace-1",
+    });
+
+    await vi.waitFor(() => expect(mocks.createSession).toHaveBeenCalledOnce());
+    expect(replacement).toBeNull();
+    createGate.resolve(runtimeSession);
+    await vi.waitFor(() => expect(replacement).not.toBeNull());
+    expect(closeSessionSlotStream).toHaveBeenCalledOnce();
+    expect(getSessionRecord(pendingSessionId)).toBeNull();
+    const commit = replacement!.commit();
+    await expect(Promise.all([materialization, commit])).resolves.toEqual([
+      pendingSessionId,
+      "retired",
+    ]);
+
+    expect(getSessionRecord(pendingSessionId)).toBeNull();
+    expect(upsertWorkspaceSessionRecord).not.toHaveBeenCalled();
+    expect(trackProductEvent).not.toHaveBeenCalled();
+    expect(replacementDismiss).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(mocks.dismissSession).toHaveBeenCalledWith(
+        expect.anything(),
+        runtimeSession.id,
+      );
+    });
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([runtimeSession.id]);
+    expect(mocks.writeTombstones).toHaveBeenCalledWith({
+      "workspace-1": [{
+        runtimeSessionId: runtimeSession.id,
+        suppressedSessionIds: expect.arrayContaining([
+          runtimeSession.id,
+          pendingSessionId,
+        ]),
+      }],
+    });
+    expect(filterReplacedSessionTombstones("workspace-1", [
+      { id: runtimeSession.id },
+      { id: "runtime-replacement" },
+    ])).toEqual([{ id: "runtime-replacement" }]);
+
+    // A cold renderer hydrates the durable fence before reconciling the next
+    // authoritative list. The late runtime remains hidden while listed, and
+    // omission clears persistence without reopening a stale in-renderer list.
+    resetReplacedSessionTombstonesForTests();
+    resetSessionReplacementDismissalsForTests();
+    hydrateCommittedReplacedSessionTombstones({
+      "workspace-1": [{
+        runtimeSessionId: runtimeSession.id,
+        suppressedSessionIds: [runtimeSession.id, pendingSessionId],
+      }],
+    });
+    reconcileReplacedSessionTombstones({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    }, [{ id: runtimeSession.id }, { id: "runtime-replacement" }]);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([runtimeSession.id]);
+    reconcileReplacedSessionTombstones({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    }, [{ id: "runtime-replacement" }]);
+    expect(committedReplacedSessionTombstonesForWorkspace("workspace-1"))
+      .toEqual([]);
+    expect(filterReplacedSessionTombstones("workspace-1", [
+      { id: runtimeSession.id },
+      { id: "runtime-replacement" },
+    ])).toEqual([{ id: "runtime-replacement" }]);
+    unregister();
+  });
+
+  it("publishes the late runtime normally when the tail-racing replacement rolls back", async () => {
+    const pendingSessionId = "pending-tail-rollback";
+    const projectedRecord = createEmptySessionRecord(pendingSessionId, "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: null,
+      modelId: "sonnet",
+    });
+    const runtimeSession = {
+      id: "runtime-tail-rollback",
+      workspaceId: "workspace-1",
+      agentKind: "claude",
+      modelId: "sonnet",
+      status: "idle",
+    };
+    putSessionRecord(projectedRecord);
+    mocks.createSession.mockResolvedValue(runtimeSession);
+    mocks.applySessionLaunchDefaults.mockResolvedValue({
+      session: runtimeSession,
+      liveConfig: null,
+    });
+    const closeSessionSlotStream = vi.fn();
+    const replacementDismiss = vi.fn(async () => undefined);
+    let replacement: EmptySessionReplacementTransaction | null = null;
+    injectReplacementAfterFinalCheckpoint(() => {
+      replacement = beginEmptySessionReplacement(
+        pendingSessionId,
+        "workspace-1",
+        {
+          closeSessionSlotStream,
+          removeWorkspaceSessionRecord: vi.fn(),
+          dismissSessionMutation: { mutateAsync: replacementDismiss } as never,
+          captureException: vi.fn(),
+        },
+      );
+    });
+    const trackProductEvent = vi.fn();
+    const upsertWorkspaceSessionRecord = vi.fn();
+    const unregister = registerSessionCreation(pendingSessionId);
+    const materialization = materializeSessionCreation({
+      trackProductEvent,
+      captureException: vi.fn(),
+      ensureCloudAgentCatalog: vi.fn(async () => ({ agents: [] })),
+      existingProjectedRecord: projectedRecord,
+      frozenDefaultLiveSessionControlValuesByAgentKind: {},
+      localRuntime: null,
+      cloudClient: null,
+      options: {
+        text: "",
+        agentKind: "claude",
+        modelId: "sonnet",
+        workspaceId: "workspace-1",
+      },
+      pendingSessionId,
+      resolvedModeId: null,
+      upsertWorkspaceSessionRecord,
+      workspaceId: "workspace-1",
+    });
+
+    await vi.waitFor(() => expect(replacement).not.toBeNull());
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    replacement!.rollback();
+    await expect(materialization).resolves.toBe(pendingSessionId);
+
+    expect(closeSessionSlotStream).toHaveBeenCalledOnce();
+    expect(getSessionRecord(pendingSessionId)?.materializedSessionId)
+      .toBe(runtimeSession.id);
+    expect(upsertWorkspaceSessionRecord).toHaveBeenCalledWith(
+      "workspace-1",
+      runtimeSession,
+    );
+    expect(trackProductEvent).toHaveBeenCalledOnce();
+    expect(replacementDismiss).not.toHaveBeenCalled();
+    expect(mocks.dismissSession).not.toHaveBeenCalled();
+    expect(isReplacedSessionTombstoned("workspace-1", runtimeSession.id))
+      .toBe(false);
+    unregister();
+    removeSessionRecord(pendingSessionId);
+  });
 });
+
+function injectReplacementAfterFinalCheckpoint(onCheckpoint: () => void): void {
+  let checkCount = 0;
+  mocks.shouldDiscardSupersededSessionCreationOverride = async (sessionId) => {
+    const shouldDiscard = await mocks.actualShouldDiscardSupersededSessionCreation!(
+      sessionId,
+    );
+    checkCount += 1;
+    if (checkCount === 3) {
+      onCheckpoint();
+    }
+    return shouldDiscard;
+  };
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-cleanup.test.ts
@@ -561,6 +561,9 @@ function injectReplacementAfterFinalCheckpoint(onCheckpoint: () => void): void {
       sessionId,
     );
     checkCount += 1;
+    // The new-runtime path checks after target resolution, creation, and launch
+    // defaults. This third call is the final awaited checkpoint immediately
+    // before atomic publication, reproducing #1333's stale-false window.
     if (checkCount === 3) {
       onCheckpoint();
     }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -50,6 +50,7 @@ import { resolveDesktopRuntimeUrlForWorkspace } from "#product/hooks/sessions/wo
 import { annotateLatencyFlow } from "#product/lib/infra/measurement/measurement-port";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
 import {
+  publishSessionCreationIfCurrent,
   shouldDiscardSupersededSessionCreation,
 } from "#product/hooks/sessions/workflows/session-creation-supersession";
 import { filterReplacedSessionTombstones } from "#product/hooks/sessions/workflows/session-replacement-tombstones";
@@ -184,17 +185,24 @@ async function runSessionCreationMaterialization({
       if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
         return pendingSessionId;
       }
-      return materializeExistingSession({
-        existingProjectedRecord,
-        existingSession,
-        fallbackModelId: options.modelId,
-        latencyFlowId: options.latencyFlowId,
-        pendingSessionId,
-        resolvedModeId,
-        upsertWorkspaceSessionRecord,
-        workspaceId,
-        launchIntentId: options.launchIntentId,
+      await publishSessionCreationIfCurrent({
+        sessionId: pendingSessionId,
+        onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
+        publish: () => {
+          materializeExistingSession({
+            existingProjectedRecord,
+            existingSession,
+            fallbackModelId: options.modelId,
+            latencyFlowId: options.latencyFlowId,
+            pendingSessionId,
+            resolvedModeId,
+            upsertWorkspaceSessionRecord,
+            workspaceId,
+            launchIntentId: options.launchIntentId,
+          });
+        },
       });
+      return pendingSessionId;
     }
   }
 
@@ -331,46 +339,55 @@ async function runSessionCreationMaterialization({
     transcriptHydrated: true,
   };
 
-  materializeSessionRecord(pendingSessionId, launchedSession.id, realRecord);
-  useSessionIntentStore.getState().bindMaterializedSession(
-    pendingSessionId,
-    launchedSession.id,
-  );
-  requeuePromptIntentsBlockedOnMaterialization({
-    clientSessionId: pendingSessionId,
-    materializedSessionId: launchedSession.id,
-    workspaceId,
-  });
-  logLatency("session.create.materialized", {
-    clientSessionId: pendingSessionId,
-    materializedSessionId: launchedSession.id,
-    workspaceId,
-    agentKind: options.agentKind,
-    modelId: launchedSession.modelId ?? options.modelId,
-    modeId: launchedSession.modeId ?? resolvedModeId,
-    status: realRecord.status,
-    executionPhase: launchedSession.executionSummary?.phase ?? null,
-    pendingInteractionCount: launchedSession.executionSummary?.pendingInteractions?.length ?? 0,
-    activeSessionId: useSessionSelectionStore.getState().activeSessionId,
-  });
-  if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
-    rememberLastViewedSession(workspaceId, launchedSession.id);
-  }
-  upsertWorkspaceSessionRecord(workspaceId, launchedSession);
-  trackProductEvent("chat_session_created", {
-    workspace_kind: cloudWorkspaceId ? "cloud" : "local",
-    agent_kind: options.agentKind,
-  });
-
-  if (options.launchIntentId) {
-    useChatLaunchIntentStore.getState().markMaterializedIfActive(
-      options.launchIntentId,
-      {
+  const published = await publishSessionCreationIfCurrent({
+    sessionId: pendingSessionId,
+    onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
+    publish: () => {
+      materializeSessionRecord(pendingSessionId, launchedSession.id, realRecord);
+      useSessionIntentStore.getState().bindMaterializedSession(
+        pendingSessionId,
+        launchedSession.id,
+      );
+      requeuePromptIntentsBlockedOnMaterialization({
         clientSessionId: pendingSessionId,
+        materializedSessionId: launchedSession.id,
         workspaceId,
-        sessionId: launchedSession.id,
-      },
-    );
+      });
+      logLatency("session.create.materialized", {
+        clientSessionId: pendingSessionId,
+        materializedSessionId: launchedSession.id,
+        workspaceId,
+        agentKind: options.agentKind,
+        modelId: launchedSession.modelId ?? options.modelId,
+        modeId: launchedSession.modeId ?? resolvedModeId,
+        status: realRecord.status,
+        executionPhase: launchedSession.executionSummary?.phase ?? null,
+        pendingInteractionCount: launchedSession.executionSummary?.pendingInteractions?.length ?? 0,
+        activeSessionId: useSessionSelectionStore.getState().activeSessionId,
+      });
+      if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
+        rememberLastViewedSession(workspaceId, launchedSession.id);
+      }
+      upsertWorkspaceSessionRecord(workspaceId, launchedSession);
+      trackProductEvent("chat_session_created", {
+        workspace_kind: cloudWorkspaceId ? "cloud" : "local",
+        agent_kind: options.agentKind,
+      });
+
+      if (options.launchIntentId) {
+        useChatLaunchIntentStore.getState().markMaterializedIfActive(
+          options.launchIntentId,
+          {
+            clientSessionId: pendingSessionId,
+            workspaceId,
+            sessionId: launchedSession.id,
+          },
+        );
+      }
+    },
+  });
+  if (!published) {
+    return pendingSessionId;
   }
 
   lifecycle.discardCreatedSession = null;

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -14,7 +14,6 @@ import {
 } from "#product/lib/domain/sessions/creation/compatible-session";
 import { mergeLiveDefaultLaunchControls } from "#product/lib/domain/sessions/creation/launch-controls";
 import type { ErrorContext } from "@proliferate/product-client/host/product-host";
-import type { DesktopProductEventMap } from "#product/lib/domain/telemetry/events";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import {
@@ -22,9 +21,7 @@ import {
   getSessionRecord,
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
-import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
-import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import {
   assertDirectSessionCreateSupported,
 } from "#product/lib/access/anyharness/direct-session-create-guard";
@@ -33,17 +30,11 @@ import {
   createSession,
   listWorkspaceSessions,
 } from "#product/lib/access/anyharness/sessions";
-import { rememberLastViewedSession } from "#product/stores/preferences/workspace-ui-store";
 import { buildLatencyRequestOptions } from "#product/hooks/sessions/workflows/session-creation-request-options";
-import {
-  materializeSessionRecord,
-} from "#product/hooks/sessions/workflows/session-creation-local-state";
 import {
   materializeExistingSession,
   pendingConfigValuesForSession,
-  requeuePromptIntentsBlockedOnMaterialization,
 } from "#product/hooks/sessions/workflows/session-creation-materialization-helpers";
-import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { buildDesktopLaunchModelRegistries } from "#product/lib/domain/agents/cloud-launch-catalog";
 import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
 import { resolveDesktopRuntimeUrlForWorkspace } from "#product/hooks/sessions/workflows/session-creation-runtime";
@@ -56,16 +47,16 @@ import {
 import { filterReplacedSessionTombstones } from "#product/hooks/sessions/workflows/session-replacement-tombstones";
 import { scheduleCreatedRuntimeSessionCleanup } from "#product/hooks/sessions/workflows/session-created-runtime-cleanup";
 import { runInterruptibleSessionCreationStep } from "#product/hooks/sessions/workflows/session-creation-materialization-interruption";
+import {
+  publishCreatedSessionMaterialization,
+  type TrackChatSessionCreated,
+} from "#product/hooks/sessions/workflows/session-creation-publication";
 
 /**
  * Narrow typed telemetry dependencies injected from the calling hook (which
  * reads the product telemetry facade). Keeps this plain workflow free of any
  * vendor import while preserving the exact event name/payload it emits.
  */
-type TrackChatSessionCreated = (
-  name: "chat_session_created",
-  payload: DesktopProductEventMap["chat_session_created"],
-) => void;
 type CaptureException = (error: unknown, context?: ErrorContext) => void;
 
 interface MaterializeSessionCreationInput {
@@ -343,47 +334,19 @@ async function runSessionCreationMaterialization({
     sessionId: pendingSessionId,
     onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
     publish: () => {
-      materializeSessionRecord(pendingSessionId, launchedSession.id, realRecord);
-      useSessionIntentStore.getState().bindMaterializedSession(
-        pendingSessionId,
-        launchedSession.id,
-      );
-      requeuePromptIntentsBlockedOnMaterialization({
-        clientSessionId: pendingSessionId,
-        materializedSessionId: launchedSession.id,
-        workspaceId,
-      });
-      logLatency("session.create.materialized", {
-        clientSessionId: pendingSessionId,
-        materializedSessionId: launchedSession.id,
-        workspaceId,
+      publishCreatedSessionMaterialization({
         agentKind: options.agentKind,
-        modelId: launchedSession.modelId ?? options.modelId,
-        modeId: launchedSession.modeId ?? resolvedModeId,
-        status: realRecord.status,
-        executionPhase: launchedSession.executionSummary?.phase ?? null,
-        pendingInteractionCount: launchedSession.executionSummary?.pendingInteractions?.length ?? 0,
-        activeSessionId: useSessionSelectionStore.getState().activeSessionId,
+        fallbackModeId: resolvedModeId,
+        fallbackModelId: options.modelId,
+        launchIntentId: options.launchIntentId,
+        pendingSessionId,
+        record: realRecord,
+        session: launchedSession,
+        trackProductEvent,
+        upsertWorkspaceSessionRecord,
+        workspaceId,
+        workspaceKind: cloudWorkspaceId ? "cloud" : "local",
       });
-      if (useSessionSelectionStore.getState().activeSessionId === pendingSessionId) {
-        rememberLastViewedSession(workspaceId, launchedSession.id);
-      }
-      upsertWorkspaceSessionRecord(workspaceId, launchedSession);
-      trackProductEvent("chat_session_created", {
-        workspace_kind: cloudWorkspaceId ? "cloud" : "local",
-        agent_kind: options.agentKind,
-      });
-
-      if (options.launchIntentId) {
-        useChatLaunchIntentStore.getState().markMaterializedIfActive(
-          options.launchIntentId,
-          {
-            clientSessionId: pendingSessionId,
-            workspaceId,
-            sessionId: launchedSession.id,
-          },
-        );
-      }
     },
   });
   if (!published) {

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-publication.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-publication.ts
@@ -1,0 +1,83 @@
+import type { Session } from "@anyharness/sdk";
+import type { DesktopProductEventMap } from "#product/lib/domain/telemetry/events";
+import {
+  materializeSessionRecord,
+} from "#product/hooks/sessions/workflows/session-creation-local-state";
+import {
+  requeuePromptIntentsBlockedOnMaterialization,
+} from "#product/hooks/sessions/workflows/session-creation-materialization-helpers";
+import { logLatency } from "#product/lib/infra/measurement/measurement-port";
+import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
+import { rememberLastViewedSession } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
+
+export type TrackChatSessionCreated = (
+  name: "chat_session_created",
+  payload: DesktopProductEventMap["chat_session_created"],
+) => void;
+
+export function publishCreatedSessionMaterialization(input: {
+  agentKind: string;
+  fallbackModeId: string | null;
+  fallbackModelId: string;
+  launchIntentId?: string | null;
+  pendingSessionId: string;
+  record: SessionRuntimeRecord;
+  session: Session;
+  trackProductEvent: TrackChatSessionCreated;
+  upsertWorkspaceSessionRecord: (
+    workspaceId: string,
+    session: Session,
+  ) => void;
+  workspaceId: string;
+  workspaceKind: "cloud" | "local";
+}): void {
+  materializeSessionRecord(
+    input.pendingSessionId,
+    input.session.id,
+    input.record,
+  );
+  useSessionIntentStore.getState().bindMaterializedSession(
+    input.pendingSessionId,
+    input.session.id,
+  );
+  requeuePromptIntentsBlockedOnMaterialization({
+    clientSessionId: input.pendingSessionId,
+    materializedSessionId: input.session.id,
+    workspaceId: input.workspaceId,
+  });
+  logLatency("session.create.materialized", {
+    clientSessionId: input.pendingSessionId,
+    materializedSessionId: input.session.id,
+    workspaceId: input.workspaceId,
+    agentKind: input.agentKind,
+    modelId: input.session.modelId ?? input.fallbackModelId,
+    modeId: input.session.modeId ?? input.fallbackModeId,
+    status: input.record.status,
+    executionPhase: input.session.executionSummary?.phase ?? null,
+    pendingInteractionCount:
+      input.session.executionSummary?.pendingInteractions?.length ?? 0,
+    activeSessionId: useSessionSelectionStore.getState().activeSessionId,
+  });
+  if (useSessionSelectionStore.getState().activeSessionId === input.pendingSessionId) {
+    rememberLastViewedSession(input.workspaceId, input.session.id);
+  }
+  input.upsertWorkspaceSessionRecord(input.workspaceId, input.session);
+  input.trackProductEvent("chat_session_created", {
+    workspace_kind: input.workspaceKind,
+    agent_kind: input.agentKind,
+  });
+
+  if (input.launchIntentId) {
+    useChatLaunchIntentStore.getState().markMaterializedIfActive(
+      input.launchIntentId,
+      {
+        clientSessionId: input.pendingSessionId,
+        workspaceId: input.workspaceId,
+        sessionId: input.session.id,
+      },
+    );
+  }
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-supersession.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-supersession.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   commitSupersededSessionCreation,
+  publishSessionCreationIfCurrent,
   registerSessionCreation,
   resetSessionCreationSupersessionForTests,
   rollbackSupersededSessionCreation,
@@ -40,6 +41,76 @@ describe("session creation supersession", () => {
     rollbackSupersededSessionCreation("old-session");
 
     await expect(disposition).resolves.toBe(false);
+    unregister();
+  });
+
+  it("blocks publication when replacement starts after a stale async checkpoint", async () => {
+    const unregister = registerSessionCreation("old-session");
+    const staleCheckpoint = shouldDiscardSupersededSessionCreation("old-session");
+    supersedeInFlightSessionCreation("old-session");
+    await expect(staleCheckpoint).resolves.toBe(false);
+    const publish = vi.fn();
+
+    const publication = publishSessionCreationIfCurrent({
+      sessionId: "old-session",
+      onSuperseded: () => shouldDiscardSupersededSessionCreation("old-session"),
+      publish,
+    });
+    await Promise.resolve();
+    expect(publish).not.toHaveBeenCalled();
+
+    commitSupersededSessionCreation("old-session");
+    await expect(publication).resolves.toBe(false);
+    expect(publish).not.toHaveBeenCalled();
+    unregister();
+  });
+
+  it("publishes after a tail-racing replacement rolls back", async () => {
+    const unregister = registerSessionCreation("old-session");
+    const staleCheckpoint = shouldDiscardSupersededSessionCreation("old-session");
+    supersedeInFlightSessionCreation("old-session");
+    await expect(staleCheckpoint).resolves.toBe(false);
+    const publish = vi.fn();
+
+    const publication = publishSessionCreationIfCurrent({
+      sessionId: "old-session",
+      onSuperseded: () => shouldDiscardSupersededSessionCreation("old-session"),
+      publish,
+    });
+    rollbackSupersededSessionCreation("old-session");
+
+    await expect(publication).resolves.toBe(true);
+    expect(publish).toHaveBeenCalledTimes(1);
+    unregister();
+  });
+
+  it("rechecks ownership when rollback is immediately followed by another replacement", async () => {
+    const unregister = registerSessionCreation("old-session");
+    supersedeInFlightSessionCreation("old-session");
+    const publish = vi.fn();
+    let replacementCount = 1;
+    const publication = publishSessionCreationIfCurrent({
+      sessionId: "old-session",
+      onSuperseded: async () => {
+        const shouldDiscard = await shouldDiscardSupersededSessionCreation(
+          "old-session",
+        );
+        if (!shouldDiscard && replacementCount === 1) {
+          replacementCount += 1;
+          supersedeInFlightSessionCreation("old-session");
+        }
+        return shouldDiscard;
+      },
+      publish,
+    });
+
+    rollbackSupersededSessionCreation("old-session");
+    await vi.waitFor(() => expect(replacementCount).toBe(2));
+    expect(publish).not.toHaveBeenCalled();
+    commitSupersededSessionCreation("old-session");
+
+    await expect(publication).resolves.toBe(false);
+    expect(publish).not.toHaveBeenCalled();
     unregister();
   });
 

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-supersession.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-supersession.ts
@@ -110,6 +110,29 @@ export async function shouldDiscardSupersededSessionCreation(
   return disposition === "committed";
 }
 
+/**
+ * Linearizes the final local publication of a materialized session against a
+ * replace-in-place request. `publish` runs synchronously in the same turn as
+ * the last supersession lookup, so a replacement can only happen entirely
+ * before publication or observe the published runtime id afterward.
+ */
+export async function publishSessionCreationIfCurrent(input: {
+  sessionId: string;
+  onSuperseded: () => Promise<boolean>;
+  publish: () => void;
+}): Promise<boolean> {
+  while (true) {
+    const supersession = supersessionBySessionId.get(input.sessionId);
+    if (!supersession || supersession.disposition === "rolled_back") {
+      input.publish();
+      return true;
+    }
+    if (await input.onSuperseded()) {
+      return false;
+    }
+  }
+}
+
 function resolveSupersession(
   sessionId: string,
   disposition: SupersessionDisposition,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.test.ts
@@ -6,8 +6,12 @@ import {
 import {
   createEmptySessionRecord,
   getSessionRecord,
+  getWorkspaceSessionRecords,
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
+import type {
+  WorkspaceSession,
+} from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
@@ -33,10 +37,15 @@ vi.mock("#product/lib/access/persistence/session-replacement-tombstones-storage"
   writeSessionReplacementTombstones: storageMocks.writeTombstones,
 }));
 
-function createDeps() {
+function createDeps(authoritativeSessions: WorkspaceSession[] = []) {
   const mutateAsync = vi.fn(async () => undefined);
   const deps: EmptySessionReplacementDeps = {
     closeSessionSlotStream: vi.fn(),
+    getWorkspaceSessionCacheSnapshot: vi.fn(() => ({
+      sessions: authoritativeSessions,
+      dataUpdatedAt: authoritativeSessions.length > 0 ? 1 : 0,
+      isInvalidated: false,
+    })),
     removeWorkspaceSessionRecord: vi.fn(),
     dismissSessionMutation: { mutateAsync } as never,
     captureException: vi.fn(),
@@ -198,6 +207,120 @@ describe("empty session replacement transaction", () => {
         sessionId: "runtime-old",
       });
     });
+  });
+
+  it("rapidly replaces a rehydrated authoritative empty tab after reload", async () => {
+    const workspaceId = "workspace-1";
+    const oldRuntimeSessionId = "runtime-reloaded-codex";
+    const replacementSessionId = "client-session:claude:rapid-switch";
+    const authoritativeSession = {
+      id: oldRuntimeSessionId,
+      workspaceId,
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+      lastPromptAt: null,
+    } as WorkspaceSession;
+
+    // Release E2E run 29602686092 exposed this ordering: reload reconstructed
+    // an empty runtime-owned Codex tab from the fresh authoritative query, but
+    // its deferred activation had not installed a local record before the
+    // immediate Claude switch staged a transient shell.
+    expect(getSessionRecord(oldRuntimeSessionId)).toBeNull();
+
+    // Session creation activates its optimistic shell before hiding the old
+    // one. The replacement must still collapse back to one visible record and
+    // retire the authoritative runtime id rather than opening a third tab.
+    putSessionRecord(createEmptySessionRecord(replacementSessionId, "claude", {
+      workspaceId,
+      materializedSessionId: null,
+      modelId: "claude-sonnet-4-5",
+    }));
+    const { deps, mutateAsync } = createDeps([authoritativeSession]);
+    const transaction = beginEmptySessionReplacement(
+      oldRuntimeSessionId,
+      workspaceId,
+      deps,
+    );
+
+    expect(transaction).not.toBeNull();
+    expect(Object.keys(getWorkspaceSessionRecords(workspaceId)))
+      .toEqual([replacementSessionId]);
+    expect(isReplacedSessionTombstoned(workspaceId, oldRuntimeSessionId))
+      .toBe(true);
+
+    await expect(transaction?.commit()).resolves.toBe("retired");
+
+    expect(deps.removeWorkspaceSessionRecord)
+      .toHaveBeenCalledWith(workspaceId, oldRuntimeSessionId);
+    await vi.waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        workspaceId,
+        sessionId: oldRuntimeSessionId,
+      });
+    });
+    expect(Object.keys(getWorkspaceSessionRecords(workspaceId)))
+      .toEqual([replacementSessionId]);
+    expect(filterReplacedSessionTombstones(workspaceId, [
+      authoritativeSession,
+      { ...authoritativeSession, id: "runtime-replacement", agentKind: "claude" },
+    ])).toEqual([
+      expect.objectContaining({ id: "runtime-replacement" }),
+    ]);
+  });
+
+  it("restores a query-only authoritative empty tab when replacement rolls back", () => {
+    const authoritativeSession = {
+      id: "runtime-reloaded-codex",
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+      lastPromptAt: null,
+    } as WorkspaceSession;
+    const { deps } = createDeps([authoritativeSession]);
+
+    const transaction = beginEmptySessionReplacement(
+      authoritativeSession.id,
+      authoritativeSession.workspaceId,
+      deps,
+    );
+    transaction?.rollback();
+
+    expect(getSessionRecord(authoritativeSession.id)).toMatchObject({
+      agentKind: "codex",
+      materializedSessionId: authoritativeSession.id,
+      workspaceId: authoritativeSession.workspaceId,
+    });
+    expect(isReplacedSessionTombstoned(
+      authoritativeSession.workspaceId,
+      authoritativeSession.id,
+    )).toBe(false);
+  });
+
+  it("preserves a query-only authoritative session that has user work", () => {
+    const authoritativeSession = {
+      id: "runtime-reloaded-nonempty",
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+      lastPromptAt: "2026-07-17T18:40:00.000Z",
+    } as WorkspaceSession;
+    const { deps } = createDeps([authoritativeSession]);
+
+    const transaction = beginEmptySessionReplacement(
+      authoritativeSession.id,
+      authoritativeSession.workspaceId,
+      deps,
+    );
+
+    expect(transaction).toBeNull();
+    expect(deps.closeSessionSlotStream).not.toHaveBeenCalled();
+    expect(isReplacedSessionTombstoned(
+      authoritativeSession.workspaceId,
+      authoritativeSession.id,
+    )).toBe(false);
   });
 
   it("retries a transient dismissal and retains the tombstone until authoritative refresh", async () => {

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-empty-session-replacement-cleanup.ts
@@ -1,5 +1,6 @@
 import { isSessionEmptyWithIntents } from "#product/lib/domain/sessions/session-emptiness";
 import {
+  createSessionRecordFromSummary,
   getSessionRecord,
   putSessionRecord,
   removeSessionRecord,
@@ -27,11 +28,17 @@ import {
 import {
   runTrackedReplacementDismissal,
 } from "#product/hooks/sessions/workflows/session-replacement-dismissals";
+import type {
+  WorkspaceSessionCacheSnapshot,
+} from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
 
 const DISMISS_RETRY_DELAYS_MS = [0, 100, 500] as const;
 
 export interface EmptySessionReplacementDeps {
   closeSessionSlotStream: (sessionId: string) => void;
+  getWorkspaceSessionCacheSnapshot?: (
+    workspaceId: string,
+  ) => WorkspaceSessionCacheSnapshot;
   removeWorkspaceSessionRecord: (workspaceId: string, sessionId: string) => void;
   dismissSessionMutation: ReturnType<typeof useDismissSessionMutation>;
   /**
@@ -58,7 +65,8 @@ export function beginEmptySessionReplacement(
   workspaceId: string | null | undefined,
   deps: EmptySessionReplacementDeps,
 ): EmptySessionReplacementTransaction | null {
-  const record = getSessionRecord(sessionId);
+  const record = getSessionRecord(sessionId)
+    ?? resolveAuthoritativeReplacementRecord(sessionId, workspaceId, deps);
   if (!record) {
     return null;
   }
@@ -193,6 +201,30 @@ export function beginEmptySessionReplacement(
       restoreCapturedSession();
     },
   };
+}
+
+function resolveAuthoritativeReplacementRecord(
+  sessionId: string,
+  workspaceId: string | null | undefined,
+  deps: EmptySessionReplacementDeps,
+) {
+  if (!workspaceId || !deps.getWorkspaceSessionCacheSnapshot) {
+    return null;
+  }
+  const snapshot = deps.getWorkspaceSessionCacheSnapshot(workspaceId);
+  if (!snapshot.dataUpdatedAt || snapshot.isInvalidated) {
+    return null;
+  }
+  const session = snapshot.sessions?.find((candidate) =>
+    candidate.id === sessionId
+    && candidate.workspaceId === workspaceId
+    && !candidate.dismissedAt
+  );
+  return session
+    ? createSessionRecordFromSummary(session, workspaceId, {
+      sessionRelationship: { kind: "root" },
+    })
+    : null;
 }
 
 async function dismissMaterializedSession(

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -73,11 +73,10 @@ export function useSessionCreationActions() {
   const { promptSession } = useSessionPromptWorkflow();
   const { activateSession, closeSessionSlotStream } = useSessionRuntimeActions();
   const { ensureCloudAgentCatalog } = useCloudAgentCatalogCache();
-  const { upsertWorkspaceSessionRecord, removeWorkspaceSessionRecord } = useWorkspaceSessionCache();
+  const { getWorkspaceSessionCacheSnapshot, removeWorkspaceSessionRecord, upsertWorkspaceSessionRecord } = useWorkspaceSessionCache();
   const dismissSessionMutation = useDismissSessionMutation();
   const showToast = useToastStore((state) => state.show);
   const telemetry = useProductTelemetry();
-
   const createSessionWithResolvedConfig = useCallback(async function createWithResolvedConfig(
     options: CreateSessionWithResolvedConfigOptions,
   ): Promise<string> {
@@ -94,7 +93,6 @@ export function useSessionCreationActions() {
     if (blockedError) {
       throw blockedError;
     }
-
     const hasPrompt = hasPromptContent(options.text, options.blocks)
       || (options.attachmentSnapshots?.length ?? 0) > 0;
     const promptId = hasPrompt ? options.promptId ?? createPromptId() : options.promptId ?? null;
@@ -258,6 +256,7 @@ export function useSessionCreationActions() {
         workspaceId,
         {
           closeSessionSlotStream,
+          getWorkspaceSessionCacheSnapshot,
           removeWorkspaceSessionRecord,
           dismissSessionMutation,
           captureException: telemetry.captureException,
@@ -386,6 +385,7 @@ export function useSessionCreationActions() {
     closeSessionSlotStream,
     dismissSessionMutation,
     ensureCloudAgentCatalog,
+    getWorkspaceSessionCacheSnapshot,
     getWorkspaceRuntimeBlockError,
     invalidateWorkspaceCollectionsForRuntime,
     runtimeUrl,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts
@@ -1,12 +1,32 @@
-import { beforeEach, describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createEmptySessionRecord,
+  getSessionRecord,
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 import { classifyTrustedSessionSelection } from "#product/hooks/sessions/workflows/session-selection-relationship";
+import { useSessionSelectionWorkflowActions } from "#product/hooks/sessions/workflows/use-session-selection-actions";
+import {
+  beginSessionActivationIntent,
+  invalidateSessionActivationIntent,
+} from "#product/hooks/sessions/workflows/session-activation-guard";
+import type {
+  WorkspaceSession,
+} from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: () => null,
+  }),
+}));
+
+afterEach(cleanup);
 
 describe("classifyTrustedSessionSelection", () => {
   beforeEach(() => {
@@ -59,3 +79,62 @@ describe("classifyTrustedSessionSelection", () => {
       .toBeUndefined();
   });
 });
+
+describe("guarded query-only session selection", () => {
+  beforeEach(() => {
+    useSessionSelectionStore.setState({
+      selectedLogicalWorkspaceId: "workspace-1",
+      selectedWorkspaceId: "workspace-1",
+      workspaceSelectionNonce: 1,
+      activeSessionId: null,
+      sessionActivationIntentEpochByWorkspace: {},
+      hotPaintGate: null,
+    });
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  it("does not publish a late authoritative slot after replacement invalidates activation", async () => {
+    const sessionsGate = deferred<WorkspaceSession[]>();
+    const ensureWorkspaceSessions = vi.fn(() => sessionsGate.promise);
+    const activateSession = vi.fn();
+    const { result } = renderHook(() => useSessionSelectionWorkflowActions({
+      activateSession,
+      ensureWorkspaceSessions,
+    }));
+    const guard = beginSessionActivationIntent("workspace-1");
+
+    const selection = result.current.selectSession("runtime-reloaded-codex", {
+      guard,
+    });
+    await vi.waitFor(() => expect(ensureWorkspaceSessions).toHaveBeenCalledOnce());
+
+    // The replacement's shell-intent write performs this invalidation while
+    // the post-reload activation is waiting on its authoritative session list.
+    invalidateSessionActivationIntent("workspace-1");
+    sessionsGate.resolve([{
+      id: "runtime-reloaded-codex",
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+      lastPromptAt: null,
+    } as WorkspaceSession]);
+
+    await expect(selection).resolves.toMatchObject({
+      result: "stale",
+      sessionId: "runtime-reloaded-codex",
+      reason: "intent-replaced",
+    });
+    expect(getSessionRecord("runtime-reloaded-codex")).toBeNull();
+    expect(activateSession).not.toHaveBeenCalled();
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts
@@ -265,6 +265,9 @@ export function useSessionSelectionWorkflowActions({
       ...options,
       measurementOperationId,
     });
+    if (guard && !isSessionActivationCurrent(guard)) {
+      return staleSelection("intent-replaced");
+    }
     recordMeasurementWorkflowStep({
       operationId: measurementOperationId,
       step: "session.select.ensure_sessions",

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -30,7 +30,6 @@ apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceIte
 apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx 421 connected sidebar host; PR 5 availability-intent begin handler threaded alongside existing repo/cloud actions; extraction pending
 apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx 433 shared ordered-readiness continuation host for Cloud registration and retry-stable local clone; split by intent owner on next growth
 apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts 401 session stream flush/apply pending reducer split
-apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts 415 injected typed telemetry deps threaded from the calling hook; split deferred
 apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model
 apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts 423 product telemetry facade threading into session-creation workflows; split deferred
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred


### PR DESCRIPTION
## Summary

- linearize final ProductClient session publication against empty-session replacement
- retire and durably suppress a runtime that completes after its projected shell loses ownership
- replace a fresh query-only authoritative empty tab even when post-reload activation has not installed its local record yet
- prevent a superseded delayed tab activation from publishing or reactivating the retired session
- preserve rollback, compatible-session reuse, non-empty sessions, and honest retention when cleanup cannot be confirmed
- add deterministic delayed-creation, cleanup failure, reload/list reconciliation, re-armed replacement, and rapid post-reload switch regressions
- extract publication side effects into a focused workflow module and remove the stale materializer size allowance

## Evidence

Release E2E run 29602686092 captured the post-reload failure as three tabs: runtime Claude, visibly empty runtime Codex, and a new transient Claude. The new regression reproduces the ownership window with a fresh authoritative session summary but no local record, then proves replacement dismissal/list suppression while a separate delayed-selection regression proves late activation cannot recreate the old slot.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.
- [x] Rebased onto `db656132ce9f084c6b029ee8e8e7058e7556ee11` (#1340 on #1336).

## Verification

- ProductClient TypeScript: `node_modules/.bin/tsc -p tsconfig.json --noEmit`
- ProductClient overlap-focused lifecycle/default suite: 9 files, 49 tests passed
- #1340 release termination fixture: 1 test passed
- Repository structure strict check: zero violations
- `git diff --check`
- independent concurrency, diff, reload-race, and #1336 overlap reviews: no actionable findings

Fixes #1333
