### PR TITLE
test(release): resolve the newest local session, not the stalest

### DIFF
--- a/tests/release/src/scenarios/local/local-session.test.ts
+++ b/tests/release/src/scenarios/local/local-session.test.ts
@@ -63,10 +63,14 @@ test("resolveLocalWorkspaceIdOnce returns null when no local workspace matches t
 test("resolveLocalWorkspaceSessionId joins the local workspace (by path) to its latest session", async () => {
   const world = fakeWorld(
     [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    // Ordered as the real `GET /v1/sessions` returns them —
+    // `SessionStore::list_visible_all()` sorts `updated_at DESC`, so the
+    // most-recently-active session comes FIRST. The resolver must pick index 0
+    // of the workspace-filtered slice, not the last element (the stalest).
     [
-      { id: "session-old", workspaceId: RAW_WORKSPACE_ID },
-      { id: "session-elsewhere", workspaceId: "some-other-workspace" },
       { id: "session-new", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-elsewhere", workspaceId: "some-other-workspace" },
+      { id: "session-old", workspaceId: RAW_WORKSPACE_ID },
     ],
   );
   // The DOM logical ui-key never appears as a session.workspaceId; matching on it

--- a/tests/release/src/scenarios/local/local-session.ts
+++ b/tests/release/src/scenarios/local/local-session.ts
@@ -32,7 +32,19 @@ export async function resolveLocalWorkspaceSessionId(
       const sessions = await world.runtime.client.listSessions().catch(() => []);
       const forWorkspace = sessions.filter((session) => session.workspaceId === workspaceId);
       if (forWorkspace.length > 0) {
-        return forWorkspace[forWorkspace.length - 1]!.id;
+        // `GET /v1/sessions` is served by `SessionStore::list_visible_all()`,
+        // which orders `ORDER BY updated_at DESC` (anyharness-lib
+        // domains/sessions/store/sessions.rs) — the most-recently-active session
+        // FIRST, not last. Filtering by workspace preserves that order, so index
+        // 0 is the session this call is trying to resolve (the one whose turn was
+        // just sent). Taking `[length - 1]` returned the STALEST session in the
+        // workspace, which surfaced once LOCAL-6 opened a second in-workspace
+        // session (the gateway tab): the untouched user-key session sorted last,
+        // so the gateway leg's reopen resolve returned the user-key session id
+        // and the session-equality check spuriously fired even though the
+        // product genuinely created two sessions (two distinct ids in the
+        // network log, Actions run 29602686092, T3-AUTHROUTE-1/route=change).
+        return forWorkspace[0]!.id;
       }
     } else {
       lastWorkspaces = JSON.stringify(


### PR DESCRIPTION
## Outcome

`resolveLocalWorkspaceSessionId` selected `forWorkspace[length - 1]` from `GET /v1/sessions` — but `SessionStore::list_visible_all()` orders `updated_at DESC`, so that's the **stalest** session in the workspace, not the latest. Harmless while a workspace holds one session; wrong the moment it holds two: in LOCAL-6's route-change leg the reopen resolve bound to the untouched user-key session instead of the fresh gateway session (Actions run 29602686092, `T3-AUTHROUTE-1/local/route=change` — the network log showed two distinct session ids while the collector reported them equal).

Fix: pick index 0. The unit fixture is reordered to the real DESC contract so the test proves the selection (it previously passed with `[length-1]` because the fixture was oldest-first).

Main's #1350 snapshot-based send-path resolution (`snapshotLocalWorkspaceSessionIds`/`resolveLocalWorkspaceSessionAfter`) is untouched — this only corrects the reopen/verify-path resolver.

## Proof

- tests/release typecheck clean; unit suite **1185/1185**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)