### PR TITLE
fix(auth): map rejected GitHub profile callbacks

### DIFF
--- a/server/proliferate/auth/identity/providers.py
+++ b/server/proliferate/auth/identity/providers.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 
 import httpx
 from fastapi import HTTPException, Request, status
-from httpx_oauth.exceptions import GetIdEmailError
+from httpx_oauth.exceptions import GetIdEmailError, GetProfileError
 from jose import JWTError, jwt
 
 from proliferate.auth.identity.routing import auth_route_path_for_base
@@ -27,6 +27,10 @@ GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
 APPLE_AUTHORIZE_URL = "https://appleid.apple.com/auth/authorize"
 APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
 APPLE_ISSUER = "https://appleid.apple.com"
+
+
+class OAuthProviderAuthorizationError(Exception):
+    """The callback grant was rejected while resolving provider identity."""
 
 
 def parse_scope_string(value: object) -> frozenset[str]:
@@ -128,7 +132,12 @@ async def verify_oauth_callback(
             # "Email addresses" permission or the grant predates it. The
             # profile endpoint still identifies the account; the email is
             # recovered below.
-            github_profile = await github_oauth_client.get_profile(access_token)
+            try:
+                github_profile = await github_oauth_client.get_profile(access_token)
+            except GetProfileError as exc:
+                if exc.response is not None and exc.response.status_code == 401:
+                    raise OAuthProviderAuthorizationError from exc
+                raise
             account_id = str(github_profile["id"])
             raw_email = github_profile.get("email")
             account_email = raw_email if isinstance(raw_email, str) and raw_email else None

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -197,14 +197,21 @@ async def complete_oauth_provider_callback(
         surface=surface,
     )
     callback_surface = surface or challenge.surface
-    verified = await providers.verify_oauth_callback(
-        provider=provider,
-        surface=callback_surface,
-        code=code,
-        provider_callback_url=providers.provider_callback_url(
-            request, provider=provider, surface=callback_surface
-        ),
-    )
+    try:
+        verified = await providers.verify_oauth_callback(
+            provider=provider,
+            surface=callback_surface,
+            code=code,
+            provider_callback_url=providers.provider_callback_url(
+                request, provider=provider, surface=callback_surface
+            ),
+        )
+    except providers.OAuthProviderAuthorizationError:
+        return append_query(
+            challenge.redirect_uri,
+            error="provider_error",
+            state=challenge.client_state,
+        )
     if callback_surface == "web" and challenge.purpose == "login":
         beta_email = await _beta_email_for_provider_login(db, verified=verified)
         ensure_web_beta_email_allowed(beta_email)

--- a/server/tests/unit/auth/test_oauth_provider_callback.py
+++ b/server/tests/unit/auth/test_oauth_provider_callback.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import uuid
+from typing import cast
+
+import httpx
+import pytest
+from fastapi import Request
+from httpx_oauth.exceptions import GetIdEmailError, GetProfileError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.identity import providers, service
+from proliferate.auth.identity.types import AuthChallengeSnapshot
+from proliferate.auth.oauth import github_oauth_client
+
+
+def _provider_response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        request=httpx.Request("GET", "https://api.github.test/user"),
+    )
+
+
+def _challenge() -> AuthChallengeSnapshot:
+    return AuthChallengeSnapshot(
+        id=uuid.uuid4(),
+        provider="github",
+        surface="desktop",
+        purpose="login",
+        user_id=None,
+        client_state="desktop-state",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+        redirect_uri="proliferate://auth/callback",
+        nonce_hash="nonce-hash",
+    )
+
+
+def _install_github_profile_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    status_code: int,
+) -> None:
+    async def get_access_token(code: str, redirect_uri: str) -> dict[str, str]:
+        assert code == "github-code"
+        assert redirect_uri == "https://api.example.test/auth/github/callback"
+        return {"access_token": "unusable-token"}
+
+    async def get_id_email(access_token: str) -> tuple[str, str]:
+        assert access_token == "unusable-token"
+        raise GetIdEmailError(response=_provider_response(status_code))
+
+    async def get_profile(access_token: str) -> dict[str, object]:
+        assert access_token == "unusable-token"
+        raise GetProfileError(response=_provider_response(status_code))
+
+    monkeypatch.setattr(github_oauth_client, "get_access_token", get_access_token)
+    monkeypatch.setattr(github_oauth_client, "get_id_email", get_id_email)
+    monkeypatch.setattr(github_oauth_client, "get_profile", get_profile)
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_github_profile_401_returns_to_originating_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    challenge = _challenge()
+
+    async def consume_challenge(
+        _db: object,
+        *,
+        state: str,
+        provider: str,
+        surface: str | None,
+    ) -> AuthChallengeSnapshot:
+        assert state == "oauth-state"
+        assert provider == "github"
+        assert surface is None
+        return challenge
+
+    monkeypatch.setattr(service, "_consume_challenge_for_callback", consume_challenge)
+    monkeypatch.setattr(
+        providers,
+        "provider_callback_url",
+        lambda _request, *, provider, surface: "https://api.example.test/auth/github/callback",
+    )
+    _install_github_profile_failure(monkeypatch, status_code=401)
+
+    redirect_url = await service.complete_oauth_provider_callback(
+        cast(AsyncSession, object()),
+        cast(Request, object()),
+        provider="github",
+        surface=None,
+        state="oauth-state",
+        code="github-code",
+    )
+
+    assert redirect_url == ("proliferate://auth/callback?error=provider_error&state=desktop-state")
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_github_profile_5xx_remains_reportable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_github_profile_failure(monkeypatch, status_code=503)
+
+    with pytest.raises(GetProfileError) as caught:
+        await providers.verify_oauth_callback(
+            provider="github",
+            surface="desktop",
+            code="github-code",
+            provider_callback_url="https://api.example.test/auth/github/callback",
+        )
+
+    assert caught.value.response is not None
+    assert caught.value.response.status_code == 503

