### PR TITLE
fix(anyharness): reject unapplied session modes

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -2,7 +2,7 @@ use super::access::map_access_error;
 use super::error::ApiError;
 use crate::domains::agents::route_auth::RouteAuthError;
 use crate::domains::sessions::mcp_bindings::crypto::SessionMcpBindingsError;
-use crate::domains::sessions::model::AgentStartupExitError;
+use crate::domains::sessions::model::{AgentStartupExitError, RequestedModeApplyError};
 use crate::domains::sessions::runtime::{
     CreateAndStartSessionError, EnsureLiveSessionError, ForkSessionError,
     PendingPromptMutationError, PendingPromptQueueError, ResolveInteractionError, SendPromptError,
@@ -28,6 +28,10 @@ fn map_internal_anyhow_error(
 }
 
 pub(super) fn map_acp_session_start_error(error: anyhow::Error) -> ApiError {
+    if let Some(mode_error) = error.downcast_ref::<RequestedModeApplyError>() {
+        return ApiError::bad_request(mode_error.to_string(), RequestedModeApplyError::CODE);
+    }
+
     let telemetry_safe_detail = format!("ACP session start failed: {error}");
     map_internal_anyhow_error(error, telemetry_safe_detail, "ACP session start failed: ")
 }
@@ -352,7 +356,7 @@ mod tests {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
-    use crate::domains::sessions::model::AgentStartupExitError;
+    use crate::domains::sessions::model::{AgentStartupExitError, RequestedModeApplyError};
     use crate::domains::sessions::runtime::{CreateAndStartSessionError, ResolveInteractionError};
     use crate::domains::workspaces::access_gate::WorkspaceAccessError;
 
@@ -398,6 +402,22 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn unconfirmed_requested_mode_maps_to_typed_bad_request() {
+        let mapped = super::map_create_session_error(CreateAndStartSessionError::StartFailed(
+            anyhow::Error::new(RequestedModeApplyError::new("claude", "bypassPermissions")),
+        ));
+
+        assert_eq!(mapped.code(), Some("SESSION_MODE_UNSUPPORTED"));
+        assert_eq!(
+            mapped.detail(),
+            Some(
+                "mode 'bypassPermissions' is not supported by the active session for agent 'claude'"
+            )
+        );
+        assert_eq!(mapped.into_response().status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
@@ -48,6 +48,46 @@ impl fmt::Debug for AgentStartupExitError {
 
 impl std::error::Error for AgentStartupExitError {}
 
+/// A catalog-authorized mode that the active agent session did not expose or
+/// confirm. Session creation must fail instead of reporting success with the
+/// agent's default mode.
+#[derive(Clone, Debug)]
+pub(crate) struct RequestedModeApplyError {
+    agent_kind: String,
+    mode_id: String,
+}
+
+impl RequestedModeApplyError {
+    pub(crate) const CODE: &'static str = "SESSION_MODE_UNSUPPORTED";
+
+    pub(crate) fn new(agent_kind: impl Into<String>, mode_id: impl Into<String>) -> Self {
+        Self {
+            agent_kind: agent_kind.into(),
+            mode_id: mode_id.into(),
+        }
+    }
+
+    pub(crate) fn clone_for_readiness(error: &anyhow::Error) -> anyhow::Error {
+        error
+            .downcast_ref::<Self>()
+            .cloned()
+            .map(anyhow::Error::new)
+            .unwrap_or_else(|| anyhow::anyhow!(error.to_string()))
+    }
+}
+
+impl fmt::Display for RequestedModeApplyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "mode '{}' is not supported by the active session for agent '{}'",
+            self.mode_id, self.agent_kind
+        )
+    }
+}
+
+impl std::error::Error for RequestedModeApplyError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionMcpBindingPolicy {
     InheritWorkspace,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -15,12 +15,12 @@ use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose,
 };
 use crate::live::sessions::actor::state::{SessionActor, SessionStartupState};
-pub(in crate::live::sessions::actor) async fn apply_requested_session_preferences(
+pub(in crate::live::sessions::actor) async fn apply_requested_model_preference(
     conn: &acp::ConnectionTo<acp::Agent>,
     native_session_id: &str,
     session: &SessionRecord,
     startup_state: &mut SessionStartupState,
-) -> anyhow::Result<()> {
+) {
     if let Some(model_id) = session.requested_model_id.as_deref() {
         match try_apply_model_preference(conn, native_session_id, model_id, startup_state).await {
             Ok(ConfigApplyOutcome::NotApplied) => {
@@ -52,6 +52,14 @@ pub(in crate::live::sessions::actor) async fn apply_requested_session_preference
             }
         }
     }
+}
+
+pub(in crate::live::sessions::actor) async fn apply_requested_mode_preference(
+    conn: &acp::ConnectionTo<acp::Agent>,
+    native_session_id: &str,
+    session: &SessionRecord,
+    startup_state: &mut SessionStartupState,
+) -> anyhow::Result<()> {
     if let Some(mode_id) = session.requested_mode_id.as_deref() {
         let mut outcome = try_apply_config_option(
             conn,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -1,7 +1,7 @@
 use agent_client_protocol as acp;
 use anyharness_contract::v1::ConfigApplyState;
 
-use crate::domains::sessions::model::SessionRecord;
+use crate::domains::sessions::model::{RequestedModeApplyError, SessionRecord};
 use crate::live::sessions::actor::config::apply::{
     apply_mode_via_direct_setter_legacy, apply_specific_config_option, try_apply_config_option,
     try_apply_model_preference,
@@ -53,7 +53,7 @@ pub(in crate::live::sessions::actor) async fn apply_requested_session_preference
         }
     }
     if let Some(mode_id) = session.requested_mode_id.as_deref() {
-        let outcome = try_apply_config_option(
+        let mut outcome = try_apply_config_option(
             conn,
             native_session_id,
             startup_state,
@@ -62,7 +62,7 @@ pub(in crate::live::sessions::actor) async fn apply_requested_session_preference
         )
         .await?;
         if outcome == ConfigApplyOutcome::NotApplied {
-            let _ = apply_mode_via_direct_setter_legacy(
+            outcome = apply_mode_via_direct_setter_legacy(
                 conn,
                 native_session_id,
                 startup_state,
@@ -70,9 +70,23 @@ pub(in crate::live::sessions::actor) async fn apply_requested_session_preference
             )
             .await?;
         }
+        validate_requested_mode_outcome(&session.agent_kind, mode_id, outcome)?;
     }
 
     Ok(())
+}
+
+pub(in crate::live::sessions::actor) fn validate_requested_mode_outcome(
+    agent_kind: &str,
+    mode_id: &str,
+    outcome: ConfigApplyOutcome,
+) -> Result<(), RequestedModeApplyError> {
+    match outcome {
+        ConfigApplyOutcome::NoChange | ConfigApplyOutcome::AppliedAuthoritative => Ok(()),
+        ConfigApplyOutcome::AppliedRequested | ConfigApplyOutcome::NotApplied => {
+            Err(RequestedModeApplyError::new(agent_kind, mode_id))
+        }
+    }
 }
 
 fn live_model_ids(startup_state: &SessionStartupState) -> Vec<String> {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -9,7 +9,9 @@ use crate::domains::sessions::model::serialize_action_capabilities;
 use crate::domains::sessions::model::RequestedModeApplyError as ModeApplyError;
 use crate::domains::sessions::prompt::capabilities::capabilities_from_acp;
 use crate::live::sessions::actor::config::apply::restore_persisted_live_config_if_needed;
-use crate::live::sessions::actor::config::handle::apply_requested_session_preferences;
+use crate::live::sessions::actor::config::handle::{
+    apply_requested_mode_preference, apply_requested_model_preference,
+};
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, emit_startup_state, load_startup_restore_snapshot,
 };
@@ -249,33 +251,13 @@ impl SessionActor {
                 "[workspace-latency] session.actor.initial_live_config.completed"
             );
         }
-        let apply_preferences_started = Instant::now();
-        if let Err(error) = apply_requested_session_preferences(
+        apply_requested_model_preference(
             &conn,
             &native_session_id,
             &config.launch.session,
             &mut startup_state,
         )
-        .await
-        {
-            tracing::warn!(session_id = %session_id, error = %error, "failed to apply session preferences");
-            tracing::warn!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                error = %error,
-                elapsed_ms = apply_preferences_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.apply_preferences.failed"
-            );
-            let _ = ready_tx.send(Err(ModeApplyError::clone_for_readiness(&error)));
-            return Err(error);
-        } else {
-            tracing::info!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                elapsed_ms = apply_preferences_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.apply_preferences.completed"
-            );
-        }
+        .await;
         let restore_live_config_started = Instant::now();
         if let Err(error) = restore_persisted_live_config_if_needed(
             &conn,
@@ -305,6 +287,18 @@ impl SessionActor {
                 elapsed_ms = restore_live_config_started.elapsed().as_millis(),
                 "[workspace-latency] session.actor.restore_live_config.completed"
             );
+        }
+        if let Err(error) = apply_requested_mode_preference(
+            &conn,
+            &native_session_id,
+            &config.launch.session,
+            &mut startup_state,
+        )
+        .await
+        {
+            tracing::warn!(session_id = %session_id, error = %error, "failed to apply requested session mode");
+            let _ = ready_tx.send(Err(ModeApplyError::clone_for_readiness(&error)));
+            return Err(error);
         }
         let post_preferences_live_config_started = Instant::now();
         if let Err(error) = emit_live_config_update(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -6,6 +6,7 @@ use anyharness_contract::v1::{SessionActionCapabilities, SessionExecutionPhase};
 use tokio::sync::{mpsc, Mutex};
 
 use crate::domains::sessions::model::serialize_action_capabilities;
+use crate::domains::sessions::model::RequestedModeApplyError as ModeApplyError;
 use crate::domains::sessions::prompt::capabilities::capabilities_from_acp;
 use crate::live::sessions::actor::config::apply::restore_persisted_live_config_if_needed;
 use crate::live::sessions::actor::config::handle::apply_requested_session_preferences;
@@ -213,7 +214,6 @@ impl SessionActor {
             &source_agent_kind,
             startup_strategy.resumes_durable_history(),
         )?;
-
         {
             let mut sink = event_sink.lock().await;
             if startup_disposition == NativeSessionStartupDisposition::CreatedFresh {
@@ -221,7 +221,6 @@ impl SessionActor {
             }
             emit_startup_state(&mut sink, &startup_state);
         }
-
         let initial_live_config_started = Instant::now();
         if let Err(error) = emit_live_config_update(
             &source_agent_kind,
@@ -250,7 +249,6 @@ impl SessionActor {
                 "[workspace-latency] session.actor.initial_live_config.completed"
             );
         }
-
         let apply_preferences_started = Instant::now();
         if let Err(error) = apply_requested_session_preferences(
             &conn,
@@ -268,6 +266,8 @@ impl SessionActor {
                 elapsed_ms = apply_preferences_started.elapsed().as_millis(),
                 "[workspace-latency] session.actor.apply_preferences.failed"
             );
+            let _ = ready_tx.send(Err(ModeApplyError::clone_for_readiness(&error)));
+            return Err(error);
         } else {
             tracing::info!(
                 session_id = %session_id,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -54,6 +54,7 @@ mod domain_ops;
 mod notifications;
 mod prompt;
 mod queue;
+mod requested_mode;
 mod shutdown;
 
 async fn actor_exit_test_context(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/requested_mode.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/requested_mode.rs
@@ -1,5 +1,34 @@
-use crate::live::sessions::actor::config::handle::validate_requested_mode_outcome;
-use crate::live::sessions::actor::config::types::ConfigApplyOutcome;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_client_protocol as acp;
+use anyharness_contract::v1::{
+    NormalizedSessionControl, NormalizedSessionControlValue, NormalizedSessionControls,
+    SessionEventEnvelope, SessionLiveConfigSnapshot,
+};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::app::test_support;
+use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::actor::config::apply::restore_persisted_live_config_if_needed;
+use crate::live::sessions::actor::config::handle::{
+    apply_requested_mode_preference, validate_requested_mode_outcome,
+};
+use crate::live::sessions::actor::config::persist::emit_live_config_update;
+use crate::live::sessions::actor::config::types::{
+    ConfigApplyOutcome, PersistedSessionConfigState,
+};
+use crate::live::sessions::actor::state::SessionStartupState;
+use crate::live::sessions::sink::SessionEventSink;
+use crate::persistence::Db;
+
+const SESSION_ID: &str = "session-queued-mode";
+const NATIVE_SESSION_ID: &str = "native-queued-mode";
+const OLD_MODE: &str = "default";
+const NEW_MODE: &str = "bypassPermissions";
 
 #[test]
 fn requested_startup_mode_requires_authoritative_confirmation() {
@@ -22,4 +51,238 @@ fn requested_startup_mode_requires_authoritative_confirmation() {
             "mode 'bypassPermissions' is not supported by the active session for agent 'claude'"
         );
     }
+}
+
+#[tokio::test]
+async fn queued_mode_wins_over_stale_snapshot_on_cold_resume() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (conn, _shutdown, mut applied_modes) = mode_test_connection().await;
+            let session = queued_mode_session();
+            let (store, event_sink) = session_store_and_sink(&session);
+            let mut persisted_config_state = PersistedSessionConfigState::from_session(&session);
+            // Recreate the vulnerable intermediate state: startup confirmed the queued
+            // mode, but the captured pre-queue snapshot still contains the old mode.
+            let mut startup_state = SessionStartupState {
+                current_mode_id: Some(NEW_MODE.to_string()),
+                legacy_mode_state: None,
+                config_options: vec![mode_option(NEW_MODE)],
+                current_model_id: None,
+                available_models: Vec::new(),
+                prompt_capabilities: Default::default(),
+            };
+
+            restore_persisted_live_config_if_needed(
+                &conn,
+                NATIVE_SESSION_ID,
+                "claude",
+                SESSION_ID,
+                &store,
+                &event_sink,
+                &mut persisted_config_state,
+                &mut startup_state,
+                Some(&stale_mode_snapshot()),
+            )
+            .await
+            .expect("restore stale pre-queue snapshot");
+            assert_eq!(startup_state.current_mode_id.as_deref(), Some(OLD_MODE));
+
+            apply_requested_mode_preference(&conn, NATIVE_SESSION_ID, &session, &mut startup_state)
+                .await
+                .expect("final requested-mode confirmation");
+            emit_live_config_update(
+                "claude",
+                SESSION_ID,
+                &store,
+                &event_sink,
+                &mut persisted_config_state,
+                &mut startup_state,
+                "2026-07-18T00:00:01Z".to_string(),
+            )
+            .await
+            .expect("persist final live config");
+
+            assert_eq!(
+                next_applied_mode(&mut applied_modes).await.as_deref(),
+                Some(OLD_MODE),
+                "the resume restore reproduces the stale snapshot overwrite"
+            );
+            assert_eq!(
+                next_applied_mode(&mut applied_modes).await.as_deref(),
+                Some(NEW_MODE),
+                "the queued requested mode must be the final authoritative write"
+            );
+            assert_eq!(startup_state.current_mode_id.as_deref(), Some(NEW_MODE));
+            let persisted = store
+                .find_by_id(SESSION_ID)
+                .expect("read session")
+                .expect("session exists");
+            assert_eq!(persisted.requested_mode_id.as_deref(), Some(NEW_MODE));
+            assert_eq!(persisted.current_mode_id.as_deref(), Some(NEW_MODE));
+        })
+        .await;
+}
+
+fn queued_mode_session() -> SessionRecord {
+    SessionRecord {
+        id: SESSION_ID.to_string(),
+        workspace_id: "workspace-1".to_string(),
+        agent_kind: "claude".to_string(),
+        native_session_id: Some(NATIVE_SESSION_ID.to_string()),
+        agent_auth_contexts: None,
+        requested_model_id: None,
+        current_model_id: None,
+        requested_mode_id: Some(NEW_MODE.to_string()),
+        current_mode_id: Some(OLD_MODE.to_string()),
+        title: None,
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: "busy".to_string(),
+        created_at: "2026-07-18T00:00:00Z".to_string(),
+        updated_at: "2026-07-18T00:00:00Z".to_string(),
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+        system_prompt_append: None,
+        subagents_enabled: true,
+        action_capabilities_json: None,
+        origin: None,
+    }
+}
+
+async fn next_applied_mode(receiver: &mut mpsc::UnboundedReceiver<String>) -> Option<String> {
+    tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+        .await
+        .expect("mode application timeout")
+}
+
+fn session_store_and_sink(session: &SessionRecord) -> (SessionStore, Arc<Mutex<SessionEventSink>>) {
+    let db = Db::open_in_memory().expect("open db");
+    test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace");
+    let store = SessionStore::new(db);
+    store.insert(session).expect("insert session");
+    let (event_tx, _) = broadcast::channel::<SessionEventEnvelope>(16);
+    let sink = Arc::new(Mutex::new(SessionEventSink::new(
+        SESSION_ID.to_string(),
+        "claude".to_string(),
+        PathBuf::from("/tmp/workspace"),
+        event_tx,
+        Arc::new(store.clone()),
+    )));
+    (store, sink)
+}
+
+fn stale_mode_snapshot() -> SessionLiveConfigSnapshot {
+    SessionLiveConfigSnapshot {
+        raw_config_options: Vec::new(),
+        normalized_controls: NormalizedSessionControls {
+            mode: Some(normalized_mode_control(OLD_MODE)),
+            ..Default::default()
+        },
+        prompt_capabilities: Default::default(),
+        source_seq: 1,
+        updated_at: "2026-07-17T23:59:59Z".to_string(),
+    }
+}
+
+fn normalized_mode_control(current: &str) -> NormalizedSessionControl {
+    NormalizedSessionControl {
+        key: "mode".to_string(),
+        raw_config_id: "mode".to_string(),
+        label: "Mode".to_string(),
+        current_value: Some(current.to_string()),
+        settable: true,
+        values: vec![
+            NormalizedSessionControlValue {
+                value: OLD_MODE.to_string(),
+                label: "Default".to_string(),
+                description: None,
+            },
+            NormalizedSessionControlValue {
+                value: NEW_MODE.to_string(),
+                label: "Bypass permissions".to_string(),
+                description: None,
+            },
+        ],
+    }
+}
+
+fn mode_option(current: &str) -> acp::schema::SessionConfigOption {
+    let mut option = acp::schema::SessionConfigOption::select(
+        "mode",
+        "Mode",
+        current,
+        vec![
+            acp::schema::SessionConfigSelectOption::new(OLD_MODE, "Default"),
+            acp::schema::SessionConfigSelectOption::new(NEW_MODE, "Bypass permissions"),
+        ],
+    );
+    option.category = Some(acp::schema::SessionConfigOptionCategory::Mode);
+    option
+}
+
+async fn mode_test_connection() -> (
+    acp::ConnectionTo<acp::Agent>,
+    oneshot::Sender<()>,
+    mpsc::UnboundedReceiver<String>,
+) {
+    let (client_io, agent_io) = tokio::io::duplex(64 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_io);
+    let (agent_read, agent_write) = tokio::io::split(agent_io);
+    let (cx_tx, cx_rx) = oneshot::channel::<acp::ConnectionTo<acp::Agent>>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let client_transport = acp::ByteStreams::new(client_write.compat_write(), client_read.compat());
+    let client = acp::Client.builder().connect_with(
+        client_transport,
+        move |cx: acp::ConnectionTo<acp::Agent>| async move {
+            let _ = cx_tx.send(cx);
+            let _ = shutdown_rx.await;
+            Ok(())
+        },
+    );
+    tokio::task::spawn_local(async move {
+        let _ = client.await;
+    });
+
+    let (applied_tx, applied_rx) = mpsc::unbounded_channel::<String>();
+    let agent_transport = acp::ByteStreams::new(agent_write.compat_write(), agent_read.compat());
+    let agent = acp::Agent
+        .builder()
+        .name("requested-mode-resume-test-agent")
+        .on_receive_request(
+            async move |request: acp::schema::SetSessionConfigOptionRequest,
+                        responder: acp::Responder<acp::schema::SetSessionConfigOptionResponse>,
+                        _cx| {
+                let value = request
+                    .value
+                    .as_value_id()
+                    .expect("mode request carries a value id")
+                    .0
+                    .to_string();
+                let _ = applied_tx.send(value.clone());
+                responder.respond(acp::schema::SetSessionConfigOptionResponse::new(vec![
+                    mode_option(&value),
+                ]))
+            },
+            acp::on_receive_request!(),
+        )
+        .connect_with(
+            agent_transport,
+            move |_cx: acp::ConnectionTo<acp::Client>| async move {
+                std::future::pending::<()>().await;
+                Ok(())
+            },
+        );
+    tokio::task::spawn_local(async move {
+        let _ = agent.await;
+    });
+
+    let conn = tokio::time::timeout(Duration::from_secs(2), cx_rx)
+        .await
+        .expect("client connection timeout")
+        .expect("client connection established");
+    (conn, shutdown_tx, applied_rx)
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/requested_mode.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/requested_mode.rs
@@ -1,0 +1,25 @@
+use crate::live::sessions::actor::config::handle::validate_requested_mode_outcome;
+use crate::live::sessions::actor::config::types::ConfigApplyOutcome;
+
+#[test]
+fn requested_startup_mode_requires_authoritative_confirmation() {
+    for outcome in [
+        ConfigApplyOutcome::NoChange,
+        ConfigApplyOutcome::AppliedAuthoritative,
+    ] {
+        validate_requested_mode_outcome("claude", "bypassPermissions", outcome)
+            .expect("authoritative mode outcome should be accepted");
+    }
+
+    for outcome in [
+        ConfigApplyOutcome::AppliedRequested,
+        ConfigApplyOutcome::NotApplied,
+    ] {
+        let error = validate_requested_mode_outcome("claude", "bypassPermissions", outcome)
+            .expect_err("unconfirmed mode outcome must fail session startup");
+        assert_eq!(
+            error.to_string(),
+            "mode 'bypassPermissions' is not supported by the active session for agent 'claude'"
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/requested_mode.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/requested_mode.rs
@@ -214,7 +214,7 @@ fn mode_option(current: &str) -> acp::schema::SessionConfigOption {
     let mut option = acp::schema::SessionConfigOption::select(
         "mode",
         "Mode",
-        current,
+        current.to_string(),
         vec![
             acp::schema::SessionConfigSelectOption::new(OLD_MODE, "Default"),
             acp::schema::SessionConfigSelectOption::new(NEW_MODE, "Bypass permissions"),

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -65,5 +65,5 @@ apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 p
 anyharness/crates/anyharness-lib/src/api/router.rs 628 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs/cancel + local materialization operations + workflow-run-workspaces routes)
 anyharness/crates/anyharness-lib/src/app/mod.rs 647 AnyHarness app wiring (+session mutation admission purge/retention wiring, +goal/loop/activity/feed services, +two-phase workflow-run and workflow-workspace wiring, +local materialization service wiring)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam)
-anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 648 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
+anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 642 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations


### PR DESCRIPTION
## Summary

- require the live ACP session to confirm an explicitly requested mode before startup reports ready
- make requested-mode application the final authoritative mode step after cold-resume snapshot restoration
- fall back from the live config option to the legacy mode setter, but reject the create request when neither path applies the value
- return a typed `400 SESSION_MODE_UNSUPPORTED` response instead of silently running the agent's default mode

## Root cause

Session creation validated and persisted `modeId`, but actor startup discarded the legacy setter's `NotApplied` result. The startup path then logged and swallowed every preference-application error before sending its ready signal. A request such as Claude `bypassPermissions` could therefore return success while the active session remained in `default` mode.

Review finding B1367-1 identified a second ordering hazard: a mode queued during a busy turn persists the new requested value while the live-config snapshot still contains the old active mode. Applying the request before cold-resume restoration allowed the stale snapshot to overwrite the confirmed mode before readiness. Startup now keeps model preference behavior in its original best-effort position, restores persisted controls, and only then applies and confirms the explicit requested mode.

## Impact

Explicit session modes are now fail-closed: startup succeeds only when the active agent state already matches or authoritatively confirms the requested value. Best-effort model selection behavior is unchanged.

## Tests

- deterministic unit matrix for confirmed versus unconfirmed mode outcomes
- in-process ACP regression for queued new mode + stale old-mode snapshot + cold resume; asserts the queued mode is the final wire write and persisted current mode
- API mapping unit coverage for the typed 400 response
- `rustfmt --edition 2021 --check` on touched Rust files
- `python3 scripts/check_max_lines.py`
- `git diff --check`

Rust compilation was not run locally because this machine has a protected single-build lane; the draft PR delegates the focused Rust tests and workspace build to CI.

Fixes #979
