### PR TITLE
test(release): harden qualification execution reliability

### DIFF
--- a/.github/workflows/release-e2e-selfhost.yml
+++ b/.github/workflows/release-e2e-selfhost.yml
@@ -42,10 +42,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: release-e2e-selfhost
-  cancel-in-progress: false
-
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -54,6 +50,9 @@ jobs:
     name: T4-SH-2 desktop artifact chain (release gate)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: release-e2e-tier4
+      cancel-in-progress: false
     steps:
       # fetch-depth 0 + tags: T4-SH-2 verifies the desktop-v<version> tag exists
       # and shares lineage with the release SHA.
@@ -63,6 +62,17 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
+      - name: Preflight Tier 4 artifact-chain inputs
+        run: |
+          node scripts/ci-cd/qualification-preflight.mjs \
+            --world tier4 \
+            --source-sha "${GITHUB_SHA}" \
+            --run-id "qt4-${GITHUB_RUN_ID}" \
+            --shard-id artifact-chain \
+            --attempt "${GITHUB_RUN_ATTEMPT}" \
+            --scenarios T4-SH-2 \
+            --artifact-mode build \
+            --output "tests/release/.output/preflight/tier4/qualification-preflight.json"
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -70,11 +80,22 @@ jobs:
         env:
           RELEASE_E2E_RELEASE_DESKTOP_VERSION: ${{ inputs.release_desktop_version }}
         run: make release-e2e LANE=local DESKTOP=web AGENTS=all SCENARIOS=T4-SH-2
+      - name: Upload Tier 4 preflight evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tier4-preflight-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tests/release/.output/preflight/tier4/
+          retention-days: 7
+          if-no-files-found: error
 
   provisioning:
     name: T3-SH-1 / T4-SH-1 / T3-SH-2 / T3-SH-3 (provisional)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: release-e2e-self-host
+      cancel-in-progress: false
     # Never gates a merge (README CI mapping — tier 3 is not a merge gate).
     continue-on-error: true
     steps:

--- a/.github/workflows/release-e2e-selfhost.yml
+++ b/.github/workflows/release-e2e-selfhost.yml
@@ -71,7 +71,7 @@ jobs:
             --shard-id artifact-chain \
             --attempt "${GITHUB_RUN_ATTEMPT}" \
             --scenarios T4-SH-2 \
-            --artifact-mode build \
+            --artifact-mode external \
             --output "tests/release/.output/preflight/tier4/qualification-preflight.json"
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -96,18 +96,18 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: release-e2e-tier3
-  cancel-in-progress: false
-
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release-e2e-local:
     name: tier-3 local lane (provisional)
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: release-e2e-local
+      cancel-in-progress: false
     # Provisional posture, enforced twice: the job name says so, and the job
     # never fails the workflow while it is provisional (README CI mapping —
     # tier 3 is not yet a merge gate).
@@ -317,6 +317,9 @@ jobs:
     name: tier-3 staging lane (provisional)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: release-e2e-staging
+      cancel-in-progress: false
     continue-on-error: true
     environment: staging
     steps:
@@ -387,78 +390,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # ---------------------------------------------------------------------------
-  # Local-world smoke — "Prove One Real Local Workspace Turn": builds one
-  # exact candidate Server, one exact candidate AnyHarness, and one exact
-  # candidate Desktop renderer; starts them as an isolated local world; and
-  # drives one real cheap managed-gateway turn through the actual product UI
-  # (the LOCAL-WORLD-SMOKE-1 cell). This is a provisional infrastructure
-  # proof, not the canonical LOCAL-2 guarantee.
-  #
-  # `workflow_dispatch` only while stability is established (no `schedule`
-  # trigger yet) — unlike the two lanes above, this job is NOT
-  # `continue-on-error`: a red command here stays red, with its real exit
-  # code. It runs `make qualification-local-workspace`, the exact same
-  # entrypoint a laptop uses; only the LiteLLM input source differs (the
-  # protected `Qualification` GitHub environment's vars/secrets, never the
-  # ignored local secret profile, and never routed to arbitrary pull-request
-  # code — the environment's branch policy allows only main and
-  # codex/local-world-smoke-1).
-  release-e2e-local-world-smoke:
-    name: local-world-smoke-1 (manual, strict)
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    environment: Qualification
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "."
-
-      - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build the three exact candidates and run LOCAL-WORLD-SMOKE-1 (strict)
-        env:
-          # Mapped directly from the protected `Qualification` environment. Both
-          # the admin/control-plane and public URLs exist there as distinct
-          # variables, so each maps to its own input (no public-covers-admin
-          # fallback). Arbitrary PR code never runs this job or sees these.
-          AGENT_GATEWAY_LITELLM_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_BASE_URL }}
-          AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
-          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
-          # Bounded, secret-free failure diagnostics written inside the uploaded
-          # logs/ tree (all captures pass through redact-diagnostics.ts before
-          # they are written). Deliberately OUTSIDE the run dir
-          # (<base>/<run-id>/<shard>) — the cleanup stack deletes the run dir on
-          # teardown, which would delete the captures before upload. This
-          # sibling path still matches the `*/*/logs/` upload glob below.
-          LOCAL_WORLD_SMOKE_DEBUG_DIR: ${{ github.workspace }}/tests/release/.output/local-world/ql-ci-${{ github.run_id }}-${{ github.run_attempt }}/debug/logs
-        run: |
-          set -euo pipefail
-          make qualification-local-workspace \
-            PROFILE="ci-${{ github.run_id }}-${{ github.run_attempt }}" \
-            BEHAVIOR=strict
-
-      - name: Upload V4 report and bounded diagnostic logs
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: local-world-smoke-1-evidence
-          path: |
-            tests/release/.output/local-world/*/*/evidence/
-            tests/release/.output/local-world/*/*/logs/
-          retention-days: 7
-          if-no-files-found: ignore
-
   # ── PR 4: Tier-2 strict billing/auth qualification ──────────────────────────
   # `workflow_dispatch` only while stability is established. NOT
   # `continue-on-error` — a red command stays red with its real exit code. Runs
@@ -473,6 +404,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: release-e2e-tier2
+      cancel-in-progress: false
     environment: Qualification
     services:
       postgres:
@@ -560,32 +494,54 @@ jobs:
   # (~/Vault/Vault/Workspace/Testing/Complete Local Workspace Qualification
   # (Functional).md; specs/developing/testing/tier-3-scenario-contract.md
   # §"Local cases" LOCAL-1..7, billing carve-out excepted — see LOCAL-BILL-1..7,
-  # out of scope until PR 4). Same three exact candidates as the smoke job
-  # above (identical build step), but drives the full functional local cell
-  # set — repo-to-workspace, gateway chat, user-key auth route + route change,
-  # config matrix, session tabs, and the MCP integration turn — instead of the
-  # single LOCAL-WORLD-SMOKE-1 infrastructure proof.
+  # out of scope until PR 4). This one job builds the three exact candidates,
+  # runs LOCAL-WORLD-SMOKE-1, then materializes and re-hashes that exact map for
+  # the functional cell set. Candidate bytes are built and published once per
+  # workflow run; no second cargo/docker/pnpm build seam is entered.
   #
   # `workflow_dispatch` only, same posture as the smoke job: NOT
   # `continue-on-error`, `environment: Qualification` (protected — branch
   # policy gates which refs may run it; the BYOK/integration/LiteLLM secrets
   # below never see arbitrary pull-request code). Before dispatching this
   # manually, check the Actions tab for an in-progress/pending release-e2e.yml
-  # run first — every job in this workflow shares the `release-e2e-tier3`
-  # concurrency group (queued, not cancelled, since cancel-in-progress is
-  # false above), so a second dispatch just waits rather than racing the
-  # first one's world.
+  # run first — this world has its own non-cancelling concurrency group, so an
+  # unrelated managed-cloud, self-host, Tier-2, or Tier-4 run cannot replace it.
   release-e2e-local-functional:
-    name: local-functional (manual, LOCAL-1..7)
+    name: local smoke + functional (manual, build once)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency:
+      group: release-e2e-local
+      cancel-in-progress: false
     environment: Qualification
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
+      - name: Preflight local world before installs or candidate builds
+        env:
+          AGENT_GATEWAY_LITELLM_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_BASE_URL }}
+          AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
+          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
+          RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY }}
+          RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY }}
+          RELEASE_E2E_BYOK_OPENAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_OPENAI_API_KEY }}
+          RELEASE_E2E_BYOK_XAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_XAI_API_KEY }}
+          RELEASE_E2E_INTEGRATION_NAMESPACE: ${{ vars.RELEASE_E2E_INTEGRATION_NAMESPACE }}
+          RELEASE_E2E_INTEGRATION_API_KEY: ${{ secrets.RELEASE_E2E_INTEGRATION_API_KEY }}
+          SCENARIOS_INPUT: ${{ github.event.inputs.scenarios || 'all' }}
+        run: |
+          node scripts/ci-cd/qualification-preflight.mjs \
+            --world local \
+            --source-sha "${GITHUB_SHA}" \
+            --run-id "qlf-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --shard-id 1 \
+            --attempt "${GITHUB_RUN_ATTEMPT}" \
+            --scenarios "${SCENARIOS_INPUT}" \
+            --artifact-mode build \
+            --output "tests/release/.output/preflight/local/qualification-preflight.json"
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -594,10 +550,7 @@ jobs:
         with:
           workspaces: "."
 
-      - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build the three exact candidates and run the local-functional cell set
+      - name: Build once, run the smoke, then reuse the exact candidates for functional cells
         env:
           # Same LiteLLM mapping as local-world-smoke-1 above — one source of
           # truth, the protected `Qualification` environment.
@@ -633,11 +586,21 @@ jobs:
           BEHAVIOR: ${{ github.event.inputs.local_functional_behavior || 'strict' }}
         run: |
           set -euo pipefail
+          profile="ci-${{ github.run_id }}-${{ github.run_attempt }}"
+          smoke_rc=0
+          functional_rc=0
+          make qualification-local-workspace \
+            PROFILE="$profile" \
+            BEHAVIOR=strict || smoke_rc=$?
+          candidate_dir="${GITHUB_WORKSPACE}/tests/release/.output/local-world/ql-${profile}/1"
           make qualification-local-functional \
-            PROFILE="ci-${{ github.run_id }}-${{ github.run_attempt }}" \
+            PROFILE="$profile" \
             BEHAVIOR="$BEHAVIOR" \
             AGENTS="$AGENTS" \
-            SCENARIOS="$SCENARIOS"
+            SCENARIOS="$SCENARIOS" \
+            REUSE_CANDIDATES="$candidate_dir" || functional_rc=$?
+          if [ "$smoke_rc" -eq 2 ] || [ "$functional_rc" -eq 2 ]; then exit 2; fi
+          if [ "$smoke_rc" -ne 0 ] || [ "$functional_rc" -ne 0 ]; then exit 1; fi
 
       - name: Upload V4 report and bounded diagnostic logs
         if: always()
@@ -647,6 +610,12 @@ jobs:
           path: |
             tests/release/.output/local-world/*/*/evidence/
             tests/release/.output/local-world/*/*/logs/
+            tests/release/.output/local-world/*/*/preflight/
+            tests/release/.output/local-world/ql-*/*/candidate-build.json
+            tests/release/.output/local-world/ql-*/*/local-world-ports.json
+            tests/release/.output/local-world/ql-*/*/artifacts/
+            tests/release/.output/local-world/**/*-cancellation-finalization.json
+            tests/release/.output/preflight/local/
           retention-days: 7
           if-no-files-found: ignore
 
@@ -672,6 +641,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.selfhost
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency:
+      group: release-e2e-self-host
+      cancel-in-progress: false
     environment: Qualification
     permissions:
       contents: read
@@ -682,6 +654,42 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
+      - name: Preflight self-host world before installs, builds, or AWS mutation
+        env:
+          RELEASE_E2E_SELFHOST_REGION: ${{ vars.RELEASE_E2E_SELFHOST_REGION }}
+          RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID: ${{ vars.RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID }}
+          RELEASE_E2E_SELFHOST_INSTANCE_TYPE: ${{ vars.RELEASE_E2E_SELFHOST_INSTANCE_TYPE }}
+          RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY }}
+          RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY }}
+          RELEASE_E2E_SELFHOST_GITHUB_OAUTH_CLIENT_ID: ${{ vars.RELEASE_E2E_SELFHOST_GITHUB_OAUTH_CLIENT_ID }}
+          RELEASE_E2E_SELFHOST_GITHUB_OAUTH_SECRET: ${{ secrets.RELEASE_E2E_SELFHOST_GITHUB_OAUTH_SECRET }}
+          RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_STATE: ${{ secrets.RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_STATE }}
+          RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_STATE: ${{ secrets.RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_STATE }}
+          RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_EMAIL: ${{ vars.RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_EMAIL }}
+          RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_EMAIL: ${{ vars.RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_EMAIL }}
+          RELEASE_E2E_SELFHOST_LITELLM_IMAGE_TAG: ${{ vars.RELEASE_E2E_SELFHOST_LITELLM_IMAGE_TAG }}
+          RELEASE_E2E_SELFHOST_CLOUD_E2B_API_KEY: ${{ secrets.RELEASE_E2E_SELFHOST_CLOUD_E2B_API_KEY }}
+          RELEASE_E2E_SELFHOST_CLOUD_E2B_TEMPLATE_NAME: ${{ vars.RELEASE_E2E_SELFHOST_CLOUD_E2B_TEMPLATE_NAME }}
+          RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_ID: ${{ vars.RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_ID }}
+          RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_ID: ${{ vars.RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_ID }}
+          RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_SECRET: ${{ secrets.RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_SECRET }}
+          RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_PRIVATE_KEY: ${{ secrets.RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_PRIVATE_KEY }}
+          RELEASE_E2E_SELFHOST_CFN_BUCKET: ${{ vars.RELEASE_E2E_SELFHOST_CFN_BUCKET }}
+          RELEASE_E2E_SELFHOST_CFN_IMAGE_REPO: ${{ vars.RELEASE_E2E_SELFHOST_CFN_IMAGE_REPO }}
+          RELEASE_E2E_AWS_ROLE_ARN: ${{ vars.RELEASE_E2E_SELFHOST_AWS_ROLE_ARN }}
+          SELFHOST_SCENARIOS_INPUT: ${{ inputs.selfhost_scenarios }}
+          SELFHOST_CELLS_INPUT: ${{ inputs.selfhost_cells }}
+        run: |
+          node scripts/ci-cd/qualification-preflight.mjs \
+            --world self-host \
+            --source-sha "${GITHUB_SHA}" \
+            --run-id "qs-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --shard-id 1 \
+            --attempt "${GITHUB_RUN_ATTEMPT}" \
+            --scenarios "${SELFHOST_SCENARIOS_INPUT:-SELFHOST-INSTALL-1}" \
+            --cells "${SELFHOST_CELLS_INPUT:-all}" \
+            --artifact-mode build \
+            --output "tests/release/.output/preflight/self-host/qualification-preflight.json"
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -836,6 +844,8 @@ jobs:
             tests/release/.output/selfhost-world/**/evidence/
             tests/release/.output/selfhost-world/**/logs/
             tests/release/.output/selfhost-world/**/cleanup-ledger.json
+            tests/release/.output/selfhost-world/**/*-cancellation-finalization.json
+            tests/release/.output/preflight/self-host/
           retention-days: 7
           if-no-files-found: ignore
 