--- a/specs/codebase/systems/product/auth/README.md
+++ b/specs/codebase/systems/product/auth/README.md
@@ -71,6 +71,12 @@ Denied web sessions return a stable `403` error code. OAuth callback denials
 redirect back to the web auth error route with the same stable code so the web
 app can render beta-specific copy and point the user to Desktop.
 
+When GitHub rejects a callback grant with `401` while the server resolves the
+provider profile, the consumed challenge returns to its originating surface as
+the existing `provider_error` callback state. That expected unusable-grant path
+does not escape as a server error; non-401 provider profile failures remain
+reportable.
+
 ## Email/Password
 
 Email/password auth is a controlled sign-in method for accounts that already


### PR DESCRIPTION
## Summary

- Return a rejected GitHub profile lookup to the OAuth challenge's originating
  surface as the existing `provider_error` callback state.
- Keep non-401 provider profile failures reportable instead of treating them as
  expected authorization failures.
- Add deterministic callback regressions and document the auth failure contract.

## Root cause

The GitHub identity adapter correctly falls back from the email endpoint to the
readable profile endpoint. When an unusable callback grant was also rejected by
that fallback with `401`, the provider exception escaped as a server error. The
challenge already records the correct client surface, so this expected grant
rejection now completes through that surface's existing provider-error path.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The support relationship is linked through the tracker API. No tracker,
  report, user, or support IDs or private source data appear in this PR.

## Verification

- `DEBUG=true uv run --extra dev pytest -q tests/unit/auth/test_oauth_provider_callback.py`
- `uv run --extra dev ruff check proliferate/auth/identity/providers.py proliferate/auth/identity/service.py tests/unit/auth/test_oauth_provider_callback.py`
- `uv run --extra dev ruff format --check proliferate/auth/identity/providers.py proliferate/auth/identity/service.py tests/unit/auth/test_oauth_provider_callback.py`
- `uv run --extra dev mypy --follow-imports=skip tests/unit/auth/test_oauth_provider_callback.py`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
