### PR TITLE
fix(integrations): fail closed on Slack writes

### DIFF
--- a/server/proliferate/integrations/integration_oauth/tokens.py
+++ b/server/proliferate/integrations/integration_oauth/tokens.py
@@ -10,6 +10,17 @@ from proliferate.integrations.integration_oauth.errors import IntegrationOAuthPr
 from proliferate.integrations.integration_oauth.models import TokenResponse
 
 _SCOPE_SEPARATOR_RE = re.compile(r"[\s,]+")
+_SLACK_TOKEN_ENDPOINT = "https://slack.com/api/oauth.v2.user.access"
+_SLACK_INVALID_CLIENT_ERRORS = frozenset({"bad_client_secret", "invalid_client_id"})
+_SLACK_INVALID_GRANT_ERRORS = frozenset(
+    {
+        "bad_redirect_uri",
+        "invalid_code",
+        "invalid_refresh_token",
+        "token_expired",
+        "token_revoked",
+    }
+)
 
 
 def _granted_scopes(payload: dict[str, Any]) -> tuple[str, ...] | None:
@@ -30,6 +41,21 @@ def _granted_scopes(payload: dict[str, Any]) -> tuple[str, ...] | None:
             normalized.append(scope)
             seen.add(scope)
     return tuple(normalized)
