### PR TITLE
fix(transcript): surface native subagent activity

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs
@@ -361,6 +361,7 @@ async fn catalog_poke_waits_for_compatible_job_then_uses_latest_pins() {
     use crate::domains::agents::catalog::schema::AgentCatalogArtifactSource;
     use crate::domains::agents::catalog::service::AgentCatalogService;
     use crate::domains::agents::catalog::sync::CatalogSyncService;
+    use crate::domains::agents::installer::install_policy::ResolvedPinSource;
     use crate::domains::agents::installer::seed::AgentSeedStore;
     use crate::domains::agents::runtime::AgentRuntime;
 
@@ -396,7 +397,8 @@ async fn catalog_poke_waits_for_compatible_job_then_uses_latest_pins() {
         assert_eq!(admitted_pin.as_deref(), Some(old_pin.as_str()));
     }
 
-    let latest_ref = "1111111111111111111111111111111111111111";
+    let latest_pin = "catalog-poke-latest";
+    let latest_package = "@proliferate-ai/codex-acp@catalog-poke-latest";
     let mut latest = bundled_agent_catalog_document().clone();
     latest.catalog_version = "2099-01-01.catalog-poke".into();
     let codex = latest
@@ -404,12 +406,12 @@ async fn catalog_poke_waits_for_compatible_job_then_uses_latest_pins() {
         .iter_mut()
         .find(|agent| agent.kind == "codex")
         .expect("codex catalog row");
-    codex.harness.agent_process.version = "catalog-poke-latest".into();
+    codex.harness.agent_process.version = latest_pin.into();
     match codex.harness.agent_process.source.as_mut() {
-        Some(AgentCatalogArtifactSource::Git { git_ref, .. }) => {
-            *git_ref = latest_ref.into();
+        Some(AgentCatalogArtifactSource::Npm { package, .. }) => {
+            *package = latest_package.into();
         }
-        _ => panic!("codex adapter must use a git pin"),
+        _ => panic!("codex adapter must use an npm pin"),
     }
     sync.apply_fetched(
         &serde_json::to_vec(&latest).expect("serialize latest catalog"),
@@ -458,12 +460,16 @@ async fn catalog_poke_waits_for_compatible_job_then_uses_latest_pins() {
     assert!(fresh.installed_only);
     assert!(fresh.agent_kinds.is_empty());
     let job = service.job.lock().await;
-    let used_pin = job
+    let used_pins = job
         .as_ref()
         .and_then(|job| job.catalog.as_ref())
         .and_then(|catalog| catalog.pin_overrides("codex"))
-        .and_then(|pins| pins.agent_process);
-    assert_eq!(used_pin.as_deref(), Some(latest_ref));
+        .expect("fresh job codex pins");
+    assert_eq!(used_pins.agent_process.as_deref(), Some(latest_pin));
+    assert!(matches!(
+        used_pins.agent_process_source,
+        Some(ResolvedPinSource::Npm { package, .. }) if package == latest_package
+    ));
 
     let _ = std::fs::remove_dir_all(home);
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/metadata.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/metadata.rs
@@ -1,16 +1,29 @@
 use super::normalization::meta::parse_meta;
+use super::state::ParsedMeta;
 use super::SessionEventSink;
+
+impl ParsedMeta {
+    pub(super) fn parent_tool_call_id(&self, source_agent_kind: &str) -> Option<String> {
+        self.anyharness
+            .as_ref()
+            .and_then(|meta| meta.parent_tool_call_id.clone())
+            .or_else(|| {
+                (source_agent_kind == "claude")
+                    .then(|| {
+                        self.claude_code
+                            .as_ref()
+                            .and_then(|meta| meta.parent_tool_use_id.clone())
+                    })
+                    .flatten()
+            })
+    }
+}
 
 impl SessionEventSink {
     pub(super) fn meta_parent_tool_call_id(
         &self,
         meta: Option<&serde_json::Value>,
     ) -> Option<String> {
-        if self.source_agent_kind != "claude" {
-            return None;
-        }
-        parse_meta(meta)
-            .claude_code
-            .and_then(|meta| meta.parent_tool_use_id)
+        parse_meta(meta).parent_tool_call_id(&self.source_agent_kind)
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/normalization/text.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/normalization/text.rs
@@ -19,7 +19,8 @@ pub(in crate::live::sessions::sink) fn extract_text(content: &serde_json::Value)
 }
 
 fn is_subagent_tool(tool_kind: Option<&str>, native_tool_name: Option<&str>) -> bool {
-    native_tool_name == Some("Agent") || tool_kind == Some("think")
+    matches!(native_tool_name, Some("Agent" | "Task"))
+        || matches!(tool_kind, Some("subagent" | "think"))
 }
 
 pub(in crate::live::sessions::sink) fn normalize_text_parts(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/state.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/state.rs
@@ -87,6 +87,7 @@ pub(super) struct AnyHarnessMeta {
     pub(super) transcript_event: Option<String>,
     pub(super) native_tool_name: Option<String>,
     pub(super) tool_kind: Option<String>,
+    pub(super) parent_tool_call_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use serde_json::json;
 use tokio::sync::broadcast;
 
+mod native_subagents;
 mod support;
 
 use super::{AcpChunkPayload, SessionEventSink};

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests/native_subagents.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tests/native_subagents.rs
@@ -1,0 +1,129 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use agent_client_protocol as acp;
+use anyharness_contract::v1::{SessionEvent, SessionEventEnvelope, StopReason};
+use serde::Deserialize;
+use tokio::sync::broadcast;
+
+use super::super::SessionEventSink;
+use super::support::{drain_events, seeded_store};
+
+const CLAUDE_FIXTURE: &str = include_str!(
+    "../../../../../../../../fixtures/contracts/native-subagent-transcript/claude.json"
+);
+const CODEX_FIXTURE: &str = include_str!(
+    "../../../../../../../../fixtures/contracts/native-subagent-transcript/codex.json"
+);
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeSubagentFixture {
+    provider: String,
+    parent_id: String,
+    parent_terminal_before_turn_end: bool,
+    acp_notifications: Vec<acp::schema::SessionNotification>,
+    events: Vec<SessionEventEnvelope>,
+}
+
+#[test]
+fn native_subagent_fixtures_preserve_live_and_replay_attribution() {
+    for fixture_json in [CLAUDE_FIXTURE, CODEX_FIXTURE] {
+        let fixture: NativeSubagentFixture =
+            serde_json::from_str(fixture_json).expect("native subagent fixture parses");
+        let store = seeded_store();
+        let (tx, mut rx) = broadcast::channel(64);
+        let mut sink = SessionEventSink::new(
+            "session-1".to_string(),
+            fixture.provider.clone(),
+            PathBuf::from("/tmp/workspace"),
+            tx,
+            Arc::new(store.clone()),
+        );
+
+        for notification in &fixture.acp_notifications {
+            let _ = sink.ingest(notification);
+        }
+        let before_turn_end = store
+            .list_events("session-1")
+            .expect("pre-turn-boundary replay");
+        let parent_was_terminal = before_turn_end.iter().any(|record| {
+            record.item_id.as_deref() == Some(fixture.parent_id.as_str())
+                && serde_json::from_str::<SessionEvent>(&record.payload_json)
+                    .is_ok_and(|event| matches!(event, SessionEvent::ItemCompleted(_)))
+        });
+        assert_eq!(
+            parent_was_terminal, fixture.parent_terminal_before_turn_end,
+            "{} parent terminal causality",
+            fixture.provider,
+        );
+        sink.turn_ended(StopReason::EndTurn);
+
+        let live = drain_events(&mut rx);
+        let persisted = store.list_events("session-1").expect("persisted replay");
+        assert_eq!(
+            persisted.len(),
+            live.len(),
+            "{} event count",
+            fixture.provider
+        );
+        for (record, envelope) in persisted.iter().zip(&live) {
+            assert_eq!(
+                record.seq, envelope.seq,
+                "{} replay sequence",
+                fixture.provider
+            );
+            assert_eq!(
+                record.turn_id, envelope.turn_id,
+                "{} replay turn",
+                fixture.provider
+            );
+            assert_eq!(
+                record.item_id, envelope.item_id,
+                "{} replay item",
+                fixture.provider
+            );
+            let replay_event: SessionEvent =
+                serde_json::from_str(&record.payload_json).expect("persisted event parses");
+            assert_eq!(
+                serde_json::to_value(replay_event).expect("serialize replay event"),
+                serde_json::to_value(&envelope.event).expect("serialize live event"),
+                "{} replay payload",
+                fixture.provider,
+            );
+        }
+
+        assert_eq!(
+            live.len(),
+            fixture.events.len(),
+            "{} fixture count",
+            fixture.provider
+        );
+        for (actual, expected) in live.iter().zip(&fixture.events) {
+            assert_eq!(
+                actual.seq, expected.seq,
+                "{} fixture sequence",
+                fixture.provider
+            );
+            let message_item_has_runtime_envelope_id = match &expected.event {
+                SessionEvent::ItemStarted(event) => event.item.message_id.is_some(),
+                SessionEvent::ItemCompleted(event) => event.item.message_id.is_some(),
+                _ => false,
+            };
+            if !message_item_has_runtime_envelope_id {
+                assert_eq!(
+                    actual.item_id, expected.item_id,
+                    "{} fixture item identity at seq {}",
+                    fixture.provider, actual.seq,
+                );
+            }
+            assert_eq!(
+                serde_json::to_value(&actual.event).expect("serialize actual event"),
+                serde_json::to_value(&expected.event).expect("serialize fixture event"),
+                "{} normalized event payload at seq {}",
+                fixture.provider,
+                actual.seq,
+            );
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/tools.rs
@@ -111,14 +111,9 @@ impl SessionEventSink {
                 }
             })
             .or_else(|| previous.and_then(|prev| prev.item.native_tool_name.clone()));
-        let parent_tool_call_id = if self.source_agent_kind == "claude" {
-            meta.claude_code
-                .as_ref()
-                .and_then(|meta| meta.parent_tool_use_id.clone())
-                .or_else(|| previous.and_then(|prev| prev.item.parent_tool_call_id.clone()))
-        } else {
-            previous.and_then(|prev| prev.item.parent_tool_call_id.clone())
-        };
+        let parent_tool_call_id = meta
+            .parent_tool_call_id(&self.source_agent_kind)
+            .or_else(|| previous.and_then(|prev| prev.item.parent_tool_call_id.clone()));
 
         let title = payload
             .title

--- a/anyharness/sdk/src/reducer/__tests__/native-subagent-transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/native-subagent-transcript.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEventEnvelope, ToolCallItem } from "../../index.js";
+import { reduceEvents } from "../../index.js";
+import claudeFixtureJson from "../../../../../fixtures/contracts/native-subagent-transcript/claude.json";
+import codexFixtureJson from "../../../../../fixtures/contracts/native-subagent-transcript/codex.json";
+
+type NativeSubagentFixture = {
+  provider: "claude" | "codex";
+  sessionId: string;
+  turnId: string;
+  parentId: string;
+  parentTerminalBeforeTurnEnd: boolean;
+  childIds: string[];
+  events: SessionEventEnvelope[];
+};
+
+const fixtures = [
+  claudeFixtureJson,
+  codexFixtureJson,
+] as unknown as NativeSubagentFixture[];
+
+describe.each(fixtures)("$provider native subagent transcript fixture", (fixture) => {
+  it("preserves provider-neutral parent identity and provider-specific child detail", () => {
+    const transcript = reduceEvents(
+      fixture.events,
+      fixture.sessionId,
+      { replayMode: true },
+    );
+    const parent = transcript.itemsById[fixture.parentId] as ToolCallItem;
+
+    expect(transcript.turnOrder).toEqual([fixture.turnId]);
+    expect(transcript.turnsById[fixture.turnId]?.itemOrder).toEqual([
+      fixture.parentId,
+      ...fixture.childIds,
+    ]);
+    expect(parent).toMatchObject({
+      kind: "tool_call",
+      status: "completed",
+      semanticKind: "subagent",
+    });
+    if (!fixture.parentTerminalBeforeTurnEnd) {
+      const boundaryCompletionIndex = fixture.events.findIndex((envelope) =>
+        envelope.itemId === fixture.parentId
+        && envelope.event.type === "item_completed"
+      );
+      const beforeBoundary = reduceEvents(
+        fixture.events.slice(0, boundaryCompletionIndex),
+        fixture.sessionId,
+        { replayMode: true },
+      );
+      expect(beforeBoundary.itemsById[fixture.parentId]?.status).toBe("in_progress");
+    }
+    expect(
+      fixture.childIds.map((itemId) => transcript.itemsById[itemId]?.parentToolCallId),
+    ).toEqual(fixture.childIds.map(() => fixture.parentId));
+
+    const children = fixture.childIds.map((itemId) => transcript.itemsById[itemId]);
+    if (fixture.provider === "claude") {
+      expect(parent.nativeToolName).toBe("Task");
+      expect(children.map((item) => item?.kind)).toEqual([
+        "assistant_prose",
+        "thought",
+        "tool_call",
+      ]);
+    } else {
+      expect(parent.nativeToolName).toBe("Agent");
+      expect(children.map((item) => item?.kind)).toEqual(["tool_call"]);
+      expect((children[0] as ToolCallItem).semanticKind).toBe("other");
+      expect(Object.values(transcript.itemsById).some((item) =>
+        item.kind === "assistant_prose" || item.kind === "thought"
+      )).toBe(false);
+    }
+  });
+});

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -1431,7 +1431,7 @@ function deriveToolCallSemanticKind(
     return "subagent";
   }
 
-  if (nativeToolName === "Agent" || normalizedToolKind === "think") {
+  if (nativeToolName === "Agent" || nativeToolName === "Task" || normalizedToolKind === "think") {
     return "subagent";
   }
   if (

--- a/anyharness/tests/src/harness/local-agent-launchers.ts
+++ b/anyharness/tests/src/harness/local-agent-launchers.ts
@@ -71,7 +71,7 @@ function ensureCodexNpmLauncher(): { program: string; args: string[]; cwd: strin
   const installRoot = process.env.ANYHARNESS_TEST_CODEX_NPM_ROOT?.trim() || CODEX_NPM_INSTALL_ROOT;
   const packageSpec =
     process.env.ANYHARNESS_TEST_CODEX_NPM_SPEC?.trim() ||
-    "@proliferate-ai/codex-acp@0.18.2-proliferate.1";
+    "@proliferate-ai/codex-acp@0.18.3-proliferate.1";
   const forceInstall = process.env.ANYHARNESS_TEST_FORCE_AGENT_INSTALL === "1";
   const binaryPath = join(installRoot, "node_modules", ".bin", "codex-acp");
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx
@@ -6,7 +6,7 @@ import { toolItem } from "@proliferate/product-domain/chats/transcript/transcrip
 import { SubagentCreationGroupBlock } from "#product/components/workspace/chat/transcript/SubagentCreationGroupBlock";
 
 describe("SubagentCreationGroupBlock", () => {
-  it("renders a quiet done-line for finished subagents", () => {
+  it("renders a quiet done-line for finished creation receipts", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       "create-1": toolItem("create-1", "turn-1", 1, "subagent"),
@@ -30,7 +30,7 @@ describe("SubagentCreationGroupBlock", () => {
     expect(html).not.toContain("Created");
   });
 
-  it("renders nothing while a subagent is still running (roster owns it)", () => {
+  it("renders nothing while a creation receipt is still running", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       "create-1": toolItem("create-1", "turn-1", 1, "subagent", "in_progress"),

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.tsx
@@ -27,8 +27,8 @@ export function SubagentCreationGroupBlock({
     .map((itemId) => transcript.itemsById[itemId])
     .filter((item): item is ToolCallItem => item?.kind === "tool_call");
 
-  // Filter to only show finished subagents in the transcript.
-  // Running subagents appear only in the composer ⑂ roster.
+  // This block receives compact product-MCP creation receipts. Native
+  // subagent calls render through TranscriptAgentGroupBlock instead.
   const finishedItems = items.filter((item) => isSubagentWorkComplete(item));
   const openSession = useTranscriptOpenSession();
   const summary = finishedItems.length === 1 ? "Subagent finished" : `${finishedItems.length} subagents finished`;
@@ -77,8 +77,9 @@ export function SubagentCreationGroupBlock({
 }
 
 /**
- * A quiet, collapsible line for a finished subagent showing the clean result
- * summary the parent agent used. The line reads "⑂ <task title> — done" and
+ * A quiet, collapsible line for a finished product-MCP creation receipt showing
+ * the clean result summary the parent agent used. The line reads
+ * "⑂ <task title> — done" and
  * expands to show the subagent's summary field (never the raw orchestration
  * metadata).
  */

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
@@ -1,0 +1,198 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  createTranscriptState,
+  reduceEvents,
+} from "@anyharness/sdk";
+import type {
+  SessionEventEnvelope,
+  ToolCallItem,
+  TranscriptState,
+} from "@anyharness/sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTurnPresentation,
+} from "@proliferate/product-domain/chats/transcript/transcript-presentation";
+import {
+  toolItem,
+} from "@proliferate/product-domain/chats/transcript/transcript-presentation-test-fixtures";
+import claudeFixtureJson from "../../../../../../../../fixtures/contracts/native-subagent-transcript/claude.json";
+import codexFixtureJson from "../../../../../../../../fixtures/contracts/native-subagent-transcript/codex.json";
+import {
+  TranscriptAgentGroupBlock,
+} from "#product/components/workspace/chat/transcript/TranscriptAgentGroupBlock";
+import {
+  TranscriptTreeNode,
+} from "#product/components/workspace/chat/transcript/TranscriptTreeNode";
+
+vi.mock("#product/hooks/cowork/workflows/use-open-cowork-coding-session", () => ({
+  useOpenCoworkCodingSession: () => vi.fn(),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({ selectWorkspace: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
+  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
+    reference: {
+      rawPath,
+      path: rawPath,
+      line: null,
+      column: null,
+      absolutePath: `/repo/${rawPath}`,
+      workspacePath: rawPath,
+    },
+    openTargets: [],
+    canOpenInSidebar: true,
+    canOpenExternal: true,
+    copyPath: vi.fn(),
+    openInSidebar: vi.fn(),
+    openDefault: vi.fn(),
+    openPrimary: vi.fn(),
+    openWithTarget: vi.fn(),
+    reveal: vi.fn(),
+  }),
+}));
+
+vi.mock("#product/components/workspace/chat/tool-calls/ToolFileChip", () => ({
+  ToolFileChip: ({ basename }: { basename: string }) => createElement("span", null, basename),
+}));
+
+vi.mock("#product/components/content/ui/HighlightedCodeBlock", () => ({
+  HighlightedCodeBlock: ({ code }: { code: string }) => createElement("pre", null, code),
+}));
+
+vi.mock("#product/components/workspace/chat/transcript/ConnectedProposedPlanItem", () => ({
+  ConnectedProposedPlanItem: () => null,
+}));
+
+vi.mock("#product/components/workspace/chat/transcript/SessionErrorItem", () => ({
+  SessionErrorItem: () => null,
+}));
+
+vi.mock("#product/components/workspace/chat/transcript/UserMessage", () => ({
+  UserMessage: () => null,
+}));
+
+vi.mock("#product/hooks/ui/native/use-native-context-menu", () => ({
+  useNativeContextMenu: () => ({
+    onContextMenuCapture: vi.fn(),
+    showNativeMenu: vi.fn(),
+  }),
+  useNativeMenu: () => ({ showNativeMenu: vi.fn() }),
+}));
+
+type NativeSubagentFixture = {
+  provider: "claude" | "codex";
+  sessionId: string;
+  turnId: string;
+  parentId: string;
+  childIds: string[];
+  events: SessionEventEnvelope[];
+};
+
+const fixtures = {
+  claude: claudeFixtureJson as unknown as NativeSubagentFixture,
+  codex: codexFixtureJson as unknown as NativeSubagentFixture,
+};
+
+describe.each(["in_progress", "completed"] as const)(
+  "TranscriptAgentGroupBlock %s",
+  (status) => {
+    it("renders the durable native subagent row", () => {
+      const transcript = createTranscriptState("session-1");
+      const item: ToolCallItem = {
+        ...toolItem("native-task", "turn-1", 1, "subagent", status),
+        title: "Inspect the repository",
+        nativeToolName: "Task",
+        rawInput: { prompt: "Inspect the transcript pipeline" },
+        rawOutput: status === "completed"
+          ? { summary: "Transcript pipeline inspected." }
+          : undefined,
+      };
+      transcript.itemsById[item.itemId] = item;
+
+      const html = renderToStaticMarkup(
+        createElement(TranscriptAgentGroupBlock, {
+          item,
+          childIds: [],
+          transcript,
+          childrenByParentId: new Map(),
+          renderChild: () => null,
+        }),
+      );
+
+      expect(html).not.toBe("");
+      expect(html).toContain("Inspect the repository");
+    });
+  },
+);
+
+describe("native subagent transcript tree rendering", () => {
+  it("renders Codex collaboration activity as a tool, not another spawn", () => {
+    const { fixture, transcript, childrenByParentId } = fixtureTree("codex");
+    const html = renderNodes(fixture.childIds, transcript, childrenByParentId);
+
+    expect(html).toContain("send_input");
+    expect(html).toContain("Send follow-up to child");
+    expect(html).not.toContain("Subagent created");
+    expect(html).not.toContain("Creating subagent");
+  });
+
+  it("renders Claude child prose, reasoning, and file activity", () => {
+    const { fixture, transcript, childrenByParentId } = fixtureTree("claude");
+    const html = renderNodes(fixture.childIds, transcript, childrenByParentId);
+
+    expect(html).toContain("Inspecting the transcript pipeline.");
+    expect(html).toContain("Checking reducer ordering.");
+    expect(html).toContain("transcript.ts");
+  });
+
+  it.each(["claude", "codex"] as const)(
+    "routes the %s parent through the durable subagent group",
+    (provider) => {
+      const { fixture, transcript, childrenByParentId } = fixtureTree(provider);
+      const html = renderNodes([fixture.parentId], transcript, childrenByParentId);
+
+      expect(html).toContain("Subagent created");
+      expect(html).toContain("Inspect the repository");
+    },
+  );
+});
+
+function fixtureTree(provider: keyof typeof fixtures): {
+  fixture: NativeSubagentFixture;
+  transcript: TranscriptState;
+  childrenByParentId: Map<string, string[]>;
+} {
+  const fixture = fixtures[provider];
+  const transcript = reduceEvents(fixture.events, fixture.sessionId, { replayMode: true });
+  const turn = transcript.turnsById[fixture.turnId];
+  if (!turn) {
+    throw new Error(`missing fixture turn ${fixture.turnId}`);
+  }
+  const { childrenByParentId } = buildTurnPresentation(turn, transcript);
+  return { fixture, transcript, childrenByParentId };
+}
+
+function renderNodes(
+  itemIds: readonly string[],
+  transcript: TranscriptState,
+  childrenByParentId: Map<string, string[]>,
+): string {
+  return renderToStaticMarkup(
+    createElement(
+      "div",
+      null,
+      ...itemIds.map((itemId) => createElement(TranscriptTreeNode, {
+        key: itemId,
+        itemId,
+        transcript,
+        childrenByParentId,
+        workspaceId: "workspace-1",
+        onOpenArtifact: () => {},
+      })),
+    ),
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -71,27 +71,6 @@ export function TranscriptAgentGroupBlock({
   const [expanded, setExpanded] = useState(false);
   const [workExpanded, setWorkExpanded] = useState(false);
 
-  // Native subagent lifecycle (session-activity-architecture): while a
-  // subagent is still running it lives ONLY in the composer ⑂ roster — the
-  // transcript stays quiet and shows nothing. Once finished, the item is
-  // routed to SubagentCreationGroupBlock (via buildTranscriptDisplayBlocks)
-  // and renders as a quiet done-line there. This block should NEVER receive
-  // finished subagents, but if one leaks through (e.g., stale transcript
-  // state or classification gap), hide it rather than show the old metadata
-  // block.
-  if (isRunning) {
-    return null;
-  }
-
-  // Finished subagents should have been routed to SubagentCreationGroupBlock
-  // by buildTranscriptDisplayBlocks. If one reached here, it's a
-  // classification gap — hide it silently (the roster already showed the live
-  // work, and SubagentCreationGroupBlock will render the done-line if the
-  // transcript re-classifies correctly on next update).
-  if (isWorkComplete) {
-    return null;
-  }
-
   const subagentDisplay = resolveSubagentLaunchDisplay(item);
   const normalizedPrompt = subagentDisplay.prompt?.trim() ?? "";
 
@@ -127,9 +106,8 @@ export function TranscriptAgentGroupBlock({
   const hasWork = childIds.length > 0;
   const hasLaunchLedger = !!normalizedPrompt || hasProvisioningLedger;
   const hasBodyContent = hasWork || hasLaunchLedger || !!normalizedAgentResult;
-  // Only finished subagents render here (running ones return null above and
-  // live in the composer roster), so the work view is always the collapsed
-  // done-state form.
+  // The activity roster is a session-level summary. This durable transcript
+  // item is the canonical place to inspect the native subagent's nested work.
   const renderScopedWork = () => (
     <ScopedTranscriptBlocks
       displayBlocks={scopedDisplayBlocks}

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { reduceEvents } from "@anyharness/sdk";
 import type { SessionEventEnvelope } from "@anyharness/sdk";
+import claudeNativeSubagentFixture from "../../../../../../../../fixtures/contracts/native-subagent-transcript/claude.json";
+import codexNativeSubagentFixture from "../../../../../../../../fixtures/contracts/native-subagent-transcript/codex.json";
 import {
   appendHistoryTail,
   applyStreamEnvelope,
@@ -8,7 +10,44 @@ import {
   replaySessionHistory,
 } from "#product/lib/domain/sessions/stream/stream-state";
 
+type NativeSubagentFixture = {
+  provider: "claude" | "codex";
+  sessionId: string;
+  events: SessionEventEnvelope[];
+};
+
+const nativeSubagentFixtures = [
+  claudeNativeSubagentFixture,
+  codexNativeSubagentFixture,
+] as unknown as NativeSubagentFixture[];
+
 describe("session-stream-state", () => {
+  describe.each(nativeSubagentFixtures)("$provider native subagent fixture", (fixture) => {
+    it("deduplicates and orders a live batch to match durable replay", () => {
+      const replay = replaySessionHistory(fixture.sessionId, fixture.events);
+      const initial = replaySessionHistory(fixture.sessionId, fixture.events.slice(0, 1));
+      const tail = fixture.events.slice(1);
+      const duplicatedTailEvent = tail[Math.floor(tail.length / 2)];
+
+      const result = applyStreamEnvelopeBatch(initial, [
+        ...[...tail].reverse(),
+        fixture.events[0],
+        duplicatedTailEvent,
+      ]);
+
+      expect(result.gapEnvelope).toBeNull();
+      expect(result.appliedEnvelopes.map((event) => event.seq)).toEqual(
+        tail.map((event) => event.seq),
+      );
+      expect(result.duplicateEnvelopes.map((event) => event.seq)).toEqual([
+        fixture.events[0].seq,
+        duplicatedTailEvent.seq,
+      ]);
+      expect(result.state.events).toEqual(fixture.events);
+      expect(result.state.transcript).toEqual(replay.transcript);
+    });
+  });
+
   it("ignores duplicate stream envelopes", () => {
     const state = replaySessionHistory("session-1", [turnStarted(1)]);
 

--- a/apps/packages/product-domain/src/chats/subagents/subagent-launch.ts
+++ b/apps/packages/product-domain/src/chats/subagents/subagent-launch.ts
@@ -61,14 +61,14 @@ export function resolveSubagentExecutionState(
     return "completed_background";
   }
 
-  // A native-Agent fire-and-forget async launch flips its launch tool-call to
+  // A native Agent/Task fire-and-forget async launch flips its launch tool-call to
   // status:"completed" the instant the launch receipt returns, while the
   // subagent keeps running. When the pending-background metadata is not
   // attached to this item's rawOutput, the checks above fall through and the
   // launch would be mis-classified as completed. Detect the bare launch
-  // receipt (no structured summary yet) and treat it as still running so the
-  // transcript stays quiet — the live subagent lives in the composer roster,
-  // and the raw orchestration receipt never leaks into the transcript.
+  // receipt (no structured summary yet) and treat it as still running. The
+  // transcript can show the durable task row without exposing the raw
+  // orchestration receipt, while the composer roster summarizes live state.
   if (isAsyncLaunchReceipt(item)) {
     return "background";
   }
@@ -124,7 +124,7 @@ export function parseAsyncSubagentLaunch(
   }
 
   const backgroundWork = getBackgroundWork(item);
-  // A native-Agent async launch may or may not carry pending-background
+  // A native Agent/Task async launch may or may not carry pending-background
   // metadata on this item's rawOutput. Recognise the launch receipt either
   // way: prefer the structured metadata, else fall back to the receipt text
   // signature. The final synthesized result replaces this text once the
@@ -141,10 +141,10 @@ export function parseAsyncSubagentLaunch(
 }
 
 /**
- * True when this item is a native-Agent background launch whose result is
+ * True when this item is a native Agent/Task background launch whose result is
  * still only the orchestration launch receipt (no final synthesized result
- * yet). Used to keep the transcript quiet while the subagent runs even when
- * the pending-background metadata is absent from rawOutput.
+ * yet). Used to keep the receipt out of the transcript while the subagent runs
+ * even when the pending-background metadata is absent from rawOutput.
  */
 function isAsyncLaunchReceipt(item: ToolCallItem): boolean {
   if (!isSubagent(item) || !readBooleanField(item.rawInput, "run_in_background")) {

--- a/apps/packages/product-domain/src/chats/subagents/subagent-tool-presentation.ts
+++ b/apps/packages/product-domain/src/chats/subagents/subagent-tool-presentation.ts
@@ -88,9 +88,8 @@ export function isSubagentProvisioningAction(item: ToolNameOwner): boolean {
 
 export function isSubagentCreationAction(item: ToolNameOwner): boolean {
   // Only the product-MCP create_subagent receipt collapses into a creation
-  // group. Native Agent calls are now routed dynamically by
-  // isFinishedNativeAgentSubagent() — they MUST NOT match here or they'll be
-  // misclassified while still running.
+  // group. Native subagent calls stay as durable transcript items throughout
+  // their lifecycle and must not match here.
   return normalizeToolName(item.nativeToolName) === "mcp__subagents__create_subagent";
 }
 

--- a/apps/packages/product-domain/src/chats/transcript/transcript-presentation.test.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-presentation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createTranscriptState } from "@anyharness/sdk";
-import type { ToolCallItem } from "@anyharness/sdk";
+import { createTranscriptState, reduceEvents } from "@anyharness/sdk";
+import type { SessionEventEnvelope, ToolCallItem } from "@anyharness/sdk";
+import claudeNativeSubagentFixture from "../../../../../../fixtures/contracts/native-subagent-transcript/claude.json";
+import codexNativeSubagentFixture from "../../../../../../fixtures/contracts/native-subagent-transcript/codex.json";
 import {
   formatCollapsedActionsSummary,
   summarizeCollapsedActions,
@@ -22,7 +24,45 @@ import {
   userItem,
 } from "./transcript-presentation-test-fixtures";
 
+type NativeSubagentFixture = {
+  provider: "claude" | "codex";
+  sessionId: string;
+  turnId: string;
+  parentId: string;
+  childIds: string[];
+  events: SessionEventEnvelope[];
+};
+
+const nativeSubagentFixtures = [
+  claudeNativeSubagentFixture,
+  codexNativeSubagentFixture,
+] as unknown as NativeSubagentFixture[];
+
 describe("buildTurnPresentation", () => {
+  describe.each(nativeSubagentFixtures)("$provider native subagent fixture", (fixture) => {
+    it("keeps ordered child activity under a durable parent item", () => {
+      const transcript = reduceEvents(
+        fixture.events,
+        fixture.sessionId,
+        { replayMode: true },
+      );
+      const turn = transcript.turnsById[fixture.turnId];
+
+      if (!turn) {
+        throw new Error(`missing fixture turn ${fixture.turnId}`);
+      }
+      const presentation = buildTurnPresentation(turn, transcript);
+
+      expect(presentation.rootIds).toEqual([fixture.parentId]);
+      expect(presentation.childrenByParentId.get(fixture.parentId)).toEqual(
+        fixture.childIds,
+      );
+      expect(presentation.displayBlocks).toEqual([
+        { kind: "item", itemId: fixture.parentId },
+      ]);
+    });
+  });
+
   it("orders items by startedSeq before insertion order", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
@@ -125,7 +165,7 @@ describe("buildTurnPresentation", () => {
     ]);
   });
 
-  it("keeps native Agent calls with nested child work as normal item blocks ONLY while running", () => {
+  it("keeps running native Agent calls with nested child work as normal item blocks", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       agent: {
@@ -142,8 +182,6 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Running native Agent items produce normal item blocks (the renderer
-    // hides them with an early-return).
     expect(presentation.childrenByParentId.get("agent")).toEqual(["childRead"]);
     expect(presentation.displayBlocks).toEqual([
       { kind: "item", itemId: "agent" },
@@ -151,7 +189,7 @@ describe("buildTurnPresentation", () => {
     ]);
   });
 
-  it("routes finished foreground native Agent subagents to subagent_creations blocks", () => {
+  it("keeps finished foreground native Agent subagents in the durable transcript", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       agent: {
@@ -165,19 +203,13 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Finished foreground native Agent items route to subagent_creations
-    // blocks (rendered via SubagentCreationGroupBlock as quiet done-lines).
     expect(presentation.displayBlocks).toEqual([
-      {
-        kind: "subagent_creations",
-        blockId: "agent-agent",
-        itemIds: ["agent"],
-      },
+      { kind: "item", itemId: "agent" },
       { kind: "item", itemId: "final" },
     ]);
   });
 
-  it("routes finished background native Agent subagents to subagent_creations blocks", () => {
+  it("keeps finished background native Agent subagents in the durable transcript", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       agent: {
@@ -200,14 +232,8 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Finished background native Agent items also route to subagent_creations
-    // blocks.
     expect(presentation.displayBlocks).toEqual([
-      {
-        kind: "subagent_creations",
-        blockId: "agent-agent",
-        itemIds: ["agent"],
-      },
+      { kind: "item", itemId: "agent" },
       { kind: "item", itemId: "final" },
     ]);
   });
@@ -239,8 +265,6 @@ describe("buildTurnPresentation", () => {
 
     const presentation = buildTurnPresentation(turn, transcript);
 
-    // Background launches with pending state are still running, so they
-    // produce normal item blocks (the renderer hides them).
     expect(presentation.displayBlocks).toEqual([
       { kind: "item", itemId: "agent" },
     ]);

--- a/apps/packages/product-domain/src/chats/transcript/transcript-presentation.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-presentation.ts
@@ -4,7 +4,6 @@ import type {
   TurnRecord,
 } from "@anyharness/sdk";
 import { isSubagentCreationAction } from "../subagents/subagent-tool-presentation";
-import { isSubagentWorkComplete } from "../subagents/subagent-launch";
 import { isKnownModeSwitchToolCall } from "../tools/mode-switch-display";
 
 export type TurnDisplayBlock =
@@ -73,21 +72,10 @@ export function buildTranscriptDisplayBlocks({
     const item = transcript.itemsById[itemId];
     if (!item) continue;
 
-    // Route finished subagents (both MCP create_subagent and native Agent) to
-    // subagent_creations blocks. Running native subagents are hidden by the
-    // renderer (TranscriptAgentGroupBlock returns null), so they never reach
-    // this classification path.
+    // Provisioning receipts stay compact. Native subagent calls remain normal
+    // transcript items for their whole lifecycle so their nested work is
+    // visible during streaming and after durable replay.
     if (item.kind === "tool_call" && isSubagentCreationAction(item)) {
-      flushActions();
-      pendingSubagentCreationIds.push(itemId);
-      continue;
-    }
-
-    if (
-      item.kind === "tool_call"
-      && isFinishedNativeAgentSubagent(item)
-      && isSubagentWorkComplete(item)
-    ) {
       flushActions();
       pendingSubagentCreationIds.push(itemId);
       continue;
@@ -307,14 +295,4 @@ function isCollapsibleAction(
     && item.semanticKind !== "cowork_artifact_create"
     && item.semanticKind !== "cowork_artifact_update"
     && item.nativeToolName !== "Agent";
-}
-
-function isFinishedNativeAgentSubagent(
-  item: Extract<TranscriptItem, { kind: "tool_call" }>,
-): boolean {
-  // Only native Agent tool calls. MCP subagent communication tools
-  // (send_subagent_message, get_subagent_status, etc.) have semanticKind
-  // "subagent" but are NOT creation actions — they render via their own
-  // blocks (TranscriptMcpSubagentActionBlock).
-  return item.nativeToolName === "Agent";
 }

--- a/apps/packages/product-ui/src/activity/AgentsRosterPanel.tsx
+++ b/apps/packages/product-ui/src/activity/AgentsRosterPanel.tsx
@@ -10,8 +10,8 @@ export interface AgentsRosterPanelProps {
 /**
  * The ⑂ chip's click-in panel: a read-only summary of harness-native
  * subagents. Shows ONLY running subagents — finished ones leave the roster
- * immediately and appear as a quiet done-line in the transcript instead. This
- * is the standalone rendering for this PR — a follow-up integration pass
+ * immediately, while their durable nested work remains in the transcript.
+ * This is the standalone rendering for this PR — a follow-up integration pass
  * merges this roster into the existing delegated-work surfaces
  * (`features/delegated-work.md`) as a new `subagent` source, inheriting
  * generated identity/color there.

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-17.5",
+  "catalogVersion": "2026-07-17.6",
   "probedAgainst": {
-    "registryVersion": "2026-07-17.1"
+    "registryVersion": "2026-07-17.2"
   },
-  "generatedAt": "2026-07-17T17:36:08.000Z",
+  "generatedAt": "2026-07-17T20:49:47.861Z",
   "defaultAgentKind": "claude",
   "agents": [
     {
@@ -16,7 +16,7 @@
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
-            "gitRef": "6addb0f1694cff90cd64b7cf99ddab6f129aaeb2",
+            "gitRef": "26f9ee7a0049507bff5476ce390695515ce92840",
             "executableRelpath": "node_modules/.bin/claude-agent-acp"
           }
         },
@@ -1208,9 +1208,9 @@
         }
       ],
       "provenance": {
-        "probedAt": "2026-07-17T05:34:23.802840+00:00",
+        "probedAt": "2026-07-17T20:48:49.740807+00:00",
         "attestation": {
-          "name": "@agentclientprotocol/claude-agent-acp",
+          "name": "@proliferate/claude-agent-acp",
           "version": "0.59.0-proliferate.1",
           "title": "Claude Agent"
         },
@@ -1235,13 +1235,11 @@
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.18.2-proliferate.1",
+          "version": "0.18.3-proliferate.1",
           "source": {
-            "kind": "git",
-            "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "8a6ce248c07417b0b5b84056164996ad7080d03f",
-            "packageSubdir": "npm",
-            "executableRelpath": "node_modules/.bin/codex-acp"
+            "kind": "npm",
+            "package": "@proliferate-ai/codex-acp@0.18.3-proliferate.1",
+            "sha256": "sha512-xBxL9ixgX0uYPtXRe4/P4KEx7K3CyxEarjECgszrK1St7amcx9ChAiYm6Qe91V4lykRyM+PCpaa2QM0GrWmOKA=="
           }
         },
         "native": {
@@ -1252,17 +1250,20 @@
               "macos_arm64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-aarch64-apple-darwin.tar.gz",
                 "sha256": "a5b77d2fb393f201777809425ab28d9beb65ee0c0b2bf792f09eaf8ef1151592",
-                "expectedBinary": "codex-aarch64-apple-darwin"
+                "expectedBinary": "codex-aarch64-apple-darwin",
+                "downloadSizeBytes": 98292704
               },
               "macos_x64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-apple-darwin.tar.gz",
                 "sha256": "ff5c894a9ffa6d97c225c8d3c869c7ef7573dcbd0cf9b762ecfb9fa96dbb7d88",
-                "expectedBinary": "codex-x86_64-apple-darwin"
+                "expectedBinary": "codex-x86_64-apple-darwin",
+                "downloadSizeBytes": 107348115
               },
               "linux_x64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-unknown-linux-musl.tar.gz",
                 "sha256": "b6bea13bedf493232f6717714c45e783788c695cedcf37c344f73afc97b1ec9f",
-                "expectedBinary": "codex-x86_64-unknown-linux-musl"
+                "expectedBinary": "codex-x86_64-unknown-linux-musl",
+                "downloadSizeBytes": 109365651
               }
             },
             "args": []
@@ -2165,10 +2166,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-07-17T05:35:01.459582+00:00",
+        "probedAt": "2026-07-17T20:49:47.676715+00:00",
         "attestation": {
           "name": "codex-acp",
-          "version": "0.18.2-proliferate.1",
+          "version": "0.18.3-proliferate.1",
           "title": "Codex"
         },
         "runs": [

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "registryVersion": "2026-07-17.1",
+  "registryVersion": "2026-07-17.2",
   "generatedAt": "2026-07-17T03:08:00Z",
   "agents": [
     {
@@ -25,7 +25,7 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#6addb0f1694cff90cd64b7cf99ddab6f129aaeb2",
+          "package": "git+https://github.com/proliferate-ai/claude-agent-acp.git#26f9ee7a0049507bff5476ce390695515ce92840",
           "packageSubdir": null,
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/claude-agent-acp"
@@ -133,8 +133,8 @@
       "agentProcess": {
         "install": {
           "kind": "managed_npm_package",
-          "package": "git+https://github.com/proliferate-ai/codex-acp.git#8a6ce248c07417b0b5b84056164996ad7080d03f",
-          "packageSubdir": "npm",
+          "package": "@proliferate-ai/codex-acp@0.18.3-proliferate.1",
+          "packageSubdir": null,
           "sourceBuildBinaryName": null,
           "executableRelpath": "node_modules/.bin/codex-acp"
         }

--- a/fixtures/contracts/native-subagent-transcript/claude.json
+++ b/fixtures/contracts/native-subagent-transcript/claude.json
@@ -1,0 +1,452 @@
+{
+  "provider": "claude",
+  "sessionId": "session-1",
+  "turnId": "turn-1",
+  "parentId": "claude-task-1",
+  "parentTerminalBeforeTurnEnd": true,
+  "childIds": [
+    "claude-message-1",
+    "claude-thought-1",
+    "claude-read-1"
+  ],
+  "acpNotifications": [
+    {
+      "sessionId": "native-claude-session",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "claude-task-1",
+        "title": "Inspect the repository",
+        "kind": "think",
+        "status": "in_progress",
+        "rawInput": {
+          "prompt": "Inspect the transcript pipeline"
+        },
+        "_meta": {
+          "anyharness": {
+            "nativeToolName": "Task",
+            "toolKind": "subagent"
+          },
+          "claudeCode": {
+            "toolName": "Task"
+          }
+        }
+      }
+    },
+    {
+      "sessionId": "native-claude-session",
+      "update": {
+        "sessionUpdate": "agent_message_chunk",
+        "content": {
+          "type": "text",
+          "text": "Inspecting the transcript pipeline."
+        },
+        "messageId": "claude-message-1",
+        "_meta": {
+          "anyharness": {
+            "parentToolCallId": "claude-task-1",
+            "futureChildState": {
+              "phase": "working"
+            }
+          },
+          "claudeCode": {
+            "parentToolUseId": "wrong-legacy-parent"
+          }
+        }
+      }
+    },
+    {
+      "sessionId": "native-claude-session",
+      "update": {
+        "sessionUpdate": "agent_thought_chunk",
+        "content": {
+          "type": "text",
+          "text": "Checking reducer ordering."
+        },
+        "messageId": "claude-thought-1",
+        "_meta": {
+          "claudeCode": {
+            "parentToolUseId": "claude-task-1"
+          }
+        }
+      }
+    },
+    {
+      "sessionId": "native-claude-session",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "claude-read-1",
+        "title": "Read transcript reducer",
+        "kind": "read",
+        "status": "in_progress",
+        "rawInput": {
+          "file_path": "anyharness/sdk/src/reducer/transcript.ts"
+        },
+        "_meta": {
+          "anyharness": {
+            "nativeToolName": "Read",
+            "toolKind": "read",
+            "parentToolCallId": "claude-task-1",
+            "futureToolState": [
+              "safe",
+              "ignored"
+            ]
+          },
+          "claudeCode": {
+            "toolName": "Read",
+            "parentToolUseId": "wrong-legacy-parent"
+          }
+        }
+      }
+    },
+    {
+      "sessionId": "native-claude-session",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "claude-read-1",
+        "status": "completed"
+      }
+    },
+    {
+      "sessionId": "native-claude-session",
+      "update": {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "claude-task-1",
+        "status": "completed",
+        "rawOutput": {
+          "summary": "Transcript pipeline inspected."
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "sessionId": "session-1",
+      "seq": 1,
+      "timestamp": "2026-07-17T00:00:01Z",
+      "turnId": "turn-1",
+      "event": {
+        "type": "turn_started"
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 2,
+      "timestamp": "2026-07-17T00:00:02Z",
+      "turnId": "turn-1",
+      "itemId": "claude-task-1",
+      "event": {
+        "type": "item_started",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "in_progress",
+          "sourceAgentKind": "claude",
+          "title": "Inspect the repository",
+          "toolCallId": "claude-task-1",
+          "nativeToolName": "Task",
+          "rawInput": {
+            "prompt": "Inspect the transcript pipeline"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "claude-task-1",
+              "title": "Inspect the repository",
+              "toolKind": "subagent",
+              "nativeToolName": "Task"
+            },
+            {
+              "type": "tool_input_text",
+              "text": "Inspect the transcript pipeline"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 3,
+      "timestamp": "2026-07-17T00:00:03Z",
+      "turnId": "turn-1",
+      "itemId": "claude-message-1",
+      "event": {
+        "type": "item_started",
+        "item": {
+          "kind": "assistant_message",
+          "status": "in_progress",
+          "sourceAgentKind": "claude",
+          "messageId": "claude-message-1",
+          "parentToolCallId": "claude-task-1",
+          "contentParts": [
+            {
+              "type": "text",
+              "text": "Inspecting the transcript pipeline."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 4,
+      "timestamp": "2026-07-17T00:00:04Z",
+      "turnId": "turn-1",
+      "itemId": "claude-thought-1",
+      "event": {
+        "type": "item_started",
+        "item": {
+          "kind": "reasoning",
+          "status": "in_progress",
+          "sourceAgentKind": "claude",
+          "messageId": "claude-thought-1",
+          "parentToolCallId": "claude-task-1",
+          "contentParts": [
+            {
+              "type": "reasoning",
+              "text": "Checking reducer ordering.",
+              "visibility": "private"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 5,
+      "timestamp": "2026-07-17T00:00:05Z",
+      "turnId": "turn-1",
+      "itemId": "claude-message-1",
+      "event": {
+        "type": "item_completed",
+        "item": {
+          "kind": "assistant_message",
+          "status": "completed",
+          "sourceAgentKind": "claude",
+          "messageId": "claude-message-1",
+          "parentToolCallId": "claude-task-1",
+          "contentParts": [
+            {
+              "type": "text",
+              "text": "Inspecting the transcript pipeline."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 6,
+      "timestamp": "2026-07-17T00:00:06Z",
+      "turnId": "turn-1",
+      "itemId": "claude-thought-1",
+      "event": {
+        "type": "item_completed",
+        "item": {
+          "kind": "reasoning",
+          "status": "completed",
+          "sourceAgentKind": "claude",
+          "messageId": "claude-thought-1",
+          "parentToolCallId": "claude-task-1",
+          "contentParts": [
+            {
+              "type": "reasoning",
+              "text": "Checking reducer ordering.",
+              "visibility": "private"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 7,
+      "timestamp": "2026-07-17T00:00:07Z",
+      "turnId": "turn-1",
+      "itemId": "claude-read-1",
+      "event": {
+        "type": "item_started",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "in_progress",
+          "sourceAgentKind": "claude",
+          "title": "Read transcript reducer",
+          "toolCallId": "claude-read-1",
+          "nativeToolName": "Read",
+          "parentToolCallId": "claude-task-1",
+          "rawInput": {
+            "file_path": "anyharness/sdk/src/reducer/transcript.ts"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "claude-read-1",
+              "title": "Read transcript reducer",
+              "toolKind": "read",
+              "nativeToolName": "Read"
+            },
+            {
+              "type": "file_read",
+              "path": "anyharness/sdk/src/reducer/transcript.ts",
+              "workspacePath": "anyharness/sdk/src/reducer/transcript.ts",
+              "basename": "transcript.ts",
+              "scope": "full"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 8,
+      "timestamp": "2026-07-17T00:00:08Z",
+      "turnId": "turn-1",
+      "itemId": "claude-read-1",
+      "event": {
+        "type": "item_delta",
+        "delta": {
+          "status": "completed",
+          "title": "Read transcript reducer",
+          "nativeToolName": "Read",
+          "parentToolCallId": "claude-task-1",
+          "rawInput": {
+            "file_path": "anyharness/sdk/src/reducer/transcript.ts"
+          },
+          "replaceContentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "claude-read-1",
+              "title": "Read transcript reducer",
+              "toolKind": "read",
+              "nativeToolName": "Read"
+            },
+            {
+              "type": "file_read",
+              "path": "anyharness/sdk/src/reducer/transcript.ts",
+              "workspacePath": "anyharness/sdk/src/reducer/transcript.ts",
+              "basename": "transcript.ts",
+              "scope": "full"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 9,
+      "timestamp": "2026-07-17T00:00:09Z",
+      "turnId": "turn-1",
+      "itemId": "claude-read-1",
+      "event": {
+        "type": "item_completed",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "completed",
+          "sourceAgentKind": "claude",
+          "title": "Read transcript reducer",
+          "toolCallId": "claude-read-1",
+          "nativeToolName": "Read",
+          "parentToolCallId": "claude-task-1",
+          "rawInput": {
+            "file_path": "anyharness/sdk/src/reducer/transcript.ts"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "claude-read-1",
+              "title": "Read transcript reducer",
+              "toolKind": "read",
+              "nativeToolName": "Read"
+            },
+            {
+              "type": "file_read",
+              "path": "anyharness/sdk/src/reducer/transcript.ts",
+              "workspacePath": "anyharness/sdk/src/reducer/transcript.ts",
+              "basename": "transcript.ts",
+              "scope": "full"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 10,
+      "timestamp": "2026-07-17T00:00:10Z",
+      "turnId": "turn-1",
+      "itemId": "claude-task-1",
+      "event": {
+        "type": "item_delta",
+        "delta": {
+          "status": "completed",
+          "title": "Inspect the repository",
+          "nativeToolName": "Task",
+          "rawInput": {
+            "prompt": "Inspect the transcript pipeline"
+          },
+          "rawOutput": {
+            "summary": "Transcript pipeline inspected."
+          },
+          "replaceContentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "claude-task-1",
+              "title": "Inspect the repository",
+              "toolKind": "subagent",
+              "nativeToolName": "Task"
+            },
+            {
+              "type": "tool_input_text",
+              "text": "Inspect the transcript pipeline"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 11,
+      "timestamp": "2026-07-17T00:00:11Z",
+      "turnId": "turn-1",
+      "itemId": "claude-task-1",
+      "event": {
+        "type": "item_completed",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "completed",
+          "sourceAgentKind": "claude",
+          "title": "Inspect the repository",
+          "toolCallId": "claude-task-1",
+          "nativeToolName": "Task",
+          "rawInput": {
+            "prompt": "Inspect the transcript pipeline"
+          },
+          "rawOutput": {
+            "summary": "Transcript pipeline inspected."
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "claude-task-1",
+              "title": "Inspect the repository",
+              "toolKind": "subagent",
+              "nativeToolName": "Task"
+            },
+            {
+              "type": "tool_input_text",
+              "text": "Inspect the transcript pipeline"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 12,
+      "timestamp": "2026-07-17T00:00:12Z",
+      "turnId": "turn-1",
+      "event": {
+        "type": "turn_ended",
+        "stopReason": "end_turn"
+      }
+    }
+  ]
+}

--- a/fixtures/contracts/native-subagent-transcript/codex.json
+++ b/fixtures/contracts/native-subagent-transcript/codex.json
@@ -1,0 +1,208 @@
+{
+  "provider": "codex",
+  "sessionId": "session-1",
+  "turnId": "turn-1",
+  "parentId": "codex-agent-1",
+  "parentTerminalBeforeTurnEnd": false,
+  "childIds": [
+    "codex-send-input-1"
+  ],
+  "acpNotifications": [
+    {
+      "sessionId": "native-codex-session",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "codex-agent-1",
+        "title": "Inspect the repository",
+        "kind": "think",
+        "status": "in_progress",
+        "rawInput": {
+          "prompt": "Inspect the transcript pipeline"
+        },
+        "_meta": {
+          "anyharness": {
+            "nativeToolName": "Agent",
+            "toolKind": "subagent"
+          }
+        }
+      }
+    },
+    {
+      "sessionId": "native-codex-session",
+      "update": {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "codex-send-input-1",
+        "title": "Send follow-up to child",
+        "kind": "other",
+        "status": "completed",
+        "rawInput": {
+          "id": "child-thread-1",
+          "message": "Check replay ordering too"
+        },
+        "_meta": {
+          "anyharness": {
+            "nativeToolName": "send_input",
+            "toolKind": "subagent",
+            "parentToolCallId": "codex-agent-1",
+            "futureActivity": {
+              "attempt": 1
+            }
+          }
+        }
+      }
+    }
+  ],
+  "events": [
+    {
+      "sessionId": "session-1",
+      "seq": 1,
+      "timestamp": "2026-07-17T00:00:01Z",
+      "turnId": "turn-1",
+      "event": {
+        "type": "turn_started"
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 2,
+      "timestamp": "2026-07-17T00:00:02Z",
+      "turnId": "turn-1",
+      "itemId": "codex-agent-1",
+      "event": {
+        "type": "item_started",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "in_progress",
+          "sourceAgentKind": "codex",
+          "title": "Inspect the repository",
+          "toolCallId": "codex-agent-1",
+          "nativeToolName": "Agent",
+          "rawInput": {
+            "prompt": "Inspect the transcript pipeline"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "codex-agent-1",
+              "title": "Inspect the repository",
+              "toolKind": "subagent",
+              "nativeToolName": "Agent"
+            },
+            {
+              "type": "tool_input_text",
+              "text": "Inspect the transcript pipeline"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 3,
+      "timestamp": "2026-07-17T00:00:03Z",
+      "turnId": "turn-1",
+      "itemId": "codex-send-input-1",
+      "event": {
+        "type": "item_started",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "completed",
+          "sourceAgentKind": "codex",
+          "title": "Send follow-up to child",
+          "toolCallId": "codex-send-input-1",
+          "nativeToolName": "send_input",
+          "parentToolCallId": "codex-agent-1",
+          "rawInput": {
+            "id": "child-thread-1",
+            "message": "Check replay ordering too"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "codex-send-input-1",
+              "title": "Send follow-up to child",
+              "toolKind": "subagent",
+              "nativeToolName": "send_input"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 4,
+      "timestamp": "2026-07-17T00:00:04Z",
+      "turnId": "turn-1",
+      "itemId": "codex-send-input-1",
+      "event": {
+        "type": "item_completed",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "completed",
+          "sourceAgentKind": "codex",
+          "title": "Send follow-up to child",
+          "toolCallId": "codex-send-input-1",
+          "nativeToolName": "send_input",
+          "parentToolCallId": "codex-agent-1",
+          "rawInput": {
+            "id": "child-thread-1",
+            "message": "Check replay ordering too"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "codex-send-input-1",
+              "title": "Send follow-up to child",
+              "toolKind": "subagent",
+              "nativeToolName": "send_input"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 5,
+      "timestamp": "2026-07-17T00:00:05Z",
+      "turnId": "turn-1",
+      "itemId": "codex-agent-1",
+      "event": {
+        "type": "item_completed",
+        "item": {
+          "kind": "tool_invocation",
+          "status": "in_progress",
+          "sourceAgentKind": "codex",
+          "title": "Inspect the repository",
+          "toolCallId": "codex-agent-1",
+          "nativeToolName": "Agent",
+          "rawInput": {
+            "prompt": "Inspect the transcript pipeline"
+          },
+          "contentParts": [
+            {
+              "type": "tool_call",
+              "toolCallId": "codex-agent-1",
+              "title": "Inspect the repository",
+              "toolKind": "subagent",
+              "nativeToolName": "Agent"
+            },
+            {
+              "type": "tool_input_text",
+              "text": "Inspect the transcript pipeline"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sessionId": "session-1",
+      "seq": 6,
+      "timestamp": "2026-07-17T00:00:06Z",
+      "turnId": "turn-1",
+      "event": {
+        "type": "turn_ended",
+        "stopReason": "end_turn"
+      }
+    }
+  ]
+}

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-07-17.5",
+  "catalogVersion": "2026-07-17.6",
   "probedAgainst": {
-    "registryVersion": "2026-07-17.1"
+    "registryVersion": "2026-07-17.2"
   },
-  "generatedAt": "2026-07-17T17:36:08.000Z",
+  "generatedAt": "2026-07-17T20:49:47.861Z",
   "defaultAgentKind": "claude",
   "agents": [
     {
@@ -16,7 +16,7 @@
           "source": {
             "kind": "git",
             "repo": "https://github.com/proliferate-ai/claude-agent-acp.git",
-            "gitRef": "6addb0f1694cff90cd64b7cf99ddab6f129aaeb2",
+            "gitRef": "26f9ee7a0049507bff5476ce390695515ce92840",
             "executableRelpath": "node_modules/.bin/claude-agent-acp"
           }
         },
@@ -1208,9 +1208,9 @@
         }
       ],
       "provenance": {
-        "probedAt": "2026-07-17T05:34:23.802840+00:00",
+        "probedAt": "2026-07-17T20:48:49.740807+00:00",
         "attestation": {
-          "name": "@agentclientprotocol/claude-agent-acp",
+          "name": "@proliferate/claude-agent-acp",
           "version": "0.59.0-proliferate.1",
           "title": "Claude Agent"
         },
@@ -1235,13 +1235,11 @@
       "displayName": "Codex",
       "harness": {
         "agentProcess": {
-          "version": "0.18.2-proliferate.1",
+          "version": "0.18.3-proliferate.1",
           "source": {
-            "kind": "git",
-            "repo": "https://github.com/proliferate-ai/codex-acp.git",
-            "gitRef": "8a6ce248c07417b0b5b84056164996ad7080d03f",
-            "packageSubdir": "npm",
-            "executableRelpath": "node_modules/.bin/codex-acp"
+            "kind": "npm",
+            "package": "@proliferate-ai/codex-acp@0.18.3-proliferate.1",
+            "sha256": "sha512-xBxL9ixgX0uYPtXRe4/P4KEx7K3CyxEarjECgszrK1St7amcx9ChAiYm6Qe91V4lykRyM+PCpaa2QM0GrWmOKA=="
           }
         },
         "native": {
@@ -1252,17 +1250,20 @@
               "macos_arm64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-aarch64-apple-darwin.tar.gz",
                 "sha256": "a5b77d2fb393f201777809425ab28d9beb65ee0c0b2bf792f09eaf8ef1151592",
-                "expectedBinary": "codex-aarch64-apple-darwin"
+                "expectedBinary": "codex-aarch64-apple-darwin",
+                "downloadSizeBytes": 98292704
               },
               "macos_x64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-apple-darwin.tar.gz",
                 "sha256": "ff5c894a9ffa6d97c225c8d3c869c7ef7573dcbd0cf9b762ecfb9fa96dbb7d88",
-                "expectedBinary": "codex-x86_64-apple-darwin"
+                "expectedBinary": "codex-x86_64-apple-darwin",
+                "downloadSizeBytes": 107348115
               },
               "linux_x64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-x86_64-unknown-linux-musl.tar.gz",
                 "sha256": "b6bea13bedf493232f6717714c45e783788c695cedcf37c344f73afc97b1ec9f",
-                "expectedBinary": "codex-x86_64-unknown-linux-musl"
+                "expectedBinary": "codex-x86_64-unknown-linux-musl",
+                "downloadSizeBytes": 109365651
               }
             },
             "args": []
@@ -2165,10 +2166,10 @@
         }
       },
       "provenance": {
-        "probedAt": "2026-07-17T05:35:01.459582+00:00",
+        "probedAt": "2026-07-17T20:49:47.676715+00:00",
         "attestation": {
           "name": "codex-acp",
-          "version": "0.18.2-proliferate.1",
+          "version": "0.18.3-proliferate.1",
           "title": "Codex"
         },
         "runs": [

--- a/scripts/agent-catalog/generated/claude.anthropic-api.probe.json
+++ b/scripts/agent-catalog/generated/claude.anthropic-api.probe.json
@@ -1,9 +1,9 @@
 {
-  "probedAt": "2026-07-17T05:32:48.831389+00:00",
+  "probedAt": "2026-07-17T20:46:58.500864+00:00",
   "agentKind": "claude",
   "authContext": "anthropic-api",
   "attestation": {
-    "name": "@agentclientprotocol/claude-agent-acp",
+    "name": "@proliferate/claude-agent-acp",
     "version": "0.59.0-proliferate.1",
     "title": "Claude Agent"
   },

--- a/scripts/agent-catalog/generated/claude.anthropic-oauth.probe.json
+++ b/scripts/agent-catalog/generated/claude.anthropic-oauth.probe.json
@@ -1,9 +1,9 @@
 {
-  "probedAt": "2026-07-17T05:32:49.472793+00:00",
+  "probedAt": "2026-07-17T20:46:57.133593+00:00",
   "agentKind": "claude",
   "authContext": "anthropic-oauth",
   "attestation": {
-    "name": "@agentclientprotocol/claude-agent-acp",
+    "name": "@proliferate/claude-agent-acp",
     "version": "0.59.0-proliferate.1",
     "title": "Claude Agent"
   },

--- a/scripts/agent-catalog/generated/claude.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/claude.bedrock.probe.json
@@ -1,9 +1,9 @@
 {
-  "probedAt": "2026-07-17T05:34:23.802840+00:00",
+  "probedAt": "2026-07-17T20:48:49.740807+00:00",
   "agentKind": "claude",
   "authContext": "bedrock",
   "attestation": {
-    "name": "@agentclientprotocol/claude-agent-acp",
+    "name": "@proliferate/claude-agent-acp",
     "version": "0.59.0-proliferate.1",
     "title": "Claude Agent"
   },

--- a/scripts/agent-catalog/generated/codex.bedrock.probe.json
+++ b/scripts/agent-catalog/generated/codex.bedrock.probe.json
@@ -1,10 +1,10 @@
 {
-  "probedAt": "2026-07-17T05:35:01.459582+00:00",
+  "probedAt": "2026-07-17T20:49:47.676715+00:00",
   "agentKind": "codex",
   "authContext": "bedrock",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.18.2-proliferate.1",
+    "version": "0.18.3-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",

--- a/scripts/agent-catalog/generated/codex.openai-api.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-api.probe.json
@@ -1,10 +1,10 @@
 {
-  "probedAt": "2026-07-17T05:35:00.330612+00:00",
+  "probedAt": "2026-07-17T20:49:39.156563+00:00",
   "agentKind": "codex",
   "authContext": "openai-api",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.18.2-proliferate.1",
+    "version": "0.18.3-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",

--- a/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
+++ b/scripts/agent-catalog/generated/codex.openai-oauth.probe.json
@@ -1,10 +1,10 @@
 {
-  "probedAt": "2026-07-17T05:35:01.238029+00:00",
+  "probedAt": "2026-07-17T20:49:47.388664+00:00",
   "agentKind": "codex",
   "authContext": "openai-oauth",
   "attestation": {
     "name": "codex-acp",
-    "version": "0.18.2-proliferate.1",
+    "version": "0.18.3-proliferate.1",
     "title": "Codex"
   },
   "modelSource": "modelConfigOption",

--- a/specs/codebase/structures/anyharness/harnesses/claude.md
+++ b/specs/codebase/structures/anyharness/harnesses/claude.md
@@ -18,6 +18,17 @@ override supplies a local adapter executable.
   assistant transcript item.
 - Transient progress uses the AnyHarness `transient_status` marker and is
   converted at the ACP boundary into typed normalized state.
+- Native `Agent`/`Task` child prose, reasoning, and tools use
+  `_meta.anyharness.parentToolCallId`. The adapter keeps the legacy
+  `_meta.claudeCode.parentToolUseId` alongside it for compatibility, uses each
+  Anthropic message id as stable live/replay identity, and deduplicates
+  assembled blocks already delivered as deltas.
+
+The maintained fork is installed directly from the immutable root Git source;
+its `prepare` script builds the adapter. This path does not depend on a
+published Claude fork package. The registry owns the manually curated Git ref;
+the generated catalog locks that ref together with the installed version and
+successful probe attestations.
 
 ## Extension Capabilities
 

--- a/specs/codebase/structures/anyharness/harnesses/codex.md
+++ b/specs/codebase/structures/anyharness/harnesses/codex.md
@@ -1,15 +1,16 @@
 # Codex Harness
 
-AnyHarness installs the Proliferate Codex ACP fork from the exact Git commit in
-the agent registry. The managed npm installer checks out that immutable source,
-selects its `npm/` package subdirectory, and resolves the wrapper executable
-from `node_modules/.bin/codex-acp`.
+AnyHarness installs the published Proliferate Codex ACP fork from the exact npm
+package version in the agent registry. The managed npm installer relies on
+npm's registry-integrity verification, while the generated catalog records the
+resolved `dist.integrity` as provenance. The wrapper executable resolves from
+`node_modules/.bin/codex-acp`.
 
-- Agent-process line: `@proliferate-ai/codex-acp@0.18.2-proliferate.1`
-- Install strategy: Git-backed `ManagedNpmPackage` with
-  `package_subdir = "npm"`
-- Runtime expectation: the wrapper's matching optional platform package is
-  published before the registry commit is promoted
+- Agent-process line: `@proliferate-ai/codex-acp@0.18.3-proliferate.1`
+- Install strategy: direct registry-backed `ManagedNpmPackage`; there is no
+  Git checkout or package subdirectory in the runtime install path
+- Runtime expectation: the wrapper and its matching optional platform package
+  are published before the registry version is promoted
 - Engine relationship: the adapter embeds the Codex core it serves over ACP;
   the separately pinned native Codex CLI is used for native auth/readiness and
   must be updated and probed alongside the embedded core
@@ -17,3 +18,19 @@ from `node_modules/.bin/codex-acp`.
 The Codex ACP session config surface also exposes `fast_mode` as a live control.
 That maps to Codex `service_tier = fast` for the current session, but it is not
 persisted across reload/resume by the current Codex rollout replay path.
+
+Native collaboration events are normalized by the ACP adapter before they
+reach AnyHarness. Spawn events own a stable parent `Agent` tool item; child
+interaction, wait, resume, close, and activity milestones become ordered tool
+items carrying `_meta.anyharness.parentToolCallId`. Terminal statuses update
+the original parent rather than creating a second receipt. Live and paginated
+rollout replay share the same bounded deduplication state machine.
+
+The current Codex protocol does not expose the child thread's full prose,
+reasoning, or inner tool stream, and V2 supplies no natural child-completion
+event. The transcript therefore shows only the collaboration activity that the
+adapter receives. A parent stays running until an explicit terminal update or
+the enclosing AnyHarness turn boundary closes the still-open item; turn-boundary
+closure does not prove that Codex observed the child's natural completion.
+Multi-target activity without one unambiguous parent remains unattributed
+rather than being nested under a guess.

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -144,18 +144,16 @@ Rules:
   call cluster.
 - Do not group creation with send, wake, status, read, search, close, or
   generic tool calls.
-- A single collapsed creation label is `Created subagent`.
-- Multiple adjacent creation receipts collapse as `Created N subagents`.
+- A single completed creation receipt collapses as `Subagent finished`.
+- Multiple adjacent completed creation receipts collapse as
+  `N subagents finished`.
 - Collapsed creation labels use the same muted, backgroundless collapsed-action
   trigger treatment as normal transcript tool summaries such as
   `Explored 1 listing`.
-- Expanded rows use
-  `Created subagent GeneratedName (title ID) with prompt "..."`.
-- Expanded creation rows stay on one truncating line. The row uses one text
-  treatment except for the generated identity, which keeps the colored robot
-  affordance and opens the child session when a valid target exists.
-- Hovering the generated identity shows the delegated-agent card. When a valid
-  child target exists, that card is clickable and opens the same child session.
+- Expanded group rows use `GeneratedName — done` (or `— failed`) and stay on
+  one truncating line. Expanding a row shows only the clean structured result
+  summary, plus an `Open subagent session` action when a valid target exists;
+  raw orchestration receipts remain hidden.
 
 Communication receipts:
 
@@ -167,6 +165,26 @@ Communication receipts:
   `linkCompletionsByCompletionId`.
 - When a valid child target exists, the whole wake/completion receipt chip and
   not a separate visible action or hover card, opens the child session.
+
+Native harness subagents use the same durable item stream as the parent turn:
+
+- The native `Agent`/`Task` spawn operation is one stable tool item from start
+  through completion or failure. It remains visible while running and after
+  replay.
+- Child events carry `parentToolCallId = <native spawn tool id>` and render
+  inside that parent in runtime sequence order. Claude currently supplies child
+  prose, reasoning, and tools; Codex currently supplies collaboration lifecycle
+  and activity tools, not the child thread's full prose/reasoning stream.
+- Provider adapters emit `_meta.anyharness.parentToolCallId`. The sink accepts
+  Claude's older `_meta.claudeCode.parentToolUseId` only as a compatibility
+  fallback, after the provider-neutral field.
+- Session activity roster upserts are summary state, not transcript content.
+  They must never synthesize a second copy of native subagent work.
+- Live stream application deduplicates by durable sequence and orders batches
+  before reduction. Persisted replay consumes the same normalized item events,
+  so identity, nesting, ordering, and terminal status must match.
+- Missing or ambiguous parent identity is not inferred. Such events stay at the
+  root rather than being attached to a guessed child group.
 
 ## Layout Invariants
 


### PR DESCRIPTION
## Summary

- Replace stale draft [#1234](https://github.com/proliferate-ai/proliferate/pull/1234) from current `main` with the still-needed provider-neutral behavior only: durable native-subagent parents, ordered child activity, and identical live/replay attribution.
- Normalize `_meta.anyharness.parentToolCallId` in AnyHarness, retain Claude's legacy parent key only as a fallback, and preserve parent identity across metadata-light tool updates.
- Keep native `Agent`/`Task` rows in the product transcript while preserving MCP creation-receipt grouping and classifying Codex child collaboration operations without synthesizing duplicate spawns.
- Promote the accepted adapter descendants through the repository's authoritative install/catalog path and add deterministic Codex/Claude fixtures across sink, SDK, stream, domain, and rendered component layers.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The support relationship is linked through the production tracker.
  No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Dependency provenance

- Codex: published `@proliferate-ai/codex-acp@0.18.3-proliferate.1`, from [codex-acp #18](https://github.com/proliferate-ai/codex-acp/pull/18); release run [29607145835](https://github.com/proliferate-ai/codex-acp/actions/runs/29607145835), tag `v0.18.3-proliferate.1`, and all platform packages resolve to exact source `dcdf2b6c249934cc1f919f7df03802b0cdc4dc7a`.
- Claude: immutable root Git source `26f9ee7a0049507bff5476ce390695515ce92840`, containing the accepted native-subagent work from [#28](https://github.com/proliferate-ai/claude-agent-acp/pull/28) and [#29](https://github.com/proliferate-ai/claude-agent-acp/pull/29). No published Claude fork release is required or claimed.
- Authoritative catalog promotion completed all Claude/Codex API, OAuth, and Bedrock probes and generated catalog `2026-07-17.6` against registry `2026-07-17.2`. Claude remains `bypassPermissions`; Codex remains `full-access`.

## Verification

- `CARGO_BUILD_JOBS=1 cargo test -p anyharness-lib native_subagent_fixtures_preserve_live_and_replay_attribution`: 1 passed, 1,265 filtered.
- `CARGO_BUILD_JOBS=1 cargo test -p anyharness-lib catalog_poke_waits_for_compatible_job_then_uses_latest_pins`: 1 passed, 1,265 filtered; verifies the refreshed Codex npm version and package source.
- AnyHarness SDK native-subagent + #1349 batch-reducer suites: 5 passed.
- Product-domain transcript presentation + subagent-launch suites: 53 passed.
- Product-client stream-state, creation-receipt, and transcript-tree suites: 23 passed.
- Shared SDK, cloud SDK, product-domain, UI, and product-UI TypeScript builds: passed.
- `make catalog-update CATALOG_PROBE_AGENTS=claude,codex`: six required contexts passed; `complete=true`.
- `node scripts/validate-agent-catalog.mjs`: catalog OK; catalog/draft byte-identical.
- `python3 scripts/check_docs.py`: 219 Markdown files passed.
- Changed Rust files pass targeted `rustfmt --check`; `git diff --check` and secret-pattern scan are clean.
- GitHub checks on head `027cafd2c2f5876ed6b398729fb449b2ae556bac`: 27/27 passing, including [CI 29619730643](https://github.com/proliferate-ai/proliferate/actions/runs/29619730643), [Server CI 29619730658](https://github.com/proliferate-ai/proliferate/actions/runs/29619730658), [CodeQL 29619730667](https://github.com/proliferate-ai/proliferate/actions/runs/29619730667), [Intent Tests 29619730652](https://github.com/proliferate-ai/proliferate/actions/runs/29619730652), and [Self-Host Smoke 29619730653](https://github.com/proliferate-ai/proliferate/actions/runs/29619730653).
- Fresh pnpm bootstrap was left fail-closed when the configured minimum-release-age policy rejected two unchanged PostHog lock entries; focused tests used an existing qualified dependency store and did not modify the lockfile.

## Preserved behavior

- Based directly on `475ac020ee0e6671c728df44ba5510f870ef4503`, preserving #1336 catalog/session defaults, #1340 billing boot fixtures, #1337 replacement-race behavior, #1349 batch reduction, #1351 managed-cloud cancellation cleanup, and #1355 LiteLLM attribution attestations.
- GoalPort, goal mirroring, runtime update/download flow, and stale #1234's custom resolver/compatibility stack are untouched.
- Old draft #1234 remains open for merge custody until this successor is accepted.

## Residual protocol limits

- Codex exposes collaboration activity, not child prose, reasoning, or inner tool streams.
- Codex V2 has no natural child-completion event; AnyHarness turn-boundary closure is not proof of natural child completion.
- Ambiguous multi-target activity stays root-level instead of guessing a parent.
- Claude's legacy `parentToolUseId` is compatibility-only; provider-neutral metadata wins.
