### PR TITLE
perf(transcript): batch high-volume stream reduction

### DIFF
--- a/anyharness/sdk/src/index.ts
+++ b/anyharness/sdk/src/index.ts
@@ -433,6 +433,7 @@ export type {
 export {
   createTranscriptState,
   reduceEvent,
+  reduceEventBatch,
   reduceEvents,
   selectPendingApprovalInteraction,
   selectPendingMcpElicitationInteraction,

--- a/anyharness/sdk/src/reducer/__tests__/transcript-batch.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript-batch.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTranscriptState,
+  reduceEvent,
+  reduceEventBatch,
+  reduceEvents,
+} from "../../index.js";
+import type { SessionEventEnvelope, ThoughtItem } from "../../index.js";
+
+describe("transcript batch reducer", () => {
+  it("treats an empty batch as a referential no-op", () => {
+    const before = createTranscriptState("session-1");
+
+    expect(reduceEventBatch(before, [])).toBe(before);
+  });
+
+  it("avoids per-delta copies for a high-volume reasoning item", () => {
+    const before = reduceEvents([
+      turnStarted(1),
+      reasoningStarted(2, "reasoning-1", "seed:"),
+      assistantCompleted(3, "assistant-1", "done"),
+    ], "session-1");
+    const beforeItem = before.itemsById["reasoning-1"] as ThoughtItem;
+    const beforeAssistant = before.itemsById["assistant-1"];
+    const beforeContentParts = beforeItem.contentParts;
+    const beforeContentPart = beforeContentParts[0];
+    const chunks = Array.from({ length: 200 }, (_, index) => `chunk-${index}|`);
+    const deltas = chunks.map((chunk, index) =>
+      reasoningDelta(index + 4, "reasoning-1", chunk)
+    );
+    const copies = { itemMap: 0, reasoningItem: 0 };
+    const instrumentedItem = new Proxy(beforeItem, {
+      ownKeys(target) {
+        copies.reasoningItem += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+    const instrumentedState = {
+      ...before,
+      itemsById: new Proxy({
+        ...before.itemsById,
+        "reasoning-1": instrumentedItem,
+      }, {
+        ownKeys(target) {
+          copies.itemMap += 1;
+          return Reflect.ownKeys(target);
+        },
+      }),
+    };
+
+    const after = reduceEventBatch(instrumentedState, deltas);
+    const sequential = deltas.reduce(reduceOne, before);
+    const afterItem = after.itemsById["reasoning-1"] as ThoughtItem;
+
+    expect(after).toEqual(sequential);
+    expect(copies).toEqual({ itemMap: 1, reasoningItem: 1 });
+    expect(after.turnsById).toBe(before.turnsById);
+    expect(before.itemsById["reasoning-1"]).toBe(beforeItem);
+    expect(after.itemsById["assistant-1"]).toBe(beforeAssistant);
+    expect(beforeItem.contentParts).toBe(beforeContentParts);
+    expect(beforeContentParts[0]).toBe(beforeContentPart);
+    expect(beforeContentPart).toEqual({
+      type: "reasoning",
+      text: "seed:",
+      visibility: "private",
+    });
+    expect(beforeItem.text).toBe("seed:");
+    expect(afterItem).not.toBe(beforeItem);
+    expect(afterItem.contentParts).not.toBe(beforeContentParts);
+    expect(afterItem.text).toBe(`seed:${chunks.join("")}`);
+    expect(after.lastSeq).toBe(203);
+  });
+
+  it("preserves order-sensitive sequential semantics for one item", () => {
+    const before = reduceEvents([
+      turnStarted(1),
+      reasoningStarted(2, "reasoning-1", "seed"),
+    ], "session-1");
+    const events = [
+      reasoningDelta(3, "reasoning-1", ":append"),
+      reasoningSnapshotDelta(4, "reasoning-1", "snapshot"),
+      reasoningDelta(5, "reasoning-1", ":tail"),
+      reasoningCompleted(6, "reasoning-1", "final"),
+    ];
+
+    const batched = reduceEventBatch(before, events);
+    const sequential = events.reduce(reduceOne, before);
+    const item = batched.itemsById["reasoning-1"] as ThoughtItem;
+
+    expect(batched).toEqual(sequential);
+    expect(item.text).toBe("final");
+    expect(item.isStreaming).toBe(false);
+  });
+});
+
+function reduceOne(state: ReturnType<typeof createTranscriptState>, event: SessionEventEnvelope) {
+  return reduceEvent(state, event);
+}
+
+function baseEnvelope(seq: number, itemId?: string) {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: "2026-04-04T00:00:00Z",
+    turnId: "turn-1",
+    ...(itemId ? { itemId } : {}),
+  };
+}
+
+function turnStarted(seq: number): SessionEventEnvelope {
+  return { ...baseEnvelope(seq), event: { type: "turn_started" } };
+}
+
+function reasoningStarted(seq: number, itemId: string, text: string): SessionEventEnvelope {
+  return {
+    ...baseEnvelope(seq, itemId),
+    event: {
+      type: "item_started",
+      item: {
+        kind: "reasoning",
+        status: "in_progress",
+        sourceAgentKind: "codex",
+        contentParts: [{ type: "reasoning", text, visibility: "private" }],
+      },
+    },
+  };
+}
+
+function reasoningDelta(
+  seq: number,
+  itemId: string,
+  appendReasoning: string,
+): SessionEventEnvelope {
+  return {
+    ...baseEnvelope(seq, itemId),
+    event: { type: "item_delta", delta: { appendReasoning } },
+  };
+}
+
+function reasoningSnapshotDelta(
+  seq: number,
+  itemId: string,
+  text: string,
+): SessionEventEnvelope {
+  return {
+    ...baseEnvelope(seq, itemId),
+    event: {
+      type: "item_delta",
+      delta: {
+        replaceContentParts: [{ type: "reasoning", text, visibility: "private" }],
+      },
+    },
+  };
+}
+
+function reasoningCompleted(seq: number, itemId: string, text: string): SessionEventEnvelope {
+  return {
+    ...baseEnvelope(seq, itemId),
+    event: {
+      type: "item_completed",
+      item: {
+        kind: "reasoning",
+        status: "completed",
+        sourceAgentKind: "codex",
+        contentParts: [{ type: "reasoning", text, visibility: "private" }],
+      },
+    },
+  };
+}
+
+function assistantCompleted(seq: number, itemId: string, text: string): SessionEventEnvelope {
+  return {
+    ...baseEnvelope(seq, itemId),
+    event: {
+      type: "item_completed",
+      item: {
+        kind: "assistant_message",
+        status: "completed",
+        sourceAgentKind: "codex",
+        contentParts: [{ type: "text", text }],
+      },
+    },
+  };
+}

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createTranscriptState,
   reduceEvent,
+  reduceEventBatch,
   reduceEvents,
   selectPendingApprovalInteraction,
   selectPendingMcpElicitationInteraction,
@@ -11,6 +12,12 @@ import {
 import type { ContentPart, SessionEventEnvelope, ThoughtItem, ToolCallItem } from "../../index.js";
 
 describe("transcript reducer", () => {
+  it("treats an empty event batch as a referential no-op", () => {
+    const before = createTranscriptState("session-1");
+
+    expect(reduceEventBatch(before, [])).toBe(before);
+  });
+
   it("normalizes available slash commands at the reducer boundary", () => {
     const state = reduceEvent(createTranscriptState("session-1"), {
       sessionId: "session-1",
@@ -92,6 +99,97 @@ describe("transcript reducer", () => {
     expect(afterItem.contentParts).not.toBe(beforeContentParts);
     expect(afterItem.contentParts[0]).not.toBe(beforeContentPart);
     expect(afterItem.text).toBe("Hello");
+  });
+
+  it("copy-on-write reduces a high-volume reasoning batch without per-delta copies", () => {
+    const before = reduceEvents(
+      [
+        turnStarted(1),
+        reasoningStarted(2, "reasoning-1", "seed:"),
+        completedToolItem(3, "tool-1"),
+      ],
+      "session-1",
+    );
+    const beforeItem = before.itemsById["reasoning-1"] as ThoughtItem;
+    const beforeTool = before.itemsById["tool-1"];
+    const beforeContentParts = beforeItem.contentParts;
+    const beforeContentPart = beforeContentParts[0];
+    const chunks = Array.from({ length: 200 }, (_, index) => `chunk-${index}|`);
+    const deltas = chunks.map((chunk, index) =>
+      reasoningDelta(index + 4, "reasoning-1", chunk)
+    );
+    let itemMapCopyCount = 0;
+    let reasoningItemCopyCount = 0;
+    const instrumentedItem = new Proxy(beforeItem, {
+      ownKeys(target) {
+        reasoningItemCopyCount += 1;
+        return Reflect.ownKeys(target);
+      },
+    });
+    const proxiedState = {
+      ...before,
+      itemsById: new Proxy({
+        ...before.itemsById,
+        "reasoning-1": instrumentedItem,
+      }, {
+        ownKeys(target) {
+          itemMapCopyCount += 1;
+          return Reflect.ownKeys(target);
+        },
+      }),
+    };
+
+    const after = reduceEventBatch(proxiedState, deltas);
+    const sequential = deltas.reduce(
+      (state, envelope) => reduceEvent(state, envelope),
+      before,
+    );
+    const afterItem = after.itemsById["reasoning-1"] as ThoughtItem;
+
+    expect(after).toEqual(sequential);
+    expect(itemMapCopyCount).toBe(1);
+    expect(reasoningItemCopyCount).toBe(1);
+    expect(after.turnsById).toBe(before.turnsById);
+    expect(before.itemsById["reasoning-1"]).toBe(beforeItem);
+    expect(after.itemsById["tool-1"]).toBe(beforeTool);
+    expect(beforeItem.contentParts).toBe(beforeContentParts);
+    expect(beforeContentParts[0]).toBe(beforeContentPart);
+    expect(beforeContentPart).toEqual({
+      type: "reasoning",
+      text: "seed:",
+      visibility: "private",
+    });
+    expect(beforeItem.text).toBe("seed:");
+    expect(afterItem).not.toBe(beforeItem);
+    expect(afterItem.contentParts).not.toBe(beforeContentParts);
+    expect(afterItem.text).toBe(`seed:${chunks.join("")}`);
+    expect(after.lastSeq).toBe(203);
+  });
+
+  it("preserves sequential semantics for order-sensitive updates to one item", () => {
+    const before = reduceEvents(
+      [
+        turnStarted(1),
+        reasoningStarted(2, "reasoning-1", "seed"),
+      ],
+      "session-1",
+    );
+    const events: SessionEventEnvelope[] = [
+      reasoningDelta(3, "reasoning-1", ":append"),
+      reasoningSnapshotDelta(4, "reasoning-1", "snapshot"),
+      reasoningDelta(5, "reasoning-1", ":tail"),
+      reasoningCompleted(6, "reasoning-1", "final"),
+    ];
+
+    const batched = reduceEventBatch(before, events);
+    const sequential = events.reduce(
+      (state, envelope) => reduceEvent(state, envelope),
+      before,
+    );
+
+    expect(batched).toEqual(sequential);
+    expect((batched.itemsById["reasoning-1"] as ThoughtItem).text).toBe("final");
+    expect((batched.itemsById["reasoning-1"] as ThoughtItem).isStreaming).toBe(false);
   });
 
   it("preserves unchanged item references when one item changes", () => {
@@ -1539,6 +1637,69 @@ function reasoningStarted(
         status: "in_progress",
         sourceAgentKind: "claude",
         isTransient,
+        contentParts: [{ type: "reasoning", text, visibility: "private" }],
+      },
+    },
+  };
+}
+
+function reasoningDelta(
+  seq: number,
+  itemId: string,
+  appendReasoning: string,
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
+    turnId: "turn-1",
+    itemId,
+    event: {
+      type: "item_delta",
+      delta: {
+        appendReasoning,
+      },
+    },
+  };
+}
+
+function reasoningSnapshotDelta(
+  seq: number,
+  itemId: string,
+  text: string,
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
+    turnId: "turn-1",
+    itemId,
+    event: {
+      type: "item_delta",
+      delta: {
+        replaceContentParts: [{ type: "reasoning", text, visibility: "private" }],
+      },
+    },
+  };
+}
+
+function reasoningCompleted(
+  seq: number,
+  itemId: string,
+  text: string,
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
+    turnId: "turn-1",
+    itemId,
+    event: {
+      type: "item_completed",
+      item: {
+        kind: "reasoning",
+        status: "completed",
+        sourceAgentKind: "codex",
         contentParts: [{ type: "reasoning", text, visibility: "private" }],
       },
     },

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   createTranscriptState,
   reduceEvent,
-  reduceEventBatch,
   reduceEvents,
   selectPendingApprovalInteraction,
   selectPendingMcpElicitationInteraction,
@@ -12,12 +11,6 @@ import {
 import type { ContentPart, SessionEventEnvelope, ThoughtItem, ToolCallItem } from "../../index.js";
 
 describe("transcript reducer", () => {
-  it("treats an empty event batch as a referential no-op", () => {
-    const before = createTranscriptState("session-1");
-
-    expect(reduceEventBatch(before, [])).toBe(before);
-  });
-
   it("normalizes available slash commands at the reducer boundary", () => {
     const state = reduceEvent(createTranscriptState("session-1"), {
       sessionId: "session-1",
@@ -99,97 +92,6 @@ describe("transcript reducer", () => {
     expect(afterItem.contentParts).not.toBe(beforeContentParts);
     expect(afterItem.contentParts[0]).not.toBe(beforeContentPart);
     expect(afterItem.text).toBe("Hello");
-  });
-
-  it("copy-on-write reduces a high-volume reasoning batch without per-delta copies", () => {
-    const before = reduceEvents(
-      [
-        turnStarted(1),
-        reasoningStarted(2, "reasoning-1", "seed:"),
-        completedToolItem(3, "tool-1"),
-      ],
-      "session-1",
-    );
-    const beforeItem = before.itemsById["reasoning-1"] as ThoughtItem;
-    const beforeTool = before.itemsById["tool-1"];
-    const beforeContentParts = beforeItem.contentParts;
-    const beforeContentPart = beforeContentParts[0];
-    const chunks = Array.from({ length: 200 }, (_, index) => `chunk-${index}|`);
-    const deltas = chunks.map((chunk, index) =>
-      reasoningDelta(index + 4, "reasoning-1", chunk)
-    );
-    let itemMapCopyCount = 0;
-    let reasoningItemCopyCount = 0;
-    const instrumentedItem = new Proxy(beforeItem, {
-      ownKeys(target) {
-        reasoningItemCopyCount += 1;
-        return Reflect.ownKeys(target);
-      },
-    });
-    const proxiedState = {
-      ...before,
-      itemsById: new Proxy({
-        ...before.itemsById,
-        "reasoning-1": instrumentedItem,
-      }, {
-        ownKeys(target) {
-          itemMapCopyCount += 1;
-          return Reflect.ownKeys(target);
-        },
-      }),
-    };
-
-    const after = reduceEventBatch(proxiedState, deltas);
-    const sequential = deltas.reduce(
-      (state, envelope) => reduceEvent(state, envelope),
-      before,
-    );
-    const afterItem = after.itemsById["reasoning-1"] as ThoughtItem;
-
-    expect(after).toEqual(sequential);
-    expect(itemMapCopyCount).toBe(1);
-    expect(reasoningItemCopyCount).toBe(1);
-    expect(after.turnsById).toBe(before.turnsById);
-    expect(before.itemsById["reasoning-1"]).toBe(beforeItem);
-    expect(after.itemsById["tool-1"]).toBe(beforeTool);
-    expect(beforeItem.contentParts).toBe(beforeContentParts);
-    expect(beforeContentParts[0]).toBe(beforeContentPart);
-    expect(beforeContentPart).toEqual({
-      type: "reasoning",
-      text: "seed:",
-      visibility: "private",
-    });
-    expect(beforeItem.text).toBe("seed:");
-    expect(afterItem).not.toBe(beforeItem);
-    expect(afterItem.contentParts).not.toBe(beforeContentParts);
-    expect(afterItem.text).toBe(`seed:${chunks.join("")}`);
-    expect(after.lastSeq).toBe(203);
-  });
-
-  it("preserves sequential semantics for order-sensitive updates to one item", () => {
-    const before = reduceEvents(
-      [
-        turnStarted(1),
-        reasoningStarted(2, "reasoning-1", "seed"),
-      ],
-      "session-1",
-    );
-    const events: SessionEventEnvelope[] = [
-      reasoningDelta(3, "reasoning-1", ":append"),
-      reasoningSnapshotDelta(4, "reasoning-1", "snapshot"),
-      reasoningDelta(5, "reasoning-1", ":tail"),
-      reasoningCompleted(6, "reasoning-1", "final"),
-    ];
-
-    const batched = reduceEventBatch(before, events);
-    const sequential = events.reduce(
-      (state, envelope) => reduceEvent(state, envelope),
-      before,
-    );
-
-    expect(batched).toEqual(sequential);
-    expect((batched.itemsById["reasoning-1"] as ThoughtItem).text).toBe("final");
-    expect((batched.itemsById["reasoning-1"] as ThoughtItem).isStreaming).toBe(false);
   });
 
   it("preserves unchanged item references when one item changes", () => {
@@ -1637,69 +1539,6 @@ function reasoningStarted(
         status: "in_progress",
         sourceAgentKind: "claude",
         isTransient,
-        contentParts: [{ type: "reasoning", text, visibility: "private" }],
-      },
-    },
-  };
-}
-
-function reasoningDelta(
-  seq: number,
-  itemId: string,
-  appendReasoning: string,
-): SessionEventEnvelope {
-  return {
-    sessionId: "session-1",
-    seq,
-    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
-    turnId: "turn-1",
-    itemId,
-    event: {
-      type: "item_delta",
-      delta: {
-        appendReasoning,
-      },
-    },
-  };
-}
-
-function reasoningSnapshotDelta(
-  seq: number,
-  itemId: string,
-  text: string,
-): SessionEventEnvelope {
-  return {
-    sessionId: "session-1",
-    seq,
-    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
-    turnId: "turn-1",
-    itemId,
-    event: {
-      type: "item_delta",
-      delta: {
-        replaceContentParts: [{ type: "reasoning", text, visibility: "private" }],
-      },
-    },
-  };
-}
-
-function reasoningCompleted(
-  seq: number,
-  itemId: string,
-  text: string,
-): SessionEventEnvelope {
-  return {
-    sessionId: "session-1",
-    seq,
-    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
-    turnId: "turn-1",
-    itemId,
-    event: {
-      type: "item_completed",
-      item: {
-        kind: "reasoning",
-        status: "completed",
-        sourceAgentKind: "codex",
         contentParts: [{ type: "reasoning", text, visibility: "private" }],
       },
     },

--- a/anyharness/sdk/src/reducer/transcript-reduction-context.ts
+++ b/anyharness/sdk/src/reducer/transcript-reduction-context.ts
@@ -1,0 +1,141 @@
+import type { ContentPart, SessionEventEnvelope } from "../types/events.js";
+import type {
+  AssistantProseItem,
+  ErrorItem,
+  PlanItem,
+  ProposedPlanItem,
+  ThoughtItem,
+  ToolCallItem,
+  TranscriptItem,
+  TranscriptState,
+  TurnRecord,
+  UserMessageItem,
+} from "../types/reducer.js";
+
+export type KnownTranscriptItem =
+  | UserMessageItem
+  | AssistantProseItem
+  | ThoughtItem
+  | ToolCallItem
+  | PlanItem
+  | ProposedPlanItem
+  | ErrorItem;
+
+export interface ReduceOptions {
+  replayMode?: boolean;
+}
+
+export interface TranscriptReductionContext {
+  state: TranscriptState;
+  copiedItemsById: boolean;
+  copiedTurnsById: boolean;
+  mutableItemIds: Set<string>;
+  mutableTurnIds: Set<string>;
+}
+
+type ApplyEvent = (
+  context: TranscriptReductionContext,
+  envelope: SessionEventEnvelope,
+  options?: ReduceOptions,
+) => void;
+
+/**
+ * Reduces one delivery batch with copy-on-write transcript collections.
+ * Stream consumers already flush envelopes once per animation frame, so this
+ * avoids cloning full item/turn maps and the same streaming item per delta.
+ */
+export function reduceTranscriptEventBatch(
+  state: TranscriptState,
+  envelopes: readonly SessionEventEnvelope[],
+  options: ReduceOptions | undefined,
+  applyEvent: ApplyEvent,
+): TranscriptState {
+  if (envelopes.length === 0) {
+    return state;
+  }
+
+  const context: TranscriptReductionContext = {
+    state: { ...state },
+    copiedItemsById: false,
+    copiedTurnsById: false,
+    mutableItemIds: new Set(),
+    mutableTurnIds: new Set(),
+  };
+  for (const envelope of envelopes) {
+    applyEvent(context, envelope, options);
+  }
+  return context.state;
+}
+
+export function setContextItem(
+  context: TranscriptReductionContext,
+  itemId: string,
+  item: TranscriptItem,
+): void {
+  const state = context.state;
+  if (!context.copiedItemsById) {
+    state.itemsById = { ...state.itemsById };
+    context.copiedItemsById = true;
+  }
+  state.itemsById[itemId] = item;
+  context.mutableItemIds.add(itemId);
+}
+
+export function setContextTurn(
+  context: TranscriptReductionContext,
+  turnId: string,
+  turn: TurnRecord,
+): void {
+  const state = context.state;
+  if (!context.copiedTurnsById) {
+    state.turnsById = { ...state.turnsById };
+    context.copiedTurnsById = true;
+  }
+  state.turnsById[turnId] = turn;
+  context.mutableTurnIds.add(turnId);
+}
+
+export function ensureMutableContextItem<T extends KnownTranscriptItem>(
+  context: TranscriptReductionContext,
+  itemId: string,
+  item: T,
+): T {
+  if (context.mutableItemIds.has(itemId)) {
+    return item;
+  }
+  const nextItem = cloneKnownTranscriptItem(item);
+  setContextItem(context, itemId, nextItem);
+  return nextItem;
+}
+
+export function ensureMutableContextTurn(
+  context: TranscriptReductionContext,
+  turnId: string,
+  turn: TurnRecord,
+): TurnRecord {
+  if (context.mutableTurnIds.has(turnId)) {
+    return turn;
+  }
+  const nextTurn = {
+    ...turn,
+    itemOrder: [...turn.itemOrder],
+    fileBadges: [...turn.fileBadges],
+  };
+  setContextTurn(context, turnId, nextTurn);
+  return nextTurn;
+}
+
+function cloneKnownTranscriptItem<T extends KnownTranscriptItem>(item: T): T {
+  const cloned = {
+    ...item,
+    contentParts: item.contentParts.map(cloneContentPart),
+  };
+  if (item.kind === "plan") {
+    return { ...cloned, entries: [...item.entries] } as T;
+  }
+  return cloned as T;
+}
+
+function cloneContentPart(part: ContentPart): ContentPart {
+  return { ...part } as ContentPart;
+}

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -11,33 +11,31 @@ import type {
   TranscriptItemPayload,
 } from "../types/events.js";
 import type {
-  AssistantProseItem,
   ErrorItem,
   PendingMcpElicitationInteraction,
   PendingInteraction,
   PendingApproval,
   PendingUserInputInteraction,
-  PlanItem,
-  ProposedPlanItem,
-  ThoughtItem,
   ToolCallSemanticKind,
   ToolCallItem,
   TranscriptItem,
   TranscriptState,
   TurnRecord,
   UnknownItem,
-  UserMessageItem,
 } from "../types/reducer.js";
 import { reducePendingPrompts } from "./pending-prompts.js";
+import {
+  ensureMutableContextItem as ensureMutableKnownItem,
+  ensureMutableContextTurn,
+  reduceTranscriptEventBatch,
+  setContextItem as setItem,
+  setContextTurn as setTurn,
+  type KnownTranscriptItem,
+  type ReduceOptions,
+  type TranscriptReductionContext,
+} from "./transcript-reduction-context.js";
 
-type KnownTranscriptItem =
-  | UserMessageItem
-  | AssistantProseItem
-  | ThoughtItem
-  | ToolCallItem
-  | PlanItem
-  | ProposedPlanItem
-  | ErrorItem;
+export type { ReduceOptions } from "./transcript-reduction-context.js";
 
 export function createTranscriptState(sessionId: string): TranscriptState {
   return {
@@ -100,18 +98,6 @@ export function normalizeAvailableSessionCommands(
   return normalized;
 }
 
-export interface ReduceOptions {
-  replayMode?: boolean;
-}
-
-interface TranscriptReductionContext {
-  state: TranscriptState;
-  copiedItemsById: boolean;
-  copiedTurnsById: boolean;
-  mutableItemIds: Set<string>;
-  mutableTurnIds: Set<string>;
-}
-
 export function reduceEvents(
   events: SessionEventEnvelope[],
   sessionId: string,
@@ -128,34 +114,12 @@ export function reduceEvent(
   return reduceEventBatch(state, [envelope], options);
 }
 
-/**
- * Reduces one delivery batch with copy-on-write transcript collections.
- *
- * Stream consumers already flush envelopes once per animation frame. Keeping
- * one reduction context for that frame avoids cloning the full item and turn
- * maps (and the same growing streaming item) for every delta while preserving
- * the immutable public reducer contract.
- */
 export function reduceEventBatch(
   state: TranscriptState,
   envelopes: readonly SessionEventEnvelope[],
   options?: ReduceOptions,
 ): TranscriptState {
-  if (envelopes.length === 0) {
-    return state;
-  }
-
-  const context: TranscriptReductionContext = {
-    state: { ...state },
-    copiedItemsById: false,
-    copiedTurnsById: false,
-    mutableItemIds: new Set(),
-    mutableTurnIds: new Set(),
-  };
-  for (const envelope of envelopes) {
-    applyEvent(context, envelope, options);
-  }
-  return context.state;
+  return reduceTranscriptEventBatch(state, envelopes, options, applyEvent);
 }
 
 function applyEvent(
@@ -834,12 +798,7 @@ function ensureMutableTurn(
   ts: string,
 ): TurnRecord {
   const existing = ensureTurn(context, turnId, ts);
-  if (context.mutableTurnIds.has(turnId)) {
-    return existing;
-  }
-  const turn = cloneTurn(existing);
-  setTurn(context, turnId, turn);
-  return turn;
+  return ensureMutableContextTurn(context, turnId, existing);
 }
 
 function addItemToTurn(
@@ -950,73 +909,6 @@ function recordUnknown(
     addItemToTurn(context, turnId, itemId, ts);
   }
   s.unknownEvents = [...s.unknownEvents, envelope];
-}
-
-function setItem(
-  context: TranscriptReductionContext,
-  itemId: string,
-  item: TranscriptItem,
-): void {
-  const s = context.state;
-  if (!context.copiedItemsById) {
-    s.itemsById = { ...s.itemsById };
-    context.copiedItemsById = true;
-  }
-  s.itemsById[itemId] = item;
-  context.mutableItemIds.add(itemId);
-}
-
-function setTurn(
-  context: TranscriptReductionContext,
-  turnId: string,
-  turn: TurnRecord,
-): void {
-  const s = context.state;
-  if (!context.copiedTurnsById) {
-    s.turnsById = { ...s.turnsById };
-    context.copiedTurnsById = true;
-  }
-  s.turnsById[turnId] = turn;
-  context.mutableTurnIds.add(turnId);
-}
-
-function ensureMutableKnownItem<T extends KnownTranscriptItem>(
-  context: TranscriptReductionContext,
-  itemId: string,
-  item: T,
-): T {
-  if (context.mutableItemIds.has(itemId)) {
-    return item;
-  }
-  const nextItem = cloneKnownTranscriptItem(item);
-  setItem(context, itemId, nextItem);
-  return nextItem;
-}
-
-function cloneTurn(turn: TurnRecord): TurnRecord {
-  return {
-    ...turn,
-    itemOrder: [...turn.itemOrder],
-    fileBadges: [...turn.fileBadges],
-  };
-}
-
-function cloneKnownTranscriptItem<T extends KnownTranscriptItem>(item: T): T {
-  const cloned = {
-    ...item,
-    contentParts: item.contentParts.map(cloneContentPart),
-  };
-  if (item.kind === "plan") {
-    return {
-      ...cloned,
-      entries: [...item.entries],
-    } as T;
-  }
-  return cloned as T;
-}
-
-function cloneContentPart(part: ContentPart): ContentPart {
-  return { ...part } as ContentPart;
 }
 
 function extractText(parts: ContentPart[]): string {

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -182,7 +182,6 @@ function applyEvent(
       }
       const updated = ensureMutableKnownItem(context, itemId, existing);
       applyItemDelta(updated, evt, ts, envelope.seq);
-      setItem(context, itemId, updated);
       syncStreamingPointers(s, itemId, updated);
       break;
     }

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -104,24 +104,66 @@ export interface ReduceOptions {
   replayMode?: boolean;
 }
 
+interface TranscriptReductionContext {
+  state: TranscriptState;
+  copiedItemsById: boolean;
+  copiedTurnsById: boolean;
+  mutableItemIds: Set<string>;
+  mutableTurnIds: Set<string>;
+}
+
 export function reduceEvents(
   events: SessionEventEnvelope[],
   sessionId: string,
   options?: ReduceOptions,
 ): TranscriptState {
-  let state = createTranscriptState(sessionId);
-  for (const env of events) {
-    state = reduceEvent(state, env, options);
-  }
-  return state;
+  return reduceEventBatch(createTranscriptState(sessionId), events, options);
 }
 
 export function reduceEvent(
   state: TranscriptState,
   envelope: SessionEventEnvelope,
-  _options?: ReduceOptions,
+  options?: ReduceOptions,
 ): TranscriptState {
-  const s = { ...state };
+  return reduceEventBatch(state, [envelope], options);
+}
+
+/**
+ * Reduces one delivery batch with copy-on-write transcript collections.
+ *
+ * Stream consumers already flush envelopes once per animation frame. Keeping
+ * one reduction context for that frame avoids cloning the full item and turn
+ * maps (and the same growing streaming item) for every delta while preserving
+ * the immutable public reducer contract.
+ */
+export function reduceEventBatch(
+  state: TranscriptState,
+  envelopes: readonly SessionEventEnvelope[],
+  options?: ReduceOptions,
+): TranscriptState {
+  if (envelopes.length === 0) {
+    return state;
+  }
+
+  const context: TranscriptReductionContext = {
+    state: { ...state },
+    copiedItemsById: false,
+    copiedTurnsById: false,
+    mutableItemIds: new Set(),
+    mutableTurnIds: new Set(),
+  };
+  for (const envelope of envelopes) {
+    applyEvent(context, envelope, options);
+  }
+  return context.state;
+}
+
+function applyEvent(
+  context: TranscriptReductionContext,
+  envelope: SessionEventEnvelope,
+  _options?: ReduceOptions,
+): void {
+  const s = context.state;
   s.lastSeq = Math.max(s.lastSeq, envelope.seq);
 
   const evt = envelope.event;
@@ -139,19 +181,19 @@ export function reduceEvent(
       break;
 
     case "session_ended":
-      clearPendingInteractions(s, "none");
+      clearPendingInteractions(context, "none");
       s.isStreaming = false;
       break;
 
     case "turn_started": {
-      ensureTurn(s, turnId, ts);
+      ensureTurn(context, turnId, ts);
       s.isStreaming = true;
       break;
     }
 
     case "turn_ended": {
-      const turn = ensureMutableTurn(s, turnId, ts);
-      closeStreamingItems(s);
+      const turn = ensureMutableTurn(context, turnId, ts);
+      closeStreamingItems(context);
       turn.completedAt = ts;
       turn.stopReason = evt.stopReason;
       turn.fileBadges = collectFileBadges(s, turnId);
@@ -161,9 +203,9 @@ export function reduceEvent(
 
     case "item_started": {
       const item = createItemFromPayload(itemId, turnId, evt.item, ts, envelope.seq);
-      setItem(s, itemId, item);
-      addItemToTurn(s, turnId, itemId, ts);
-      openStreamingItem(s, itemId, item);
+      setItem(context, itemId, item);
+      addItemToTurn(context, turnId, itemId, ts);
+      openStreamingItem(context, itemId, item);
       s.isStreaming = s.isStreaming || item.status === "in_progress";
       break;
     }
@@ -171,12 +213,12 @@ export function reduceEvent(
     case "item_delta": {
       const existing = s.itemsById[itemId];
       if (!existing || existing.kind === "unknown") {
-        recordUnknown(s, envelope, itemId, ts, turnId);
+        recordUnknown(context, envelope, itemId, ts, turnId);
         break;
       }
-      const updated = cloneKnownTranscriptItem(existing);
+      const updated = ensureMutableKnownItem(context, itemId, existing);
       applyItemDelta(updated, evt, ts, envelope.seq);
-      setItem(s, itemId, updated);
+      setItem(context, itemId, updated);
       syncStreamingPointers(s, itemId, updated);
       break;
     }
@@ -184,11 +226,16 @@ export function reduceEvent(
     case "item_completed": {
       const existing = s.itemsById[itemId];
       const item = existing && existing.kind !== "unknown"
-        ? applyCompletion(cloneKnownTranscriptItem(existing), evt, ts, envelope.seq)
+        ? applyCompletion(
+          ensureMutableKnownItem(context, itemId, existing),
+          evt,
+          ts,
+          envelope.seq,
+        )
         : createCompletedItem(itemId, turnId, evt, ts, envelope.seq);
-      setItem(s, itemId, item);
-      addItemToTurn(s, turnId, itemId, ts);
-      closeStreamingPointer(s, itemId);
+      setItem(context, itemId, item);
+      addItemToTurn(context, turnId, itemId, ts);
+      closeStreamingPointer(context, itemId);
       break;
     }
 
@@ -284,16 +331,16 @@ export function reduceEvent(
       break;
 
     case "interaction_requested":
-      applyInteractionRequested(s, evt);
+      applyInteractionRequested(context, evt);
       break;
 
     case "interaction_resolved":
-      applyInteractionResolved(s, evt.requestId, evt.outcome);
+      applyInteractionResolved(context, evt.requestId, evt.outcome);
       break;
 
     case "error": {
-      closeStreamingItems(s);
-      clearPendingInteractions(s, "none");
+      closeStreamingItems(context);
+      clearPendingInteractions(context, "none");
       const item: ErrorItem = {
         kind: "error",
         itemId,
@@ -316,18 +363,16 @@ export function reduceEvent(
         code: evt.code ?? null,
         details: evt.details ?? null,
       };
-      setItem(s, itemId, item);
-      addItemToTurn(s, turnId, itemId, ts);
+      setItem(context, itemId, item);
+      addItemToTurn(context, turnId, itemId, ts);
       s.isStreaming = false;
       break;
     }
 
     default:
-      recordUnknown(s, envelope, itemId, ts, envelope.turnId ?? null);
+      recordUnknown(context, envelope, itemId, ts, envelope.turnId ?? null);
       break;
   }
-
-  return s;
 }
 
 function createCompletedItem(
@@ -623,7 +668,11 @@ export function selectPrimaryPendingInteraction(
   ) ?? null;
 }
 
-function applyInteractionRequested(s: TranscriptState, evt: InteractionRequestedEvent): void {
+function applyInteractionRequested(
+  context: TranscriptReductionContext,
+  evt: InteractionRequestedEvent,
+): void {
+  const s = context.state;
   const toolCallId = evt.source.toolCallId ?? null;
   const basePendingInteraction = {
     requestId: evt.requestId,
@@ -638,7 +687,7 @@ function applyInteractionRequested(s: TranscriptState, evt: InteractionRequested
   let pendingInteraction: PendingInteraction;
   if (evt.kind === "permission" && evt.payload.type === "permission") {
     if (toolCallId) {
-      const item = findMutableToolItemByToolCallId(s, toolCallId);
+      const item = findMutableToolItemByToolCallId(context, toolCallId);
       if (item) item.approvalState = "pending";
     }
     pendingInteraction = {
@@ -673,24 +722,30 @@ function applyInteractionRequested(s: TranscriptState, evt: InteractionRequested
 }
 
 function applyInteractionResolved(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   requestId: string,
   outcome: InteractionOutcome,
 ): void {
+  const s = context.state;
   const pendingInteraction = s.pendingInteractions.find((entry) => entry.requestId === requestId);
   if (!pendingInteraction) return;
 
-  clearPendingInteraction(s, requestId, approvalStateForOutcome(pendingInteraction, outcome));
+  clearPendingInteraction(
+    context,
+    requestId,
+    approvalStateForOutcome(pendingInteraction, outcome),
+  );
 }
 
 function clearPendingInteraction(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   requestId: string,
   toolApprovalState: ToolCallItem["approvalState"],
 ): void {
+  const s = context.state;
   const pendingInteraction = s.pendingInteractions.find((entry) => entry.requestId === requestId);
   if (pendingInteraction?.toolCallId) {
-    const item = findMutableToolItemByToolCallId(s, pendingInteraction.toolCallId);
+    const item = findMutableToolItemByToolCallId(context, pendingInteraction.toolCallId);
     if (item) {
       item.approvalState = toolApprovalState;
     }
@@ -699,12 +754,13 @@ function clearPendingInteraction(
 }
 
 function clearPendingInteractions(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   toolApprovalState: ToolCallItem["approvalState"],
 ): void {
+  const s = context.state;
   for (const pendingInteraction of s.pendingInteractions) {
     if (pendingInteraction.toolCallId) {
-      const item = findMutableToolItemByToolCallId(s, pendingInteraction.toolCallId);
+      const item = findMutableToolItemByToolCallId(context, pendingInteraction.toolCallId);
       if (item) {
         item.approvalState = toolApprovalState;
       }
@@ -737,20 +793,24 @@ function approvalStateForOutcome(
 }
 
 function findMutableToolItemByToolCallId(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   toolCallId: string,
 ): ToolCallItem | null {
+  const s = context.state;
   for (const [itemId, item] of Object.entries(s.itemsById)) {
     if (item.kind === "tool_call" && item.toolCallId === toolCallId) {
-      const nextItem = cloneKnownTranscriptItem(item);
-      setItem(s, itemId, nextItem);
-      return nextItem;
+      return ensureMutableKnownItem(context, itemId, item);
     }
   }
   return null;
 }
 
-function ensureTurn(s: TranscriptState, turnId: string, ts: string): TurnRecord {
+function ensureTurn(
+  context: TranscriptReductionContext,
+  turnId: string,
+  ts: string,
+): TurnRecord {
+  const s = context.state;
   const existing = s.turnsById[turnId];
   if (!existing) {
     const turn: TurnRecord = {
@@ -761,42 +821,54 @@ function ensureTurn(s: TranscriptState, turnId: string, ts: string): TurnRecord 
       stopReason: null,
       fileBadges: [],
     };
-    setTurn(s, turnId, turn);
+    setTurn(context, turnId, turn);
     s.turnOrder = [...s.turnOrder, turnId];
     return turn;
   }
   return existing;
 }
 
-function ensureMutableTurn(s: TranscriptState, turnId: string, ts: string): TurnRecord {
-  const turn = cloneTurn(ensureTurn(s, turnId, ts));
-  setTurn(s, turnId, turn);
+function ensureMutableTurn(
+  context: TranscriptReductionContext,
+  turnId: string,
+  ts: string,
+): TurnRecord {
+  const existing = ensureTurn(context, turnId, ts);
+  if (context.mutableTurnIds.has(turnId)) {
+    return existing;
+  }
+  const turn = cloneTurn(existing);
+  setTurn(context, turnId, turn);
   return turn;
 }
 
 function addItemToTurn(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   turnId: string,
   itemId: string,
   ts: string,
 ): void {
-  const existing = ensureTurn(s, turnId, ts);
+  const existing = ensureTurn(context, turnId, ts);
   if (existing.itemOrder.includes(itemId)) {
     return;
   }
 
-  const turn = cloneTurn(existing);
-  setTurn(s, turnId, turn);
-  turn.itemOrder = [...turn.itemOrder, itemId];
+  const turn = ensureMutableTurn(context, turnId, ts);
+  turn.itemOrder.push(itemId);
 }
 
-function openStreamingItem(s: TranscriptState, itemId: string, item: TranscriptItem): void {
+function openStreamingItem(
+  context: TranscriptReductionContext,
+  itemId: string,
+  item: TranscriptItem,
+): void {
+  const s = context.state;
   if (item.kind === "assistant_prose" && item.isStreaming) {
-    closeAssistantPointer(s);
+    closeAssistantPointer(context);
     s.openAssistantItemId = itemId;
   }
   if (item.kind === "thought" && item.isStreaming) {
-    closeThoughtPointer(s);
+    closeThoughtPointer(context);
     s.openThoughtItemId = itemId;
   }
 }
@@ -812,54 +884,58 @@ function syncStreamingPointers(s: TranscriptState, itemId: string, item: Transcr
   }
 }
 
-function closeStreamingPointer(s: TranscriptState, itemId: string): void {
+function closeStreamingPointer(
+  context: TranscriptReductionContext,
+  itemId: string,
+): void {
+  const s = context.state;
   if (s.openAssistantItemId === itemId) s.openAssistantItemId = null;
   if (s.openThoughtItemId === itemId) s.openThoughtItemId = null;
   const item = s.itemsById[itemId];
   if (!item) return;
   if (item.kind === "user_message" || item.kind === "assistant_prose" || item.kind === "thought") {
-    const nextItem = cloneKnownTranscriptItem(item);
+    const nextItem = ensureMutableKnownItem(context, itemId, item);
     nextItem.isStreaming = false;
-    setItem(s, itemId, nextItem);
   }
 }
 
-function closeStreamingItems(s: TranscriptState): void {
-  closeAssistantPointer(s);
-  closeThoughtPointer(s);
+function closeStreamingItems(context: TranscriptReductionContext): void {
+  closeAssistantPointer(context);
+  closeThoughtPointer(context);
 }
 
-function closeAssistantPointer(s: TranscriptState): void {
+function closeAssistantPointer(context: TranscriptReductionContext): void {
+  const s = context.state;
   if (!s.openAssistantItemId) return;
   const itemId = s.openAssistantItemId;
   const item = s.itemsById[itemId];
   if (item?.kind === "assistant_prose") {
-    const nextItem = cloneKnownTranscriptItem(item);
+    const nextItem = ensureMutableKnownItem(context, itemId, item);
     nextItem.isStreaming = false;
-    setItem(s, itemId, nextItem);
   }
   s.openAssistantItemId = null;
 }
 
-function closeThoughtPointer(s: TranscriptState): void {
+function closeThoughtPointer(context: TranscriptReductionContext): void {
+  const s = context.state;
   if (!s.openThoughtItemId) return;
   const itemId = s.openThoughtItemId;
   const item = s.itemsById[itemId];
   if (item?.kind === "thought") {
-    const nextItem = cloneKnownTranscriptItem(item);
+    const nextItem = ensureMutableKnownItem(context, itemId, item);
     nextItem.isStreaming = false;
-    setItem(s, itemId, nextItem);
   }
   s.openThoughtItemId = null;
 }
 
 function recordUnknown(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   envelope: SessionEventEnvelope,
   itemId: string,
   ts: string,
   turnId: string | null,
 ): void {
+  const s = context.state;
   const item: UnknownItem = {
     kind: "unknown",
     itemId,
@@ -869,33 +945,52 @@ function recordUnknown(
     timestamp: ts,
     startedSeq: envelope.seq,
   };
-  setItem(s, itemId, item);
+  setItem(context, itemId, item);
   if (turnId) {
-    addItemToTurn(s, turnId, itemId, ts);
+    addItemToTurn(context, turnId, itemId, ts);
   }
   s.unknownEvents = [...s.unknownEvents, envelope];
 }
 
 function setItem(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   itemId: string,
   item: TranscriptItem,
 ): void {
-  s.itemsById = {
-    ...s.itemsById,
-    [itemId]: item,
-  };
+  const s = context.state;
+  if (!context.copiedItemsById) {
+    s.itemsById = { ...s.itemsById };
+    context.copiedItemsById = true;
+  }
+  s.itemsById[itemId] = item;
+  context.mutableItemIds.add(itemId);
 }
 
 function setTurn(
-  s: TranscriptState,
+  context: TranscriptReductionContext,
   turnId: string,
   turn: TurnRecord,
 ): void {
-  s.turnsById = {
-    ...s.turnsById,
-    [turnId]: turn,
-  };
+  const s = context.state;
+  if (!context.copiedTurnsById) {
+    s.turnsById = { ...s.turnsById };
+    context.copiedTurnsById = true;
+  }
+  s.turnsById[turnId] = turn;
+  context.mutableTurnIds.add(turnId);
+}
+
+function ensureMutableKnownItem<T extends KnownTranscriptItem>(
+  context: TranscriptReductionContext,
+  itemId: string,
+  item: T,
+): T {
+  if (context.mutableItemIds.has(itemId)) {
+    return item;
+  }
+  const nextItem = cloneKnownTranscriptItem(item);
+  setItem(context, itemId, nextItem);
+  return nextItem;
 }
 
 function cloneTurn(turn: TurnRecord): TurnRecord {

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts
@@ -117,6 +117,59 @@ describe("session-stream-state", () => {
     expect(result.state.transcript.lastSeq).toBe(4);
   });
 
+  it("applies a high-volume reasoning frame as one transcript reduction batch", () => {
+    const state = replaySessionHistory("session-1", [
+      turnStarted(1),
+      reasoningStarted(2, "reasoning-1", "seed:"),
+    ]);
+    const beforeItem = state.transcript.itemsById["reasoning-1"];
+    const chunks = Array.from({ length: 200 }, (_, index) => `chunk-${index}|`);
+    const instrumented = instrumentReasoningCopies(state, "reasoning-1");
+
+    const result = applyStreamEnvelopeBatch(
+      instrumented.state,
+      chunks.map((chunk, index) => reasoningDelta(index + 3, "reasoning-1", chunk)),
+    );
+    const afterItem = result.state.transcript.itemsById["reasoning-1"];
+
+    expect(result.gapEnvelope).toBeNull();
+    expect(result.appliedEnvelopes).toHaveLength(200);
+    expect(result.state.events).toHaveLength(202);
+    expect(result.state.transcript.lastSeq).toBe(202);
+    expect(instrumented.copyCounts).toEqual({ itemMap: 1, reasoningItem: 1 });
+    expect(state.transcript.itemsById["reasoning-1"]).toBe(beforeItem);
+    expect(afterItem).not.toBe(beforeItem);
+    expect(afterItem.kind).toBe("thought");
+    if (afterItem.kind !== "thought") {
+      throw new Error("expected reasoning item");
+    }
+    expect(afterItem.text).toBe(`seed:${chunks.join("")}`);
+  });
+
+  it("applies a high-volume reasoning history tail as one transcript batch", () => {
+    const state = replaySessionHistory("session-1", [
+      turnStarted(1),
+      reasoningStarted(2, "reasoning-1", "seed:"),
+    ]);
+    const instrumented = instrumentReasoningCopies(state, "reasoning-1");
+    const chunks = Array.from({ length: 200 }, (_, index) => `tail-${index}|`);
+
+    const result = appendHistoryTail(
+      instrumented.state,
+      chunks.map((chunk, index) => reasoningDelta(index + 3, "reasoning-1", chunk)),
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.state.transcript.lastSeq).toBe(202);
+    expect(instrumented.copyCounts).toEqual({ itemMap: 1, reasoningItem: 1 });
+    const afterItem = result.state.transcript.itemsById["reasoning-1"];
+    expect(afterItem.kind).toBe("thought");
+    if (afterItem.kind !== "thought") {
+      throw new Error("expected reasoning item");
+    }
+    expect(afterItem.text).toBe(`seed:${chunks.join("")}`);
+  });
+
   it("sorts stream batches by sequence before detecting gaps", () => {
     const state = replaySessionHistory("session-1", [turnStarted(1)]);
 
@@ -166,6 +219,37 @@ describe("session-stream-state", () => {
   });
 });
 
+function instrumentReasoningCopies(
+  state: ReturnType<typeof replaySessionHistory>,
+  itemId: string,
+) {
+  const item = state.transcript.itemsById[itemId];
+  const copyCounts = { itemMap: 0, reasoningItem: 0 };
+  return {
+    copyCounts,
+    state: {
+      ...state,
+      transcript: {
+        ...state.transcript,
+        itemsById: new Proxy({
+          ...state.transcript.itemsById,
+          [itemId]: new Proxy(item, {
+            ownKeys(target) {
+              copyCounts.reasoningItem += 1;
+              return Reflect.ownKeys(target);
+            },
+          }),
+        }, {
+          ownKeys(target) {
+            copyCounts.itemMap += 1;
+            return Reflect.ownKeys(target);
+          },
+        }),
+      },
+    },
+  };
+}
+
 function turnStarted(seq: number): SessionEventEnvelope {
   return {
     sessionId: "session-1",
@@ -195,6 +279,47 @@ function assistantStarted(
         sourceAgentKind: "claude",
         contentParts: [{ type: "text", text }],
       },
+    },
+  };
+}
+
+function reasoningStarted(
+  seq: number,
+  itemId: string,
+  text: string,
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
+    turnId: "turn-1",
+    itemId,
+    event: {
+      type: "item_started",
+      item: {
+        kind: "reasoning",
+        status: "in_progress",
+        sourceAgentKind: "codex",
+        contentParts: [{ type: "reasoning", text, visibility: "private" }],
+      },
+    },
+  };
+}
+
+function reasoningDelta(
+  seq: number,
+  itemId: string,
+  appendReasoning: string,
+): SessionEventEnvelope {
+  return {
+    sessionId: "session-1",
+    seq,
+    timestamp: `2026-04-04T00:00:${String(seq).padStart(2, "0")}Z`,
+    turnId: "turn-1",
+    itemId,
+    event: {
+      type: "item_delta",
+      delta: { appendReasoning },
     },
   };
 }

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.ts
@@ -1,6 +1,7 @@
 import {
   createTranscriptState,
   reduceEvent,
+  reduceEventBatch,
   reduceEvents,
 } from "@anyharness/sdk";
 import type {
@@ -46,23 +47,23 @@ export function appendHistoryTail(
 ): { applied: boolean; state: SessionStreamState } {
   const sortedEvents = [...events].sort((a, b) => a.seq - b.seq);
   let nextEvents: SessionEventEnvelope[] | null = null;
-  let nextTranscript = state.transcript;
-  let applied = false;
+  const appliedEnvelopes: SessionEventEnvelope[] = [];
+  let lastSeq = state.transcript.lastSeq;
 
   for (const envelope of sortedEvents) {
-    if (envelope.seq <= nextTranscript.lastSeq) {
+    if (envelope.seq <= lastSeq) {
       continue;
     }
-    if (envelope.seq > nextTranscript.lastSeq + 1) {
+    if (envelope.seq > lastSeq + 1) {
       break;
     }
-    applied = true;
+    lastSeq = envelope.seq;
     nextEvents ??= [...state.events];
     nextEvents.push(envelope);
-    nextTranscript = reduceEvent(nextTranscript, envelope);
+    appliedEnvelopes.push(envelope);
   }
 
-  if (!applied || !nextEvents) {
+  if (appliedEnvelopes.length === 0 || !nextEvents) {
     return { applied: false, state };
   }
 
@@ -70,7 +71,7 @@ export function appendHistoryTail(
     applied: true,
     state: {
       events: nextEvents,
-      transcript: nextTranscript,
+      transcript: reduceEventBatch(state.transcript, appliedEnvelopes),
     },
   };
 }
@@ -102,7 +103,7 @@ export function applyStreamEnvelopeBatch(
 ): StreamEnvelopeBatchApplyResult {
   const sortedEnvelopes = [...envelopes].sort((a, b) => a.seq - b.seq);
   let nextEvents: SessionEventEnvelope[] | null = null;
-  let nextTranscript = state.transcript;
+  let lastSeq = state.transcript.lastSeq;
   const appliedEnvelopes: SessionEventEnvelope[] = [];
   const duplicateEnvelopes: SessionEventEnvelope[] = [];
   let gapEnvelope: SessionEventEnvelope | null = null;
@@ -110,7 +111,6 @@ export function applyStreamEnvelopeBatch(
 
   for (let index = 0; index < sortedEnvelopes.length; index += 1) {
     const envelope = sortedEnvelopes[index];
-    const lastSeq = nextTranscript.lastSeq;
     if (envelope.seq <= lastSeq) {
       duplicateEnvelopes.push(envelope);
       continue;
@@ -123,7 +123,7 @@ export function applyStreamEnvelopeBatch(
 
     nextEvents ??= [...state.events];
     nextEvents.push(envelope);
-    nextTranscript = reduceEvent(nextTranscript, envelope);
+    lastSeq = envelope.seq;
     appliedEnvelopes.push(envelope);
   }
 
@@ -131,7 +131,7 @@ export function applyStreamEnvelopeBatch(
     state: nextEvents
       ? {
         events: nextEvents,
-        transcript: nextTranscript,
+        transcript: reduceEventBatch(state.transcript, appliedEnvelopes),
       }
       : state,
     appliedEnvelopes,

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -36,7 +36,7 @@ anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1126 custo
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 796 existing generated cloud SDK type surface (+workspaceKind, git numstat fields, OpenAPI-derived materialization types, app-extra overlay, and PR 5 exact-ref create request fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
-anyharness/sdk/src/reducer/transcript.ts 1542 existing SDK oversized file
+anyharness/sdk/src/reducer/transcript.ts 1529 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 server/proliferate/auth/identity/store.py 686 managed sandbox GitHub grant read path extends existing identity store
 server/proliferate/config.py 618 managed Cloud, GitHub App, and Workflow flags extend the centralized deployment settings surface; split pending

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -36,7 +36,7 @@ anyharness/crates/anyharness-lib/src/persistence/custom_migrations.rs 1126 custo
 anyharness/sdk-react/src/hooks/sessions.ts 723 existing SDK React oversized file
 cloud/sdk/src/types/generated.ts 796 existing generated cloud SDK type surface (+workspaceKind, git numstat fields, OpenAPI-derived materialization types, app-extra overlay, and PR 5 exact-ref create request fields)
 anyharness/sdk/src/reducer/__tests__/transcript.test.ts 1817 existing SDK oversized test file
-anyharness/sdk/src/reducer/transcript.ts 1529 existing SDK oversized file
+anyharness/sdk/src/reducer/transcript.ts 1528 existing SDK oversized file
 apps/desktop/src-tauri/src/commands/ssh_tunnel.rs 729 existing desktop native oversized file
 server/proliferate/auth/identity/store.py 686 managed sandbox GitHub grant read path extends existing identity store
 server/proliferate/config.py 618 managed Cloud, GitHub App, and Workflow flags extend the centralized deployment settings surface; split pending


### PR DESCRIPTION
## Summary

- reduce each accepted live-stream frame and history-tail prefix through one copy-on-write transcript context
- clone item/turn maps and each touched streaming item at most once per batch while preserving the immutable reducer API
- cover a synthetic 200-delta reasoning item, order-sensitive updates, empty batches, history tails, and prior-state/reference stability
- keep the new coordinator and regression suite in focused sibling files, lowering the existing reducer's max-lines allowance

The stream was already frame-batched, but each envelope still invoked the single-event reducer independently. A delta-heavy frame therefore recopied the entire item map and the same growing reasoning item for every delta. This change moves the batch boundary into the SDK reducer and keeps duplicate/gap handling unchanged in ProductClient.

For users, high-volume reasoning transcripts now do bounded collection/object copy work per delivery frame instead of per delta.

This is a performance-only scope. It does not change goal lifecycle, timer meaning, total event retention, or transcript virtualization policy.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- `anyharness/sdk/node_modules/.bin/tsc -p anyharness/sdk/tsconfig.json --noEmit`
- `anyharness/sdk/node_modules/.bin/tsc -p anyharness/sdk/tsconfig.type-tests.json --noEmit`
- `anyharness/sdk/node_modules/.bin/vitest run anyharness/sdk/src` (104 tests)
- `vitest run src/lib/domain/sessions/stream/stream-state.test.ts` from ProductClient (13 tests)
- `python3 scripts/check_max_lines.py`
- deterministic Proxy instrumentation proves one item-map copy and one reasoning-item clone for 200 deltas in both live and history-tail paths
- independent review passed prior-state immutability, intra-batch ordering, duplicate/gap prefix behavior, history/live equivalence, and bounded-copy checks

Residual risk: copy work is bounded per accepted batch, not across total retained history. Event retention, transcript-wide selectors/rendering, and one-envelope frames remain unchanged.
