### PR TITLE
Desktop Direct Delivery: reconciliation + separable workflowRuns SDK groundwork (DRAFT)

### DIFF
--- a/anyharness/sdk/src/client/core.ts
+++ b/anyharness/sdk/src/client/core.ts
@@ -15,6 +15,7 @@ import { ReviewsClient } from "./reviews.js";
 import { RuntimeClient } from "./runtime.js";
 import { SessionsClient } from "./sessions.js";
 import { TerminalsClient } from "./terminals.js";
+import { WorkflowRunsClient } from "./workflow-runs.js";
 import { WorktreesClient } from "./worktrees.js";
 import { WorkspacesClient } from "./workspaces.js";
 
@@ -435,6 +436,7 @@ export class AnyHarnessClient {
   readonly replay: ReplayClient;
   readonly reviews: ReviewsClient;
   readonly workspaces: WorkspacesClient;
+  readonly workflowRuns: WorkflowRunsClient;
   readonly worktrees: WorktreesClient;
   readonly cowork: CoworkClient;
   readonly files: FilesClient;
@@ -456,6 +458,7 @@ export class AnyHarnessClient {
     this.replay = new ReplayClient(transport);
     this.reviews = new ReviewsClient(transport);
     this.workspaces = new WorkspacesClient(transport);
+    this.workflowRuns = new WorkflowRunsClient(transport);
     this.worktrees = new WorktreesClient(transport);
     this.cowork = new CoworkClient(transport);
     this.files = new FilesClient(transport);

--- a/anyharness/sdk/src/client/workflow-runs.test.ts
+++ b/anyharness/sdk/src/client/workflow-runs.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  VersionedPutWorkflowRunRequest,
+  VersionedWorkflowRunResponse,
+} from "../types/workflow-runs.js";
+import type { AnyHarnessTransport } from "./core.js";
+import { WorkflowRunsClient } from "./workflow-runs.js";
+
+const RUN_ID = "11111111-2222-3333-4444-555555555555";
+
+const RESPONSE: VersionedWorkflowRunResponse = {
+  run: {
+    id: RUN_ID,
+    status: "running",
+    workspaceId: "local-workspace-123",
+  } as VersionedWorkflowRunResponse["run"],
+  steps: [],
+} as VersionedWorkflowRunResponse;
+
+const PUT_REQUEST: VersionedPutWorkflowRunRequest = {
+  schemaVersion: 2,
+  workspaceId: "local-workspace-123",
+  definition: {
+    inputs: [{ name: "ticket", type: "string", required: true }],
+    stages: [
+      {
+        harnessConfig: {
+          agentKind: "claude",
+          modelSelection: { kind: "targetDefault" },
+          permissionPolicy: "workflowDefault",
+        },
+        steps: [{ kind: "agent.prompt", prompt: "Investigate {{inputs.ticket}}" }],
+      },
+    ],
+  },
+  arguments: { ticket: "PROL-123" },
+};
+
+describe("WorkflowRunsClient", () => {
+  it("PUTs the versioned request to the canonical run path", async () => {
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const transport = {
+      put: async (path: string, body: unknown) => {
+        calls.push({ path, body });
+        return RESPONSE;
+      },
+    } as unknown as AnyHarnessTransport;
+    const client = new WorkflowRunsClient(transport);
+
+    const result = await client.put(RUN_ID, PUT_REQUEST);
+
+    expect(calls).toEqual([{ path: `/v1/workflow-runs/${RUN_ID}`, body: PUT_REQUEST }]);
+    expect(result).toBe(RESPONSE);
+  });
+
+  it("URL-encodes the run ID on GET", async () => {
+    const calls: string[] = [];
+    const transport = {
+      get: async (path: string) => {
+        calls.push(path);
+        return RESPONSE;
+      },
+    } as unknown as AnyHarnessTransport;
+    const client = new WorkflowRunsClient(transport);
+
+    await client.get("run/with slash");
+
+    expect(calls).toEqual(["/v1/workflow-runs/run%2Fwith%20slash"]);
+  });
+
+  it("POSTs to the cancel subresource with an empty body", async () => {
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const transport = {
+      post: async (path: string, body: unknown) => {
+        calls.push({ path, body });
+        return RESPONSE;
+      },
+    } as unknown as AnyHarnessTransport;
+    const client = new WorkflowRunsClient(transport);
+
+    await client.cancel(RUN_ID);
+
+    expect(calls).toEqual([{ path: `/v1/workflow-runs/${RUN_ID}/cancel`, body: {} }]);
+  });
+});

--- a/anyharness/sdk/src/client/workflow-runs.ts
+++ b/anyharness/sdk/src/client/workflow-runs.ts
@@ -1,0 +1,76 @@
+import type {
+  VersionedPutWorkflowRunRequest,
+  VersionedWorkflowRunResponse,
+} from "../types/workflow-runs.js";
+import type { AnyHarnessRequestOptions, AnyHarnessTransport } from "./core.js";
+
+/**
+ * Typed local AnyHarness Workflow-run resource.
+ *
+ * Wraps the already-generated `/v1/workflow-runs/{runId}` contract that the
+ * runtime exposes (PUT create/replay, GET durable status, POST cancel). The
+ * versioned request/response unions carry both the schema-v1 (`managedCloud`)
+ * and schema-v2 (portable / connected-Desktop) families, so this single
+ * resource serves both delivery targets without a fork.
+ *
+ * Behavior preserved from the generated contract:
+ * - PUT returns `201` for a new durable acceptance and `200` for an exact
+ *   replay of an identical invocation; both carry the same versioned response
+ *   body, so callers reconcile idempotently on the body, not the status line.
+ *   (The shared transport does not surface success status codes; a caller that
+ *   must branch created-vs-replayed observes the same durable run either way.)
+ * - `409` (same ID, different invocation, or workspace-binding conflict),
+ *   `404`, `400`, `403`, `422`, and RFC 7807 Problem Details all surface as
+ *   `AnyHarnessError` from the transport.
+ *
+ * The `runId` is the canonical UUID: for a connected-Desktop invocation it is
+ * the Cloud invocation UUID reused byte-for-byte as the local run ID.
+ */
+export class WorkflowRunsClient {
+  constructor(private readonly transport: AnyHarnessTransport) {}
+
+  /**
+   * PUT a workflow run by its canonical UUID.
+   *
+   * Idempotent: the same `runId` with an identical request replays the exact
+   * durable run (`200`); a new request creates it (`201`). Both return the same
+   * versioned response body.
+   */
+  async put(
+    runId: string,
+    request: VersionedPutWorkflowRunRequest,
+    options?: AnyHarnessRequestOptions,
+  ): Promise<VersionedWorkflowRunResponse> {
+    return this.transport.put<VersionedWorkflowRunResponse>(
+      `/v1/workflow-runs/${encodeURIComponent(runId)}`,
+      request,
+      options,
+    );
+  }
+
+  /** GET the durable run and step status for a canonical run UUID. */
+  async get(
+    runId: string,
+    options?: AnyHarnessRequestOptions,
+  ): Promise<VersionedWorkflowRunResponse> {
+    return this.transport.get<VersionedWorkflowRunResponse>(
+      `/v1/workflow-runs/${encodeURIComponent(runId)}`,
+      options,
+    );
+  }
+
+  /**
+   * POST durable cancellation intent for a run. Returns the current truthful
+   * versioned snapshot. This is Workflow-run cancel, not direct session cancel.
+   */
+  async cancel(
+    runId: string,
+    options?: AnyHarnessRequestOptions,
+  ): Promise<VersionedWorkflowRunResponse> {
+    return this.transport.post<VersionedWorkflowRunResponse>(
+      `/v1/workflow-runs/${encodeURIComponent(runId)}/cancel`,
+      {},
+      options,
+    );
+  }
+}

--- a/anyharness/sdk/src/index.ts
+++ b/anyharness/sdk/src/index.ts
@@ -292,6 +292,25 @@ export type {
 } from "./types/plans.js";
 
 export type {
+  VersionedPutWorkflowRunRequest,
+  PutWorkflowRunRequest,
+  PutWorkflowRunRequestV2,
+  VersionedWorkflowRunResponse,
+  WorkflowRunResponse,
+  WorkflowRunResponseV2,
+  WorkflowRun,
+  WorkflowRunV2,
+  WorkflowRunStep,
+  WorkflowRunStepV2,
+  WorkflowRunStatus,
+  WorkflowRunStepStatus,
+  WorkflowRunFailureCode,
+  WorkflowRunFailureCodeV2,
+  WorkflowRunInterruptionCode,
+  WorkflowRunModelSelection,
+} from "./types/workflow-runs.js";
+
+export type {
   ReviewKind,
   ReviewRunStatus,
   ReviewRoundStatus,

--- a/anyharness/sdk/src/types/workflow-runs.ts
+++ b/anyharness/sdk/src/types/workflow-runs.ts
@@ -1,0 +1,35 @@
+import type { components } from "../generated/openapi.js";
+
+/**
+ * Owned type surface for the local AnyHarness Workflow-run resource.
+ *
+ * These are thin re-exports of the generated OpenAPI contract; the resource
+ * client never hand-defines request/response shapes. The versioned request and
+ * response unions carry both the schema-v1 (`managedCloud`) and schema-v2
+ * (portable / connected-Desktop) families, so a single typed resource serves
+ * both delivery targets.
+ */
+
+export type VersionedPutWorkflowRunRequest =
+  components["schemas"]["VersionedPutWorkflowRunRequest"];
+export type PutWorkflowRunRequest = components["schemas"]["PutWorkflowRunRequest"];
+export type PutWorkflowRunRequestV2 = components["schemas"]["PutWorkflowRunRequestV2"];
+
+export type VersionedWorkflowRunResponse =
+  components["schemas"]["VersionedWorkflowRunResponse"];
+export type WorkflowRunResponse = components["schemas"]["WorkflowRunResponse"];
+export type WorkflowRunResponseV2 = components["schemas"]["WorkflowRunResponseV2"];
+
+export type WorkflowRun = components["schemas"]["WorkflowRun"];
+export type WorkflowRunV2 = components["schemas"]["WorkflowRunV2"];
+export type WorkflowRunStep = components["schemas"]["WorkflowRunStep"];
+export type WorkflowRunStepV2 = components["schemas"]["WorkflowRunStepV2"];
+export type WorkflowRunStatus = components["schemas"]["WorkflowRunStatus"];
+export type WorkflowRunStepStatus = components["schemas"]["WorkflowRunStepStatus"];
+export type WorkflowRunFailureCode = components["schemas"]["WorkflowRunFailureCode"];
+export type WorkflowRunFailureCodeV2 =
+  components["schemas"]["WorkflowRunFailureCodeV2"];
+export type WorkflowRunInterruptionCode =
+  components["schemas"]["WorkflowRunInterruptionCode"];
+export type WorkflowRunModelSelection =
+  components["schemas"]["WorkflowRunModelSelection"];


### PR DESCRIPTION
## Desktop Direct Delivery — reconciliation + separable client groundwork (DRAFT)

**Not merge-ready.** Spec 8 (*Desktop Direct Delivery*) is a **provisional 0.5 draft, not frozen**, and its Cloud/Server side depends on sibling lanes that are **not merged** (Cloud Execution "5", Workflow UI "6"). This PR delivers (a) a reconciliation of spec 8 against merged-main reality and (b) the one piece of groundwork that is cleanly separable and safe on current main. Everything else is design-only pending 5/6.

- Base: `main` @ `1c690d9ae`
- Head: `32e0fa051`
- Reconciliation baseline: Product Experience #1303 @ `0a155125a` — confirmed an ancestor of current main.

---

## Landed separable groundwork

### `AnyHarnessClient.workflowRuns` typed resource

Spec 8 §"AnyHarness SDK" calls this out as the clean additive seam: the generated OpenAPI types and the portable contract tests already exist on main (from #1177), and only the owned resource wrapper + its attachment to `AnyHarnessClient` were missing.

- `anyharness/sdk/src/client/workflow-runs.ts` — `WorkflowRunsClient` with `put(runId, request)`, `get(runId)`, `cancel(runId)` over the already-generated `/v1/workflow-runs/{run_id}` (+ `/cancel`) contract.
- `anyharness/sdk/src/types/workflow-runs.ts` — thin re-exports of the generated `VersionedPutWorkflowRunRequest` / `VersionedWorkflowRunResponse` unions (v1 managed + v2 portable). No hand-defined shapes.
- `anyharness/sdk/src/client/core.ts` — attached as `AnyHarnessClient.workflowRuns`.
- `anyharness/sdk/src/index.ts` — public type exports.
- `anyharness/sdk/src/client/workflow-runs.test.ts` — unit tests pinning path/method/body for all three ops.

**Why this is separable:** purely additive local-AnyHarness typed HTTP; it consumes only contracts already merged on main; it presupposes **no** unmerged Cloud/Server code. It is usable identically by managed and Desktop delivery, so it does not fork per-target.

**Evidence (no Rust built):**
- `npm run typecheck` (tsc --noEmit) — clean
- `npm run typecheck:contracts` — clean
- `npx vitest run` (full SDK suite) — **104 passed**, including the pre-existing portable-contract tests and the new resource tests
- `npm run build` (tsc dist) — clean; `dist/client/workflow-runs.js` emitted

---

## Reconciliation findings

### Settled (Green) — verified on current main

- **ProductHost / desktopBridge / lifecycle root** all present: `product-host.ts`, `desktop-bridge.ts`, `ProductHostProvider.tsx`, `DesktopProductLifecycleRoot.tsx`, and the desktop-side `DesktopProductHostProvider.tsx` + Tauri `desktop-bridge.ts` all exist. The bridge already exposes runtime-connection + install-ID methods. No new host plumbing or second root needed — confirmed.
- **`useWorkspaces().localWorkspaces`** exists and composes the local AnyHarness inventory (use-workspaces.ts:160/191). The Desktop target picker can receive explicit local options without path/repo inference — confirmed.
- **`useWorkspaceActivationWorkflow()`** present for exact `workspaceId + sessionId` open — confirmed.
- **Generated AnyHarness v2 contracts** (`PutWorkflowRunRequestV2`, `VersionedPutWorkflowRunRequest`, `VersionedWorkflowRunResponse`, `WorkflowRunResponseV2`) and the three endpoints already exist on main — confirmed; this PR's resource wraps them.

### Open decisions (still founder-gated; provisional draft)

The 8 "Founder decisions before freeze" (spec §1053-1073) remain open — install-ID-as-custody-not-auth, explicit-workspace-only, renderer-driven pull vs push, Cloud-history/local-execution authority split, no auto-placement, the two-PR split, `payloadIssuedAt` ambiguity boundary, and `workflowDesktopRuns` default-off gate. None are contradicted by merged main; they are simply not yet ruled. **No code here presupposes any of them.**

### Blocked on unmerged 5/6 (design-only — deliberately NOT coded)

Verified absent on current main; would require the sibling lanes:

1. **Capability contract v4.** Main is `SELF_HOST_CAPABILITY_CONTRACT_VERSION = 3` with `workflowManagedRuns` on `/meta` (server `meta.py`, client `server-capability-contract.ts`). Adding `workflowDesktopRuns` + bumping to v4 is a Server+client contract change. Deferred — it touches the shared `/meta` shape that lane 5/6 also move.
2. **Cloud `connectedDesktop` target + schema v2 invocation.** Cloud SDK today has only `kind: "managedCloud"` and `schemaVersion: 1` for invocation creation; grep for `connectedDesktop` / `desktopExecution` / `workflowDesktopRuns` / `desktop-pending` in `cloud/sdk` returns **zero**. The whole Cloud API block (§"Cloud API"), the `workflow_desktop_execution` table (§"Cloud persistence"), and the generated Cloud SDK clients depend on Server work in lane 5.
3. **Target-discriminated run presentation.** `product-domain/src/workflows/run-presentation.ts` is hard-bound to `run.managedExecution`; `WorkflowRun = ManagedWorkflowInvocationResponse`. Making it render `managedExecution | desktopExecution` requires the `desktopExecution` type, which does not exist until the Cloud contract lands. Coding a discriminator now would mean inventing an unmerged type.
4. **ProductClient delivery/recovery workflow + Desktop target picker.** `lib/workflows/workflows/desktop-workflow-delivery.ts`, `hooks/workflows/lifecycle/use-desktop-workflow-recovery.ts`, and the "This Mac" picker all orchestrate the unmerged Cloud custody/pending/report APIs. Not separable.

---

## Material decisions raised (primary output of this lane)

1. **Delivery-status enum contradiction.** Spec 8 repeatedly uses `deliveryStatus = waiting_for_desktop` (§Cloud API, §persistence dimensions, §guarded transitions). **Merged main's managed enum is `prepared | queued | delivering | accepted | delivery_failed | delivery_cancelled`** (cloud generated openapi 4876/4964) — there is **no `waiting_for_desktop`**. Spec 8 must either (a) add `waiting_for_desktop` as a Desktop-only delivery status to the shared enum, or (b) reuse `prepared`/`queued`. This is a shared-contract decision that lane 5 (Cloud Execution) owns the enum for; it needs an explicit ruling before spec 8 freezes, and it is a cross-lane contract coordination point with 5/6.
2. **201-vs-200 not observable through the shared transport.** Spec 8 §"AnyHarness SDK" says to "preserve typed `201` created, `200` exact replay." The generated contract returns the **same `VersionedWorkflowRunResponse` body** for both, and the shared `AnyHarnessTransport` discards success status codes (only surfaces status on `AnyHarnessError`). The landed resource therefore reconciles idempotently on the durable body, not the status line — documented in the resource doc-comment. If a caller genuinely must branch created-vs-replayed, that requires a **shared transport change** (surfacing success status), which I deliberately did **not** make in this separable slice. Flagging as a design item for the ProductClient delivery PR.

Neither is a blocker for the landed SDK resource; both are contract decisions the full delivery PR / lane 5 must settle.

---

## Scope / non-goals

Per the lane directive this PR is reconciliation + separable groundwork only. It does **not** build: Cloud/Server APIs, the `workflow_desktop_execution` row, capability v4, ProductClient delivery/recovery orchestration, the Desktop target picker, target-discriminated presentation, or any Tier 3 journey. Those are design-only above, pending 5/6 merge and founder rulings. **No Rust built, no Docker, no migration, no deploy.** One PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

