### PR TITLE
fix(release): preserve local qualification truth

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -605,16 +605,18 @@ jobs:
           AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
           AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
           # BYOK provider keys for the LOCAL-3 user-key route + LOCAL-6 route
-          # change (env-manifest.ts). Absent -> those cells report blocked,
-          # never fail the run (cursor has no BYOK var by design — no account
-          # key here, per BRIEF §5).
-          # The env var NAMES the runner reads are the provisioned _API_KEY-suffixed
-          # names (env-manifest.ts / BYOK_ENV_BY_HARNESS); the GitHub secret names
-          # on the right are unchanged.
-          RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_A }}
-          RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_B }}
-          RELEASE_E2E_BYOK_OPENAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_OPENAI }}
-          RELEASE_E2E_BYOK_XAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_XAI }}
+          # change (env-manifest.ts). In strict mode an absent required key
+          # blocks its selected cells, cancels otherwise-runnable cells, and
+          # makes the aggregate non-qualifying. Cursor has no BYOK var by
+          # design — no account key here, per BRIEF §5.
+          # Both the runner env names and the protected Qualification secret
+          # names use the provisioned `_API_KEY` suffix. A mismatched right-hand
+          # name expands to an empty value and strict preflight blocks the whole
+          # local-functional matrix before a scenario can run.
+          RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY }}
+          RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY }}
+          RELEASE_E2E_BYOK_OPENAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_OPENAI_API_KEY }}
+          RELEASE_E2E_BYOK_XAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_XAI_API_KEY }}
           # LOCAL-7 MCP integration connect + audit-row assertion. The audit
           # probe reads back `cloud_integration_tool_call_event` from THIS run's
           # own ephemeral local-world Postgres, derived at runtime from the booted

