### PR TITLE
test(release): re-land local Tier-3 collector repairs missing from main

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -589,6 +589,16 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10
+      # T3-INT-1's audit-readback probe (tests/release/scripts/integration_audit_probe.py)
+      # runs via `uv run python …` to read the cloud_integration_tool_call_event
+      # row back from the run's own Postgres — the same `spawn("uv", …)` idiom the
+      # tier-2/tier-3/self-host jobs use. Without uv on PATH the probe dies
+      # `spawn uv ENOENT` after a fully successful MCP tool call. Match the sibling
+      # jobs (uv + python 3.12, the script's requires-python).
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -604,6 +614,15 @@ jobs:
           AGENT_GATEWAY_LITELLM_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_BASE_URL }}
           AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
           AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
+          # CI-only server secrets (same throwaway values server-ci.yml + the
+          # tier-3 job above use). T3-INT-1's audit-readback probe
+          # (integration_audit_probe.py) imports `proliferate.config`, which
+          # constructs Settings() at import time and requires both in non-debug
+          # mode — absent, the probe exits 1 (proven: Actions run 29617987951).
+          # Non-secret CI placeholders: the world's candidate Server builds its
+          # own random secrets in buildServerEnv (world.ts), so nothing leaks.
+          JWT_SECRET: release-e2e-ci-jwt-secret
+          CLOUD_SECRET_KEY: release-e2e-ci-cloud-secret
           # BYOK provider keys for the LOCAL-3 user-key route + LOCAL-6 route
           # change (env-manifest.ts). In strict mode an absent required key
           # blocks its selected cells, cancels otherwise-runnable cells, and

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -288,8 +288,21 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     // after the user-key turn, so navigate back to the harness pane first.
     await openHarnessSettings(p, harness);
     await selectHarnessRoute(p, harness, "gateway");
-    await returnToAppHome(p);
+    // A workspace is already active here (unlike LOCAL-2/3's first settings
+    // visit), so "Back to app" returns to the workspace chat shell, not the
+    // home composer.
+    await returnToAppHome(p, "[data-workspace-shell]");
     await this.waitForRouteSync(world, page, harness, "gateway");
+    // LOCAL-6 requires the gateway turn to run on a NEW session (the cell
+    // asserts gatewayTurn.sessionId !== userKeyTurn.sessionId). Back on the
+    // workspace shell the user-key session is still active, and picking the
+    // gateway model there fires the product's same-harness LIVE model switch on
+    // that session (setActiveSessionConfigOption), which the server correctly
+    // 400s SESSION_CONFIG_REJECTED — a session must not silently jump auth
+    // contexts via a config PATCH (proven: Actions run 29570511844,
+    // T3-AUTHROUTE-1/local/route=change). Open a fresh in-workspace chat tab so
+    // the gateway model pick + send go through the create-session/launch path.
+    await openNewChat(p);
   },
   async waitForRouteSync(world, _page, harness, route) {
     // Desktop's use-local-auth-state-sync pushes the newly selected route's auth
@@ -360,7 +373,11 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     // bind the gateway leg to the already-completed user-key session while the
     // new process is still reconciling.
     const preSendSessionIds = await snapshotLocalWorkspaceSessionIds(world, repoPath);
-    const editor = p.locator("[data-home-composer-editor]").first();
+    // LOCAL-2/3's first turn runs from the home screen (`[data-home-composer-editor]`);
+    // LOCAL-6's gateway turn runs from a fresh in-workspace tab
+    // (`[data-chat-composer-editor]`, opened by `openNewChat`). Accept either
+    // surface — the same dual-composer idiom `config-session.ts` uses.
+    const editor = p.locator("[data-home-composer-editor], [data-chat-composer-editor]").first();
     await editor.waitFor({ state: "visible", timeout: 15_000 });
     await editor.fill(DETERMINISTIC_PROMPT);
     const send = p.locator("[data-chat-send-button]:not([disabled])").first();
@@ -845,6 +862,11 @@ async function runLocal6RouteChangeCell(
       });
 
       // 2) Switch the selected route to gateway; a NEW session launches on it.
+      // `switchSelectedRouteToGateway` opens a fresh in-workspace chat tab (so the
+      // gateway turn is a genuinely new session, not a rejected live config-switch
+      // on the user-key session). The workspace/repo binding is retained by the
+      // new-tab path — no repo re-selection needed (those "Project:"/"Runtime:"
+      // controls exist only on the home screen).
       await driver.switchSelectedRouteToGateway(world, page, harness);
       const gatewaySelection = await driver.resolveRouteModel(world, page, harness, "gateway");
       await driver.selectModelInUi(page, gatewaySelection.modelId);
@@ -1158,12 +1180,33 @@ async function ensureSidebarOpen(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: SETTINGS_STEP_TIMEOUT_MS });
 }
 
