### PR TITLE
fix(release): harden INT audit probe

### DIFF
--- a/specs/developing/testing/tier-3-scenario-contract.md
+++ b/specs/developing/testing/tier-3-scenario-contract.md
@@ -307,7 +307,15 @@ For each supported harness, connect the deterministic real integration through
 the product UI, create a fresh session so startup MCP injection is exercised,
 and use the cheapest eligible model to make one real call through the
 Proliferate integrations MCP. Assert the expected provider/tool operation and
-product audit correlation.
+product audit correlation. The audit row must be new relative to a successful
+pre-turn snapshot and match the actor, organization, exact enrolled runtime
+worker, integration namespace, tool, and successful outcome; a historical or
+otherwise visible tool call cannot satisfy the cell. The read-only DB probe
+uses the exact world's database URL and an explicit local-development,
+debug-enabled, background-workers-disabled Settings posture scoped only to its
+qualification subprocess. Probe configuration or query failures are red and
+never become absent/empty evidence; production Settings validation remains
+fail-closed.
 
 This case proves positive per-harness Product MCP translation. It does not
 assert hidden server credential state or a disconnect/failure matrix.

--- a/tests/release/src/fixtures/integration-gateway.test.ts
+++ b/tests/release/src/fixtures/integration-gateway.test.ts
@@ -161,6 +161,13 @@ test("integration audit probe propagates a real query failure instead of returni
   );
 });
 
