### PR TITLE
fix(auth): map Google token rejections

### DIFF
--- a/server/proliferate/auth/identity/providers.py
+++ b/server/proliferate/auth/identity/providers.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 import httpx
 from fastapi import HTTPException, Request, status
 from httpx_oauth.exceptions import GetIdEmailError
+from httpx_oauth.oauth2 import GetAccessTokenError
 from jose import JWTError, jwt
 
 from proliferate.auth.identity.routing import auth_route_path_for_base
@@ -27,6 +28,10 @@ GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
 APPLE_AUTHORIZE_URL = "https://appleid.apple.com/auth/authorize"
 APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
 APPLE_ISSUER = "https://appleid.apple.com"
+
+
+class OAuthProviderTokenRejectedError(Exception):
+    """The provider returned a response rejecting an OAuth token exchange."""
 
 
 def parse_scope_string(value: object) -> frozenset[str]:
@@ -170,7 +175,12 @@ async def verify_oauth_callback(
         )
 
     if provider == "google":
-        token = await google_oauth_client.get_access_token(code, provider_callback_url)
+        try:
+            token = await google_oauth_client.get_access_token(code, provider_callback_url)
+        except GetAccessTokenError as exc:
+            if exc.response is None or exc.response.status_code not in {400, 401}:
+                raise
+            raise OAuthProviderTokenRejectedError from exc
         access_token = str(token["access_token"])
         id_token = token.get("id_token")
         if isinstance(id_token, str) and id_token:

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -197,14 +197,21 @@ async def complete_oauth_provider_callback(
         surface=surface,
     )
     callback_surface = surface or challenge.surface
-    verified = await providers.verify_oauth_callback(
-        provider=provider,
-        surface=callback_surface,
-        code=code,
-        provider_callback_url=providers.provider_callback_url(
-            request, provider=provider, surface=callback_surface
-        ),
-    )
+    try:
+        verified = await providers.verify_oauth_callback(
+            provider=provider,
+            surface=callback_surface,
+            code=code,
+            provider_callback_url=providers.provider_callback_url(
+                request, provider=provider, surface=callback_surface
+            ),
+        )
+    except providers.OAuthProviderTokenRejectedError:
+        return append_query(
+            challenge.redirect_uri,
+            error="provider_error",
+            state=challenge.client_state,
+        )
     if callback_surface == "web" and challenge.purpose == "login":
         beta_email = await _beta_email_for_provider_login(db, verified=verified)
         ensure_web_beta_email_allowed(beta_email)

