### PR TITLE
test(intent): make T2-SH-6 fixture run-scoped

### DIFF
--- a/.github/workflows/intent-tests.yml
+++ b/.github/workflows/intent-tests.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Install Playwright chromium
         run: pnpm -C tests/intent exec playwright install --with-deps chromium
 
+      - name: Run tier-2 fixture unit tests
+        run: pnpm -C tests/intent test:unit
+
       - name: Run tier-2 intent suite
         env:
           # The boot fixture allocates the t2intent profile itself; on the

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -272,6 +272,10 @@ genuinely needs a real agent or sandbox is tier 3, not tier 2.
   the stack once per run and publishes `TIER2_INTENT_*` env vars to every
   worker; you never boot it yourself. The stack runs `SINGLE_ORG_MODE=true`
   with GitHub OAuth env unset (password + first-run claim only).
+  A dedicated server-only posture that must boot separately uses
+  `ownedEphemeralProfileForWorker`: the profile, setup-token path, database,
+  and local state are run/attempt/worker/retry-owned and removed only by that
+  owner. A retry never reuses a claimed profile or consumed setup token.
 - **Seed through the product's own API, not the DB.** Reuse the helpers in
   `stack/seed.ts` (`ensureInstanceClaimed`, `passwordLogin`, `inviteMember`,
   `registerFreshMember`, `getOwnOrganization`, …). Add new helpers there rather

--- a/tests/intent/package.json
+++ b/tests/intent/package.json
@@ -14,7 +14,7 @@
     "test:billing": "playwright test --config playwright.billing.config.ts",
     "test:billing-import": "playwright test --config playwright.billing-import.config.ts",
     "test:sso": "playwright test specs/sso.spec.ts",
