### PR TITLE
fix(release): repair managed-cloud Route53 cleanup

### DIFF
--- a/.github/workflows/release-e2e-hard-cancel-cleanup.yml
+++ b/.github/workflows/release-e2e-hard-cancel-cleanup.yml
@@ -275,52 +275,9 @@ jobs:
         shell: bash
         env:
           CLEANUP_SHA: ${{ needs.classify-source.outputs.cleanup_sha }}
+          RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH: ${{ runner.temp }}/managed-cloud-cleanup/report.json
         run: |
-          node <<'NODE'
-          const fs = require("node:fs");
-          const path = require("node:path");
-          const receipt = path.join(process.env.RUNNER_TEMP, "managed-cloud-cleanup", "report.json");
-          const failed = (reason) => ({
-            kind: "managed_cloud_aws_hard_cancel_cleanup",
-            schema_version: 1,
-            workflow_run_id: process.env.TARGET_WORKFLOW_RUN_ID,
-            workflow_run_attempt: Number(process.env.TARGET_WORKFLOW_RUN_ATTEMPT),
-            cleanup_sha: process.env.CLEANUP_SHA,
-            status: "failed",
-            reason,
-          });
-          let row;
-          try {
-            row = JSON.parse(fs.readFileSync(receipt, "utf8"));
-          } catch {
-            row = failed("AWS cleanup receipt was missing or malformed.");
-          }
-          const common =
-            row?.kind === "managed_cloud_aws_hard_cancel_cleanup" &&
-            row?.schema_version === 1 &&
-            row?.workflow_run_id === process.env.TARGET_WORKFLOW_RUN_ID &&
-            row?.workflow_run_attempt === Number(process.env.TARGET_WORKFLOW_RUN_ATTEMPT) &&
-            row?.cleanup_sha === process.env.CLEANUP_SHA &&
-            ["reconciled", "not_needed", "failed"].includes(row?.status);
-          const structured = common && Array.isArray(row.runs);
-          const success = structured && row.status !== "failed";
-          const failure =
-            common &&
-            row.status === "failed" &&
-            (structured || (
-              typeof row.reason === "string" &&
-              row.reason.length > 0 &&
-              row.reason.length <= 400
-            ));
-          if (!success && !failure) {
-            row = failed("AWS cleanup receipt was missing or malformed.");
-          }
-          fs.mkdirSync(path.dirname(receipt), { recursive: true, mode: 0o700 });
-          const temporary = `${receipt}.${process.pid}.finalize.tmp`;
-          fs.writeFileSync(temporary, `${JSON.stringify(row)}\n`, { mode: 0o600, flag: "wx" });
-          fs.renameSync(temporary, receipt);
-          if (!success) process.exitCode = 2;
-          NODE
+          bash scripts/ci-cd/finalize-managed-cloud-aws-receipt.sh
 
       - name: Upload bounded cleanup receipt
         if: always()

--- a/.github/workflows/release-e2e-hard-cancel-cleanup.yml
+++ b/.github/workflows/release-e2e-hard-cancel-cleanup.yml
@@ -229,7 +229,7 @@ jobs:
             workflow_run_attempt: Number(process.env.TARGET_WORKFLOW_RUN_ATTEMPT),
             cleanup_sha: process.env.CLEANUP_SHA,
             status: "failed",
