### PR TITLE
fix(release): configure local worker API base URL

### DIFF
--- a/tests/release/src/worlds/local-workspace/world.test.ts
+++ b/tests/release/src/worlds/local-workspace/world.test.ts
@@ -181,6 +181,18 @@ test("constructLocalWorld runs the ordered startup and returns a ready handle", 
     assert.ok(cp, "expected a docker cp of the setup token");
     assert.equal(cp!.at(-1), path.join(runDir, "setup-token"));
 
+    // T3-INT-1's host Worker needs the candidate Server's host-mapped origin
+    // for enrollment and integration-gateway calls. Without it the Server
+    // rejects every /v1/cloud/worker/enroll as cloud_worker_misconfigured.
+    const serverRun = h.argv.find(
+      (cmd) => cmd[0] === "docker" && cmd.includes("--name") && cmd.some((arg) => arg.endsWith("-server")),
+    );
+    assert.ok(serverRun, "expected the candidate Server docker run");
+    assert.ok(
+      serverRun!.includes(`API_BASE_URL=http://127.0.0.1:${PORTS.server}`),
+      "expected Server env to publish the host-reachable API base URL",
+    );
+
     // A fresh actor enrolled for cleanup, then a full green teardown.
     await world.trackActorSubjects!({
       userId: "u1",

--- a/tests/release/src/worlds/local-workspace/world.ts
+++ b/tests/release/src/worlds/local-workspace/world.ts
@@ -271,7 +271,12 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
     // Steps 3–6: run-scoped Docker network + Postgres + Redis + migrations +
     // Server (gateway enabled, SINGLE_ORG_MODE, short backfill interval).
     const naming = dockerNaming(options.run.run_id, options.run.shard_id);
-    const serverEnv = buildServerEnv(naming, options.litellm, options.ports.renderer);
+    const serverEnv = buildServerEnv(
+      naming,
+      options.litellm,
+      options.ports.renderer,
+      options.ports.server,
+    );
     const setupTokenHostPath = path.join(worldRoot, SETUP_TOKEN_FILENAME);
     const server = await startDockerStack({
       naming,
@@ -415,6 +420,7 @@ function buildServerEnv(
   naming: DockerNaming,
   litellm: QualificationLiteLlmConfig,
   rendererPort: number,
+  serverPort: number,
 ): ServerContainerEnv {
   const { databaseUrl, redisUrl } = dockerInternalUrls(naming);
   return {
@@ -443,6 +449,10 @@ function buildServerEnv(
     SETUP_TOKEN_FILE: SERVER_SETUP_TOKEN_CONTAINER_PATH,
     DATABASE_URL: databaseUrl,
     REDBEAT_REDIS_URL: redisUrl,
+    // The candidate Server publishes this origin into local Worker and
+    // integration-gateway configuration. The Worker runs on the host, so use
+    // the Server container's host-mapped port rather than its Docker hostname.
+    API_BASE_URL: `http://127.0.0.1:${serverPort}`,
   };
 }
 


### PR DESCRIPTION
## Summary

- publish the candidate local Server origin through `API_BASE_URL`
- use the run-scoped host port that the host Worker can reach
- lock the Server container environment into the local-world unit test

## Root cause

The local Tier-3 world started the candidate Server without either supported Worker base URL setting. The Server therefore failed closed with `cloud_worker_misconfigured` when the T3-INT-1 integration Worker enrolled, before the Product-MCP turn could run.

## Validation

- `pnpm --dir tests/release exec tsx --test src/worlds/local-workspace/world.test.ts` (5/5 passed)
- `pnpm --dir tests/release typecheck`
- `git diff --check`

Closes #1314