@@ -862,12 +872,52 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency:
+      group: release-e2e-managed-cloud
+      cancel-in-progress: false
     environment: Qualification
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Fetch the trusted default-branch cleanup authorization
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .qualification-trusted-default
+          fetch-depth: 1
+          sparse-checkout: tests/release/fixtures/managed-cloud-litellm-attribution-attestations.v1.json
+          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
+      - name: Preflight managed cloud before installs, builds, or provider mutation
+        env:
+          AGENT_GATEWAY_LITELLM_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_BASE_URL }}
+          AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: ${{ vars.AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL }}
+          AGENT_GATEWAY_LITELLM_MASTER_KEY: ${{ secrets.AGENT_GATEWAY_LITELLM_MASTER_KEY }}
+          RELEASE_E2E_E2B_API_KEY: ${{ secrets.RELEASE_E2E_E2B_API_KEY }}
+          RELEASE_E2E_E2B_TEAM_ID: ${{ vars.RELEASE_E2E_E2B_TEAM_ID }}
+          RELEASE_E2E_CLOUD_AWS_REGION: ${{ vars.RELEASE_E2E_CLOUD_AWS_REGION }}
+          RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: ${{ vars.RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID }}
+          RELEASE_E2E_CLOUD_GITHUB_APP_ID: ${{ vars.RELEASE_E2E_CLOUD_GITHUB_APP_ID }}
+          RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_ID: ${{ vars.RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_ID }}
+          RELEASE_E2E_CLOUD_GITHUB_APP_INSTALLATION_ID: ${{ vars.RELEASE_E2E_CLOUD_GITHUB_APP_INSTALLATION_ID }}
+          RELEASE_E2E_CLOUD_GITHUB_APP_PRIVATE_KEY: ${{ secrets.RELEASE_E2E_CLOUD_GITHUB_APP_PRIVATE_KEY }}
+          RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_SECRET: ${{ secrets.RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_SECRET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_E2E_CLOUD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_E2E_CLOUD_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          node scripts/ci-cd/qualification-preflight.mjs \
+            --world managed-cloud \
+            --source-sha "${GITHUB_SHA}" \
+            --run-id "qlc-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --shard-id 1 \
+            --attempt "${GITHUB_RUN_ATTEMPT}" \
+            --scenarios CLOUD-PROVISION-1 \
+            --artifact-mode build \
+            --cleanup-attestation-repository "${GITHUB_WORKSPACE}/.qualification-trusted-default" \
+            --cleanup-attestation-default-branch "${{ github.event.repository.default_branch }}" \
+            --cleanup-attestations "${GITHUB_WORKSPACE}/.qualification-trusted-default/tests/release/fixtures/managed-cloud-litellm-attribution-attestations.v1.json" \
+            --output "tests/release/.output/preflight/managed-cloud/qualification-preflight.json"
       - uses: pnpm/action-setup@v6
         with:
           version: 10
@@ -939,7 +989,9 @@ jobs:
           set -euo pipefail
           make qualification-managed-cloud \
             PROFILE="ci-${{ github.run_id }}-${{ github.run_attempt }}" \
-            BEHAVIOR=strict
+            BEHAVIOR=strict \
+            QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY="${GITHUB_WORKSPACE}/.qualification-trusted-default" \
+            QUALIFICATION_TRUSTED_CLEANUP_DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
 
       - name: Upload V4 report and bounded diagnostic logs
         if: always()
@@ -949,5 +1001,7 @@ jobs:
           path: |
             tests/release/.output/managed-cloud-world/*/*/evidence/
             tests/release/.output/managed-cloud-world/*/*/logs/
+            tests/release/.output/managed-cloud-world/**/*-cancellation-finalization.json
+            tests/release/.output/preflight/managed-cloud/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -550,7 +550,7 @@ jobs:
         with:
           workspaces: "."
 
-      - name: Build once, run the smoke, then reuse the exact candidates for functional cells
+      - name: Build once, run the smoke, then reuse the exact candidates after clean success
         env:
           # Same LiteLLM mapping as local-world-smoke-1 above — one source of
           # truth, the protected `Qualification` environment.
@@ -593,14 +593,19 @@ jobs:
             PROFILE="$profile" \
             BEHAVIOR=strict || smoke_rc=$?
           candidate_dir="${GITHUB_WORKSPACE}/tests/release/.output/local-world/ql-${profile}/1"
+          # A red smoke can include incomplete cleanup. Preserve its candidate
+          # publication for the always-running evidence upload, but do not boot
+          # a second world on the same baked ports unless smoke and cleanup both
+          # completed successfully.
+          if [ "$smoke_rc" -ne 0 ]; then exit "$smoke_rc"; fi
           make qualification-local-functional \
             PROFILE="$profile" \
             BEHAVIOR="$BEHAVIOR" \
             AGENTS="$AGENTS" \
             SCENARIOS="$SCENARIOS" \
             REUSE_CANDIDATES="$candidate_dir" || functional_rc=$?
-          if [ "$smoke_rc" -eq 2 ] || [ "$functional_rc" -eq 2 ]; then exit 2; fi
-          if [ "$smoke_rc" -ne 0 ] || [ "$functional_rc" -ne 0 ]; then exit 1; fi
+          if [ "$functional_rc" -eq 2 ]; then exit 2; fi
+          if [ "$functional_rc" -ne 0 ]; then exit 1; fi
 
       - name: Upload V4 report and bounded diagnostic logs
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -952,8 +952,6 @@ qualification-local-workspace:
 			exit 1; \
 		}; \
 	fi
-	pnpm install --silent
-	pnpm exec playwright install --with-deps chromium
 	@if [ "$$GITHUB_ACTIONS" = "true" ]; then \
 		: "$${AGENT_GATEWAY_LITELLM_BASE_URL:=$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL}"; \
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
@@ -964,20 +962,34 @@ qualification-local-workspace:
 		set +a; \
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
 	fi; \
-	test -n "$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL" || { \
-		echo "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment vars)."; \
-		exit 1; \
-	}; \
-	test -n "$$AGENT_GATEWAY_LITELLM_MASTER_KEY" || { \
-		echo "AGENT_GATEWAY_LITELLM_MASTER_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment secrets)."; \
-		exit 1; \
-	}; \
 	run_id="ql-$(PROFILE)"; \
 	shard_id="1"; \
 	run_dir="$(QUALIFICATION_LOCAL_WORLD_BASE_DIR)/$$run_id/$$shard_id"; \
-	mkdir -p "$$run_dir"; \
-	build_summary=$$(node scripts/ci-cd/build-local-qualification-candidates.mjs \
-		--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$run_dir") || exit $$?; \
+	mkdir -p "$$run_dir/preflight"; \
+	source_sha=$$(git rev-parse HEAD); \
+	attempt="$${GITHUB_RUN_ATTEMPT:-1}"; \
+	if [ -n "$(REUSE_CANDIDATES)" ]; then \
+		node scripts/ci-cd/qualification-preflight.mjs \
+			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+			--scenarios LOCAL-WORLD-SMOKE-1 --artifact-mode reuse \
+			--candidate-build-map "$(REUSE_CANDIDATES)/candidate-build.json" \
+			--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
+	else \
+		node scripts/ci-cd/qualification-preflight.mjs \
+			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+			--scenarios LOCAL-WORLD-SMOKE-1 --artifact-mode build \
+			--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
+	fi; \
+	pnpm install --silent; \
+	pnpm exec playwright install --with-deps chromium; \
+	if [ -n "$(REUSE_CANDIDATES)" ]; then \
+		build_summary=$$(node scripts/ci-cd/build-local-qualification-candidates.mjs \
+			--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$run_dir" \
+			--reuse-from "$(REUSE_CANDIDATES)") || exit $$?; \
+	else \
+		build_summary=$$(node scripts/ci-cd/build-local-qualification-candidates.mjs \
+			--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$run_dir") || exit $$?; \
+	fi; \
 	echo "$$build_summary"; \
 	candidate_map=$$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).candidate_build_map)' "$$build_summary"); \
 	cd tests/release && pnpm exec tsx src/cli/run.ts \
@@ -1088,8 +1100,6 @@ qualification-local-functional:
 			exit 1; \
 		}; \
 	fi
-	pnpm install --silent
-	pnpm exec playwright install --with-deps chromium
 	@if [ "$$GITHUB_ACTIONS" = "true" ]; then \
 		: "$${AGENT_GATEWAY_LITELLM_BASE_URL:=$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL}"; \
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
@@ -1101,40 +1111,39 @@ qualification-local-functional:
 		set +a; \
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
 	fi; \
-	test -n "$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL" || { \
-		echo "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment vars)."; \
-		exit 1; \
-	}; \
-	test -n "$$AGENT_GATEWAY_LITELLM_MASTER_KEY" || { \
-		echo "AGENT_GATEWAY_LITELLM_MASTER_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment secrets)."; \
-		exit 1; \
-	}; \
 	run_id="qlf-$(PROFILE)"; \
 	shard_id="1"; \
 	build_dir="$(QUALIFICATION_LOCAL_WORLD_BASE_DIR)/$$run_id/$$shard_id"; \
 	evidence_dir="$$build_dir/evidence"; \
+	scenarios="$(if $(filter-out all,$(SCENARIOS)),$(SCENARIOS),$(QUALIFICATION_LOCAL_FUNCTIONAL_SCENARIOS))"; \
+	mkdir -p "$$build_dir/preflight"; \
+	source_sha=$$(git rev-parse HEAD); \
+	attempt="$${GITHUB_RUN_ATTEMPT:-1}"; \
 	if [ -n "$(REUSE_CANDIDATES)" ]; then \
-		build_dir="$(REUSE_CANDIDATES)"; \
-		test -f "$$build_dir/candidate-build.json" || { \
-			echo "REUSE_CANDIDATES=$$build_dir has no candidate-build.json — build it first (e.g. a prior qualification-local-functional or qualification-local-workspace run), or omit REUSE_CANDIDATES."; \
-			exit 1; \
-		}; \
-		test -f "$$build_dir/local-world-ports.json" || { \
-			echo "REUSE_CANDIDATES=$$build_dir has no local-world-ports.json sidecar next to its candidate-build.json."; \
-			exit 1; \
-		}; \
-		echo "Reusing already-built local-world candidates from $$build_dir (skipping build-local-qualification-candidates.mjs)."; \
-		evidence_dir="$(QUALIFICATION_LOCAL_WORLD_BASE_DIR)/$$run_id/$$shard_id/evidence"; \
-		candidate_map="$$build_dir/candidate-build.json"; \
+		node scripts/ci-cd/qualification-preflight.mjs \
+			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+			--scenarios "$$scenarios" --artifact-mode reuse \
+			--candidate-build-map "$(REUSE_CANDIDATES)/candidate-build.json" \
+			--output "$$build_dir/preflight/qualification-preflight.json" || exit $$?; \
 	else \
-		mkdir -p "$$build_dir"; \
+		node scripts/ci-cd/qualification-preflight.mjs \
+			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+			--scenarios "$$scenarios" --artifact-mode build \
+			--output "$$build_dir/preflight/qualification-preflight.json" || exit $$?; \
+	fi; \
+	pnpm install --silent; \
+	pnpm exec playwright install --with-deps chromium; \
+	if [ -n "$(REUSE_CANDIDATES)" ]; then \
+		build_summary=$$(node scripts/ci-cd/build-local-qualification-candidates.mjs \
+			--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$build_dir" \
+			--reuse-from "$(REUSE_CANDIDATES)") || exit $$?; \
+	else \
 		build_summary=$$(node scripts/ci-cd/build-local-qualification-candidates.mjs \
 			--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$build_dir") || exit $$?; \
-		echo "$$build_summary"; \
-		candidate_map=$$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).candidate_build_map)' "$$build_summary"); \
 	fi; \
+	echo "$$build_summary"; \
+	candidate_map=$$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).candidate_build_map)' "$$build_summary"); \
 	mkdir -p "$$evidence_dir"; \
-	scenarios="$(if $(filter-out all,$(SCENARIOS)),$(SCENARIOS),$(QUALIFICATION_LOCAL_FUNCTIONAL_SCENARIOS))"; \
 	cd tests/release && pnpm exec tsx src/cli/run.ts \
 		--behavior $(BEHAVIOR) \
 		--lane local \
@@ -1213,7 +1222,7 @@ qualification-selfhost:
 	@if [ "$$GITHUB_ACTIONS" != "true" ]; then \
 		test -f "$(QUALIFICATION_INFRA_ENV)" || { \
 			echo "Missing qualification secret profile at $(QUALIFICATION_INFRA_ENV)."; \
-			echo "It must define the RELEASE_E2E_SELFHOST_* inputs and RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY (mode 0600, never committed)."; \
+			echo "It must define the selected scenario's RELEASE_E2E_SELFHOST_* and optional BYOK inputs (mode 0600, never committed)."; \
 			exit 1; \
 		}; \
 		perm=$$(stat -f '%Lp' "$(QUALIFICATION_INFRA_ENV)" 2>/dev/null || stat -c '%a' "$(QUALIFICATION_INFRA_ENV)"); \
@@ -1222,29 +1231,25 @@ qualification-selfhost:
 			exit 1; \
 		}; \
 	fi
-	pnpm install --silent
-	pnpm exec playwright install --with-deps chromium
 	@if [ "$$GITHUB_ACTIONS" != "true" ]; then \
 		set -a; \
 		. "$(QUALIFICATION_INFRA_ENV)"; \
 		set +a; \
 	fi; \
-	test -n "$$RELEASE_E2E_SELFHOST_REGION" || { \
-		echo "RELEASE_E2E_SELFHOST_REGION is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment vars)."; \
-		exit 1; \
-	}; \
-	test -n "$$RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID" || { \
-		echo "RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment vars)."; \
-		exit 1; \
-	}; \
-	test -n "$$RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY" || { \
-		echo "RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment secrets)."; \
-		exit 1; \
-	}; \
 	run_id="qs-$(PROFILE)"; \
 	shard_id="1"; \
 	run_dir="$(QUALIFICATION_SELFHOST_BASE_DIR)/$$run_id/$$shard_id"; \
-	mkdir -p "$$run_dir"; \
+	preflight_cells="$(SELFHOST_CELLS)"; \
+	if [ -z "$$preflight_cells" ]; then preflight_cells=all; fi; \
+	mkdir -p "$$run_dir/preflight"; \
+	source_sha=$$(git rev-parse HEAD); \
+	attempt="$${GITHUB_RUN_ATTEMPT:-1}"; \
+	node scripts/ci-cd/qualification-preflight.mjs \
+		--world self-host --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+		--scenarios "$(SELFHOST_SCENARIOS)" --cells "$$preflight_cells" --artifact-mode build \
+		--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
+	pnpm install --silent; \
+	pnpm exec playwright install --with-deps chromium; \
 	api_base_url="$${SELFHOST_API_BASE_URL:-}"; \
 	if [ -z "$$api_base_url" ]; then \
 		api_base_url=$$(cd tests/release && pnpm exec tsx src/cli/print-selfhost-run-api-base-url.ts "$$run_id" "$$shard_id") || exit $$?; \
@@ -1291,6 +1296,11 @@ qualification-selfhost:
 # directly; this target does not read or expect the local file there. AWS
 # credentials themselves stay ambient (the `aws` CLI), never a manifest var.
 QUALIFICATION_MANAGED_CLOUD_BASE_DIR ?= $(CURDIR)/tests/release/.output/managed-cloud-world
+# A separate clean checkout of the canonical repository pinned to the trusted
+# default-branch cleanup revision. Candidate checkout bytes cannot authorize
+# their own LiteLLM hard-cancel reconciliation.
+QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY ?=
+QUALIFICATION_TRUSTED_CLEANUP_DEFAULT_BRANCH ?= main
 qualification-managed-cloud:
 	@test -n "$(PROFILE)" || { \
 		echo "PROFILE=<unique-name> is required, e.g. make qualification-managed-cloud PROFILE=$$(whoami)-1 BEHAVIOR=diagnostic"; \
@@ -1312,8 +1322,6 @@ qualification-managed-cloud:
 			exit 1; \
 		}; \
 	fi
-	pnpm install --silent
-	pnpm exec playwright install --with-deps chromium
 	@if [ "$$GITHUB_ACTIONS" = "true" ]; then \
 		: "$${AGENT_GATEWAY_LITELLM_BASE_URL:=$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL}"; \
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
@@ -1324,22 +1332,38 @@ qualification-managed-cloud:
 		set +a; \
 		export AGENT_GATEWAY_LITELLM_BASE_URL; \
 	fi; \