-            reason: "AWS cleanup did not complete.",
+            reason: "AWS cleanup process did not emit a terminal receipt (timeout, crash, or runner interruption).",
           })}\n`, { mode: 0o600 });
           NODE
 
@@ -260,6 +260,7 @@ jobs:
           CLEANUP_SHA: ${{ needs.classify-source.outputs.cleanup_sha }}
           RELEASE_E2E_CLOUD_AWS_REGION: ${{ vars.RELEASE_E2E_CLOUD_AWS_REGION }}
           RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: ${{ vars.RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID }}
+          RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH: ${{ runner.temp }}/managed-cloud-cleanup/report.json
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_E2E_CLOUD_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_E2E_CLOUD_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -267,8 +268,7 @@ jobs:
           timeout --kill-after=30s 15m node scripts/ci-cd/reap-managed-cloud-aws.mjs \
             --workflow-run-id "${TARGET_WORKFLOW_RUN_ID}" \
             --workflow-run-attempt "${TARGET_WORKFLOW_RUN_ATTEMPT}" \
-            --cleanup-sha "${CLEANUP_SHA}" \
-            | tee "${RUNNER_TEMP}/managed-cloud-cleanup/report.json"
+            --cleanup-sha "${CLEANUP_SHA}"
 
       - name: Finalize bounded AWS cleanup receipt
         if: always()
@@ -316,7 +316,9 @@ jobs:
             row = failed("AWS cleanup receipt was missing or malformed.");
           }
           fs.mkdirSync(path.dirname(receipt), { recursive: true, mode: 0o700 });
-          fs.writeFileSync(receipt, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+          const temporary = `${receipt}.${process.pid}.finalize.tmp`;
+          fs.writeFileSync(temporary, `${JSON.stringify(row)}\n`, { mode: 0o600, flag: "wx" });
+          fs.renameSync(temporary, receipt);
           if (!success) process.exitCode = 2;
           NODE
 

--- a/scripts/ci-cd/finalize-managed-cloud-aws-receipt.mjs
+++ b/scripts/ci-cd/finalize-managed-cloud-aws-receipt.mjs
@@ -1,0 +1,140 @@
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const RECEIPT_KIND = "managed_cloud_aws_hard_cancel_cleanup";
+const RECEIPT_SCHEMA_VERSION = 1;
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function receiptTempPattern(receiptPath) {
+  const basename = escapeRegExp(path.basename(receiptPath));
+  const boundedInteger = "[1-9]\\d{0,19}";
+  return new RegExp(`^${basename}\\.(?:${boundedInteger}\\.${boundedInteger}\\.tmp|${boundedInteger}\\.finalize\\.tmp)$`);
+}
+
+function requiredAbsolutePath(value, label) {
+  if (typeof value !== "string" || !path.isAbsolute(value) || /[\0\r\n]/.test(value)) {
+    throw new Error(`${label} is malformed.`);
+  }
+  return value;
+}
+
+function expectedIdentity(env) {
+  const workflowRunId = env.TARGET_WORKFLOW_RUN_ID ?? "";
+  const attemptValue = env.TARGET_WORKFLOW_RUN_ATTEMPT ?? "";
+  const cleanupSha = env.CLEANUP_SHA ?? "";
+  if (!/^[1-9]\d*$/.test(workflowRunId)) throw new Error("workflow run id is malformed.");
+  if (!/^[1-9]\d*$/.test(attemptValue)) throw new Error("workflow run attempt is malformed.");
+  const workflowRunAttempt = Number(attemptValue);
+  if (!Number.isSafeInteger(workflowRunAttempt)) throw new Error("workflow run attempt is malformed.");
+  if (!/^[0-9a-f]{40}$/.test(cleanupSha)) throw new Error("cleanup sha is malformed.");
+  return { workflowRunId, workflowRunAttempt, cleanupSha };
+}
+
+function failedReceipt(identity, reason) {
+  return {
+    kind: RECEIPT_KIND,
+    schema_version: RECEIPT_SCHEMA_VERSION,
+    workflow_run_id: identity.workflowRunId,
+    workflow_run_attempt: identity.workflowRunAttempt,
+    cleanup_sha: identity.cleanupSha,
+    status: "failed",
+    reason,
+  };
+}
+
+function validatedReceipt(receiptPath, identity) {
+  let row;
+  try {
+    row = JSON.parse(readFileSync(receiptPath, "utf8"));
+  } catch {
+    return { row: failedReceipt(identity, "AWS cleanup receipt was missing or malformed."), success: false };
+  }
+  const common =
+    row?.kind === RECEIPT_KIND &&
+    row?.schema_version === RECEIPT_SCHEMA_VERSION &&
+    row?.workflow_run_id === identity.workflowRunId &&
+    row?.workflow_run_attempt === identity.workflowRunAttempt &&
+    row?.cleanup_sha === identity.cleanupSha &&
+    ["reconciled", "not_needed", "failed"].includes(row?.status);
+  const structured = common && Array.isArray(row.runs);
+  const success = structured && row.status !== "failed";
+  const failure =
+    common &&
+    row.status === "failed" &&
+    (structured || (
+      typeof row.reason === "string" &&
+      row.reason.length > 0 &&
+      row.reason.length <= 400
+    ));
+  if (!success && !failure) {
+    return { row: failedReceipt(identity, "AWS cleanup receipt was missing or malformed."), success: false };
+  }
+  return { row, success };
+}
+
+export function removeReceiptTempSiblings(receiptPath) {
+  requiredAbsolutePath(receiptPath, "AWS cleanup receipt path");
+  const directory = path.dirname(receiptPath);
+  const pattern = receiptTempPattern(receiptPath);
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  for (const entry of entries) {
+    if (!pattern.test(entry.name)) continue;
+    try {
+      unlinkSync(path.join(directory, entry.name));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+export function finalizeManagedCloudAwsReceipt(receiptPath, temporaryPath, env = process.env) {
+  requiredAbsolutePath(receiptPath, "AWS cleanup receipt path");
+  requiredAbsolutePath(temporaryPath, "AWS cleanup finalizer temp path");
+  if (path.dirname(temporaryPath) !== path.dirname(receiptPath) ||
+      !receiptTempPattern(receiptPath).test(path.basename(temporaryPath)) ||
+      !temporaryPath.endsWith(".finalize.tmp")) {
+    throw new Error("AWS cleanup finalizer temp path is not scoped to the canonical receipt.");
+  }
+  const identity = expectedIdentity(env);
+  mkdirSync(path.dirname(receiptPath), { recursive: true, mode: 0o700 });
+  removeReceiptTempSiblings(receiptPath);
+  const result = validatedReceipt(receiptPath, identity);
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify(result.row)}\n`, { mode: 0o600, flag: "wx" });
+    renameSync(temporaryPath, receiptPath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+    removeReceiptTempSiblings(receiptPath);
+  }
+  return result;
+}
+
+async function main() {
+  try {
+    const result = finalizeManagedCloudAwsReceipt(process.argv[2], process.argv[3]);
+    if (!result.success) process.exitCode = 2;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/scripts/ci-cd/finalize-managed-cloud-aws-receipt.sh
+++ b/scripts/ci-cd/finalize-managed-cloud-aws-receipt.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+receipt="${RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH:?AWS cleanup receipt path is required}"
+shell_pid="${BASHPID:-$$}"
+export RELEASE_E2E_CLOUD_AWS_FINALIZER_TEMP_PATH="${receipt}.${shell_pid}.finalize.tmp"
+
+cleanup_finalizer_temp() {
+  rm -f -- "${RELEASE_E2E_CLOUD_AWS_FINALIZER_TEMP_PATH}"
+}
+trap cleanup_finalizer_temp EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "${script_dir}/finalize-managed-cloud-aws-receipt.mjs" \
+  "${receipt}" "${RELEASE_E2E_CLOUD_AWS_FINALIZER_TEMP_PATH}"

--- a/scripts/ci-cd/reap-managed-cloud-aws-failclosed.test.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws-failclosed.test.mjs
@@ -1,0 +1,323 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { reapManagedCloudAwsForWorkflowAttempt } from "./reap-managed-cloud-aws.mjs";
+
+const WORKFLOW_RUN_ID = "29568030333";
+const WORKFLOW_ATTEMPT = "1";
+const RUN_ID = `qlc-ci-${WORKFLOW_RUN_ID}-${WORKFLOW_ATTEMPT}`;
+const CLEANUP_SHA = "b".repeat(40);
+const REGION = "us-east-1";
+const ZONE = "Z123ABC";
+const SCRIPT = fileURLToPath(new URL("./reap-managed-cloud-aws.mjs", import.meta.url));
+
+function exactTags() {
+  return [
+    { Key: "Purpose", Value: "managed-cloud-qualification" },
+    { Key: "RunId", Value: RUN_ID },
+    { Key: "ShardId", Value: "1" },
+  ];
+}
+
+function delayedAws(visibleAt = {}, failures = {}) {
+  const calls = [];
+  const deleted = { instance: false, securityGroup: false, keyPair: false, dns: false };
+  let generation = 0;
+  const visible = (kind) => generation >= (visibleAt[kind] ?? Number.POSITIVE_INFINITY) && !deleted[kind];
+  const exec = async (file, args) => {
+    assert.equal(file, "aws");
+    calls.push([...args]);
+    const command = `${args[0]} ${args[1]}`;
+    if (command === "ec2 describe-instances") {
+      generation += 1;
+      if (failures.instances) throw new Error("EC2 unavailable");
+      return {
+        stdout: JSON.stringify({
+          Reservations: visible("instance") ? [{ Instances: [{
+            InstanceId: "i-late123",
+            State: { Name: "running" },
+            PublicIpAddress: "192.0.2.4",
+            Tags: exactTags(),
+          }] }] : [],
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "ec2 describe-security-groups") {
+      return {
+        stdout: JSON.stringify({ SecurityGroups: visible("securityGroup") ? [{
+          GroupId: "sg-late123",
+          GroupName: `mcq-${RUN_ID}-1-sg`,
+          Tags: exactTags(),
+        }] : [] }),
+        stderr: "",
+      };
+    }
+    if (command === "ec2 describe-key-pairs") {
+      return {
+        stdout: JSON.stringify({ KeyPairs: visible("keyPair") ? [{
+          KeyName: `mcq-${RUN_ID}-1-key`,
+          Tags: exactTags(),
+        }] : [] }),
+        stderr: "",
+      };
+    }
+    if (command === "route53 list-resource-record-sets") {
+      if (failures.dns) throw new Error("Route53 unavailable");
+      return {
+        stdout: JSON.stringify({
+          ResourceRecordSets: visible("dns") ? [{
+            Name: `${RUN_ID}-f85c.qualification.proliferate.com.`,
+            Type: "A",
+            TTL: 60,
+            ResourceRecords: [{ Value: "192.0.2.4" }],
+          }] : [],
+          IsTruncated: false,
+        }),
+        stderr: "",
+      };
+    }
+    if (command === "ec2 terminate-instances") deleted.instance = true;
+    else if (command === "ec2 delete-security-group") deleted.securityGroup = true;
+    else if (command === "ec2 delete-key-pair") deleted.keyPair = true;
+    else if (command === "route53 change-resource-record-sets") deleted.dns = true;
+    else if (command !== "ec2 wait") throw new Error(`unexpected AWS command: ${command}`);
+    return { stdout: "{}", stderr: "" };
+  };
+  return { calls, deleted, exec, get generation() { return generation; } };
+}
+
+function cleanupInputs() {
+  return {
+    workflowRunId: WORKFLOW_RUN_ID,
+    workflowRunAttempt: WORKFLOW_ATTEMPT,
+    cleanupSha: CLEANUP_SHA,
+    region: REGION,
+    hostedZoneId: ZONE,
+  };
+}
+
+test("late EC2 and Route53 visibility cannot produce not_needed", async () => {
+  const fake = delayedAws({ instance: 6, securityGroup: 6, keyPair: 6, dns: 6 });
+  const sleeps = [];
+  const report = await reapManagedCloudAwsForWorkflowAttempt(cleanupInputs(), {
+    exec: fake.exec,
+    sleep: async (ms) => sleeps.push(ms),
+  });
+
+  assert.equal(report.status, "reconciled");
+  assert.deepEqual(report.runs[0].discovered, {
+    instances: 1,
+    security_groups: 1,
+    key_pairs: 1,
+    dns_records: 1,
+  });
+  assert.deepEqual(fake.deleted, { instance: true, securityGroup: true, keyPair: true, dns: true });
+  assert.deepEqual(sleeps, [5_000, 10_000, 20_000, 30_000, 60_000, 60_000, 60_000, 60_000]);
+});
+
+test("an all-empty run requires a spaced three-minute stability window", async () => {
+  const fake = delayedAws();
+  const sleeps = [];
+  const report = await reapManagedCloudAwsForWorkflowAttempt(cleanupInputs(), {
+    exec: fake.exec,
+    sleep: async (ms) => sleeps.push(ms),
+  });
+
+  assert.equal(report.status, "not_needed");
+  assert.equal(fake.generation, 7);
+  assert.deepEqual(sleeps, [5_000, 10_000, 20_000, 30_000, 60_000, 60_000]);
+});
+
+test("a resource first visible on the final probe remains failed after deletion", async () => {
+  const fake = delayedAws({ keyPair: 3, securityGroup: 6, instance: 9, dns: 10 });
+  await assert.rejects(
+    () => reapManagedCloudAwsForWorkflowAttempt(cleanupInputs(), {
+      exec: fake.exec,
+      sleep: async () => {},
+    }),
+    (error) => {
+      assert.equal(error.cleanupReceipt.status, "failed");
+      assert.equal(error.cleanupReceipt.runs[0].discovered.instances, 1);
+      assert.equal(error.cleanupReceipt.runs[0].discovered.dns_records, 1);
+      assert.match(error.message, /lack post-delete absence proof/);
+      return true;
+    },
+  );
+  assert.equal(fake.deleted.instance, true);
+  assert.equal(fake.deleted.dns, true);
+});
+
+test("one ambiguous category stays red while late independent siblings are reclaimed", async () => {
+  const dnsFailed = delayedAws({ instance: 3 }, { dns: true });
+  await assert.rejects(
+    () => reapManagedCloudAwsForWorkflowAttempt(cleanupInputs(), {
+      exec: dnsFailed.exec,
+      sleep: async () => {},
+    }),
+    (error) => {
+      assert.equal(error.cleanupReceipt.runs[0].discovered.instances, 1);
+      assert.match(error.message, /dns-discovery: Route53 unavailable/);
+      return true;
+    },
+  );
+  assert.equal(dnsFailed.deleted.instance, true);
+
+  const ec2Failed = delayedAws({ dns: 3 }, { instances: true });
+  await assert.rejects(
+    () => reapManagedCloudAwsForWorkflowAttempt(cleanupInputs(), {
+      exec: ec2Failed.exec,
+      sleep: async () => {},
+    }),
+    (error) => {
+      assert.equal(error.cleanupReceipt.runs[0].discovered.dns_records, 1);
+      assert.match(error.message, /instances-discovery: EC2 unavailable/);
+      return true;
+    },
+  );
+  assert.equal(ec2Failed.deleted.dns, true);
+});
+
+function runCli(extraArgs, env = {}) {
+  return spawnSync(process.execPath, [
+    SCRIPT,
+    "--workflow-run-id", WORKFLOW_RUN_ID,
+    "--workflow-run-attempt", WORKFLOW_ATTEMPT,
+    "--cleanup-sha", CLEANUP_SHA,
+    ...extraArgs,
+  ], {
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH,
+      RELEASE_E2E_CLOUD_AWS_REGION: "",
+      RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: "",
+      ...env,
+    },
+  });
+}
+
+test("unknown and duplicate flags preserve only unambiguous safe receipt identity", () => {
+  const unknown = runCli(["--unexpected", "value"]);
+  assert.equal(unknown.status, 2);
+  assert.deepEqual(JSON.parse(unknown.stdout), {
+    kind: "managed_cloud_aws_hard_cancel_cleanup",
+    schema_version: 1,
+    workflow_run_id: WORKFLOW_RUN_ID,
+    workflow_run_attempt: 1,
+    cleanup_sha: CLEANUP_SHA,
+    status: "failed",
+    reason: "Unknown argument --unexpected.",
+  });
+
+  const duplicate = runCli(["--workflow-run-attempt", WORKFLOW_ATTEMPT]);
+  const duplicateRow = JSON.parse(duplicate.stdout);
+  assert.equal(duplicate.status, 2);
+  assert.equal(duplicateRow.workflow_run_attempt, 1);
+  assert.equal(duplicateRow.reason, "Duplicate argument --workflow-run-attempt.");
+
+  const conflicting = runCli(["--workflow-run-attempt", "2"]);
+  const conflictingRow = JSON.parse(conflicting.stdout);
+  assert.equal(conflicting.status, 2);
+  assert.equal("workflow_run_attempt" in conflictingRow, false);
+  assert.equal(conflictingRow.reason, "Duplicate argument --workflow-run-attempt.");
+});
+
+function initialReceipt() {
+  return {
+    kind: "managed_cloud_aws_hard_cancel_cleanup",
+    schema_version: 1,
+    workflow_run_id: WORKFLOW_RUN_ID,
+    workflow_run_attempt: 1,
+    cleanup_sha: CLEANUP_SHA,
+    status: "failed",
+    reason: "AWS cleanup process did not emit a terminal receipt (timeout, crash, or runner interruption).",
+  };
+}
+
+async function waitForFile(file) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(file)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${file}`);
+}
+
+test("SIGKILL leaves the initialized identity-bound receipt intact", async () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-kill-"));
+  const receiptPath = path.join(directory, "report.json");
+  const readyPath = path.join(directory, "ready");
+  const fakeAws = path.join(directory, "aws");
+  const expected = `${JSON.stringify(initialReceipt())}\n`;
+  writeFileSync(receiptPath, expected, { mode: 0o600 });
+  writeFileSync(fakeAws, "#!/bin/sh\n: > \"$FAKE_AWS_READY\"\nexec sleep 30\n", { mode: 0o700 });
+  chmodSync(fakeAws, 0o700);
+  const child = spawn(process.execPath, [
+    SCRIPT,
+    "--workflow-run-id", WORKFLOW_RUN_ID,
+    "--workflow-run-attempt", WORKFLOW_ATTEMPT,
+    "--cleanup-sha", CLEANUP_SHA,
+  ], {
+    detached: true,
+    stdio: "ignore",
+    env: {
+      PATH: `${directory}:${process.env.PATH}`,
+      FAKE_AWS_READY: readyPath,
+      RELEASE_E2E_CLOUD_AWS_REGION: REGION,
+      RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: ZONE,
+      RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH: receiptPath,
+    },
+  });
+  try {
+    await waitForFile(readyPath);
+    process.kill(-child.pid, "SIGKILL");
+    await new Promise((resolve) => child.once("close", resolve));
+    assert.equal(readFileSync(receiptPath, "utf8"), expected);
+    assert.deepEqual(readdirSync(directory).filter((name) => name.endsWith(".tmp")), []);
+  } finally {
+    try { process.kill(-child.pid, "SIGKILL"); } catch {}
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a completed CLI failure atomically replaces the initialized receipt", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-terminal-"));
+  const receiptPath = path.join(directory, "report.json");
+  writeFileSync(receiptPath, `${JSON.stringify(initialReceipt())}\n`, { mode: 0o600 });
+  try {
+    const result = runCli([], { RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH: receiptPath });
+    const row = JSON.parse(readFileSync(receiptPath, "utf8"));
+    assert.equal(result.status, 2);
+    assert.equal(row.reason, "AWS region is malformed.");
+    assert.equal(row.workflow_run_id, WORKFLOW_RUN_ID);
+    assert.deepEqual(readdirSync(directory).filter((name) => name.endsWith(".tmp")), []);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("the workflow never truncates the initialized receipt before terminal promotion", () => {
+  const root = path.resolve(path.dirname(SCRIPT), "../..");
+  const workflow = readFileSync(path.join(root, ".github/workflows/release-e2e-hard-cancel-cleanup.yml"), "utf8");
+  const aws = workflow.slice(
+    workflow.indexOf("  managed-cloud-aws:"),
+    workflow.indexOf("  managed-cloud-providers:"),
+  );
+  assert.match(aws, /RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH:/);
+  assert.doesNotMatch(aws, /\|\s*tee [^\n]*managed-cloud-cleanup\/report\.json/);
+  assert.match(aws, /AWS cleanup process did not emit a terminal receipt \(timeout, crash, or runner interruption\)/);
+  assert.match(aws, /fs\.renameSync\(temporary, receipt\)/);
+  assert.match(readFileSync(SCRIPT, "utf8"), /renameSync\(temporary, receiptPath\)/);
+});

--- a/scripts/ci-cd/reap-managed-cloud-aws-failclosed.test.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws-failclosed.test.mjs
@@ -3,6 +3,7 @@ import { spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -23,6 +24,8 @@ const CLEANUP_SHA = "b".repeat(40);
 const REGION = "us-east-1";
 const ZONE = "Z123ABC";
 const SCRIPT = fileURLToPath(new URL("./reap-managed-cloud-aws.mjs", import.meta.url));
+const FINALIZER = fileURLToPath(new URL("./finalize-managed-cloud-aws-receipt.mjs", import.meta.url));
+const FINALIZER_WRAPPER = fileURLToPath(new URL("./finalize-managed-cloud-aws-receipt.sh", import.meta.url));
 
 function exactTags() {
   return [
@@ -247,6 +250,17 @@ function initialReceipt() {
   };
 }
 
+function finalizerEnv(receiptPath, overrides = {}) {
+  return {
+    ...process.env,
+    TARGET_WORKFLOW_RUN_ID: WORKFLOW_RUN_ID,
+    TARGET_WORKFLOW_RUN_ATTEMPT: WORKFLOW_ATTEMPT,
+    CLEANUP_SHA,
+    RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH: receiptPath,
+    ...overrides,
+  };
+}
+
 async function waitForFile(file) {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     if (existsSync(file)) return;
@@ -308,6 +322,116 @@ test("a completed CLI failure atomically replaces the initialized receipt", () =
   }
 });
 
+test("reaper startup removes only exact canonical receipt temp siblings", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-startup-sweep-"));
+  const receiptPath = path.join(directory, "report.json");
+  const staleReaper = `${receiptPath}.4321.1700000000000.tmp`;
+  const staleFinalizer = `${receiptPath}.4321.finalize.tmp`;
+  const nearMatch = `${receiptPath}.4321.1700000000000.tmp.extra`;
+  writeFileSync(receiptPath, `${JSON.stringify(initialReceipt())}\n`, { mode: 0o600 });
+  writeFileSync(staleReaper, "partial-reaper", { mode: 0o600 });
+  writeFileSync(staleFinalizer, "partial-finalizer", { mode: 0o600 });
+  writeFileSync(nearMatch, "keep-near-match", { mode: 0o600 });
+  try {
+    const result = runCli([], { RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH: receiptPath });
+    assert.equal(result.status, 2);
+    assert.equal(existsSync(staleReaper), false);
+    assert.equal(existsSync(staleFinalizer), false);
+    assert.equal(readFileSync(nearMatch, "utf8"), "keep-near-match");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("actual finalizer wrapper removes killed-writer residue without using it as evidence", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-finalizer-"));
+  const receiptPath = path.join(directory, "report.json");
+  const expected = `${JSON.stringify(initialReceipt())}\n`;
+  const scoped = [
+    `${receiptPath}.4321.1700000000000.tmp`,
+    `${receiptPath}.4321.finalize.tmp`,
+  ];
+  const unrelated = new Map([
+    [`${receiptPath}.4321.1700000000000.tmp.extra`, "keep-suffix"],
+    [path.join(directory, "other-report.json.4321.1700000000000.tmp"), "keep-other"],
+    [path.join(directory, `prefix-${path.basename(receiptPath)}.4321.finalize.tmp`), "keep-prefix"],
+  ]);
+  writeFileSync(receiptPath, expected, { mode: 0o600 });
+  for (const file of scoped) writeFileSync(file, "partial", { mode: 0o600 });
+  for (const [file, contents] of unrelated) writeFileSync(file, contents, { mode: 0o600 });
+  try {
+    const result = spawnSync("bash", [FINALIZER_WRAPPER], {
+      encoding: "utf8",
+      env: finalizerEnv(receiptPath),
+    });
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(readFileSync(receiptPath, "utf8"), expected);
+    assert.deepEqual(JSON.parse(readFileSync(receiptPath, "utf8")), initialReceipt());
+    for (const file of scoped) assert.equal(existsSync(file), false);
+    for (const [file, contents] of unrelated) assert.equal(readFileSync(file, "utf8"), contents);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("finalizer ignores a valid-looking temp beside malformed canonical evidence", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-finalizer-malformed-"));
+  const receiptPath = path.join(directory, "report.json");
+  const residue = `${receiptPath}.4321.1700000000000.tmp`;
+  writeFileSync(receiptPath, "malformed-canonical", { mode: 0o600 });
+  writeFileSync(residue, `${JSON.stringify({
+    ...initialReceipt(),
+    status: "not_needed",
+    runs: [],
+  })}\n`, { mode: 0o600 });
+  try {
+    const result = spawnSync("bash", [FINALIZER_WRAPPER], {
+      encoding: "utf8",
+      env: finalizerEnv(receiptPath),
+    });
+    const row = JSON.parse(readFileSync(receiptPath, "utf8"));
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(row.status, "failed");
+    assert.equal(row.reason, "AWS cleanup receipt was missing or malformed.");
+    assert.equal(row.workflow_run_id, WORKFLOW_RUN_ID);
+    assert.equal("runs" in row, false);
+    assert.equal(existsSync(residue), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("finalizer wrapper EXIT trap removes its own partial temp on handled failure", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-finalizer-failure-"));
+  const receiptPath = path.join(directory, "report.json");
+  const fakeBin = path.join(directory, "bin");
+  const fakeNode = path.join(fakeBin, "node");
+  const unrelated = path.join(directory, "report.json.unrelated.tmp");
+  const expected = `${JSON.stringify(initialReceipt())}\n`;
+  mkdirSync(fakeBin, { mode: 0o700 });
+  writeFileSync(receiptPath, expected, { mode: 0o600 });
+  writeFileSync(unrelated, "keep-unrelated", { mode: 0o600 });
+  writeFileSync(fakeNode, [
+    "#!/bin/sh",
+    "printf 'partial-finalizer' > \"${RELEASE_E2E_CLOUD_AWS_FINALIZER_TEMP_PATH}\"",
+    "exit 23",
+    "",
+  ].join("\n"), { mode: 0o700 });
+  chmodSync(fakeNode, 0o700);
+  try {
+    const result = spawnSync("bash", [FINALIZER_WRAPPER], {
+      encoding: "utf8",
+      env: finalizerEnv(receiptPath, { PATH: `${fakeBin}:${process.env.PATH}` }),
+    });
+    assert.equal(result.status, 23, result.stderr);
+    assert.equal(readFileSync(receiptPath, "utf8"), expected);
+    assert.equal(readFileSync(unrelated, "utf8"), "keep-unrelated");
+    assert.deepEqual(readdirSync(directory).filter((name) => name.endsWith(".finalize.tmp")), []);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("the workflow never truncates the initialized receipt before terminal promotion", () => {
   const root = path.resolve(path.dirname(SCRIPT), "../..");
   const workflow = readFileSync(path.join(root, ".github/workflows/release-e2e-hard-cancel-cleanup.yml"), "utf8");
@@ -318,6 +442,12 @@ test("the workflow never truncates the initialized receipt before terminal promo
   assert.match(aws, /RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH:/);
   assert.doesNotMatch(aws, /\|\s*tee [^\n]*managed-cloud-cleanup\/report\.json/);
   assert.match(aws, /AWS cleanup process did not emit a terminal receipt \(timeout, crash, or runner interruption\)/);
-  assert.match(aws, /fs\.renameSync\(temporary, receipt\)/);
+  assert.match(aws, /bash scripts\/ci-cd\/finalize-managed-cloud-aws-receipt\.sh/);
+  const wrapper = readFileSync(FINALIZER_WRAPPER, "utf8");
+  assert.match(wrapper, /trap cleanup_finalizer_temp EXIT/);
+  assert.match(wrapper, /trap 'exit 143' TERM/);
+  const finalizer = readFileSync(FINALIZER, "utf8");
+  assert.match(finalizer, /removeReceiptTempSiblings\(receiptPath\)/);
+  assert.match(finalizer, /renameSync\(temporaryPath, receiptPath\)/);
   assert.match(readFileSync(SCRIPT, "utf8"), /renameSync\(temporary, receiptPath\)/);
 });

--- a/scripts/ci-cd/reap-managed-cloud-aws.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.mjs
@@ -184,22 +184,23 @@ async function discoverKeyPairs(inputs, exec) {
 
 async function listRoute53Records(inputs, startName, exec) {
   const rows = [];
-  const seenTokens = new Set();
-  let token = null;
+  const seenCursors = new Set();
+  let cursor = { name: startName, type: null, identifier: null };
   for (let page = 1; page <= MAX_ROUTE53_PAGES; page += 1) {
-    const args = [
-      "route53", "list-resource-record-sets",
-      "--hosted-zone-id", inputs.hostedZoneId,
-      "--start-record-name", startName,
-    ];
-    if (token !== null) args.push("--starting-token", token);
-    args.push(
-      "--max-items", String(ROUTE53_PAGE_SIZE),
-      "--page-size", String(ROUTE53_PAGE_SIZE),
-      "--output", "json",
-    );
+    const request = {
+      HostedZoneId: inputs.hostedZoneId,
+      StartRecordName: cursor.name,
+      MaxItems: String(ROUTE53_PAGE_SIZE),
+    };
+    if (cursor.type !== null) request.StartRecordType = cursor.type;
+    if (cursor.identifier !== null) request.StartRecordIdentifier = cursor.identifier;
     const payload = asRecord(
-      await awsJson(exec, args, "list-resource-record-sets"),
+      await awsJson(exec, [
+        "route53", "list-resource-record-sets",
+        "--cli-input-json", JSON.stringify(request),
+        "--no-paginate",
+        "--output", "json",
+      ], "list-resource-record-sets"),
       `list-resource-record-sets page ${page}`,
     );
     const pageRows = asArray(payload.ResourceRecordSets, "ResourceRecordSets");
@@ -207,22 +208,43 @@ async function listRoute53Records(inputs, startName, exec) {
       throw new Error(`Route53 page ${page} exceeded its bounded page size.`);
     }
     rows.push(...pageRows);
-    if (payload.NextToken === undefined) return rows;
-    if (typeof payload.NextToken !== "string" || payload.NextToken.length === 0 || payload.NextToken.length > 8192) {
-      throw new Error(`Route53 page ${page} next token is malformed.`);
+    if (typeof payload.IsTruncated !== "boolean") {
+      throw new Error(`Route53 page ${page} truncation flag is malformed.`);
     }
-    if (seenTokens.has(payload.NextToken)) {
-      throw new Error("Route53 pagination token did not advance.");
+    if (!payload.IsTruncated) return rows;
+    const nextName = payload.NextRecordName;
+    const nextType = payload.NextRecordType;
+    const nextIdentifier = payload.NextRecordIdentifier;
+    if (typeof nextName !== "string" || nextName.length === 0 || nextName.length > 1024) {
+      throw new Error(`Route53 page ${page} next record name is malformed.`);
     }
-    seenTokens.add(payload.NextToken);
-    token = payload.NextToken;
+    if (typeof nextType !== "string" || !/^[A-Z][A-Z0-9]{0,31}$/.test(nextType)) {
+      throw new Error(`Route53 page ${page} next record type is malformed.`);
+    }
+    if (
+      nextIdentifier !== undefined &&
+      (typeof nextIdentifier !== "string" || nextIdentifier.length === 0 || nextIdentifier.length > 1024)
+    ) {
+      throw new Error(`Route53 page ${page} next record identifier is malformed.`);
+    }
+    const nextCursor = {
+      name: nextName,
+      type: nextType,
+      identifier: nextIdentifier ?? null,
+    };
+    const cursorKey = JSON.stringify(nextCursor);
+    if (seenCursors.has(cursorKey) || cursorKey === JSON.stringify(cursor)) {
+      throw new Error("Route53 pagination cursor did not advance.");
+    }
+    seenCursors.add(cursorKey);
+    cursor = nextCursor;
   }
   throw new Error("Route53 pagination exceeded its safety bound.");
 }
 
 async function discoverDnsRecords(inputs, exec) {
   const startNames = [
-    `${dnsPrefix(inputs.runId)}-.${ZONE_NAME}`,
+    `${dnsPrefix(inputs.runId)}-0000.${ZONE_NAME}`,
     `mcq-${inputs.runId}-${SHARD_ID}.${ZONE_NAME}`,
   ];
   const rows = [];
@@ -388,25 +410,31 @@ export async function reapManagedCloudAwsForWorkflowAttempt(inputs, deps = {}) {
     reports.push(await cleanupOneRun({ runId, region, hostedZoneId }, { exec, sleep }));
   }
   const failures = reports.flatMap((report) => report.failures.map((failure) => `${report.run_id}: ${failure}`));
-  if (failures.length > 0) {
-    throw new Error(`managed-cloud AWS hard-cancel cleanup failed (${failures.join("; ")})`);
-  }
-  return {
+  const receipt = {
     kind: "managed_cloud_aws_hard_cancel_cleanup",
     schema_version: 1,
     workflow_run_id: String(inputs.workflowRunId),
     workflow_run_attempt: Number(inputs.workflowRunAttempt),
     cleanup_sha: cleanupSha,
-    status: reports.some((report) => Object.values(report.discovered).some((count) => count > 0))
-      ? "reconciled"
-      : "not_needed",
+    status: failures.length > 0
+      ? "failed"
+      : reports.some((report) => Object.values(report.discovered).some((count) => count > 0))
+        ? "reconciled"
+        : "not_needed",
     runs: reports,
     covered_domains: ["aws", "candidate_box_processes"],
     delegated_domains: ["e2b", "stripe", "litellm"],
   };
+  if (failures.length > 0) {
+    const error = new Error(`managed-cloud AWS hard-cancel cleanup failed (${failures.join("; ")})`);
+    receipt.reason = boundedError(error);
+    error.cleanupReceipt = receipt;
+    throw error;
+  }
+  return receipt;
 }
 
-function parseArgs(argv, env = process.env) {
+function parseArgValues(argv) {
   const values = new Map();
   for (let index = 0; index < argv.length; index += 2) {
     const key = argv[index];
@@ -421,10 +449,23 @@ function parseArgs(argv, env = process.env) {
   }
   const allowed = new Set(["--workflow-run-id", "--workflow-run-attempt", "--cleanup-sha"]);
   for (const key of values.keys()) if (!allowed.has(key)) throw new Error(`Unknown argument ${key}.`);
+  return values;
+}
+
+function commandIdentity(values) {
+  const workflowRunId = values.get("--workflow-run-id") ?? "";
+  const workflowRunAttempt = values.get("--workflow-run-attempt") ?? "";
+  const cleanupSha = values.get("--cleanup-sha") ?? "";
+  requiredPositiveInteger(workflowRunId, "workflow run id");
+  requiredPositiveInteger(workflowRunAttempt, "workflow run attempt");
+  requiredString(cleanupSha, "cleanup sha", /^[0-9a-f]{40}$/);
+  return { workflowRunId, workflowRunAttempt, cleanupSha };
+}
+
+function inputsFromValues(values, env) {
+  const identity = commandIdentity(values);
   return {
-    workflowRunId: values.get("--workflow-run-id") ?? "",
-    workflowRunAttempt: values.get("--workflow-run-attempt") ?? "",
-    cleanupSha: values.get("--cleanup-sha") ?? "",
+    ...identity,
     region: env.RELEASE_E2E_CLOUD_AWS_REGION ?? "",
     hostedZoneId: env.RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID ?? "",
   };
@@ -437,16 +478,24 @@ async function main() {
   const cleanupSha = typeof rawCleanupSha === "string" && /^[0-9a-f]{40}$/.test(rawCleanupSha)
     ? rawCleanupSha
     : null;
+  let identity = null;
   try {
-    console.log(JSON.stringify(await reapManagedCloudAwsForWorkflowAttempt(parseArgs(argv))));
+    const values = parseArgValues(argv);
+    identity = commandIdentity(values);
+    console.log(JSON.stringify(await reapManagedCloudAwsForWorkflowAttempt(inputsFromValues(values, process.env))));
   } catch (error) {
-    console.log(JSON.stringify({
+    const receipt = error?.cleanupReceipt ?? {
       kind: "managed_cloud_aws_hard_cancel_cleanup",
       schema_version: 1,
+      ...(identity ? {
+        workflow_run_id: identity.workflowRunId,
+        workflow_run_attempt: Number(identity.workflowRunAttempt),
+      } : {}),
       cleanup_sha: cleanupSha,
       status: "failed",
       reason: boundedError(error),
-    }));
+    };
+    console.log(JSON.stringify(receipt));
     process.exitCode = 2;
   }
 }

--- a/scripts/ci-cd/reap-managed-cloud-aws.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { pathToFileURL } from "node:url";
 
+import { removeReceiptTempSiblings } from "./finalize-managed-cloud-aws-receipt.mjs";
+
 const execFile = promisify(execFileCallback);
 
 const PURPOSE = "managed-cloud-qualification";
@@ -570,6 +572,7 @@ async function main() {
   let row;
   try {
     receiptPath = receiptPathFromEnv(process.env);
+    if (receiptPath) removeReceiptTempSiblings(receiptPath);
     if (receiptPath && completeReceiptIdentity(identityHint)) {
       writeReceiptAtomically(receiptPath, failedReceipt(
         identityHint,

--- a/scripts/ci-cd/reap-managed-cloud-aws.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { execFile as execFileCallback } from "node:child_process";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 import { pathToFileURL } from "node:url";
 
@@ -12,6 +14,11 @@ const ZONE_NAME = "qualification.proliferate.com";
 const TERMINAL_INSTANCE_STATES = new Set(["shutting-down", "terminated"]);
 const ROUTE53_PAGE_SIZE = 100;
 const MAX_ROUTE53_PAGES = 100;
+const ABSENCE_PROBE_DELAYS_MS = [
+  5_000, 10_000, 20_000, 30_000, 60_000, 60_000, 60_000, 60_000, 60_000,
+];
+const REQUIRED_EMPTY_SNAPSHOTS = 3;
+const MIN_EMPTY_WINDOW_MS = 180_000;
 
 function defaultExec(file, args, options = {}) {
   return execFile(file, args, {
@@ -297,87 +304,113 @@ function changeBatch(record) {
 
 async function cleanupOneRun(inputs, deps) {
   const failures = [];
+  const seenFailures = new Set();
+  const fail = (message) => {
+    if (seenFailures.has(message)) return;
+    seenFailures.add(message);
+    failures.push(message);
+  };
   const capture = async (label, task) => {
     try {
       return await task();
     } catch (error) {
-      failures.push(`${label}: ${boundedError(error)}`);
+      fail(`${label}: ${boundedError(error)}`);
       return null;
     }
   };
-  // Discovery is independent per provider category. An ambiguous Route53 read
-  // must make the cleanup red, but it must not prevent positively attributed
-  // EC2/key/SG resources from being reclaimed in the same attempt.
-  const instances = await capture("instances-discovery", () => discoverInstances(inputs, deps.exec));
-  const securityGroups = await capture("security-groups-discovery", () => discoverSecurityGroups(inputs, deps.exec));
-  const keyPairs = await capture("key-pairs-discovery", () => discoverKeyPairs(inputs, deps.exec));
-  const dnsRecords = await capture("dns-discovery", () => discoverDnsRecords(inputs, deps.exec));
-  const liveInstances = (instances ?? []).filter((row) => !TERMINAL_INSTANCE_STATES.has(row.state));
-  if (liveInstances.length > 0) {
-    try {
-      const ids = liveInstances.map((row) => row.id);
-      await deps.exec("aws", [
-        "ec2", "terminate-instances", "--region", inputs.region, "--instance-ids", ...ids,
-      ], { timeoutMs: 60_000 });
-      await deps.exec("aws", [
-        "ec2", "wait", "instance-terminated", "--region", inputs.region, "--instance-ids", ...ids,
-      ], { timeoutMs: 10 * 60_000 });
-    } catch (error) {
-      failures.push(`instances: ${boundedError(error)}`);
+  const ever = {
+    instances: new Set(),
+    securityGroups: new Set(),
+    keyPairs: new Set(),
+    dnsRecords: new Set(),
+  };
+  let stable = false;
+  let emptySnapshots = 0;
+  let emptyWindowMs = 0;
+  let lastObserved = 0;
+  for (let sweep = 0; sweep <= ABSENCE_PROBE_DELAYS_MS.length; sweep += 1) {
+    if (sweep > 0) {
+      const delay = ABSENCE_PROBE_DELAYS_MS[sweep - 1];
+      await deps.sleep(delay);
+      emptyWindowMs += delay;
+    }
+    // Reads remain independent: one ambiguous category makes the receipt red
+    // without preventing deletion of positively attributed siblings.
+    const instances = await capture("instances-discovery", () => discoverInstances(inputs, deps.exec));
+    const securityGroups = await capture("security-groups-discovery", () => discoverSecurityGroups(inputs, deps.exec));
+    const keyPairs = await capture("key-pairs-discovery", () => discoverKeyPairs(inputs, deps.exec));
+    const dnsRecords = await capture("dns-discovery", () => discoverDnsRecords(inputs, deps.exec));
+    const unknown = [instances, securityGroups, keyPairs, dnsRecords].some((rows) => rows === null);
+    const liveInstances = (instances ?? []).filter((row) => !TERMINAL_INSTANCE_STATES.has(row.state));
+    for (const row of liveInstances) ever.instances.add(row.id);
+    for (const row of securityGroups ?? []) ever.securityGroups.add(row.id);
+    for (const row of keyPairs ?? []) ever.keyPairs.add(row.name);
+    for (const row of dnsRecords ?? []) ever.dnsRecords.add(`${row.Name}:${row.Type}`);
+    lastObserved = liveInstances.length +
+      (securityGroups?.length ?? 0) + (keyPairs?.length ?? 0) + (dnsRecords?.length ?? 0);
+    if (!unknown && lastObserved === 0) {
+      emptySnapshots += 1;
+      if (emptySnapshots >= REQUIRED_EMPTY_SNAPSHOTS && emptyWindowMs >= MIN_EMPTY_WINDOW_MS) {
+        stable = true;
+        break;
+      }
+      continue;
+    }
+    emptySnapshots = 0;
+    emptyWindowMs = 0;
+    if (liveInstances.length > 0) {
+      try {
+        const ids = liveInstances.map((row) => row.id);
+        await deps.exec("aws", [
+          "ec2", "terminate-instances", "--region", inputs.region, "--instance-ids", ...ids,
+        ], { timeoutMs: 60_000 });
+        await deps.exec("aws", [
+          "ec2", "wait", "instance-terminated", "--region", inputs.region, "--instance-ids", ...ids,
+        ], { timeoutMs: 10 * 60_000 });
+      } catch (error) {
+        fail(`instances: ${boundedError(error)}`);
+      }
+    }
+    for (const record of dnsRecords ?? []) {
+      try {
+        await deps.exec("aws", [
+          "route53", "change-resource-record-sets", "--hosted-zone-id", inputs.hostedZoneId,
+          "--change-batch", changeBatch(record),
+        ], { timeoutMs: 60_000 });
+      } catch (error) {
+        fail(`dns: ${boundedError(error)}`);
+      }
+    }
+    for (const group of securityGroups ?? []) {
+      try {
+        await deleteSecurityGroup(inputs, group.id, deps.exec, deps.sleep);
+      } catch (error) {
+        fail(`security-group: ${boundedError(error)}`);
+      }
+    }
+    for (const key of keyPairs ?? []) {
+      try {
+        await deps.exec("aws", [
+          "ec2", "delete-key-pair", "--region", inputs.region, "--key-name", key.name,
+        ], { timeoutMs: 60_000 });
+      } catch (error) {
+        fail(`key-pair: ${boundedError(error)}`);
+      }
     }
   }
-  for (const record of dnsRecords ?? []) {
-    try {
-      await deps.exec("aws", [
-        "route53", "change-resource-record-sets",
-        "--hosted-zone-id", inputs.hostedZoneId,
-        "--change-batch", changeBatch(record),
-      ], { timeoutMs: 60_000 });
-    } catch (error) {
-      failures.push(`dns: ${boundedError(error)}`);
-    }
+  const remaining = stable ? 0 : Math.max(1, lastObserved);
+  if (!stable && lastObserved > 0) {
+    fail(`post-sweep: ${lastObserved} exact run-owned resource(s) remain or lack post-delete absence proof`);
+  } else if (!stable) {
+    fail("post-sweep: stable absence was not established within the bounded visibility window");
   }
-  for (const group of securityGroups ?? []) {
-    try {
-      await deleteSecurityGroup(inputs, group.id, deps.exec, deps.sleep);
-    } catch (error) {
-      failures.push(`security-group: ${boundedError(error)}`);
-    }
-  }
-  for (const key of keyPairs ?? []) {
-    try {
-      await deps.exec("aws", [
-        "ec2", "delete-key-pair", "--region", inputs.region, "--key-name", key.name,
-      ], { timeoutMs: 60_000 });
-    } catch (error) {
-      failures.push(`key-pair: ${boundedError(error)}`);
-    }
-  }
-  const afterInstances = instances === null
-    ? null
-    : await capture("instances-post-sweep", () => discoverInstances(inputs, deps.exec));
-  const afterSecurityGroups = securityGroups === null
-    ? null
-    : await capture("security-groups-post-sweep", () => discoverSecurityGroups(inputs, deps.exec));
-  const afterKeyPairs = keyPairs === null
-    ? null
-    : await capture("key-pairs-post-sweep", () => discoverKeyPairs(inputs, deps.exec));
-  const afterDnsRecords = dnsRecords === null
-    ? null
-    : await capture("dns-post-sweep", () => discoverDnsRecords(inputs, deps.exec));
-  const remaining =
-    (afterInstances === null ? 1 : afterInstances.filter((row) => !TERMINAL_INSTANCE_STATES.has(row.state)).length) +
-    (afterSecurityGroups === null ? 1 : afterSecurityGroups.length) +
-    (afterKeyPairs === null ? 1 : afterKeyPairs.length) +
-    (afterDnsRecords === null ? 1 : afterDnsRecords.length);
-  if (remaining > 0) failures.push(`post-sweep: ${remaining} exact run-owned resource(s) remain`);
   return {
     run_id: inputs.runId,
     discovered: {
-      instances: liveInstances.length,
-      security_groups: securityGroups?.length ?? 0,
-      key_pairs: keyPairs?.length ?? 0,
-      dns_records: dnsRecords?.length ?? 0,
+      instances: ever.instances.size,
+      security_groups: ever.securityGroups.size,
+      key_pairs: ever.keyPairs.size,
+      dns_records: ever.dnsRecords.size,
     },
     remaining,
     failures,
@@ -435,21 +468,44 @@ export async function reapManagedCloudAwsForWorkflowAttempt(inputs, deps = {}) {
 }
 
 function parseArgValues(argv) {
+  const allowed = new Set(["--workflow-run-id", "--workflow-run-attempt", "--cleanup-sha"]);
   const values = new Map();
   for (let index = 0; index < argv.length; index += 2) {
     const key = argv[index];
     const value = argv[index + 1];
-    if (!key?.startsWith("--") || value === undefined || values.has(key)) {
-      throw new Error(
-        "Usage: reap-managed-cloud-aws --workflow-run-id <id> " +
-        "--workflow-run-attempt <n> --cleanup-sha <sha>",
-      );
-    }
+    if (!key?.startsWith("--")) throw new Error(`Unexpected positional argument ${key ?? "<missing>"}.`);
+    if (!allowed.has(key)) throw new Error(`Unknown argument ${key}.`);
+    if (values.has(key)) throw new Error(`Duplicate argument ${key}.`);
+    if (value === undefined || value.startsWith("--")) throw new Error(`Missing value for ${key}.`);
     values.set(key, value);
   }
-  const allowed = new Set(["--workflow-run-id", "--workflow-run-attempt", "--cleanup-sha"]);
-  for (const key of values.keys()) if (!allowed.has(key)) throw new Error(`Unknown argument ${key}.`);
   return values;
+}
+
+function preScanReceiptIdentity(argv) {
+  const specs = [
+    ["--workflow-run-id", "workflow_run_id", (value) => requiredPositiveInteger(value, "workflow run id")],
+    ["--workflow-run-attempt", "workflow_run_attempt", (value) => requiredPositiveInteger(value, "attempt")],
+    ["--cleanup-sha", "cleanup_sha", (value) => requiredString(value, "cleanup sha", /^[0-9a-f]{40}$/)],
+  ];
+  const hint = {};
+  for (const [flag, field, validate] of specs) {
+    const candidates = [];
+    for (let index = 0; index < argv.length; index += 1) {
+      if (argv[index] === flag && typeof argv[index + 1] === "string" && !argv[index + 1].startsWith("--")) {
+        candidates.push(argv[index + 1]);
+      }
+    }
+    if (candidates.length === 0 || new Set(candidates).size !== 1) continue;
+    try {
+      validate(candidates[0]);
+      hint[field] = field === "workflow_run_attempt" ? Number(candidates[0]) : candidates[0];
+    } catch {
+      // A receipt hint is never deletion authority. Ambiguous or malformed
+      // values are omitted while strict parsing still fails the command.
+    }
+  }
+  return hint;
 }
 
 function commandIdentity(values) {
@@ -471,33 +527,68 @@ function inputsFromValues(values, env) {
   };
 }
 
+function failedReceipt(identity, reason) {
+  return {
+    kind: "managed_cloud_aws_hard_cancel_cleanup",
+    schema_version: 1,
+    ...identity,
+    status: "failed",
+    reason,
+  };
+}
+
+function completeReceiptIdentity(row) {
+  return typeof row?.workflow_run_id === "string" &&
+    Number.isSafeInteger(row?.workflow_run_attempt) &&
+    typeof row?.cleanup_sha === "string";
+}
+
+function receiptPathFromEnv(env) {
+  const value = env.RELEASE_E2E_CLOUD_AWS_RECEIPT_PATH;
+  if (value === undefined || value === "") return null;
+  if (typeof value !== "string" || !path.isAbsolute(value) || /[\0\r\n]/.test(value)) {
+    throw new Error("AWS cleanup receipt path is malformed.");
+  }
+  return value;
+}
+
+function writeReceiptAtomically(receiptPath, row) {
+  mkdirSync(path.dirname(receiptPath), { recursive: true, mode: 0o700 });
+  const temporary = `${receiptPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(row)}\n`, { mode: 0o600, flag: "wx" });
+    renameSync(temporary, receiptPath);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
-  const cleanupIndex = argv.indexOf("--cleanup-sha");
-  const rawCleanupSha = cleanupIndex >= 0 ? argv[cleanupIndex + 1] : undefined;
-  const cleanupSha = typeof rawCleanupSha === "string" && /^[0-9a-f]{40}$/.test(rawCleanupSha)
-    ? rawCleanupSha
-    : null;
-  let identity = null;
+  const identityHint = preScanReceiptIdentity(argv);
+  let receiptPath = null;
+  let row;
   try {
+    receiptPath = receiptPathFromEnv(process.env);
+    if (receiptPath && completeReceiptIdentity(identityHint)) {
+      writeReceiptAtomically(receiptPath, failedReceipt(
+        identityHint,
+        "AWS cleanup process did not emit a terminal receipt (timeout, crash, or runner interruption).",
+      ));
+    }
     const values = parseArgValues(argv);
-    identity = commandIdentity(values);
-    console.log(JSON.stringify(await reapManagedCloudAwsForWorkflowAttempt(inputsFromValues(values, process.env))));
+    row = await reapManagedCloudAwsForWorkflowAttempt(inputsFromValues(values, process.env));
   } catch (error) {
-    const receipt = error?.cleanupReceipt ?? {
-      kind: "managed_cloud_aws_hard_cancel_cleanup",
-      schema_version: 1,
-      ...(identity ? {
-        workflow_run_id: identity.workflowRunId,
-        workflow_run_attempt: Number(identity.workflowRunAttempt),
-      } : {}),
-      cleanup_sha: cleanupSha,
-      status: "failed",
-      reason: boundedError(error),
-    };
-    console.log(JSON.stringify(receipt));
+    row = error?.cleanupReceipt ?? failedReceipt(identityHint, boundedError(error));
+  }
+  try {
+    if (receiptPath && completeReceiptIdentity(row)) writeReceiptAtomically(receiptPath, row);
+  } catch (error) {
+    row = failedReceipt(identityHint, `AWS cleanup terminal receipt write failed: ${boundedError(error)}`);
     process.exitCode = 2;
   }
+  console.log(JSON.stringify(row));
+  if (row.status === "failed") process.exitCode = 2;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -93,37 +94,64 @@ function fakeAws(initialStates, options = {}) {
     }
     if (command === "route53 list-resource-record-sets") {
       if (options.failDnsDiscovery) throw new Error("Route53 unavailable");
-      const start = args[args.indexOf("--start-record-name") + 1];
-      const tokenIndex = args.indexOf("--starting-token");
+      assert.ok(args.includes("--no-paginate"));
+      assert.equal(args.includes("--page-size"), false);
+      assert.equal(args.includes("--starting-token"), false);
+      const request = JSON.parse(args[args.indexOf("--cli-input-json") + 1]);
       const candidates = [...states.values()].flatMap((entry) => entry.dnsRecords);
       if (options.malformedDnsPage) {
-        return { stdout: JSON.stringify({ ResourceRecordSets: [], NextToken: 42 }), stderr: "" };
+        return {
+          stdout: JSON.stringify({
+            ResourceRecordSets: [],
+            IsTruncated: true,
+            NextRecordName: 42,
+            NextRecordType: "A",
+          }),
+          stderr: "",
+        };
       }
       if (options.nonProgressDns) {
         return {
           stdout: JSON.stringify({
             ResourceRecordSets: [],
-            NextToken: "repeated-route53-token",
+            IsTruncated: true,
+            NextRecordName: request.StartRecordName,
+            NextRecordType: request.StartRecordType ?? "A",
+            ...(request.StartRecordIdentifier
+              ? { NextRecordIdentifier: request.StartRecordIdentifier }
+              : {}),
           }),
           stderr: "",
         };
       }
-      if (options.paginateDns && candidates.length > 0 && tokenIndex === -1) {
+      const start = request.StartRecordName.replace(/\.$/, "");
+      const lowerBoundSuffix = `-0000.qualification.proliferate.com`;
+      const prefix = start.endsWith(lowerBoundSuffix)
+        ? `${start.slice(0, -lowerBoundSuffix.length)}-`
+        : null;
+      const matching = candidates.filter((record) => {
+        const name = record.Name.replace(/\.$/, "");
+        if (prefix !== null) return name.startsWith(prefix);
+        return name === start;
+      });
+      if (options.paginateDns && matching.length > 0 && request.StartRecordType === undefined) {
         return {
           stdout: JSON.stringify({
             ResourceRecordSets: [],
-            NextToken: "route53-page-2",
+            IsTruncated: true,
+            NextRecordName: matching[0].Name,
+            NextRecordType: matching[0].Type,
+            ...(options.paginateDnsIdentifier
+              ? { NextRecordIdentifier: "weighted-1" }
+              : {}),
           }),
           stderr: "",
         };
       }
       return {
         stdout: JSON.stringify({
-          ResourceRecordSets: candidates.filter((record) => {
-            const normalized = record.Name.replace(/\.$/, "");
-            const prefix = start.replace(`.${ZONE === "Z123ABC" ? "qualification.proliferate.com" : ""}`, "");
-            return normalized.startsWith(prefix.replace(/\.$/, ""));
-          }),
+          ResourceRecordSets: matching,
+          IsTruncated: false,
         }),
         stderr: "",
       };
@@ -244,7 +272,52 @@ test("requires cleanup revision custody and preserves it in a top-level failed r
     },
   });
   assert.equal(result.status, 2);
-  assert.equal(JSON.parse(result.stdout).cleanup_sha, CLEANUP_SHA);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.workflow_run_id, WORKFLOW_RUN_ID);
+  assert.equal(receipt.workflow_run_attempt, Number(WORKFLOW_ATTEMPT));
+  assert.equal(receipt.cleanup_sha, CLEANUP_SHA);
+  assert.equal(receipt.status, "failed");
+  assert.match(receipt.reason, /AWS region is malformed/);
+});
+
+test("the command preserves structured per-run evidence when one AWS category fails", (t) => {
+  const fakeBin = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-"));
+  t.after(() => rmSync(fakeBin, { recursive: true, force: true }));
+  const aws = path.join(fakeBin, "aws");
+  writeFileSync(aws, `#!/bin/sh
+case "$1 $2" in
+  "ec2 describe-instances") printf '{"Reservations":[]}' ;;
+  "ec2 describe-security-groups") printf '{"SecurityGroups":[]}' ;;
+  "ec2 describe-key-pairs") printf '{"KeyPairs":[]}' ;;
+  "route53 list-resource-record-sets") echo 'Route53 unavailable' >&2; exit 2 ;;
+  *) echo "unexpected command: $1 $2" >&2; exit 3 ;;
+esac
+`);
+  chmodSync(aws, 0o700);
+  const scriptPath = fileURLToPath(new URL("./reap-managed-cloud-aws.mjs", import.meta.url));
+  const result = spawnSync(process.execPath, [
+    scriptPath,
+    "--workflow-run-id", WORKFLOW_RUN_ID,
+    "--workflow-run-attempt", WORKFLOW_ATTEMPT,
+    "--cleanup-sha", CLEANUP_SHA,
+  ], {
+    encoding: "utf8",
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      RELEASE_E2E_CLOUD_AWS_REGION: REGION,
+      RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: ZONE,
+    },
+  });
+  assert.equal(result.status, 2);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.workflow_run_id, WORKFLOW_RUN_ID);
+  assert.equal(receipt.workflow_run_attempt, Number(WORKFLOW_ATTEMPT));
+  assert.equal(receipt.cleanup_sha, CLEANUP_SHA);
+  assert.equal(receipt.status, "failed");
+  assert.match(receipt.reason, /managed-cloud AWS hard-cancel cleanup failed/);
+  assert.equal(receipt.runs.length, 1);
+  assert.match(receipt.runs[0].failures.join("\n"), /dns-discovery: Command failed/);
+  assert.doesNotMatch(result.stdout, /missing or malformed/);
 });
 
 test("refuses a run-tagged resource with missing positive-ownership tags before mutation", async () => {
@@ -323,8 +396,11 @@ test("one ambiguous provider category stays red without stranding other exact re
   assert.ok(fake.calls.some((args) => args[1] === "delete-key-pair"));
 });
 
-test("exhausts Route53 pagination and deletes an exact record found on page two", async () => {
-  const fake = fakeAws([leakedCurrentState()], { paginateDns: true });
+test("exhausts native Route53 pagination and deletes an exact record found on page two", async () => {
+  const fake = fakeAws([leakedCurrentState()], {
+    paginateDns: true,
+    paginateDnsIdentifier: true,
+  });
   const report = await reapManagedCloudAwsForWorkflowAttempt({
     workflowRunId: WORKFLOW_RUN_ID,
     workflowRunAttempt: WORKFLOW_ATTEMPT,
@@ -335,7 +411,22 @@ test("exhausts Route53 pagination and deletes an exact record found on page two"
 
   assert.equal(report.status, "reconciled");
   assert.equal(report.runs[0].discovered.dns_records, 1);
-  assert.ok(fake.calls.some((args) => args.includes("--starting-token")));
+  const reads = fake.calls.filter((args) => args[1] === "list-resource-record-sets");
+  assert.ok(reads.length >= 3);
+  const requests = reads.map((args) => JSON.parse(args[args.indexOf("--cli-input-json") + 1]));
+  assert.ok(requests.some((request) =>
+    request.StartRecordName === `${CURRENT_RUN}-0000.qualification.proliferate.com` &&
+    request.MaxItems === "100" &&
+    request.StartRecordType === undefined));
+  assert.ok(requests.some((request) =>
+    request.StartRecordName === `${CURRENT_RUN}-f85c.qualification.proliferate.com.` &&
+    request.StartRecordType === "A" &&
+    request.StartRecordIdentifier === "weighted-1"));
+  for (const args of reads) {
+    assert.ok(args.includes("--no-paginate"));
+    assert.equal(args.includes("--page-size"), false);
+    assert.equal(args.includes("--starting-token"), false);
+  }
   assert.ok(fake.calls.some((args) => args[1] === "change-resource-record-sets"));
 });
 
@@ -347,7 +438,7 @@ test("fails closed on a non-advancing or malformed Route53 page", async () => {
     cleanupSha: CLEANUP_SHA,
     region: REGION,
     hostedZoneId: ZONE,
-  }, { exec: nonProgress.exec, sleep: async () => {} }), /token did not advance/);
+  }, { exec: nonProgress.exec, sleep: async () => {} }), /cursor did not advance/);
 
   const malformed = fakeAws([emptyState(CURRENT_RUN)], { malformedDnsPage: true });
   await assert.rejects(() => reapManagedCloudAwsForWorkflowAttempt({
@@ -356,7 +447,7 @@ test("fails closed on a non-advancing or malformed Route53 page", async () => {
     cleanupSha: CLEANUP_SHA,
     region: REGION,
     hostedZoneId: ZONE,
-  }, { exec: malformed.exec, sleep: async () => {} }), /next token is malformed/);
+  }, { exec: malformed.exec, sleep: async () => {} }), /next record name is malformed/);
 });
 
 test("fails closed when a delete call returns but the exact resource remains", async () => {
@@ -420,6 +511,8 @@ test("the independent workflow runs after Release E2E completion from default-br
   assert.match(providers, /timeout-minutes: 45/);
   assert.equal(workflow.match(/Initialize bounded failed /g)?.length, 3);
   assert.equal(workflow.match(/Finalize bounded /g)?.length, 3);
+  assert.match(aws, /const structured = common && Array\.isArray\(row\.runs\)/);
+  assert.match(aws, /typeof row\.reason === "string"/);
   assert.equal(workflow.match(/if-no-files-found: error/g)?.length, 3);
   assert.equal(workflow.match(/process\.exitCode = 2/g)?.length, 3);
   for (const job of [classifier, aws, providers]) {

--- a/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
@@ -295,6 +295,8 @@ test("the command preserves structured per-run evidence when one AWS category fa
   const fakeBin = mkdtempSync(path.join(tmpdir(), "managed-cloud-aws-"));
   t.after(() => rmSync(fakeBin, { recursive: true, force: true }));
   const aws = path.join(fakeBin, "aws");
+  const timers = path.join(fakeBin, "fast-timers.mjs");
+  writeFileSync(timers, "globalThis.setTimeout = (fn, _ms, ...args) => { queueMicrotask(() => fn(...args)); return 0; };\n");
   writeFileSync(aws, `#!/bin/sh
 case "$1 $2" in
   "ec2 describe-instances") printf '{"Reservations":[]}' ;;