-/** Returns from the settings surface to the home composer so the subsequent
- * repo-selection / send flow runs on the home screen. */
-async function returnToAppHome(page: Page): Promise<void> {
+/** Returns from the settings surface to the app. Waits for `expectedSurface` to
+ * become visible afterward — the home composer by default (LOCAL-2/3 callers,
+ * where no workspace is active yet), but callers with an already-active
+ * workspace (e.g. LOCAL-6's `switchSelectedRouteToGateway`, where the product
+ * returns to the workspace chat shell rather than the home screen) must pass
+ * the surface it actually lands on, or this waits forever for a selector that
+ * never appears (proven: Actions run 29549140268, T3-AUTHROUTE-1/local/route=change). */
+async function returnToAppHome(page: Page, expectedSurface = "[data-home-composer-editor]"): Promise<void> {
   await page.getByRole("button", { name: /back to app/i }).first().click();
   await page
-    .locator("[data-home-composer-editor]")
+    .locator(expectedSurface)
+    .first()
+    .waitFor({ state: "visible", timeout: SETTINGS_STEP_TIMEOUT_MS });
+}
+
+/** Opens a NEW, genuinely-empty session tab in the CURRENT workspace via the
+ * header "+" new-tab button (`data-chat-new-tab-button`, sr-only label "New
+ * chat" → openNewSessionTab → createEmptySessionWithResolvedConfig). This stays
+ * inside the active workspace shell — the workspace/repo binding is retained —
+ * and lands on the in-workspace chat composer (`[data-chat-composer-editor]`),
+ * NOT the standalone home screen's `[data-home-composer-editor]`. That fresh
+ * session is what makes the gateway turn a new session distinct from the
+ * user-key one, without a rejected live config switch on the old session. */
+async function openNewChat(page: Page): Promise<void> {
+  await page.locator("[data-chat-new-tab-button]:not([disabled])").first().click();
+  await page
+    .locator("[data-chat-composer-editor]")
     .first()
     .waitFor({ state: "visible", timeout: SETTINGS_STEP_TIMEOUT_MS });
 }

--- a/tests/release/src/scenarios/local/config-session.test.ts
+++ b/tests/release/src/scenarios/local/config-session.test.ts
@@ -351,10 +351,10 @@ function makeSessionDriver(
     openPage: async () => fakePage(),
     ensureHarnessReady: async () => undefined,
     selectRepoAndWorkLocally: async () => undefined,
-    createEmptyChat: async () => ({ workspaceId: "ws-1", sessionId: "s0", tabId: "tab-0" }),
-    switchHarnessEmptyChat: async () => ({ oldSessionId: "s0", newSessionId: "s1", tabId: "tab-0" }),
-    sendMessage: async () => ({ sessionId: "s1" }),
-    switchHarnessAfterMessages: async () => ({ preservedTabId: "tab-0", preservedTabHarness: "codex", newTabId: "tab-1", newTabHarness: "claude", newSessionId: "s2" }),
+    materializeFirstChat: async () => ({ workspaceId: "ws-1", sessionId: "s0", tabId: "tab-0" }),
+    switchHarnessAfterMessages: async () => ({ preservedTabId: "tab-0", preservedTabHarness: "claude", newTabId: "tab-1", newTabHarness: "codex", newTabIndex: 1, newSessionId: "s1" }),
+    switchHarnessEmptyChat: async () => ({ oldSessionId: "s1", newSessionId: "s2", tabIndex: 1, tabCountUnchanged: true, noOp: false }),
+    sendMessage: async () => ({ sessionId: "s2" }),
     changeModelSameHarness: async () => ({ sessionId: "s2", fromModelId: "claude-a", toModelId: "claude-b", stayedInSession: true }),
     reloadAndVerifyTabs: async () => undefined,
     closeWorld: async () => options.cleanup ?? cleanupEvidence(),
@@ -382,7 +382,8 @@ test("LOCAL-5: green cell carries local_session_tabs evidence with four proofs +
   assert.equal(ev.messaged_switch_new_tab, true);
   assert.equal(ev.same_harness_model_change_in_session, true);
   assert.equal(ev.reload_preserved, true);
-  // s0, s1, s2 distinct (s1 seen twice — deduped) → 3 hashes.
+  // s0 (tab A), s1 (after-messages switch), s2 (empty-chat switch; sendMessage
+  // and the model change both stay on s2) → 3 distinct hashes after dedupe.
   assert.equal(ev.session_id_hashes.length, 3);
   assert.equal(new Set(ev.session_id_hashes).size, 3);
 });
@@ -397,11 +398,38 @@ test("LOCAL-5: a diagnostic run (no candidate map) is cleanly blocked, not faile
 
 test("LOCAL-5: empty-chat switch that does NOT replace the backend session fails the cell", async () => {
   const { driver } = makeSessionDriver({
-    switchHarnessEmptyChat: async () => ({ oldSessionId: "s0", newSessionId: "s0", tabId: "tab-0" }),
+    switchHarnessEmptyChat: async () => ({ oldSessionId: "s1", newSessionId: "s1", tabIndex: 1, tabCountUnchanged: true, noOp: false }),
   });
   const outcome = await collectLocal5SessionTabsCell(fakeCtx(), sessionCell(), driver);
   assert.equal(outcome.status, "failed");
   assert.match(outcome.reason?.message ?? "", /did not replace the backend session/);
+});
+
+test("LOCAL-5: empty-chat switch that is a no-op (same harness) fails the cell", async () => {
+  const { driver } = makeSessionDriver({
+    switchHarnessEmptyChat: async () => ({ oldSessionId: "s1", newSessionId: "s1", tabIndex: 1, tabCountUnchanged: true, noOp: true }),
+  });
+  const outcome = await collectLocal5SessionTabsCell(fakeCtx(), sessionCell(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /was a no-op/);
+});
+
+test("LOCAL-5: empty-chat switch that changes the tab count fails the cell", async () => {
+  const { driver } = makeSessionDriver({
+    switchHarnessEmptyChat: async () => ({ oldSessionId: "s1", newSessionId: "s2", tabIndex: 1, tabCountUnchanged: false, noOp: false }),
+  });
+  const outcome = await collectLocal5SessionTabsCell(fakeCtx(), sessionCell(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /changed the number of tabs/);
+});
+
+test("LOCAL-5: empty-chat switch that moves the tab's position fails the cell", async () => {
+  const { driver } = makeSessionDriver({
+    switchHarnessEmptyChat: async () => ({ oldSessionId: "s1", newSessionId: "s2", tabIndex: 2, tabCountUnchanged: true, noOp: false }),
+  });
+  const outcome = await collectLocal5SessionTabsCell(fakeCtx(), sessionCell(), driver);
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason?.message ?? "", /moved the tab's position/);
 });
 
 test("LOCAL-5: a same-harness model change that leaves the session fails the cell", async () => {
@@ -424,7 +452,7 @@ test("LOCAL-5: a same-harness model change that is a no-op (same model id) fails
 
 test("LOCAL-5: switch-after-messages that reuses the same tab fails the cell", async () => {
   const { driver } = makeSessionDriver({
-    switchHarnessAfterMessages: async () => ({ preservedTabId: "tab-0", preservedTabHarness: "codex", newTabId: "tab-0", newTabHarness: "claude", newSessionId: "s2" }),
+    switchHarnessAfterMessages: async () => ({ preservedTabId: "tab-0", preservedTabHarness: "claude", newTabId: "tab-0", newTabHarness: "codex", newTabIndex: 1, newSessionId: "s1" }),
   });
   const outcome = await collectLocal5SessionTabsCell(fakeCtx(), sessionCell(), driver);
   assert.equal(outcome.status, "failed");
@@ -433,7 +461,7 @@ test("LOCAL-5: switch-after-messages that reuses the same tab fails the cell", a
 
 test("LOCAL-5: switch-after-messages that is not a real harness switch (both tabs same harness) fails the cell", async () => {
   const { driver } = makeSessionDriver({
-    switchHarnessAfterMessages: async () => ({ preservedTabId: "tab-0", preservedTabHarness: "claude", newTabId: "tab-1", newTabHarness: "claude", newSessionId: "s2" }),
+    switchHarnessAfterMessages: async () => ({ preservedTabId: "tab-0", preservedTabHarness: "claude", newTabId: "tab-1", newTabHarness: "claude", newTabIndex: 1, newSessionId: "s1" }),
   });
   const outcome = await collectLocal5SessionTabsCell(fakeCtx(), sessionCell(), driver);
   assert.equal(outcome.status, "failed");

--- a/tests/release/src/scenarios/local/config-session.ts
+++ b/tests/release/src/scenarios/local/config-session.ts
@@ -129,20 +129,31 @@ export interface LocalSessionTabsDriver {
   openPage(world: ReadyLocalWorld, actor: AuthenticatedActor): Promise<ProductPage>;
   ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, harness: LocalHarnessKind): Promise<void>;
   selectRepoAndWorkLocally(page: ProductPage, repo: PreparedRepository): Promise<void>;
-  createEmptyChat(world: ReadyLocalWorld, page: ProductPage, harness: LocalHarnessKind): Promise<{ workspaceId: string; sessionId: string; tabId: string }>;
+  /** Materializes the FIRST chat (tab A) by sending a prompt and awaiting turn
+   * completion — this necessarily gives the tab transcript (a materialized
+   * session is never empty per the product's `isSessionEmpty`), so this is the
+   * "messaged" starting point, not an empty chat. Named for what it does: the
+   * genuinely EMPTY tab used for the empty-chat-switch proof is the one the
+   * product itself opens later, in `switchHarnessAfterMessages`. */
+  materializeFirstChat(world: ReadyLocalWorld, page: ProductPage, harness: LocalHarnessKind): Promise<{ workspaceId: string; sessionId: string; tabId: string }>;
 
-  /** Switch harness in a VISIBLE EMPTY chat: assert one visible tab preserved,
-   * backend session replaced (new session id), returning old+new ids. */
-  switchHarnessEmptyChat(world: ReadyLocalWorld, page: ProductPage, toHarness: LocalHarnessKind): Promise<{ oldSessionId: string; newSessionId: string; tabId: string }>;
+  /** Switch harness on a GENUINELY EMPTY chat tab (the one `switchHarnessAfterMessages`
+   * just opened): asserts the in-place replacement (tab count and the tab's
+   * position/index unchanged; a NEW backend session id on the SAME tab
+   * position). Returns the old/new session ids, the tab's (unchanged) index,
+   * whether the tab count stayed the same, and whether the call was a no-op
+   * (requested the harness the tab was already on). */
+  switchHarnessEmptyChat(world: ReadyLocalWorld, page: ProductPage, toHarness: LocalHarnessKind): Promise<{ oldSessionId: string; newSessionId: string; tabIndex: number; tabCountUnchanged: boolean; noOp: boolean }>;
 
-  /** Send a message so the current session has transcript. */
+  /** Send a message so the current (active) session has transcript. */
   sendMessage(world: ReadyLocalWorld, page: ProductPage): Promise<{ sessionId: string }>;
 
   /** Switch harness AFTER messages: old transcript preserved on its tab, a NEW
-   * tab created immediately to the right on `toHarness`. Returns both tabs'
-   * ids AND their harnesses so the caller can prove the switch was real (the
-   * two tabs are on different harnesses). */
-  switchHarnessAfterMessages(world: ReadyLocalWorld, page: ProductPage, toHarness: LocalHarnessKind): Promise<{ preservedTabId: string; preservedTabHarness: LocalHarnessKind; newTabId: string; newTabHarness: LocalHarnessKind; newSessionId: string }>;
+   * EMPTY tab created immediately to the right on `toHarness`. Returns both
+   * tabs' ids, harnesses, AND the new tab's index so the caller can prove the
+   * switch was real (the two tabs are on different harnesses) and later verify
+   * the empty-chat switch kept that new tab's position stable. */
+  switchHarnessAfterMessages(world: ReadyLocalWorld, page: ProductPage, toHarness: LocalHarnessKind): Promise<{ preservedTabId: string; preservedTabHarness: LocalHarnessKind; newTabId: string; newTabHarness: LocalHarnessKind; newTabIndex: number; newSessionId: string }>;
 
   /** Same harness, change to a DIFFERENT supported model (excluding the active
    * one): returns the before/after model ids and whether it stayed in-session
@@ -218,7 +229,7 @@ export const defaultLocalSessionTabsDriver: LocalSessionTabsDriver = {
   openPage: (world, actor) => productPage(world, actor),
   ensureHarnessReady: (world, page, harness) => ensureHarnessReady(world, page, harness),
   selectRepoAndWorkLocally: (page, repo) => selectRepoAndWorkLocally(page, repo),
-  createEmptyChat: (world, page, harness) => createEmptyChat(world, page, harness),
+  materializeFirstChat: (world, page, harness) => materializeFirstChat(world, page, harness),
   switchHarnessEmptyChat: (world, page, toHarness) => switchHarnessEmptyChat(world, page, toHarness),
   sendMessage: (world, page) => sendMessage(world, page),
   switchHarnessAfterMessages: (world, page, toHarness) => switchHarnessAfterMessages(world, page, toHarness),
@@ -469,51 +480,68 @@ export async function collectLocal5SessionTabsCell(
     await driver.selectRepoAndWorkLocally(page, repo);
 
     const sessionIds: string[] = [];
-    const empty = await driver.createEmptyChat(world, page, startHarness);
-    sessionIds.push(empty.sessionId);
+    // Tab A: materialize the FIRST chat by sending a prompt and awaiting turn
+    // completion. This tab is MESSAGED (per the product's `isSessionEmpty`, a
+    // materialized session with transcript is never empty), so it is deliberately
+    // NOT the tab used for the empty-chat-switch proof.
+    const tabA = await driver.materializeFirstChat(world, page, startHarness);
+    sessionIds.push(tabA.sessionId);
 
-    // Proof 1: empty-chat harness switch preserves one visible tab, replaces the
-    // unused backend session (session id changes).
-    const emptySwitch = await driver.switchHarnessEmptyChat(world, page, SESSION_TABS_SWITCH_HARNESS);
+    // Proof 1 ("switch after messages"): a REAL harness switch on tab A's
+    // messaged session preserves tab A (its harness + transcript intact) and
+    // opens a NEW, genuinely EMPTY tab B, on the switched-to harness, immediately
+    // to tab A's right.
+    const afterMessagesSwitch = await driver.switchHarnessAfterMessages(world, page, SESSION_TABS_SWITCH_HARNESS);
+    if (afterMessagesSwitch.preservedTabId === afterMessagesSwitch.newTabId) {
+      throw new Error("LOCAL-5: switch-after-messages did not open a new tab beside the preserved one");
+    }
+    if (afterMessagesSwitch.preservedTabHarness === afterMessagesSwitch.newTabHarness) {
+      throw new Error(
+        `LOCAL-5: switch-after-messages was not a real harness switch (both tabs on "${afterMessagesSwitch.newTabHarness}")`,
+      );
+    }
+    if (afterMessagesSwitch.newTabHarness !== SESSION_TABS_SWITCH_HARNESS) {
+      throw new Error(
+        `LOCAL-5: the new tab is on "${afterMessagesSwitch.newTabHarness}", expected the switched-to "${SESSION_TABS_SWITCH_HARNESS}"`,
+      );
+    }
+    sessionIds.push(afterMessagesSwitch.newSessionId);
+
+    // Proof 2 ("empty-chat switch"): switch tab B — the product's OWN genuinely
+    // empty tab — back to SESSION_TABS_START_HARNESS (claude), a harness
+    // genuinely different from tab B's current codex. The switch must be a real
+    // in-place replacement, not a no-op and not a second new tab:
+    //  - tab COUNT stays the same (the driver observed it before/after),
+    //  - the switch was not requested against the harness the tab was already on,
+    //  - the session id changed from tab B's messaged-turn-free session (the DOM
+    //    tab ELEMENT id itself changes with the session — see the driver
+    //    contract note — so the poll targets the ACTIVE tab, not tab B's stale id).
+    const emptySwitch = await driver.switchHarnessEmptyChat(world, page, SESSION_TABS_START_HARNESS);
+    if (emptySwitch.noOp) {
+      throw new Error("LOCAL-5: empty-chat harness switch was a no-op (requested the harness the tab was already on)");
+    }
     if (emptySwitch.oldSessionId === emptySwitch.newSessionId) {
       throw new Error("LOCAL-5: empty-chat harness switch did not replace the backend session (id unchanged)");
     }
-    if (emptySwitch.tabId !== empty.tabId) {
-      throw new Error("LOCAL-5: empty-chat harness switch did not preserve the single visible tab");
+    if (!emptySwitch.tabCountUnchanged) {
+      throw new Error("LOCAL-5: empty-chat harness switch changed the number of tabs (expected in-place replacement)");
+    }
+    if (emptySwitch.tabIndex !== afterMessagesSwitch.newTabIndex) {
+      throw new Error(
+        `LOCAL-5: empty-chat harness switch moved the tab's position (was index ${afterMessagesSwitch.newTabIndex}, ` +
+          `now ${emptySwitch.tabIndex}); the in-place replacement must keep the same slot`,
+      );
     }
     sessionIds.push(emptySwitch.newSessionId);
 
-    // Give the current session (now on SESSION_TABS_SWITCH_HARNESS) transcript,
-    // then switch after messages. The after-message switch target MUST differ
-    // from the harness the messaged tab is on — otherwise it is not a switch and
-    // must not create a new tab. Proof 1 left the active tab on
-    // SESSION_TABS_SWITCH_HARNESS, so proof 2 switches back to
-    // SESSION_TABS_START_HARNESS (a genuinely different harness).
+    // Give the now-claude active tab (tab B, post-replacement) transcript so
+    // reload can verify it.
     const messaged = await driver.sendMessage(world, page);
     sessionIds.push(messaged.sessionId);
 
-    // Proof 2: a REAL harness switch after messages preserves the old tab (with
-    // its harness + transcript intact) and opens a new tab, on the new harness,
-    // immediately to its right.
-    const messagedSwitch = await driver.switchHarnessAfterMessages(world, page, SESSION_TABS_START_HARNESS);
-    if (messagedSwitch.preservedTabId === messagedSwitch.newTabId) {
-      throw new Error("LOCAL-5: switch-after-messages did not open a new tab beside the preserved one");
-    }
-    if (messagedSwitch.preservedTabHarness === messagedSwitch.newTabHarness) {
-      throw new Error(
-        `LOCAL-5: switch-after-messages was not a real harness switch (both tabs on "${messagedSwitch.newTabHarness}")`,
-      );
-    }
-    if (messagedSwitch.newTabHarness !== SESSION_TABS_START_HARNESS) {
-      throw new Error(
-        `LOCAL-5: the new tab is on "${messagedSwitch.newTabHarness}", expected the switched-to "${SESSION_TABS_START_HARNESS}"`,
-      );
-    }
-    sessionIds.push(messagedSwitch.newSessionId);
-
-    // Proof 3: same-harness model change (on the new tab's harness) selects a
-    // DIFFERENT eligible model and stays in-session where the harness contract
-    // permits it.
+    // Proof 3 ("same-harness model change"): on the now-claude active tab,
+    // selects a DIFFERENT eligible model and stays in-session where the harness
+    // contract permits it.
     const modelChange = await driver.changeModelSameHarness(world, page);
     if (modelChange.fromModelId === modelChange.toModelId) {
       throw new Error("LOCAL-5: same-harness model change was a no-op (model id unchanged)");
@@ -523,17 +551,19 @@ export async function collectLocal5SessionTabsCell(
     }
     sessionIds.push(modelChange.sessionId);
 
-    // Proof 4: reload preserves tab order, active tab, and — for BOTH the
-    // preserved old tab and the active new tab — the expected harness and its
-    // transcript.
+    // Proof 4 ("reload"): tab order [tab A, the current active tab id (tab B's
+    // slot, now on claude after the in-place replacement)]; both the preserved
+    // tab A and the current active tab survive with their expected harness and
+    // transcript. The active tab's CURRENT id is read fresh (post model-change),
+    // since the replacement changed it from tab B's original id.
     await driver.reloadAndVerifyTabs(world, page, {
-      tabOrder: [messagedSwitch.preservedTabId, messagedSwitch.newTabId],
-      activeTabId: messagedSwitch.newTabId,
-      preservedTab: { id: messagedSwitch.preservedTabId, harness: messagedSwitch.preservedTabHarness },
-      activeTab: { id: messagedSwitch.newTabId, harness: messagedSwitch.newTabHarness },
+      tabOrder: [afterMessagesSwitch.preservedTabId, modelChange.sessionId],
+      activeTabId: modelChange.sessionId,
+      preservedTab: { id: afterMessagesSwitch.preservedTabId, harness: afterMessagesSwitch.preservedTabHarness },
+      activeTab: { id: modelChange.sessionId, harness: startHarness },
     });
 
-    cellData = { workspaceId: empty.workspaceId, sessionIds: dedupe(sessionIds) };
+    cellData = { workspaceId: tabA.workspaceId, sessionIds: dedupe(sessionIds) };
   } catch (error) {
     await captureLocalDriverFailure(page, `${cell.cell_id}-ui-failure`);
     failure = describe(error);
@@ -968,7 +998,7 @@ async function stepReasoningEffortToValue(
 
 // ── LOCAL-5 tab-strip production bodies (new tab-strip testids, BRIEF §4.6) ──
 
-async function createEmptyChat(
+async function materializeFirstChat(
   world: ReadyLocalWorld,
   page: ProductPage,
   harness: LocalHarnessKind,
@@ -980,12 +1010,15 @@ async function createEmptyChat(
   // (single-turn) session through the real send path: select the cheapest
   // eligible model, send one bounded prompt from the home composer, then read the
   // materialized session's tab off the strip. Sending to create the session is
-  // not "seeding" — it is the only real creation path.
+  // not "seeding" — it is the only real creation path. NOTE: this necessarily
+  // gives the tab transcript (a materialized session is never empty per the
+  // product's `isSessionEmpty`), so tab A is the MESSAGED starting point, not an
+  // empty chat.
   const preflight = await world.gateway.preflight();
   const probe = (await world.runtime.client.getGatewayModels(harness).catch(() => [])).map((model) => model.id);
   const modelId = selectCheapestEligibleClaudeModel(preflight.eligibleClaudeModels, probe);
   if (!modelId) {
-    throw new Error(`createEmptyChat: no eligible non-Fable model for "${harness}" in the allowlist ∩ live probe`);
+    throw new Error(`materializeFirstChat: no eligible non-Fable model for "${harness}" in the allowlist ∩ live probe`);
   }
   await selectModelInComposer(page, modelId);
   const editor = p.locator("[data-home-composer-editor]").first();
@@ -1011,26 +1044,105 @@ async function createEmptyChat(
   const anyharnessSessionId = await resolveActiveSessionId(world, sessionId);
   const completion = await waitForTurnCompletion(world, anyharnessSessionId, TURN_TIMEOUT_MS);
   if (completion.error) {
-    throw new Error(`createEmptyChat: the materializing turn errored: ${completion.error}`);
+    throw new Error(`materializeFirstChat: the materializing turn errored: ${completion.error}`);
   }
   return { workspaceId, sessionId, tabId };
 }
 
+/**
+ * Switches the harness of the CURRENTLY ACTIVE tab — by construction the
+ * genuinely empty tab `switchHarnessAfterMessages` just opened. A messaged
+ * session is never empty per the product's `isSessionEmpty`
+ * (`transcript.turnOrder.length === 0` — see
+ * `apps/packages/product-client/src/lib/domain/sessions/session-emptiness.ts`),
+ * so a `beginEmptySessionReplacement` in-place swap only fires on a tab that
+ * never received a message — proven false for `materializeFirstChat`'s tab
+ * (Actions run 29549140268, cell T3-SESSION-1/local/harness=claude).
+ *
+ * `data-chat-tab` (the tab id) equals the session id in the DOM, so an in-place
+ * replacement necessarily changes the tab ELEMENT's own id attribute — a
+ * `tabId === tabId` equality check can never hold across a real replacement.
+ * The stable proof is POSITIONAL: the tab's `data-chat-tab-index` and the total
+ * tab count stay the same; only `data-chat-tab-session-id` (read off the
+ * ACTIVE-tab selector, not the old tab id) changes.
+ */
 async function switchHarnessEmptyChat(
   world: ReadyLocalWorld,
   page: ProductPage,
   toHarness: LocalHarnessKind,
-): Promise<{ oldSessionId: string; newSessionId: string; tabId: string }> {
-  await ensureHarnessReady(world, page, toHarness);
+): Promise<{ oldSessionId: string; newSessionId: string; tabIndex: number; tabCountUnchanged: boolean; noOp: boolean }> {
   const p = page.page;
-  const tab = p.locator("[data-chat-tab]").first();
-  const tabId = await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab", tab);
-  const oldSessionId = await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-session-id", tab);
+  // Capture the target (empty) tab's identity from the ACTIVE tab BEFORE
+  // `ensureHarnessReady` — it reloads the page, and reload re-activates the
+  // durable, messaged tab A (its backend session is persisted; tab B's empty,
+  // in-place-replaceable session is not), so any read taken after the reload
+  // describes tab A, not the empty tab B this switch must act on. The failing
+  // run (Actions 29570511844, T3-SESSION-1) reloaded with tab A active and then
+  // "switched" claude→claude on it — a silent no-op whose session id never
+  // changed. Playwright locators are lazy (re-resolved at call time), so the
+  // index/session-id must be read here, pre-reload, and the tab re-activated by
+  // that index afterwards.
+  const activeTabBefore = p.locator('[data-chat-tab][data-chat-tab-active="true"]').first();
+  const harnessBefore = (await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-harness", activeTabBefore)) as LocalHarnessKind;
+  const tabIndex = Number((await activeTabBefore.getAttribute("data-chat-tab-index").catch(() => null)) ?? "0");
+  if (harnessBefore === toHarness) {
+    const noopSessionId = await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-session-id", activeTabBefore);
+    return { oldSessionId: noopSessionId, newSessionId: noopSessionId, tabIndex, tabCountUnchanged: true, noOp: true };
+  }
+  const beforeCount = await p.locator("[data-chat-tab]").count();
+  await ensureHarnessReady(world, page, toHarness);
+  // Reload re-activated tab A; re-select the empty tab B at its captured index
+  // so the harness switch acts on the intended empty session, not the messaged
+  // one.
+  const targetTab = p.locator(`[data-chat-tab-index="${tabIndex}"]`).first();
+  await targetTab.waitFor({ state: "visible", timeout: TAB_SETTLE_TIMEOUT_MS });
+  await targetTab.click();
+  await p
+    .locator(`[data-chat-tab-index="${tabIndex}"][data-chat-tab-active="true"]`)
+    .first()
+    .waitFor({ state: "attached", timeout: TAB_SETTLE_TIMEOUT_MS });
+  // Capture the reconciled server id of tab B AFTER the reload+reactivation. Two
+  // reasons: (1) reload rebuilds the tab from the authoritative session list, so
+  // it now carries the server id, not the pre-reload optimistic one — comparing
+  // the post-switch id against the pre-reload id would spuriously "detect a
+  // change" from the reload alone; (2) waiting for a reconciled (non
+  // `client-session:`) id means the empty session is fully MATERIALIZED before
+  // the switch, so the product's replace-in-place path dismisses a known
+  // materialized session rather than racing a still-in-flight creation and
+  // orphaning it — the orphan reappeared as a spurious 3rd tab after reload
+  // (Actions run 29575928457, T3-SESSION-1). A materialized-but-empty session is
+  // still empty (isSessionEmptyWithIntents checks transcript/intents, not
+  // materialization), so this stays faithful to the empty-chat-switch proof.
+  const activeTabByIndex = p.locator(`[data-chat-tab-index="${tabIndex}"]`).first();
+  const oldSessionId = await waitForReconciledSessionId(p, activeTabByIndex);
+  // KNOWN PRODUCT RACE (same class as issue #1333; #1337 landed a product fix
+  // for the orphan variant, but the round-4 no-op / spurious-new-tab symptom
+  // may persist — this cell is allowed to be red on it until proven otherwise).
+  // The tab strip's `data-chat-tab-active`/`-session-id` are driven by the
+  // optimistic pending-highlight (`resolveWorkspaceShellActivation` →
+  // `{kind:"chat-session-pending"}`), which lands the instant a tab click
+  // registers; the AUTHORITATIVE `useSessionSelectionStore.activeSessionId`
+  // commit is deferred and coalesced ~180ms later
+  // (`CHAT_TAB_ACTIVATION_COALESCE_MS`, use-chat-tab-activation.ts). If the
+  // harness switch fires before that commit, `handleLaunchSelect` resolves
+  // `replacesSessionId` from the still-stale active session (tab A, messaged),
+  // so `beginEmptySessionReplacement` sees a non-empty record, returns null, and
+  // the product opens a NEW empty tab instead of replacing in place — the
+  // watched tab's id never changes and a spurious 3rd tab appears (Actions run
+  // 29602686092: 3 tabs [Claude,Codex,Claude], id 53c6870d… frozen).
+  //
+  // A `waitForComposerHarnessCommitted` gate was tried here to close the race
+  // and PROVEN UNSOUND (removed): it passes on a stale `defaultChatAgentKind`
+  // preference fallback during the chat-session-pending suppressed phase, not on
+  // the real activeSessionId commit, so Actions runs 29602686092 + 29617987951
+  // showed the SAME 3-tab failure with and without it.
   await selectHarnessInComposer(world, page, toHarness);
-  // The unused backend session is replaced in place: same visible tab, a new
-  // session id. Poll the same tab until its session-id attribute changes.
-  const newSessionId = await waitForAttrChange(p, "[data-chat-tab]", "data-chat-tab-session-id", oldSessionId, tab);
-  return { oldSessionId, newSessionId, tabId };
+  // The unused backend session is replaced IN PLACE at the same tab position:
+  // poll the tab AT THIS INDEX (not the stale tab-id locator, since the tab
+  // element's own id changes with the session) until its session-id changes.
+  const newSessionId = await waitForAttrChange(p, "[data-chat-tab]", "data-chat-tab-session-id", oldSessionId, activeTabByIndex);
+  const afterCount = await p.locator("[data-chat-tab]").count();
+  return { oldSessionId, newSessionId, tabIndex, tabCountUnchanged: afterCount === beforeCount, noOp: false };
 }
 
 async function sendMessage(world: ReadyLocalWorld, page: ProductPage): Promise<{ sessionId: string }> {
@@ -1054,7 +1166,7 @@ async function switchHarnessAfterMessages(
   world: ReadyLocalWorld,
   page: ProductPage,
   toHarness: LocalHarnessKind,
-): Promise<{ preservedTabId: string; preservedTabHarness: LocalHarnessKind; newTabId: string; newTabHarness: LocalHarnessKind; newSessionId: string }> {
+): Promise<{ preservedTabId: string; preservedTabHarness: LocalHarnessKind; newTabId: string; newTabHarness: LocalHarnessKind; newTabIndex: number; newSessionId: string }> {
   await ensureHarnessReady(world, page, toHarness);
   const p = page.page;
   const activeTab = p.locator('[data-chat-tab][data-chat-tab-active="true"]').first();
@@ -1073,6 +1185,7 @@ async function switchHarnessAfterMessages(
   const newTab = p.locator('[data-chat-tab][data-chat-tab-active="true"]').first();
   const newTabId = await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab", newTab);
   const newTabHarness = (await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-harness", newTab)) as LocalHarnessKind;
+  const newTabIndex = Number((await newTab.getAttribute("data-chat-tab-index").catch(() => null)) ?? String(beforeCount));
   const newSessionId = await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-session-id", newTab);
   // The preserved (old) tab still exists, on its original harness, with its
   // transcript intact — it was not mutated by the switch.
@@ -1084,7 +1197,7 @@ async function switchHarnessAfterMessages(
         `"${preservedHarnessAfter}" — the switch mutated the old tab instead of opening a new one.`,
     );
   }
-  return { preservedTabId, preservedTabHarness, newTabId, newTabHarness, newSessionId };
+  return { preservedTabId, preservedTabHarness, newTabId, newTabHarness, newTabIndex, newSessionId };
 }
 
 async function changeModelSameHarness(
@@ -1093,7 +1206,12 @@ async function changeModelSameHarness(
 ): Promise<{ sessionId: string; fromModelId: string; toModelId: string; stayedInSession: boolean }> {
   const p = page.page;
   const activeTab = p.locator('[data-chat-tab][data-chat-tab-active="true"]').first();
-  const sessionId = await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-session-id", activeTab);
+  // Capture the RECONCILED server id, not the transient `client-session:` one:
+  // this id becomes the reload expectation's active/ordered tab id
+  // (collectLocal5SessionTabsCell → reloadAndVerifyTabs), and a fresh renderer
+  // only ever shows the server id, so a client id could never match post-reload
+  // (Actions run 29575928457, T3-SESSION-1).
+  const sessionId = await waitForReconciledSessionId(p, activeTab);
   const harness = (await readRequiredAttr(p, "[data-chat-tab]", "data-chat-tab-harness", activeTab)) as LocalHarnessKind;
   // The model the composer is currently on — the change must move OFF this one,
   // otherwise a no-op selection would trivially "stay in session".
@@ -1262,6 +1380,37 @@ async function waitForAttrChange(
     await sleep(500);
   }
   throw new Error(`waitForAttrChange: attribute "${attr}" on "${selector}" never changed from "${from}"`);
+}
+
+/**
+ * Waits until the active tab's `data-chat-tab-session-id` is a RECONCILED server
+ * id — i.e. no longer a `client-session:` optimistic id (the client-side
+ * directory key a freshly-created session carries until its background
+ * materialization commits the real id; see session-creation-local-state.ts +
+ * persisted-chat-sessions.ts `isTransientClientSessionId`). Any id captured for
+ * a post-RELOAD expectation MUST be the server id: a fresh renderer only ever
+ * shows the server uuid for that tab, so an expectation built from the transient
+ * client id can never match (proven: Actions run 29575928457, T3-SESSION-1,
+ * `reloadAndVerifyTabs: tab order not preserved` — the wanted id was
+ * `client-session:claude:…`). Returns the reconciled id.
+ */
+async function waitForReconciledSessionId(
+  page: Page,
+  activeTab: ReturnType<Page["locator"]>,
+): Promise<string> {
+  const deadline = Date.now() + TAB_SETTLE_TIMEOUT_MS;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = (await activeTab.getAttribute("data-chat-tab-session-id").catch(() => null)) ?? "";
+    if (last && !last.startsWith("client-session:")) {
+      return last;
+    }
+    await sleep(500);
+  }
+  throw new Error(
+    `waitForReconciledSessionId: the active tab's session id never reconciled off the optimistic ` +
+      `client id (last "${last}") within ${TAB_SETTLE_TIMEOUT_MS}ms.`,
+  );
 }
 
 /** Resolves the AnyHarness native session id backing the currently-active chat.

--- a/tests/release/src/scenarios/local/integration-mcp.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.ts
@@ -246,6 +246,17 @@ export const defaultLocalMcpDriver: LocalMcpDriver = {
       );
     }
     await selectModelInUi(page, modelId);
+    // The integration prompt REQUIRES an `integrations.call_tool` MCP call, and
+    // the session's default permission mode gates every tool call behind an
+    // interactive approval card ("Permission — AWAITING RESPONSE"; proven:
+    // Actions run 29570511844, T3-INT-1/local/harness=claude). Nothing in this
+    // headless collector clicks Allow, so the turn sits awaiting response until
+    // it times out. Select `bypassPermissions` (the same mode the product's own
+    // workflows pick for claude — anyharness workflows/resolution.rs) on the
+    // home composer BEFORE sending, so the fresh session launches with tool
+    // calls auto-executed. Not a product bug: the gate is correct behaviour; the
+    // collector simply never drove the mode.
+    await selectSessionModeInUi(page, "bypassPermissions");
 
     // A successful historical or sibling call must not satisfy this cell. Take
     // a fail-closed baseline immediately before Send and bind the later audit
@@ -672,6 +683,30 @@ async function selectModelInUi(page: ProductPage, modelId: string): Promise<void
     await sleep(2_000);
   }
   throw new Error(`selectModelInUi: model "${modelId}" was not offered by the composer picker within ${MODEL_PICKER_TIMEOUT_MS}ms.`);
+}
+
+/**
+ * Selects a session permission mode (e.g. `bypassPermissions`) in the composer's
+ * SessionModeControl popover. The trigger stamps `data-session-mode-trigger`
+ * (readback in `data-session-mode-selected`) and each option a
+ * `data-session-mode-option="<modeId>"` (SessionModeControl.tsx). The same
+ * popover renders on the home composer pre-launch (home-composer-controls.ts),
+ * so a selection here is carried into the session the send materializes. Read
+ * the selection back so a rejected apply surfaces loudly rather than silently
+ * leaving the session on its approval-gated default.
+ */
+async function selectSessionModeInUi(page: ProductPage, modeId: string): Promise<void> {
+  const p = page.page;
+  const trigger = p.locator("[data-session-mode-trigger]").first();
+  await trigger.waitFor({ state: "visible", timeout: 15_000 });
+  await trigger.click();
+  const option = p.locator(`[data-session-mode-option="${cssAttr(modeId)}"]`).first();
+  await option.waitFor({ state: "visible", timeout: 15_000 });
+  await option.click();
+  await p
+    .locator(`[data-session-mode-trigger][data-session-mode-selected="${cssAttr(modeId)}"]`)
+    .first()
+    .waitFor({ state: "attached", timeout: 15_000 });
 }
 
 async function readWorkspaceUiKey(page: Page): Promise<string> {

--- a/tests/release/src/scenarios/t3-repo-1.test.ts
+++ b/tests/release/src/scenarios/t3-repo-1.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { t3Repo1 } from "./t3-repo-1.js";
+import { ScenarioBlockedError } from "./types.js";
+import type { ScenarioRunContext } from "./types.js";
+import type { EnvResolution } from "../config/env-resolution.js";
+
+function fakeEnv(): EnvResolution {
+  return {
+    all: [],
+    missing: [],
+    present: () => false,
+    get: () => undefined,
+    require: (name) => {
+      throw new Error(`missing ${name}`);
+    },
+  };
+}
+
+/** A diagnostic run: no candidate map, so `isWorldBackedRun` is false and the
+ * legacy repo-environment branch runs. */
+function diagnosticCtx(): ScenarioRunContext {
+  return {
+    targetLane: "local",
+    runtimeLane: "local",
+    desktop: "web",
+    agents: ["all"],
+    dryRun: false,
+    env: fakeEnv(),
+    candidateBuildMap: null,
+    runIdentity: null,
+    runDir: null,
+    ports: null,
+  };
+}
+
+// Regression for the strict local-functional preflight cascade (2026-07-16,
+// run 29483042778): a scenario-level requiredEnv of
+// RELEASE_E2E_SERVER_URL/_DURABLE_USER_* blocked T3-REPO-1/local under strict
+// behavior even though the world-backed LOCAL-1 path needs none of them —
+// and strict preflight then cancelled every sibling cell. The requirement now
+// lives inside the legacy path only.
+test("T3-REPO-1 declares no scenario-level requiredEnv (world-backed strict path must plan clean)", () => {
+  assert.deepEqual([...t3Repo1.requiredEnv], []);
+});
+
+test("T3-REPO-1 legacy path self-reports blocked when the durable-server env is absent", async (t) => {
+  for (const name of [
+    "RELEASE_E2E_SERVER_URL",
+    "RELEASE_E2E_DURABLE_USER_EMAIL",
+    "RELEASE_E2E_DURABLE_USER_PASSWORD",
+  ]) {
+    const previous = process.env[name];
+    delete process.env[name];
+    t.after(() => {
+      if (previous !== undefined) {
+        process.env[name] = previous;
+      }
+    });
+  }
+  await assert.rejects(
+    () => (t3Repo1 as { run: (ctx: ScenarioRunContext) => Promise<void> }).run(diagnosticCtx()),
+    (error: unknown) => {
+      assert.ok(error instanceof ScenarioBlockedError);
+      assert.match(error.message, /RELEASE_E2E_SERVER_URL/);
+      return true;
+    },
+  );
+});

--- a/tests/release/src/scenarios/t3-repo-1.ts
+++ b/tests/release/src/scenarios/t3-repo-1.ts
@@ -57,7 +57,12 @@ export const t3Repo1: ScenarioDefinition = {
   title: "repo settings take effect, both lanes",
   registryFlowRef: "specs/developing/testing/scenarios.md#T3-REPO-1",
   lanes: ["local", "sandbox"],
-  requiredEnv: ["RELEASE_E2E_SERVER_URL", "RELEASE_E2E_DURABLE_USER_EMAIL", "RELEASE_E2E_DURABLE_USER_PASSWORD"],
+  // Empty like every sibling local scenario: the world-backed LOCAL-1 path
+  // needs no pre-run server/durable-user env (the world boots its own), so a
+  // scenario-level requirement here would block the strict world-backed cell
+  // and cancel every sibling via strict preflight. The legacy diagnostic path
+  // guards its own env below and reports blocked when it is absent.
+  requiredEnv: [],
   plan: ({ runtimeLane }) => [
     { description: "seed the durable user's real GitHub App authorization (github_app_seed.py seed; no browser)" },
     {
@@ -85,13 +90,22 @@ export const t3Repo1: ScenarioDefinition = {
       });
       return;
     }
-    await runReal(ctx.env.require("RELEASE_E2E_SERVER_URL"));
+    await runReal();
   },
 };
 
-async function runReal(serverUrl: string): Promise<void> {
-  const durableEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL as string;
-  const durablePassword = process.env.RELEASE_E2E_DURABLE_USER_PASSWORD as string;
+async function runReal(): Promise<void> {
+  const serverUrl = process.env.RELEASE_E2E_SERVER_URL;
+  const durableEmail = process.env.RELEASE_E2E_DURABLE_USER_EMAIL;
+  const durablePassword = process.env.RELEASE_E2E_DURABLE_USER_PASSWORD;
+  if (!serverUrl || !durableEmail || !durablePassword) {
+    throw new ScenarioBlockedError(
+      "T3-REPO-1 (legacy repo-environment path): RELEASE_E2E_SERVER_URL / RELEASE_E2E_DURABLE_USER_EMAIL / " +
+        "RELEASE_E2E_DURABLE_USER_PASSWORD are not all set — this path drives a pre-running target server " +
+        "with a durable identity, which the world-backed functional entrypoint does not provide. Supply them " +
+        "(diagnostic staging/local runs) to exercise the legacy PUT .../environment path for real.",
+    );
+  }
   const [owner, repo] = (process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO).split("/");
 
   // Seed the durable user's real App authorization (deliverable A). Without it,

--- a/tests/release/src/scenarios/t3-session-1.ts
+++ b/tests/release/src/scenarios/t3-session-1.ts
@@ -32,8 +32,8 @@ export const t3Session1: MatrixScenarioDefinition = {
   kind: "matrix",
   expandCells: (): ScenarioCellSpec[] => [{ dimensions: { harness: SESSION_TABS_START_HARNESS } }],
   planCell: (_ctx, cell: PlannedCellV1): ScenarioPlanStep[] => [
-    { description: `[${cell.cell_id}] empty-chat harness switch preserves one visible tab, replaces the backend session (id changes)` },
-    { description: `[${cell.cell_id}] switch after messages preserves the old transcript, opens a new tab to its right` },
+    { description: `[${cell.cell_id}] switch after messages preserves the old transcript, opens a new (genuinely empty) tab to its right` },
+    { description: `[${cell.cell_id}] empty-chat harness switch on that new tab replaces the backend session in place (same tab position, id changes)` },
     { description: `[${cell.cell_id}] same-harness model change stays in-session where the harness contract permits` },
     { description: `[${cell.cell_id}] reload preserves tab order, active tab, harness attachment, and transcript` },
   ],


### PR DESCRIPTION
## Outcome

Re-lands the local Tier-3 (LOCAL-1..7) collector/workflow repairs that were proven on `codex/local-t3-proof` across four Actions diagnostic rounds (29549140268 → 29570511844 → 29575928457 → 29602686092 → 29617987951) but were not part of #1350's leaner subset. Test infrastructure only — no product code.

- **T3-REPO-1 strict preflight**: `requiredEnv: []`; the durable-server guard moves into the legacy `runReal()` path (`ScenarioBlockedError`). Previously the scenario-level requiredEnv fail-closed-cancelled the entire strict LOCAL matrix.
- **#1315 (T3-SESSION-1 collector)**: empty-chat-switch resequencing — `materializeFirstChat`, switch-after-messages first, positional (index-based) assertions, pre-reload index capture, `waitForReconciledSessionId`. The `waitForComposerHarnessCommitted` gate from the proof branch is deliberately **not** re-landed (proven unsound: satisfied by the stale `defaultChatAgentKind` fallback during the suppressed pending phase, runs 29602686092/29617987951); a comment documents the residual product race (#1333 class; product fix #1337 covers the orphan variant).
- **#1316**: `returnToAppHome` expected-surface param; route-change flow waits on `[data-workspace-shell]` when a workspace is active.
- **T3-INT-1**: `selectSessionModeInUi(page, "bypassPermissions")` before send — the integrations MCP approval card otherwise blocks the headless collector for the full 300s turn timeout (run 29570511844, screenshot-confirmed).
- **T3-AUTHROUTE-1/route=change**: `openNewChat` via `[data-chat-new-tab-button]` after route sync so the gateway turn runs on a NEW session (live same-session auth-context switch is correctly 400'd `SESSION_CONFIG_REJECTED`, run 29570511844); dual-composer locator in `sendBoundedTurn`. Main's #1350 session-resolution kept untouched.
- **release-e2e.yml local-functional job**: `astral-sh/setup-uv@v7` + Python 3.12 (the audit-readback probe runs `uv run python`, `spawn uv ENOENT` in run 29575928457) and `JWT_SECRET`/`CLOUD_SECRET_KEY` CI placeholders (probe imports `proliferate.config`; `Settings()` requires both in non-debug mode, probe exited 1 in run 29617987951). The world's candidate Server builds its own random secrets (`buildServerEnv`), so nothing leaks.

## Proof

- tests/release typecheck (`tsc --noEmit`) clean
- tests/release unit suite: **1177/1177**
- No live worlds/Playwright in this PR; the live proof is the LOCAL-1..7 diagnostic → strict sequence on main (baseline diagnostic run 29628508223 dispatched at 1269ee5db).

Refs: #1314 (already on main), #1315, #1316, #1333, #1356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)