-    "test:unit": "tsx --test \"fakes/**/*.test.ts\""
+    "test:unit": "tsx --test \"fakes/**/*.test.ts\" \"stack/**/*.test.ts\""
   },
   "dependencies": {
     "pg": "^8.13.1"

--- a/tests/intent/specs/cloud-provisioning-gating.spec.ts
+++ b/tests/intent/specs/cloud-provisioning-gating.spec.ts
@@ -26,50 +26,25 @@
 // CLOUD_SECRET_KEY to be set to something other than the "CHANGE-ME" defaults
 // (config.py's `validate_secrets_in_production`), so this boot sets those too.
 
-import { readFileSync } from "node:fs";
 import { expect, test } from "@playwright/test";
+import { claimOwnedInstance } from "../stack/claim.ts";
 import { bootStack, type BootedStack } from "../stack/boot.ts";
+import { ownedEphemeralProfileForWorker } from "../stack/ephemeral-profile.ts";
 import { ADMIN_EMAIL, ADMIN_PASSWORD } from "../stack/seed.ts";
-
-async function claimInstance(stack: BootedStack): Promise<void> {
-  const token = readFileSync(stack.setupTokenFile, "utf8").trim();
-  const response = await fetch(`${stack.apiBaseUrl}/setup`, {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      email: ADMIN_EMAIL,
-      password: ADMIN_PASSWORD,
-      setup_token: token,
-      organization_name: "T2 Self-Host Gating",
-    }).toString(),
-  });
-  const html = await response.text();
-  if (response.status !== 200) {
-    throw new Error(`T2-SH-6: instance claim failed (${response.status}): ${html.slice(0, 300)}`);
-  }
-}
-
-async function loginOn(baseUrl: string, email: string, password: string): Promise<string> {
-  const response = await fetch(`${baseUrl}/auth/desktop/password/login`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ email, password }),
-  });
-  const body = (await response.json()) as { access_token?: string };
-  if (response.status !== 200 || !body.access_token) {
-    throw new Error(`T2-SH-6: login failed for ${email} (${response.status}): ${JSON.stringify(body)}`);
-  }
-  return body.access_token;
-}
 
 test.describe("T2-SH-6: cloud-workspace provisioning stays safe when E2B is half-configured", () => {
   test.setTimeout(180_000);
   let stack: BootedStack;
   let ownerToken: string;
 
-  test.beforeAll(async () => {
+  test.beforeAll(async ({}, testInfo) => {
+    const ownedProfile = ownedEphemeralProfileForWorker({
+      namespace: "t2e2bgate",
+      workerIndex: testInfo.workerIndex,
+      retry: testInfo.retry,
+    });
     stack = await bootStack({
-      profile: "t2e2bgate",
+      ownedProfile,
       skipFrontend: true,
       extraServerEnv: {
         DEBUG: "false",
@@ -79,8 +54,18 @@ test.describe("T2-SH-6: cloud-workspace provisioning stays safe when E2B is half
         E2B_TEMPLATE_NAME: "",
       },
     });
-    await claimInstance(stack);
-    ownerToken = await loginOn(stack.apiBaseUrl, ADMIN_EMAIL, ADMIN_PASSWORD);
+    try {
+      ownerToken = await claimOwnedInstance({
+        stack,
+        ownedProfile,
+        email: ADMIN_EMAIL,
+        password: ADMIN_PASSWORD,
+        organizationName: "T2 Self-Host Gating",
+      });
+    } catch (error) {
+      await stack.teardown();
+      throw error;
+    }
   });
 
   test.afterAll(async () => {

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -1,28 +1,21 @@
 // Tier-2 "mocked intent" stack-boot fixture.
 //
-// Boots a real server (FastAPI/uvicorn) + real desktop web frontend (Vite,
-// `apps/desktop` in web-port mode) against a seeded Postgres, on a dedicated,
-// profile-isolated port set. Nothing here fakes the sandbox provider or an
-// LLM (that's the tier-2 rule, see specs/developing/testing/README.md) — the
-// only things faked at this boundary are auth-adjacent externals (mock IdP,
-// email capture, Stripe test mode), and this suite doesn't even need those.
-//
-// Profile name is fixed to `t2intent` per
-// specs/developing/local/dev-profiles.md (one profile per worktree/purpose,
-// never `main`, kept for this suite's lifetime since it owns its own
-// Postgres DB).
-//
-// Reuses the same primitives `make run PROFILE=<name>` uses
-// (scripts/dev.mjs for port/profile allocation, alembic for migrations)
-// rather than shelling out to `make run` itself, because `make run` always
-// launches the Tauri desktop shell — tier 2 needs the desktop **web** build
-// (`pnpm dev` / vite) per specs/developing/testing/scenarios.md's stated
-// convention ("desktop web build (`pnpm dev` on PROLIFERATE_WEB_PORT)").
+// Boots real FastAPI, Vite, and Postgres on profile-isolated ports. It reuses
+// the profile allocator and migrations behind `make run`, but launches Vite
+// directly because Tier 2 needs the Desktop web build, not the Tauri shell.
+// Network neighbors remain fake or absent per specs/developing/testing/README.md.
 
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  assertOwnedProfileResources,
+  cleanupOwnedEphemeralProfile,
+  prepareOwnedEphemeralProfile,
+  setupTokenFileForProfile,
+  type OwnedEphemeralProfile,
+} from "./ephemeral-profile.ts";
 
 export const PROFILE = "t2intent";
 export const BILLING_PROFILE = "t2billing";
@@ -40,6 +33,8 @@ export interface StripeBillingEnv {
 export interface BootOptions {
   /** Profile name to boot under (default: the auth/org `t2intent` profile). */
   profile?: string;
+  /** Fresh run/attempt/worker/retry-owned profile. Mutually exclusive with profile. */
+  ownedProfile?: OwnedEphemeralProfile;
   /** When set, the server boots with Stripe test-mode billing wired: pro
    * billing enabled, `CLOUD_BILLING_MODE` (default `enforce`), and the Stripe
    * test keys/prices. Used only by the billing suite. */
@@ -286,14 +281,27 @@ function killTracked(child: ChildProcess): void {
 }
 
 export async function bootStack(options: BootOptions = {}): Promise<BootedStack> {
-  // TIER2_INTENT_PROFILE lets a local run boot the same harness on its own
-  // profile so parallel worktrees don't collide on ports/DB/run-lock (this
-  // branch was verified on `t2auth`). Callers that pass an explicit profile
-  // (the billing suite) still win; CI keeps the default, one profile per
-  // isolated container.
-  const profile = options.profile ?? process.env.TIER2_INTENT_PROFILE ?? PROFILE;
+  if (options.profile && options.ownedProfile) {
+    throw new Error("bootStack profile and ownedProfile are mutually exclusive.");
+  }
+  const ownedProfile = options.ownedProfile;
+  const profile = ownedProfile?.profile ?? options.profile ?? process.env.TIER2_INTENT_PROFILE ?? PROFILE;
+  if (ownedProfile) {
+    prepareOwnedEphemeralProfile(ownedProfile);
+  }
   log(`preparing profile "${profile}"...`);
   const instance = ensureProfilePorts(profile);
+  const setupTokenFile = ownedProfile?.setupTokenFile ?? setupTokenFileForProfile(profile);
+  if (ownedProfile) {
+    assertOwnedProfileResources(ownedProfile, {
+      profile,
+      setupTokenFile,
+      databaseName: instance.databaseName,
+      profileDirectory: path.dirname(profileInstancePath(profile)),
+      runtimeDirectory: instance.anyharnessRuntimeHome,
+      desktopDirectory: instance.desktopHome,
+    });
+  }
   ensureDatabase(instance.databaseName);
   ensureRedisReachable();
 
@@ -304,11 +312,6 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
   // CI, or `skipFrontend`) so a spec can probe reachability itself and skip
   // gracefully rather than the boot deciding for it.
   const anyharnessBaseUrl = `http://127.0.0.1:${instance.ports.anyharness}`;
-  const setupTokenFile = `/tmp/proliferate-${profile}-setup-token`;
-  // Fresh setup token file per boot: a stale token from a prior claimed run
-  // would otherwise sit there confusing the next claim attempt.
-  rmSync(setupTokenFile, { force: true });
-
   log(`running alembic migrations against ${instance.databaseName}...`);
   run(serverVenvExecutable("alembic"), ["upgrade", "head"], {
     cwd: path.join(REPO_ROOT, "server"),
@@ -480,6 +483,16 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
     // 2-minute staleness window refuses to start.
     rmSync(path.join(path.dirname(profileInstancePath(profile)), "run.lock"), { force: true });
     await new Promise((resolve) => setTimeout(resolve, 500));
+    if (ownedProfile) {
+      cleanupOwnedEphemeralProfile(ownedProfile, {
+        profile,
+        setupTokenFile,
+        databaseName: instance.databaseName,
+        profileDirectory: path.dirname(profileInstancePath(profile)),
+        runtimeDirectory: instance.anyharnessRuntimeHome,
+        desktopDirectory: instance.desktopHome,
+      });
+    }
   };
 
   return { profile, apiBaseUrl, webBaseUrl, anyharnessBaseUrl, databaseUrl, setupTokenFile, teardown };

--- a/tests/intent/stack/boot.ts
+++ b/tests/intent/stack/boot.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import {
   assertOwnedProfileResources,
   cleanupOwnedEphemeralProfile,
+  createOwnedProfilePostgresCustody,
   prepareOwnedEphemeralProfile,
   setupTokenFileForProfile,
   type OwnedEphemeralProfile,
@@ -109,16 +110,6 @@ function run(command: string, args: string[], options: { cwd?: string; env?: Nod
   return result.stdout.trim();
 }
 
-function localPgHost(): string {
-  if (process.env.LOCAL_PGHOST) {
-    return process.env.LOCAL_PGHOST;
-  }
-  // Matches the Makefile's OS-conditional default: Docker Desktop's Postgres
-  // listener on macOS is reached over ::1 so it isn't confused with a
-  // Homebrew Postgres bound to 127.0.0.1.
-  return process.platform === "darwin" ? "::1" : "127.0.0.1";
-}
-
 function profileInstancePath(profile: string): string {
   return path.join(
     process.env.HOME ?? "",
@@ -136,15 +127,15 @@ function ensureProfilePorts(profile: string): ProfileInstance {
   return JSON.parse(raw) as ProfileInstance;
 }
 
-function ensureDatabase(dbName: string): void {
+function ensureDatabase(dbName: string, postgresEnvironment: NodeJS.ProcessEnv): void {
   run("node", ["scripts/dev.mjs", "ensure-db", "--db-name", dbName], {
-    env: { USE_EXISTING_POSTGRES: "1" },
+    env: { ...postgresEnvironment, USE_EXISTING_POSTGRES: "1" },
   });
 }
 
-function databaseUrlFor(dbName: string): string {
+function databaseUrlFor(dbName: string, postgresEnvironment: NodeJS.ProcessEnv): string {
   return run("node", ["scripts/dev.mjs", "database-url", "--db-name", dbName], {
-    env: { LOCAL_PGHOST: localPgHost() },
+    env: postgresEnvironment,
   });
 }
 
@@ -285,9 +276,10 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
     throw new Error("bootStack profile and ownedProfile are mutually exclusive.");
   }
   const ownedProfile = options.ownedProfile;
+  const postgresCustody = createOwnedProfilePostgresCustody();
   const profile = ownedProfile?.profile ?? options.profile ?? process.env.TIER2_INTENT_PROFILE ?? PROFILE;
   if (ownedProfile) {
-    prepareOwnedEphemeralProfile(ownedProfile);
+    prepareOwnedEphemeralProfile(ownedProfile, postgresCustody.lifecycle);
   }
   log(`preparing profile "${profile}"...`);
   const instance = ensureProfilePorts(profile);
@@ -302,10 +294,10 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
       desktopDirectory: instance.desktopHome,
     });
   }
-  ensureDatabase(instance.databaseName);
+  ensureDatabase(instance.databaseName, postgresCustody.commandEnvironment);
   ensureRedisReachable();
 
-  const databaseUrl = databaseUrlFor(instance.databaseName);
+  const databaseUrl = databaseUrlFor(instance.databaseName, postgresCustody.commandEnvironment);
   const apiBaseUrl = `http://127.0.0.1:${instance.ports.api}`;
   const webBaseUrl = `http://127.0.0.1:${instance.ports.desktopWeb}`;
   // Published even when the runtime is skipped (TIER2_INTENT_SKIP_RUNTIME=1 in
@@ -491,7 +483,7 @@ export async function bootStack(options: BootOptions = {}): Promise<BootedStack>
         profileDirectory: path.dirname(profileInstancePath(profile)),
         runtimeDirectory: instance.anyharnessRuntimeHome,
         desktopDirectory: instance.desktopHome,
-      });
+      }, postgresCustody.lifecycle);
     }
   };
 

--- a/tests/intent/stack/claim.test.ts
+++ b/tests/intent/stack/claim.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BootedStack } from "./boot.ts";
+import { claimOwnedInstance } from "./claim.ts";
+import { createOwnedEphemeralProfile } from "./ephemeral-profile.ts";
+
+const ownedProfile = createOwnedEphemeralProfile({
+  namespace: "t2e2bgate",
+  runId: "unit-run",
+  runAttempt: 1,
+  workerIndex: 0,
+  retry: 0,
+  roots: {
+    profileRoot: "/state/profiles",
+    runtimeRoot: "/state/runtimes",
+    tempRoot: "/state/tmp",
+  },
+});
+
+const stack: BootedStack = {
+  profile: ownedProfile.profile,
+  apiBaseUrl: "http://intent.test",
+  webBaseUrl: "http://web.test",
+  anyharnessBaseUrl: "http://runtime.test",
+  databaseUrl: "postgresql://intent",
+  setupTokenFile: ownedProfile.setupTokenFile,
+  teardown: async () => {},
+};
+
+function response(status: number, body = ""): Response {
+  return new Response(body, { status, headers: { "content-type": "application/json" } });
+}
+
+test("claim waits for durable closure then logs in exactly once", async () => {
+  const calls: Array<{ path: string; method: string }> = [];
+  const setupGets = [200, 200, 404];
+  let tokenReads = 0;
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input : input.url);
+    const method = init?.method ?? "GET";
+    calls.push({ path: url.pathname, method });
+    if (url.pathname === "/setup" && method === "GET") {
+      return response(setupGets.shift() ?? 500);
+    }
+    if (url.pathname === "/setup" && method === "POST") {
+      assert.match(String(init?.body), /setup_token=owned-token/);
+      return response(200, "claimed");
+    }
+    if (url.pathname === "/auth/desktop/password/login") {
+      return response(200, JSON.stringify({ access_token: "owner-access" }));
+    }
+    return response(500);
+  }) as typeof fetch;
+
+  const accessToken = await claimOwnedInstance({
+    stack,
+    ownedProfile,
+    email: "owner@example.com",
+    password: "password",
+    organizationName: "Owned Org",
+    fetchImpl,
+    readToken: (tokenFile) => {
+      tokenReads += 1;
+      assert.equal(tokenFile, ownedProfile.setupTokenFile);
+      return "owned-token";
+    },
+    visibilityIntervalMs: 0,
+    delay: async () => {},
+  });
+
+  assert.equal(accessToken, "owner-access");
+  assert.equal(tokenReads, 1);
+  assert.equal(calls.filter((call) => call.path.endsWith("/password/login")).length, 1);
+  assert.deepEqual(setupGets, []);
+});
+
+test("a failed login remains red and is never retried", async () => {
+  let loginCalls = 0;
+  let setupGets = 0;
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input : input.url);
+    if (url.pathname === "/setup" && (init?.method ?? "GET") === "GET") {
+      setupGets += 1;
+      return response(setupGets === 1 ? 200 : 404);
+    }
+    if (url.pathname === "/setup") {
+      return response(200);
+    }
+    loginCalls += 1;
+    return response(401, JSON.stringify({ detail: "invalid" }));
+  }) as typeof fetch;
+
+  await assert.rejects(
+    claimOwnedInstance({
+      stack,
+      ownedProfile,
+      email: "owner@example.com",
+      password: "password",
+      organizationName: "Owned Org",
+      fetchImpl,
+      readToken: () => "owned-token",
+      visibilityIntervalMs: 0,
+    }),
+    /login failed.*not retried/,
+  );
+  assert.equal(loginCalls, 1);
+});
+
+test("missing token custody fails before claim or login", async () => {
+  const methods: string[] = [];
+  const fetchImpl = (async (_input: string | URL | Request, init?: RequestInit) => {
+    methods.push(init?.method ?? "GET");
+    return response(200);
+  }) as typeof fetch;
+
+  await assert.rejects(
+    claimOwnedInstance({
+      stack,
+      ownedProfile,
+      email: "owner@example.com",
+      password: "password",
+      organizationName: "Owned Org",
+      fetchImpl,
+      readToken: () => {
+        throw new Error("ENOENT");
+      },
+    }),
+    /custody/,
+  );
+  assert.deepEqual(methods, ["GET"]);
+});
+
+test("an already-claimed profile fails without reading a token", async () => {
+  let tokenReads = 0;
+  const fetchImpl = (async () => response(404)) as typeof fetch;
+  await assert.rejects(
+    claimOwnedInstance({
+      stack,
+      ownedProfile,
+      email: "owner@example.com",
+      password: "password",
+      organizationName: "Owned Org",
+      fetchImpl,
+      readToken: () => {
+        tokenReads += 1;
+        return "unexpected";
+      },
+    }),
+    /not fresh/,
+  );
+  assert.equal(tokenReads, 0);
+});