+
+
+def _raise_for_slack_token_error(token_endpoint: str, payload: dict[str, Any]) -> None:
+    """Translate Slack's HTTP-2xx error envelope without exposing its payload."""
+    if token_endpoint != _SLACK_TOKEN_ENDPOINT or payload.get("ok") is not False:
+        return
+    provider_error = payload.get("error")
+    if isinstance(provider_error, str) and provider_error in _SLACK_INVALID_CLIENT_ERRORS:
+        raise IntegrationOAuthProviderError("invalid_client", "OAuth provider rejected client.")
+    if isinstance(provider_error, str) and provider_error in _SLACK_INVALID_GRANT_ERRORS:
+        raise IntegrationOAuthProviderError("invalid_grant", "OAuth grant is no longer valid.")
+    raise IntegrationOAuthProviderError(
+        "token_request_failed",
+        "OAuth provider rejected the token request.",
+    )
 
 
 async def exchange_token(
@@ -130,6 +156,7 @@ async def _token_request(
                 "OAuth provider rejected the token request.",
             ) from exc
         payload = response.json()
+        _raise_for_slack_token_error(token_endpoint, payload)
     expires_in = payload.get("expires_in")
     expires_at = (
         datetime.now(UTC) + timedelta(seconds=int(expires_in))

--- a/server/proliferate/integrations/integration_oauth/tokens.py
+++ b/server/proliferate/integrations/integration_oauth/tokens.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -10,7 +11,9 @@ from proliferate.integrations.integration_oauth.errors import IntegrationOAuthPr
 from proliferate.integrations.integration_oauth.models import TokenResponse
 
 _SCOPE_SEPARATOR_RE = re.compile(r"[\s,]+")
-_SLACK_TOKEN_ENDPOINT = "https://slack.com/api/oauth.v2.user.access"
+_SLACK_PROVIDER_NAMESPACE = "slack"
+_SLACK_TOKEN_HOST = "slack.com"
+_SLACK_TOKEN_PATH = "/api/oauth.v2.user.access"
 _SLACK_INVALID_CLIENT_ERRORS = frozenset({"bad_client_secret", "invalid_client_id"})
 _SLACK_INVALID_GRANT_ERRORS = frozenset(
     {
@@ -43,9 +46,45 @@ def _granted_scopes(payload: dict[str, Any]) -> tuple[str, ...] | None:
     return tuple(normalized)
 
 
-def _raise_for_slack_token_error(token_endpoint: str, payload: dict[str, Any]) -> None:
+def _is_slack_token_endpoint(
+    token_endpoint: str,
+    *,
+    provider_namespace: str | None,
+) -> bool:
+    """Identify Slack by trusted namespace, then a narrow canonical URL fallback."""
+    if provider_namespace is not None:
+        return provider_namespace == _SLACK_PROVIDER_NAMESPACE
+    try:
+        parsed = urlsplit(token_endpoint)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() == "https"
+        and parsed.hostname == _SLACK_TOKEN_HOST
+        and port in {None, 443}
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.path in {_SLACK_TOKEN_PATH, f"{_SLACK_TOKEN_PATH}/"}
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _raise_for_slack_token_error(
+    token_endpoint: str,
+    payload: dict[str, Any],
+    *,
+    provider_namespace: str | None,
+) -> None:
     """Translate Slack's HTTP-2xx error envelope without exposing its payload."""
-    if token_endpoint != _SLACK_TOKEN_ENDPOINT or payload.get("ok") is not False:
+    if (
+        not _is_slack_token_endpoint(
+            token_endpoint,
+            provider_namespace=provider_namespace,
+        )
+        or payload.get("ok") is not False
+    ):
         return
     provider_error = payload.get("error")
     if isinstance(provider_error, str) and provider_error in _SLACK_INVALID_CLIENT_ERRORS:
@@ -68,6 +107,7 @@ async def exchange_token(
     resource: str,
     client_secret: str | None = None,
     token_endpoint_auth_method: str | None = None,
+    provider_namespace: str | None = None,
 ) -> TokenResponse:
     return await _token_request(
         token_endpoint,
@@ -81,6 +121,7 @@ async def exchange_token(
         },
         client_secret=client_secret,
         token_endpoint_auth_method=token_endpoint_auth_method,
+        provider_namespace=provider_namespace,
     )
 
 
@@ -92,6 +133,7 @@ async def refresh_token(
     resource: str,
     client_secret: str | None = None,
     token_endpoint_auth_method: str | None = None,
+    provider_namespace: str | None = None,
 ) -> TokenResponse:
     return await _token_request(
         token_endpoint,
@@ -103,6 +145,7 @@ async def refresh_token(
         },
         client_secret=client_secret,
         token_endpoint_auth_method=token_endpoint_auth_method,
+        provider_namespace=provider_namespace,
     )
 
 
@@ -133,6 +176,7 @@ async def _token_request(
     *,
     client_secret: str | None,
     token_endpoint_auth_method: str | None,
+    provider_namespace: str | None,
 ) -> TokenResponse:
     request_data, auth = _token_request_auth_options(
         data,
@@ -156,7 +200,11 @@ async def _token_request(
                 "OAuth provider rejected the token request.",
             ) from exc
         payload = response.json()
-        _raise_for_slack_token_error(token_endpoint, payload)
+        _raise_for_slack_token_error(
+            token_endpoint,
+            payload,
+            provider_namespace=provider_namespace,
+        )
     expires_in = payload.get("expires_in")
     expires_at = (
         datetime.now(UTC) + timedelta(seconds=int(expires_in))

--- a/server/proliferate/server/cloud/integration_gateway/domain/tool_policy.py
+++ b/server/proliferate/server/cloud/integration_gateway/domain/tool_policy.py
@@ -1,0 +1,89 @@
+"""Pure provider-tool policy for integration gateway calls.
+
+Slack is the first provider whose upstream catalog mixes read-only and external
+actions behind one OAuth-backed MCP endpoint.  Keep the decision exact and
+data-only so a later durable approval service can consume the same verdict
+without trusting agent arguments or an in-memory confirmation flag.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+SLACK_PROVIDER = "slack"
+
+# Canonical Slack MCP names are matched exactly.  A newly introduced or renamed
+# Slack tool is denied until this policy is deliberately updated.
+SLACK_READ_TOOL_NAMES = frozenset(
+    {
+        "slack_get_reactions",
+        "slack_list_channel_members",
+        "slack_list_starred_items",
+        "slack_list_user_conversations",
+        "slack_list_user_groups",
+        "slack_list_workspaces",
+        "slack_read_canvas",
+        "slack_read_channel",
+        "slack_read_file",
+        "slack_read_thread",
+        "slack_read_user_profile",
+        "slack_search_channels",
+        "slack_search_emojis",
+        "slack_search_public",
+        "slack_search_public_and_private",
+        "slack_search_users",
+    }
+)
+
+SLACK_MUTATING_TOOL_NAMES = frozenset(
+    {
+        "slack_add_reaction",
+        "slack_complete_file_upload",
+        "slack_create_canvas",
+        "slack_create_conversation",
+        "slack_create_reminder",
+        "slack_delete_message",
+        "slack_edit_message",
+        "slack_get_file_upload_url",
+        "slack_invite_to_conversation",
+        "slack_join_conversation",
+        "slack_leave_conversation",
+        "slack_schedule_message",
+        "slack_send_message",
+        "slack_send_message_draft",
+        "slack_update_canvas",
+        "slack_update_user_profile",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ToolCallAllowed:
+    provider: str
+    tool: str
+
+
+@dataclass(frozen=True)
+class ToolCallRequiresApproval:
+    provider: str
+    tool: str
+
+
+@dataclass(frozen=True)
+class ToolCallDenied:
+    provider: str
+    tool: str
+
+
+ToolCallPolicyDecision = ToolCallAllowed | ToolCallRequiresApproval | ToolCallDenied
+
+
+def decide_tool_call(*, provider: str, tool: str) -> ToolCallPolicyDecision:
+    """Classify one exact provider/tool identity without inspecting arguments."""
+    if provider != SLACK_PROVIDER:
+        return ToolCallAllowed(provider=provider, tool=tool)
+    if tool in SLACK_READ_TOOL_NAMES:
+        return ToolCallAllowed(provider=provider, tool=tool)
+    if tool in SLACK_MUTATING_TOOL_NAMES:
+        return ToolCallRequiresApproval(provider=provider, tool=tool)
+    return ToolCallDenied(provider=provider, tool=tool)

--- a/server/proliferate/server/cloud/integration_gateway/errors.py
+++ b/server/proliferate/server/cloud/integration_gateway/errors.py
@@ -1,0 +1,61 @@
+"""Typed integration-gateway product errors."""
+
+from __future__ import annotations
+
+from proliferate.server.cloud.errors import CloudApiError
+
+
+class IntegrationToolPolicyError(CloudApiError):
+    """Base for fail-closed provider-tool policy results."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        provider: str,
+        tool: str,
+        approval_required: bool,
+        approval_status: str,
+    ) -> None:
+        super().__init__(code, message, status_code=403)
+        self.provider = provider
+        self.tool = tool
+        self.approval_required = approval_required
+        self.approval_status = approval_status
+
+    def structured_error(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "provider": self.provider,
+            "tool": self.tool,
+            "approval": {
+                "required": self.approval_required,
+                "status": self.approval_status,
+            },
+        }
+
+
+class IntegrationToolApprovalRequired(IntegrationToolPolicyError):
+    def __init__(self, *, provider: str, tool: str) -> None:
+        super().__init__(
+            "integration_tool_approval_required",
+            "This external action requires approval and is not supported until approved.",
+            provider=provider,
+            tool=tool,
+            approval_required=True,
+            approval_status="unsupported",
+        )
+
+
+class IntegrationToolNotAllowed(IntegrationToolPolicyError):
+    def __init__(self, *, provider: str, tool: str) -> None:
+        super().__init__(
+            "integration_tool_not_allowed",
+            "This provider tool is not allowed by the integration gateway.",
+            provider=provider,
+            tool=tool,
+            approval_required=False,
+            approval_status="not_applicable",
+        )

--- a/server/proliferate/server/cloud/integration_gateway/service.py
+++ b/server/proliferate/server/cloud/integration_gateway/service.py
@@ -25,6 +25,17 @@ from proliferate.server.cloud.integration_gateway.domain.tool_args import (
     parse_call_tool_args,
     parse_list_tools_args,
 )
+from proliferate.server.cloud.integration_gateway.domain.tool_policy import (
+    ToolCallAllowed,
+    ToolCallDenied,
+    ToolCallRequiresApproval,
+    decide_tool_call,
+)
+from proliferate.server.cloud.integration_gateway.errors import (
+    IntegrationToolApprovalRequired,
+    IntegrationToolNotAllowed,
+    IntegrationToolPolicyError,
+)
 from proliferate.server.cloud.integration_gateway.models import GatewayProviderAccount
 from proliferate.server.cloud.integrations.access import resolve_launch
 from proliferate.server.cloud.integrations.tools import get_or_refresh_tool_cache
@@ -140,6 +151,13 @@ async def call_provider_tool(
     ok = False
     error_code: str | None = None
     try:
+        decision = decide_tool_call(provider=provider, tool=tool)
+        if isinstance(decision, ToolCallRequiresApproval):
+            raise IntegrationToolApprovalRequired(provider=provider, tool=tool)
+        if isinstance(decision, ToolCallDenied):
+            raise IntegrationToolNotAllowed(provider=provider, tool=tool)
+        if not isinstance(decision, ToolCallAllowed):
+            raise IntegrationToolNotAllowed(provider=provider, tool=tool)
         pair = await account_for_provider(db, grant=grant, provider=provider)
         url, headers, query = await resolve_launch(db, pair.account, pair.definition)
         result = await mcp_remote.call_tool(
@@ -265,6 +283,15 @@ async def handle_integration_gateway_json_rpc(
         params = params if isinstance(params, dict) else {}
         try:
             result = await _handle_tools_call(db, grant=grant, params=params)
+        except IntegrationToolPolicyError as error:
+            return json_rpc.json_rpc_result(
+                request_id=request_id,
+                result={
+                    "content": [{"type": "text", "text": error.message}],
+                    "structuredContent": {"error": error.structured_error()},
+                    "isError": True,
+                },
+            )
         except (CloudApiError, McpRemoteError) as error:
             # Surface tool-level failures (bad provider, or an upstream MCP that
             # is down/timing out) as an MCP error result, not a transport error,

--- a/server/proliferate/server/cloud/integrations/access.py
+++ b/server/proliferate/server/cloud/integrations/access.py
@@ -230,6 +230,7 @@ async def _refresh_oauth_bundle(
     account: IntegrationAccountRecord,
     bundle: dict[str, Any],
     cfg: IntegrationConfig,
+    provider_namespace: str,
 ) -> tuple[str, datetime | None]:
     """Refresh the access token in ``bundle`` and persist the new credential.
 
@@ -276,6 +277,7 @@ async def _refresh_oauth_bundle(
             resource=str(bundle.get("resource") or ""),
             client_secret=client_secret,
             token_endpoint_auth_method=token_endpoint_auth_method,
+            provider_namespace=provider_namespace,
         )
     except CloudApiError:
         raise
@@ -364,7 +366,12 @@ async def ensure_provider_access(
         return _api_key_access(cfg, account_record, settings)
 
     if auth_kind == "oauth2":
-        return await _oauth_access(cfg, account_record, settings)
+        return await _oauth_access(
+            cfg,
+            account_record,
+            settings,
+            provider_namespace=definition_record.namespace,
+        )
 
     raise CloudApiError(
         "integration_auth_kind_unsupported",
@@ -392,6 +399,8 @@ async def _oauth_access(
     cfg: IntegrationConfig,
     account: IntegrationAccountRecord,
     settings: dict[str, Any],
+    *,
+    provider_namespace: str,
 ) -> ProviderAccess:
     bundle = _decode_bundle(account)
     try:
@@ -411,7 +420,10 @@ async def _oauth_access(
         resolved_expiry = expires_at
     else:
         resolved_token, resolved_expiry = await _refresh_oauth_bundle(
-            account=account, bundle=bundle, cfg=cfg
+            account=account,
+            bundle=bundle,
+            cfg=cfg,
+            provider_namespace=provider_namespace,
         )
 
     # Expose bundle string fields (plus the resolved access token) as secrets so

--- a/server/proliferate/server/cloud/integrations/oauth/service.py
+++ b/server/proliferate/server/cloud/integrations/oauth/service.py
@@ -491,6 +491,7 @@ async def complete_oauth_callback(
             token_endpoint_auth_method=(
                 oauth_client.token_endpoint_auth_method if oauth_client else None
             ),
+            provider_namespace=definition.namespace,
         )
     except IntegrationOAuthProviderError as exc:
         if _should_drop_cached_oauth_client_on_token_error(exc.code) and oauth_client is not None:

--- a/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
@@ -1,0 +1,338 @@
+"""Fail-closed Slack tool policy at the hosted integration gateway."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.db.models.cloud.integrations import CloudIntegrationToolCallEvent
+from proliferate.db.models.cloud.runtime_workers import CloudRuntimeWorker
+from proliferate.db.store.integrations import accounts as accounts_store
+from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.server.cloud.integration_gateway.domain.tool_policy import (
+    SLACK_MUTATING_TOOL_NAMES,
+)
+from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
+from proliferate.utils.crypto import encrypt_json
+from tests.integration.test_cloud_integration_gateway_api import (
+    GATEWAY_URL,
+    _authed_user,
+    _gateway_bearer,
+    _seed_ready_account,
+    _tool_call,
+)
+
+
+@pytest.fixture(autouse=True)
+def _worker_cloud_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "cloud_worker_base_url", "http://cloud.test")
+
+
+async def _first_worker(db_session: AsyncSession) -> CloudRuntimeWorker:
+    worker = (await db_session.execute(select(CloudRuntimeWorker))).scalars().first()
+    assert worker is not None
+    return worker
+
+
+async def _seed_ready_slack_account(
+    db_session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+) -> None:
+    await sync_seed_definitions(db_session)
+    await db_session.commit()
+    definition = await definitions_store.get_seed_by_namespace(db_session, "slack")
+    assert definition is not None
+    account = await accounts_store.upsert_account(
+        db_session,
+        user_id=user_id,
+        definition_id=definition.id,
+        auth_kind="oauth2",
+        status="ready",
+    )
+    await accounts_store.set_account_credentials(
+        db_session,
+        account_id=account.id,
+        credential_ciphertext=encrypt_json(
+            {
+                "issuer": "https://slack.com",
+                "resource": "https://mcp.slack.com/mcp",
+                "clientId": "slack-client",
+                "accessToken": "slack-read-token",
+                "refreshToken": "slack-refresh-token",
+                "expiresAt": None,
+                "scopes": [],
+                "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+                "redirectUri": ("https://api.example.com/v1/cloud/integrations/oauth/callback"),
+            }
+        ),
+        credential_format="oauth-bundle-v1",
+        auth_status="ready",
+        token_expires_at=None,
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_known_slack_read_tool_executes_directly(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bearer = await _gateway_bearer(client, db_session, prefix="gw-slack-policy-read")
+    worker = await _first_worker(db_session)
+    await _seed_ready_slack_account(db_session, user_id=worker.owner_user_id)
+    captured: dict[str, object] = {}
+
+    async def fake_call_tool(*, url, headers, tool_name, arguments, query=None):
+        captured.update(
+            {
+                "headers": headers,
+                "tool_name": tool_name,
+                "arguments": arguments,
+            }
+        )
+        return {"content": [{"type": "text", "text": "read result"}], "isError": False}
+
+    monkeypatch.setattr(
+        "proliferate.server.cloud.integration_gateway.service.mcp_remote.call_tool",
+        fake_call_tool,
+    )
+
+    result = await _tool_call(
+        client,
+        {"Authorization": f"Bearer {bearer}"},
+        name="integrations.call_tool",
+        arguments={
+            "provider": "slack",
+            "tool": "slack_search_public",
+            "arguments": {"query": "release"},
+        },
+    )
+
+    assert result["structuredContent"]["isError"] is False
+    assert captured["tool_name"] == "slack_search_public"
+    assert captured["arguments"] == {"query": "release"}
+    captured_headers = captured["headers"]
+    assert isinstance(captured_headers, dict)
+    assert captured_headers.get("Authorization") == "Bearer slack-read-token"
+
+
+@pytest.mark.asyncio
+async def test_every_known_slack_mutation_returns_typed_approval_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bearer = await _gateway_bearer(client, db_session, prefix="gw-slack-policy-write")
+
+    async def unexpected_call_tool(**_kwargs: object) -> dict[str, object]:
+        raise AssertionError("Slack mutation reached the upstream MCP")
+
+    monkeypatch.setattr(
+        "proliferate.server.cloud.integration_gateway.service.mcp_remote.call_tool",
+        unexpected_call_tool,
+    )
+
+    for tool in sorted(SLACK_MUTATING_TOOL_NAMES):
+        result = await _tool_call(
+            client,
+            {"Authorization": f"Bearer {bearer}"},
+            name="integrations.call_tool",
+            arguments={
+                "provider": "slack",
+                "tool": tool,
+                "arguments": {
+                    "approved": True,
+                    "userConfirmed": True,
+                    "approvalToken": "agent-claimed-approval",
+                },
+            },
+        )
+
+        assert result["isError"] is True
+        assert result["structuredContent"]["error"] == {
+            "code": "integration_tool_approval_required",
+            "message": (
+                "This external action requires approval and is not supported until approved."
+            ),
+            "provider": "slack",
+            "tool": tool,
+            "approval": {"required": True, "status": "unsupported"},
+        }
+
+    await db_session.rollback()
+    events = list(
+        (
+            await db_session.execute(
+                select(CloudIntegrationToolCallEvent).order_by(
+                    CloudIntegrationToolCallEvent.created_at
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {event.tool_name for event in events} == set(SLACK_MUTATING_TOOL_NAMES)
+    assert {event.error_code for event in events} == {"integration_tool_approval_required"}
+    assert all(event.ok is False for event in events)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool",
+    ["slack_send_message_v2", "slack_search_public ", "Slack_search_public"],
+)
+async def test_unknown_or_inexact_slack_tool_fails_closed(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tool: str,
+) -> None:
+    bearer = await _gateway_bearer(
+        client,
+        db_session,
+        prefix=f"gw-slack-policy-unknown-{uuid.uuid4().hex}",
+    )
+
+    async def unexpected_call_tool(**_kwargs: object) -> dict[str, object]:
+        raise AssertionError("Unknown Slack tool reached the upstream MCP")
+
+    monkeypatch.setattr(
+        "proliferate.server.cloud.integration_gateway.service.mcp_remote.call_tool",
+        unexpected_call_tool,
+    )
+
+    result = await _tool_call(
+        client,
+        {"Authorization": f"Bearer {bearer}"},
+        name="integrations.call_tool",
+        arguments={"provider": "slack", "tool": tool, "arguments": {}},
+    )
+
+    assert result["isError"] is True
+    assert result["structuredContent"]["error"] == {
+        "code": "integration_tool_not_allowed",
+        "message": "This provider tool is not allowed by the integration gateway.",
+        "provider": "slack",
+        "tool": tool,
+        "approval": {"required": False, "status": "not_applicable"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_policy_verdict_fails_closed(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bearer = await _gateway_bearer(client, db_session, prefix="gw-policy-verdict")
+
+    monkeypatch.setattr(
+        "proliferate.server.cloud.integration_gateway.service.decide_tool_call",
+        lambda **_kwargs: object(),
+    )
+
+    result = await _tool_call(
+        client,
+        {"Authorization": f"Bearer {bearer}"},
+        name="integrations.call_tool",
+        arguments={
+            "provider": "slack",
+            "tool": "slack_search_public",
+            "arguments": {},
+        },
+    )
+
+    assert result["isError"] is True
+    assert result["structuredContent"]["error"]["code"] == ("integration_tool_not_allowed")
+
+
+@pytest.mark.asyncio
+async def test_non_slack_provider_preserves_current_tool_execution(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bearer = await _gateway_bearer(client, db_session, prefix="gw-provider-isolation")
+    worker = await _first_worker(db_session)
+    await _seed_ready_account(
+        db_session,
+        user_id=str(worker.owner_user_id),
+        namespace="context7",
+    )
+    called = False
+
+    async def fake_call_tool(**_kwargs: object) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+    monkeypatch.setattr(
+        "proliferate.server.cloud.integration_gateway.service.mcp_remote.call_tool",
+        fake_call_tool,
+    )
+
+    result = await _tool_call(
+        client,
+        {"Authorization": f"Bearer {bearer}"},
+        name="integrations.call_tool",
+        arguments={
+            "provider": "context7",
+            "tool": "slack_send_message",
+            "arguments": {},
+        },
+    )
+
+    assert result["structuredContent"]["isError"] is False
+    assert called is True
+
+
+@pytest.mark.asyncio
+async def test_worker_token_and_gateway_arguments_cannot_bypass_policy(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    auth = await _authed_user(client, db_session, prefix="gw-policy-worker-bypass")
+    enrollment = await client.post(
+        "/v1/cloud/workers/desktop/enrollment",
+        headers=auth.headers,
+        json={"desktopInstallId": "install-gw-policy-worker-bypass"},
+    )
+    assert enrollment.status_code == 200, enrollment.text
+    enrolled = await client.post(
+        "/v1/cloud/worker/enroll",
+        json={"enrollmentToken": enrollment.json()["enrollmentToken"]},
+    )
+    assert enrolled.status_code == 200, enrolled.text
+
+    worker_token = enrolled.json()["workerToken"]
+    worker_attempt = await client.post(
+        GATEWAY_URL,
+        headers={"Authorization": f"Bearer {worker_token}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+    )
+    assert worker_attempt.status_code == 401
+
+    gateway_authorization = enrolled.json()["integrationGateway"]["authorization"]
+    result = await _tool_call(
+        client,
+        {"Authorization": gateway_authorization},
+        name="integrations.call_tool",
+        arguments={
+            "provider": "slack",
+            "tool": "slack_send_message",
+            "arguments": {
+                "approved": True,
+                "userConfirmed": True,
+                "message": "do not send",
+            },
+        },
+    )
+    assert result["isError"] is True
+    assert result["structuredContent"]["error"]["code"] == ("integration_tool_approval_required")

--- a/server/tests/integration/test_integration_oauth_scope_policy.py
+++ b/server/tests/integration/test_integration_oauth_scope_policy.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import uuid
 from urllib.parse import parse_qs, urlsplit
 
+import httpx
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.integrations.integration_oauth import tokens as oauth_tokens
 from proliferate.integrations.integration_oauth.models import (
     AuthorizationServerMetadata,
     ProtectedResourceMetadata,
@@ -169,6 +171,55 @@ async def test_slack_http_callback_rejects_invalid_scope_grant(
     assert flow.status_code == 200
     assert flow.json()["status"] == "failed"
     assert flow.json()["failureCode"] == "oauth_scope_mismatch"
+
+    await db_session.rollback()
+    account = await accounts_store.get_account(
+        db_session, uuid.UUID(str(started["account"]["accountId"]))
+    )
+    assert account is not None
+    assert account.status == "setup_required"
+    assert account.credential_ciphertext is None
+
+
+@pytest.mark.asyncio
+async def test_slack_http_callback_translates_2xx_error_without_persisting(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth, started, state = await _start_slack_flow(client, db_session, monkeypatch)
+    async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            json={
+                "ok": False,
+                "error": "invalid_code",
+                "private": "must-not-leak",
+            },
+        )
+    )
+    monkeypatch.setattr(
+        oauth_tokens.httpx,
+        "AsyncClient",
+        lambda **kwargs: async_client(transport=transport, **kwargs),
+    )
+
+    callback = await client.get(
+        "/v1/cloud/integrations/oauth/callback",
+        params={"state": state, "code": "authorization-code"},
+    )
+
+    assert callback.status_code == 200
+    assert "invalid_code" not in callback.text
+    assert "must-not-leak" not in callback.text
+    flow = await client.get(
+        f"/v1/cloud/integrations/oauth/flows/{started['oauthFlowId']}",
+        headers=auth.headers,
+    )
+    assert flow.status_code == 200
+    assert flow.json()["status"] == "failed"
+    assert flow.json()["failureCode"] == "invalid_grant"
 
     await db_session.rollback()
     account = await accounts_store.get_account(

--- a/server/tests/integration/test_integration_oauth_scope_policy.py
+++ b/server/tests/integration/test_integration_oauth_scope_policy.py
@@ -38,6 +38,8 @@ async def _start_slack_flow(
     client: AsyncClient,
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    token_endpoint: str = "https://slack.com/api/oauth.v2.user.access",
 ) -> tuple[AuthSession, dict[str, object], str]:
     prefix = f"oauth-scope-{uuid.uuid4().hex}"
     auth = await create_user_and_login(client, db_session, email_prefix=prefix)
@@ -75,7 +77,7 @@ async def _start_slack_flow(
         return AuthorizationServerMetadata(
             issuer=issuer,
             authorization_endpoint="https://slack.com/oauth/v2_user/authorize",
-            token_endpoint="https://slack.com/api/oauth.v2.user.access",
+            token_endpoint=token_endpoint,
             registration_endpoint=None,
             token_endpoint_auth_methods_supported=("client_secret_post",),
         )
@@ -187,7 +189,12 @@ async def test_slack_http_callback_translates_2xx_error_without_persisting(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    auth, started, state = await _start_slack_flow(client, db_session, monkeypatch)
+    auth, started, state = await _start_slack_flow(
+        client,
+        db_session,
+        monkeypatch,
+        token_endpoint="https://slack.com/api/oauth.v3.user.access",
+    )
     async_client = httpx.AsyncClient
     transport = httpx.MockTransport(
         lambda _request: httpx.Response(

--- a/server/tests/integration/test_integration_provider_access.py
+++ b/server/tests/integration/test_integration_provider_access.py
@@ -371,7 +371,7 @@ async def test_slack_refresh_translates_2xx_error_without_persisting(
         "refreshToken": "slack-refresh-token",
         "expiresAt": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
         "scopes": list(SLACK_SCOPES),
-        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "tokenEndpoint": "https://slack.com/api/oauth.v3.user.access",
         "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
     }
     definition, account = await _account_for(

--- a/server/tests/integration/test_integration_provider_access.py
+++ b/server/tests/integration/test_integration_provider_access.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime, timedelta
 
+import httpx
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,6 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.db.models.auth import User
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
+from proliferate.integrations.integration_oauth import tokens as oauth_tokens
+from proliferate.integrations.integration_oauth.errors import IntegrationOAuthProviderError
 from proliferate.integrations.integration_oauth.models import TokenResponse
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integrations import access as integration_access
@@ -347,6 +350,68 @@ async def test_slack_refresh_rejects_reported_scope_above_ceiling_without_persis
         )
 
     assert exc_info.value.code == "integration_reauth_required"
+    await db_session.rollback()
+    unchanged = await accounts_store.get_account(db_session, account.id)
+    assert unchanged is not None
+    assert unchanged.credential_ciphertext == original_ciphertext
+    assert unchanged.auth_version == original_auth_version
+
+
+@pytest.mark.asyncio
+async def test_slack_refresh_translates_2xx_error_without_persisting(
+    db_session: AsyncSession,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = {
+        "issuer": "https://slack.com",
+        "resource": "https://mcp.slack.com/mcp",
+        "clientId": "slack-client",
+        "accessToken": "expired-access-token",
+        "refreshToken": "slack-refresh-token",
+        "expiresAt": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+        "scopes": list(SLACK_SCOPES),
+        "tokenEndpoint": "https://slack.com/api/oauth.v2.user.access",
+        "redirectUri": "https://api.example.com/v1/cloud/integrations/oauth/callback",
+    }
+    definition, account = await _account_for(
+        db_session,
+        namespace="slack",
+        auth_kind="oauth2",
+        credential_ciphertext=encrypt_json(bundle),
+        credential_format="oauth-bundle-v1",
+    )
+    original_ciphertext = account.credential_ciphertext
+    original_auth_version = account.auth_version
+    async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            json={
+                "ok": False,
+                "error": "invalid_refresh_token",
+                "private": "must-not-leak",
+            },
+        )
+    )
+    monkeypatch.setattr(
+        oauth_tokens.httpx,
+        "AsyncClient",
+        lambda **kwargs: async_client(transport=transport, **kwargs),
+    )
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await ensure_provider_access(
+            db_session, account_record=account, definition_record=definition
+        )
+
+    assert exc_info.value.code == "integration_reauth_required"
+    assert str(exc_info.value) == "Integration requires re-authentication."
+    provider_error = exc_info.value.__cause__
+    assert isinstance(provider_error, IntegrationOAuthProviderError)
+    assert provider_error.code == "invalid_grant"
+    assert "invalid_refresh_token" not in str(provider_error)
+    assert "must-not-leak" not in str(provider_error)
     await db_session.rollback()
     unchanged = await accounts_store.get_account(db_session, account.id)
     assert unchanged is not None

--- a/server/tests/unit/test_cloud_integration_gateway_tool_policy.py
+++ b/server/tests/unit/test_cloud_integration_gateway_tool_policy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from proliferate.server.cloud.integration_gateway.domain.tool_policy import (
+    SLACK_MUTATING_TOOL_NAMES,
+    SLACK_READ_TOOL_NAMES,
+    ToolCallAllowed,
+    ToolCallDenied,
+    ToolCallRequiresApproval,
+    decide_tool_call,
+)
+
+EXPECTED_SLACK_READ_TOOLS = {
+    "slack_get_reactions",
+    "slack_list_channel_members",
+    "slack_list_starred_items",
+    "slack_list_user_conversations",
+    "slack_list_user_groups",
+    "slack_list_workspaces",
+    "slack_read_canvas",
+    "slack_read_channel",
+    "slack_read_file",
+    "slack_read_thread",
+    "slack_read_user_profile",
+    "slack_search_channels",
+    "slack_search_emojis",
+    "slack_search_public",
+    "slack_search_public_and_private",
+    "slack_search_users",
+}
+
+EXPECTED_SLACK_MUTATING_FAMILIES = {
+    "send": {"slack_send_message", "slack_send_message_draft"},
+    "schedule": {"slack_schedule_message"},
+    "message_update_delete": {"slack_edit_message", "slack_delete_message"},
+    "reaction": {"slack_add_reaction"},
+    "file_write": {"slack_get_file_upload_url", "slack_complete_file_upload"},
+    "conversation_write": {
+        "slack_create_conversation",
+        "slack_invite_to_conversation",
+        "slack_join_conversation",
+        "slack_leave_conversation",
+    },
+    "canvas_write": {"slack_create_canvas", "slack_update_canvas"},
+    "profile_write": {"slack_update_user_profile"},
+    "reminder_write": {"slack_create_reminder"},
+}
+
+
+def test_slack_read_allowlist_is_exact() -> None:
+    assert SLACK_READ_TOOL_NAMES == EXPECTED_SLACK_READ_TOOLS
+    for tool in EXPECTED_SLACK_READ_TOOLS:
+        assert decide_tool_call(provider="slack", tool=tool) == ToolCallAllowed(
+            provider="slack", tool=tool
+        )
+
+
+@pytest.mark.parametrize(
+    ("family", "tools"),
+    EXPECTED_SLACK_MUTATING_FAMILIES.items(),
+)
+def test_every_known_slack_mutating_family_requires_approval(
+    family: str,
+    tools: set[str],
+) -> None:
+    assert family
+    for tool in tools:
+        assert decide_tool_call(provider="slack", tool=tool) == ToolCallRequiresApproval(
+            provider="slack", tool=tool
+        )
+
+
+def test_slack_mutating_catalog_is_exact() -> None:
+    expected = set().union(*EXPECTED_SLACK_MUTATING_FAMILIES.values())
+    assert expected == SLACK_MUTATING_TOOL_NAMES
+    assert SLACK_READ_TOOL_NAMES.isdisjoint(SLACK_MUTATING_TOOL_NAMES)
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        "slack_send_message_v2",
+        "slack_search_public ",
+        "Slack_search_public",
+        "search_public",
+    ],
+)
+def test_unknown_or_inexact_slack_tool_fails_closed(tool: str) -> None:
+    assert decide_tool_call(provider="slack", tool=tool) == ToolCallDenied(
+        provider="slack", tool=tool
+    )
+
+
+@pytest.mark.parametrize("provider", ["linear", "Slack", "slack ", "acme-slack"])
+def test_other_provider_identities_preserve_direct_execution(provider: str) -> None:
+    assert decide_tool_call(provider=provider, tool="slack_send_message") == ToolCallAllowed(
+        provider=provider,
+        tool="slack_send_message",
+    )

--- a/server/tests/unit/test_integration_oauth_tokens.py
+++ b/server/tests/unit/test_integration_oauth_tokens.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import httpx
 import pytest
 
-from proliferate.integrations.integration_oauth.tokens import _granted_scopes
+from proliferate.integrations.integration_oauth import tokens
+from proliferate.integrations.integration_oauth.errors import IntegrationOAuthProviderError
+from proliferate.integrations.integration_oauth.tokens import (
+    _granted_scopes,
+    exchange_token,
+    refresh_token,
+)
 
 
 @pytest.mark.parametrize(
@@ -25,3 +32,72 @@ def test_granted_scopes_normalizes_standard_and_slack_payloads(
     payload: dict[str, object], expected: tuple[str, ...] | None
 ) -> None:
     assert _granted_scopes(payload) == expected
+
+
+def _install_token_response(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+) -> None:
+    async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json=payload))
+    monkeypatch.setattr(
+        tokens.httpx,
+        "AsyncClient",
+        lambda **_kwargs: async_client(transport=transport),
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider_error", "expected_code"),
+    [
+        ("bad_client_secret", "invalid_client"),
+        ("invalid_code", "invalid_grant"),
+        ("unexpected_slack_failure", "token_request_failed"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_slack_exchange_translates_http_2xx_error_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_error: str,
+    expected_code: str,
+) -> None:
+    _install_token_response(
+        monkeypatch,
+        {"ok": False, "error": provider_error, "private": "must-not-leak"},
+    )
+
+    with pytest.raises(IntegrationOAuthProviderError) as exc_info:
+        await exchange_token(
+            token_endpoint="https://slack.com/api/oauth.v2.user.access",
+            client_id="client",
+            code="code",
+            code_verifier="verifier",
+            redirect_uri="https://api.example.com/callback",
+            resource="https://mcp.slack.com/mcp",
+        )
+
+    assert exc_info.value.code == expected_code
+    assert provider_error not in str(exc_info.value)
+    assert "must-not-leak" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_slack_refresh_translates_http_2xx_invalid_refresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_token_response(
+        monkeypatch,
+        {"ok": False, "error": "invalid_refresh_token", "token": "must-not-leak"},
+    )
+
+    with pytest.raises(IntegrationOAuthProviderError) as exc_info:
+        await refresh_token(
+            token_endpoint="https://slack.com/api/oauth.v2.user.access",
+            client_id="client",
+            refresh_token_value="refresh",
+            resource="https://mcp.slack.com/mcp",
+        )
+
+    assert exc_info.value.code == "invalid_grant"
+    assert "invalid_refresh_token" not in str(exc_info.value)
+    assert "must-not-leak" not in str(exc_info.value)

--- a/server/tests/unit/test_integration_oauth_tokens.py
+++ b/server/tests/unit/test_integration_oauth_tokens.py
@@ -101,3 +101,76 @@ async def test_slack_refresh_translates_http_2xx_invalid_refresh_token(
     assert exc_info.value.code == "invalid_grant"
     assert "invalid_refresh_token" not in str(exc_info.value)
     assert "must-not-leak" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("token_endpoint", "provider_namespace"),
+    [
+        ("https://slack.com/api/oauth.v2.user.access/", None),
+        ("HTTPS://SLACK.COM/api/oauth.v2.user.access", None),
+        ("https://slack.com:443/api/oauth.v2.user.access", None),
+        ("https://slack.com/api/oauth.v3.user.access", "slack"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_slack_exchange_translates_2xx_error_for_endpoint_variants(
+    monkeypatch: pytest.MonkeyPatch,
+    token_endpoint: str,
+    provider_namespace: str | None,
+) -> None:
+    _install_token_response(
+        monkeypatch,
+        {"ok": False, "error": "invalid_code", "private": "must-not-leak"},
+    )
+
+    with pytest.raises(IntegrationOAuthProviderError) as exc_info:
+        await exchange_token(
+            token_endpoint=token_endpoint,
+            client_id="client",
+            code="code",
+            code_verifier="verifier",
+            redirect_uri="https://api.example.com/callback",
+            resource="https://mcp.slack.com/mcp",
+            provider_namespace=provider_namespace,
+        )
+
+    assert exc_info.value.code == "invalid_grant"
+    assert "invalid_code" not in str(exc_info.value)
+    assert "must-not-leak" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("token_endpoint", "provider_namespace"),
+    [
+        ("https://slack.com/api/oauth.v2.user.access", "linear"),
+        ("https://slack.com.evil.example/api/oauth.v2.user.access", None),
+        ("http://slack.com/api/oauth.v2.user.access", None),
+        ("https://slack.com:444/api/oauth.v2.user.access", None),
+        ("https://user:secret@slack.com/api/oauth.v2.user.access", None),
+        ("https://slack.com/api/oauth.v2.user.access?variant=true", None),
+        ("https://slack.com/api/oauth.v2.user.access#fragment", None),
+        ("https://slack.com/api/oauth.v3.user.access", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_other_provider_identity_and_noncanonical_urls_preserve_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+    token_endpoint: str,
+    provider_namespace: str | None,
+) -> None:
+    _install_token_response(
+        monkeypatch,
+        {"ok": False, "access_token": "other-provider-token"},
+    )
+
+    token = await exchange_token(
+        token_endpoint=token_endpoint,
+        client_id="client",
+        code="code",
+        code_verifier="verifier",
+        redirect_uri="https://api.example.com/callback",
+        resource="https://mcp.example.com/mcp",
+        provider_namespace=provider_namespace,
+    )
+
+    assert token.access_token == "other-provider-token"

--- a/specs/codebase/platforms/product/integrations.md
+++ b/specs/codebase/platforms/product/integrations.md
@@ -78,6 +78,10 @@ Slack's token endpoint can also return an HTTP-success response whose JSON body
 has `ok: false`. Cloud translates that envelope into a typed provider error
 before reading or persisting token fields; callback and refresh surfaces expose
 only fixed product-safe codes and messages, never the raw provider payload.
+Hosted callback and refresh paths identify Slack from the trusted definition
+namespace. Generic protocol callers fall back only to a narrowly validated
+equivalent of the canonical Slack token URL; a non-Slack namespace overrides a
+Slack-looking URL so other providers retain their existing response semantics.
 
 A refresh response that omits scope metadata preserves the stored value. An
 explicit non-empty refresh grant may be a subset but cannot exceed the ceiling;

--- a/specs/codebase/platforms/product/integrations.md
+++ b/specs/codebase/platforms/product/integrations.md
@@ -74,6 +74,10 @@ subset, but it cannot add a scope; Cloud always requests the canonical
 configured set. The callback must report that same set before credentials can
 become ready. Token parsing accepts standard top-level scope metadata and
 Slack's nested user-token scope metadata with comma or whitespace separators.
+Slack's token endpoint can also return an HTTP-success response whose JSON body
+has `ok: false`. Cloud translates that envelope into a typed provider error
+before reading or persisting token fields; callback and refresh surfaces expose
+only fixed product-safe codes and messages, never the raw provider payload.
 
 A refresh response that omits scope metadata preserves the stored value. An
 explicit non-empty refresh grant may be a subset but cannot exceed the ceiling;
@@ -185,6 +189,68 @@ Cloud, invokes the remote provider, and records a
 `cloud_integration_tool_call_event` on success or failure. Provider credentials
 and rendered auth headers never cross the Cloud boundary.
 
+### Slack tool-call policy
+
+The gateway classifies Slack by the exact canonical `(provider, tool)` pair
+before account resolution, credential rendering, or an upstream MCP call. The
+provider identity must be exactly `slack`; other providers preserve the generic
+gateway behavior.
+
+These known read/search tools execute directly:
+
+```text
+slack_get_reactions
+slack_list_channel_members
+slack_list_starred_items
+slack_list_user_conversations
+slack_list_user_groups
+slack_list_workspaces
+slack_read_canvas
+slack_read_channel
+slack_read_file
+slack_read_thread
+slack_read_user_profile
+slack_search_channels
+slack_search_emojis
+slack_search_public
+slack_search_public_and_private
+slack_search_users
+```
+
+These known external-action tools require approval and are currently rejected
+as unsupported until a durable approval has been consumed:
+
+```text
+slack_add_reaction
+slack_complete_file_upload
+slack_create_canvas
+slack_create_conversation
+slack_create_reminder
+slack_delete_message
+slack_edit_message
+slack_get_file_upload_url
+slack_invite_to_conversation
+slack_join_conversation
+slack_leave_conversation
+slack_schedule_message
+slack_send_message
+slack_send_message_draft
+slack_update_canvas
+slack_update_user_profile
+```
+
+Every other Slack tool name fails closed. Matching is case-sensitive and does
+not normalize whitespace or infer behavior from prefixes. A mutation returns
+the typed code `integration_tool_approval_required` with approval status
+`unsupported`; an unknown Slack tool returns `integration_tool_not_allowed`.
+Both are MCP tool errors and audit as failed calls.
+
+The pure policy verdict is the seam for the durable one-time external-action
+approval state machine. Until that state exists, neither a Worker token, a
+valid gateway bearer, nor approval-like fields in agent-supplied tool arguments
+can authorize a Slack mutation. There is no process-local or prompt-based
+approval fallback.
+
 ## Mounted Routes
 
 Worker and public artifact routes:
@@ -242,9 +308,15 @@ and [`runtime_workers/api.py`](../../../../server/proliferate/server/cloud/runti
 - OAuth refresh and provider access errors are product errors owned by the
   integrations service; tool-level provider errors are returned to the agent
   without leaking credentials.
+- Slack HTTP-success token error envelopes become typed OAuth provider errors
+  before token indexing or persistence, and raw provider payloads do not cross
+  callback or refresh failure surfaces.
 - An exact-policy challenge cannot exceed the ceiling, a callback grant must
   equal the requested set, and an explicit refresh grant must be non-empty and
   remain within the ceiling; failures store no replacement credentials.
+- Slack gateway calls use an exact read allowlist, a typed approval-required
+  result for known external actions, and a deny-by-default result for unknown
+  tools. Agent arguments do not participate in the authorization decision.
 
 ## Verification
 
@@ -253,10 +325,14 @@ Focused server tests include:
 - `server/tests/integration/test_cloud_runtime_workers_api.py`
 - `server/tests/integration/test_cloud_runtime_worker_versions_api.py`
 - `server/tests/integration/test_cloud_integration_gateway_api.py`
+- `server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py`
 - `server/tests/integration/test_cloud_integrations_api.py`
 - `server/tests/integration/test_cloud_integration_catalog_api.py`
 - `server/tests/integration/test_cloud_integration_health_api.py`
 - `server/tests/integration/test_integration_provider_access.py`
+- `server/tests/integration/test_integration_oauth_scope_policy.py`
+- `server/tests/unit/test_cloud_integration_gateway_tool_policy.py`
+- `server/tests/unit/test_integration_oauth_tokens.py`
 
 Worker behavior is covered by `cargo test -p proliferate-worker`. For an
 enrollment incident, use


### PR DESCRIPTION
## Summary

- classify exact Slack provider/tool identities at the hosted integration gateway: the known read/search catalog executes directly, every known external-action family returns a typed approval-required/unsupported result, and unknown Slack tools fail closed while other providers keep current behavior
- expose a pure, argument-independent policy verdict plus a stable structured MCP error seam for the next durable-approval slice; Worker identity, gateway bearer possession, and agent-claimed confirmation fields cannot authorize a mutation
- translate Slack HTTP-2xx `ok: false` token envelopes into `IntegrationOAuthProviderError` before token indexing or persistence, with fixed callback/refresh failures that do not leak provider payloads
- identify hosted Slack token responses from the DB-resolved definition namespace; namespace-less callers use only a narrow canonical Slack URL fallback, and a non-Slack namespace overrides Slack-looking URLs
- preserve Slack's existing six read/search OAuth scopes; no write scope, Slack installation/re-authorization, live provider call, message, edit, schedule, reaction, or file write is included

The branch is rebased onto `1786d5cf8afa78e03df2016ecf581d44fbb6557c`, which contains merged #1337, #1344, #1340, and #1336. The Slack seed and its exact six-scope ceiling are unchanged by this PR.

## Next PR contract

PR 3 will consume `ToolCallRequiresApproval` as the only entry point for a persisted one-time external-action request. It will bind the durable request to the product principal and exact provider/tool/action payload, return its durable identity and state through the typed approval result, and allow approve/reject/expiry transitions only through product-authenticated APIs. Gateway bearers and agent-supplied arguments will remain unable to create an approval claim. PR 3 will not add Slack write scopes, UI, provider delivery, or an in-memory/prompt fallback; atomic consume-before-delivery remains a later activation boundary.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `JWT_SECRET=... CLOUD_SECRET_KEY=... uv run --extra dev pytest -q tests/unit/test_cloud_integration_gateway_tool_policy.py tests/unit/test_integration_oauth_tokens.py tests/integration/test_cloud_integration_gateway_tool_policy_api.py tests/integration/test_cloud_integration_gateway_api.py tests/integration/test_integration_oauth_scope_policy.py tests/integration/test_integration_provider_access.py` — 80 passed on the final rebased head
- `uv run --extra dev ruff check proliferate/ tests/`
- `uv run --extra dev ruff format --check proliferate/ tests/` — 796 files formatted
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_server_boundaries.py`
- `python3 -m unittest scripts/test_check_docs.py` — 17 passed
- `python3 scripts/check_docs.py` — 219 Markdown files checked
- Greptile P2 `G1341-URL` fixed with trusted provider identity plus narrow URL fallback, proven, replied to, and resolved
- four independent review rounds: fail-closed verdict fallback and endpoint-identity coverage findings fixed and re-reviewed; final rebase audit has no open findings
- no Docker, local Rust build, Slack installation/re-authorization, live Slack call, schedule, edit, reaction, file write, or message send was performed
