### PR TITLE
fix(goals): fence UI cancellation lifecycle

### DIFF
--- a/apps/packages/product-client/src/config/goals.ts
+++ b/apps/packages/product-client/src/config/goals.ts
@@ -1,0 +1,2 @@
+/** Finite default requested when the product creates a goal on a budget-capable engine. */
+export const DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET = 50_000;

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-session-goal-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-session-goal-actions.test.tsx
@@ -1,0 +1,323 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { GoalWire } from "@proliferate/product-domain/activity/goal";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  activeSessionId: "client-session-0",
+  materializedSessionId: "runtime-session-0",
+  workspaceId: "workspace-0",
+  setGoal: vi.fn(),
+  clearGoal: vi.fn(),
+  cancelSession: vi.fn(),
+  patchSessionRecord: vi.fn(),
+  beginComposing: vi.fn(),
+  endComposing: vi.fn(),
+  dismissResult: vi.fn(),
+  setPendingGoal: vi.fn(),
+  clearPendingGoal: vi.fn(),
+  showToast: vi.fn(),
+  logLatency: vi.fn(),
+  activeGoal: null as ReturnType<typeof goalSnapshot> | null,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useSetSessionGoalMutation: () => ({
+    mutateAsync: mocks.setGoal,
+    isPending: false,
+  }),
+  useClearSessionGoalMutation: () => ({
+    mutateAsync: mocks.clearGoal,
+    isPending: false,
+  }),
+  useCancelSessionMutation: () => ({
+    mutateAsync: mocks.cancelSession,
+    isPending: false,
+  }),
+}));
+
+vi.mock("#product/hooks/chat/derived/use-active-session-identity", () => ({
+  useActiveSessionId: () => mocks.activeSessionId,
+}));
+
+vi.mock("#product/stores/sessions/session-records", () => ({
+  getSessionRecord: () => ({
+    materializedSessionId: mocks.materializedSessionId,
+    workspaceId: mocks.workspaceId,
+    activeGoal: mocks.activeGoal,
+  }),
+  patchSessionRecord: mocks.patchSessionRecord,
+}));
+
+vi.mock("#product/stores/activity/goal-bar-store", () => ({
+  goalResultDismissKey: (status: string, updatedAtMs: number) => `${status}:${updatedAtMs}`,
+  useGoalBarStore: (
+    selector: (state: Record<string, unknown>) => unknown,
+  ) => selector({
+    beginComposing: mocks.beginComposing,
+    endComposing: mocks.endComposing,
+    dismissResult: mocks.dismissResult,
+    setPendingGoal: mocks.setPendingGoal,
+    clearPendingGoal: mocks.clearPendingGoal,
+  }),
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (
+    selector: (state: Record<string, unknown>) => unknown,
+  ) => selector({ show: mocks.showToast }),
+}));
+
+vi.mock("#product/lib/infra/measurement/measurement-port", () => ({
+  logLatency: mocks.logLatency,
+}));
+
+import { useSessionGoalActions } from "./use-session-goal-actions";
+
+function goal(status: "active" | "paused"): GoalWire {
+  return {
+    objective: "Existing objective",
+    status,
+    nativeStatus: status,
+    tokenBudget: 12_345,
+    tokensUsed: 123,
+    timeUsedSeconds: 45,
+    metReason: null,
+    iterations: null,
+    native: true,
+    updatedAtMs: 1_000,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("useSessionGoalActions", () => {
+  let testSequence = 0;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testSequence += 1;
+    mocks.activeSessionId = `client-session-${testSequence}`;
+    mocks.materializedSessionId = `runtime-session-${testSequence}`;
+    mocks.workspaceId = `workspace-${testSequence}`;
+    mocks.activeGoal = null;
+    mocks.setGoal.mockResolvedValue({
+      goal: goalSnapshot("active", "2026-07-17T12:00:02Z", 2),
+    });
+    mocks.clearGoal.mockResolvedValue({ cleared: true });
+    mocks.cancelSession.mockResolvedValue({});
+  });
+
+  afterEach(cleanup);
+
+  it("trims a fresh objective and applies the finite UI default budget", async () => {
+    const { result } = renderHook(() => useSessionGoalActions(null));
+
+    act(() => {
+      result.current.editGoal("  Ship the lifecycle repair  ");
+    });
+
+    await waitFor(() => {
+      expect(mocks.setGoal).toHaveBeenCalledWith({
+        sessionId: mocks.materializedSessionId,
+        workspaceId: mocks.workspaceId,
+        request: {
+          objective: "Ship the lifecycle repair",
+          tokenBudget: 50_000,
+        },
+      });
+    });
+  });
+
+  it("confirms pause before cancelling and waits for cancellation before patching idle", async () => {
+    mocks.activeGoal = goalSnapshot("active", "2026-07-17T12:00:01Z", 1);
+    const pause = deferred<{ goal: ReturnType<typeof goalSnapshot> }>();
+    const cancel = deferred<unknown>();
+    mocks.setGoal.mockReturnValueOnce(pause.promise);
+    mocks.cancelSession.mockReturnValueOnce(cancel.promise);
+    const { result } = renderHook(() => useSessionGoalActions(goal("active")));
+
+    act(() => {
+      result.current.pauseGoal();
+    });
+
+    await waitFor(() => {
+      expect(mocks.setGoal).toHaveBeenCalledWith({
+        sessionId: mocks.materializedSessionId,
+        workspaceId: mocks.workspaceId,
+        request: { status: "paused" },
+      });
+    });
+    expect(mocks.cancelSession).not.toHaveBeenCalled();
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pause.resolve({
+        goal: goalSnapshot("paused", "2026-07-17T12:00:02Z", 2),
+      });
+      await pause.promise;
+    });
+
+    await waitFor(() => {
+      expect(mocks.cancelSession).toHaveBeenCalledWith({
+        sessionId: mocks.materializedSessionId,
+        workspaceId: mocks.workspaceId,
+      });
+    });
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+
+    await act(async () => {
+      cancel.resolve({});
+      await cancel.promise;
+    });
+
+    await waitFor(() => {
+      expect(mocks.patchSessionRecord).toHaveBeenCalledWith(
+        mocks.activeSessionId,
+        { status: "idle" },
+      );
+    });
+  });
+
+  it("resumes with only the active arm-state request and does not cancel", async () => {
+    mocks.activeGoal = goalSnapshot("paused", "2026-07-17T12:00:01Z", 1);
+    const { result } = renderHook(() => useSessionGoalActions(goal("paused")));
+
+    act(() => {
+      result.current.resumeGoal();
+    });
+
+    await waitFor(() => {
+      expect(mocks.setGoal).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.setGoal).toHaveBeenCalledWith({
+      sessionId: mocks.materializedSessionId,
+      workspaceId: mocks.workspaceId,
+      request: { status: "active" },
+    });
+    expect(mocks.cancelSession).not.toHaveBeenCalled();
+  });
+
+  it("waits for a confirmed clear before cancelling", async () => {
+    mocks.activeGoal = goalSnapshot("active", "2026-07-17T12:00:01Z", 1);
+    const clear = deferred<{ cleared: boolean }>();
+    mocks.clearGoal.mockReturnValueOnce(clear.promise);
+    const { result } = renderHook(() => useSessionGoalActions(goal("active")));
+
+    act(() => {
+      result.current.clearGoal();
+    });
+
+    await waitFor(() => {
+      expect(mocks.clearGoal).toHaveBeenCalledWith({
+        sessionId: mocks.materializedSessionId,
+        workspaceId: mocks.workspaceId,
+      });
+    });
+    expect(mocks.cancelSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      clear.resolve({ cleared: true });
+      await clear.promise;
+    });
+
+    await waitFor(() => {
+      expect(mocks.cancelSession).toHaveBeenCalledWith({
+        sessionId: mocks.materializedSessionId,
+        workspaceId: mocks.workspaceId,
+      });
+    });
+  });
+
+  it("cancels when a mirrored goal is already authoritatively absent", async () => {
+    mocks.activeGoal = goalSnapshot("active", "2026-07-17T12:00:01Z", 1);
+    mocks.clearGoal.mockResolvedValueOnce({ cleared: false });
+    const { result } = renderHook(() => useSessionGoalActions(goal("active")));
+
+    act(() => {
+      result.current.clearGoal();
+    });
+
+    await waitFor(() => expect(mocks.cancelSession).toHaveBeenCalledTimes(1));
+    expect(mocks.showToast).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel when clear has not observed a just-created goal", async () => {
+    mocks.clearGoal.mockResolvedValueOnce({ cleared: false });
+    const { result } = renderHook(() => useSessionGoalActions(null));
+
+    act(() => {
+      result.current.editGoal("Create then clear");
+    });
+    await waitFor(() => expect(mocks.setGoal).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.clearGoal();
+    });
+
+    await waitFor(() => expect(mocks.clearGoal).toHaveBeenCalledTimes(1));
+    expect(mocks.cancelSession).not.toHaveBeenCalled();
+  });
+
+  it("applies the fresh default when create follows clear before the mirror catches up", async () => {
+    mocks.activeGoal = goalSnapshot("active", "2026-07-17T12:00:01Z", 1);
+    const { result } = renderHook(() => useSessionGoalActions(goal("active")));
+
+    act(() => {
+      result.current.clearGoal();
+    });
+    await waitFor(() => expect(mocks.cancelSession).toHaveBeenCalledTimes(1));
+    mocks.setGoal.mockClear();
+
+    act(() => {
+      result.current.editGoal("Replacement goal");
+    });
+
+    await waitFor(() => {
+      expect(mocks.setGoal).toHaveBeenCalledWith({
+        sessionId: mocks.materializedSessionId,
+        workspaceId: mocks.workspaceId,
+        request: {
+          objective: "Replacement goal",
+          tokenBudget: 50_000,
+        },
+      });
+    });
+  });
+
+  it("does not cancel when a pause response still reports active", async () => {
+    mocks.activeGoal = goalSnapshot("active", "2026-07-17T12:00:01Z", 1);
+    mocks.setGoal.mockResolvedValueOnce({
+      goal: goalSnapshot("active", "2026-07-17T12:00:02Z", 2),
+    });
+    const { result } = renderHook(() => useSessionGoalActions(goal("active")));
+
+    act(() => {
+      result.current.pauseGoal();
+    });
+
+    await waitFor(() => expect(mocks.showToast).toHaveBeenCalledTimes(1));
+    expect(mocks.cancelSession).not.toHaveBeenCalled();
+  });
+});
+
+function goalSnapshot(
+  status: "active" | "paused",
+  updatedAt: string,
+  revision: number,
+) {
+  return {
+    createdAt: "2026-07-17T11:00:00Z",
+    objective: "Existing objective",
+    revision,
+    status,
+    updatedAt,
+  };
+}

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-session-goal-actions.ts
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-session-goal-actions.ts
@@ -1,11 +1,25 @@
 import { useCallback, useMemo } from "react";
 import type { GoalArmState } from "@anyharness/sdk";
