### PR TITLE
refactor(server): move setup claim commit into the service layer

### DIFF
--- a/server/proliferate/server/setup/api.py
+++ b/server/proliferate/server/setup/api.py
@@ -33,7 +33,7 @@ async def first_run_setup_page(db: AsyncSession = Depends(get_async_session)) ->
 
 @router.post("/setup", response_class=HTMLResponse, include_in_schema=False)
 async def first_run_setup_claim(
-    db: AsyncSession = Depends(get_async_session, scope="function"),
+    db: AsyncSession = Depends(get_async_session),
     email: Annotated[str, Form()] = "",
     password: Annotated[str, Form()] = "",
     setup_token: Annotated[str, Form()] = "",

--- a/server/proliferate/server/setup/service.py
+++ b/server/proliferate/server/setup/service.py
@@ -49,6 +49,7 @@ from proliferate.server.setup.errors import (
     SetupClosedError,
     SetupValidationError,
 )
+from proliferate.server.setup.transactions import commit_first_run_claim
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,12 @@ async def claim_first_run(
         # Injected by the transport (see lifecycle.py); when omitted the file
         # still gets cleaned up by the next boot's ensure_setup_token pass.
         await schedule_token_file_cleanup(db)
+
+    # The claim owns its transaction: commit before the transport can queue a
+    # response (see transactions.commit_first_run_claim for the full rationale
+    # — store callees only flush(), and the dependency-cleanup commit runs
+    # after the response is sent, so an immediate follow-up login could 401).
+    await commit_first_run_claim(db)
 
     logger.info(
         "Instance claimed: owner %s, organization %r.",

--- a/server/proliferate/server/setup/transactions.py
+++ b/server/proliferate/server/setup/transactions.py
@@ -1,0 +1,30 @@
+"""Commit helper for the first-run claim service.
+
+Split out of service.py because the repo-shape server-boundary check forbids
+service.py from calling session methods or DB session entrypoints directly
+(SERVICE_DB_METHOD_CALL) — mirrors the transactions.py convention used
+elsewhere (e.g. organizations/usage/transactions.py).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.engine import commit_session
+
+
+async def commit_first_run_claim(db: AsyncSession) -> None:
+    """Commit the owner-account + organization claim durably.
+
+    The claim owns its transaction: it must commit BEFORE the transport can
+    queue the 2xx. Store callees only ``flush()``, and the request-scoped
+    session dependency commits on cleanup — which FastAPI runs AFTER the
+    response has been handed to the ASGI server. A client that claims /setup
+    and immediately calls ``POST /auth/desktop/password/login`` (the desktop
+    first-run flow, and the Tier-3 qualification harness) could then hit the
+    user-not-found branch of ``authenticate_password_user`` and get a spurious
+    401 (Release E2E run 29602686092, cell T3-INT-1). The commit also releases
+    the first-run claim advisory lock and fires the scheduled token-file
+    cleanup callback.
+    """
+    await commit_session(db)

--- a/server/tests/unit/test_first_run_claim.py
+++ b/server/tests/unit/test_first_run_claim.py
@@ -325,11 +325,21 @@ async def test_claim_session_commit_finishes_before_response_starts(
     commit_state_at_response_start: list[bool] = []
 
     async def observed_session() -> AsyncGenerator[AsyncSession, None]:
-        nonlocal commit_finished
+        # Observe the SESSION's own commit (whoever issues it), not the
+        # dependency-cleanup commit: transaction ownership lives in
+        # `service.claim_first_run`, which must commit before the handler can
+        # queue the response. The cleanup commit below is a no-op afterwards.
         async with _factory(test_engine)() as session:
+            original_commit = session.commit
+
+            async def marking_commit() -> None:
+                nonlocal commit_finished
+                await original_commit()
+                commit_finished = True
+
+            session.commit = marking_commit  # type: ignore[method-assign]
             yield session
             await session.commit()
-            commit_finished = True
 
     app.dependency_overrides[get_async_session] = observed_session
 


### PR DESCRIPTION
## Outcome

Follow-up to #1359 (merged). Design ruling for the Local Tier-3 program: transaction ownership for the first-run claim lives in the **service layer**, not transport dependency wiring. #1359 merged with the `Depends(get_async_session, scope="function")` variant; this PR replaces it:

- `setup/transactions.py` owns `commit_first_run_claim` via `db.engine.commit_session` — the repo's `transactions.py` convention (`organizations/usage`, `organizations/sso`), keeping `SERVICE_DB_METHOD_CALL` / `API_DB_METHOD_CALL` boundary rules green.
- `service.claim_first_run` commits before returning; `api.py` returns to the plain request-scoped dependency.

Behavior is unchanged: the claim is durable before the 2xx is queued (the #1359 race fix holds), the advisory lock still releases on the service commit, and the scheduled token-file cleanup still fires.

## Proof

- `tests/unit/test_first_run_claim.py`: 17/17 — including `test_claim_session_commit_finishes_before_response_starts`, which observes the session's own commit at the ASGI `http.response.start` boundary (mutation-checked: fails if the service commit is removed).
- `scripts/check_server_boundaries.py`: passes.
- Dedicated agent review at tree-identical head `e4f391163` on the #1359 branch: MERGE_READY (initial + delta re-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)