+test("integration audit probe reports a signal-killed child unambiguously", () => {
+  assert.throws(
+    () => parseIntegrationAuditProbeResult(null, "", "terminated", "SIGTERM"),
+    /integration_audit_probe\.py was killed by SIGTERM: terminated/,
+  );
+});
+
 test("audit correlation returns no evidence when the tool call left no row", () => {
   assert.equal(
     findCorrelatedToolCallEvent([], { namespace: "exa", toolName: "web_search", correlation }),
@@ -183,6 +190,7 @@ test("stale and incorrectly correlated visible tool calls cannot satisfy LOCAL-7
     toolCallEvent({ id: "wrong-provider", namespace: "github" }),
     toolCallEvent({ id: "wrong-tool", toolName: "get_contents" }),
     toolCallEvent({ id: "failed-call", ok: false, errorCode: "tool_error" }),
+    toolCallEvent({ id: "ok-but-errored", errorCode: "partial_error" }),
   ];
 
   assert.equal(

--- a/tests/release/src/fixtures/integration-gateway.test.ts
+++ b/tests/release/src/fixtures/integration-gateway.test.ts
@@ -1,7 +1,37 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { pickSearchTool, resolveRuntimeHome } from "./integration-gateway.js";
+import {
+  buildIntegrationAuditProbeEnv,
+  findCorrelatedToolCallEvent,
+  parseIntegrationAuditProbeResult,
+  pickSearchTool,
+  requireIntegrationAuditProbeEvents,
+  resolveRuntimeHome,
+  type ToolCallAuditCorrelation,
+  type ToolCallEvent,
+} from "./integration-gateway.js";
+
+function toolCallEvent(overrides: Partial<ToolCallEvent> = {}): ToolCallEvent {
+  return {
+    id: "audit-new",
+    namespace: "exa",
+    toolName: "web_search",
+    ok: true,
+    errorCode: null,
+    latencyMs: 12,
+    runtimeWorkerId: "worker-current",
+    organizationId: "org-current",
+    createdAt: "2026-07-17T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const correlation: ToolCallAuditCorrelation = {
+  baselineEventIds: ["audit-old"],
+  runtimeWorkerId: "worker-current",
+  organizationId: "org-current",
+};
 
 test("pickSearchTool prefers a web_search-shaped tool and fills a query arg", () => {
   const picked = pickSearchTool(
@@ -62,4 +92,89 @@ test("resolveRuntimeHome prefers ANYHARNESS_RUNTIME_HOME", () => {
 test("resolveRuntimeHome falls back to the desktop default under HOME", () => {
   const resolved = resolveRuntimeHome({});
   assert.ok(resolved && resolved.endsWith("/.proliferate/anyharness"));
+});
+
+test("integration audit probe adds the Settings posture missing from the legacy DATABASE_URL-only spawn", () => {
+  const databaseUrl = "postgresql+asyncpg://probe@127.0.0.1:5432/probe";
+  const legacyEnv: NodeJS.ProcessEnv = { DATABASE_URL: databaseUrl };
+  assert.equal(legacyEnv.DEBUG, undefined);
+  assert.equal(legacyEnv.PROLIFERATE_TELEMETRY_MODE, undefined);
+
+  const env = buildIntegrationAuditProbeEnv(databaseUrl, {});
+  assert.equal(env.DATABASE_URL, databaseUrl);
+  assert.equal(env.DEBUG, "true");
+  assert.equal(env.PROLIFERATE_TELEMETRY_MODE, "local_dev");
+  assert.equal(env.RUN_BACKGROUND_WORKERS, "false");
+  assert.equal(env.AGENT_GATEWAY_QUALIFICATION_RUN_ID, "");
+  assert.equal(env.AGENT_GATEWAY_QUALIFICATION_SHARD_ID, "");
+});
+
+test("integration audit probe posture overrides unsafe ambient production settings only in its child env", () => {
+  const ambient: NodeJS.ProcessEnv = {
+    DEBUG: "false",
+    PROLIFERATE_TELEMETRY_MODE: "hosted_product",
+    RUN_BACKGROUND_WORKERS: "true",
+    AGENT_GATEWAY_QUALIFICATION_RUN_ID: "incomplete-parent-identity",
+  };
+  const env = buildIntegrationAuditProbeEnv("postgresql+asyncpg://probe", ambient);
+
+  assert.equal(env.DEBUG, "true");
+  assert.equal(env.PROLIFERATE_TELEMETRY_MODE, "local_dev");
+  assert.equal(env.RUN_BACKGROUND_WORKERS, "false");
+  assert.equal(env.AGENT_GATEWAY_QUALIFICATION_RUN_ID, "");
+  assert.equal(env.AGENT_GATEWAY_QUALIFICATION_SHARD_ID, "");
+  assert.equal(ambient.DEBUG, "false", "the parent/production environment must not be mutated");
+});
+
+test("integration audit probe propagates a real query failure instead of returning empty evidence", () => {
+  assert.throws(
+    () => parseIntegrationAuditProbeResult(1, "", "ConnectionRefusedError: audit query failed"),
+    /integration_audit_probe\.py exited 1: ConnectionRefusedError: audit query failed/,
+  );
+});
+
+test("audit correlation returns no evidence when the tool call left no row", () => {
+  assert.equal(
+    findCorrelatedToolCallEvent([], { namespace: "exa", toolName: "web_search", correlation }),
+    undefined,
+  );
+});
+
+test("audit correlation rejects a probe result resolved to the wrong actor", () => {
+  assert.throws(
+    () => requireIntegrationAuditProbeEvents({ userId: "user-other", events: [] }, "user-current"),
+    /resolved user "user-other"; expected "user-current"/,
+  );
+});
+
+test("stale and incorrectly correlated visible tool calls cannot satisfy LOCAL-7", () => {
+  const unrelated = [
+    toolCallEvent({ id: "audit-old" }),
+    toolCallEvent({ id: "wrong-worker", runtimeWorkerId: "worker-other" }),
+    toolCallEvent({ id: "wrong-org", organizationId: "org-other" }),
+    toolCallEvent({ id: "wrong-provider", namespace: "github" }),
+    toolCallEvent({ id: "wrong-tool", toolName: "get_contents" }),
+    toolCallEvent({ id: "failed-call", ok: false, errorCode: "tool_error" }),
+  ];
+
+  assert.equal(
+    findCorrelatedToolCallEvent(unrelated, {
+      namespace: "exa",
+      toolName: "web_search",
+      correlation,
+    }),
+    undefined,
+  );
+});
+
+test("audit correlation accepts the new successful row from the exact worker and organization", () => {
+  const exact = toolCallEvent({ id: "audit-exact" });
+  assert.equal(
+    findCorrelatedToolCallEvent([toolCallEvent({ id: "audit-old" }), exact], {
+      namespace: "exa",
+      toolName: "web_search",
+      correlation,
+    }),
+    exact,
+  );
 });

--- a/tests/release/src/fixtures/integration-gateway.test.ts
+++ b/tests/release/src/fixtures/integration-gateway.test.ts
@@ -111,10 +111,14 @@ test("integration audit probe adds the Settings posture missing from the legacy 
 
 test("integration audit probe posture overrides unsafe ambient production settings only in its child env", () => {
   const ambient: NodeJS.ProcessEnv = {
-    DEBUG: "false",
-    PROLIFERATE_TELEMETRY_MODE: "hosted_product",
-    RUN_BACKGROUND_WORKERS: "true",
-    AGENT_GATEWAY_QUALIFICATION_RUN_ID: "incomplete-parent-identity",
+    debug: "false",
+    proliferate_telemetry_mode: "hosted_product",
+    telemetry_mode: "self_managed",
+    run_background_workers: "true",
+    agent_gateway_qualification_run_id: "incomplete-parent-identity",
+    agent_gateway_qualification_shard_id: "bad shard with spaces",
+    database_url: "postgresql+asyncpg://wrong-database",
+    UNRELATED_ENV: "preserved",
   };
   const env = buildIntegrationAuditProbeEnv("postgresql+asyncpg://probe", ambient);
 
@@ -123,7 +127,31 @@ test("integration audit probe posture overrides unsafe ambient production settin
   assert.equal(env.RUN_BACKGROUND_WORKERS, "false");
   assert.equal(env.AGENT_GATEWAY_QUALIFICATION_RUN_ID, "");
   assert.equal(env.AGENT_GATEWAY_QUALIFICATION_SHARD_ID, "");
-  assert.equal(ambient.DEBUG, "false", "the parent/production environment must not be mutated");
+  assert.equal(env.DATABASE_URL, "postgresql+asyncpg://probe");
+  assert.equal(env.UNRELATED_ENV, "preserved");
+  for (const ownedKey of [
+    "DATABASE_URL",
+    "DEBUG",
+    "PROLIFERATE_TELEMETRY_MODE",
+    "TELEMETRY_MODE",
+    "RUN_BACKGROUND_WORKERS",
+    "AGENT_GATEWAY_QUALIFICATION_RUN_ID",
+    "AGENT_GATEWAY_QUALIFICATION_SHARD_ID",
+  ]) {
+    const matchingKeys = Object.keys(env).filter(
+      (key) => key.toUpperCase() === ownedKey,
+    );
+    assert.equal(
+      matchingKeys.length,
+      ownedKey === "TELEMETRY_MODE" ? 0 : 1,
+      `${ownedKey} must not retain a case-insensitive ambient collision`,
+    );
+  }
+  assert.equal(
+    ambient.debug,
+    "false",
+    "the parent/production environment must not be mutated",
+  );
 });
 
 test("integration audit probe propagates a real query failure instead of returning empty evidence", () => {

--- a/tests/release/src/fixtures/integration-gateway.ts
+++ b/tests/release/src/fixtures/integration-gateway.ts
@@ -222,6 +222,102 @@ export interface ToolCallEvent {
   createdAt: string;
 }
 
+export interface ToolCallAuditCorrelation {
+  baselineEventIds: readonly string[];
+  runtimeWorkerId: string;
+  organizationId: string;
+}
+
+const INTEGRATION_AUDIT_PROBE_SETTINGS_POSTURE = Object.freeze({
+  DEBUG: "true",
+  PROLIFERATE_TELEMETRY_MODE: "local_dev",
+  RUN_BACKGROUND_WORKERS: "false",
+  // The read-only probe owns no provider cleanup identity. Clearing both keeps
+  // an incomplete or malformed parent qualification pair from tripping the
+  // server Settings validator before the query runs.
+  AGENT_GATEWAY_QUALIFICATION_RUN_ID: "",
+  AGENT_GATEWAY_QUALIFICATION_SHARD_ID: "",
+});
+
+/**
+ * Pins the read-only probe to an explicit qualification-only Settings posture.
+ * The server's production defaults intentionally fail closed when real secrets
+ * are absent; this override is scoped to the child process that only imports
+ * the DB engine/models and executes the audit query.
+ */
+export function buildIntegrationAuditProbeEnv(
+  databaseUrl: string,
+  ambient: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...ambient,
+    ...INTEGRATION_AUDIT_PROBE_SETTINGS_POSTURE,
+    DATABASE_URL: databaseUrl,
+  };
+}
+
+export function parseIntegrationAuditProbeResult(
+  code: number | null,
+  stdout: string,
+  stderr: string,
+): { userId: string; events: ToolCallEvent[]; error?: string } {
+  if (code !== 0) {
+    throw new Error(`integration_audit_probe.py exited ${code}: ${stderr || stdout}`);
+  }
+  try {
+    const lastLine = stdout.trim().split("\n").pop() ?? "{}";
+    return JSON.parse(lastLine);
+  } catch (error) {
+    throw new Error(`integration_audit_probe.py did not print valid JSON: ${stdout}\n${error}`);
+  }
+}
+
+export function requireIntegrationAuditProbeEvents(
+  result: { userId: string; events: ToolCallEvent[]; error?: string },
+  expectedUserId: string,
+): readonly ToolCallEvent[] {
+  if (result.error) {
+    throw new Error(`integration_audit_probe.py query failed: ${result.error}`);
+  }
+  if (result.userId !== expectedUserId) {
+    throw new Error(
+      `integration_audit_probe.py resolved user ${JSON.stringify(result.userId)}; ` +
+        `expected ${JSON.stringify(expectedUserId)}`,
+    );
+  }
+  if (!Array.isArray(result.events)) {
+    throw new Error("integration_audit_probe.py returned no events array");
+  }
+  return result.events;
+}
+
+/**
+ * Selects only the successful row attributable to this cell's exact gateway
+ * grant and post-baseline tool call. User scoping is enforced by the probe's
+ * email lookup; worker + organization + baseline keep another visible call
+ * from satisfying LOCAL-7.
+ */
+export function findCorrelatedToolCallEvent(
+  events: readonly ToolCallEvent[],
+  expected: {
+    namespace: string;
+    toolName: string;
+    correlation: ToolCallAuditCorrelation;
+  },
+): ToolCallEvent | undefined {
+  const baselineIds = new Set(expected.correlation.baselineEventIds);
+  return events.find(
+    (event) =>
+      !baselineIds.has(event.id) &&
+      event.namespace === expected.namespace &&
+      event.toolName === expected.toolName &&
+      event.ok &&
+      event.errorCode === null &&
+      event.runtimeWorkerId === expected.correlation.runtimeWorkerId &&
+      event.organizationId === expected.correlation.organizationId,
+  );
+}
+
 /**
  * Runs `tests/release/scripts/integration_audit_probe.py` in-process to read
  * back the `cloud_integration_tool_call_event` audit row.
@@ -256,7 +352,7 @@ export async function runIntegrationAuditProbe(
   return new Promise((resolve, reject) => {
     const child = spawn("uv", ["run", "python", ...args], {
       cwd: serverDir,
-      env: { ...process.env, DATABASE_URL: databaseUrl },
+      env: buildIntegrationAuditProbeEnv(databaseUrl),
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
@@ -269,15 +365,10 @@ export async function runIntegrationAuditProbe(
     });
     child.on("error", reject);
     child.on("exit", (code) => {
-      if (code !== 0) {
-        reject(new Error(`integration_audit_probe.py exited ${code}: ${stderr || stdout}`));
-        return;
-      }
       try {
-        const lastLine = stdout.trim().split("\n").pop() ?? "{}";
-        resolve(JSON.parse(lastLine));
+        resolve(parseIntegrationAuditProbeResult(code, stdout, stderr));
       } catch (error) {
-        reject(new Error(`integration_audit_probe.py did not print valid JSON: ${stdout}\n${error}`));
+        reject(error);
       }
     });
   });

--- a/tests/release/src/fixtures/integration-gateway.ts
+++ b/tests/release/src/fixtures/integration-gateway.ts
@@ -239,18 +239,34 @@ const INTEGRATION_AUDIT_PROBE_SETTINGS_POSTURE = Object.freeze({
   AGENT_GATEWAY_QUALIFICATION_SHARD_ID: "",
 });
 
+const INTEGRATION_AUDIT_PROBE_OWNED_ENV_KEYS = new Set([
+  "DATABASE_URL",
+  "DEBUG",
+  "PROLIFERATE_TELEMETRY_MODE",
+  "TELEMETRY_MODE",
+  "RUN_BACKGROUND_WORKERS",
+  "AGENT_GATEWAY_QUALIFICATION_RUN_ID",
+  "AGENT_GATEWAY_QUALIFICATION_SHARD_ID",
+]);
+
 /**
  * Pins the read-only probe to an explicit qualification-only Settings posture.
  * The server's production defaults intentionally fail closed when real secrets
- * are absent; this override is scoped to the child process that only imports
- * the DB engine/models and executes the audit query.
+ * are absent. Case-insensitive collisions are removed because BaseSettings
+ * treats env keys case-insensitively; the resulting override is scoped to the
+ * child process that only imports the DB engine/models and executes the query.
  */
 export function buildIntegrationAuditProbeEnv(
   databaseUrl: string,
   ambient: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
+  const inherited = Object.fromEntries(
+    Object.entries(ambient).filter(
+      ([key]) => !INTEGRATION_AUDIT_PROBE_OWNED_ENV_KEYS.has(key.toUpperCase()),
+    ),
+  );
   return {
-    ...ambient,
+    ...inherited,
     ...INTEGRATION_AUDIT_PROBE_SETTINGS_POSTURE,
     DATABASE_URL: databaseUrl,
   };

--- a/tests/release/src/fixtures/integration-gateway.ts
+++ b/tests/release/src/fixtures/integration-gateway.ts
@@ -276,9 +276,12 @@ export function parseIntegrationAuditProbeResult(
   code: number | null,
   stdout: string,
   stderr: string,
+  signal: NodeJS.Signals | null = null,
 ): { userId: string; events: ToolCallEvent[]; error?: string } {
   if (code !== 0) {
-    throw new Error(`integration_audit_probe.py exited ${code}: ${stderr || stdout}`);
+    const exitDescription =
+      code === null ? `was killed by ${signal ?? "an unknown signal"}` : `exited ${code}`;
+    throw new Error(`integration_audit_probe.py ${exitDescription}: ${stderr || stdout}`);
   }
   try {
     const lastLine = stdout.trim().split("\n").pop() ?? "{}";
@@ -380,9 +383,9 @@ export async function runIntegrationAuditProbe(
       stderr += String(chunk);
     });
     child.on("error", reject);
-    child.on("exit", (code) => {
+    child.on("exit", (code, signal) => {
       try {
-        resolve(parseIntegrationAuditProbeResult(code, stdout, stderr));
+        resolve(parseIntegrationAuditProbeResult(code, stdout, stderr, signal));
       } catch (error) {
         reject(error);
       }

--- a/tests/release/src/scenarios/local/integration-mcp.test.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.test.ts
@@ -141,7 +141,11 @@ function greenDriver(closedCount: { value: number }): LocalMcpDriver {
       toolName: "web_search",
       auditCorrelation: auditCorrelation(harness),
     }),
-    assertAuditRow: async (_world, _actor, _namespace, _toolName) => ({ auditEventId: "audit-1" }),
+    assertAuditRow: async (_world, actor, _namespace, _toolName, correlation) => {
+      const harness = actor.userId.replace(/^user-/, "");
+      assert.deepEqual(correlation, auditCorrelation(harness));
+      return { auditEventId: "audit-1" };
+    },
     closeWorld: async (world) => {
       closedCount.value += 1;
       return world.close();

--- a/tests/release/src/scenarios/local/integration-mcp.test.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.test.ts
@@ -117,6 +117,14 @@ function fakeRepo(): PreparedRepository {
   return { path: "/tmp/repo", repoUrl: "https://github.com/x/y.git", commit: "c".repeat(40), repoRootId: "root-1" };
 }
 
+function auditCorrelation(harness: string) {
+  return {
+    baselineEventIds: [`audit-old-${harness}`],
+    runtimeWorkerId: `worker-${harness}`,
+    organizationId: `org-${harness}`,
+  };
+}
+
 /** A driver whose every step succeeds deterministically for a fixed harness set. */
 function greenDriver(closedCount: { value: number }): LocalMcpDriver {
   return {
@@ -131,6 +139,7 @@ function greenDriver(closedCount: { value: number }): LocalMcpDriver {
       sessionId: `sess-${harness}`,
       modelId: "us.anthropic.claude-haiku-4-6",
       toolName: "web_search",
+      auditCorrelation: auditCorrelation(harness),
     }),
     assertAuditRow: async (_world, _actor, _namespace, _toolName) => ({ auditEventId: "audit-1" }),
     closeWorld: async (world) => {
@@ -168,7 +177,13 @@ test("runLocal7McpCellsAgainstWorld: a per-cell failure does not affect its sibl
       if (harness === "cursor") {
         throw new Error("cursor turn errored");
       }
-      return { workspaceId: `ws-${harness}`, sessionId: `sess-${harness}`, modelId: "m", toolName: "web_search" };
+      return {
+        workspaceId: `ws-${harness}`,
+        sessionId: `sess-${harness}`,
+        modelId: "m",
+        toolName: "web_search",
+        auditCorrelation: auditCorrelation(harness),
+      };
     },
   };
   const cells = [fakeCell("claude"), fakeCell("cursor")];
@@ -178,6 +193,23 @@ test("runLocal7McpCellsAgainstWorld: a per-cell failure does not affect its sibl
   assert.equal(outcomes[0]!.status, "green");
   assert.equal(outcomes[1]!.status, "failed");
   assert.match(outcomes[1]!.reason!.message, /cursor turn errored/);
+});
+
+test("runLocal7McpCellsAgainstWorld: a real audit query failure stays failed", async () => {
+  const world = fakeWorld();
+  const base = greenDriver({ value: 0 });
+  const driver: LocalMcpDriver = {
+    ...base,
+    assertAuditRow: async () => {
+      throw new Error("database query failed: connection refused");
+    },
+  };
+
+  const outcomes = await runLocal7McpCellsAgainstWorld(world, [fakeCell("claude")], driver);
+
+  assert.equal(outcomes[0]!.status, "failed");
+  assert.match(outcomes[0]!.reason!.message, /database query failed: connection refused/);
+  assert.equal(outcomes[0]!.evidence, undefined);
 });
 
 test("runLocal7McpCellsAgainstWorld: no eligible model maps to a typed blocked cell, not failed", async () => {

--- a/tests/release/src/scenarios/local/integration-mcp.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.ts
@@ -19,11 +19,14 @@ import { productPage, type ProductPage } from "../../fixtures/product-page.js";
 import { resolveIntegrationNamespace } from "../../fixtures/integrations.js";
 import {
   enrollGatewayWorker,
+  findCorrelatedToolCallEvent,
   gatewayListTools,
   pickSearchTool,
+  requireIntegrationAuditProbeEvents,
   runIntegrationAuditProbe,
   writeGatewayDotfile,
   type GatewayGrant,
+  type ToolCallAuditCorrelation,
 } from "../../fixtures/integration-gateway.js";
 import { findErrorEvent, findTurnEndedEvent } from "../../fixtures/local-runtime.js";
 import { selectCheapestEligibleClaudeModel } from "../../services/qualification-litellm.js";
@@ -71,13 +74,25 @@ export interface LocalMcpDriver {
   /** Create a FRESH session (so startup MCP injection runs) and drive one agent
    * turn on the cheapest eligible model, prompted to call an integration tool
    * through the `proliferate_integrations` MCP. Returns the ids + tool name. */
-  runIntegrationTurn(world: ReadyLocalWorld, page: ProductPage, harness: LocalHarnessKind, namespace: string, repoPath: string): Promise<{ workspaceId: string; sessionId: string; modelId: string; toolName: string }>;
+  runIntegrationTurn(world: ReadyLocalWorld, page: ProductPage, harness: LocalHarnessKind, namespace: string, repoPath: string): Promise<{
+    workspaceId: string;
+    sessionId: string;
+    modelId: string;
+    toolName: string;
+    auditCorrelation: ToolCallAuditCorrelation;
+  }>;
 
   /** Read back the `cloud_integration_tool_call_event` audit row via the reused
    * DB probe seam and assert ok=true for this namespace/tool. Reads THIS world's
    * own run-scoped Postgres (`world.db.databaseUrl`), the database the turn wrote
    * to — never an ambient static DB. Returns its id. */
-  assertAuditRow(world: ReadyLocalWorld, actor: AuthenticatedActor, namespace: string, toolName: string): Promise<{ auditEventId: string }>;
+  assertAuditRow(
+    world: ReadyLocalWorld,
+    actor: AuthenticatedActor,
+    namespace: string,
+    toolName: string,
+    correlation: ToolCallAuditCorrelation,
+  ): Promise<{ auditEventId: string }>;
 
   closeWorld(world: ReadyLocalWorld): ReturnType<ReadyLocalWorld["close"]>;
 }
@@ -232,6 +247,21 @@ export const defaultLocalMcpDriver: LocalMcpDriver = {
     }
     await selectModelInUi(page, modelId);
 
+    // A successful historical or sibling call must not satisfy this cell. Take
+    // a fail-closed baseline immediately before Send and bind the later audit
+    // row to this cell's exact worker grant + organization.
+    const baseline = await runIntegrationAuditProbe(actor.session.email, {
+      namespace,
+      sinceSeconds: 3600,
+      databaseUrl: world.db.databaseUrl,
+    });
+    const baselineEvents = requireIntegrationAuditProbeEvents(baseline, actor.userId);
+    const auditCorrelation: ToolCallAuditCorrelation = {
+      baselineEventIds: baselineEvents.map((event) => event.id),
+      runtimeWorkerId: grant.workerId,
+      organizationId: actor.organizationId,
+    };
+
     const prompt =
       `You have an MCP server named "proliferate_integrations" that proxies external integrations. ` +
       `Call the tool "${picked.tool}" through it with the "${namespace}" provider — use ` +
@@ -264,9 +294,9 @@ export const defaultLocalMcpDriver: LocalMcpDriver = {
       throw new Error(`runIntegrationTurn: assistant turn did not end within ${TURN_TIMEOUT_MS}ms.`);
     }
 
-    return { workspaceId, sessionId, modelId, toolName: picked.tool };
+    return { workspaceId, sessionId, modelId, toolName: picked.tool, auditCorrelation };
   },
-  async assertAuditRow(world, actor, namespace, toolName) {
+  async assertAuditRow(world, actor, namespace, toolName, correlation) {
     const deadline = Date.now() + 15_000;
     for (;;) {
       const probe = await runIntegrationAuditProbe(actor.session.email, {
@@ -274,14 +304,15 @@ export const defaultLocalMcpDriver: LocalMcpDriver = {
         sinceSeconds: 3600,
         databaseUrl: world.db.databaseUrl,
       });
-      const row = probe.events.find((event) => event.ok && event.toolName === toolName);
+      const events = requireIntegrationAuditProbeEvents(probe, actor.userId);
+      const row = findCorrelatedToolCallEvent(events, { namespace, toolName, correlation });
       if (row) {
         return { auditEventId: row.id };
       }
       if (Date.now() >= deadline) {
         throw new Error(
-          `assertAuditRow: no ok=true cloud_integration_tool_call_event for "${namespace}.${toolName}" ` +
-            `was found for ${actor.session.email}.`,
+          `assertAuditRow: no new ok=true cloud_integration_tool_call_event for "${namespace}.${toolName}" ` +
+            `matched worker ${correlation.runtimeWorkerId} and organization ${correlation.organizationId}.`,
         );
       }
       await sleep(2_000);
@@ -349,7 +380,13 @@ export async function runLocal7McpCellsAgainstWorld(
         await driver.connectIntegration(page, namespace);
         await driver.selectRepoAndWorkLocally(page, repo);
         const turn = await driver.runIntegrationTurn(world, page, harness, namespace, repo.path);
-        const audit = await driver.assertAuditRow(world, actor, namespace, turn.toolName);
+        const audit = await driver.assertAuditRow(
+          world,
+          actor,
+          namespace,
+          turn.toolName,
+          turn.auditCorrelation,
+        );
         entries.push({
           cell,
           ok: true,


### PR DESCRIPTION
## Summary

- give `integration_audit_probe.py` an explicit child-only qualification Settings posture and the exact world database URL, stripping case-insensitive ambient aliases so production secret validation cannot stop the read-only probe before SQL
- snapshot audit rows before the agent turn and require a new successful row for the exact actor, organization, enrolled runtime worker, integration namespace, and tool
- keep query/configuration failures red and document the tightened LOCAL-7 evidence contract

## Root cause

The TypeScript wrapper previously inherited ambient server configuration while overriding only `DATABASE_URL`. With the server's intentional production default (`DEBUG=false`), importing the DB engine instantiated `Settings` and rejected the placeholder production secrets before the probe could issue its first query.

Because server Settings keys are case-insensitive, merely adding uppercase child overrides was insufficient: an inherited lowercase alias such as `debug=false` could still win. The child builder now removes case-insensitive collisions for every owned posture key, telemetry alias, and database URL before adding the bounded canonical values.

LOCAL-7 also accepted any successful row for the actor/namespace/tool within the lookback window. A historical row or a visible call from another worker could therefore satisfy the audit assertion without proving the just-completed harness call.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- `pnpm -C tests/release test` — 1,172 passed
- focused integration probe/orchestration tests — 22 passed
- `pnpm -C tests/release typecheck`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- offline reproduction: the legacy `DATABASE_URL`-only process failed in `Settings()` on the JWT-secret validator before SQL
- offline repaired-path proof: with simultaneous hostile upper/lowercase production, telemetry, background-worker, qualification-identity, and database aliases plus an intentionally unreachable loopback DSN, the actual TypeScript wrapper reached SQLAlchemy's query path and preserved `ConnectionRefusedError` (no provider call or live secret)
- earlier-head Greptile findings covered: exact signal-kill diagnostics, contradictory-success rejection, and end-to-end correlation threading

## Residual risk

The probe process still inherits unrelated ambient operational variables for `uv` compatibility. A malformed recognized server setting outside the probe-owned posture can fail the cell red before SQL, but cannot create evidence or turn a provider/query failure green. The audit schema has no session id; exact correlation therefore relies on the fresh per-cell worker grant plus sequential cell execution, both enforced by the current LOCAL-7 collector.