-import { useClearSessionGoalMutation, useSetSessionGoalMutation } from "@anyharness/sdk-react";
+import {
+  useCancelSessionMutation,
+  useClearSessionGoalMutation,
+  useSetSessionGoalMutation,
+} from "@anyharness/sdk-react";
 import type { GoalWire } from "@proliferate/product-domain/activity/goal";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
 import { useActiveSessionId } from "#product/hooks/chat/derived/use-active-session-identity";
+import {
+  buildQueuedGoalObjectiveRequest,
+  enqueueSessionGoalLifecycleMutation,
+  recordSessionGoalCleared,
+  recordSessionGoalMutation,
+  requireGoalArmState,
+  requireSafeGoalClear,
+  sessionCancelGoalFence,
+  stopGoalThenCancelCurrentWork,
+} from "#product/hooks/sessions/workflows/session-goal-lifecycle";
 import { goalResultDismissKey, useGoalBarStore } from "#product/stores/activity/goal-bar-store";
-import { getSessionRecord } from "#product/stores/sessions/session-records";
+import { getSessionRecord, patchSessionRecord } from "#product/stores/sessions/session-records";
 import { useToastStore } from "#product/stores/toast/toast-store";
 
 export interface SessionGoalActions {
@@ -20,15 +34,20 @@ export interface SessionGoalActions {
   pendingWrite: boolean;
 }
 
+interface GoalMutationTarget {
+  clientSessionId: string;
+  sessionId: string;
+  workspaceId: string;
+}
+
 /**
  * Goal mutations for the active session. Goals are strict mirrors of native
  * harness state: every write goes through the runtime goal surface
- * (PUT/DELETE /v1/sessions/{id}/goal → `_anyharness/goal/set|clear`), which
- * responds only after the native notification round-trips. The slot mirror
- * transitions solely from the stream's goal_* events (the single authoritative
- * writer) — never optimistically and never from the mutation response, so two
- * unordered writers can't clobber each other. The resolved promise is used
- * only for compose/pending/error handling.
+ * (PUT/DELETE /v1/sessions/{id}/goal → `_anyharness/goal/set|clear`). The slot
+ * mirror transitions solely from streamed goal events; mutation responses
+ * provide only short-lived lifecycle intent while that authoritative stream
+ * catches up. Claude may return a provisional deferred-set response before its
+ * native notification reaches the mirror.
  *
  * Dismissal and compose-mode are client-only UI state.
  */
@@ -36,6 +55,7 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
   const activeSessionId = useActiveSessionId();
   const setGoalMutation = useSetSessionGoalMutation();
   const clearGoalMutation = useClearSessionGoalMutation();
+  const cancelSessionMutation = useCancelSessionMutation();
   const showToast = useToastStore((state) => state.show);
   const beginComposingInStore = useGoalBarStore((state) => state.beginComposing);
   const endComposingInStore = useGoalBarStore((state) => state.endComposing);
@@ -55,7 +75,7 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
     }
   }, [activeSessionId, endComposingInStore]);
 
