### PR TITLE
test(release): verify workspace file secret materialization

### DIFF
--- a/tests/release/src/fixtures/http.ts
+++ b/tests/release/src/fixtures/http.ts
@@ -52,8 +52,8 @@ export class ApiClient {
     return this.request<TResponse>("GET", path);
   }
 
-  async delete<TResponse>(path: string): Promise<TResponse> {
-    return this.request<TResponse>("DELETE", path);
+  async delete<TResponse>(path: string, body?: unknown): Promise<TResponse> {
+    return this.request<TResponse>("DELETE", path, body);
   }
 
   private async request<TResponse>(method: string, path: string, body?: unknown): Promise<TResponse> {

--- a/tests/release/src/fixtures/workspace-secret-lifecycle.test.ts
+++ b/tests/release/src/fixtures/workspace-secret-lifecycle.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { RunIdentityV1 } from "../runner/identity.js";
+import {
+  runScopedWorkspaceSecretPath,
+  withWorkspaceSecretLifecycle,
+  type WorkspaceSecretLifecycleClient,
+} from "./workspace-secret-lifecycle.js";
+
+const run: RunIdentityV1 = {
+  run_id: "run-1",
+  shard_id: "sandbox-1",
+  attempt: 2,
+  source_sha: "a".repeat(40),
+  origin: { kind: "local", github_run_id: null, github_job: null },
+};
+
+class FakeClient implements WorkspaceSecretLifecycleClient {
+  readonly events: string[];
+  secretExists = false;
+  workspaceExists = false;
+  failSecretDelete = false;
+  failWorkspaceDelete = false;
+
+  constructor(events: string[]) {
+    this.events = events;
+  }
+
+  async put<TResponse>(path: string, body: unknown): Promise<TResponse> {
+    const secretPath = (body as { path: string }).path;
+    this.events.push(`put:${path}:${secretPath}`);
+    this.secretExists = true;
+    return { materialization: { status: "pending" } } as TResponse;
+  }
+
+  async post<TResponse>(path: string): Promise<TResponse> {
+    this.events.push(`post:${path}`);
+    this.workspaceExists = true;
+    return { id: "workspace-1", status: "materializing" } as TResponse;
+  }
+
+  async delete<TResponse>(path: string, body?: unknown): Promise<TResponse> {
+    if (path.includes("/secrets/files")) {
+      this.events.push(`delete-secret:${(body as { path: string }).path}`);
+      if (this.failSecretDelete) {
+        throw new Error("secret delete failed");
+      }
+      this.secretExists = false;
+      return undefined as TResponse;
+    }
+    this.events.push(`delete-workspace:${path}`);
+    if (this.failWorkspaceDelete) {
+      throw new Error("workspace delete failed");
+    }
+    this.workspaceExists = false;
+    return undefined as TResponse;
+  }
+}
+
+function lifecycleOptions(client: FakeClient, events: string[], exercise: () => Promise<string>) {
+  const secretPath = runScopedWorkspaceSecretPath(run);
+  return {
+    client,
+    owner: "example",
+    repo: "fixture",
+    secretPath,
+    secretContent: "synthetic-secret",
+    workspaceRequest: { branchName: "run-branch" },
+    exercise: async () => exercise(),
+    verifySecretAbsent: async () => {
+      events.push("verify-secret-absent");
+      if (client.secretExists) {
+        throw new Error("secret remained materialized");
+      }
+    },
+  };
+}
+
+test("run-scoped path is stable for one attempt and distinct across attempts", () => {
+  const path = runScopedWorkspaceSecretPath(run);
+  assert.match(path, /^\.proliferate\/qualification\/t3-sec-mat-1-[0-9a-f]{20}\.txt$/);
+  assert.equal(path, runScopedWorkspaceSecretPath(run));
+  assert.notEqual(path, runScopedWorkspaceSecretPath({ ...run, attempt: run.attempt + 1 }));
+});
+
+test("lifecycle cleans the secret before the workspace after a successful proof", async () => {
+  const events: string[] = [];
+  const client = new FakeClient(events);
+  const result = await withWorkspaceSecretLifecycle(
+    lifecycleOptions(client, events, async () => {
+      events.push("exercise");
+      return "proved";
+    }),
+  );
+
+  assert.equal(result, "proved");
+  assert.equal(client.secretExists, false);
+  assert.equal(client.workspaceExists, false);
+  assert.deepEqual(events.slice(0, 2), [
+    `put:/v1/cloud/repos/example/fixture/secrets/files:${runScopedWorkspaceSecretPath(run)}`,
+    "post:/v1/cloud/workspaces",
+  ]);
+  assert.deepEqual(events.slice(-3), [
+    `delete-secret:${runScopedWorkspaceSecretPath(run)}`,
+    "verify-secret-absent",
+    "delete-workspace:/v1/cloud/workspaces/workspace-1",
+  ]);
+});
+
+test("lifecycle cleans both resources after the proof assertion fails", async () => {
+  const events: string[] = [];
+  const client = new FakeClient(events);
+  const primary = new Error("byte proof failed");
+
+  await assert.rejects(
+    withWorkspaceSecretLifecycle(
+      lifecycleOptions(client, events, async () => {
+        throw primary;
+      }),
+    ),
+    (error) => error === primary,
+  );
+  assert.equal(client.secretExists, false);
+  assert.equal(client.workspaceExists, false);
+  assert.ok(events.includes("verify-secret-absent"));
+});
+
+test("cleanup failures are non-green and preserve the primary plus every cleanup error", async () => {
+  const events: string[] = [];
+  const client = new FakeClient(events);
+  client.failSecretDelete = true;
+  client.failWorkspaceDelete = true;
+
+  await assert.rejects(
+    withWorkspaceSecretLifecycle(
+      lifecycleOptions(client, events, async () => {
+        throw new Error("byte proof failed");
+      }),
+    ),
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.deepEqual(
+        error.errors.map((entry) => (entry as Error).message),
+        [
+          "byte proof failed",
+          "T3-SEC-MAT-1 cleanup failed to delete workspace secret: secret delete failed",
+          "T3-SEC-MAT-1 cleanup failed to verify workspace secret absence: secret remained materialized",
+          "T3-SEC-MAT-1 cleanup failed to delete cloud workspace: workspace delete failed",
+        ],
+      );
+      return true;
+    },
+  );
+  assert.ok(events.some((event) => event.startsWith("delete-workspace:")));
+});

--- a/tests/release/src/fixtures/workspace-secret-lifecycle.ts
+++ b/tests/release/src/fixtures/workspace-secret-lifecycle.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import type { RunIdentityV1 } from "../runner/identity.js";
+
+interface MaterializationResponse {
+  materialization: { status: "pending" | "running" | "ready" | "error" } | null;
+}
+
+export interface WorkspaceSecretLifecycleClient {
+  put<TResponse>(path: string, body: unknown): Promise<TResponse>;
+  post<TResponse>(path: string, body: unknown): Promise<TResponse>;
+  delete<TResponse>(path: string, body?: unknown): Promise<TResponse>;
+}
+
+interface WorkspaceResponse {
+  id: string;
+  status: string;
+}
+
+export interface WorkspaceSecretLifecycleOptions<TResult> {
+  client: WorkspaceSecretLifecycleClient;
+  owner: string;
+  repo: string;
+  secretPath: string;
+  secretContent: string;
+  workspaceRequest: Record<string, unknown>;
+  exercise(workspace: WorkspaceResponse): Promise<TResult>;
+  verifySecretAbsent(): Promise<void>;
+}
+
+/** A bounded repo-relative target unique to one run, shard, and attempt. */
+export function runScopedWorkspaceSecretPath(run: RunIdentityV1): string {
+  const identity = `${run.run_id}:${run.shard_id}:${run.attempt}`;
+  const suffix = createHash("sha256").update(identity, "utf8").digest("hex").slice(0, 20);
+  return `.proliferate/qualification/t3-sec-mat-1-${suffix}.txt`;
+}
+
+/**
+ * Owns the scenario's repo secret and workspace as one fail-aware lifecycle.
+ * Cleanup never masks the primary failure and every cleanup failure makes the
+ * scenario non-green.
+ */
+export async function withWorkspaceSecretLifecycle<TResult>(
+  options: WorkspaceSecretLifecycleOptions<TResult>,
+): Promise<TResult> {
+  const secretEndpoint = `/v1/cloud/repos/${options.owner}/${options.repo}/secrets/files`;
+  let secretCreated = false;
+  let workspace: WorkspaceResponse | null = null;
+  let result: TResult | undefined;
+  let primaryError: unknown;
+  let hasPrimaryError = false;
+
+  try {
+    const secretPut = await options.client.put<MaterializationResponse>(secretEndpoint, {
+      path: options.secretPath,
+      content: options.secretContent,
+    });
+    secretCreated = true;
+    assert.ok(
+      secretPut.materialization && ["pending", "running", "ready"].includes(secretPut.materialization.status),
+      "T3-SEC-MAT-1: PUT workspace file secret must return a materialization status",
+    );
+
+    workspace = await options.client.post<WorkspaceResponse>("/v1/cloud/workspaces", options.workspaceRequest);
+    result = await options.exercise(workspace);
+  } catch (error) {
+    hasPrimaryError = true;
+    primaryError = error;
+  }
+
+  const cleanupErrors: Error[] = [];
+  if (secretCreated) {
+    await captureCleanupError(cleanupErrors, "delete workspace secret", () =>
+      options.client.delete(secretEndpoint, { path: options.secretPath }),
+    );
+    await captureCleanupError(cleanupErrors, "verify workspace secret absence", options.verifySecretAbsent);
+  }
+  if (workspace !== null) {
+    const workspaceId = workspace.id;
+    await captureCleanupError(cleanupErrors, "delete cloud workspace", () =>
+      options.client.delete(`/v1/cloud/workspaces/${workspaceId}`),
+    );
+  }
+
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(
+      hasPrimaryError ? [primaryError, ...cleanupErrors] : cleanupErrors,
+      "T3-SEC-MAT-1: scenario or cleanup failed",
+    );
+  }
+  if (hasPrimaryError) {
+    throw primaryError;
+  }
+  return result as TResult;
+}
+
+async function captureCleanupError(errors: Error[], label: string, cleanup: () => Promise<unknown>): Promise<void> {
+  try {
+    await cleanup();
+  } catch (error) {
+    errors.push(
+      new Error(`T3-SEC-MAT-1 cleanup failed to ${label}: ${error instanceof Error ? error.message : String(error)}`, {
+        cause: error,
+      }),
+    );
+  }
+}

