### PR TITLE
test(release): attest managed-cloud candidate c872b36ed

### DIFF
--- a/tests/release/fixtures/managed-cloud-litellm-attribution-attestations.v1.json
+++ b/tests/release/fixtures/managed-cloud-litellm-attribution-attestations.v1.json
@@ -2,6 +2,7 @@
   "kind": "managed_cloud_litellm_attribution_attestations",
   "schema_version": 1,
   "source_shas": [
-    "c2de95e19b1892c68d39d2a20014354d3784a021"
+    "c2de95e19b1892c68d39d2a20014354d3784a021",
+    "c872b36eda396c9d2de845e7d52624b06376a420"
   ]
 }


### PR DESCRIPTION
Adds the reconciled #1304 candidate head `c872b36eda396c9d2de845e7d52624b06376a420` (merge of `origin/main` @ 7f9151db4 into `codex/managed-cloud-fixture-smoke-1`) to the trusted default-branch LiteLLM attribution cleanup attestations, per the #1373 fail-closed preflight contract.

Required so the managed-cloud strict acceptance run for PR #1304 can pass `cleanup_authorization` for that exact candidate SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)