-  const resolveGoalTarget = useCallback(() => {
+  const resolveGoalTarget = useCallback((): GoalMutationTarget | null => {
     if (!activeSessionId) {
       return null;
     }
@@ -81,12 +101,19 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
     // the bar transitions from editor → provisional live row with no gap.
     endComposingInStore(target.clientSessionId);
     setPendingGoalInStore(target.clientSessionId, trimmed);
-    void setGoalMutation
-      .mutateAsync({
+    void enqueueSessionGoalLifecycleMutation(target.clientSessionId, async () => {
+      const result = await setGoalMutation.mutateAsync({
         sessionId: target.sessionId,
         workspaceId: target.workspaceId,
-        request: { objective: trimmed },
-      })
+        request: buildQueuedGoalObjectiveRequest(
+          target.sessionId,
+          trimmed,
+          getSessionRecord(target.clientSessionId)?.activeGoal ?? null,
+        ),
+      });
+      recordSessionGoalMutation(target.sessionId, result.goal);
+      return result;
+    })
       .catch((error) => {
         clearPendingGoalInStore(target.clientSessionId);
         const message = error instanceof Error ? error.message : String(error);
@@ -95,17 +122,30 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
       });
   }, [clearPendingGoalInStore, endComposing, endComposingInStore, resolveGoalTarget, setPendingGoalInStore, setGoalMutation, showToast]);
 
+  const cancelCurrentWork = useCallback(async (target: GoalMutationTarget) => {
+    const result = await cancelSessionMutation.mutateAsync({
+      sessionId: target.sessionId,
+      workspaceId: target.workspaceId,
+    });
+    patchSessionRecord(target.clientSessionId, { status: "idle" });
+    return result;
+  }, [cancelSessionMutation]);
+
   const setArmState = useCallback((status: GoalArmState) => {
     const target = resolveGoalTarget();
     if (!target) {
       return;
     }
-    void setGoalMutation
-      .mutateAsync({
+    void enqueueSessionGoalLifecycleMutation(target.clientSessionId, async () => {
+      const result = await setGoalMutation.mutateAsync({
         sessionId: target.sessionId,
         workspaceId: target.workspaceId,
         request: { status },
-      })
+      });
+      requireGoalArmState(result.goal, status);
+      recordSessionGoalMutation(target.sessionId, result.goal);
+      return result;
+    })
       .catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
         logLatency("session.goal.arm.failed", { sessionId: target.sessionId, status, message });
@@ -114,8 +154,33 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
   }, [resolveGoalTarget, setGoalMutation, showToast]);
 
   const pauseGoal = useCallback(() => {
-    setArmState("paused");
-  }, [setArmState]);
+    const target = resolveGoalTarget();
+    if (!target) {
+      return;
+    }
+    void enqueueSessionGoalLifecycleMutation(target.clientSessionId, () => (
+      stopGoalThenCancelCurrentWork({
+        stopGoal: async () => {
+          const result = await setGoalMutation.mutateAsync({
+            sessionId: target.sessionId,
+            workspaceId: target.workspaceId,
+            request: { status: "paused" },
+          });
+          requireGoalArmState(result.goal, "paused");
+          recordSessionGoalMutation(target.sessionId, result.goal);
+        },
+        cancelCurrentWork: () => cancelCurrentWork(target),
+      })
+    )).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      logLatency("session.goal.arm.failed", {
+        sessionId: target.sessionId,
+        status: "paused",
+        message,
+      });
+      showToast(`Failed to pause goal or stop current work: ${message}`);
+    });
+  }, [cancelCurrentWork, resolveGoalTarget, setGoalMutation, showToast]);
 
   const resumeGoal = useCallback(() => {
     setArmState("active");
@@ -126,17 +191,31 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
     if (!target) {
       return;
     }
-    void clearGoalMutation
-      .mutateAsync({
-        sessionId: target.sessionId,
-        workspaceId: target.workspaceId,
+    void enqueueSessionGoalLifecycleMutation(target.clientSessionId, () => (
+      stopGoalThenCancelCurrentWork({
+        stopGoal: async () => {
+          const mirrorGoal = getSessionRecord(target.clientSessionId)?.activeGoal ?? null;
+          const fence = sessionCancelGoalFence({
+            materializedSessionId: target.sessionId,
+            mirrorGoal,
+            pauseSupported: false,
+          });
+          const response = await clearGoalMutation.mutateAsync({
+            sessionId: target.sessionId,
+            workspaceId: target.workspaceId,
+          });
+          requireSafeGoalClear(response, fence);
+          recordSessionGoalCleared(target.sessionId, mirrorGoal);
+        },
+        cancelCurrentWork: () => cancelCurrentWork(target),
       })
+    ))
       .catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
         logLatency("session.goal.clear.failed", { sessionId: target.sessionId, message });
-        showToast(`Failed to clear goal: ${message}`);
+        showToast(`Failed to clear goal or stop current work: ${message}`);
       });
-  }, [clearGoalMutation, resolveGoalTarget, showToast]);
+  }, [cancelCurrentWork, clearGoalMutation, resolveGoalTarget, showToast]);
 
   const dismissResult = useCallback(() => {
     if (!goal || !activeSessionId) {
@@ -145,7 +224,10 @@ export function useSessionGoalActions(goal: GoalWire | null): SessionGoalActions
     dismissResultInStore(activeSessionId, goalResultDismissKey(goal.status, goal.updatedAtMs));
   }, [activeSessionId, dismissResultInStore, goal]);
 
-  const pendingWrite = setGoalMutation.isPending || clearGoalMutation.isPending;
+  const pendingWrite =
+    setGoalMutation.isPending
+    || clearGoalMutation.isPending
+    || cancelSessionMutation.isPending;
 
   return useMemo(() => ({
     editGoal,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-goal-lifecycle.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-goal-lifecycle.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Goal } from "@anyharness/sdk";
+import { DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET } from "#product/config/goals";
+import {
+  buildGoalObjectiveRequest,
+  buildQueuedGoalObjectiveRequest,
+  enqueueSessionGoalLifecycleMutation,
+  forgetSessionGoalIntent,
+  recordSessionGoalCleared,
+  recordSessionGoalMutation,
+  requireGoalArmState,
+  requireSafeGoalClear,
+  sessionCancelGoalFence,
+  stopGoalThenCancelCurrentWork,
+} from "#product/hooks/sessions/workflows/session-goal-lifecycle";
+
+describe("session goal lifecycle", () => {
+  it("gives every fresh product-created goal a finite requested token budget", () => {
+    expect(DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET).toBeGreaterThan(0);
+    expect(buildGoalObjectiveRequest("Finish the task", null)).toEqual({
+      objective: "Finish the task",
+      tokenBudget: DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET,
+    });
+    expect(buildGoalObjectiveRequest("Try again", "failed")).toEqual({
+      objective: "Try again",
+      tokenBudget: DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET,
+    });
+  });
+
+  it("does not replace native accounting when editing an active or paused goal", () => {
+    expect(buildGoalObjectiveRequest("Narrow the task", "active"))
+      .toEqual({ objective: "Narrow the task" });
+    expect(buildGoalObjectiveRequest("Revise while paused", "paused"))
+      .toEqual({ objective: "Revise while paused" });
+  });
+
+  it("keeps a later cancel behind an already-started goal write", async () => {
+    const calls: string[] = [];
+    let releaseGoalWrite: (() => void) | undefined;
+    const goalWrite = enqueueSessionGoalLifecycleMutation("session-ordered", async () => {
+      calls.push("goal-write");
+      await new Promise<void>((resolve) => {
+        releaseGoalWrite = resolve;
+      });
+    });
+    const cancel = enqueueSessionGoalLifecycleMutation("session-ordered", async () => {
+      calls.push("cancel");
+    });
+
+    await vi.waitFor(() => expect(calls).toEqual(["goal-write"]));
+    releaseGoalWrite?.();
+    await Promise.all([goalWrite, cancel]);
+
+    expect(calls).toEqual(["goal-write", "cancel"]);
+  });
+
+  it("continues the session queue after a failed write so retry can run", async () => {
+    const calls: string[] = [];
+    const failed = enqueueSessionGoalLifecycleMutation("session-retry", async () => {
+      calls.push("failed-write");
+      throw new Error("native write failed");
+    });
+    const retry = enqueueSessionGoalLifecycleMutation("session-retry", async () => {
+      calls.push("retry");
+    });
+
+    await expect(failed).rejects.toThrow("native write failed");
+    await expect(retry).resolves.toBeUndefined();
+    expect(calls).toEqual(["failed-write", "retry"]);
+  });
+
+  it("lets a confirmed resume outrank a stale paused mirror", () => {
+    recordSessionGoalMutation(
+      "session-resume-lag",
+      snapshot("active", "2026-07-17T12:00:01Z", 2),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-resume-lag",
+      mirrorGoal: snapshot("paused", "2026-07-17T12:00:00Z", 1),
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+
+    forgetSessionGoalIntent("session-resume-lag");
+  });
+
+  it("retires active intent when the streamed mirror exactly catches up", () => {
+    const confirmed = snapshot("active", "2026-07-17T12:00:01Z", 2);
+    recordSessionGoalMutation("session-active-caught-up", confirmed);
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-active-caught-up",
+      mirrorGoal: confirmed,
+      pauseSupported: false,
+    })).toEqual({ action: "clear", requirePresentGoalForClear: false });
+  });
+
+  it("uses revision when intent and mirror timestamps share one millisecond", () => {
+    recordSessionGoalMutation(
+      "session-same-ms-resume",
+      snapshot("active", "2026-07-17T12:00:01.000900Z", 2),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-same-ms-resume",
+      mirrorGoal: snapshot("paused", "2026-07-17T12:00:01.000100Z", 1),
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+
+    forgetSessionGoalIntent("session-same-ms-resume");
+  });
+
+  it("fences an active provisional intent over a same-ms paused mirror", () => {
+    recordSessionGoalMutation(
+      "session-same-ms-provisional",
+      snapshot("active", "2026-07-17T12:00:01.000900Z", 0),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-same-ms-provisional",
+      mirrorGoal: snapshot("paused", "2026-07-17T12:00:01.000100Z", 1),
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+
+    forgetSessionGoalIntent("session-same-ms-provisional");
+  });
+
+  it("fences a same-millisecond active replacement whose revision reset", () => {
+    recordSessionGoalMutation(
+      "session-same-ms-replacement",
+      snapshot("paused", "2026-07-17T12:00:01.000100Z", 2, "Old goal"),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-same-ms-replacement",
+      mirrorGoal: snapshot(
+        "active",
+        "2026-07-17T12:00:01.000900Z",
+        1,
+        "Remote replacement",
+      ),
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+
+    forgetSessionGoalIntent("session-same-ms-replacement");
+  });
+
+  it("lets a demonstrably newer terminal mirror retire an active intent", () => {
+    recordSessionGoalMutation(
+      "session-terminal",
+      snapshot("active", "2026-07-17T12:00:01Z", 2),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-terminal",
+      mirrorGoal: snapshot("met", "2026-07-17T12:00:02Z", 3),
+      pauseSupported: true,
+    })).toEqual({ action: "none", requirePresentGoalForClear: false });
+  });
+
+  it("lets a newer different-objective mirror supersede local stopped intent", () => {
+    recordSessionGoalMutation(
+      "session-other-renderer",
+      snapshot("paused", "2026-07-17T12:00:01Z", 2, "Local goal"),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-other-renderer",
+      mirrorGoal: snapshot("active", "2026-07-17T12:00:02Z", 1, "Remote replacement"),
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+  });
+
+  it("lets a new active mirror supersede a confirmed clear of its predecessor", () => {
+    const oldGoal = snapshot("active", "2026-07-17T12:00:01Z", 2, "Old goal");
+    recordSessionGoalCleared("session-clear-then-remote", oldGoal);
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-clear-then-remote",
+      mirrorGoal: snapshot(
+        "active",
+        "2026-07-17T12:00:02Z",
+        1,
+        "New remote goal",
+        "2026-07-17T11:30:00Z",
+      ),
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+  });
+
+  it("fences blocked goals through pause or clear according to native capability", () => {
+    const blocked = snapshot("blocked", "2026-07-17T12:00:01Z", 2);
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-blocked-pause",
+      mirrorGoal: blocked,
+      pauseSupported: true,
+    })).toEqual({ action: "pause", requirePresentGoalForClear: false });
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-blocked-clear",
+      mirrorGoal: blocked,
+      pauseSupported: false,
+    })).toEqual({ action: "clear", requirePresentGoalForClear: false });
+  });
+
+  it("preserves a confirmed pause across cancel retry while the mirror lags", () => {
+    recordSessionGoalMutation(
+      "session-stopped-retry",
+      snapshot("paused", "2026-07-17T12:00:02Z", 2),
+    );
+
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-stopped-retry",
+      mirrorGoal: snapshot("active", "2026-07-17T12:00:01Z", 1),
+      pauseSupported: true,
+    })).toEqual({ action: "none", requirePresentGoalForClear: false });
+
+    forgetSessionGoalIntent("session-stopped-retry");
+  });
+
+  it("treats an edit after confirmed clear as a fresh budgeted goal despite mirror lag", () => {
+    const staleMirror = snapshot("active", "2026-07-17T12:00:00Z", 4, "Old goal");
+    recordSessionGoalCleared("session-clear-create", staleMirror);
+
+    expect(buildQueuedGoalObjectiveRequest(
+      "session-clear-create",
+      "Start a replacement goal",
+      staleMirror,
+    )).toEqual({
+      objective: "Start a replacement goal",
+      tokenBudget: DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET,
+    });
+
+    forgetSessionGoalIntent("session-clear-create");
+  });
+
+  it("keeps clear authoritative over a newer stale update from the same goal lifetime", () => {
+    const cleared = snapshot("active", "2026-07-17T12:00:00Z", 4, "Old goal");
+    recordSessionGoalCleared("session-clear-stale-update", cleared);
+
+    expect(buildQueuedGoalObjectiveRequest(
+      "session-clear-stale-update",
+      "Replacement goal",
+      snapshot("active", "2026-07-17T12:00:01Z", 5, "Old goal"),
+    )).toEqual({
+      objective: "Replacement goal",
+      tokenBudget: DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET,
+    });
+
+    forgetSessionGoalIntent("session-clear-stale-update");
+  });
+
+  it("defaults a post-clear create across provisional and persisted lifetime identities", () => {
+    recordSessionGoalMutation(
+      "session-clear-provisional",
+      snapshot(
+        "active",
+        "2026-07-17T12:00:01Z",
+        0,
+        "Deferred goal",
+        "2026-07-17T11:00:01Z",
+      ),
+    );
+    recordSessionGoalCleared(
+      "session-clear-provisional",
+      snapshot(
+        "paused",
+        "2026-07-17T12:00:00Z",
+        4,
+        "Old mirror",
+        "2026-07-17T11:00:00Z",
+      ),
+    );
+    const eventualDeferredMirror = snapshot(
+      "active",
+      "2026-07-17T12:00:02Z",
+      1,
+      "Deferred goal",
+      "2026-07-17T11:00:02Z",
+    );
+
+    expect(buildQueuedGoalObjectiveRequest(
+      "session-clear-provisional",
+      "Replacement goal",
+      eventualDeferredMirror,
+    )).toEqual({
+      objective: "Replacement goal",
+      tokenBudget: DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET,
+    });
+    expect(sessionCancelGoalFence({
+      materializedSessionId: "session-clear-provisional",
+      mirrorGoal: eventualDeferredMirror,
+      pauseSupported: false,
+    })).toEqual({ action: "clear", requirePresentGoalForClear: false });
+
+    forgetSessionGoalIntent("session-clear-provisional");
+  });
+
+  it("requires a present clear result only for a newer active UI intent", () => {
+    recordSessionGoalMutation(
+      "session-deferred-create",
+      snapshot("active", "2026-07-17T12:00:01Z", 0),
+    );
+    const intentFence = sessionCancelGoalFence({
+      materializedSessionId: "session-deferred-create",
+      mirrorGoal: null,
+      pauseSupported: false,
+    });
+    expect(intentFence).toEqual({ action: "clear", requirePresentGoalForClear: true });
+    expect(() => requireSafeGoalClear({ cleared: false }, intentFence))
+      .toThrow("has not observed the newer goal mutation");
+
+    const mirrorFence = sessionCancelGoalFence({
+      materializedSessionId: "session-mirror-only",
+      mirrorGoal: snapshot("active", "2026-07-17T12:00:00Z", 1),
+      pauseSupported: false,
+    });
+    expect(mirrorFence).toEqual({ action: "clear", requirePresentGoalForClear: false });
+    expect(() => requireSafeGoalClear({ cleared: false }, mirrorFence)).not.toThrow();
+
+    forgetSessionGoalIntent("session-deferred-create");
+  });
+
+  it("rejects a status-only response that did not confirm the requested arm state", () => {
+    expect(() => requireGoalArmState({ status: "paused" }, "paused")).not.toThrow();
+    expect(() => requireGoalArmState({ status: "active" }, "paused"))
+      .toThrow("confirmed active, not paused");
+  });
+
+  it("persists a selected goal stop fence before cancelling current work", async () => {
+    const calls: string[] = [];
+
+    await expect(stopGoalThenCancelCurrentWork({
+      stopGoal: vi.fn(async () => {
+        calls.push("stop-goal");
+      }),
+      cancelCurrentWork: vi.fn(async () => {
+        calls.push("cancel-current-work");
+      }),
+    })).resolves.toBeUndefined();
+
+    expect(calls).toEqual(["stop-goal", "cancel-current-work"]);
+  });
+
+  it("does not cancel when the stop fence fails and retries the full safe order", async () => {
+    const calls: string[] = [];
+    const stopGoal = vi.fn()
+      .mockImplementationOnce(async () => {
+        calls.push("stop-goal");
+        throw new Error("native pause failed");
+      })
+      .mockImplementationOnce(async () => {
+        calls.push("stop-goal");
+      });
+    const cancelCurrentWork = vi.fn(async () => {
+      calls.push("cancel-current-work");
+    });
+
+    await expect(stopGoalThenCancelCurrentWork({ stopGoal, cancelCurrentWork }))
+      .rejects.toThrow("goal stop could not be confirmed: native pause failed");
+    expect(cancelCurrentWork).not.toHaveBeenCalled();
+
+    await expect(stopGoalThenCancelCurrentWork({ stopGoal, cancelCurrentWork }))
+      .resolves.toBeUndefined();
+    expect(calls).toEqual(["stop-goal", "stop-goal", "cancel-current-work"]);
+  });
+});
+
+function snapshot(
+  status: Goal["status"],
+  updatedAt: string,
+  revision: number,
+  objective = "Finish the task",
+  createdAt = "2026-07-17T11:00:00Z",
+) {
+  return { createdAt, objective, revision, status, updatedAt };
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-goal-lifecycle.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-goal-lifecycle.ts
@@ -1,0 +1,255 @@
+import type { Goal, GoalArmState, SetSessionGoalRequest } from "@anyharness/sdk";
+import { DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET } from "#product/config/goals";
+
+type GoalSnapshot = Pick<
+  Goal,
+  "createdAt" | "objective" | "revision" | "status" | "updatedAt"
+>;
+
+interface SessionGoalIntent {
+  createdAt: string | null;
+  objective: string | null;
+  revision: number | null;
+  status: Goal["status"];
+  updatedAt: string | null;
+  updatedAtMs: number | null;
+}
+
+export interface SessionCancelGoalFence {
+  action: "none" | "pause" | "clear";
+  /** A false clear cannot fence a newer UI mutation that the mirror has not observed. */
+  requirePresentGoalForClear: boolean;
+}
+
+// Renderer-scoped workflow coordination. Goal intent is short-lived metadata
+// that bridges a confirmed mutation response to its later streamed mirror
+// event; the session mirror remains authoritative product state.
+const sessionLifecycleTails = new Map<string, Promise<void>>();
+const sessionGoalIntents = new Map<string, SessionGoalIntent>();
+
+/**
+ * Preserve per-client-session intent order across pending-to-materialized ID
+ * transitions. Enqueue callers before their first await so later goal writes,
+ * Pause/Resume, and Cancel cannot overtake.
+ */
+export function enqueueSessionGoalLifecycleMutation<T>(
+  clientSessionId: string,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  const previous = sessionLifecycleTails.get(clientSessionId) ?? Promise.resolve();
+  const result = previous.then(mutation, mutation);
+  const tail = result.then(() => undefined, () => undefined);
+  sessionLifecycleTails.set(clientSessionId, tail);
+  void tail.finally(() => {
+    if (sessionLifecycleTails.get(clientSessionId) === tail) {
+      sessionLifecycleTails.delete(clientSessionId);
+    }
+  });
+  return result;
+}
+
+export function recordSessionGoalMutation(
+  materializedSessionId: string,
+  goal: GoalSnapshot,
+): void {
+  sessionGoalIntents.set(materializedSessionId, {
+    createdAt: goal.createdAt,
+    objective: goal.objective,
+    revision: goal.revision,
+    status: goal.status,
+    updatedAt: goal.updatedAt,
+    updatedAtMs: parsedTime(goal.updatedAt),
+  });
+}
+
+export function recordSessionGoalCleared(
+  materializedSessionId: string,
+  previousMirrorGoal: GoalSnapshot | null,
+): void {
+  const previousIntent = sessionGoalIntents.get(materializedSessionId);
+  sessionGoalIntents.set(materializedSessionId, {
+    createdAt: previousMirrorGoal?.createdAt ?? previousIntent?.createdAt ?? null,
+    objective: previousMirrorGoal?.objective ?? previousIntent?.objective ?? null,
+    revision: previousMirrorGoal?.revision ?? previousIntent?.revision ?? null,
+    status: "cleared",
+    updatedAt: previousMirrorGoal?.updatedAt ?? previousIntent?.updatedAt ?? null,
+    updatedAtMs: previousMirrorGoal
+      ? parsedTime(previousMirrorGoal.updatedAt)
+      : previousIntent?.updatedAtMs ?? null,
+  });
+}
+
+export function forgetSessionGoalIntent(materializedSessionId: string): void {
+  sessionGoalIntents.delete(materializedSessionId);
+}
+
+export function buildGoalObjectiveRequest(
+  objective: string,
+  currentGoalStatus: Goal["status"] | null,
+): SetSessionGoalRequest {
+  if (currentGoalStatus === "active" || currentGoalStatus === "paused") {
+    // An in-place edit must not silently replace accounting the native goal
+    // engine already owns.
+    return { objective };
+  }
+  return {
+    objective,
+    tokenBudget: DEFAULT_NEW_SESSION_GOAL_TOKEN_BUDGET,
+  };
+}
+
+/** Build at queue execution time, after earlier Clear/Pause/Resume has landed. */
+export function buildQueuedGoalObjectiveRequest(
+  materializedSessionId: string,
+  objective: string,
+  mirrorGoal: GoalSnapshot | null,
+): SetSessionGoalRequest {
+  // A local clear makes the next local objective a new goal lifetime even if
+  // an older active event (or a deferred-set insert with a new createdAt) is
+  // still catching up in the mirror.
+  if (sessionGoalIntents.get(materializedSessionId)?.status === "cleared") {
+    return buildGoalObjectiveRequest(objective, "cleared");
+  }
+  return buildGoalObjectiveRequest(
+    objective,
+    resolveSessionGoalState(materializedSessionId, mirrorGoal).status,
+  );
+}
+
+export function sessionCancelGoalFence(input: {
+  materializedSessionId: string;
+  mirrorGoal: GoalSnapshot | null;
+  pauseSupported: boolean;
+}): SessionCancelGoalFence {
+  const state = resolveSessionGoalState(input.materializedSessionId, input.mirrorGoal);
+  if (state.status !== "active" && state.status !== "blocked") {
+    return { action: "none", requirePresentGoalForClear: false };
+  }
+  if (input.pauseSupported) {
+    return { action: "pause", requirePresentGoalForClear: false };
+  }
+  return {
+    action: "clear",
+    requirePresentGoalForClear: state.source === "intent",
+  };
+}
+
+export class SessionGoalStopError extends Error {
+  readonly causeValue: unknown;
+
+  constructor(causeValue: unknown) {
+    const detail = causeValue instanceof Error ? `: ${causeValue.message}` : "";
+    super(`The goal stop could not be confirmed${detail}`);
+    this.name = "SessionGoalStopError";
+    this.causeValue = causeValue;
+  }
+}
+
+export function requireSafeGoalClear(
+  response: { cleared: boolean },
+  fence: Pick<SessionCancelGoalFence, "requirePresentGoalForClear">,
+): void {
+  if (fence.requirePresentGoalForClear && !response.cleared) {
+    throw new Error("the native harness has not observed the newer goal mutation");
+  }
+}
+
+export function requireGoalArmState(
+  goal: Pick<Goal, "status">,
+  expected: GoalArmState,
+): void {
+  if (goal.status !== expected) {
+    throw new Error(`the native harness confirmed ${goal.status}, not ${expected}`);
+  }
+}
+
+/**
+ * Persist the goal's stop fence before interrupting the current turn. Native
+ * goal continuation runs after a turn becomes idle, so cancelling first can
+ * immediately re-arm another iteration.
+ */
+export async function stopGoalThenCancelCurrentWork(input: {
+  stopGoal: () => Promise<unknown>;
+  cancelCurrentWork: () => Promise<unknown>;
+}): Promise<void> {
+  try {
+    await input.stopGoal();
+  } catch (error) {
+    throw new SessionGoalStopError(error);
+  }
+  await input.cancelCurrentWork();
+}
+
+function resolveSessionGoalState(
+  materializedSessionId: string,
+  mirrorGoal: GoalSnapshot | null,
+): { status: Goal["status"] | null; source: "intent" | "mirror" | "none" } {
+  const intent = sessionGoalIntents.get(materializedSessionId);
+  if (!intent) {
+    return mirrorGoal
+      ? { status: mirrorGoal.status, source: "mirror" }
+      : { status: null, source: "none" };
+  }
+
+  if (intent.status === "cleared") {
+    if (!mirrorGoal) {
+      sessionGoalIntents.delete(materializedSessionId);
+      return { status: null, source: "none" };
+    }
+    if (mirrorMatchesClearedPredecessor(intent, mirrorGoal)) {
+      return { status: "cleared", source: "intent" };
+    }
+    sessionGoalIntents.delete(materializedSessionId);
+    return { status: mirrorGoal.status, source: "mirror" };
+  }
+
+  if (mirrorGoal && mirrorHasCaughtUp(intent, mirrorGoal)) {
+    sessionGoalIntents.delete(materializedSessionId);
+    return { status: mirrorGoal.status, source: "mirror" };
+  }
+  return { status: intent.status, source: "intent" };
+}
+
+function mirrorMatchesClearedPredecessor(
+  intent: SessionGoalIntent,
+  mirrorGoal: GoalSnapshot,
+): boolean {
+  return intent.createdAt !== null
+    && intent.createdAt === mirrorGoal.createdAt;
+}
+
+function mirrorHasCaughtUp(intent: SessionGoalIntent, mirrorGoal: GoalSnapshot): boolean {
+  if (
+    intent.createdAt === mirrorGoal.createdAt
+    && intent.objective === mirrorGoal.objective
+    && intent.revision === mirrorGoal.revision
+    && intent.status === mirrorGoal.status
+    && intent.updatedAt === mirrorGoal.updatedAt
+  ) {
+    return true;
+  }
+  const mirrorUpdatedAtMs = parsedTime(mirrorGoal.updatedAt);
+  if (intent.updatedAtMs !== null && mirrorUpdatedAtMs !== null) {
+    if (mirrorUpdatedAtMs !== intent.updatedAtMs) {
+      return mirrorUpdatedAtMs > intent.updatedAtMs;
+    }
+    // JS timestamps lose RFC3339 sub-millisecond precision. On an equal
+    // parsed millisecond, prefer any mirrored running state over a local
+    // stopped intent; that conservative tie-break cannot permit an armed goal
+    // to bypass its fence even when a new lifetime reset the revision.
+    const intentMayRun = intent.status === "active" || intent.status === "blocked";
+    const mirrorMayRun = mirrorGoal.status === "active" || mirrorGoal.status === "blocked";
+    if (intentMayRun || mirrorMayRun) {
+      return mirrorMayRun && !intentMayRun;
+    }
+    return intent.revision !== null && mirrorGoal.revision >= intent.revision;
+  }
+  return intent.objective === mirrorGoal.objective
+    && intent.revision !== null
+    && mirrorGoal.revision >= intent.revision;
+}
+
+function parsedTime(value: string): number | null {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-cancel-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-cancel-actions.test.tsx
@@ -1,0 +1,449 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  forgetSessionGoalIntent,
+  recordSessionGoalMutation,
+} from "#product/hooks/sessions/workflows/session-goal-lifecycle";
+import { useSessionGoalActions } from "#product/hooks/activity/workflows/use-session-goal-actions";
+import { useSessionCancelActions } from "#product/hooks/sessions/workflows/use-session-cancel-actions";
+
+const mocks = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  clearGoal: vi.fn(),
+  setGoal: vi.fn(),
+  patchSessionRecord: vi.fn(),
+  showToast: vi.fn(),
+  resolveSession: vi.fn(async () => ({
+    materializedSessionId: "runtime-1",
+    workspaceId: "workspace-1",
+  })),
+  record: null as any,
+  selection: {
+    activeSessionId: "client-1" as string | null,
+    selectedWorkspaceId: "workspace-1" as string | null,
+  },
+  goalBarAction: vi.fn(),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useCancelSessionMutation: () => ({ mutateAsync: mocks.cancel, isPending: false }),
+  useClearSessionGoalMutation: () => ({ mutateAsync: mocks.clearGoal, isPending: false }),
+  useSetSessionGoalMutation: () => ({ mutateAsync: mocks.setGoal, isPending: false }),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    desktop: null,
+    cloud: { client: {} },
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: vi.fn(() => null),
+  }),
+}));
+
+vi.mock("#product/hooks/chat/derived/use-active-session-identity", () => ({
+  useActiveSessionId: () => mocks.selection.activeSessionId,
+}));
+
+vi.mock("#product/stores/activity/goal-bar-store", () => ({
+  goalResultDismissKey: (status: string, updatedAtMs: number) => `${status}:${updatedAtMs}`,
+  useGoalBarStore: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    beginComposing: mocks.goalBarAction,
+    endComposing: mocks.goalBarAction,
+    dismissResult: mocks.goalBarAction,
+    setPendingGoal: mocks.goalBarAction,
+    clearPendingGoal: mocks.goalBarAction,
+  }),
+}));
+
+vi.mock("#product/lib/infra/measurement/measurement-port", () => ({
+  logLatency: vi.fn(),
+}));
+
+vi.mock("#product/lib/access/anyharness/session-runtime", () => ({
+  getSessionClientAndWorkspace: mocks.resolveSession,
+}));
+
+vi.mock("#product/stores/sessions/session-records", () => ({
+  getSessionRecord: () => mocks.record,
+  patchSessionRecord: mocks.patchSessionRecord,
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: Object.assign(vi.fn(), {
+    getState: () => mocks.selection,
+  }),
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof mocks.showToast }) => unknown) =>
+    selector({ show: mocks.showToast }),
+}));
+
+describe("useSessionCancelActions goal lifecycle", () => {
+  beforeEach(() => {
+    forgetSessionGoalIntent("runtime-1");
+    mocks.cancel.mockReset().mockResolvedValue(undefined);
+    mocks.clearGoal.mockReset().mockResolvedValue({ cleared: true });
+    mocks.setGoal.mockReset().mockResolvedValue({
+      goal: goalSnapshot("paused", "2026-07-17T12:00:02Z", 2),
+    });
+    mocks.patchSessionRecord.mockReset();
+    mocks.showToast.mockReset();
+    mocks.resolveSession.mockClear();
+    mocks.goalBarAction.mockReset();
+    mocks.selection.activeSessionId = "client-1";
+    mocks.selection.selectedWorkspaceId = "workspace-1";
+    mocks.record = sessionRecord("codex", "active");
+  });
+
+  afterEach(() => {
+    cleanup();
+    forgetSessionGoalIntent("runtime-1");
+  });
+
+  it("confirms native pause before cancelling and patching idle", async () => {
+    const pause = deferred<{ goal: ReturnType<typeof goalSnapshot> }>();
+    mocks.setGoal.mockReturnValueOnce(pause.promise);
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    let cancellation!: Promise<void>;
+    act(() => {
+      cancellation = result.current.cancelActiveSession();
+    });
+
+    await waitFor(() => {
+      expect(mocks.setGoal).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        sessionId: "runtime-1",
+        request: { status: "paused" },
+      });
+    });
+    expect(mocks.cancel).not.toHaveBeenCalled();
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+
+    pause.resolve({ goal: goalSnapshot("paused", "2026-07-17T12:00:02Z", 2) });
+    await act(async () => cancellation);
+
+    expect(mocks.cancel).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      sessionId: "runtime-1",
+    });
+    expect(mocks.patchSessionRecord).toHaveBeenCalledWith("client-1", { status: "idle" });
+  });
+
+  it("keeps ordinary cancel behind create and fences the confirmed active intent", async () => {
+    mocks.record = {
+      ...sessionRecord("codex", "active"),
+      activeGoal: null,
+    };
+    const create = deferred<{ goal: ReturnType<typeof goalSnapshot> }>();
+    mocks.setGoal
+      .mockReset()
+      .mockReturnValueOnce(create.promise)
+      .mockResolvedValueOnce({
+        goal: goalSnapshot("paused", "2026-07-17T12:00:02Z", 2),
+      });
+    const { result } = renderHook(() => ({
+      goal: useSessionGoalActions(null),
+      session: useSessionCancelActions(),
+    }));
+
+    act(() => {
+      result.current.goal.editGoal("Create then cancel");
+    });
+    let cancellation!: Promise<void>;
+    act(() => {
+      cancellation = result.current.session.cancelActiveSession();
+    });
+
+    await waitFor(() => expect(mocks.setGoal).toHaveBeenCalledTimes(1));
+    expect(mocks.cancel).not.toHaveBeenCalled();
+
+    create.resolve({
+      goal: {
+        ...goalSnapshot("active", "2026-07-17T12:00:01Z", 1),
+        objective: "Create then cancel",
+      },
+    });
+    await waitFor(() => expect(mocks.setGoal).toHaveBeenCalledTimes(2));
+    expect(mocks.setGoal).toHaveBeenLastCalledWith({
+      workspaceId: "workspace-1",
+      sessionId: "runtime-1",
+      request: { status: "paused" },
+    });
+
+    await act(async () => cancellation);
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a later deliberate resume behind an earlier cancel", async () => {
+    const lookup = deferred<{
+      materializedSessionId: string;
+      workspaceId: string;
+    }>();
+    mocks.resolveSession.mockReturnValueOnce(lookup.promise);
+    mocks.setGoal
+      .mockReset()
+      .mockResolvedValueOnce({
+        goal: goalSnapshot("paused", "2026-07-17T12:00:02Z", 2),
+      })
+      .mockResolvedValueOnce({
+        goal: goalSnapshot("active", "2026-07-17T12:00:03Z", 3),
+      });
+    const { result } = renderHook(() => ({
+      goal: useSessionGoalActions(null),
+      session: useSessionCancelActions(),
+    }));
+
+    let cancellation!: Promise<void>;
+    act(() => {
+      cancellation = result.current.session.cancelActiveSession();
+      result.current.goal.resumeGoal();
+    });
+    await Promise.resolve();
+    expect(mocks.setGoal).not.toHaveBeenCalled();
+
+    lookup.resolve({
+      materializedSessionId: "runtime-1",
+      workspaceId: "workspace-1",
+    });
+    await act(async () => cancellation);
+    await waitFor(() => expect(mocks.setGoal).toHaveBeenCalledTimes(2));
+
+    expect(mocks.setGoal.mock.calls.map(([input]) => input.request)).toEqual([
+      { status: "paused" },
+      { status: "active" },
+    ]);
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps client click order across pending-to-materialized ID transition", async () => {
+    const lookup = deferred<{
+      materializedSessionId: string;
+      workspaceId: string;
+    }>();
+    mocks.record = {
+      ...sessionRecord("codex", "active"),
+      activeGoal: null,
+      materializedSessionId: null,
+    };
+    mocks.resolveSession.mockReturnValueOnce(lookup.promise);
+    mocks.setGoal.mockReset().mockResolvedValue({
+      goal: goalSnapshot("active", "2026-07-17T12:00:02Z", 1),
+    });
+    const { result } = renderHook(() => ({
+      goal: useSessionGoalActions(null),
+      session: useSessionCancelActions(),
+    }));
+
+    let cancellation!: Promise<void>;
+    act(() => {
+      cancellation = result.current.session.cancelActiveSession();
+    });
+    mocks.record = {
+      ...mocks.record,
+      materializedSessionId: "runtime-1",
+    };
+    act(() => {
+      result.current.goal.editGoal("Deliberate later goal");
+    });
+    await Promise.resolve();
+    expect(mocks.setGoal).not.toHaveBeenCalled();
+
+    lookup.resolve({
+      materializedSessionId: "runtime-1",
+      workspaceId: "workspace-1",
+    });
+    await act(async () => cancellation);
+    await waitFor(() => expect(mocks.setGoal).toHaveBeenCalledTimes(1));
+
+    expect(mocks.cancel.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.setGoal.mock.invocationCallOrder[0]);
+  });
+
+  it("does not cancel after a stop failure and retries the full safe sequence", async () => {
+    mocks.setGoal
+      .mockRejectedValueOnce(new Error("native pause failed"))
+      .mockResolvedValueOnce({
+        goal: goalSnapshot("paused", "2026-07-17T12:00:02Z", 2),
+      });
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.setGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).not.toHaveBeenCalled();
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      "Could not confirm the goal stopped, so current work was not cancelled.",
+    );
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.setGoal).toHaveBeenCalledTimes(2);
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+    expect(mocks.patchSessionRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when the pause response still reports an active goal", async () => {
+    mocks.setGoal.mockResolvedValueOnce({
+      goal: goalSnapshot("active", "2026-07-17T12:00:02Z", 2),
+    });
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.setGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).not.toHaveBeenCalled();
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+  });
+
+  it("retries cancellation without repeating a confirmed stop", async () => {
+    mocks.cancel
+      .mockRejectedValueOnce(new Error("cancel transport failed"))
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+    expect(mocks.setGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.setGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).toHaveBeenCalledTimes(2);
+    expect(mocks.patchSessionRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("fences a resumed goal even while the streamed mirror still reads paused", async () => {
+    mocks.record = sessionRecord("codex", "paused");
+    recordSessionGoalMutation(
+      "runtime-1",
+      goalSnapshot("active", "2026-07-17T12:00:02Z", 2),
+    );
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.setGoal).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      sessionId: "runtime-1",
+      request: { status: "paused" },
+    });
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses confirmed clear when native pause is unavailable", async () => {
+    mocks.record = sessionRecord("claude", "active");
+    const clear = deferred<{ cleared: boolean }>();
+    mocks.clearGoal.mockReturnValueOnce(clear.promise);
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    let cancellation!: Promise<void>;
+    act(() => {
+      cancellation = result.current.cancelActiveSession();
+    });
+
+    await waitFor(() => expect(mocks.clearGoal).toHaveBeenCalledTimes(1));
+    expect(mocks.cancel).not.toHaveBeenCalled();
+
+    clear.resolve({ cleared: true });
+    await act(async () => cancellation);
+
+    expect(mocks.setGoal).not.toHaveBeenCalled();
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries cancel directly after a confirmed clear", async () => {
+    mocks.record = sessionRecord("claude", "active");
+    mocks.cancel
+      .mockRejectedValueOnce(new Error("cancel transport failed"))
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+    expect(mocks.clearGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+
+    // A lagging update from the same cleared goal lifetime must not erase the
+    // confirmed stop before retry.
+    mocks.record = {
+      ...mocks.record,
+      activeGoal: goalSnapshot("active", "2026-07-17T12:00:03Z", 3),
+    };
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.clearGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).toHaveBeenCalledTimes(2);
+    expect(mocks.patchSessionRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts an authoritative already-absent clear for a mirrored goal", async () => {
+    mocks.record = sessionRecord("claude", "active");
+    mocks.clearGoal.mockResolvedValueOnce({ cleared: false });
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.clearGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).toHaveBeenCalledTimes(1);
+    expect(mocks.patchSessionRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when clear has not observed a newer UI goal mutation", async () => {
+    mocks.record = sessionRecord("claude", "paused");
+    recordSessionGoalMutation(
+      "runtime-1",
+      goalSnapshot("active", "2026-07-17T12:00:02Z", 2),
+    );
+    mocks.clearGoal.mockResolvedValueOnce({ cleared: false });
+    const { result } = renderHook(() => useSessionCancelActions());
+
+    await act(async () => result.current.cancelActiveSession());
+
+    expect(mocks.clearGoal).toHaveBeenCalledTimes(1);
+    expect(mocks.cancel).not.toHaveBeenCalled();
+    expect(mocks.patchSessionRecord).not.toHaveBeenCalled();
+  });
+});
+
+function sessionRecord(agentKind: string, goalStatus: "active" | "paused") {
+  return {
+    workspaceId: "workspace-1",
+    materializedSessionId: "runtime-1",
+    agentKind,
+    actionCapabilities: { supportsGoals: true },
+    activeGoal: goalSnapshot(goalStatus, "2026-07-17T12:00:01Z", 1),
+  };
+}
+
+function goalSnapshot(
+  status: "active" | "paused",
+  updatedAt: string,
+  revision: number,
+) {
+  return {
+    createdAt: "2026-07-17T11:00:00Z",
+    objective: "Finish safely",
+    revision,
+    status,
+    updatedAt,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-cancel-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-cancel-actions.ts
@@ -1,7 +1,22 @@
-import { useCancelSessionMutation } from "@anyharness/sdk-react";
+import {
+  useCancelSessionMutation,
+  useClearSessionGoalMutation,
+  useSetSessionGoalMutation,
+} from "@anyharness/sdk-react";
 import { useCallback } from "react";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
+import { goalCapabilitiesForSession } from "#product/lib/domain/sessions/goal-mirror";
+import {
+  enqueueSessionGoalLifecycleMutation,
+  recordSessionGoalCleared,
+  recordSessionGoalMutation,
+  requireGoalArmState,
+  requireSafeGoalClear,
+  sessionCancelGoalFence,
+  SessionGoalStopError,
+  stopGoalThenCancelCurrentWork,
+} from "#product/hooks/sessions/workflows/session-goal-lifecycle";
 import {
   getSessionClientAndWorkspace,
 } from "#product/lib/access/anyharness/session-runtime";
@@ -19,6 +34,8 @@ export function useSessionCancelActions() {
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const showToast = useToastStore((state) => state.show);
   const cancelSessionMutation = useCancelSessionMutation();
+  const clearGoalMutation = useClearSessionGoalMutation();
+  const setGoalMutation = useSetSessionGoalMutation();
 
   const cancelActiveSession = useCallback(async () => {
     const state = useSessionSelectionStore.getState();
@@ -27,25 +44,83 @@ export function useSessionCancelActions() {
       return;
     }
 
-    const workspaceId = getSessionRecord(sessionId)?.workspaceId ?? state.selectedWorkspaceId;
-    const blockedReason = getWorkspaceRuntimeBlockReason(workspaceId);
+    const initialRecord = getSessionRecord(sessionId);
+    const selectedWorkspaceId = initialRecord?.workspaceId ?? state.selectedWorkspaceId;
+    const blockedReason = getWorkspaceRuntimeBlockReason(selectedWorkspaceId);
     if (blockedReason) {
       showToast(blockedReason);
       return;
     }
 
     try {
-      const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(
-        sessionId,
-        ssh,
-        cloudClient,
-      );
-      await cancelSessionMutation.mutateAsync({ workspaceId, sessionId: materializedSessionId });
-      patchSessionRecord(sessionId, { status: "idle" });
-    } catch {
-      // Cancel failed.
+      // Enqueue before the first async lookup so a later goal write or Resume
+      // click cannot overtake the user's earlier Cancel intent.
+      await enqueueSessionGoalLifecycleMutation(sessionId, async () => {
+        const { materializedSessionId, workspaceId } = await getSessionClientAndWorkspace(
+          sessionId,
+          ssh,
+          cloudClient,
+        );
+        // Re-read after earlier queued goal writes have settled. The streamed
+        // mirror can lag a successful response, so the lifecycle helper also
+        // considers the latest confirmed product-side intent.
+        const record = getSessionRecord(sessionId);
+        const pauseSupported = record
+          ? goalCapabilitiesForSession(record.actionCapabilities, record.agentKind).pause
+          : false;
+        const fence = sessionCancelGoalFence({
+          materializedSessionId,
+          mirrorGoal: record?.activeGoal ?? null,
+          pauseSupported,
+        });
+        const cancelCurrentWork = () => cancelSessionMutation.mutateAsync({
+          workspaceId,
+          sessionId: materializedSessionId,
+        });
+
+        if (fence.action === "none") {
+          await cancelCurrentWork();
+        } else {
+          await stopGoalThenCancelCurrentWork({
+            stopGoal: async () => {
+              if (fence.action === "pause") {
+                const response = await setGoalMutation.mutateAsync({
+                  workspaceId,
+                  sessionId: materializedSessionId,
+                  request: { status: "paused" },
+                });
+                requireGoalArmState(response.goal, "paused");
+                recordSessionGoalMutation(materializedSessionId, response.goal);
+              } else {
+                const response = await clearGoalMutation.mutateAsync({
+                  workspaceId,
+                  sessionId: materializedSessionId,
+                });
+                requireSafeGoalClear(response, fence);
+                recordSessionGoalCleared(materializedSessionId, record?.activeGoal ?? null);
+              }
+            },
+            cancelCurrentWork,
+          });
+        }
+        patchSessionRecord(sessionId, { status: "idle" });
+      });
+    } catch (error) {
+      if (error instanceof SessionGoalStopError) {
+        showToast("Could not confirm the goal stopped, so current work was not cancelled.");
+      }
+      // Preserve the confirmed stop intent when only cancellation failed; a
+      // retry re-reads it and does not re-arm or repeat the stop mutation.
     }
-  }, [cancelSessionMutation, getWorkspaceRuntimeBlockReason, showToast, ssh, cloudClient]);
+  }, [
+    cancelSessionMutation,
+    clearGoalMutation,
+    cloudClient,
+    getWorkspaceRuntimeBlockReason,
+    setGoalMutation,
+    showToast,
+    ssh,
+  ]);
 
   return { cancelActiveSession };
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-prompt-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-prompt-actions.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionPromptActions } from "#product/hooks/sessions/workflows/use-session-prompt-actions";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const mocks = vi.hoisted(() => ({
+  getWorkspaceRuntimeBlockReason: vi.fn(),
+  promptSession: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-prompt-workflow", () => ({
+  useSessionPromptWorkflow: () => ({ promptSession: mocks.promptSession }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: mocks.getWorkspaceRuntimeBlockReason,
+  }),
+}));
+
+describe("useSessionPromptActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getWorkspaceRuntimeBlockReason.mockReturnValue(null);
+    mocks.promptSession.mockResolvedValue(undefined);
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.getState().clearSelection();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("dispatches an intentional prompt for an idle prompt-ready session with an active goal", async () => {
+    const sessionId = "client-session-active-goal";
+    const workspaceId = "workspace-active-goal";
+    putSessionRecord({
+      ...createEmptySessionRecord(sessionId, "codex", {
+        materializedSessionId: "runtime-session-active-goal",
+        workspaceId,
+        activeGoal: {
+          createdAt: "2026-07-17T12:00:00.000Z",
+          native: true,
+          objective: "Finish the requested repair",
+          revision: 1,
+          status: "active",
+          tokenBudget: 50_000,
+          updatedAt: "2026-07-17T12:00:00.000Z",
+        },
+      }),
+      status: "idle",
+      transcriptHydrated: true,
+    });
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: workspaceId,
+      workspaceId,
+      initialActiveSessionId: sessionId,
+    });
+
+    expect(getSessionRecord(sessionId)).toMatchObject({
+      materializedSessionId: "runtime-session-active-goal",
+      status: "idle",
+      transcriptHydrated: true,
+      activeGoal: { status: "active" },
+    });
+
+    const { result } = renderHook(() => useSessionPromptActions());
+    await act(async () => {
+      await result.current.promptActiveSession("Continue deliberately");
+    });
+
+    expect(mocks.getWorkspaceRuntimeBlockReason).toHaveBeenCalledWith(workspaceId);
+    expect(mocks.promptSession).toHaveBeenCalledOnce();
+    expect(mocks.promptSession).toHaveBeenCalledWith({
+      sessionId,
+      text: "Continue deliberately",
+      blocks: undefined,
+      attachmentSnapshots: undefined,
+      optimisticContentParts: undefined,
+      workspaceId,
+      latencyFlowId: undefined,
+      measurementOperationId: undefined,
+      promptId: undefined,
+    });
+  });
+});

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -249,6 +249,34 @@ Dock panes share one width and one neutral tray treatment. Hierarchy comes from
 state order, copy, and control weight, not from different colors or a width
 staircase.
 
