### PR TITLE
fix(release): fail closed on leaked runner handles

### DIFF
--- a/tests/release/src/cli/exit-watchdog.fixture.ts
+++ b/tests/release/src/cli/exit-watchdog.fixture.ts
@@ -1,0 +1,18 @@
+import { createServer } from "node:http";
+
+import { armPostReportExitWatchdog } from "./exit-watchdog.js";
+
+const mode = process.argv[2];
+if (mode === "leak") {
+  const server = createServer((_request, response) => response.end("ok"));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  console.log("Combined report written: fixture-report.json");
+  process.exitCode = 0;
+  armPostReportExitWatchdog({ graceMs: 75 });
+} else if (mode === "clean") {
+  console.log("Combined report written: fixture-report.json");
+  process.exitCode = 0;
+  armPostReportExitWatchdog({ graceMs: 5_000 });
+} else {
+  throw new Error(`unknown fixture mode: ${mode ?? "<missing>"}`);
+}

--- a/tests/release/src/cli/exit-watchdog.test.ts
+++ b/tests/release/src/cli/exit-watchdog.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const FIXTURE = fileURLToPath(new URL("./exit-watchdog.fixture.ts", import.meta.url));
+const TSX_LOADER_ARGS = currentTsxLoaderArgs();
+
+test("a leaked post-report handle fails closed before it can monopolize CI", async () => {
+  const result = await runFixture("leak", 3_000);
+
+  assert.equal(result.timedOut, false, result.stderr);
+  assert.equal(result.code, 2, result.stderr);
+  assert.match(result.stdout, /Combined report written:/);
+  assert.match(result.stderr, /process did not quiesce/);
+  assert.match(result.stderr, /forcing infrastructure exit 2/);
+});
+
+test("the unref'd watchdog does not delay a healthy runner", async () => {
+  const result = await runFixture("clean", 2_000);
+
+  assert.equal(result.timedOut, false, result.stderr);
+  assert.equal(result.code, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /process did not quiesce/);
+});
+
+function runFixture(
+  mode: "clean" | "leak",
+  timeoutMs: number,
+): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [...TSX_LOADER_ARGS, path.resolve(FIXTURE), mode], {
+      cwd: path.resolve(fileURLToPath(new URL("../../", import.meta.url))),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+  });
+}
+
+function currentTsxLoaderArgs(): string[] {
+  const loaderArgs: string[] = [];
+  for (let index = 0; index < process.execArgv.length; index += 1) {
+    const arg = process.execArgv[index];
+    if ((arg === "--require" || arg === "--import") && process.execArgv[index + 1]) {
+      loaderArgs.push(arg, process.execArgv[index + 1]);
+      index += 1;
+    }
+  }
+  return loaderArgs.length > 0 ? loaderArgs : ["--import", "tsx"];
+}

--- a/tests/release/src/cli/exit-watchdog.ts
+++ b/tests/release/src/cli/exit-watchdog.ts
@@ -1,0 +1,32 @@
+const DEFAULT_EXIT_WATCHDOG_MS = 10_000;
+
+export interface ExitWatchdogOptions {
+  graceMs?: number;
+  activeResources?: () => readonly string[];
+  terminate?: (code: number) => never;
+  error?: (message: string) => void;
+}
+
+/**
+ * Arms a last-resort guard after the authoritative report and awaited cleanup
+ * have completed. The timer is unref'd, so a healthy runner exits naturally.
+ * It only fires when some other leaked handle is still keeping Node alive.
+ */
+export function armPostReportExitWatchdog(options: ExitWatchdogOptions = {}): NodeJS.Timeout {
+  const graceMs = options.graceMs ?? DEFAULT_EXIT_WATCHDOG_MS;
+  const activeResources = options.activeResources ?? (() => process.getActiveResourcesInfo());
+  const terminate = options.terminate ?? ((code: number): never => process.exit(code));
+  const error = options.error ?? ((message: string) => console.error(message));
+
+  const timer = setTimeout(() => {
+    const resources = [...new Set(activeResources())].sort();
+    const suffix = resources.length > 0 ? resources.join(", ") : "unknown";
+    error(
+      `[release-e2e] process did not quiesce within ${graceMs}ms after report completion; `
+        + `forcing infrastructure exit 2 (active resources: ${suffix})`,
+    );
+    terminate(2);
+  }, graceMs);
+  timer.unref();
+  return timer;
+}

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -14,6 +14,7 @@ import { executeSelectedCells } from "../runner/execute.js";
 import { loadCandidateBuildMap } from "../artifacts/build-map.js";
 import { readLocalWorldPortsFile } from "../worlds/local-workspace/ports.js";
 import { writeReportV4 } from "../evidence/write.js";
+import { armPostReportExitWatchdog } from "./exit-watchdog.js";
 
 /**
  * Thin process adapter: supplies the real side-effect dependencies to
@@ -141,3 +142,4 @@ process.exitCode = await runReleaseCommand(process.argv.slice(2), {
   log: (message) => console.log(message),
   error: (message) => console.error(message),
 });
+armPostReportExitWatchdog();


### PR DESCRIPTION
## Outcome

Prevent a future leaked Node handle from monopolizing the single Release E2E concurrency group after the runner has already written its aggregate report.

## Change

- Arm an unref'd 10-second watchdog only after `runReleaseCommand` returns.
- Healthy runs exit naturally; the watchdog does not keep Node alive.
- If another handle keeps the process alive, emit bounded active-resource type diagnostics and force infrastructure exit 2.
- Do not rewrite the already-persisted aggregate or turn red cells green.

## Evidence

- Reproduces the failure mode from Release E2E run 29602686092, which wrote its final report and then occupied the job until the 60-minute timeout.
- Focused subprocess regressions prove a leaked HTTP server exits 2 within the guard window and a healthy process exits 0 without waiting for the watchdog.
- Focused tests: 2/2 green.
- Local workspace-wide typecheck was unavailable because the current lockfile's newly published PostHog entries are rejected by the machine's minimum-release-age policy; exact-head Actions owns the normal typecheck/CI proof.

## Scope

Test infrastructure only. No scenario verdict changes, provider calls, product code, credentials, deploy, or Release E2E dispatch.