--- a/tests/intent/stack/claim.ts
+++ b/tests/intent/stack/claim.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import type { BootedStack } from "./boot.ts";
+import type { OwnedEphemeralProfile } from "./ephemeral-profile.ts";
+
+interface ClaimInputs {
+  stack: BootedStack;
+  ownedProfile: OwnedEphemeralProfile;
+  email: string;
+  password: string;
+  organizationName: string;
+  fetchImpl?: typeof fetch;
+  readToken?: (tokenFile: string) => string;
+  visibilityAttempts?: number;
+  visibilityIntervalMs?: number;
+  delay?: (milliseconds: number) => Promise<void>;
+}
+
+async function responseText(response: Response): Promise<string> {
+  return (await response.text()).slice(0, 300);
+}
+
+export async function claimOwnedInstance(inputs: ClaimInputs): Promise<string> {
+  const fetchImpl = inputs.fetchImpl ?? fetch;
+  const readToken = inputs.readToken ?? ((tokenFile) => readFileSync(tokenFile, "utf8"));
+  const delay = inputs.delay ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  if (
+    inputs.stack.profile !== inputs.ownedProfile.profile
+    || inputs.stack.setupTokenFile !== inputs.ownedProfile.setupTokenFile
+  ) {
+    throw new Error("Owned setup-token custody does not match the booted stack.");
+  }
+
+  const initialProbe = await fetchImpl(`${inputs.stack.apiBaseUrl}/setup`);
+  if (initialProbe.status !== 200) {
+    throw new Error(`Owned ephemeral profile was not fresh (setup returned ${initialProbe.status}).`);
+  }
+
+  let setupToken: string;
+  try {
+    setupToken = readToken(inputs.ownedProfile.setupTokenFile).trim();
+  } catch {
+    throw new Error("Owned setup token is missing; refusing to claim without custody.");
+  }
+  if (!setupToken) {
+    throw new Error("Owned setup token is empty; refusing to claim without custody.");
+  }
+
+  const claim = await fetchImpl(`${inputs.stack.apiBaseUrl}/setup`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      email: inputs.email,
+      password: inputs.password,
+      setup_token: setupToken,
+      organization_name: inputs.organizationName,
+    }).toString(),
+  });
+  if (claim.status !== 200) {
+    throw new Error(`Owned instance claim failed (${claim.status}): ${await responseText(claim)}`);
+  }
+
+  const attempts = inputs.visibilityAttempts ?? 80;
+  const intervalMs = inputs.visibilityIntervalMs ?? 25;
+  let claimVisible = false;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const probe = await fetchImpl(`${inputs.stack.apiBaseUrl}/setup`);
+    if (probe.status === 404) {
+      claimVisible = true;
+      break;
+    }
+    if (probe.status !== 200) {
+      throw new Error(`Setup visibility probe failed (${probe.status}).`);
+    }
+    await delay(intervalMs);
+  }
+  if (!claimVisible) {
+    throw new Error("Owned instance claim did not become durably visible.");
+  }
+
+  const login = await fetchImpl(`${inputs.stack.apiBaseUrl}/auth/desktop/password/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: inputs.email, password: inputs.password }),
+  });
+  const body = (await login.json()) as { access_token?: string };
+  if (login.status !== 200 || !body.access_token) {
+    throw new Error(`Owned instance login failed (${login.status}); login is not retried.`);
+  }
+  return body.access_token;
+}

--- a/tests/intent/stack/ephemeral-profile.test.ts
+++ b/tests/intent/stack/ephemeral-profile.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cleanupOwnedEphemeralProfile,
+  createOwnedEphemeralProfile,
+  ownedEphemeralProfileForWorker,
+  prepareOwnedEphemeralProfile,
+  type OwnedProfileLifecycle,
+  type OwnedProfileResources,
+} from "./ephemeral-profile.ts";
+
+const ROOTS = {
+  profileRoot: "/state/profiles",
+  runtimeRoot: "/state/runtimes",
+  tempRoot: "/state/tmp",
+};
+
+function owned(retry = 0) {
+  return createOwnedEphemeralProfile({
+    namespace: "t2e2bgate",
+    runId: "29569721872",
+    runAttempt: 2,
+    workerIndex: 3,
+    retry,
+    roots: ROOTS,
+  });
+}
+
+function lifecycle(options: {
+  existingPaths?: string[];
+  databaseExists?: boolean;
+  calls?: string[];
+} = {}): OwnedProfileLifecycle {
+  const calls = options.calls ?? [];
+  const existingPaths = new Set(options.existingPaths ?? []);
+  return {
+    pathExists: (target) => existingPaths.has(target),
+    databaseExists: () => options.databaseExists ?? false,
+    dropDatabase: (databaseName) => calls.push(`drop:${databaseName}`),
+    removeFile: (target) => calls.push(`file:${target}`),
+    removeDirectory: (target) => calls.push(`directory:${target}`),
+  };
+}
+
+test("profile identity is bounded and changes across attempt, worker, and retry", () => {
+  const base = ownedEphemeralProfileForWorker({
+    namespace: "t2e2bgate",
+    workerIndex: 0,
+    retry: 0,
+    env: { GITHUB_RUN_ID: "29569721872", GITHUB_RUN_ATTEMPT: "1" },
+  });
+  const variants = [
+    ownedEphemeralProfileForWorker({
+      namespace: "t2e2bgate",
+      workerIndex: 0,
+      retry: 0,
+      env: { GITHUB_RUN_ID: "29569721872", GITHUB_RUN_ATTEMPT: "2" },
+    }),
+    ownedEphemeralProfileForWorker({
+      namespace: "t2e2bgate",
+      workerIndex: 1,
+      retry: 0,
+      env: { GITHUB_RUN_ID: "29569721872", GITHUB_RUN_ATTEMPT: "1" },
+    }),
+    ownedEphemeralProfileForWorker({
+      namespace: "t2e2bgate",
+      workerIndex: 0,
+      retry: 1,
+      env: { GITHUB_RUN_ID: "29569721872", GITHUB_RUN_ATTEMPT: "1" },
+    }),
+  ];
+
+  for (const profile of [base, ...variants]) {
+    assert.match(profile.profile, /^[a-z0-9][a-z0-9_-]{0,39}$/);
+    assert.ok(profile.profile.length <= 40);
+  }
+  assert.equal(new Set([base.profile, ...variants.map((value) => value.profile)]).size, 4);
+  assert.notEqual(base.setupTokenFile, variants[2]!.setupTokenFile);
+  assert.notEqual(base.databaseName, variants[2]!.databaseName);
+});
+
+test("freshness is fail-closed and never deletes a colliding owner", () => {
+  const profile = owned();
+  for (const collision of [
+    { existingPaths: [profile.setupTokenFile] },
+    { existingPaths: [profile.profileDirectory] },
+    { existingPaths: [profile.runtimeDirectory] },
+    { databaseExists: true },
+  ]) {
+    const calls: string[] = [];
+    assert.throws(
+      () => prepareOwnedEphemeralProfile(profile, lifecycle({ ...collision, calls })),
+      /not fresh/,
+    );
+    assert.deepEqual(calls, []);
+  }
+});
+
+test("cleanup removes only the exact resources carried by the owner", () => {
+  const profile = owned();
+  const calls: string[] = [];
+  cleanupOwnedEphemeralProfile(profile, profile, lifecycle({ calls }));
+  assert.deepEqual(calls, [
+    `drop:${profile.databaseName}`,
+    `file:${profile.setupTokenFile}`,
+    `directory:${profile.runtimeDirectory}`,
+    `directory:${profile.profileDirectory}`,
+  ]);
+});
+
+test("cleanup rejects mismatched custody before touching any resource", () => {
+  const profile = owned();
+  const calls: string[] = [];
+  const mismatched: OwnedProfileResources = {
+    ...profile,
+    setupTokenFile: `${profile.setupTokenFile}-other-owner`,
+  };
+  assert.throws(
+    () => cleanupOwnedEphemeralProfile(profile, mismatched, lifecycle({ calls })),
+    /resource mismatch/,
+  );
+  assert.deepEqual(calls, []);
+});

--- a/tests/intent/stack/ephemeral-profile.test.ts
+++ b/tests/intent/stack/ephemeral-profile.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   cleanupOwnedEphemeralProfile,
+  createOwnedProfilePostgresCustody,
   createOwnedEphemeralProfile,
   ownedEphemeralProfileForWorker,
   prepareOwnedEphemeralProfile,
@@ -77,6 +78,29 @@ test("profile identity is bounded and changes across attempt, worker, and retry"
   assert.equal(new Set([base.profile, ...variants.map((value) => value.profile)]).size, 4);
   assert.notEqual(base.setupTokenFile, variants[2]!.setupTokenFile);
   assert.notEqual(base.databaseName, variants[2]!.databaseName);
+});
+
+test("database freshness, creation, server URL, and cleanup share one endpoint", () => {
+  const sqlHosts: string[] = [];
+  const custody = createOwnedProfilePostgresCustody({
+    env: {},
+    platform: "darwin",
+    executeSql: (identity, sql) => {
+      sqlHosts.push(`${identity.host}:${identity.port}:${identity.user}:${sql}`);
+      return "";
+    },
+  });
+  const profile = owned();
+
+  prepareOwnedEphemeralProfile(profile, custody.lifecycle);
+  cleanupOwnedEphemeralProfile(profile, profile, custody.lifecycle);
+
+  assert.equal(custody.identity.host, "::1");
+  assert.equal(custody.commandEnvironment.LOCAL_PGHOST, custody.identity.host);
+  assert.equal(custody.commandEnvironment.LOCAL_PGPORT, custody.identity.port);
+  assert.equal(custody.commandEnvironment.LOCAL_PGUSER, custody.identity.user);
+  assert.equal(sqlHosts.length, 2);
+  assert.ok(sqlHosts.every((call) => call.startsWith("::1:5432:proliferate:")));
 });
 
 test("freshness is fail-closed and never deletes a colliding owner", () => {

--- a/tests/intent/stack/ephemeral-profile.ts
+++ b/tests/intent/stack/ephemeral-profile.ts
@@ -1,0 +1,259 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const MAX_PROFILE_LENGTH = 40;
+const PROFILE_PATTERN = /^[a-z0-9][a-z0-9_-]{0,39}$/;
+const LOCAL_RUN_SCOPE = `local-${process.pid}-${randomUUID()}`;
+
+export interface OwnedEphemeralProfile {
+  readonly profile: string;
+  readonly setupTokenFile: string;
+  readonly databaseName: string;
+  readonly profileDirectory: string;
+  readonly runtimeDirectory: string;
+  readonly desktopDirectory: string;
+}
+
+export type OwnedProfileResources = OwnedEphemeralProfile;
+
+export interface OwnedProfileRoots {
+  profileRoot: string;
+  runtimeRoot: string;
+  tempRoot: string;
+}
+
+export interface OwnedProfileLifecycle {
+  pathExists: (target: string) => boolean;
+  databaseExists: (databaseName: string) => boolean;
+  dropDatabase: (databaseName: string) => void;
+  removeFile: (target: string) => void;
+  removeDirectory: (target: string) => void;
+}
+
+function defaultRoots(): OwnedProfileRoots {
+  return {
+    profileRoot: path.join(homedir(), ".proliferate-local", "dev", "profiles"),
+    runtimeRoot: path.join(homedir(), ".proliferate-local", "runtimes"),
+    tempRoot: "/tmp",
+  };
+}
+
+function normalizeFragment(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "") || "run";
+}
+
+function nonnegativeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer.`);
+  }
+  return value;
+}
+
+function shortCoordinate(value: number): string {
+  return value.toString(36).slice(-3);
+}
+
+function profileName(
+  namespace: string,
+  runId: string,
+  runAttempt: number,
+  workerIndex: number,
+  retry: number,
+): string {
+  const normalizedNamespace = normalizeFragment(namespace);
+  const normalizedRunId = normalizeFragment(runId);
+  const coordinates = [
+    `a${shortCoordinate(runAttempt)}`,
+    `w${shortCoordinate(workerIndex)}`,
+    `r${shortCoordinate(retry)}`,
+  ].join("");
+  const digest = createHash("sha256")
+    .update(`${namespace}\0${runId}\0${runAttempt}\0${workerIndex}\0${retry}`)
+    .digest("hex")
+    .slice(0, 8);
+  const suffix = `${normalizedRunId.slice(-8)}-${coordinates}-${digest}`;
+  const namespaceBudget = MAX_PROFILE_LENGTH - suffix.length - 1;
+  const boundedNamespace = normalizedNamespace.slice(0, Math.max(1, namespaceBudget));
+  return `${boundedNamespace}-${suffix}`;
+}
+
+export function setupTokenFileForProfile(profile: string, tempRoot = "/tmp"): string {
+  return path.join(tempRoot, `proliferate-${profile}-setup-token`);
+}
+
+export function createOwnedEphemeralProfile(options: {
+  namespace: string;
+  runId: string;
+  runAttempt: number;
+  workerIndex: number;
+  retry: number;
+  roots?: OwnedProfileRoots;
+}): OwnedEphemeralProfile {
+  const runAttempt = nonnegativeInteger(options.runAttempt, "run attempt");
+  const workerIndex = nonnegativeInteger(options.workerIndex, "worker index");
+  const retry = nonnegativeInteger(options.retry, "retry");
+  if (!options.runId.trim()) {
+    throw new Error("run id must not be empty.");
+  }
+  const roots = options.roots ?? defaultRoots();
+  const profile = profileName(options.namespace, options.runId, runAttempt, workerIndex, retry);
+  if (!PROFILE_PATTERN.test(profile)) {
+    throw new Error(`Derived profile name is invalid: ${profile}`);
+  }
+  const profileDirectory = path.join(roots.profileRoot, profile);
+  return Object.freeze({
+    profile,
+    setupTokenFile: setupTokenFileForProfile(profile, roots.tempRoot),
+    databaseName: `proliferate_dev_${profile.replaceAll("-", "_")}`,
+    profileDirectory,
+    runtimeDirectory: path.join(roots.runtimeRoot, profile),
+    desktopDirectory: path.join(profileDirectory, "app"),
+  });
+}
+
+export function ownedEphemeralProfileForWorker(options: {
+  namespace: string;
+  workerIndex: number;
+  retry: number;
+  env?: NodeJS.ProcessEnv;
+  localRunScope?: string;
+}): OwnedEphemeralProfile {
+  const env = options.env ?? process.env;
+  const runId = env.GITHUB_RUN_ID
+    ? `gh-${env.GITHUB_RUN_ID}`
+    : env.TIER2_INTENT_RUN_SCOPE || options.localRunScope || LOCAL_RUN_SCOPE;
+  const rawAttempt = env.GITHUB_RUN_ATTEMPT ?? "1";
+  if (!/^\d+$/.test(rawAttempt)) {
+    throw new Error("GITHUB_RUN_ATTEMPT must be a non-negative integer.");
+  }
+  return createOwnedEphemeralProfile({
+    namespace: options.namespace,
+    runId,
+    runAttempt: Number(rawAttempt),
+    workerIndex: options.workerIndex,
+    retry: options.retry,
+  });
+}
+
+function runPsql(sql: string): string {
+  const result = spawnSync(
+    "psql",
+    [
+      "-h",
+      process.env.LOCAL_PGHOST || "127.0.0.1",
+      "-p",
+      process.env.LOCAL_PGPORT || "5432",
+      "-U",
+      process.env.LOCAL_PGUSER || "proliferate",
+      "-d",
+      "postgres",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-tA",
+      "-c",
+      sql,
+    ],
+    {
+      env: {
+        ...process.env,
+        PGPASSWORD: process.env.LOCAL_PGPASSWORD || "localdev",
+      },
+      encoding: "utf8",
+    },
+  );
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || result.error?.message || "unknown psql error").trim();
+    throw new Error(`Owned profile database operation failed: ${detail}`);
+  }
+  return result.stdout.trim();
+}
+
+const defaultLifecycle: OwnedProfileLifecycle = {
+  pathExists: existsSync,
+  databaseExists: (databaseName) => (
+    runPsql(`SELECT 1 FROM pg_database WHERE datname = '${databaseName}'`) === "1"
+  ),
+  dropDatabase: (databaseName) => {
+    runPsql(`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
+  },
+  removeFile: (target) => rmSync(target, { force: true }),
+  removeDirectory: (target) => rmSync(target, { force: true, recursive: true }),
+};
+
+function assertOwnedProfileShape(owned: OwnedEphemeralProfile): void {
+  if (!PROFILE_PATTERN.test(owned.profile)) {
+    throw new Error("Owned profile name is invalid.");
+  }
+  const expectedDatabase = `proliferate_dev_${owned.profile.replaceAll("-", "_")}`;
+  const expectedToken = `proliferate-${owned.profile}-setup-token`;
+  if (
+    owned.databaseName !== expectedDatabase
+    || path.basename(owned.setupTokenFile) !== expectedToken
+    || path.basename(owned.profileDirectory) !== owned.profile
+    || path.basename(owned.runtimeDirectory) !== owned.profile
+    || path.resolve(owned.desktopDirectory) !== path.resolve(owned.profileDirectory, "app")
+  ) {
+    throw new Error("Owned profile paths do not match its identity.");
+  }
+}
+
+export function prepareOwnedEphemeralProfile(
+  owned: OwnedEphemeralProfile,
+  lifecycle: OwnedProfileLifecycle = defaultLifecycle,
+): void {
+  assertOwnedProfileShape(owned);
+  const collisions = [
+    ["setup token", lifecycle.pathExists(owned.setupTokenFile)],
+    ["profile directory", lifecycle.pathExists(owned.profileDirectory)],
+    ["runtime directory", lifecycle.pathExists(owned.runtimeDirectory)],
+    ["database", lifecycle.databaseExists(owned.databaseName)],
+  ].filter(([, exists]) => exists).map(([label]) => label);
+  if (collisions.length > 0) {
+    throw new Error(`Owned ephemeral profile is not fresh (${collisions.join(", ")}).`);
+  }
+}
+
+export function assertOwnedProfileResources(
+  owned: OwnedEphemeralProfile,
+  resources: OwnedProfileResources,
+): void {
+  assertOwnedProfileShape(owned);
+  if (resources.profile !== owned.profile || resources.databaseName !== owned.databaseName) {
+    throw new Error("Owned profile resource identity does not match.");
+  }
+  for (const key of ["setupTokenFile", "profileDirectory", "runtimeDirectory", "desktopDirectory"] as const) {
+    if (path.resolve(resources[key]) !== path.resolve(owned[key])) {
+      throw new Error(`Owned profile resource mismatch: ${key}.`);
+    }
+  }
+}
+
+export function cleanupOwnedEphemeralProfile(
+  owned: OwnedEphemeralProfile,
+  resources: OwnedProfileResources,
+  lifecycle: OwnedProfileLifecycle = defaultLifecycle,
+): void {
+  assertOwnedProfileResources(owned, resources);
+  const failures: unknown[] = [];
+  for (const operation of [
+    () => lifecycle.dropDatabase(owned.databaseName),
+    () => lifecycle.removeFile(owned.setupTokenFile),
+    () => lifecycle.removeDirectory(owned.runtimeDirectory),
+    () => lifecycle.removeDirectory(owned.profileDirectory),
+  ]) {
+    try {
+      operation();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Owned ephemeral profile cleanup failed.");
+  }
+}

--- a/tests/intent/stack/ephemeral-profile.ts
+++ b/tests/intent/stack/ephemeral-profile.ts
@@ -33,6 +33,21 @@ export interface OwnedProfileLifecycle {
   removeDirectory: (target: string) => void;
 }
 
+export interface LocalPostgresIdentity {
+  readonly host: string;
+  readonly port: string;
+  readonly user: string;
+  readonly password: string;
+}
+
+export interface OwnedProfilePostgresCustody {
+  readonly identity: LocalPostgresIdentity;
+  readonly commandEnvironment: NodeJS.ProcessEnv;
+  readonly lifecycle: OwnedProfileLifecycle;
+}
+
+type PostgresSqlExecutor = (identity: LocalPostgresIdentity, sql: string) => string;
+
 function defaultRoots(): OwnedProfileRoots {
   return {
     profileRoot: path.join(homedir(), ".proliferate-local", "dev", "profiles"),
@@ -141,16 +156,16 @@ export function ownedEphemeralProfileForWorker(options: {
   });
 }
 
-function runPsql(sql: string): string {
+function runPsql(identity: LocalPostgresIdentity, sql: string): string {
   const result = spawnSync(
     "psql",
     [
       "-h",
-      process.env.LOCAL_PGHOST || "127.0.0.1",
+      identity.host,
       "-p",
-      process.env.LOCAL_PGPORT || "5432",
+      identity.port,
       "-U",
-      process.env.LOCAL_PGUSER || "proliferate",
+      identity.user,
       "-d",
       "postgres",
       "-v",
@@ -162,7 +177,7 @@ function runPsql(sql: string): string {
     {
       env: {
         ...process.env,
-        PGPASSWORD: process.env.LOCAL_PGPASSWORD || "localdev",
+        PGPASSWORD: identity.password,
       },
       encoding: "utf8",
     },
@@ -174,17 +189,43 @@ function runPsql(sql: string): string {
   return result.stdout.trim();
 }
 
-const defaultLifecycle: OwnedProfileLifecycle = {
-  pathExists: existsSync,
-  databaseExists: (databaseName) => (
-    runPsql(`SELECT 1 FROM pg_database WHERE datname = '${databaseName}'`) === "1"
-  ),
-  dropDatabase: (databaseName) => {
-    runPsql(`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
-  },
-  removeFile: (target) => rmSync(target, { force: true }),
-  removeDirectory: (target) => rmSync(target, { force: true, recursive: true }),
-};
+export function createOwnedProfilePostgresCustody(options: {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  executeSql?: PostgresSqlExecutor;
+} = {}): OwnedProfilePostgresCustody {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const identity = Object.freeze({
+    host: env.LOCAL_PGHOST || (platform === "darwin" ? "::1" : "127.0.0.1"),
+    port: env.LOCAL_PGPORT || "5432",
+    user: env.LOCAL_PGUSER || "proliferate",
+    password: env.LOCAL_PGPASSWORD || "localdev",
+  });
+  const executeSql = options.executeSql ?? runPsql;
+  const commandEnvironment = Object.freeze({
+    LOCAL_PGHOST: identity.host,
+    LOCAL_PGPORT: identity.port,
+    LOCAL_PGUSER: identity.user,
+    LOCAL_PGPASSWORD: identity.password,
+  });
+  const lifecycle: OwnedProfileLifecycle = {
+    pathExists: existsSync,
+    databaseExists: (databaseName) => (
+      executeSql(identity, `SELECT 1 FROM pg_database WHERE datname = '${databaseName}'`) === "1"
+    ),
+    dropDatabase: (databaseName) => {
+      executeSql(identity, `DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`);
+    },
+    removeFile: (target) => rmSync(target, { force: true }),
+    removeDirectory: (target) => rmSync(target, { force: true, recursive: true }),
+  };
+  return Object.freeze({ identity, commandEnvironment, lifecycle });
+}
+
+function defaultLifecycle(): OwnedProfileLifecycle {
+  return createOwnedProfilePostgresCustody().lifecycle;
+}
 
 function assertOwnedProfileShape(owned: OwnedEphemeralProfile): void {
   if (!PROFILE_PATTERN.test(owned.profile)) {
@@ -205,7 +246,7 @@ function assertOwnedProfileShape(owned: OwnedEphemeralProfile): void {
 
 export function prepareOwnedEphemeralProfile(
   owned: OwnedEphemeralProfile,
-  lifecycle: OwnedProfileLifecycle = defaultLifecycle,
+  lifecycle: OwnedProfileLifecycle = defaultLifecycle(),
 ): void {
   assertOwnedProfileShape(owned);
   const collisions = [
@@ -237,7 +278,7 @@ export function assertOwnedProfileResources(
 export function cleanupOwnedEphemeralProfile(
   owned: OwnedEphemeralProfile,
   resources: OwnedProfileResources,
-  lifecycle: OwnedProfileLifecycle = defaultLifecycle,
+  lifecycle: OwnedProfileLifecycle = defaultLifecycle(),
 ): void {
   assertOwnedProfileResources(owned, resources);
   const failures: unknown[] = [];


### PR DESCRIPTION
## Summary

- give T2-SH-6 a bounded profile identity derived from the Actions run, run attempt, Playwright worker, and retry
- bind the setup-token path, database, profile directory, and runtime directory to that exact owner
- fail closed if any owned resource already exists, and remove only exact matching resources during teardown
- probe setup closure before issuing one password login; a failed login is never retried into success
- run deterministic fixture unit tests in the provisional intent job

## Root cause

T2-SH-6 used fixed profile `t2e2bgate`. `bootStack` also deleted the fixed setup-token path before every boot. When Playwright restarted a worker, the retry reused the already-claimed database but expected a fresh one-time token, producing the observed missing-token failure and risking cross-attempt state leakage.

Merged PR #1359 separately fixed the `/setup` post-response transaction race that triggered the first failed login. This PR owns the remaining fixture lifecycle defect: every retry receives a fresh profile/token/database identity, persistent caller-supplied profiles are no longer allowed to have their token file deleted by `bootStack`, and stale or mismatched custody remains red.

Closes #1330

## Validation

- `pnpm -C tests/intent test:unit` — 13/13 pass
- focused TypeScript check for the changed fixture, helper, tests, and T2-SH-6 spec
- `playwright test specs/cloud-provisioning-gating.spec.ts --list` — all three cells collect
- real server-only T2-SH-6 smoke against native Postgres/Redis: claim, one login, health 200, half-configured workspace request 503 with `e2b_template_not_configured`, then exact cleanup/freshness re-check
- `actionlint .github/workflows/intent-tests.yml`
- max-lines, documentation integrity, documentation unit tests, and `git diff --check`

No Release E2E workflow, provider state, Docker service, or Rust build was invoked.