+### Goal lifecycle safety
+
+Fresh goals created from the Desktop/Web product surface request a finite
+50,000-token budget. Engines that implement GoalPort token budgets enforce
+that default; a harness that reports no native token budget remains governed
+by its own native stopping semantics. The product does not fabricate budget
+accounting in the strict goal mirror. Editing an active or paused goal
+preserves the native engine's existing accounting instead of silently
+replacing its budget.
+
+Product goal writes and cancellation share a per-client-session lifecycle
+queue, so a later cancel cannot overtake an earlier goal create or edit. When
+cancel reaches the head of that queue, it re-reads the strict goal mirror and
+also considers the latest confirmed product-side intent while the stream
+catches up. It confirms native pause first when the goal supports pause;
+otherwise it confirms native clear or authoritative absence. Only then does it
+interrupt the current turn. The goal bar's Pause and Clear controls follow the
+same stop-before-cancel order.
+
+A stop failure leaves the turn running and cancellation unrequested, so the
+full safe sequence can be retried. If stopping succeeds but cancellation fails,
+the confirmed stopped intent survives long enough for retry to cancel directly
+without re-running or reversing the stop. A harness that cannot confirm a clear
+for a deferred goal fails closed instead of interrupting and risking re-arm.
+Deliberate Resume remains the only product transition from paused back to
+active, and an active goal does not prevent an idle session from accepting an
+intentional prompt.
+
 Queued user prompts render only in `outboundSlot`; they are not transcript
 rows while they remain pending. The queue supports drag or keyboard reorder,
 steer-next, edit, and delete. A queue entry's `seq` is its immutable runtime


