### PR TITLE
fix(server): commit invitation writes before responding

### DIFF
--- a/server/proliferate/server/organizations/api.py
+++ b/server/proliferate/server/organizations/api.py
@@ -236,7 +236,7 @@ async def resend_organization_invitation_endpoint(
 async def revoke_organization_invitation_endpoint(
     invitation_id: UUID,
     org_admin: CurrentOrgUser = Depends(current_path_org_admin),
-    db: AsyncSession = Depends(get_async_session),
+    db: AsyncSession = Depends(get_async_session, scope="function"),
 ) -> OrganizationInvitationResponse:
     invitation = await revoke_invitation(db, org_admin, invitation_id)
     return invitation_response(invitation)

--- a/server/proliferate/server/organizations/registration_api.py
+++ b/server/proliferate/server/organizations/registration_api.py
@@ -8,11 +8,12 @@ reopens for allowlisted (invited) emails after the instance is claimed.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.auth import PASSWORD_EMAIL_MAX_LENGTH, PASSWORD_MAX_LENGTH
-from proliferate.db.engine import AsyncSessionDep
+from proliferate.db.engine import get_async_session
 from proliferate.server.organizations.self_registration import register_invited_account
 
 router = APIRouter(prefix="/password", tags=["auth"])
@@ -42,7 +43,7 @@ class PasswordRegisterResponse(BaseModel):
 )
 async def register_with_password(
     body: PasswordRegisterRequest,
-    db: AsyncSessionDep,
+    db: AsyncSession = Depends(get_async_session, scope="function"),
 ) -> PasswordRegisterResponse:
     """Create an account for an invited email, joining the instance organization."""
     registration = await register_invited_account(

--- a/server/proliferate/server/organizations/registration_pages.py
+++ b/server/proliferate/server/organizations/registration_pages.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 import html
 from typing import Annotated
 
-from fastapi import APIRouter, Form
+from fastapi import APIRouter, Depends, Form
 from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
-from proliferate.db.engine import AsyncSessionDep
+from proliferate.db.engine import get_async_session
 from proliferate.server.organizations.errors import OrganizationServiceError
 from proliferate.server.organizations.self_registration import register_invited_account
 from proliferate.server.setup.pages import render_page
@@ -93,7 +94,7 @@ async def invited_registration_page(token: str = "", email: str = "") -> HTMLRes
 
 @router.post("/register", response_class=HTMLResponse, include_in_schema=False)
 async def invited_registration_submit(
-    db: AsyncSessionDep,
+    db: AsyncSession = Depends(get_async_session, scope="function"),
     email: Annotated[str, Form()] = "",
     password: Annotated[str, Form()] = "",
     invitation_token: Annotated[str, Form()] = "",

--- a/server/tests/unit/test_registration_page.py
+++ b/server/tests/unit/test_registration_page.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from datetime import timedelta
 from uuid import uuid4
 
+import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.types import Message, Receive, Scope, Send
 
 from proliferate.auth.identity.store import create_auth_user
 from proliferate.auth.passwords import verify_password
@@ -18,6 +21,7 @@ from proliferate.constants.organizations import (
     ORGANIZATION_MEMBERSHIP_STATUS_ACTIVE,
     ORGANIZATION_ROLE_MEMBER,
 )
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.db.models.organizations import OrganizationInvitation, OrganizationMembership
 from proliferate.db.store import organization_invitations as invitation_store
@@ -203,6 +207,72 @@ async def test_register_page_creates_account_and_membership(single_org_client, t
         assert invitation is not None
         assert invitation.status == ORGANIZATION_INVITATION_STATUS_ACCEPTED
         assert invitation.accepted_by_user_id == user.id
+
+
+@pytest.mark.parametrize(
+    ("path", "wire_kind", "expected_status"),
+    [
+        ("/register", "form", 200),
+        ("/auth/password/register", "json", 201),
+    ],
+)
+async def test_registration_commit_finishes_before_response_starts(
+    test_engine,
+    monkeypatch,
+    path: str,
+    wire_kind: str,
+    expected_status: int,
+) -> None:
+    """Both invited-registration surfaces publish only durable success."""
+    from proliferate.db import engine as engine_module
+    from proliferate.main import create_app
+
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+    monkeypatch.setattr(engine_module, "engine", test_engine)
+    monkeypatch.setattr(engine_module, "async_session_factory", _factory(test_engine))
+
+    _, organization_id = await _claim_instance(test_engine)
+    invitation_id = await _invite(test_engine, organization_id)
+    app = create_app()
+    commit_finished = False
+    commit_state_at_response_start: list[bool] = []
+
+    async def observed_session() -> AsyncGenerator[AsyncSession, None]:
+        nonlocal commit_finished
+        async with _factory(test_engine)() as session:
+            yield session
+            await session.commit()
+            commit_finished = True
+
+    app.dependency_overrides[get_async_session] = observed_session
+
+    async def observed_app(scope: Scope, receive: Receive, send: Send) -> None:
+        async def observe_response_start(message: Message) -> None:
+            if message["type"] == "http.response.start" and scope["path"] == path:
+                commit_state_at_response_start.append(commit_finished)
+            await send(message)
+
+        await app(scope, receive, observe_response_start)
+
+    request_kwargs = (
+        {"data": _form(invitation_token=str(invitation_id))}
+        if wire_kind == "form"
+        else {
+            "json": {
+                "email": INVITED_EMAIL,
+                "password": PASSWORD,
+                "invitationToken": str(invitation_id),
+            }
+        }
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=observed_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(path, **request_kwargs)
+
+    assert response.status_code == expected_status
+    assert commit_state_at_response_start == [True]
 
 
 async def test_register_page_wrong_token_rerenders_with_generic_error(

--- a/server/tests/unit/test_self_registration.py
+++ b/server/tests/unit/test_self_registration.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.types import Message, Receive, Scope, Send
 
 from proliferate.auth.identity.store import create_auth_user
 from proliferate.auth.passwords import hash_password, verify_password
@@ -19,6 +21,7 @@ from proliferate.constants.organizations import (
     ORGANIZATION_ROLE_ADMIN,
     ORGANIZATION_ROLE_MEMBER,
 )
+from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.db.models.organizations import OrganizationInvitation, OrganizationMembership
 from proliferate.db.store import organization_invitations as invitation_store
@@ -247,6 +250,103 @@ async def test_revoked_invitation_cannot_register(single_org_client, test_engine
     )
     assert response.status_code == 403
     assert await _count_users(test_engine) == 1
+
+
+async def test_revocation_commit_finishes_before_response_starts(
+    test_engine,
+    monkeypatch,
+) -> None:
+    """A revoked response is durable before another client can observe it."""
+    from proliferate.db import engine as engine_module
+    from proliferate.main import create_app
+
+    monkeypatch.setattr(settings, "single_org_mode_override", True)
+    session_factory = _factory(test_engine)
+    monkeypatch.setattr(engine_module, "engine", test_engine)
+    monkeypatch.setattr(engine_module, "async_session_factory", session_factory)
+
+    owner_id, organization_id = await _claim_instance(test_engine)
+    invited_email = "revoked-member@example.com"
+    invited_password = "another-strong-password"
+    async with session_factory() as session:
+        await update_user_password_hash(
+            session,
+            user_id=owner_id,
+            hashed_password=hash_password(PASSWORD),
+            password_set_at=datetime.now(UTC),
+        )
+        invited_user = await create_auth_user(
+            session,
+            email=invited_email,
+            display_name=None,
+            avatar_url=None,
+        )
+        await update_user_password_hash(
+            session,
+            user_id=invited_user.id,
+            hashed_password=hash_password(invited_password),
+            password_set_at=datetime.now(UTC),
+        )
+        await session.commit()
+    invitation_id = await _invite(test_engine, organization_id, email=invited_email)
+
+    app = create_app()
+    commits_finished = 0
+    commit_count_at_response_start: list[int] = []
+    target_path = f"/v1/organizations/{organization_id}/invitations/{invitation_id}"
+
+    async def observed_session() -> AsyncGenerator[AsyncSession, None]:
+        nonlocal commits_finished
+        async with session_factory() as session:
+            yield session
+            await session.commit()
+            commits_finished += 1
+
+    app.dependency_overrides[get_async_session] = observed_session
+
+    async def observed_app(scope: Scope, receive: Receive, send: Send) -> None:
+        async def observe_response_start(message: Message) -> None:
+            if message["type"] == "http.response.start" and scope["path"] == target_path:
+                commit_count_at_response_start.append(commits_finished)
+            await send(message)
+
+        await app(scope, receive, observe_response_start)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=observed_app),
+        base_url="http://test",
+    ) as client:
+        owner_login = await client.post(
+            "/auth/desktop/password/login",
+            json={"email": OWNER_EMAIL, "password": PASSWORD},
+        )
+        invited_login = await client.post(
+            "/auth/desktop/password/login",
+            json={"email": invited_email, "password": invited_password},
+        )
+        owner_headers = {"Authorization": f"Bearer {owner_login.json()['access_token']}"}
+        invited_headers = {"Authorization": f"Bearer {invited_login.json()['access_token']}"}
+
+        commits_finished = 0
+        revoked = await client.delete(target_path, headers=owner_headers)
+
+        assert revoked.status_code == 200
+        assert revoked.json()["status"] == "revoked"
+        assert commit_count_at_response_start == [1]
+
+        listed = await client.get(
+            "/v1/organizations/invitations/current",
+            headers=invited_headers,
+        )
+        assert listed.status_code == 200
+        assert listed.json()["invitations"] == []
+
+        rejected = await client.post(
+            f"/v1/organizations/invitations/current/{invitation_id}/accept",
+            headers=invited_headers,
+        )
+        assert rejected.status_code == 404
+        assert rejected.json()["detail"]["code"] == "invalid_invitation"
 
 
 async def test_existing_account_registration_conflicts(single_org_client, test_engine):

--- a/specs/codebase/systems/product/organizations/invitations.md
+++ b/specs/codebase/systems/product/organizations/invitations.md
@@ -104,6 +104,12 @@ remains pending and delivery status is `skipped`.
 Admins can also copy the invite link. The copied URL is exactly the same URL
 that email delivery sends.
 
+Successful invited-registration and invitation-revocation responses are
+durability boundaries: their database transaction commits before the response
+starts. An immediate password login, invitation list, or accept attempt must
+therefore observe the registered or revoked state without retrying a
+contradictory product result into success.
+
 ## Global Pending Invites
 
 Pending invitations for the signed-in email should be visible from the


### PR DESCRIPTION
## Summary

- commit invited-account registration before either HTML or JSON success starts streaming
- commit invitation revocation before returning its successful response
- cover both registration surfaces and revocation with ASGI lifecycle regressions, including immediate revoked-list and accept behavior
- document successful registration and revocation responses as durability boundaries

## Root cause

The affected mutation routes used the default request-scoped `get_async_session` yield dependency. FastAPI finalized that dependency only after the response had started, so another request could briefly observe the pre-commit state even after receiving a success response.

This change scopes only the three affected mutation-route sessions to the endpoint function. Their session teardown and commit now finish before `http.response.start`; unrelated read and mutation routes retain the existing dependency behavior.

Before the product change, the deterministic response-lifecycle regressions observed an uncommitted registration at response start for both surfaces and zero completed revoke commits at response start. They pass with the scoped fix.

Closes #1342

## Validation

- `26 passed` — `tests/unit/test_registration_page.py` and `tests/unit/test_self_registration.py`
- focused commit-before-response lifecycle regressions: HTML registration, JSON registration, and revocation
- Ruff lint and format checks for all changed Python files
- server boundary check
- repository max-lines check
- documentation integrity check and its 17 unit tests
- `git diff --check`

No matching open production-tracker issue was found; #1342 is a release-suite issue and this PR contains no customer data.