-	test -n "$$AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL" || { \
-		echo "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment vars)."; \
-		exit 1; \
-	}; \
-	test -n "$$AGENT_GATEWAY_LITELLM_MASTER_KEY" || { \
-		echo "AGENT_GATEWAY_LITELLM_MASTER_KEY is required (local: $(QUALIFICATION_INFRA_ENV); Actions: Qualification environment secrets)."; \
+	test -n "$(QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY)" || { \
+		echo "QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY=<clean trusted-default-branch checkout> is required before managed-cloud build or provider work."; \
 		exit 1; \
 	}; \
 	run_id="qlc-$(PROFILE)"; \
 	shard_id="1"; \
 	run_dir="$(QUALIFICATION_MANAGED_CLOUD_BASE_DIR)/$$run_id/$$shard_id"; \
-	mkdir -p "$$run_dir"; \
+	mkdir -p "$$run_dir/preflight"; \
+	source_sha=$$(git rev-parse HEAD); \
+	attempt="$${GITHUB_RUN_ATTEMPT:-1}"; \
 	candidate_map="$$run_dir/candidate-build.json"; \
 	if [ "$(REUSE_CANDIDATES)" = "1" ] && [ -f "$$candidate_map" ]; then \
-		echo "[reuse] REUSE_CANDIDATES=1 — skipping candidate build, using $$candidate_map"; \
+		node scripts/ci-cd/qualification-preflight.mjs \
+			--world managed-cloud --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+			--scenarios CLOUD-PROVISION-1 --artifact-mode reuse --candidate-build-map "$$candidate_map" \
+			--cleanup-attestation-repository "$(QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY)" \
+			--cleanup-attestation-default-branch "$(QUALIFICATION_TRUSTED_CLEANUP_DEFAULT_BRANCH)" \
+			--cleanup-attestations "$(QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY)/tests/release/fixtures/managed-cloud-litellm-attribution-attestations.v1.json" \
+			--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
+		echo "[reuse] REUSE_CANDIDATES=1 — exact candidate cache verified at $$candidate_map"; \
 	else \
+		node scripts/ci-cd/qualification-preflight.mjs \
+			--world managed-cloud --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
+			--scenarios CLOUD-PROVISION-1 --artifact-mode build \
+			--cleanup-attestation-repository "$(QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY)" \
+			--cleanup-attestation-default-branch "$(QUALIFICATION_TRUSTED_CLEANUP_DEFAULT_BRANCH)" \
+			--cleanup-attestations "$(QUALIFICATION_TRUSTED_CLEANUP_REPOSITORY)/tests/release/fixtures/managed-cloud-litellm-attribution-attestations.v1.json" \
+			--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
+	fi; \
+	pnpm install --silent; \
+	pnpm exec playwright install --with-deps chromium; \
+	if ! { [ "$(REUSE_CANDIDATES)" = "1" ] && [ -f "$$candidate_map" ]; }; then \
 		build_summary=$$(node scripts/ci-cd/build-cloud-qualification-candidates.mjs \
 			--run-id "$$run_id" --shard-id "$$shard_id" --run-dir "$$run_dir") || exit $$?; \
 		echo "$$build_summary"; \

--- a/scripts/ci-cd/assemble-candidate-build-map.mjs
+++ b/scripts/ci-cd/assemble-candidate-build-map.mjs
@@ -74,6 +74,87 @@ function hashFile(filePath) {
 }
 
 /**
+ * Loads and re-verifies an existing CandidateBuildMapV1 before it is reused.
+ * This is the plain-Node companion to the runner's TypeScript loader: CI must
+ * be able to reject a stale/tampered cache before installing dependencies or
+ * invoking an expensive builder. It deliberately accepts only the existing
+ * local_file V1 contract and returns the same map shape; it does not introduce
+ * a second receipt or locator format.
+ */
+export function loadCandidateBuildMapForReuse({ mapPath, expectedSourceSha, expectedArtifactIds }) {
+  if (!mapPath) {
+    throw new Error("candidate build map path is required for reuse");
+  }
+  const sourceSha = resolveSourceSha(expectedSourceSha);
+  let map;
+  try {
+    map = JSON.parse(readFileSync(mapPath, "utf8"));
+  } catch (error) {
+    throw new Error(`candidate build map is unreadable or malformed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!map || typeof map !== "object" || Array.isArray(map)) {
+    throw new Error("candidate build map must be an object");
+  }
+  const mapKeys = Object.keys(map).sort();
+  if (JSON.stringify(mapKeys) !== JSON.stringify(["artifacts", "kind", "schema_version", "source_sha"])) {
+    throw new Error("candidate build map has unknown or missing fields");
+  }
+  if (map.schema_version !== 1 || map.kind !== "proliferate.candidate-build") {
+    throw new Error("candidate build map has an unsupported schema or kind");
+  }
+  if (map.source_sha !== sourceSha) {
+    throw new Error(`candidate build map source SHA does not match the requested source SHA`);
+  }
+  if (!Array.isArray(map.artifacts) || map.artifacts.length === 0) {
+    throw new Error("candidate build map artifacts must be a non-empty array");
+  }
+
+  const seen = new Set();
+  for (const artifact of map.artifacts) {
+    if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) {
+      throw new Error("candidate build map artifact must be an object");
+    }
+    const keys = Object.keys(artifact).sort();
+    if (JSON.stringify(keys) !== JSON.stringify(["artifact_id", "locator", "sha256", "version"])) {
+      throw new Error("candidate build map artifact has unknown or missing fields");
+    }
+    checkArtifactId(artifact.artifact_id);
+    if (seen.has(artifact.artifact_id)) {
+      throw new Error(`Duplicate artifact_id "${artifact.artifact_id}".`);
+    }
+    seen.add(artifact.artifact_id);
+    resolveVersion(artifact.version);
+    if (typeof artifact.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(artifact.sha256)) {
+      throw new Error(`candidate artifact ${artifact.artifact_id} has a malformed SHA-256`);
+    }
+    if (
+      !artifact.locator ||
+      typeof artifact.locator !== "object" ||
+      Array.isArray(artifact.locator) ||
+      JSON.stringify(Object.keys(artifact.locator).sort()) !== JSON.stringify(["kind", "path"]) ||
+      artifact.locator.kind !== "local_file" ||
+      typeof artifact.locator.path !== "string" ||
+      artifact.locator.path.trim().length === 0
+    ) {
+      throw new Error(`candidate artifact ${artifact.artifact_id} must use a local_file locator`);
+    }
+    const actual = hashFile(artifact.locator.path);
+    if (actual !== artifact.sha256) {
+      throw new Error(`candidate artifact ${artifact.artifact_id} SHA-256 does not match its bytes`);
+    }
+  }
+
+  if (expectedArtifactIds) {
+    const expected = [...expectedArtifactIds].sort();
+    const actual = [...seen].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`candidate build map artifact set is incompatible with the selected world`);
+    }
+  }
+  return map;
+}
+
+/**
  * Single-binary assembler. Unchanged signature/behavior from PR #1159 so
  * existing callers (`make qualification-candidate-build-map`,
  * `make qualification-candidate-handoff-smoke`) and their tests keep working.

--- a/scripts/ci-cd/build-local-qualification-candidates.mjs
+++ b/scripts/ci-cd/build-local-qualification-candidates.mjs
@@ -30,7 +30,12 @@ import net from "node:net";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { assembleCandidateBuildMapFromArtifacts, gitHeadSha, repositoryVersion } from "./assemble-candidate-build-map.mjs";
+import {
+  assembleCandidateBuildMapFromArtifacts,
+  gitHeadSha,
+  loadCandidateBuildMapForReuse,
+  repositoryVersion,
+} from "./assemble-candidate-build-map.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -238,6 +243,23 @@ export async function buildLocalQualificationCandidates(options, deps = {}) {
   if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
     throw new Error(`source SHA must be a lowercase 40-hex commit SHA, got "${sourceSha}"`);
   }
+
+  // An explicit reuse request is fail-closed and happens before port
+  // allocation or any docker/cargo/pnpm build seam. The existing candidate map
+  // remains the authority: every source identity and artifact digest is
+  // re-verified, then the exact bytes are copied into this run's directory and
+  // the local_file locators are rebased. This is the bounded build-once path
+  // shared by the local smoke and functional jobs.
+  if (options.reuseFrom) {
+    return materializeReusableLocalCandidates({
+      sourceDir: path.resolve(options.reuseFrom),
+      runDir,
+      runId,
+      shardId,
+      sourceSha,
+    });
+  }
+
   const version = (options.version ?? repositoryVersion()).trim();
   const target = (options.target ?? resolveRustHostTarget(exec)).trim();
   const dockerPlatform = options.dockerPlatform ?? resolveDockerPlatform(exec);
@@ -300,6 +322,80 @@ export async function buildLocalQualificationCandidates(options, deps = {}) {
   };
 }
 
+export function materializeReusableLocalCandidates({ sourceDir, runDir, runId, shardId, sourceSha }) {
+  const sourceMapPath = path.join(sourceDir, "candidate-build.json");
+  const map = loadCandidateBuildMapForReuse({ mapPath: sourceMapPath, expectedSourceSha: sourceSha });
+  const ids = map.artifacts.map((artifact) => artifact.artifact_id);
+  const compatible =
+    ids.length === 3 &&
+    ids.filter((id) => id.startsWith("server/")).length === 1 &&
+    ids.filter((id) => id.startsWith("anyharness/")).length === 1 &&
+    ids.filter((id) => id === "desktop-renderer/browser").length === 1;
+  if (!compatible) {
+    throw new Error("candidate build map artifact set is incompatible with the local world");
+  }
+
+  const sourcePortsPath = path.join(sourceDir, "local-world-ports.json");
+  const ports = validatePorts(JSON.parse(readFileSync(sourcePortsPath, "utf8")));
+  const destinationMapPath = path.join(runDir, "candidate-build.json");
+  const destinationPortsPath = path.join(runDir, "local-world-ports.json");
+
+  if (path.resolve(sourceDir) === path.resolve(runDir)) {
+    return localCandidateSummary({ runId, shardId, candidateBuildMapPath: destinationMapPath, portsPath: destinationPortsPath, ports, reused: true });
+  }
+
+  const artifactsDir = path.join(runDir, "artifacts");
+  mkdirSync(artifactsDir, { recursive: true });
+  const usedNames = new Set();
+  const rebased = map.artifacts.map((artifact) => {
+    const basename = path.basename(artifact.locator.path);
+    if (usedNames.has(basename)) {
+      throw new Error(`candidate reuse has duplicate artifact basename "${basename}"`);
+    }
+    usedNames.add(basename);
+    const destination = path.join(artifactsDir, basename);
+    copyFileSync(artifact.locator.path, destination);
+    if (artifact.artifact_id.startsWith("anyharness/")) {
+      chmodSync(destination, 0o755);
+    }
+    return { ...artifact, locator: { kind: "local_file", path: destination } };
+  });
+  const rebasedMap = { ...map, artifacts: rebased };
+  writeFileSync(destinationMapPath, `${JSON.stringify(rebasedMap, null, 2)}\n`, "utf8");
+  writeFileSync(destinationPortsPath, `${JSON.stringify(ports, null, 2)}\n`, "utf8");
+  // Re-verify after copying so a partial or modified materialization can never
+  // reach the runner as a cache hit.
+  loadCandidateBuildMapForReuse({ mapPath: destinationMapPath, expectedSourceSha: sourceSha, expectedArtifactIds: ids });
+  return localCandidateSummary({ runId, shardId, candidateBuildMapPath: destinationMapPath, portsPath: destinationPortsPath, ports, reused: true });
+}
+
+function validatePorts(value) {
+  const keys = ["server", "postgres", "redis", "anyharness", "renderer"];
+  if (!value || typeof value !== "object" || Array.isArray(value) || JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...keys].sort())) {
+    throw new Error("local-world ports sidecar is malformed");
+  }
+  const values = keys.map((key) => value[key]);
+  if (values.some((port) => !Number.isInteger(port) || port < 1 || port > 65535) || new Set(values).size !== values.length) {
+    throw new Error("local-world ports sidecar contains invalid or duplicate ports");
+  }
+  return value;
+}
+
+function localCandidateSummary({ runId, shardId, candidateBuildMapPath, portsPath, ports, reused = false }) {
+  return {
+    run_id: runId,
+    shard_id: shardId,
+    candidate_build_map: candidateBuildMapPath,
+    ports_file: portsPath,
+    ports,
+    urls: {
+      api_base_url: `http://127.0.0.1:${ports.server}`,
+      anyharness_dev_url: `http://127.0.0.1:${ports.anyharness}`,
+    },
+    reused,
+  };
+}
+
 function argValue(flag) {
   const index = process.argv.indexOf(flag);
   return index >= 0 ? process.argv[index + 1] : undefined;
@@ -313,6 +409,7 @@ async function main() {
     sourceSha: argValue("--source-sha"),
     version: argValue("--version"),
     target: argValue("--target"),
+    reuseFrom: argValue("--reuse-from"),
   }, {
     log: (message) => console.error(`[build-local-qualification-candidates] ${message}`),
   });

--- a/scripts/ci-cd/build-local-qualification-candidates.test.mjs
+++ b/scripts/ci-cd/build-local-qualification-candidates.test.mjs
@@ -271,3 +271,93 @@ test("buildLocalQualificationCandidates rejects unsafe run-id/shard-id and a mis
     ),
   );
 });