### PR DESCRIPTION
## Summary

- Request a finite 50,000-token default whenever the product creates a fresh goal on a budget-capable engine, while preserving accounting for active/paused edits.
- Serialize product goal writes and cancellation per client session; persist and validate pause or clear/absence before interrupting, fail closed for unobserved deferred goals, and preserve explicit Resume ordering.
- Keep active-goal + idle-prompt behavior intact and document the lifecycle contract and native-budget caveat.
- A related internal production report is attached through the tracker workflow. This bounded repair does not claim full production resolution before release verification.

## Readiness

- [x] I followed the pull-request procedure for scope, title, body, and draft readiness.

## Support and attribution (optional)

- [x] The support relationship is linked through the production tracker; no private source data appears in this PR.

## Verification

- pnpm --config.minimumReleaseAge=0 --filter @proliferate/product-client exec vitest run src/hooks/sessions/workflows/session-goal-lifecycle.test.ts src/hooks/activity/workflows/use-session-goal-actions.test.tsx src/hooks/sessions/workflows/use-session-cancel-actions.test.tsx src/hooks/sessions/workflows/use-session-prompt-actions.test.tsx (42 passed)
- pnpm --config.minimumReleaseAge=0 --filter @proliferate/product-client exec tsc -p tsconfig.json --noEmit
- python3 scripts/check_docs.py
- git diff --check origin/main...HEAD
- Independent final diff review: no actionable findings.
