### PR TITLE
fix(release): close failed billing boot fixture

### DIFF
--- a/tests/intent/stack/billing-usage-import.ts
+++ b/tests/intent/stack/billing-usage-import.ts
@@ -38,6 +38,18 @@ export type BootWithFakeResult =
   | { skipped: true; reason: string }
   | ({ skipped: false } & BillingStackWithFake);
 
+/** Injectable boot seams for the failed-boot cleanup regression. Production
+ * always uses the real management fake + billing stack. */
+export interface BootBillingStackWithLitellmFakeDeps {
+  startFake: typeof startLitellmManagementFake;
+  bootStack: typeof bootBillingStack;
+}
+
+const DEFAULT_BOOT_WITH_FAKE_DEPS: BootBillingStackWithLitellmFakeDeps = {
+  startFake: startLitellmManagementFake,
+  bootStack: bootBillingStack,
+};
+
 function required(name: string): string {
   const value = process.env[name];
   if (!value) {
@@ -103,17 +115,36 @@ export async function seedFakeSpendRows(rows: import("../fakes/litellm-managemen
  * desktop web/AnyHarness runtime (`skipFrontend`) since every import/exhaustion
  * assertion is API + DB, never UI.
  */
-export async function bootBillingStackWithLitellmFake(): Promise<BootWithFakeResult> {
-  const fake = await startLitellmManagementFake();
-  const boot: BillingBootResult = await bootBillingStack({
-    skipFrontend: true,
-    extraServerEnv: {
-      AGENT_GATEWAY_ENABLED: "true",
-      AGENT_GATEWAY_LITELLM_BASE_URL: fake.baseUrl,
-      AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: fake.baseUrl,
-      AGENT_GATEWAY_LITELLM_MASTER_KEY: fake.masterKey,
-    },
-  });
+export async function bootBillingStackWithLitellmFake(
+  deps: BootBillingStackWithLitellmFakeDeps = DEFAULT_BOOT_WITH_FAKE_DEPS,
+): Promise<BootWithFakeResult> {
+  const fake = await deps.startFake();
+  let boot: BillingBootResult;
+  try {
+    boot = await deps.bootStack({
+      skipFrontend: true,
+      extraServerEnv: {
+        AGENT_GATEWAY_ENABLED: "true",
+        AGENT_GATEWAY_LITELLM_BASE_URL: fake.baseUrl,
+        AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: fake.baseUrl,
+        AGENT_GATEWAY_LITELLM_MASTER_KEY: fake.masterKey,
+      },
+    });
+  } catch (bootError) {
+    // The fake is created before Stripe/profile setup because the Server needs
+    // its URL at boot. If that later setup throws, no NormalizedBoot reaches
+    // the release harness teardown. Close here so the listening HTTP server
+    // cannot keep the runner alive after it writes the aggregate report.
+    try {
+      await fake.close();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [bootError, cleanupError],
+        "Tier-2 billing stack boot failed and the LiteLLM management fake could not close",
+      );
+    }
+    throw bootError;
+  }
   if (boot.skipped) {
     await fake.close();
     return { skipped: true, reason: boot.reason };

--- a/tests/release/src/cli/run-termination.fixture.ts
+++ b/tests/release/src/cli/run-termination.fixture.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { bootBillingStackWithLitellmFake } from "../../../intent/stack/billing-usage-import.ts";
+import { startLitellmManagementFake } from "../../../intent/fakes/litellm-management/server.ts";
+import { writeReportV4 } from "../evidence/write.js";
+import { executeSelectedCells } from "../runner/execute.js";
+import type { RunIdentityV1 } from "../runner/identity.js";
+import type { MatrixScenarioDefinition } from "../scenarios/types.js";
+import { runReleaseCommand, type CommandDeps } from "./command.js";
+
+const SOURCE_SHA = "a".repeat(40);
+const IDENTITY: RunIdentityV1 = {
+  run_id: "termination-regression",
+  shard_id: "local-0",
+  attempt: 1,
+  source_sha: SOURCE_SHA,
+  origin: { kind: "local", github_run_id: null, github_job: null },
+};
+
+const FAILED_BOOT_SCENARIO: MatrixScenarioDefinition = {
+  id: "T2-FAILED-BOOT",
+  kind: "matrix",
+  title: "failed Tier-2 boot cleanup",
+  registryFlowRef: "tests/release#failed-boot-cleanup",
+  lanes: ["local"],
+  requiredEnv: [],
+  sourceBacked: true,
+  expandCells: () => [{ dimensions: { case: "failed-boot" } }],
+  planCell: () => [],
+  runCells: async () => {
+    await bootBillingStackWithLitellmFake({
+      startFake: startLitellmManagementFake,
+      bootStack: async () => {
+        throw new Error("intentional billing boot failure");
+      },
+    });
+    throw new Error("failed boot unexpectedly returned");
+  },
+};
+
+async function main(): Promise<number> {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "release-runner-termination-"));
+  const deps: CommandDeps = {
+    resolveIdentity: async () => IDENTITY,
+    selectScenarios: () => [FAILED_BOOT_SCENARIO],
+    loadBuildMap: async () => {
+      throw new Error("candidate map is not used by this source-backed fixture");
+    },
+    loadLocalWorldPorts: async () => null,
+    seedLocalDurableUser: async () => undefined,
+    pushLocalGatewayAuth: async () => undefined,
+    printEnvManifestReport: () => undefined,
+    execute: executeSelectedCells,
+    write: (dir, report) => writeReportV4(dir, report, []),
+    fileIssues: async () => [],
+    log: (message) => console.log(message),
+    error: (message) => console.error(message),
+  };
+
+  try {
+    return await runReleaseCommand(
+      [
+        "--behavior",
+        "diagnostic",
+        "--source-candidate",
+        "--output-dir",
+        outputDir,
+      ],
+      deps,
+    );
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+}
+
+process.exitCode = await main();

--- a/tests/release/src/cli/run-termination.test.ts
+++ b/tests/release/src/cli/run-termination.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const FIXTURE = fileURLToPath(new URL("./run-termination.fixture.ts", import.meta.url));
+
+test("a failed Tier-2 boot closes its fake and the CLI exits after writing the aggregate", async () => {
+  const result = await runFixture(FIXTURE, 15_000);
+
+  assert.equal(result.timedOut, false, `fixture did not terminate; stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stdout, /Combined report written:/);
+  assert.match(result.stdout, /1 failed/);
+  assert.match(result.stdout, /intended exit 1/);
+  assert.equal(result.code, 1, `unexpected exit; stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+});
+
+function runFixture(
+  fixture: string,
+  timeoutMs: number,
+): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", path.resolve(fixture)], {
+      cwd: path.resolve(fileURLToPath(new URL("../../", import.meta.url))),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- close the in-process LiteLLM management fake when Tier-2 billing boot fails before returning a teardown handle
- preserve both boot and cleanup errors if emergency cleanup also fails
- add a real child-process regression proving the release runner writes its aggregate and exits naturally without `process.exit`

Root cause from [Release E2E run 29602686092](https://github.com/proliferate-ai/proliferate/actions/runs/29602686092): the local runner wrote its aggregate, but an HTTP server opened before the failing Stripe/profile setup remained listening and held Node open until the 60-minute job timeout.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- `cd tests/release && npm run typecheck`
- `cd tests/release && ./node_modules/.bin/tsx --test src/cli/run-termination.test.ts src/scenarios/tier2/harness.test.ts` (20/20)
- exact base: `1c690d9aeb536835d3a19f852c6a9e0201f82e6e`
- exact head: `04e652cf4f69d7ff5c02f70b715c4deb8875c924`

## Scope

This fixes only failed-boot resource ownership. It does not mask or repair the Stripe setup failure that triggered the path, change runner verdicts, or touch managed-cloud/self-host qualification branches.