### PR TITLE
test(release): preserve self-host setup failure phase

### DIFF
--- a/tests/release/src/scenarios/selfhost-qual-1.test.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.test.ts
@@ -64,11 +64,15 @@ import {
 } from "../evidence/schema.js";
 
 test("self-host setup diagnostics preserve the phase while withholding external payloads", () => {
+  const commandError = Object.assign(
+    new Error("Command failed: ssh qualification-box sudo install\nsecret remote stderr"),
+    { stdout: "secret remote stdout", stderr: "secret remote stderr" },
+  );
   const install = redactExternalPayloads(
-    describeSelfHostSetupFailure("install", new Error("ssh command failed: secret installer output")),
+    describeSelfHostSetupFailure("install", commandError),
   );
   assert.match(install, /phase=install/);
-  assert.doesNotMatch(install, /secret installer output/);
+  assert.doesNotMatch(install, /qualification-box|secret remote/);
   assert.match(install, /output withheld from evidence/);
 
   const claim = redactExternalPayloads(

--- a/tests/release/src/scenarios/selfhost-qual-1.test.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.test.ts
@@ -10,6 +10,7 @@ import {
   SH_GATEWAY,
   SH_GITHUB_AUTH,
   attachCleanupEvidence,
+  describeSelfHostSetupFailure,
   runCloudAddonCell,
   runGatewayCell,
   runGithubAuthCell,
@@ -56,10 +57,31 @@ import {
 } from "../fixtures/selfhost-github-auth.js";
 import {
   expectedVerdict,
+  redactExternalPayloads,
   validateReportV4,
   type CellEvidenceV1,
   type TestRunReportV4,
 } from "../evidence/schema.js";
+
+test("self-host setup diagnostics preserve the phase while withholding external payloads", () => {
+  const install = redactExternalPayloads(
+    describeSelfHostSetupFailure("install", new Error("ssh command failed: secret installer output")),
+  );
+  assert.match(install, /phase=install/);
+  assert.doesNotMatch(install, /secret installer output/);
+  assert.match(install, /output withheld from evidence/);
+
+  const claim = redactExternalPayloads(
+    describeSelfHostSetupFailure(
+      "owner_claim",
+      new Error("GET /v1/organizations -> 500: secret response body"),
+    ),
+  );
+  assert.match(claim, /phase=owner_claim/);
+  assert.match(claim, /GET \/v1\/organizations -> 500/);
+  assert.doesNotMatch(claim, /secret response body/);
+  assert.match(claim, /response body withheld from evidence/);
+});
 
 // ── Shared fakes ─────────────────────────────────────────────────────────────
 

--- a/tests/release/src/scenarios/selfhost-qual-1.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.ts
@@ -298,9 +298,10 @@ export const defaultSelfHostQualDriver: SelfHostQualDriver = {
     }),
 
   async installAndClaim(world, opts) {
+    let receipt: Awaited<ReturnType<typeof runShippedInstaller>>;
     try {
       const { repo, tag } = splitCandidateImageRef(world.artifacts.serverImage);
-      const receipt = await runShippedInstaller({
+      receipt = await runShippedInstaller({
         box: world.control.box,
         ssh: world.control.ssh,
         serverImageArchive: world.artifacts.serverImage,
@@ -311,19 +312,25 @@ export const defaultSelfHostQualDriver: SelfHostQualDriver = {
         candidateImageTag: tag,
         corsAllowOrigins: browserOriginsForBox(world),
       });
-      const candidateServerVersion = world.artifacts.serverImage.version;
-      if (receipt.serverVersion !== candidateServerVersion) {
-        return {
-          ok: false,
-          reason:
-            `SELFHOST-QUAL-1 install: the running server advertises "${receipt.serverVersion}", ` +
-            `but the candidate map pins "${candidateServerVersion}"; refusing to claim a mismatched build.`,
-        };
-      }
+    } catch (error) {
+      return { ok: false, reason: describeSelfHostSetupFailure("install", error) };
+    }
+
+    const candidateServerVersion = world.artifacts.serverImage.version;
+    if (receipt.serverVersion !== candidateServerVersion) {
+      return {
+        ok: false,
+        reason:
+          `SELFHOST-QUAL-1 install: the running server advertises "${receipt.serverVersion}", ` +
+          `but the candidate map pins "${candidateServerVersion}"; refusing to claim a mismatched build.`,
+      };
+    }
+
+    try {
       const owner = await claimSelfHostOwner(world, opts.ownerEmail ? { email: opts.ownerEmail } : {});
       return { ok: true, owner };
     } catch (error) {
-      return { ok: false, reason: `SELFHOST-QUAL-1 install/claim failed: ${describe(error)}` };
+      return { ok: false, reason: describeSelfHostSetupFailure("owner_claim", error) };
     }
   },
 
@@ -1206,6 +1213,19 @@ function sha256Hex(value: string): string {
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Preserves the safe setup phase before the aggregate sanitizer removes any
+ * external response or command payload. The separator deliberately avoids a
+ * generic `claim failed:` prefix, which previously caused the sanitizer to
+ * discard both the phase and an already-safe HTTP status.
+ */
+export function describeSelfHostSetupFailure(
+  phase: "install" | "owner_claim",
+  error: unknown,
+): string {
+  return `SELFHOST-QUAL-1 prerequisite phase=${phase}; ${describe(error)}`;
 }
 
 function failedOutcome(cellId: string, message: string): ScenarioCellOutcome {

--- a/tests/release/src/scenarios/selfhost-qual-1.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.ts
@@ -1225,7 +1225,22 @@ export function describeSelfHostSetupFailure(
   phase: "install" | "owner_claim",
   error: unknown,
 ): string {
-  return `SELFHOST-QUAL-1 prerequisite phase=${phase}; ${describe(error)}`;
+  return `SELFHOST-QUAL-1 prerequisite phase=${phase}; ${evidenceSafeSetupError(error)}`;
+}
+
+function evidenceSafeSetupError(error: unknown): string {
+  if (error instanceof SyntaxError) {
+    return "SyntaxError: invalid JSON response (payload withheld from evidence)";
+  }
+  if (error instanceof Error && ("stdout" in error || "stderr" in error)) {
+    return `${error.name}: external command failed (output withheld from evidence)`;
+  }
+  const status = error instanceof Error ? (error as { status?: unknown }).status : undefined;
+  if (error instanceof Error && typeof status === "number" && "body" in error) {
+    const prefix = /^(.*?->\s*\d+)/.exec(error.message)?.[1] ?? `request failed with status ${status}`;
+    return `${error.name}: ${prefix} (response body withheld from evidence)`;
+  }
+  return describe(error);
 }
 
 function failedOutcome(cellId: string, message: string): ScenarioCellOutcome {


### PR DESCRIPTION
## Outcome

Preserve the exact self-host setup phase in bounded qualification evidence. Installation and owner claim are now reported separately, while external command output and HTTP response bodies remain withheld.

## Evidence

Run 29606890776 produced `SELFHOST-QUAL-1 install/claim failed: (response body withheld from evidence)`, which could not distinguish installer failure from owner-claim/login/org-resolution failure. This change records `phase=install` or `phase=owner_claim` before sanitization.

- Focused self-host qualification tests: 61/61 green
- Release runner TypeScript typecheck: green
- No provider calls, product changes, credential changes, or live qualification claims

The failed self-host journey remains red until rerun after the owning #1312 reconciliation.