--- a/server/tests/integration/test_auth_oauth_provider_rejection.py
+++ b/server/tests/integration/test_auth_oauth_provider_rejection.py
@@ -1,0 +1,82 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from httpx import AsyncClient, Request, Response
+from httpx_oauth.oauth2 import GetAccessTokenError
+
+from proliferate.auth.oauth import google_oauth_client
+from proliferate.config import settings
+from tests.helpers.desktop_auth import make_pkce_pair
+
+
+@pytest.mark.asyncio
+async def test_web_google_token_rejection_redirects_to_provider_error(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, challenge = make_pkce_pair()
+    monkeypatch.setattr(settings, "google_oauth_client_id", "google-client-id")
+    monkeypatch.setattr(settings, "google_oauth_client_secret", "google-client-secret")
+
+    async def authorization_url(
+        redirect_uri: str,
+        state: str | None = None,
+        scope: list[str] | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+        extras_params: dict[str, str] | None = None,
+    ) -> str:
+        assert redirect_uri.endswith("/auth/web/google/callback")
+        assert state is not None
+        assert scope == ["openid", "email", "profile"]
+        assert code_challenge is None
+        assert code_challenge_method is None
+        assert extras_params is None
+        return f"https://accounts.google.com/o/oauth2/v2/auth?state={state}"
+
+    async def reject_access_token(code: str, redirect_uri: str) -> dict[str, object]:
+        assert code == "google-code"
+        assert redirect_uri.endswith("/auth/web/google/callback")
+        response = Response(
+            status_code=401,
+            request=Request("POST", "https://oauth2.googleapis.com/token"),
+        )
+        raise GetAccessTokenError("Google rejected the token exchange.", response)
+
+    monkeypatch.setattr(google_oauth_client, "get_authorization_url", authorization_url)
+    monkeypatch.setattr(google_oauth_client, "get_access_token", reject_access_token)
+    started = await client.post(
+        "/auth/web/google/start",
+        json={
+            "purpose": "login",
+            "clientState": "google-rejection-state",
+            "codeChallenge": challenge,
+            "codeChallengeMethod": "S256",
+            "redirectUri": "http://localhost:5174/auth/callback",
+        },
+    )
+    assert started.status_code == 200
+    oauth_state = parse_qs(urlparse(started.json()["authorizationUrl"]).query)["state"][0]
+
+    callback = await client.get(
+        "/auth/web/google/callback",
+        params={"code": "google-code", "state": oauth_state},
+        follow_redirects=False,
+    )
+
+    assert callback.status_code == 302
+    parsed = urlparse(callback.headers["location"])
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == (
+        "http://localhost:5174/auth/callback"
+    )
+    callback_query = parse_qs(parsed.query)
+    assert callback_query["error"] == ["provider_error"]
+    assert callback_query["state"] == ["google-rejection-state"]
+
+    replay = await client.get(
+        "/auth/web/google/callback",
+        params={"code": "google-code", "state": oauth_state},
+        follow_redirects=False,
+    )
+    assert replay.status_code == 400
+    assert replay.json()["detail"] == "Invalid or expired auth state."

--- a/server/tests/unit/auth/test_identity.py
+++ b/server/tests/unit/auth/test_identity.py
@@ -1,6 +1,8 @@
 import uuid
 
 import pytest
+from httpx import Request, Response
+from httpx_oauth.oauth2 import GetAccessTokenError
 
 import proliferate.auth.identity.providers as providers
 from proliferate.auth.identity import (
@@ -8,6 +10,7 @@ from proliferate.auth.identity import (
     user_has_product_identity,
     user_has_provider,
 )
+from proliferate.auth.oauth import google_oauth_client
 from proliferate.db.models.auth import OAuthAccount, User
 
 
@@ -47,6 +50,38 @@ def test_github_link_is_product_identity() -> None:
     assert user_has_provider(user, "github") is True
     assert user_has_product_identity(user) is True
     assert onboarding_state_for_user(user) == "active"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [None, 503], ids=["transport", "provider-outage"])
+async def test_google_non_rejection_token_failure_stays_a_server_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int | None,
+) -> None:
+    response = (
+        None
+        if status_code is None
+        else Response(
+            status_code=status_code,
+            request=Request("POST", "https://oauth2.googleapis.com/token"),
+        )
+    )
+    error = GetAccessTokenError("Google token endpoint failed.", response)
+
+    async def fail_access_token(_code: str, _redirect_uri: str) -> dict[str, object]:
+        raise error
+
+    monkeypatch.setattr(google_oauth_client, "get_access_token", fail_access_token)
+
+    with pytest.raises(GetAccessTokenError) as exc_info:
+        await providers.verify_oauth_callback(
+            provider="google",
+            surface="web",
+            code="google-code",
+            provider_callback_url="https://api.example.com/auth/web/google/callback",
+        )
+
+    assert exc_info.value is error
 
 
 @pytest.mark.asyncio

--- a/specs/codebase/systems/product/auth/README.md
+++ b/specs/codebase/systems/product/auth/README.md
@@ -101,6 +101,13 @@ hashes when `PasswordHelper` returns an updated hash.
 
 ## Abuse And Failure Behavior
 
+OAuth provider failures stay visible without turning provider-declared protocol rejections
+into server errors. A provider callback that carries an error returns that error to the
+original client callback. A Google HTTP response rejecting the access-token exchange
+terminates the stored challenge and returns the generic `provider_error` code instead of
+exposing provider response details. Transport failures and provider outages remain server
+failures and are not normalized as provider rejections.
+
 Password login failures must return generic copy:
 
 ```text


### PR DESCRIPTION
## Summary

- redirect Google OAuth token responses that reject the client or grant back to the originating auth surface with `provider_error`
- consume the terminal auth challenge without exposing provider response details
- preserve transport failures and provider outages as real server failures
- document the product auth failure contract

## Root cause

Google token-exchange HTTP rejections escaped the auth provider adapter and became unhandled callback 500s. User cancellation already follows the separate provider-error callback path; the recorded 401 is a provider/client rejection, not evidence of a user cancellation.

## Validation

- `DATABASE_URL=... JWT_SECRET=... CLOUD_SECRET_KEY=... uv --directory server run pytest -q tests/integration/test_auth_oauth_provider_rejection.py tests/unit/auth/test_identity.py` (7 passed)
- `uv --directory server run ruff format --check ...`
- `uv --directory server run ruff check ...`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_docs.py`
- `git diff --check origin/main...HEAD`

Production issue relationship is linked through the tracker.