+
+test("same-SHA local candidates are materialized without invoking a duplicate build", async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-reuse-"));
+  try {
+    const sourceDir = path.join(dir, "source");
+    const destinationDir = path.join(dir, "destination");
+    const distDir = path.join(dir, "desktop-dist");
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(path.join(distDir, "index.html"), "<html></html>");
+    const first = fakeExecFactory();
+    await buildLocalQualificationCandidates(
+      {
+        runId: "build-once",
+        shardId: "1",
+        runDir: sourceDir,
+        sourceSha: SHA,
+        version: "0.3.28",
+        target: "x86_64-unknown-linux-gnu",
+        dockerPlatform: "linux/amd64",
+        desktopDistDir: distDir,
+      },
+      { exec: first.exec, allocatePorts: fakeAllocatePorts() },
+    );
+    assert.ok(first.calls.some((call) => call.command === "cargo"));
+
+    const summary = await buildLocalQualificationCandidates(
+      { runId: "reuse-consumer", shardId: "1", runDir: destinationDir, sourceSha: SHA, reuseFrom: sourceDir },
+      {
+        exec: () => {
+          throw new Error("reuse must not call a build seam");
+        },
+        allocatePorts: async () => {
+          throw new Error("reuse must not allocate fresh ports");
+        },
+      },
+    );
+
+    assert.equal(summary.reused, true);
+    assert.ok(existsSync(summary.candidate_build_map));
+    const sourceMap = JSON.parse(readFileSync(path.join(sourceDir, "candidate-build.json"), "utf8"));
+    const destinationMap = JSON.parse(readFileSync(summary.candidate_build_map, "utf8"));
+    assert.deepEqual(
+      destinationMap.artifacts.map(({ artifact_id, version, sha256 }) => ({ artifact_id, version, sha256 })),
+      sourceMap.artifacts.map(({ artifact_id, version, sha256 }) => ({ artifact_id, version, sha256 })),
+    );
+    assert.ok(destinationMap.artifacts.every((artifact) => artifact.locator.path.startsWith(destinationDir)));
+    assert.deepEqual(summary.ports, JSON.parse(readFileSync(path.join(sourceDir, "local-world-ports.json"), "utf8")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("local candidate reuse fails closed when the requested source identity changes", async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "build-candidates-reuse-miss-"));
+  try {
+    const sourceDir = path.join(dir, "source");
+    const distDir = path.join(dir, "desktop-dist");
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(path.join(distDir, "index.html"), "<html></html>");
+    const { exec } = fakeExecFactory();
+    await buildLocalQualificationCandidates(
+      {
+        runId: "build-once",
+        shardId: "1",
+        runDir: sourceDir,
+        sourceSha: SHA,
+        version: "0.3.28",
+        target: "x86_64-unknown-linux-gnu",
+        dockerPlatform: "linux/amd64",
+        desktopDistDir: distDir,
+      },
+      { exec, allocatePorts: fakeAllocatePorts() },
+    );
+
+    await assert.rejects(
+      () =>
+        buildLocalQualificationCandidates({
+          runId: "reuse-consumer",
+          shardId: "1",
+          runDir: path.join(dir, "destination"),
+          sourceSha: "c".repeat(40),
+          reuseFrom: sourceDir,
+        }),
+      /source SHA does not match/,
+    );
+    assert.equal(existsSync(path.join(dir, "destination", "candidate-build.json")), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci-cd/qualification-preflight.mjs
+++ b/scripts/ci-cd/qualification-preflight.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { loadCandidateBuildMapForReuse } from "./assemble-candidate-build-map.mjs";
+
+export const PREFLIGHT_KIND = "proliferate.qualification-preflight";
+export const PREFLIGHT_SCHEMA_VERSION = 1;
+export const PREFLIGHT_DEADLINE_MS = 120_000;
+
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SHA = /^[0-9a-f]{40}$/;
+const WORLDS = new Set(["local", "managed-cloud", "self-host", "tier4"]);
+const SECRET_NAMES = new Set([
+  "AGENT_GATEWAY_LITELLM_MASTER_KEY",
+  "RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY",
+  "RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY",
+  "RELEASE_E2E_BYOK_OPENAI_API_KEY",
+  "RELEASE_E2E_BYOK_XAI_API_KEY",
+  "RELEASE_E2E_INTEGRATION_API_KEY",
+  "RELEASE_E2E_E2B_API_KEY",
+  "RELEASE_E2E_CLOUD_GITHUB_APP_PRIVATE_KEY",
+  "RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_SECRET",
+  "RELEASE_E2E_SELFHOST_GITHUB_OAUTH_SECRET",
+  "RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_STATE",
+  "RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_STATE",
+  "RELEASE_E2E_SELFHOST_CLOUD_E2B_API_KEY",
+  "RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_SECRET",
+  "RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_PRIVATE_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+]);
+
+const WORLD_REQUIREMENTS = {
+  local: [
+    ["AGENT_GATEWAY_LITELLM_BASE_URL", "https_url"],
+    ["AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL", "https_url"],
+    ["AGENT_GATEWAY_LITELLM_MASTER_KEY", "present"],
+  ],
+  "managed-cloud": [
+    ["AGENT_GATEWAY_LITELLM_BASE_URL", "https_url"],
+    ["AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL", "https_url"],
+    ["AGENT_GATEWAY_LITELLM_MASTER_KEY", "present"],
+    ["RELEASE_E2E_E2B_API_KEY", "present"],
+    ["RELEASE_E2E_E2B_TEAM_ID", "safe_reference"],
+    ["RELEASE_E2E_CLOUD_AWS_REGION", "aws_region"],
+    ["RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID", "route53_zone"],
+    ["RELEASE_E2E_CLOUD_GITHUB_APP_ID", "positive_integer"],
+    ["RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_ID", "safe_reference"],
+    ["RELEASE_E2E_CLOUD_GITHUB_APP_INSTALLATION_ID", "positive_integer"],
+    ["RELEASE_E2E_CLOUD_GITHUB_APP_PRIVATE_KEY", "present"],
+    ["RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_SECRET", "present"],
+  ],
+  "self-host": [
+    ["RELEASE_E2E_SELFHOST_REGION", "aws_region"],
+    ["RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID", "route53_zone"],
+  ],
+  tier4: [],
+};
+
+const SELFHOST_SCENARIO_REQUIREMENTS = {
+  "SELFHOST-INSTALL-1": [
+    ["RELEASE_E2E_SELFHOST_INSTANCE_TYPE", "safe_reference"],
+    ["RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY", "present"],
+  ],
+  "SELFHOST-QUAL-1": [
+    ["RELEASE_E2E_SELFHOST_INSTANCE_TYPE", "safe_reference"],
+    ["RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY", "present"],
+  ],
+  "SELFHOST-ISOLATION-1": [
+    ["RELEASE_E2E_SELFHOST_INSTANCE_TYPE", "safe_reference"],
+    ["RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY", "present"],
+  ],
+  "SELFHOST-CFN-1": [],
+};
+
+const SELFHOST_SCENARIO_CELLS = {
+  "SELFHOST-INSTALL-1": ["SH-INSTALL-CLAIM", "SH-DESKTOP-OWNER", "SH-BASE-TURN", "SH-INVITEE"],
+  "SELFHOST-QUAL-1": ["SH-GITHUB-AUTH", "SH-GATEWAY", "SH-CLOUD-ADDON"],
+  "SELFHOST-ISOLATION-1": ["SH-SWITCH-ISOLATION"],
+  "SELFHOST-CFN-1": ["SH-CFN-WRAPPER"],
+};
+
+// These are deterministic blockers only when the operator explicitly selects
+// one SELFHOST-QUAL-1 cell. With the default all-cell selector, the scenario's
+// existing per-cell red outcomes remain independent.
+const SELFHOST_EXPLICIT_CELL_REQUIREMENTS = {
+  "SH-GITHUB-AUTH": [
+    ["RELEASE_E2E_SELFHOST_GITHUB_OAUTH_CLIENT_ID", "safe_reference"],
+    ["RELEASE_E2E_SELFHOST_GITHUB_OAUTH_SECRET", "present"],
+    ["RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_STATE", "present"],
+    ["RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_STATE", "present"],
+    ["RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_A_EMAIL", "email"],
+    ["RELEASE_E2E_SELFHOST_GITHUB_IDENTITY_B_EMAIL", "email"],
+  ],
+  "SH-GATEWAY": [
+    ["RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY", "present"],
+    ["RELEASE_E2E_SELFHOST_LITELLM_IMAGE_TAG", "safe_reference"],
+  ],
+  "SH-CLOUD-ADDON": [
+    ["RELEASE_E2E_SELFHOST_CLOUD_E2B_API_KEY", "present"],
+    ["RELEASE_E2E_SELFHOST_CLOUD_E2B_TEMPLATE_NAME", "safe_reference"],
+    ["RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_ID", "positive_integer"],
+    ["RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_ID", "safe_reference"],
+    ["RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_CLIENT_SECRET", "present"],
+    ["RELEASE_E2E_SELFHOST_CLOUD_GITHUB_APP_PRIVATE_KEY", "present"],
+  ],
+  "SH-CFN-WRAPPER": [
+    ["RELEASE_E2E_SELFHOST_CFN_BUCKET", "s3_bucket"],
+    ["RELEASE_E2E_SELFHOST_CFN_IMAGE_REPO", "ghcr_repo"],
+  ],
+};
+
+const LOCAL_SCENARIO_REQUIREMENTS = {
+  "T3-AUTHROUTE-1": [
+    ["RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY", "present"],
+    ["RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY", "present"],
+    ["RELEASE_E2E_BYOK_OPENAI_API_KEY", "present"],
+    ["RELEASE_E2E_BYOK_XAI_API_KEY", "present"],
+  ],
+  "T3-INT-1": [
+    ["RELEASE_E2E_INTEGRATION_NAMESPACE", "safe_reference"],
+    ["RELEASE_E2E_INTEGRATION_API_KEY", "present"],
+  ],
+};
+
+export function runQualificationPreflight(options, deps = {}) {
+  const started = Date.now();
+  const env = deps.env ?? process.env;
+  const checks = [];
+  const fail = (id, message) => checks.push({ id, status: "failed", message });
+  const pass = (id, message) => checks.push({ id, status: "passed", message });
+
+  if (!WORLDS.has(options.world)) {
+    fail("world", "Selected world is unsupported.");
+  } else {
+    pass("world", `Selected world ${options.world} is supported.`);
+  }
+  validateIdentity(options, pass, fail);
+
+  const scenarioIds = parseSelector(options.scenarios ?? "all", "scenario_selection", fail);
+  const cellIds = parseSelector(options.cells ?? "all", "cell_selection", fail);
+  const requirements = WORLD_REQUIREMENTS[options.world] ?? [];
+  for (const [name, shape] of requirements) {
+    validateEnv(name, shape, env, pass, fail);
+  }
+  if (options.world === "local") {
+    const selected = scenarioIds === "all" ? Object.keys(LOCAL_SCENARIO_REQUIREMENTS) : scenarioIds;
+    for (const scenario of selected) {
+      for (const [name, shape] of LOCAL_SCENARIO_REQUIREMENTS[scenario] ?? []) {
+        validateEnv(name, shape, env, pass, fail);
+      }
+    }
+  }
+  if (options.world === "self-host") {
+    const selected = scenarioIds === "all" ? Object.keys(SELFHOST_SCENARIO_REQUIREMENTS) : scenarioIds;
+    for (const scenario of selected) {
+      if (!(scenario in SELFHOST_SCENARIO_REQUIREMENTS)) {
+        fail("scenario_selection", `Scenario ${scenario} is not a supported self-host scenario.`);
+      }
+    }
+    for (const scenario of selected) {
+      for (const [name, shape] of SELFHOST_SCENARIO_REQUIREMENTS[scenario] ?? []) {
+        validateEnv(name, shape, env, pass, fail);
+      }
+    }
+    if (cellIds !== "all") {
+      const allowedCells = new Set(selected.flatMap((scenario) => SELFHOST_SCENARIO_CELLS[scenario] ?? []));
+      for (const cell of cellIds) {
+        if (!allowedCells.has(cell)) {
+          fail("cell_selection", `Cell ${cell} is not owned by the selected self-host scenarios.`);
+          continue;
+        }
+        for (const [name, shape] of SELFHOST_EXPLICIT_CELL_REQUIREMENTS[cell] ?? []) {
+          validateEnv(name, shape, env, pass, fail);
+        }
+      }
+    } else if (selected.includes("SELFHOST-CFN-1")) {
+      for (const [name, shape] of SELFHOST_EXPLICIT_CELL_REQUIREMENTS["SH-CFN-WRAPPER"]) {
+        validateEnv(name, shape, env, pass, fail);
+      }
+    }
+  }
+  if (options.world === "managed-cloud" || options.world === "self-host") {
+    validateAwsAuthorization(env, pass, fail);
+  }
+
+  let candidateBuild = null;
+  if (options.artifactMode === "reuse") {
+    try {
+      const map = loadCandidateBuildMapForReuse({
+        mapPath: options.candidateBuildMap,
+        expectedSourceSha: options.sourceSha,
+      });
+      candidateBuild = safeCandidateEvidence(map);
+      pass("artifact_cache", "Exact candidate map and every local artifact digest were verified.");
+    } catch {
+      fail("artifact_cache", "Exact candidate cache lookup failed closed.");
+    }
+  } else if (options.artifactMode === "build") {
+    if (options.candidateBuildMap) {
+      fail("artifact_cache", "Build mode cannot also claim a candidate cache hit.");
+    } else {
+      pass("artifact_cache", "No cache hit is claimed; one candidate build is required.");
+    }
+  } else {
+    fail("artifact_cache", "Artifact mode must be build or reuse.");
+  }
+
+  const cleanupAuthorizationRevision = validateCleanupAuthorization(
+    options,
+    pass,
+    fail,
+    deps.resolveTrustedDefaultTip ?? resolveTrustedDefaultTip,
+  );
+  if (Date.now() - started >= PREFLIGHT_DEADLINE_MS) {
+    fail("deadline", "Preflight exceeded its two-minute bounded deadline.");
+  } else {
+    pass("deadline", "Preflight completed within its two-minute bounded deadline.");
+  }
+
+  const verdict = checks.some((check) => check.status === "failed") ? "failed" : "passed";
+  return {
+    schema_version: PREFLIGHT_SCHEMA_VERSION,
+    kind: PREFLIGHT_KIND,
+    run: {
+      run_id: safeReceiptString(options.runId),
+      shard_id: safeReceiptString(options.shardId),
+      attempt: Number.isInteger(options.attempt) ? options.attempt : null,
+      source_sha: SHA.test(options.sourceSha ?? "") ? options.sourceSha : null,
+    },
+    world: WORLDS.has(options.world) ? options.world : null,
+    selected_scenarios: scenarioIds,
+    selected_cells: cellIds,
+    artifact_mode: options.artifactMode ?? null,
+    candidate_build: candidateBuild,
+    cleanup_authorization_revision: cleanupAuthorizationRevision,
+    checks,
+    verdict,
+    duration_ms: Date.now() - started,
+  };
+}
+
+function validateIdentity(options, pass, fail) {
+  if (!SAFE_ID.test(options.runId ?? "")) fail("run_identity", "Run id is malformed.");
+  else if (!SAFE_ID.test(options.shardId ?? "")) fail("run_identity", "Shard id is malformed.");
+  else if (!Number.isInteger(options.attempt) || options.attempt < 1) fail("run_identity", "Attempt must be positive.");
+  else if (!SHA.test(options.sourceSha ?? "")) fail("run_identity", "Source SHA is malformed.");
+  else pass("run_identity", "Run, shard, attempt, and exact source SHA are valid.");
+}
+
+function parseSelector(raw, checkId, fail) {
+  if (raw === "all") return "all";
+  const ids = String(raw)
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (ids.length === 0 || ids.some((id) => !SAFE_ID.test(id)) || new Set(ids).size !== ids.length) {
+    const label = checkId === "cell_selection" ? "Cell" : "Scenario";
+    fail(checkId, `${label} selector is empty, duplicated, or malformed.`);
+    return [];
+  }
+  return ids.sort();
+}
+
+function validateEnv(name, shape, env, pass, fail) {
+  const value = env[name]?.trim();
+  const id = `env:${name}`;
+  if (!value) {
+    fail(id, `${name} is missing.`);
+    return;
+  }
+  let valid = true;
+  if (shape === "https_url") {
+    try {
+      const url = new URL(value);
+      valid = url.protocol === "https:" && !url.username && !url.password && url.hostname.length > 0;
+    } catch {
+      valid = false;
+    }
+  } else if (shape === "safe_reference") valid = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,511}$/.test(value);
+  else if (shape === "aws_region") valid = /^[a-z]{2}-[a-z]+-\d$/.test(value);
+  else if (shape === "route53_zone") valid = /^Z[A-Z0-9]{1,63}$/.test(value);
+  else if (shape === "positive_integer") valid = /^[1-9][0-9]*$/.test(value);
+  else if (shape === "email") valid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  else if (shape === "s3_bucket") valid = /^(?!\d+\.\d+\.\d+\.\d+$)[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/.test(value);
+  else if (shape === "ghcr_repo") valid = /^ghcr\.io\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(value);
+  if (!valid) {
+    fail(id, `${name} has an invalid ${shape} shape.`);
+    return;
+  }
+  pass(id, `${name} is present${SECRET_NAMES.has(name) ? " and redacted" : " with valid shape"}.`);
+}
+
+function validateAwsAuthorization(env, pass, fail) {
+  const hasAccessKey = Boolean(env.AWS_ACCESS_KEY_ID?.trim());
+  const hasSecretKey = Boolean(env.AWS_SECRET_ACCESS_KEY?.trim());
+  const hasProfile = Boolean(env.AWS_PROFILE?.trim());
+  const hasWebIdentity = Boolean(env.AWS_WEB_IDENTITY_TOKEN_FILE?.trim());
+  const hasRole = Boolean(env.AWS_ROLE_ARN?.trim());
+  const hasPlannedActionsOidc =
+    env.GITHUB_ACTIONS === "true" &&
+    Boolean(env.ACTIONS_ID_TOKEN_REQUEST_URL?.trim()) &&
+    Boolean(env.RELEASE_E2E_AWS_ROLE_ARN?.trim());
+  let posture = null;
+  if (hasAccessKey && hasSecretKey) posture = "access-key-pair";
+  else if (hasProfile) posture = "profile";
+  else if (hasWebIdentity && hasRole) posture = "web-identity-role";
+  else if (hasPlannedActionsOidc) posture = "planned-actions-oidc-role";
+  if (!posture) {
+    fail("aws_authorization", "No complete supported AWS authorization posture is present.");
+    return;
+  }
+  pass("aws_authorization", `AWS authorization posture ${posture} is present; values are not recorded.`);
+}
+
+function validateCleanupAuthorization(options, pass, fail, resolveDefaultTip) {
+  if (options.world !== "managed-cloud") {
+    pass("cleanup_authorization", "The selected world uses the runner-owned identity-bound cleanup ledger and finalizer.");
+    return null;
+  }
+  try {
+    const repository = path.resolve(options.cleanupAttestationRepository);
+    const attestationPath = path.resolve(options.cleanupAttestations);
+    const relativePath = path.relative(repository, attestationPath).split(path.sep).join("/");
+    if (!relativePath || relativePath.startsWith("../") || !/^[A-Za-z0-9._/-]+$/.test(relativePath)) {
+      throw new Error("attestation path is outside the trusted repository");
+    }
+    const git = (args, maxBuffer = 64 * 1024) =>
+      execFileSync("git", ["-C", repository, ...args], {
+        encoding: "utf8",
+        timeout: 5_000,
+        maxBuffer,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    const revision = git(["rev-parse", "--verify", "HEAD^{commit}"]);
+    if (!SHA.test(revision)) throw new Error("trusted revision is malformed");
+    const remote = git(["remote", "get-url", "origin"]);
+    if (!isCanonicalRepositoryRemote(remote)) throw new Error("trusted repository remote is not canonical");
+    const defaultBranch = options.cleanupAttestationDefaultBranch;
+    if (
+      typeof defaultBranch !== "string" ||
+      !/^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/.test(defaultBranch) ||
+      defaultBranch.includes("..") ||
+      defaultBranch.endsWith("/")
+    ) {
+      throw new Error("trusted default branch is malformed");
+    }
+    if (resolveDefaultTip(repository, defaultBranch) !== revision) {
+      throw new Error("trusted checkout is not the remote default-branch tip");
+    }
+    const raw = JSON.parse(git(["show", `${revision}:${relativePath}`], 1024 * 1024));
+    if (
+      !raw ||
+      typeof raw !== "object" ||
+      Array.isArray(raw) ||
+      JSON.stringify(Object.keys(raw).sort()) !== JSON.stringify(["kind", "schema_version", "source_shas"]) ||
+      raw.kind !== "managed_cloud_litellm_attribution_attestations" ||
+      raw.schema_version !== 1 ||
+      !Array.isArray(raw.source_shas) ||
+      raw.source_shas.some((sha) => !SHA.test(sha)) ||
+      new Set(raw.source_shas).size !== raw.source_shas.length ||
+      !raw.source_shas.includes(options.sourceSha)
+    ) {
+      throw new Error("candidate source is not attested");
+    }
+    pass("cleanup_authorization", "Trusted default-branch cleanup authorization contains the exact source SHA.");
+    return revision;
+  } catch {
+    fail("cleanup_authorization", "Trusted default-branch cleanup authorization is absent, unproven, or does not contain the exact source SHA.");
+    return null;
+  }
+}
+
+function resolveTrustedDefaultTip(repository, defaultBranch) {
+  const ref = `refs/heads/${defaultBranch}`;
+  const output = execFileSync("git", ["-C", repository, "ls-remote", "--heads", "origin", ref], {
+    encoding: "utf8",
+    timeout: 15_000,
+    maxBuffer: 64 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  const match = /^([0-9a-f]{40})\trefs\/heads\/[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/.exec(output);
+  if (!match || output.split("\n").length !== 1) throw new Error("remote default branch did not resolve exactly once");
+  return match[1];
+}
+
+function isCanonicalRepositoryRemote(remote) {
+  return /^(?:https:\/\/github\.com\/|git@github\.com:)proliferate-ai\/proliferate(?:\.git)?$/.test(remote);
+}
+
+function safeCandidateEvidence(map) {
+  const artifacts = map.artifacts
+    .map(({ artifact_id, version, sha256 }) => ({ artifact_id, version, sha256 }))
+    .sort((a, b) => a.artifact_id.localeCompare(b.artifact_id));
+  const contentIdentity = createHash("sha256")
+    .update(JSON.stringify({ source_sha: map.source_sha, artifacts }))
+    .digest("hex");
+  return { content_identity: contentIdentity, artifacts };
+}
+
+function safeReceiptString(value) {
+  return typeof value === "string" && SAFE_ID.test(value) ? value : null;
+}
+
+function parseArgs(argv) {
+  const options = {};
+  const mappings = new Map([
+    ["--world", "world"],
+    ["--source-sha", "sourceSha"],
+    ["--run-id", "runId"],
+    ["--shard-id", "shardId"],
+    ["--attempt", "attempt"],
+    ["--scenarios", "scenarios"],
+    ["--cells", "cells"],
+    ["--artifact-mode", "artifactMode"],
+    ["--candidate-build-map", "candidateBuildMap"],
+    ["--cleanup-attestations", "cleanupAttestations"],
+    ["--cleanup-attestation-repository", "cleanupAttestationRepository"],
+    ["--cleanup-attestation-default-branch", "cleanupAttestationDefaultBranch"],
+    ["--output", "output"],
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = mappings.get(argv[index]);
+    const value = argv[index + 1];
+    if (!key || value === undefined || options[key] !== undefined) throw new Error("Invalid or duplicate preflight argument.");
+    options[key] = key === "attempt" ? Number(value) : value;
+  }
+  if (!options.output) throw new Error("--output is required.");
+  return options;
+}
+
+export function writePreflightReceipt(outputPath, receipt) {
+  const resolved = path.resolve(outputPath);
+  mkdirSync(path.dirname(resolved), { recursive: true });
+  const temporary = `${resolved}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, resolved);
+}
+
+function main() {
+  let options;
+  let receipt;
+  try {
+    options = parseArgs(process.argv.slice(2));
+    receipt = runQualificationPreflight(options);
+  } catch (error) {
+    const outputIndex = process.argv.indexOf("--output");
+    const output = outputIndex >= 0 ? process.argv[outputIndex + 1] : undefined;
+    if (!output) throw error;
+    receipt = {
+      schema_version: PREFLIGHT_SCHEMA_VERSION,
+      kind: PREFLIGHT_KIND,
+      run: { run_id: null, shard_id: null, attempt: null, source_sha: null },
+      world: null,
+      selected_scenarios: [],
+      selected_cells: [],
+      artifact_mode: null,
+      candidate_build: null,
+      cleanup_authorization_revision: null,
+      checks: [{ id: "invocation", status: "failed", message: "Preflight invocation is invalid." }],
+      verdict: "failed",
+      duration_ms: 0,
+    };
+    options = { output };
+  }
+  writePreflightReceipt(options.output, receipt);
+  process.stdout.write(`${JSON.stringify({ verdict: receipt.verdict, evidence: path.resolve(options.output) })}\n`);
+  if (receipt.verdict !== "passed") process.exitCode = 2;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch {
+    console.error("qualification preflight failed before a receipt path was available");
+    process.exitCode = 2;
+  }
+}

--- a/scripts/ci-cd/qualification-preflight.mjs
+++ b/scripts/ci-cd/qualification-preflight.mjs
@@ -208,8 +208,21 @@ export function runQualificationPreflight(options, deps = {}) {
     } else {
       pass("artifact_cache", "No cache hit is claimed; one candidate build is required.");
     }
+  } else if (options.artifactMode === "external") {
+    if (options.world !== "tier4") {
+      fail("artifact_cache", "External artifact mode is restricted to read-only Tier 4 validation.");
+    } else if (!Array.isArray(scenarioIds) || scenarioIds.length !== 1 || scenarioIds[0] !== "T4-SH-2") {
+      fail("artifact_cache", "External artifact mode currently requires the read-only T4-SH-2 scenario.");
+    } else if (options.candidateBuildMap) {
+      fail("artifact_cache", "External artifact mode cannot also claim a local candidate map.");
+    } else {
+      pass(
+        "artifact_cache",
+        "No local candidate build or reuse is claimed; the selected Tier 4 scenario validates published artifacts.",
+      );
+    }
   } else {
-    fail("artifact_cache", "Artifact mode must be build or reuse.");
+    fail("artifact_cache", "Artifact mode must be build, reuse, or external.");
   }
 
   const cleanupAuthorizationRevision = validateCleanupAuthorization(

--- a/scripts/ci-cd/qualification-preflight.test.mjs
+++ b/scripts/ci-cd/qualification-preflight.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { test } from "node:test";
+
+import { assembleCandidateBuildMapFromArtifacts } from "./assemble-candidate-build-map.mjs";
+import { PREFLIGHT_DEADLINE_MS, runQualificationPreflight, writePreflightReceipt } from "./qualification-preflight.mjs";
+
+const SHA = "a".repeat(40);
+const BASE = {
+  world: "local",
+  sourceSha: SHA,
+  runId: "ql-test",
+  shardId: "1",
+  attempt: 1,
+  scenarios: "LOCAL-WORLD-SMOKE-1",
+  artifactMode: "build",
+};
+const LOCAL_ENV = {
+  AGENT_GATEWAY_LITELLM_BASE_URL: "https://admin.qualification.invalid",
+  AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "https://gateway.qualification.invalid",
+  AGENT_GATEWAY_LITELLM_MASTER_KEY: "super-secret-master-value",
+};
+
+test("invalid preflight fails before any caller can enter build or provider seams", () => {
+  let built = false;
+  let mutatedProvider = false;
+  const receipt = runQualificationPreflight(BASE, { env: {} });
+  if (receipt.verdict === "passed") {
+    built = true;
+    mutatedProvider = true;
+  }
+  assert.equal(receipt.verdict, "failed");
+  assert.equal(built, false);
+  assert.equal(mutatedProvider, false);
+  assert.ok(receipt.duration_ms < PREFLIGHT_DEADLINE_MS);
+  assert.match(JSON.stringify(receipt), /AGENT_GATEWAY_LITELLM_MASTER_KEY is missing/);
+});
+
+test("secret values never enter passed or failed machine-readable evidence", () => {
+  const passed = runQualificationPreflight(BASE, { env: LOCAL_ENV });
+  const invalid = runQualificationPreflight(BASE, {
+    env: { ...LOCAL_ENV, AGENT_GATEWAY_LITELLM_BASE_URL: "https://user:super-secret-url@invalid.example" },
+  });
+  assert.equal(passed.verdict, "passed");
+  assert.equal(invalid.verdict, "failed");
+  for (const receipt of [passed, invalid]) {
+    const serialized = JSON.stringify(receipt);
+    assert.doesNotMatch(serialized, /super-secret-master-value/);
+    assert.doesNotMatch(serialized, /super-secret-url/);
+  }
+});
+
+test("exact candidate map reuse preserves hashes and rejects a changed source identity", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-cache-"));
+  try {
+    const artifact = path.join(dir, "anyharness");
+    writeFileSync(artifact, "exact candidate bytes");
+    const map = assembleCandidateBuildMapFromArtifacts({
+      sourceSha: SHA,
+      defaultVersion: "1.2.3",
+      artifacts: [{ artifactId: "anyharness/x86_64-unknown-linux-gnu", path: artifact }],
+    });
+    const mapPath = path.join(dir, "candidate-build.json");
+    writeFileSync(mapPath, `${JSON.stringify(map)}\n`);
+
+    const hit = runQualificationPreflight(
+      { ...BASE, artifactMode: "reuse", candidateBuildMap: mapPath },
+      { env: LOCAL_ENV },
+    );
+    assert.equal(hit.verdict, "passed");
+    assert.deepEqual(hit.candidate_build.artifacts, [
+      {
+        artifact_id: "anyharness/x86_64-unknown-linux-gnu",
+        version: "1.2.3",
+        sha256: map.artifacts[0].sha256,
+      },
+    ]);
+    assert.match(hit.candidate_build.content_identity, /^[0-9a-f]{64}$/);
+
+    const miss = runQualificationPreflight(
+      { ...BASE, sourceSha: "b".repeat(40), artifactMode: "reuse", candidateBuildMap: mapPath },
+      { env: LOCAL_ENV },
+    );
+    assert.equal(miss.verdict, "failed");
+    assert.equal(miss.candidate_build, null);
+    assert.ok(miss.checks.some((check) => check.id === "artifact_cache" && check.status === "failed"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("managed-cloud preflight requires exact trusted-revision cleanup authorization and a complete AWS posture", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-attest-"));
+  try {
+    const attestation = path.join(dir, "attestations.json");
+    const git = (...args) => execFileSync("git", ["-C", dir, ...args], { stdio: "ignore" });
+    git("init");
+    git("config", "user.email", "qualification@example.invalid");
+    git("config", "user.name", "Qualification Test");
+    git("remote", "add", "origin", "https://github.com/proliferate-ai/proliferate.git");
+    writeFileSync(
+      attestation,
+      `${JSON.stringify({ kind: "managed_cloud_litellm_attribution_attestations", schema_version: 1, source_shas: [SHA] })}\n`,
+    );
+    git("add", "attestations.json");
+    git("commit", "-m", "trusted attestation fixture");
+    const env = {
+      AGENT_GATEWAY_LITELLM_BASE_URL: "https://admin.qualification.invalid",
+      AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "https://gateway.qualification.invalid",
+      AGENT_GATEWAY_LITELLM_MASTER_KEY: "master-secret",
+      RELEASE_E2E_E2B_API_KEY: "e2b-secret",
+      RELEASE_E2E_E2B_TEAM_ID: "team_qualification",
+      RELEASE_E2E_CLOUD_AWS_REGION: "us-west-2",
+      RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID: "Z123456789",
+      RELEASE_E2E_CLOUD_GITHUB_APP_ID: "123",
+      RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_ID: "Iv1.qualification",
+      RELEASE_E2E_CLOUD_GITHUB_APP_INSTALLATION_ID: "456",
+      RELEASE_E2E_CLOUD_GITHUB_APP_PRIVATE_KEY: "private-key-secret",
+      RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_SECRET: "client-secret",
+      AWS_ACCESS_KEY_ID: "access-secret",
+      AWS_SECRET_ACCESS_KEY: "access-secret-pair",
+    };
+    const options = {
+      ...BASE,
+      world: "managed-cloud",
+      runId: "qlc-ci-123-1",
+      scenarios: "CLOUD-PROVISION-1",
+      cleanupAttestations: attestation,
+      cleanupAttestationRepository: dir,
+      cleanupAttestationDefaultBranch: "main",
+    };
+    const trustedRevision = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    const deps = { env, resolveTrustedDefaultTip: () => trustedRevision };
+    const authorized = runQualificationPreflight(options, deps);
+    assert.equal(authorized.verdict, "passed");
+    assert.match(authorized.cleanup_authorization_revision, /^[0-9a-f]{40}$/);
+
+    writeFileSync(attestation, `${JSON.stringify({ kind: "candidate-authored", source_shas: [SHA] })}\n`);
+    const workingTreeTamper = runQualificationPreflight(options, deps);
+    assert.equal(workingTreeTamper.verdict, "passed", "preflight reads committed trusted bytes, not working-tree bytes");
+
+    const untrusted = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-untrusted-"));
+    try {
+      execFileSync("git", ["-C", untrusted, "init"], { stdio: "ignore" });
+      execFileSync("git", ["-C", untrusted, "config", "user.email", "qualification@example.invalid"]);
+      execFileSync("git", ["-C", untrusted, "config", "user.name", "Qualification Test"]);
+      execFileSync("git", ["-C", untrusted, "remote", "add", "origin", "https://example.invalid/fork.git"]);
+      writeFileSync(path.join(untrusted, "attestations.json"), readFileSync(attestation));
+      execFileSync("git", ["-C", untrusted, "add", "attestations.json"]);
+      execFileSync("git", ["-C", untrusted, "commit", "-m", "untrusted"]);
+      assert.equal(
+        runQualificationPreflight(
+          { ...options, cleanupAttestations: path.join(untrusted, "attestations.json"), cleanupAttestationRepository: untrusted },
+          deps,
+        ).verdict,
+        "failed",
+      );
+    } finally {
+      rmSync(untrusted, { recursive: true, force: true });
+    }
+    const nonDefault = runQualificationPreflight(options, {
+      env,
+      resolveTrustedDefaultTip: () => "b".repeat(40),
+    });
+    assert.equal(nonDefault.verdict, "failed", "canonical-origin non-default commits cannot self-authorize");
+    const serialized = JSON.stringify(authorized);
+    for (const secret of ["master-secret", "e2b-secret", "private-key-secret", "client-secret", "access-secret", "access-secret-pair"]) {
+      assert.doesNotMatch(serialized, new RegExp(secret));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("self-host preflight scopes BYOK and instance requirements to selected scenarios", () => {
+  const base = {
+    ...BASE,
+    world: "self-host",
+    runId: "qs-test",
+    scenarios: "SELFHOST-CFN-1",
+  };
+  const env = {
+    RELEASE_E2E_SELFHOST_REGION: "us-west-2",
+    RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID: "Z123456789",
+    RELEASE_E2E_SELFHOST_CFN_BUCKET: "qualification-artifacts",
+    RELEASE_E2E_SELFHOST_CFN_IMAGE_REPO: "ghcr.io/proliferate-ai/qualification",
+    AWS_PROFILE: "qualification",
+  };
+  const cfnOnly = runQualificationPreflight(base, { env });
+  assert.equal(cfnOnly.verdict, "passed");
+  assert.doesNotMatch(JSON.stringify(cfnOnly), /RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY/);
+  assert.doesNotMatch(JSON.stringify(cfnOnly), /RELEASE_E2E_SELFHOST_INSTANCE_TYPE/);
+  assert.equal(
+    runQualificationPreflight(base, { env: { ...env, RELEASE_E2E_SELFHOST_CFN_BUCKET: "" } }).verdict,
+    "failed",
+  );
+
+  const install = runQualificationPreflight({ ...base, scenarios: "SELFHOST-INSTALL-1" }, { env });
+  assert.equal(install.verdict, "failed");
+  assert.match(JSON.stringify(install), /RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY is missing/);
+  assert.match(JSON.stringify(install), /RELEASE_E2E_SELFHOST_INSTANCE_TYPE is missing/);
+});
+
+test("self-host preflight rejects unknown scenario and cell selectors", () => {
+  const env = {
+    RELEASE_E2E_SELFHOST_REGION: "us-west-2",
+    RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID: "Z123456789",
+    AWS_PROFILE: "qualification",
+  };
+  const options = { ...BASE, world: "self-host", runId: "qs-select" };
+  assert.equal(runQualificationPreflight({ ...options, scenarios: "UNKNOWN-1" }, { env }).verdict, "failed");
+  assert.equal(
+    runQualificationPreflight({ ...options, scenarios: "SELFHOST-QUAL-1", cells: "SH-CFN-WRAPPER" }, { env }).verdict,
+    "failed",
+  );
+});
+
+test("AWS preflight rejects partial keys and accepts planned Actions OIDC", () => {
+  const options = { ...BASE, world: "self-host", runId: "qs-oidc", scenarios: "SELFHOST-CFN-1" };
+  const world = {
+    RELEASE_E2E_SELFHOST_REGION: "us-west-2",
+    RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID: "Z123456789",
+    RELEASE_E2E_SELFHOST_CFN_BUCKET: "qualification-artifacts",
+    RELEASE_E2E_SELFHOST_CFN_IMAGE_REPO: "ghcr.io/proliferate-ai/qualification",
+  };
+  assert.equal(runQualificationPreflight(options, { env: { ...world, AWS_ACCESS_KEY_ID: "partial" } }).verdict, "failed");
+  assert.equal(
+    runQualificationPreflight(options, {
+      env: {
+        ...world,
+        GITHUB_ACTIONS: "true",
+        ACTIONS_ID_TOKEN_REQUEST_URL: "https://pipelines.actions.invalid/token",
+        RELEASE_E2E_AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/qualification",
+      },
+    }).verdict,
+    "passed",
+  );
+});
+
+test("self-host optional cell inputs fail early only for an explicit selected cell", () => {
+  const options = { ...BASE, world: "self-host", runId: "qs-qual", scenarios: "SELFHOST-QUAL-1" };
+  const env = {
+    RELEASE_E2E_SELFHOST_REGION: "us-west-2",
+    RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID: "Z123456789",
+    RELEASE_E2E_SELFHOST_INSTANCE_TYPE: "t3.small",
+    RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY: "byok-a",
+    AWS_PROFILE: "qualification",
+  };
+  assert.equal(runQualificationPreflight(options, { env }).verdict, "passed", "all cells preserve independent red outcomes");
+  const selected = { ...options, cells: "SH-GATEWAY" };
+  assert.equal(runQualificationPreflight(selected, { env }).verdict, "failed");
+  assert.equal(
+    runQualificationPreflight(selected, {
+      env: {
+        ...env,
+        RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY: "byok-b",
+        RELEASE_E2E_SELFHOST_LITELLM_IMAGE_TAG: "v1.2.3",
+      },
+    }).verdict,
+    "passed",
+  );
+});
+
+test("receipt writes atomically with mode-safe bounded content", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-write-"));
+  try {
+    const output = path.join(dir, "evidence", "preflight.json");
+    const receipt = runQualificationPreflight(BASE, { env: LOCAL_ENV });
+    writePreflightReceipt(output, receipt);
+    assert.deepEqual(JSON.parse(readFileSync(output, "utf8")), receipt);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci-cd/qualification-preflight.test.mjs
+++ b/scripts/ci-cd/qualification-preflight.test.mjs
@@ -92,6 +92,57 @@ test("exact candidate map reuse preserves hashes and rejects a changed source id
   }
 });
 
+test("Tier 4 external mode claims no candidate build or local reuse", () => {
+  const receipt = runQualificationPreflight(
+    {
+      ...BASE,
+      world: "tier4",
+      runId: "qt4-test",
+      shardId: "artifact-chain",
+      scenarios: "T4-SH-2",
+      artifactMode: "external",
+    },
+    { env: {} },
+  );
+
+  assert.equal(receipt.verdict, "passed");
+  assert.equal(receipt.artifact_mode, "external");
+  assert.equal(receipt.candidate_build, null);
+  const artifactCheck = receipt.checks.find((check) => check.id === "artifact_cache");
+  assert.equal(artifactCheck?.status, "passed");
+  assert.match(artifactCheck?.message ?? "", /No local candidate build or reuse is claimed/);
+  assert.doesNotMatch(JSON.stringify(receipt), /one candidate build is required/);
+
+  assert.equal(
+    runQualificationPreflight({ ...BASE, artifactMode: "external" }, { env: LOCAL_ENV }).verdict,
+    "failed",
+    "external mode cannot bypass a world that owns local candidate preparation",
+  );
+  assert.equal(
+    runQualificationPreflight(
+      { ...BASE, world: "tier4", runId: "qt4-other", scenarios: "T4-RUNTIME-1", artifactMode: "external" },
+      { env: {} },
+    ).verdict,
+    "failed",
+    "external mode is bounded to the read-only scenario that validates published artifacts",
+  );
+  assert.equal(
+    runQualificationPreflight(
+      {
+        ...BASE,
+        world: "tier4",
+        runId: "qt4-map",
+        scenarios: "T4-SH-2",
+        artifactMode: "external",
+        candidateBuildMap: "/tmp/false-local-map.json",
+      },
+      { env: {} },
+    ).verdict,
+    "failed",
+    "external mode cannot claim a local candidate-map identity",
+  );
+});
+
 test("managed-cloud preflight requires exact trusted-revision cleanup authorization and a complete AWS posture", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-attest-"));
   try {

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -220,8 +220,8 @@ gate.
 | `codeql.yml` | Push or pull request on `main`, plus weekly schedule | Run CodeQL security analysis. |
 | `intent-tests.yml` | Pull request or manual | Run the broad intent and billing suites; these lanes are currently provisional/non-blocking. |
 | `pr-metadata.yml` | Pull-request metadata events | Enforce ready-PR title and label metadata mechanically. Human policy belongs to the PR procedure. |
-| `release-e2e-selfhost.yml` | Scheduled, manual, or reusable | Run self-host artifact-chain and optional provisioning qualification. No current release coordinator calls it. |
-| `release-e2e.yml` | Scheduled or manual | Run live Tier 3 release qualification; it is not a per-PR merge gate. |
+| `release-e2e-selfhost.yml` | Scheduled, manual, or reusable | Run self-host artifact-chain and optional provisioning qualification. Tier 4 and self-host provisioning use separate non-cancelling job groups; no current release coordinator calls it. |
+| `release-e2e.yml` | Scheduled or manual | Run live Tier 3 release qualification; it is not a per-PR merge gate. Local, staging, Tier 2, managed-cloud, and self-host use independent non-cancelling job groups, so unrelated worlds may overlap while same-world runs do not. These groups do not promise FIFO ordering. |
 | `self-host-smoke.yml` | Pull request, push to `main`, or manual | Smoke the production Compose path when relevant paths change. Branch-protection status is not encoded here. |
 | `server-ci.yml` | Relevant push/PR, `server-v*` tag, manual, or reusable | Validate/package the server and publish self-host images/assets when invoked as a release. |
 

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -180,6 +180,42 @@ Two constraints apply:
   test mode, test GitHub App, test provider accounts) are named in
   `specs/developing/reference/env-vars.yaml`, never hardcoded in scenarios.
 
+Current execution reliability is deliberately bounded:
+
+- `qualification-preflight.mjs` runs before dependency installation, candidate
+  builds, or provider mutation in the current local, managed-cloud, self-host,
+  and Tier-4 artifact-chain entrypoints. It checks required world/scenario
+  inputs and the deterministic prerequisites of an explicitly selected
+  self-host cell,
+  complete supported AWS credential postures, exact candidate-map hashes on a
+  reuse request, and cleanup authorization using local operations plus one
+  bounded remote-default-branch identity lookup. It writes a redacted
+  machine-readable receipt and exits `2` on failure. It does not authenticate
+  to product providers or prove reachability.
+- Managed-cloud preflight validates only the GitHub App inputs the current
+  candidate-world constructor actually consumes. The complete six-field Server
+  gate (including webhook secret instead of the current hard-coded/partial
+  posture) remains owned by #1304/#1318; add those preflight requirements only
+  when that production path consumes them.
+- The manual local Actions job builds the three local candidates once, runs the
+  smoke world in a child directory, then materializes and re-hashes those exact
+  source bytes for the functional cells. `REUSE_CANDIDATES` gives the same
+  fail-closed reuse to a compatible retry in one retained checkout. There is no
+  durable cross-run Actions candidate cache yet: local-file maps bake
+  run-specific ports/origins and cannot be advertised as portable artifacts.
+- Job-level non-cancelling concurrency groups serialize overlapping runs of the
+  same world while allowing unrelated worlds to run concurrently. GitHub does
+  not guarantee FIFO ordering for pending runs, so these groups are collision
+  protection, not an ordered queue.
+- Normal completion, setup failure, and supported `SIGINT`/`SIGTERM`
+  cancellation share each world's memoized cleanup finalizer. Hard runner loss
+  cannot guarantee process-local finalization or receipt upload; only the
+  managed-cloud path currently has the independent trusted-default-branch
+  hard-cancel reaper. Self-host hard-loss reconciliation remains a gap.
+
+This work does not add stable TLS/ingress capacity; worlds continue to consume
+the existing provisioner and ingress contracts.
+
 ---
 
 ## Tier 4 — packaged install and upgrade

--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -66,11 +66,12 @@ the cells whose isolation contract permits it.
 
 ## Candidate Artifacts
 
-The first implemented slice of this contract is the candidate-only,
-local-file-only `CandidateBuildMapV1` in
-[`candidate-build-handoff.md`](candidate-build-handoff.md) (one AnyHarness
-artifact, validated and recorded by the runner). The complete remote/full
-manifest below — multi-platform slots, remote locators, retained N-1, and
+The implemented bounded handoff is the candidate-only, local-file-only
+`CandidateBuildMapV1` in
+[`candidate-build-handoff.md`](candidate-build-handoff.md). Each current world
+resolver requires its exact artifact set; the runner validates source identity,
+shape, local files, and every digest before setup. The complete remote/full
+manifest below — portable remote locators, retained N-1, and cross-run
 digest-verified downloads — is later work layered on that contract.
 
 Every live or upgrade run begins with a content-addressed candidate manifest:
@@ -650,6 +651,15 @@ A red CI run must reproduce by using its candidate manifest and runner flags
 locally. Secrets are named in the environment-variable catalog and never
 embedded in scenarios, artifacts, logs, or evidence.
 
+The current local manual job is a bounded precursor to the target topology: it
+builds one local-file candidate publication, runs the smoke world beneath
+`<run>/worlds/local-world-smoke-1`, and then copies and re-verifies the same
+published bytes for the functional run. The smoke finalizer owns only its child
+world directory, not the parent candidate map, ports sidecar, or artifact
+bytes. A retained local checkout can reuse that exact map on retry. GitHub
+reruns on a fresh runner still rebuild because no immutable remote candidate
+cache exists, and no current workflow claims cross-run reuse.
+
 ## Foundation Contracts
 
 ### Run and shard identity
@@ -683,6 +693,27 @@ invoke the same preflight implementation. Diagnostic behavior marks only the
 affected cells blocked and emits non-qualifying evidence; strict behavior fails
 before any external mutation. Actual provider permissions, callback delivery,
 and reachability are world-readiness checks.
+
+The current shared preflight is `scripts/ci-cd/qualification-preflight.mjs`.
+Its receipt records names/statuses, exact run/source identity, safe candidate
+artifact identities and digests, and the trusted cleanup revision; it never
+records environment values or locator paths. Self-host requirements are
+scenario-scoped, so `SELFHOST-CFN-1` requires its bucket/image-repository pair
+but not the BYOK or instance-type inputs used by
+install/qualification/isolation cells. Optional `SELFHOST-QUAL-1` inputs become
+early blockers only when their owning cell is explicitly selected; the default
+all-cell run preserves independent per-cell red outcomes. Managed-cloud preflight
+loads the attestation bytes from a separate canonical-origin checkout, proves
+that checkout's `HEAD` equals the bounded `ls-remote` result for the repository
+default branch, reads the committed file rather than mutable working-tree
+bytes, and requires the candidate SHA to be present. An unattested candidate
+fails before dependency installation, build, or provider mutation.
+
+Managed-cloud preflight currently checks only the GitHub App fields consumed by
+the current candidate-world constructor. The Server's complete six-field App
+configuration gate is not yet wired by that path; #1304/#1318 owns that repair.
+Webhook/slug preflight requirements must be derived from the repaired production
+path when it lands, not added here as dead preflight-only inputs.
 
 ### Typed ready-world handles
 
@@ -731,6 +762,15 @@ idempotent provider cleanup after a process or runner crash, and a TTL janitor
 is the final abandoned-run backstop. Later janitor success does not
 retroactively turn a strict run with failed cleanup green.
 
+The current CLI installs one process bridge for `SIGINT` and `SIGTERM`.
+Local-workspace, managed-cloud, and self-host world constructors register their
+existing cleanup stacks with it immediately. Normal close, startup failure, and
+signal handling await one memoized finalizer, so cleanup cannot execute twice;
+signal evidence is written beside the world directory with exact
+run/shard/attempt/source identity and a red status when the cleanup summary
+reports failures. `SIGKILL`, runner loss, and a job-level timeout may bypass
+that bridge and the `if: always()` upload step.
+
 GitHub Actions cancellation and job timeout are a distinct failure boundary:
 steps on the cancelled runner, including `if: always()` cleanup and artifact
 upload, are not guaranteed to execute. Managed-cloud AWS ingress resources
@@ -761,8 +801,11 @@ SHA appears in the append-only
 `managed-cloud-litellm-attribution-attestations.v1.json` list shipped by the
 trusted default-branch cleanup revision. Candidate-authored contract bytes,
 comments, dead strings, and partial implementation markers cannot opt a source
-in. The list intentionally ships empty; a later reviewed micro-PR may append an
-exact frozen source SHA after its attribution behavior is proven. Every
+in. The list contains only individually reviewed frozen source SHAs; a later
+reviewed micro-PR may append another exact source SHA after its attribution
+behavior is proven. The source workflow's managed preflight consumes committed
+bytes from a separately fetched default-branch checkout and records that exact
+trusted revision; it never treats candidate checkout bytes as authorization. Every
 unattested candidate remains explicitly non-green rather than treating an
 empty metadata sweep as proof. The exact completed attempt's job inventory is the
 world-start gate: if `cloud-provision-1 (manual, strict)` is absent or skipped,

--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -696,8 +696,13 @@ and reachability are world-readiness checks.
 
 The current shared preflight is `scripts/ci-cd/qualification-preflight.mjs`.
 Its receipt records names/statuses, exact run/source identity, safe candidate
-artifact identities and digests, and the trusted cleanup revision; it never
-records environment values or locator paths. Self-host requirements are
+artifact identities and digests when a local map is reused, and the trusted
+cleanup revision; it never records environment values or locator paths. Artifact
+mode `external` is accepted only for read-only Tier 4 validation: it records a
+null candidate build and explicitly delegates published-CDN/git artifact
+identity and availability checks to the selected scenario, without claiming a
+local build or cache hit. `T4-SH-2` uses this posture because it validates the
+already-published Desktop release. Self-host requirements are
 scenario-scoped, so `SELFHOST-CFN-1` requires its bucket/image-repository pair
 but not the BYOK or instance-type inputs used by
 install/qualification/isolation cells. Optional `SELFHOST-QUAL-1` inputs become

--- a/tests/release/src/cli/cancellation-finalizer.test.ts
+++ b/tests/release/src/cli/cancellation-finalizer.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  clearCancellationFinalizersForTest,
+  finalizeRegisteredForSignal,
+  registerCancellationFinalizer,
+} from "./cancellation-finalizer.js";
+import type { RunIdentityV1 } from "../runner/identity.js";
+
+const SHA = "a".repeat(40);
+
+afterEach(() => clearCancellationFinalizersForTest());
+
+function run(runId: string, shardId = "1"): RunIdentityV1 {
+  return {
+    run_id: runId,
+    shard_id: shardId,
+    attempt: 2,
+    source_sha: SHA,
+    origin: { kind: "github_actions", github_run_id: "123", github_job: "qualification" },
+  };
+}
+
+test("SIGTERM uses the same memoized world finalizers in reverse registration order", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "qualification-cancel-"));
+  try {
+    const calls: string[] = [];
+    registerCancellationFinalizer({
+      world: "managed-cloud",
+      run: run("qlc-123"),
+      runDir: path.join(dir, "managed", "1"),
+      finalize: async () => {
+        calls.push("managed-cloud");
+        return { failed: 0 };
+      },
+    });
+    registerCancellationFinalizer({
+      world: "self-host",
+      run: run("qs-123"),
+      runDir: path.join(dir, "self-host", "1"),
+      finalize: async () => {
+        calls.push("self-host");
+        return { failed: 0 };
+      },
+    });
+
+    await finalizeRegisteredForSignal("SIGTERM");
+    await finalizeRegisteredForSignal("SIGTERM");
+    assert.deepEqual(calls, ["self-host", "managed-cloud"]);
+
+    const managed = JSON.parse(await readFile(path.join(dir, "managed", "1-cancellation-finalization.json"), "utf8"));
+    assert.deepEqual(managed.run, { run_id: "qlc-123", shard_id: "1", attempt: 2, source_sha: SHA });
+    assert.equal(managed.world, "managed-cloud");
+    assert.equal(managed.signal, "SIGTERM");
+    assert.equal(managed.status, "reconciled");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("normal close and cancellation share one finalizer invocation", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "qualification-cancel-once-"));
+  try {
+    let calls = 0;
+    const handle = registerCancellationFinalizer({
+      world: "local",
+      run: run("ql-123"),
+      runDir: path.join(dir, "local", "1"),
+      finalize: async () => {
+        calls += 1;
+        return { failed: 0 };
+      },
+    });
+    await Promise.all([handle.run(), handle.run()]);
+    await finalizeRegisteredForSignal("SIGINT");
+    assert.equal(calls, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a cancellation cleanup failure remains identity-bound and red", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "qualification-cancel-failed-"));
+  try {
+    registerCancellationFinalizer({
+      world: "self-host",
+      run: run("qs-failed"),
+      runDir: path.join(dir, "self-host", "1"),
+      finalize: async () => {
+        throw new Error("secret provider payload must not escape");
+      },
+    });
+    await finalizeRegisteredForSignal("SIGINT");
+    const raw = await readFile(path.join(dir, "self-host", "1-cancellation-finalization.json"), "utf8");
+    const receipt = JSON.parse(raw);
+    assert.equal(receipt.status, "failed");
+    assert.equal(receipt.run.run_id, "qs-failed");
+    assert.doesNotMatch(raw, /secret provider payload/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a non-throwing cleanup summary with failed resources stays red", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "qualification-cancel-summary-failed-"));
+  try {
+    registerCancellationFinalizer({
+      world: "managed-cloud",
+      run: run("qlc-summary-failed"),
+      runDir: path.join(dir, "managed", "1"),
+      finalize: async () => ({ reconciled: 2, failed: 1 }),
+    });
+    await finalizeRegisteredForSignal("SIGTERM");
+    const raw = await readFile(path.join(dir, "managed", "1-cancellation-finalization.json"), "utf8");
+    const receipt = JSON.parse(raw);
+    assert.equal(receipt.status, "failed");
+    assert.match(receipt.reason, /reported failures/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/release/src/cli/cancellation-finalizer.ts
+++ b/tests/release/src/cli/cancellation-finalizer.ts
@@ -1,0 +1,153 @@
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { RunIdentityV1 } from "../runner/identity.js";
+
+type SupportedSignal = "SIGINT" | "SIGTERM";
+
+interface RegisteredFinalizer {
+  id: string;
+  world: "local" | "managed-cloud" | "self-host";
+  run: RunIdentityV1;
+  receiptPath: string;
+  runOnce: () => Promise<unknown>;
+}
+
+export interface CancellationFinalizerHandle<T> {
+  run(): Promise<T>;
+  unregister(): void;
+}
+
+const registered = new Map<string, RegisteredFinalizer>();
+let handlingSignal = false;
+
+/**
+ * Registers the existing world cleanup stack with the process cancellation
+ * bridge. Normal scenario `finally` blocks and SIGINT/SIGTERM use the same
+ * memoized cleanup promise, so cleanup cannot run twice. The receipt is a
+ * bounded identity/status record; detailed zero-survivor truth remains in the
+ * world's existing cleanup evidence and durable ledger.
+ */
+export function registerCancellationFinalizer<T>(options: {
+  world: RegisteredFinalizer["world"];
+  run: RunIdentityV1;
+  runDir: string;
+  finalize: () => Promise<T>;
+}): CancellationFinalizerHandle<T> {
+  const id = `${options.world}:${options.run.run_id}:${options.run.shard_id}:${options.run.attempt}`;
+  if (registered.has(id)) {
+    throw new Error(`Cancellation finalizer is already registered for ${id}.`);
+  }
+  let inFlight: Promise<T> | undefined;
+  const runOnce = (): Promise<T> => {
+    inFlight ??= options.finalize();
+    return inFlight;
+  };
+  const receiptPath = path.join(
+    path.dirname(options.runDir),
+    `${path.basename(options.runDir)}-cancellation-finalization.json`,
+  );
+  registered.set(id, { id, world: options.world, run: options.run, receiptPath, runOnce });
+  return {
+    run: async () => {
+      try {
+        return await runOnce();
+      } finally {
+        registered.delete(id);
+      }
+    },
+    unregister: () => registered.delete(id),
+  };
+}
+
+export async function finalizeRegisteredForSignal(signal: SupportedSignal): Promise<void> {
+  const entries = [...registered.values()].reverse();
+  for (const entry of entries) {
+    let status: "reconciled" | "failed" = "reconciled";
+    let reason: string | null = null;
+    try {
+      const result = await entry.runOnce();
+      if (cleanupResultFailed(result)) {
+        status = "failed";
+        reason = "The registered cleanup finalizer reported failures; inspect the identity-bound cleanup ledger.";
+      }
+    } catch {
+      status = "failed";
+      reason = "The registered cleanup finalizer failed; inspect the identity-bound cleanup ledger.";
+    } finally {
+      registered.delete(entry.id);
+    }
+    await writeCancellationReceipt(entry, signal, status, reason);
+  }
+}
+
+function cleanupResultFailed(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "failed" in value &&
+    typeof value.failed === "number" &&
+    value.failed > 0
+  );
+}
+
+export function installCancellationHandlers(options: {
+  timeoutMs?: number;
+  log?: (message: string) => void;
+} = {}): void {
+  const timeoutMs = options.timeoutMs ?? 25_000;
+  const log = options.log ?? ((message) => console.error(message));
+  const handle = (signal: SupportedSignal): void => {
+    if (handlingSignal) return;
+    handlingSignal = true;
+    const exitCode = signal === "SIGINT" ? 130 : 143;
+    const timer = setTimeout(() => {
+      log(`release-e2e: ${signal} cleanup exceeded ${timeoutMs}ms; hard exit cannot guarantee finalization.`);
+      process.exit(2);
+    }, timeoutMs);
+    timer.unref();
+    void finalizeRegisteredForSignal(signal)
+      .then(() => {
+        clearTimeout(timer);
+        process.exit(exitCode);
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        process.exit(2);
+      });
+  };
+  process.once("SIGINT", () => handle("SIGINT"));
+  process.once("SIGTERM", () => handle("SIGTERM"));
+}
+
+async function writeCancellationReceipt(
+  entry: RegisteredFinalizer,
+  signal: SupportedSignal,
+  status: "reconciled" | "failed",
+  reason: string | null,
+): Promise<void> {
+  const receipt = {
+    schema_version: 1,
+    kind: "proliferate.qualification-cancellation-finalization",
+    run: {
+      run_id: entry.run.run_id,
+      shard_id: entry.run.shard_id,
+      attempt: entry.run.attempt,
+      source_sha: entry.run.source_sha,
+    },
+    world: entry.world,
+    signal,
+    status,
+    reason,
+  };
+  await mkdir(path.dirname(entry.receiptPath), { recursive: true });
+  const temporary = `${entry.receiptPath}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporary, entry.receiptPath);
+}
+
+/** Test-only isolation for the process-global registry. */
+export function clearCancellationFinalizersForTest(): void {
+  registered.clear();
+  handlingSignal = false;
+}

--- a/tests/release/src/cli/run.ts
+++ b/tests/release/src/cli/run.ts
@@ -15,6 +15,7 @@ import { loadCandidateBuildMap } from "../artifacts/build-map.js";
 import { readLocalWorldPortsFile } from "../worlds/local-workspace/ports.js";
 import { writeReportV4 } from "../evidence/write.js";
 import { armPostReportExitWatchdog } from "./exit-watchdog.js";
+import { installCancellationHandlers } from "./cancellation-finalizer.js";
 
 /**
  * Thin process adapter: supplies the real side-effect dependencies to
@@ -127,6 +128,8 @@ function printEnvManifestReport(): void {
     console.log(`  [${status}] ${entry.spec.name}${shown}`);
   }
 }
+
+installCancellationHandlers();
 
 process.exitCode = await runReleaseCommand(process.argv.slice(2), {
   resolveIdentity: (overrides) => resolveRunIdentity({ overrides }),

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -53,6 +53,43 @@ test("the manual local world builds and publishes once, then reuses exact candid
   assert.doesNotMatch(release, /^  release-e2e-local-world-smoke:/m);
 });
 
+test("the manual local world reuses candidates only after a clean smoke exit", () => {
+  const local = job(release, "release-e2e-local-functional");
+  const smoke = local.indexOf("make qualification-local-workspace");
+  const smokeResult = local.indexOf("BEHAVIOR=strict || smoke_rc=$?");
+  const candidatePublication = local.indexOf('candidate_dir="${GITHUB_WORKSPACE}');
+  const cleanSmokeGate = local.indexOf(
+    'if [ "$smoke_rc" -ne 0 ]; then exit "$smoke_rc"; fi',
+  );
+  const functional = local.indexOf("make qualification-local-functional");
+  const evidenceUpload = local.indexOf("- name: Upload V4 report and bounded diagnostic logs");
+  const alwaysUpload = local.indexOf("if: always()", evidenceUpload);
+  const candidateMapUpload = local.indexOf("candidate-build.json", evidenceUpload);
+
+  assert.ok(smoke >= 0);
+  assert.ok(smokeResult > smoke);
+  assert.ok(candidatePublication > smokeResult);
+  assert.ok(cleanSmokeGate > candidatePublication);
+  assert.ok(functional > cleanSmokeGate);
+  assert.ok(evidenceUpload > functional);
+  assert.ok(alwaysUpload > evidenceUpload);
+  assert.ok(candidateMapUpload > alwaysUpload);
+});
+
+test("the Tier 4 artifact-chain preflight describes read-only published artifacts", () => {
+  const artifactChain = job(selfhost, "artifact-chain");
+  const preflight = artifactChain.indexOf("qualification-preflight.mjs");
+  const scenario = artifactChain.indexOf("make release-e2e");
+
+  assert.ok(preflight >= 0);
+  assert.ok(scenario > preflight);
+  assert.match(artifactChain, /--world tier4/);
+  assert.match(artifactChain, /--scenarios T4-SH-2/);
+  assert.match(artifactChain, /--artifact-mode external/);
+  assert.doesNotMatch(artifactChain, /--artifact-mode build/);
+  assert.doesNotMatch(artifactChain, /--candidate-build-map/);
+});
+
 test("provider-backed jobs run shared preflight before build/provider setup", () => {
   const local = job(release, "release-e2e-local-functional");
   const selfHost = job(release, "release-e2e-selfhost-install");

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const release = readFileSync(path.join(REPO_ROOT, ".github/workflows/release-e2e.yml"), "utf8");
+const selfhost = readFileSync(path.join(REPO_ROOT, ".github/workflows/release-e2e-selfhost.yml"), "utf8");
+const hardCancel = readFileSync(
+  path.join(REPO_ROOT, ".github/workflows/release-e2e-hard-cancel-cleanup.yml"),
+  "utf8",
+);
+
+function job(source: string, id: string): string {
+  const start = source.indexOf(`  ${id}:`);
+  assert.ok(start >= 0, `missing job ${id}`);
+  const remainder = source.slice(start + id.length + 3);
+  const nextJob = /^  [a-zA-Z0-9_-]+:\s*$/m.exec(remainder);
+  const end = nextJob?.index === undefined ? undefined : start + id.length + 3 + nextJob.index;
+  return source.slice(start, end);
+}
+
+test("release qualification has stable independent concurrency groups by world", () => {
+  const workflowHeader = release.slice(0, release.indexOf("\njobs:"));
+  const selfhostHeader = selfhost.slice(0, selfhost.indexOf("\njobs:"));
+  assert.doesNotMatch(workflowHeader, /^concurrency:/m, "one global group would serialize unrelated worlds");
+  assert.doesNotMatch(selfhostHeader, /^concurrency:/m, "one global group would serialize unrelated worlds");
+
+  assert.match(job(release, "release-e2e-local"), /group: release-e2e-local/);
+  assert.match(job(release, "release-e2e-local-functional"), /group: release-e2e-local/);
+  assert.match(job(release, "release-e2e-managed-cloud"), /group: release-e2e-managed-cloud/);
+  assert.match(job(release, "release-e2e-selfhost-install"), /group: release-e2e-self-host/);
+  assert.match(job(release, "qualification-tier2"), /group: release-e2e-tier2/);
+  assert.match(job(selfhost, "artifact-chain"), /group: release-e2e-tier4/);
+  assert.match(job(selfhost, "provisioning"), /group: release-e2e-self-host/);
+  assert.match(job(release, "release-e2e-local"), /if: github\.event_name == 'schedule'/);
+  assert.match(job(release, "release-e2e-local-functional"), /if: github\.event_name == 'workflow_dispatch'/);
+
+  for (const source of [release, selfhost]) {
+    assert.doesNotMatch(source, /cancel-in-progress: true/);
+  }
+});
+
+test("the manual local world builds and publishes once, then reuses exact candidates", () => {
+  const local = job(release, "release-e2e-local-functional");
+  assert.equal((local.match(/make qualification-local-workspace/g) ?? []).length, 1);
+  assert.equal((local.match(/make qualification-local-functional/g) ?? []).length, 1);
+  assert.match(local, /REUSE_CANDIDATES="\$candidate_dir"/);
+  assert.match(local, /candidate-build\.json/);
+  assert.match(local, /local-world-ports\.json/);
+  assert.match(local, /\/artifacts\//);
+  assert.doesNotMatch(release, /^  release-e2e-local-world-smoke:/m);
+});
+
+test("provider-backed jobs run shared preflight before build/provider setup", () => {
+  const local = job(release, "release-e2e-local-functional");
+  const selfHost = job(release, "release-e2e-selfhost-install");
+  const managed = job(release, "release-e2e-managed-cloud");
+  for (const [body, marker] of [
+    [local, "--world local"],
+    [selfHost, "--world self-host"],
+    [managed, "--world managed-cloud"],
+  ] as const) {
+    assert.ok(body.indexOf(marker) >= 0);
+    assert.ok(body.indexOf(marker) < body.indexOf("pnpm/action-setup"));
+    assert.match(body, /qualification-preflight\.json/);
+  }
+  assert.ok(managed.indexOf("--world managed-cloud") < managed.indexOf("Install MUSL target"));
+  assert.ok(selfHost.indexOf("--world self-host") < selfHost.indexOf("Configure AWS credentials"));
+  assert.ok(managed.indexOf("Fetch the trusted default-branch cleanup authorization") < managed.indexOf("--world managed-cloud"));
+  assert.match(managed, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(managed, /--cleanup-attestation-default-branch/);
+  assert.match(managed, /--cleanup-attestation-repository/);
+  for (const name of [
+    "RELEASE_E2E_SELFHOST_REGION",
+    "RELEASE_E2E_SELFHOST_HOSTED_ZONE_ID",
+    "RELEASE_E2E_SELFHOST_INSTANCE_TYPE",
+    "RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY",
+    "RELEASE_E2E_SELFHOST_CFN_BUCKET",
+    "RELEASE_E2E_SELFHOST_CFN_IMAGE_REPO",
+    "SELFHOST_CELLS_INPUT",
+  ]) {
+    assert.match(selfHost, new RegExp(`${name}:`), `self-host preflight must receive ${name}`);
+  }
+  for (const name of [
+    "AGENT_GATEWAY_LITELLM_BASE_URL",
+    "AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL",
+    "AGENT_GATEWAY_LITELLM_MASTER_KEY",
+    "RELEASE_E2E_E2B_API_KEY",
+    "RELEASE_E2E_E2B_TEAM_ID",
+    "RELEASE_E2E_CLOUD_AWS_REGION",
+    "RELEASE_E2E_CLOUD_ROUTE53_ZONE_ID",
+    "RELEASE_E2E_CLOUD_GITHUB_APP_ID",
+    "RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_ID",
+    "RELEASE_E2E_CLOUD_GITHUB_APP_INSTALLATION_ID",
+    "RELEASE_E2E_CLOUD_GITHUB_APP_PRIVATE_KEY",
+    "RELEASE_E2E_CLOUD_GITHUB_APP_CLIENT_SECRET",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+  ]) {
+    assert.match(managed, new RegExp(`${name}:`), `managed preflight must receive ${name}`);
+  }
+});
+
+test("supported cancellation keeps local receipts and hard cancellation keeps the trusted managed reaper", () => {
+  for (const id of ["release-e2e-local-functional", "release-e2e-selfhost-install", "release-e2e-managed-cloud"]) {
+    const body = job(release, id);
+    assert.match(body, /if: always\(\)/);
+    assert.match(body, /cancellation-finalization\.json/);
+  }
+  assert.match(hardCancel, /workflow_run:\s*\n\s*workflows: \["Release E2E \(tier 3\)"\]/);
+  assert.match(hardCancel, /Reconcile exact run-owned managed-cloud AWS resources/);
+  assert.match(hardCancel, /Reconcile exact run-owned E2B, Stripe, and LiteLLM resources/);
+  assert.doesNotMatch(hardCancel, /workflow_dispatch/);
+});

--- a/tests/release/src/scenarios/local-world-smoke-1.test.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.test.ts
@@ -5,6 +5,7 @@ import {
   DETERMINISTIC_PROMPT,
   LOCAL_WORLD_SMOKE_1_ID,
   REPRESENTATIVE_HARNESS,
+  localWorldSmokeWorldRoot,
   localWorldSmoke1,
   resolveWorldConstructionInputs,
   runLocalWorldSmokeCell,
@@ -48,6 +49,13 @@ function fakeCandidateMap(): CandidateBuildMapV1 {
     ],
   };
 }
+
+test("smoke world state is isolated below the candidate publication root", () => {
+  assert.equal(
+    localWorldSmokeWorldRoot("/qualification/ql-run/1"),
+    "/qualification/ql-run/1/worlds/local-world-smoke-1",
+  );
+});
 
 function fakePorts(): LocalWorldPorts {
   return { server: 1, postgres: 2, redis: 3, anyharness: 4, renderer: 5 };

--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 
 import type { Page } from "playwright";
 
@@ -65,6 +66,11 @@ import { resolveLocalWorkspaceSessionId } from "./local/local-session.js";
 export const LOCAL_WORLD_SMOKE_1_ID = "LOCAL-WORLD-SMOKE-1";
 export const REPRESENTATIVE_HARNESS = "claude";
 export const DETERMINISTIC_PROMPT = "Reply with exactly the word: pong";
+
+/** Mutable smoke state is a child of the immutable candidate publication. */
+export function localWorldSmokeWorldRoot(runDir: string): string {
+  return path.join(runDir, "worlds", "local-world-smoke-1");
+}
 
 /** Bounded waits for the live browser flow (kept generous but finite). */
 const GATEWAY_SYNC_TIMEOUT_MS = 120_000;
@@ -204,7 +210,8 @@ export interface LocalWorldSmokeDriver {
 }
 
 export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
-  buildWorld: ({ map, litellm, run, runDir, ports }) => constructLocalWorld({ run, map, litellm, runDir, ports }),
+  buildWorld: ({ map, litellm, run, runDir, ports }) =>
+    constructLocalWorld({ run, map, litellm, runDir, worldRoot: localWorldSmokeWorldRoot(runDir), ports }),
   createActor: (world) => authenticatedActor(world, "owner"),
   prepareRepo: (world, actor, cellId) => preparedRepository(world, actor, { cellId }),
   openPage: (world, actor) => productPage(world, actor),

--- a/tests/release/src/worlds/local-workspace/world.test.ts
+++ b/tests/release/src/worlds/local-workspace/world.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -17,6 +17,7 @@ import type { Exec } from "./docker.js";
 import type { ReadinessFetch, SpawnLike } from "./processes.js";
 import type { ChromiumLauncher } from "./renderer.js";
 import { constructLocalWorld, type LocalWorldDeps, type LocalWorldPorts } from "./world.js";
+import { localWorldSmokeWorldRoot } from "../../scenarios/local-world-smoke-1.js";
 
 const RUN: RunIdentityV1 = {
   run_id: "local-run-1",
@@ -228,11 +229,13 @@ test("worldRoot: materialization targets the world subdir and cleanup never dele
   // materialize hit `copyfile server.tar ENOENT`.
   const runDir = await mkdtemp(path.join(os.tmpdir(), "world-run-"));
   const sharedArtifacts = path.join(runDir, "artifacts");
-  const worldRoot = path.join(runDir, "worlds", "t3-wt-1");
+  const worldRoot = localWorldSmokeWorldRoot(runDir);
   try {
     const { mkdir } = await import("node:fs/promises");
     await mkdir(sharedArtifacts, { recursive: true });
     const map = await buildMap(sharedArtifacts);
+    const mapPath = path.join(runDir, "candidate-build.json");
+    await writeFile(mapPath, `${JSON.stringify(map)}\n`);
     const h = harness();
     const world = await constructLocalWorld({ run: RUN, map, litellm: LITELLM, runDir, worldRoot, ports: PORTS, deps: h.deps });
 
@@ -245,6 +248,7 @@ test("worldRoot: materialization targets the world subdir and cleanup never dele
     for (const artifact of map.artifacts) {
       await access(artifact.locator.path);
     }
+    await access(mapPath);
 
     const evidence = await world.close();
     assert.equal(evidence.failed, 0);
@@ -255,6 +259,23 @@ test("worldRoot: materialization targets the world subdir and cleanup never dele
     for (const artifact of map.artifacts) {
       await access(artifact.locator.path);
     }
+    await access(mapPath);
+
+    // Only after smoke teardown, the next compatible step performs the exact
+    // source+digest validation used by `--reuse-from`. Cleanup cannot turn a
+    // missing or corrupted publication into an apparent cache hit.
+    // @ts-expect-error The repository-owned Node build helper is plain ESM JavaScript.
+    const { loadCandidateBuildMapForReuse } = await import("../../../../../scripts/ci-cd/assemble-candidate-build-map.mjs");
+    const reusable = loadCandidateBuildMapForReuse({
+      mapPath,
+      expectedSourceSha: RUN.source_sha,
+      expectedArtifactIds: map.artifacts.map((artifact) => artifact.artifact_id),
+    });
+    assert.deepEqual(
+      reusable.artifacts.map((artifact: CandidateBuildArtifactV1) => artifact.sha256),
+      map.artifacts.map((artifact) => artifact.sha256),
+    );
+    assert.deepEqual(JSON.parse(await readFile(mapPath, "utf8")), map);
   } finally {
     await rm(runDir, { recursive: true, force: true });
   }

--- a/tests/release/src/worlds/local-workspace/world.ts
+++ b/tests/release/src/worlds/local-workspace/world.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import type { Browser } from "playwright";
 
+import { registerCancellationFinalizer } from "../../cli/cancellation-finalizer.js";
+
 import type { CandidateBuildMapV1 } from "../../artifacts/build-map.js";
 import {
   resolveLocalCandidateSet,
@@ -235,6 +237,12 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
     mirror: deps.ledgerMirror,
   });
   const stack = new LocalWorldCleanupStack({ ledger, log });
+  const cancellationFinalizer = registerCancellationFinalizer({
+    world: "local",
+    run: options.run,
+    runDir: worldRoot,
+    finalize: () => stack.runAll(),
+  });
 
   const register = async (
     kind: CleanupResourceKind,
@@ -349,12 +357,12 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
       db: { databaseUrl: dockerHostDatabaseUrl(options.ports.postgres) },
       registerCleanup: register,
       trackActorSubjects: (actor) => trackActorSubjects(stack, gateway, actor),
-      close: () => stack.runAll(),
+      close: () => cancellationFinalizer.run(),
     };
   } catch (error) {
     // Any startup failure runs every registered cleanup exactly once, reverse
     // order, then rethrows so the caller marks the cell failed.
-    await stack.runAll().catch(() => undefined);
+    await cancellationFinalizer.run().catch(() => undefined);
     throw error;
   }
 }

--- a/tests/release/src/worlds/local-workspace/world.ts
+++ b/tests/release/src/worlds/local-workspace/world.ts
@@ -162,8 +162,8 @@ export interface ConstructLocalWorldOptions {
    * Per-world mutable root — runtime home, secrets, extracted renderer,
    * materialized artifact copies, setup token, and the cleanup ledger all live
    * under here, and the `run_directory` cleanup releaser deletes ONLY this
-   * subdir. Defaults to `runDir` (the single-world `LOCAL-WORLD-SMOKE-1` shape,
-   * unchanged). Functional runs pass a scenario-scoped
+   * subdir. Defaults to `runDir` for direct callers that do not select a child
+   * root. Smoke and functional runs pass a scenario-scoped
    * `<runDir>/worlds/<scenario-id-slug>` so world-per-scenario teardown never
    * touches the shared `<runDir>/artifacts` source or a sibling world's subdir.
    */
@@ -216,8 +216,8 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
   await gateway.preflight();
 
   const runDir = options.runDir;
-  // Per-world mutable root (defaults to runDir for the single-world smoke). All
-  // materialized copies, runtime home, secrets, renderer extraction, setup
+  // Per-world mutable root (defaults to runDir when a caller omits worldRoot).
+  // All materialized copies, runtime home, secrets, renderer extraction, setup
   // token, and ledger live under here; the shared `<runDir>/artifacts` source
   // the map locators point at stays outside it and is never deleted.
   const worldRoot = options.worldRoot ?? runDir;
@@ -352,7 +352,7 @@ export async function constructLocalWorld(options: ConstructLocalWorldOptions): 
       gateway,
       // `runDir` here is the per-world root: fixtures read the world's setup
       // token at `<paths.runDir>/setup-token`, which the world copied out under
-      // `worldRoot`. (Same value as `runDir` for the single-world smoke.)
+      // `worldRoot`. It equals `runDir` only when the caller omits worldRoot.
       paths: { runDir: worldRoot, runtimeHome, repositoriesDir },
       db: { databaseUrl: dockerHostDatabaseUrl(options.ports.postgres) },
       registerCleanup: register,

--- a/tests/release/src/worlds/managed-cloud/world.ts
+++ b/tests/release/src/worlds/managed-cloud/world.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 
 import type { Browser } from "playwright";
 
+import { registerCancellationFinalizer } from "../../cli/cancellation-finalizer.js";
+
 import type { CandidateBuildMapV1 } from "../../artifacts/build-map.js";
 import { resolveCloudCandidateSet } from "../../artifacts/cloud-candidate-set.js";
 import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
@@ -306,6 +308,12 @@ export async function constructManagedCloudWorld(
     mirror: deps.ledgerMirror,
   });
   const stack = new ManagedCloudCleanupStack({ ledger, log });
+  const cancellationFinalizer = registerCancellationFinalizer({
+    world: "managed-cloud",
+    run: options.run,
+    runDir,
+    finalize: () => stack.runAll(),
+  });
 
   const register = async (
     kind: ManagedCloudCleanupKind,
@@ -481,12 +489,12 @@ export async function constructManagedCloudWorld(
       registerCleanup: register,
       registerCleanupIntent,
       trackActorSubjects: (actor) => trackActorSubjects(stack, gateway, actor),
-      close: () => stack.runAll(),
+      close: () => cancellationFinalizer.run(),
     };
   } catch (error) {
     // Any startup failure runs every registered cleanup exactly once, reverse
     // order, then rethrows so the caller marks the cell failed.
-    await stack.runAll().catch(() => undefined);
+    await cancellationFinalizer.run().catch(() => undefined);
     throw error;
   }
 }

--- a/tests/release/src/worlds/selfhost/world.ts
+++ b/tests/release/src/worlds/selfhost/world.ts
@@ -6,6 +6,8 @@ import { promisify } from "node:util";
 
 import type { Browser } from "playwright";
 
+import { registerCancellationFinalizer } from "../../cli/cancellation-finalizer.js";
+
 import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
 import type { CandidateBuildMapV1 } from "../../artifacts/build-map.js";
 import {
@@ -272,6 +274,12 @@ export async function constructSelfHostWorld(
     mirror: deps.ledgerMirror,
   });
   const stack = new SelfHostCleanupStack({ ledger, log });
+  const cancellationFinalizer = registerCancellationFinalizer({
+    world: "self-host",
+    run: options.run,
+    runDir,
+    finalize: () => stack.runAll(),
+  });
 
   const register = async (
     kind: SelfHostCleanupResourceKind,
@@ -401,12 +409,12 @@ export async function constructSelfHostWorld(
       control,
       paths: { runDir, runtimeHome, artifactsDir, keyPath: box.keyPath },
       registerCleanup: (kind, providerId, release) => register(kind, providerId, release),
-      close: () => stack.runAll(),
+      close: () => cancellationFinalizer.run(),
     };
   } catch (error) {
     // Any startup failure runs every registered cleanup exactly once, reverse
     // order, then rethrows so the caller marks the cell failed.
-    await stack.runAll().catch(() => undefined);
+    await cancellationFinalizer.run().catch(() => undefined);
     throw error;
   }
 }


### PR DESCRIPTION
## Frozen scope

- Frozen implementation base: `1269ee5dbff79117d90e4a5d6d787f63f7180196`
- Implementation head: `cddb5f9166065986b226c03d44d746e419ff370b`
- Delivery shape: initial implementation commit plus one review-fix commit

## Summary

- Reuses one exact local qualification candidate build across smoke and functional execution, with source/hash validation and no duplicate build seams.
- Starts functional reuse only after smoke exits cleanly; failed smoke candidate evidence remains available to the always-running upload.
- Adds a shared fail-closed qualification preflight for local, self-hosted, managed-cloud, and tier-4 execution, including remote-default-tip trusted cleanup authorization.
- Records T4-SH-2 as read-only external-artifact validation without claiming a local candidate build or cache hit.
- Isolates workflow concurrency by execution world, preserves candidate evidence, and adds bounded exactly-once signal cleanup receipts.
- Adds offline regression coverage for workflow ordering, candidate persistence/reuse, scenario-scoped self-host inputs, trusted managed cleanup, external-artifact posture, and cancellation cleanup behavior.
- Documents the supported guarantees and the remaining boundaries.

## Verification

- `pnpm -C tests/release test` — 1,191/1,191 passed
- `pnpm -C tests/release typecheck` — passed
- `node --test scripts/ci-cd/build-local-qualification-candidates.test.mjs scripts/ci-cd/qualification-preflight.test.mjs` — 22/22 passed
- `actionlint .github/workflows/release-e2e.yml .github/workflows/release-e2e-selfhost.yml` — passed
- Repository max-lines, migration, structure, boundary, mutation-admission, workflow-boundary, docs unit, and docs-integrity checks — passed
- `git diff --check` — passed
- Make dry runs for local workspace, local functional, self-host, and managed-cloud qualification targets — passed

## Known boundaries

- Candidate reuse is bounded to one workflow run; there is no durable cross-run Actions cache.
- Stable TLS/ingress qualification is outside this slice.
- Hard runner loss has an independent cleanup reaper only for managed-cloud; self-hosted hard-kill recovery remains a gap. Supported SIGINT/SIGTERM cleanup is bounded and receipt-backed.
- The complete six-field managed GitHub App readiness gate remains owned by #1304/#1318; this preflight validates only fields consumed by current production paths.
- Managed-cloud execution still requires the exact candidate SHA to be committed in the trusted default-branch cleanup attestation before dispatch.

## Execution attestation

No Docker, Rust build, provider call, or live qualification run was performed for this slice. Validation was offline and repository-local.