### PR TITLE
fix(cloud): bootstrap repo-less sandboxes without GitHub App

### DIFF
--- a/server/proliferate/server/cloud/materialization/materialize/sandbox.py
+++ b/server/proliferate/server/cloud/materialization/materialize/sandbox.py
@@ -13,7 +13,6 @@ from proliferate.db.store import repositories as repositories_store
 from proliferate.server.cloud.materialization import operation
 from proliferate.server.cloud.materialization.materialize import (
     agent_auth,
-    github_credentials,
     secret_set,
 )
 from proliferate.server.cloud.materialization.materialize import (
@@ -41,12 +40,6 @@ async def _materialize_sandbox(
     db: AsyncSession,
     user_id: UUID,
 ) -> None:
-    await github_credentials.materialize_github_credentials(
-        db,
-        target=ctx.target,
-        operation_id=ctx.sandbox.id,
-        user_id=user_id,
-    )
     await secret_set.materialize_global_secrets_for_user(
         db,
         ctx=ctx,

--- a/server/tests/unit/test_sandbox_materialization.py
+++ b/server/tests/unit/test_sandbox_materialization.py
@@ -1,4 +1,4 @@
-"""Sandbox bootstrap pre-clones configured repos with the right call (T1).
+"""Sandbox bootstrap materialization contracts (T1).
 
 Regression (issue #948): `_materialize_sandbox` called
 `materialize_repo_environment_in_context(db, ctx=, repo_environment=obj)`, but
@@ -7,6 +7,13 @@ attempt_updated_at)`. Every GitHub-connect bootstrap for a user with >=1 cloud
 repo raised a TypeError (logged, not surfaced), so no repo was pre-cloned. The
 bootstrap now opens a materialization row per repo and calls with the correct
 kwargs, best-effort so one repo cannot abort the whole bootstrap.
+
+Regression (issue #1026): bootstrap materialized GitHub credentials before it
+even listed configured repos. A password-only user with no GitHub App
+authorization therefore aborted before global secrets and agent auth were
+materialized. Server-side credential setup belongs to each repo-environment
+attempt, while the Worker owns ongoing provider-level convergence; repo-less
+bootstrap must not require either path.
 """
 
 from __future__ import annotations
@@ -17,7 +24,7 @@ from typing import Any
 
 import pytest
 
-from proliferate.server.cloud.materialization.materialize import sandbox
+from proliferate.server.cloud.materialization.materialize import github_credentials, sandbox
 
 
 class _FakeDb:
@@ -46,10 +53,43 @@ def _patch_common(monkeypatch: pytest.MonkeyPatch, repo_envs: list[Any]) -> None
     async def _begin(*_a: Any, **_k: Any) -> Any:
         return SimpleNamespace(id=uuid.uuid4(), updated_at="2026-07-10T00:00:00Z")
 
-    monkeypatch.setattr(sandbox.github_credentials, "materialize_github_credentials", _noop)
     monkeypatch.setattr(sandbox.secret_set, "materialize_global_secrets_for_user", _noop)
     monkeypatch.setattr(sandbox.repositories_store, "list_cloud_repo_environments", _list)
     monkeypatch.setattr(sandbox.repo_mat_store, "begin_repo_environment_materialization", _begin)
+
+
+@pytest.mark.asyncio
+async def test_repo_less_bootstrap_does_not_require_github_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common(monkeypatch, [])
+
+    async def _unexpected_github_credentials(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("repo-less bootstrap must not require GitHub credentials")
+
+    non_repo_materializers: list[str] = []
+
+    async def _global_secrets(*_a: Any, **_k: Any) -> None:
+        non_repo_materializers.append("global-secrets")
+
+    async def _agent_auth(*_a: Any, **_k: Any) -> None:
+        non_repo_materializers.append("agent-auth")
+
+    monkeypatch.setattr(
+        github_credentials,
+        "materialize_github_credentials",
+        _unexpected_github_credentials,
+    )
+    monkeypatch.setattr(
+        sandbox.secret_set,
+        "materialize_global_secrets_for_user",
+        _global_secrets,
+    )
+    monkeypatch.setattr(sandbox.agent_auth, "materialize_agent_auth", _agent_auth)
+
+    await sandbox._materialize_sandbox(_ctx(), db=_FakeDb(), user_id=uuid.uuid4())
+
+    assert non_repo_materializers == ["global-secrets", "agent-auth"]
 
 
 @pytest.mark.asyncio

--- a/specs/codebase/platforms/product/sandbox-provisioning.md
+++ b/specs/codebase/platforms/product/sandbox-provisioning.md
@@ -145,6 +145,13 @@ finishes with an exact-binding ready-state write. This refreshes health
 evidence and clears `last_error` without fabricating a newer provider lifecycle
 observation, even when the runtime URL and credentials were reused.
 
+Sandbox bootstrap applies global secrets and agent-auth state independently of
+repository configuration. A user with no Cloud repository environments does
+not need GitHub App authorization for that bootstrap. Each configured
+repository attempt owns its GitHub authority check and credential
+materialization, and remains best-effort so one repository failure cannot
+prevent the non-repository state from converging.
+
 The E2B launch path does not launch Proliferate Supervisor. A missing or
 unhealthy Worker does not make direct AnyHarness access unavailable. Reusing an
 already-healthy AnyHarness does not currently restart or self-heal a missing


### PR DESCRIPTION
## Summary

- Stop personal sandbox bootstrap from requiring GitHub App authorization when the user has no Cloud repository environments.
- Keep GitHub authority checks and credential materialization in the repo-environment path that owns them, while allowing global secrets and agent-auth state to converge independently.
- Document the current bootstrap boundary and add the lower-tier regression.
- Closes #1026.

## Root cause

The sandbox-wide bootstrap materialized GitHub credentials before listing configured repositories. Missing GitHub App authorization therefore aborted the whole bootstrap before non-repository materializers ran, even though every configured repo attempt already performs its own fail-closed GitHub authority and credential setup.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] No support relationship; this PR addresses a public GitHub issue and contains no private source data.

## Verification

- `DEBUG=true uv run --extra dev pytest -q --confcutdir=tests/unit tests/unit/test_sandbox_materialization.py` — 3 passed
- `uv run --extra dev ruff check tests/unit/test_sandbox_materialization.py proliferate/server/cloud/materialization/materialize/sandbox.py`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