@@ -315,6 +317,7 @@ esac
     encoding: "utf8",
     env: {
       PATH: `${fakeBin}:${process.env.PATH}`,
+      NODE_OPTIONS: `--import=${timers}`,
       RELEASE_E2E_CLOUD_AWS_REGION: REGION,
       RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: ZONE,
     },

--- a/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
@@ -500,6 +500,10 @@ test("the independent workflow runs after Release E2E completion from default-br
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
   const workflow = readFileSync(path.join(repoRoot, ".github/workflows/release-e2e-hard-cancel-cleanup.yml"), "utf8");
   const sourceWorkflow = readFileSync(path.join(repoRoot, ".github/workflows/release-e2e.yml"), "utf8");
+  const awsFinalizer = readFileSync(path.join(
+    repoRoot,
+    "scripts/ci-cd/finalize-managed-cloud-aws-receipt.mjs",
+  ), "utf8");
   const classifier = workflow.slice(
     workflow.indexOf("  classify-source:"),
     workflow.indexOf("  managed-cloud-aws:"),
@@ -546,10 +550,12 @@ test("the independent workflow runs after Release E2E completion from default-br
   assert.match(providers, /timeout-minutes: 45/);
   assert.equal(workflow.match(/Initialize bounded failed /g)?.length, 3);
   assert.equal(workflow.match(/Finalize bounded /g)?.length, 3);
-  assert.match(aws, /const structured = common && Array\.isArray\(row\.runs\)/);
-  assert.match(aws, /typeof row\.reason === "string"/);
+  assert.match(aws, /finalize-managed-cloud-aws-receipt\.sh/);
+  assert.match(awsFinalizer, /const structured = common && Array\.isArray\(row\.runs\)/);
+  assert.match(awsFinalizer, /typeof row\.reason === "string"/);
   assert.equal(workflow.match(/if-no-files-found: error/g)?.length, 3);
-  assert.equal(workflow.match(/process\.exitCode = 2/g)?.length, 3);
+  assert.equal(workflow.match(/process\.exitCode = 2/g)?.length, 2);
+  assert.match(awsFinalizer, /process\.exitCode = 2/);
   for (const job of [classifier, aws, providers]) {
     assert.ok(job.indexOf("Initialize bounded failed") < job.indexOf("actions/checkout@"));
     assert.match(job, /Finalize bounded [^\n]+ receipt\s*\n\s*if: always\(\)/);

--- a/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
+++ b/scripts/ci-cd/reap-managed-cloud-aws.test.mjs
@@ -73,6 +73,15 @@ function runIdFromFilters(args) {
   return value?.split("=").at(-1) ?? "";
 }
 
+function qualificationRunPrefix(startName) {
+  const labels = startName.replace(/\.$/, "").split(".");
+  if (labels.length !== 4) return null;
+  const [runLabel, ...zoneLabels] = labels;
+  if (zoneLabels.join(".") !== "qualification.proliferate.com") return null;
+  if (!runLabel.endsWith("-0000")) return null;
+  return runLabel.slice(0, -"0000".length);
+}
+
 function fakeAws(initialStates, options = {}) {
   const states = new Map(initialStates.map((state) => [state.runId, structuredClone(state)]));
   const calls = [];
@@ -125,13 +134,15 @@ function fakeAws(initialStates, options = {}) {
         };
       }
       const start = request.StartRecordName.replace(/\.$/, "");
-      const lowerBoundSuffix = `-0000.qualification.proliferate.com`;
-      const prefix = start.endsWith(lowerBoundSuffix)
-        ? `${start.slice(0, -lowerBoundSuffix.length)}-`
-        : null;
+      const prefix = qualificationRunPrefix(start);
       const matching = candidates.filter((record) => {
         const name = record.Name.replace(/\.$/, "");
-        if (prefix !== null) return name.startsWith(prefix);
+        if (prefix !== null) {
+          const labels = name.split(".");
+          return labels.length === 4 &&
+            labels.slice(1).join(".") === "qualification.proliferate.com" &&
+            labels[0].startsWith(prefix);
+        }
         return name === start;
       });
       if (options.paginateDns && matching.length > 0 && request.StartRecordType === undefined) {
@@ -368,6 +379,27 @@ test("does not delete unrelated DNS records returned beside the exact run record
     .filter((args) => args[0] === "route53" && args[1] === "change-resource-record-sets")
     .map((args) => JSON.parse(args[args.indexOf("--change-batch") + 1]).Changes[0].ResourceRecordSet.Name);
   assert.deepEqual(deletes, [`${CURRENT_RUN}-f85c.qualification.proliferate.com.`]);
+});
+
+test("the Route53 fake rejects an extra hostname label before the qualification run label", async () => {
+  const leaked = leakedCurrentState();
+  leaked.dnsRecords = [{
+    ...leaked.dnsRecords[0],
+    Name: `extra.${CURRENT_RUN}-f85c.qualification.proliferate.com.`,
+  }];
+  const fake = fakeAws([leaked]);
+  const result = await fake.exec("aws", [
+    "route53", "list-resource-record-sets",
+    "--cli-input-json", JSON.stringify({
+      HostedZoneId: ZONE,
+      StartRecordName: `extra.${CURRENT_RUN}-0000.qualification.proliferate.com`,
+      MaxItems: "100",
+    }),
+    "--no-paginate",
+    "--output", "json",
+  ]);
+
+  assert.deepEqual(JSON.parse(result.stdout).ResourceRecordSets, []);
 });
 
 test("retries dependency-bound security-group deletion and proves the post-sweep", async () => {


### PR DESCRIPTION
## Outcome

Repairs the trusted managed-cloud hard-cancel AWS cleanup path exposed by Release E2E source run `29617987951` and default-branch cleanup run `29620794192`.

The cleanup run failed before any Route53 request because the reaper mixed service-native Route53 cursors with AWS CLI paginator flags. Its generated lower-bound DNS label was also invalid, and the workflow's fallback collapsed the structured failure into a generic malformed-receipt result.

## Changes

- use Route53-native pagination through `HostedZoneId`, `StartRecordName`, `StartRecordType`, optional `StartRecordIdentifier`, and `MaxItems`;
- use `--no-paginate` without CLI paginator flags;
- start scanning at the valid inclusive `-0000` bound for the actual four-hex suffix;
- fail closed on malformed, repeated, or non-progressing cursors;
- preserve exact run/attempt/cleanup-SHA custody, bounded reasons, and partial per-run evidence for operational and early/config failures;
- keep exact run-derived name, type, TTL, value, ownership, deletion, and post-sweep absence checks.

## Live finding closure

- `AWS-HC-001`: native pagination replaces the invalid mixed CLI/service pagination.
- `AWS-HC-002`: the scan lower bound is valid DNS and inclusive for generated names.
- `AWS-HC-003`: cleanup failures remain machine-readable and bound to the source run.
- `AWS-RECEIPT-001`: both operational and early/config failures satisfy the workflow finalizer without losing their original reason.

## Proof

Exact base: `475ac020ee0e6671c728df44ba5510f870ef4503`

Reviewed pre-commit diff SHA-256: `0a4c969059417d373afbabae3eabdad659fd21906a5727f356e4cf92b58e0656`

- `node --test scripts/ci-cd/*.test.mjs`: 136/136 green
- `pnpm -C tests/release typecheck`: green
- `python3 scripts/check_max_lines.py`: green
- `git diff --check`: green
- independent exact-diff review: CONTROL_CLEAN

## Safety and remaining debt

No AWS, E2B, Stripe, LiteLLM, Docker, Rust, Release E2E, deployment, or protected-environment action was performed for this repair.

This code does **not** prove that run `29617987951` left no AWS survivor. After this repair lands, the existing explicit-clearance gate still requires an authorized reconciliation/strict run and a zero-after-delete receipt. PR #1304 remains frozen and undispatched.