--- a/tests/release/src/fixtures/authenticated-actor.test.ts
+++ b/tests/release/src/fixtures/authenticated-actor.test.ts
@@ -67,6 +67,9 @@ function fakeTransport(overrides: Partial<AuthenticatedActorTransport> = {}): {
     claimSetup: async (params) => {
       calls.push(`claimSetup:${params.email}`);
     },
+    waitForSetupCommitted: async () => {
+      calls.push("waitForSetupCommitted");
+    },
     loginWithPassword: async (apiBaseUrl, email) => {
       calls.push(`loginWithPassword:${email}`);
       return {
@@ -138,6 +141,7 @@ test("authenticatedActor drives claim -> login -> org lookup -> enrollment poll 
   assert.deepEqual(calls, [
     "readSetupToken:/tmp/run-1/setup-token",
     "claimSetup:qual-owner-local-run-1-local-0@example.com",
+    "waitForSetupCommitted",
     "loginWithPassword:qual-owner-local-run-1-local-0@example.com",
     "listOrganizations",
     "getEnrollment:1",
@@ -199,4 +203,39 @@ test("authenticatedActor propagates claim failures without masking them", async 
     },
   });
   await assert.rejects(() => authenticatedActor(world, "owner", {}, transport), /invalid setup token/);
+});
+
+test("authenticatedActor requires committed setup visibility before its single password-login attempt", async () => {
+  const world = fakeWorld();
+  let readinessChecked = false;
+  const { transport, calls } = fakeTransport({
+    waitForSetupCommitted: async () => {
+      readinessChecked = true;
+      throw new Error("setup claim did not become committed/visible");
+    },
+  });
+
+  await assert.rejects(
+    () => authenticatedActor(world, "owner", {}, transport),
+    /did not become committed\/visible/,
+  );
+  assert.equal(readinessChecked, true);
+  assert.ok(!calls.some((call) => call.startsWith("loginWithPassword")));
+});
+
+test("authenticatedActor preserves password-login 401 as red and never retries it", async () => {
+  const world = fakeWorld();
+  let loginAttempts = 0;
+  const { transport } = fakeTransport({
+    loginWithPassword: async () => {
+      loginAttempts += 1;
+      throw new Error("POST /auth/desktop/password/login -> 401: invalid credentials");
+    },
+  });
+
+  await assert.rejects(
+    () => authenticatedActor(world, "owner", {}, transport),
+    /password\/login -> 401/,
+  );
+  assert.equal(loginAttempts, 1);
 });

--- a/tests/release/src/fixtures/authenticated-actor.ts
+++ b/tests/release/src/fixtures/authenticated-actor.ts
@@ -105,6 +105,10 @@ export interface AuthenticatedActorOptions {
   email?: string;
   /** Path to the plaintext setup-token file; defaults to `<runDir>/setup-token`. */
   setupTokenPath?: string;
+  /** Bounded wait for the setup claim to be visible on a fresh connection. */
+  setupCommitTimeoutMs?: number;
+  /** Poll interval while waiting for setup-claim visibility. */
+  setupCommitPollMs?: number;
   /** Bounded wait for enrollment sync (default 60s). */
   enrollmentTimeoutMs?: number;
   /** Poll interval while waiting for enrollment sync (default 2s). */
@@ -171,6 +175,8 @@ export interface AuthenticatedActorTransport {
     setupToken: string;
     organizationName: string;
   }): Promise<void>;
+  /** Proves the first-run claim is committed/visible before password login. */
+  waitForSetupCommitted(apiBaseUrl: string, timeoutMs: number, pollMs: number): Promise<void>;
   loginWithPassword(apiBaseUrl: string, email: string, password: string): Promise<DesktopTokenResponse>;
   listOrganizations(api: ApiClient): Promise<OrganizationsListResponse>;
   getEnrollment(api: ApiClient): Promise<EnrollmentResponse>;
@@ -196,6 +202,27 @@ export const defaultAuthenticatedActorTransport: AuthenticatedActorTransport = {
     if (!response.ok) {
       const text = await response.text();
       throw new Error(`POST /setup -> ${response.status}: ${text.slice(0, 2000)}`);
+    }
+  },
+  async waitForSetupCommitted(apiBaseUrl, timeoutMs, pollMs) {
+    const deadline = Date.now() + timeoutMs;
+    let lastStatus = 0;
+    let setupStillOpen = true;
+    for (;;) {
+      const response = await fetch(`${apiBaseUrl}/setup`, { method: "GET" });
+      const body = await response.text().catch(() => "");
+      lastStatus = response.status;
+      setupStillOpen = /name="setup_token"/.test(body);
+      if (response.status === 404 && !setupStillOpen) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `authenticatedActor: setup claim did not become committed/visible within ${timeoutMs}ms ` +
+            `(GET /setup status=${lastStatus}, setupStillOpen=${setupStillOpen}).`,
+        );
+      }
+      await sleep(pollMs);
     }
   },
   async loginWithPassword(apiBaseUrl, email, password) {
@@ -266,6 +293,14 @@ export async function authenticatedActor(
   const organizationName = options.organizationName ?? `local-world-smoke-${world.run.run_id}`;
 
   await transport.claimSetup({ apiBaseUrl: world.api.baseUrl, email, password, setupToken, organizationName });
+  // The setup POST can return before a second connection observes the committed
+  // owner row. Prove visibility explicitly, then make exactly one password-login
+  // attempt. A 401 remains a real red product failure; this is not a retry loop.
+  await transport.waitForSetupCommitted(
+    world.api.baseUrl,
+    options.setupCommitTimeoutMs ?? 10_000,
+    options.setupCommitPollMs ?? 250,
+  );
 
   let tokenResponse: DesktopTokenResponse;
   try {
@@ -394,7 +429,12 @@ async function captureAuthFailureDiagnostics(apiBaseUrl: string, email: string):
 
   try {
     const methods = await fetch(`${apiBaseUrl}/auth/desktop/methods`, { method: "GET" });
-    diag.authMethods = { status: methods.status, body: await methods.json().catch(() => null) };
+    const payload = (await methods.json().catch(() => null)) as Record<string, unknown> | null;
+    diag.authMethods = {
+      status: methods.status,
+      passwordLogin: typeof payload?.password_login === "boolean" ? payload.password_login : null,
+      github: typeof payload?.github === "boolean" ? payload.github : null,
+    };
   } catch (error) {
     diag.authMethods = `err: ${error instanceof Error ? error.message : String(error)}`;
   }

--- a/tests/release/src/runner/staging-workflow.test.ts
+++ b/tests/release/src/runner/staging-workflow.test.ts
@@ -17,6 +17,13 @@ function stagingJob(): string {
   return workflow.slice(start, end);
 }
 
+function localFunctionalJob(): string {
+  const start = workflow.indexOf("  release-e2e-local-functional:");
+  const end = workflow.indexOf("\n  # ---------------------------------------------------------------------------", start);
+  assert.ok(start >= 0 && end > start, "release-e2e.yml must retain the local-functional job boundary");
+  return workflow.slice(start, end);
+}
+
 test("staging workflow remains provisional and delegates compatibility to --lane staging", () => {
   const job = stagingJob();
   assert.match(job, /name: tier-3 staging lane \(provisional\)/);
@@ -39,4 +46,17 @@ test("the staging workflow's real all-selector contains only Tier-3 sandbox cell
   assert.ok(cells.every((cell) => cell.scenario_id.startsWith("T3-")));
   assert.ok(cells.some((cell) => cell.scenario_id === "T3-PROV-2"));
   assert.ok(cells.every((cell) => !cell.scenario_id.startsWith("T4-")));
+});
+
+test("local-functional maps every BYOK env var from the provisioned _API_KEY secret", () => {
+  const job = localFunctionalJob();
+  for (const name of [
+    "RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY",
+    "RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY",
+    "RELEASE_E2E_BYOK_OPENAI_API_KEY",
+    "RELEASE_E2E_BYOK_XAI_API_KEY",
+  ]) {
+    assert.match(job, new RegExp(`${name}: \\$\\{\\{ secrets\\.${name} \\}\\}`));
+  }
+  assert.doesNotMatch(job, /secrets\.RELEASE_E2E_BYOK_(?:ANTHROPIC_[AB]|OPENAI|XAI)\s*\}\}/);
 });

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -17,7 +17,11 @@ import {
 } from "../local-world-smoke-1.js";
 import { bootLocalFunctionalWorld, isWorldBackedRun, resolveLocalFunctionalWorldInputs } from "./world-boot.js";
 import { captureLocalDriverFailure } from "./debug-capture.js";
-import { resolveLocalWorkspaceSessionId } from "./local-session.js";
+import {
+  resolveLocalWorkspaceSessionAfter,
+  resolveLocalWorkspaceSessionId,
+  snapshotLocalWorkspaceSessionIds,
+} from "./local-session.js";
 import type {
   LocalCleanupV1,
   LocalHarnessKind,
@@ -351,6 +355,11 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
   selectModelInUi: (page, modelId) => defaultLocalWorldSmokeDriver.selectModelInUi(page, modelId),
   async sendBoundedTurn(world, page, _expectedRoute, repoPath) {
     const p = page.page;
+    // Snapshot before Send. LOCAL-6 uses the same concrete workspace for both
+    // routes; resolving the "latest" session after the click can otherwise
+    // bind the gateway leg to the already-completed user-key session while the
+    // new process is still reconciling.
+    const preSendSessionIds = await snapshotLocalWorkspaceSessionIds(world, repoPath);
     const editor = p.locator("[data-home-composer-editor]").first();
     await editor.waitFor({ state: "visible", timeout: 15_000 });
     await editor.fill(DETERMINISTIC_PROMPT);
@@ -365,9 +374,22 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     // `data-workspace-ui-key` is the LOGICAL workspace id (repo-remote keyed);
     // the AnyHarness session keys off the CONCRETE runtime workspace at the repo
     // clone path (see local-session.ts). Keep the ui-key for shell selectors, but
-    // resolve the session from the runtime's own local workspace.
+    // resolve only a session created after the pre-send snapshot from the
+    // runtime's own local workspace. The shell may briefly expose a
+    // `client-session:*` alias; one new runtime id is its unambiguous target.
     const workspaceId = await readWorkspaceUiKey(p);
-    const sessionId = await resolveLocalWorkspaceSessionId(world, repoPath, WORKSPACE_SETTLE_TIMEOUT_MS);
+    const activeSessionAlias =
+      (await p
+        .locator("[data-workspace-shell]")
+        .first()
+        .getAttribute("data-workspace-session-id")
+        .catch(() => null)) || null;
+    const sessionId = await resolveLocalWorkspaceSessionAfter(
+      world,
+      repoPath,
+      WORKSPACE_SETTLE_TIMEOUT_MS,
+      { existingSessionIds: preSendSessionIds, activeSessionAlias },
+    );
     const completion = await waitForTurnCompletion(world, sessionId, TURN_TIMEOUT_MS);
     if (completion.error) {
       throw new Error(`sendBoundedTurn: assistant turn errored: ${completion.error}`);

--- a/tests/release/src/scenarios/local/local-session.test.ts
+++ b/tests/release/src/scenarios/local/local-session.test.ts
@@ -147,3 +147,63 @@ test("pre-send snapshot is scoped to the concrete local workspace", async () => 
 
   assert.deepEqual(await snapshotLocalWorkspaceSessionIds(world, REPO_PATH), new Set(["session-local"]));
 });
+
+test("pre-send snapshot preserves a successful empty workspace state", async () => {
+  const world = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [],
+  );
+
+  assert.deepEqual(await snapshotLocalWorkspaceSessionIds(world, REPO_PATH), new Set());
+});
+
+test("pre-send snapshot failure cannot expose the stale session as new", async () => {
+  let listSessionsCalls = 0;
+  let resolvedSession: string | undefined;
+  const world = {
+    runtime: {
+      client: {
+        listWorkspaces: async () => [
+          { id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH },
+        ],
+        listSessions: async () => {
+          listSessionsCalls += 1;
+          if (listSessionsCalls === 1) {
+            throw new Error("snapshot query failed");
+          }
+          return [{ id: "stale-session", workspaceId: RAW_WORKSPACE_ID }];
+        },
+      },
+    },
+  } as unknown as ReadyLocalWorld;
+
+  await assert.rejects(
+    async () => {
+      const existingSessionIds = await snapshotLocalWorkspaceSessionIds(world, REPO_PATH);
+      resolvedSession = await resolveLocalWorkspaceSessionAfter(world, REPO_PATH, 2_000, {
+        existingSessionIds,
+        activeSessionAlias: null,
+      });
+    },
+    /snapshot query failed/,
+  );
+  assert.equal(resolvedSession, undefined);
+  assert.equal(listSessionsCalls, 1, "post-send resolution must not run after a failed snapshot");
+});
+
+test("pre-send snapshot propagates a workspace query failure", async () => {
+  const world = {
+    runtime: {
+      client: {
+        listWorkspaces: async () => {
+          throw new Error("workspace snapshot failed");
+        },
+      },
+    },
+  } as unknown as ReadyLocalWorld;
+
+  await assert.rejects(
+    () => snapshotLocalWorkspaceSessionIds(world, REPO_PATH),
+    /workspace snapshot failed/,
+  );
+});

--- a/tests/release/src/scenarios/local/local-session.test.ts
+++ b/tests/release/src/scenarios/local/local-session.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { resolveLocalWorkspaceIdOnce, resolveLocalWorkspaceSessionId } from "./local-session.js";
+import {
+  resolveLocalWorkspaceIdOnce,
+  resolveLocalWorkspaceSessionAfter,
+  resolveLocalWorkspaceSessionId,
+  snapshotLocalWorkspaceSessionIds,
+} from "./local-session.js";
 import type { ReadyLocalWorld } from "../../worlds/local-workspace/world.js";
 
 /**
@@ -76,4 +81,69 @@ test("resolveLocalWorkspaceSessionId times out with a bounded, path-scoped reaso
     () => resolveLocalWorkspaceSessionId(world, REPO_PATH, 50),
     /no AnyHarness session for the local workspace at ".*repro-local-abc123"/,
   );
+});
+
+test("post-send resolution excludes the pre-send route session and binds the one new exact session", async () => {
+  const world = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [
+      { id: "session-user-key", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-gateway", workspaceId: RAW_WORKSPACE_ID },
+    ],
+  );
+
+  assert.equal(
+    await resolveLocalWorkspaceSessionAfter(world, REPO_PATH, 2_000, {
+      existingSessionIds: new Set(["session-user-key"]),
+      activeSessionAlias: "client-session:claude:route-change",
+    }),
+    "session-gateway",
+  );
+});
+
+test("post-send resolution never returns the stale last session when no new runtime session exists", async () => {
+  const world = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [{ id: "session-user-key", workspaceId: RAW_WORKSPACE_ID }],
+  );
+
+  await assert.rejects(
+    () =>
+      resolveLocalWorkspaceSessionAfter(world, REPO_PATH, 1, {
+        existingSessionIds: new Set(["session-user-key"]),
+        activeSessionAlias: "session-user-key",
+      }),
+    /no unambiguous new AnyHarness session/,
+  );
+});
+
+test("post-send resolution uses an exact active id to disambiguate multiple new runtime sessions", async () => {
+  const world = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [
+      { id: "session-old", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-new-a", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-new-b", workspaceId: RAW_WORKSPACE_ID },
+    ],
+  );
+
+  assert.equal(
+    await resolveLocalWorkspaceSessionAfter(world, REPO_PATH, 2_000, {
+      existingSessionIds: new Set(["session-old"]),
+      activeSessionAlias: "session-new-b",
+    }),
+    "session-new-b",
+  );
+});
+
+test("pre-send snapshot is scoped to the concrete local workspace", async () => {
+  const world = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [
+      { id: "session-local", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-other", workspaceId: "other-workspace" },
+    ],
+  );
+
+  assert.deepEqual(await snapshotLocalWorkspaceSessionIds(world, REPO_PATH), new Set(["session-local"]));
 });

--- a/tests/release/src/scenarios/local/local-session.ts
+++ b/tests/release/src/scenarios/local/local-session.ts
@@ -49,6 +49,80 @@ export async function resolveLocalWorkspaceSessionId(
 }
 
 /**
+ * Snapshots the exact runtime session ids already owned by the concrete local
+ * workspace at `repoPath`. A UI send that is required to create a fresh
+ * process/session must take this snapshot *before* clicking Send; otherwise a
+ * later "latest session" lookup can bind the turn to the previous route's
+ * already-completed session.
+ */
+export async function snapshotLocalWorkspaceSessionIds(
+  world: ReadyLocalWorld,
+  repoPath: string,
+): Promise<ReadonlySet<string>> {
+  const workspaceId = await resolveLocalWorkspaceIdOnce(world, repoPath).catch(() => null);
+  if (!workspaceId) {
+    return new Set<string>();
+  }
+  const sessions = await world.runtime.client.listSessions().catch(() => []);
+  return new Set(sessions.filter((session) => session.workspaceId === workspaceId).map((session) => session.id));
+}
+
+/**
+ * Resolves only a session created after a pre-send snapshot. The product shell
+ * may temporarily expose a client-side session alias while AnyHarness
+ * reconciles the concrete id, so a single new runtime candidate is accepted as
+ * that alias's exact materialization. Multiple new candidates are accepted only
+ * when the shell already names one of their exact ids. A stale pre-send session
+ * is never returned.
+ */
+export async function resolveLocalWorkspaceSessionAfter(
+  world: ReadyLocalWorld,
+  repoPath: string,
+  timeoutMs: number,
+  options: {
+    existingSessionIds: ReadonlySet<string>;
+    activeSessionAlias: string | null;
+  },
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastWorkspaces = "";
+  let lastCandidates: string[] = [];
+  while (Date.now() < deadline) {
+    const workspaceId = await resolveLocalWorkspaceIdOnce(world, repoPath).catch(() => null);
+    if (workspaceId) {
+      const sessions = await world.runtime.client.listSessions().catch(() => []);
+      const candidates = sessions
+        .filter(
+          (session) =>
+            session.workspaceId === workspaceId && !options.existingSessionIds.has(session.id),
+        )
+        .map((session) => session.id);
+      lastCandidates = candidates;
+      if (options.activeSessionAlias && candidates.includes(options.activeSessionAlias)) {
+        return options.activeSessionAlias;
+      }
+      if (candidates.length === 1) {
+        // The active shell can still carry a `client-session:*` alias here. A
+        // single new exact runtime id is its unambiguous reconciliation target.
+        return candidates[0]!;
+      }
+    } else {
+      lastWorkspaces = JSON.stringify(
+        (await world.runtime.client.listWorkspaces().catch(() => []))
+          .map((workspace) => ({ kind: workspace.kind, path: workspace.path })),
+      );
+    }
+    await sleep(1_000);
+  }
+  throw new Error(
+    `resolveLocalWorkspaceSessionAfter: no unambiguous new AnyHarness session for the local workspace at ` +
+      `"${repoPath}" within ${timeoutMs}ms (pre-send sessions=${options.existingSessionIds.size}, ` +
+      `new candidates=${lastCandidates.length}, active alias present=${Boolean(options.activeSessionAlias)})` +
+      `${lastWorkspaces ? ` (runtime workspaces: ${lastWorkspaces})` : ""}.`,
+  );
+}
+
+/**
  * Resolves the raw runtime workspace id of the `kind:"local"` workspace cloned at
  * `repoPath`. Returns null until it appears (the caller polls). Exported so a
  * driver that needs only the workspace identity (not a session) can reuse it.

--- a/tests/release/src/scenarios/local/local-session.ts
+++ b/tests/release/src/scenarios/local/local-session.ts
@@ -59,11 +59,14 @@ export async function snapshotLocalWorkspaceSessionIds(
   world: ReadyLocalWorld,
   repoPath: string,
 ): Promise<ReadonlySet<string>> {
-  const workspaceId = await resolveLocalWorkspaceIdOnce(world, repoPath).catch(() => null);
+  // This is a one-time correctness boundary, not a poll. A query failure must
+  // abort the send path; treating it like a legitimately empty snapshot would
+  // let the next poll misclassify a pre-existing session as newly created.
+  const workspaceId = await resolveLocalWorkspaceIdOnce(world, repoPath);
   if (!workspaceId) {
     return new Set<string>();
   }
-  const sessions = await world.runtime.client.listSessions().catch(() => []);
+  const sessions = await world.runtime.client.listSessions();
   return new Set(sessions.filter((session) => session.workspaceId === workspaceId).map((session) => session.id));
 }
 
@@ -131,7 +134,7 @@ export async function resolveLocalWorkspaceIdOnce(
   world: ReadyLocalWorld,
   repoPath: string,
 ): Promise<string | null> {
-  const workspaces = await world.runtime.client.listWorkspaces().catch(() => []);
+  const workspaces = await world.runtime.client.listWorkspaces();
   const local = workspaces.find((workspace) => workspace.kind === "local" && workspace.path === repoPath);
   return local?.id ?? null;
 }


### PR DESCRIPTION
## Outcome

Repairs three ownership-correct failures observed in Release E2E run 29602686092 without converting product failures into green results.

- maps local-functional BYOK credentials from the real Qualification secret names
- prevents AUTHROUTE from accepting a stale pre-send session
- proves actor setup visibility before one password-login attempt and records only redacted diagnostics
- leaves SESSION/#1333 product-red and untouched

## Proof

- 43/43 focused release tests
- release TypeScript typecheck
- diff/max-lines checks
- no live provider, Docker, or Rust work

## Acceptance debt

This does not claim the local Tier-3 lane is qualification-accepted. A strict exact-head Release E2E run follows after code review and shared lane custody are clean.