--- a/tests/release/src/scenarios/t3-sec-mat-1.test.ts
+++ b/tests/release/src/scenarios/t3-sec-mat-1.test.ts
@@ -45,6 +45,25 @@ test("workspace secret proof rejects a missing secret file", () => {
   );
 });
 
+test("workspace secret proof rejects bytes that differ from the created secret", () => {
+  assert.throws(
+    () =>
+      assertWorkspaceSecretMaterialized({
+        workspaceEnvPath,
+        workspaceEnvRead: { content: "", error: null },
+        secretPath,
+        secretRead: { content: "different", error: null },
+        secretContent,
+        manifestPath,
+        manifestRead: {
+          content: JSON.stringify({ env: {}, files: { [secretPath]: secretSha256 }, versions: {} }),
+          error: null,
+        },
+      }),
+    /must match the workspace file secret/,
+  );
+});
+
 test("workspace secret proof rejects a stale manifest checksum", () => {
   assert.throws(
     () =>

--- a/tests/release/src/scenarios/t3-sec-mat-1.test.ts
+++ b/tests/release/src/scenarios/t3-sec-mat-1.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { assertWorkspaceSecretMaterialized } from "./t3-sec-mat-1.js";
+
+const workspaceEnvPath = "/home/user/workspace/repos/example/repo/.proliferate/env/workspace.env";
+const secretPath = "/home/user/workspace/repos/example/repo/.private/token.txt";
+const manifestPath = "/home/user/workspace/repos/example/repo/.proliferate/env/workspace.manifest.json";
+const secretContent = "workspace-secret";
+const secretSha256 = "fe54432b6be58e44c9c3a59bc3f0205bcd6e48f990c8e5d15b12b6138265a5a0";
+
+test("workspace secret proof accepts an empty generated env file and verifies the file plus manifest", () => {
+  assert.doesNotThrow(() =>
+    assertWorkspaceSecretMaterialized({
+      workspaceEnvPath,
+      workspaceEnvRead: { content: "", error: null },
+      secretPath,
+      secretRead: { content: secretContent, error: null },
+      secretContent,
+      manifestPath,
+      manifestRead: {
+        content: JSON.stringify({ env: {}, files: { [secretPath]: secretSha256 }, versions: {} }),
+        error: null,
+      },
+    }),
+  );
+});
+
+test("workspace secret proof rejects a missing secret file", () => {
+  assert.throws(
+    () =>
+      assertWorkspaceSecretMaterialized({
+        workspaceEnvPath,
+        workspaceEnvRead: { content: "", error: null },
+        secretPath,
+        secretRead: { content: null, error: "not found" },
+        secretContent,
+        manifestPath,
+        manifestRead: {
+          content: JSON.stringify({ env: {}, files: { [secretPath]: secretSha256 }, versions: {} }),
+          error: null,
+        },
+      }),
+    /must contain the workspace file secret/,
+  );
+});
+
+test("workspace secret proof rejects a stale manifest checksum", () => {
+  assert.throws(
+    () =>
+      assertWorkspaceSecretMaterialized({
+        workspaceEnvPath,
+        workspaceEnvRead: { content: "", error: null },
+        secretPath,
+        secretRead: { content: secretContent, error: null },
+        secretContent,
+        manifestPath,
+        manifestRead: {
+          content: JSON.stringify({ env: {}, files: { [secretPath]: "stale" }, versions: {} }),
+          error: null,
+        },
+      }),
+    /must match sha256\(content\)/,
+  );
+});

--- a/tests/release/src/scenarios/t3-sec-mat-1.ts
+++ b/tests/release/src/scenarios/t3-sec-mat-1.ts
@@ -154,7 +154,6 @@ async function runReal(ctx: ScenarioRunContext): Promise<void> {
   assert.ok(sandbox, "T3-SEC-MAT-1: the durable user must have a personal cloud sandbox after materialization");
 
   if (!e2bVerificationAvailable()) {
-    await runWorkspaceFileSecretHalf(ctx, client, organizationId as string);
     throw new ScenarioExpectedFailError(
       "T3-SEC-MAT-1: personal + org secret PUT verified for real, and materialization.status reached " +
         "'ready' (the server's own signal that it wrote the sandbox files). The in-sandbox byte-level " +
@@ -188,7 +187,7 @@ async function runReal(ctx: ScenarioRunContext): Promise<void> {
   assert.equal(readyAgain?.materialization?.status, "ready", "T3-SEC-MAT-1: personal secrets must return to ready");
   await assertGlobalEnvContains(providerSandboxId, [{ name: personalName, value: updatedPersonalValue }]);
 
-  await runWorkspaceFileSecretHalf(ctx, client, organizationId as string);
+  await runWorkspaceFileSecretHalf(ctx, client);
 }
 
 async function assertGlobalEnvContains(
@@ -244,9 +243,7 @@ async function pollSecretsReady(
 async function runWorkspaceFileSecretHalf(
   ctx: ScenarioRunContext,
   client: ApiClient,
-  organizationId: string,
 ): Promise<void> {
-  void organizationId;
   const [owner, repo] = (process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO).split("/");
   const durableEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL;
 
@@ -310,7 +307,14 @@ async function runWorkspaceFileSecretHalf(
 
   const secretPath = ".proliferate-secret/t3-sec-mat-1.txt";
   const secretContent = `t3-sec-mat-1-workspace-secret-${randomUUID().slice(0, 8)}`;
-  await client.put(`/v1/cloud/repos/${owner}/${repo}/secrets/files`, { path: secretPath, content: secretContent });
+  const secretPut = await client.put<CloudSecretsResponse>(`/v1/cloud/repos/${owner}/${repo}/secrets/files`, {
+    path: secretPath,
+    content: secretContent,
+  });
+  assert.ok(
+    secretPut.materialization && ["pending", "running", "ready"].includes(secretPut.materialization.status),
+    "T3-SEC-MAT-1: PUT workspace file secret must return a materialization status",
+  );
 
   const branchName = `t3-sec-mat-1-${randomUUID().slice(0, 8)}`;
   const workspace = await client.post<{ id: string; status: string }>("/v1/cloud/workspaces", {
@@ -326,20 +330,76 @@ async function runWorkspaceFileSecretHalf(
     const ready = await pollWorkspaceReady(client, workspace.id, { timeoutMs: 180_000 });
     assert.equal(ready?.status, "ready", "T3-SEC-MAT-1: fresh cloud workspace must reach status=ready");
 
+    const readyWorkspaceSecrets = await pollSecretsReady(client, `/v1/cloud/repos/${owner}/${repo}/secrets`, {
+      timeoutMs: 60_000,
+    });
+    assert.equal(
+      readyWorkspaceSecrets?.materialization?.status,
+      "ready",
+      "T3-SEC-MAT-1: workspace secrets must reach ready",
+    );
+
     const sandbox = await getCloudSandbox(client);
     assert.ok(sandbox, "T3-SEC-MAT-1: the workspace's personal cloud sandbox must exist");
     const found = await findProviderSandbox((sandbox as { id: string }).id);
     assert.ok(found.providerSandboxId, "T3-SEC-MAT-1: must resolve the provider sandbox via E2B metadata");
 
-    const workspaceEnvPath = `/home/user/workspace/repos/${owner}/${repo}/.proliferate/env/workspace.env`;
+    const repoPath = `/home/user/workspace/repos/${owner}/${repo}`;
+    const workspaceEnvPath = `${repoPath}/.proliferate/env/workspace.env`;
+    const workspaceManifestPath = `${repoPath}/.proliferate/env/workspace.manifest.json`;
+    const materializedSecretPath = `${repoPath}/${secretPath}`;
     const workspaceEnvRead = await readProviderSandboxFile(found.providerSandboxId as string, workspaceEnvPath);
-    assert.ok(
-      workspaceEnvRead.content,
-      `T3-SEC-MAT-1: ${workspaceEnvPath} must exist and be readable (error: ${workspaceEnvRead.error})`,
+    const secretRead = await readProviderSandboxFile(found.providerSandboxId as string, materializedSecretPath);
+    const workspaceManifestRead = await readProviderSandboxFile(
+      found.providerSandboxId as string,
+      workspaceManifestPath,
     );
+    assertWorkspaceSecretMaterialized({
+      workspaceEnvPath,
+      workspaceEnvRead,
+      secretPath: materializedSecretPath,
+      secretRead,
+      secretContent,
+      manifestPath: workspaceManifestPath,
+      manifestRead: workspaceManifestRead,
+    });
   } finally {
     await client.delete(`/v1/cloud/workspaces/${workspace.id}`).catch(() => undefined);
   }
+}
+
+export function assertWorkspaceSecretMaterialized(input: {
+  workspaceEnvPath: string;
+  workspaceEnvRead: { content: string | null; error: string | null };
+  secretPath: string;
+  secretRead: { content: string | null; error: string | null };
+  secretContent: string;
+  manifestPath: string;
+  manifestRead: { content: string | null; error: string | null };
+}): void {
+  assert.notEqual(
+    input.workspaceEnvRead.content,
+    null,
+    `T3-SEC-MAT-1: ${input.workspaceEnvPath} must exist and be readable (error: ${input.workspaceEnvRead.error})`,
+  );
+  assert.equal(
+    input.secretRead.content,
+    input.secretContent,
+    `T3-SEC-MAT-1: ${input.secretPath} must contain the workspace file secret (error: ${input.secretRead.error})`,
+  );
+  assert.notEqual(
+    input.manifestRead.content,
+    null,
+    `T3-SEC-MAT-1: ${input.manifestPath} must exist and be readable (error: ${input.manifestRead.error})`,
+  );
+
+  const manifest = JSON.parse(input.manifestRead.content as string) as SecretManifest;
+  const expectedSha256 = createHash("sha256").update(input.secretContent, "utf8").digest("hex");
+  assert.equal(
+    manifest.files[input.secretPath],
+    expectedSha256,
+    `T3-SEC-MAT-1: manifest sha256 for ${input.secretPath} must match sha256(content)`,
+  );
 }
 
 async function pollWorkspaceReady(

--- a/tests/release/src/scenarios/t3-sec-mat-1.ts
+++ b/tests/release/src/scenarios/t3-sec-mat-1.ts
@@ -7,7 +7,16 @@ import { withProductGate } from "../fixtures/product-gate.js";
 import { ApiClient } from "../fixtures/http.js";
 import { assertDurableIdentityAvailableForLane, loginDurableUserForLane } from "../fixtures/lane-identity.js";
 import { ensureCloudSandboxRow, getCloudSandbox, withCloudSandboxBillingGate } from "../fixtures/cloud-sandbox.js";
-import { e2bVerificationAvailable, findProviderSandbox, readProviderSandboxFile } from "../fixtures/e2b-verify.js";
+import {
+  e2bVerificationAvailable,
+  execInProviderSandbox,
+  findProviderSandbox,
+  readProviderSandboxFile,
+} from "../fixtures/e2b-verify.js";
+import {
+  runScopedWorkspaceSecretPath,
+  withWorkspaceSecretLifecycle,
+} from "../fixtures/workspace-secret-lifecycle.js";
 import { DEFAULT_GITHUB_TEST_REPO } from "../config/env-manifest.js";
 import {
   githubAppSeedAvailable,
@@ -305,67 +314,76 @@ async function runWorkspaceFileSecretHalf(
   }
   assert.equal(environment.defaultBranch, "develop", "T3-SEC-MAT-1: repo environment default branch must round-trip");
 
-  const secretPath = ".proliferate-secret/t3-sec-mat-1.txt";
+  assert.ok(ctx.runIdentity, "T3-SEC-MAT-1: a real run must carry its run identity");
+  const secretPath = runScopedWorkspaceSecretPath(ctx.runIdentity);
   const secretContent = `t3-sec-mat-1-workspace-secret-${randomUUID().slice(0, 8)}`;
-  const secretPut = await client.put<CloudSecretsResponse>(`/v1/cloud/repos/${owner}/${repo}/secrets/files`, {
-    path: secretPath,
-    content: secretContent,
-  });
-  assert.ok(
-    secretPut.materialization && ["pending", "running", "ready"].includes(secretPut.materialization.status),
-    "T3-SEC-MAT-1: PUT workspace file secret must return a materialization status",
-  );
-
   const branchName = `t3-sec-mat-1-${randomUUID().slice(0, 8)}`;
-  const workspace = await client.post<{ id: string; status: string }>("/v1/cloud/workspaces", {
-    gitProvider: "github",
-    gitOwner: owner,
-    gitRepoName: repo,
-    baseBranch: "develop",
-    branchName,
-    source: "web",
-  });
-
-  try {
-    const ready = await pollWorkspaceReady(client, workspace.id, { timeoutMs: 180_000 });
-    assert.equal(ready?.status, "ready", "T3-SEC-MAT-1: fresh cloud workspace must reach status=ready");
-
-    const readyWorkspaceSecrets = await pollSecretsReady(client, `/v1/cloud/repos/${owner}/${repo}/secrets`, {
-      timeoutMs: 60_000,
-    });
-    assert.equal(
-      readyWorkspaceSecrets?.materialization?.status,
-      "ready",
-      "T3-SEC-MAT-1: workspace secrets must reach ready",
-    );
-
+  const repoPath = `/home/user/workspace/repos/${owner}/${repo}`;
+  const workspaceEnvPath = `${repoPath}/.proliferate/env/workspace.env`;
+  const workspaceManifestPath = `${repoPath}/.proliferate/env/workspace.manifest.json`;
+  const materializedSecretPath = `${repoPath}/${secretPath}`;
+  let resolvedProviderSandboxId: string | null = null;
+  const resolveProviderSandboxId = async (): Promise<string> => {
+    if (resolvedProviderSandboxId !== null) {
+      return resolvedProviderSandboxId;
+    }
     const sandbox = await getCloudSandbox(client);
     assert.ok(sandbox, "T3-SEC-MAT-1: the workspace's personal cloud sandbox must exist");
     const found = await findProviderSandbox((sandbox as { id: string }).id);
     assert.ok(found.providerSandboxId, "T3-SEC-MAT-1: must resolve the provider sandbox via E2B metadata");
+    resolvedProviderSandboxId = found.providerSandboxId as string;
+    return resolvedProviderSandboxId;
+  };
 
-    const repoPath = `/home/user/workspace/repos/${owner}/${repo}`;
-    const workspaceEnvPath = `${repoPath}/.proliferate/env/workspace.env`;
-    const workspaceManifestPath = `${repoPath}/.proliferate/env/workspace.manifest.json`;
-    const materializedSecretPath = `${repoPath}/${secretPath}`;
-    const workspaceEnvRead = await readProviderSandboxFile(found.providerSandboxId as string, workspaceEnvPath);
-    const secretRead = await readProviderSandboxFile(found.providerSandboxId as string, materializedSecretPath);
-    const workspaceManifestRead = await readProviderSandboxFile(
-      found.providerSandboxId as string,
-      workspaceManifestPath,
-    );
-    assertWorkspaceSecretMaterialized({
-      workspaceEnvPath,
-      workspaceEnvRead,
-      secretPath: materializedSecretPath,
-      secretRead,
-      secretContent,
-      manifestPath: workspaceManifestPath,
-      manifestRead: workspaceManifestRead,
-    });
-  } finally {
-    await client.delete(`/v1/cloud/workspaces/${workspace.id}`).catch(() => undefined);
-  }
+  await withWorkspaceSecretLifecycle({
+    client,
+    owner,
+    repo,
+    secretPath,
+    secretContent,
+    workspaceRequest: {
+      gitProvider: "github",
+      gitOwner: owner,
+      gitRepoName: repo,
+      baseBranch: "develop",
+      branchName,
+      source: "web",
+    },
+    exercise: async (workspace) => {
+      const ready = await pollWorkspaceReady(client, workspace.id, { timeoutMs: 180_000 });
+      assert.equal(ready?.status, "ready", "T3-SEC-MAT-1: fresh cloud workspace must reach status=ready");
+
+      const readyWorkspaceSecrets = await pollSecretsReady(client, `/v1/cloud/repos/${owner}/${repo}/secrets`, {
+        timeoutMs: 60_000,
+      });
+      assert.equal(
+        readyWorkspaceSecrets?.materialization?.status,
+        "ready",
+        "T3-SEC-MAT-1: workspace secrets must reach ready",
+      );
+
+      const providerSandboxId = await resolveProviderSandboxId();
+      const workspaceEnvRead = await readProviderSandboxFile(providerSandboxId, workspaceEnvPath);
+      const secretRead = await readProviderSandboxFile(providerSandboxId, materializedSecretPath);
+      const workspaceManifestRead = await readProviderSandboxFile(providerSandboxId, workspaceManifestPath);
+      assertWorkspaceSecretMaterialized({
+        workspaceEnvPath,
+        workspaceEnvRead,
+        secretPath: materializedSecretPath,
+        secretRead,
+        secretContent,
+        manifestPath: workspaceManifestPath,
+        manifestRead: workspaceManifestRead,
+      });
+    },
+    verifySecretAbsent: async () =>
+      pollWorkspaceSecretAbsent(
+        await resolveProviderSandboxId(),
+        materializedSecretPath,
+        workspaceManifestPath,
+        { timeoutMs: 60_000 },
+      ),
+  });
 }
 
 export function assertWorkspaceSecretMaterialized(input: {
@@ -382,9 +400,9 @@ export function assertWorkspaceSecretMaterialized(input: {
     null,
     `T3-SEC-MAT-1: ${input.workspaceEnvPath} must exist and be readable (error: ${input.workspaceEnvRead.error})`,
   );
-  assert.equal(
+  assert.notEqual(
     input.secretRead.content,
-    input.secretContent,
+    null,
     `T3-SEC-MAT-1: ${input.secretPath} must contain the workspace file secret (error: ${input.secretRead.error})`,
   );
   assert.notEqual(
@@ -395,10 +413,57 @@ export function assertWorkspaceSecretMaterialized(input: {
 
   const manifest = JSON.parse(input.manifestRead.content as string) as SecretManifest;
   const expectedSha256 = createHash("sha256").update(input.secretContent, "utf8").digest("hex");
+  const materializedSha256 = createHash("sha256")
+    .update(input.secretRead.content as string, "utf8")
+    .digest("hex");
+  assert.equal(
+    materializedSha256,
+    expectedSha256,
+    `T3-SEC-MAT-1: sha256(content) for ${input.secretPath} must match the workspace file secret`,
+  );
   assert.equal(
     manifest.files[input.secretPath],
     expectedSha256,
     `T3-SEC-MAT-1: manifest sha256 for ${input.secretPath} must match sha256(content)`,
+  );
+}
+
+async function pollWorkspaceSecretAbsent(
+  providerSandboxId: string,
+  secretPath: string,
+  manifestPath: string,
+  options: { timeoutMs: number; pollMs?: number },
+): Promise<void> {
+  const pollMs = options.pollMs ?? 2000;
+  const deadline = Date.now() + options.timeoutMs;
+  let fileAbsent = false;
+  let manifestOwnsSecret = true;
+  do {
+    const existence = await execInProviderSandbox(providerSandboxId, ["test", "!", "-e", secretPath]);
+    fileAbsent = existence.exitCode === 0;
+    const manifestExistence = await execInProviderSandbox(providerSandboxId, ["test", "!", "-e", manifestPath]);
+    if (manifestExistence.exitCode === 0) {
+      manifestOwnsSecret = false;
+    } else {
+      const manifestRead = await readProviderSandboxFile(providerSandboxId, manifestPath);
+      try {
+        const manifest = JSON.parse(manifestRead.content as string) as SecretManifest;
+        manifestOwnsSecret = Object.hasOwn(manifest.files, secretPath);
+      } catch {
+        manifestOwnsSecret = true;
+      }
+    }
+    if (fileAbsent && !manifestOwnsSecret) {
+      return;
+    }
+    if (Date.now() < deadline) {
+      await sleep(pollMs);
+    }
+  } while (Date.now() < deadline);
+
+  assert.fail(
+    `T3-SEC-MAT-1: workspace secret cleanup did not propagate within ${options.timeoutMs}ms ` +
+      `(fileAbsent=${fileAbsent}, manifestOwnsSecret=${manifestOwnsSecret})`,
   );
 }
 


### PR DESCRIPTION
## Summary

- make T3-SEC-MAT-1 wait for the workspace secret set to reach ready
- read the materialized workspace file itself and verify its exact contents
- verify the workspace secret manifest records the file's absolute target path with the expected SHA-256
- treat an empty generated workspace.env as a successful readable file instead of a false failure
- skip the provider-backed workspace proof when the E2B verification credential is absent
- scope the temporary secret path to the exact run, shard, and attempt
- always delete the repo secret, prove filesystem and manifest absence, then delete the workspace
- preserve primary failures alongside every secret/workspace cleanup failure so cleanup can never report green falsely

This completes the scenario implementation tracked by #1042. The hosted durable-user GitHub App authorization operation remains separately owned by #1043; this change does not bypass that block or contact any provider.

Closes #1042

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- [x] pnpm -C tests/release exec tsx --test src/fixtures/workspace-secret-lifecycle.test.ts src/scenarios/t3-sec-mat-1.test.ts (8/8)
- [x] pnpm -C tests/release typecheck
- [x] pnpm -C tests/release test (1180/1180)
- [x] python3 scripts/check_max_lines.py
- [x] git diff --check
