### PR TITLE
test(release): claim first-run setup once per local world

### DIFF
--- a/tests/release/src/fixtures/authenticated-actor.test.ts
+++ b/tests/release/src/fixtures/authenticated-actor.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { beforeEach, test } from "node:test";
 
 import {
   authenticatedActor,
   toStoredSession,
+  __resetAuthenticatedActorClaimCacheForTests,
   type AuthenticatedActorTransport,
 } from "./authenticated-actor.js";
 import { ApiClient } from "./http.js";
@@ -104,6 +105,13 @@ function fakeTransport(overrides: Partial<AuthenticatedActorTransport> = {}): {
   };
   return { transport, calls };
 }
+
+beforeEach(() => {
+  // All fake worlds in this file share the same `runDir` ("/tmp/run-1"), so
+  // the module-level per-world claim cache must be cleared between tests or
+  // one test's cached owner would leak into the next.
+  __resetAuthenticatedActorClaimCacheForTests();
+});
 
 test("toStoredSession maps the desktop token response onto the snake_case StoredAuthSession the client persists", () => {
   const session = toStoredSession({
@@ -238,4 +246,63 @@ test("authenticatedActor preserves password-login 401 as red and never retries i
     /password\/login -> 401/,
   );
   assert.equal(loginAttempts, 1);
+});
+
+test("authenticatedActor claims setup once per world: a second call for the same world logs in with the cached owner instead of re-claiming", async () => {
+  // Regression for run 29628880856: Tier-3 scenarios loop authenticatedActor
+  // over multiple harness cells (claude, codex, grok, ...) against ONE
+  // ReadyLocalWorld. The server's one-time first-run claim 404s any second
+  // `POST /setup`, so the second+ cell must skip claimSetup entirely.
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+
+  const first = await authenticatedActor(world, "owner", { harnessKind: "claude" }, transport);
+  const second = await authenticatedActor(world, "owner", { harnessKind: "codex" }, transport);
+
+  const claimCalls = calls.filter((call) => call.startsWith("claimSetup"));
+  const commitWaits = calls.filter((call) => call === "waitForSetupCommitted");
+  assert.equal(claimCalls.length, 1, "only the first cell may claim setup");
+  assert.equal(commitWaits.length, 1, "only the first cell waits for the commit to become visible");
+
+  const loginCalls = calls.filter((call) => call.startsWith("loginWithPassword"));
+  assert.equal(loginCalls.length, 2, "every cell, including cached ones, must still log in");
+  assert.equal(loginCalls[0], loginCalls[1], "the second cell logs in with the SAME cached owner credentials");
+
+  assert.equal(first.userId, second.userId);
+});
+
+test("authenticatedActor does not cache a failed claim: a later call for the same world retries the claim honestly", async () => {
+  const world = fakeWorld();
+  let claimAttempts = 0;
+  const { transport, calls } = fakeTransport({
+    claimSetup: async (params) => {
+      claimAttempts += 1;
+      calls.push(`claimSetup:${params.email}`);
+      if (claimAttempts === 1) {
+        throw new Error("POST /setup -> 400: invalid setup token");
+      }
+    },
+  });
+
+  await assert.rejects(() => authenticatedActor(world, "owner", {}, transport), /invalid setup token/);
+  assert.equal(claimAttempts, 1);
+
+  // The failed claim must NOT be cached: the next call for the same world
+  // retries claimSetup from scratch (and here, succeeds) rather than
+  // replaying the stale rejection.
+  const actor = await authenticatedActor(world, "owner", {}, transport);
+  assert.equal(claimAttempts, 2);
+  assert.equal(actor.role, "owner");
+  assert.equal(calls.filter((call) => call.startsWith("claimSetup")).length, 2);
+});
+
+test("authenticatedActor: an explicit email opts out of the shared per-world claim cache and always claims directly", async () => {
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+
+  await authenticatedActor(world, "owner", { email: "explicit-1@example.com" }, transport);
+  await authenticatedActor(world, "owner", { email: "explicit-2@example.com" }, transport);
+
+  const claimCalls = calls.filter((call) => call.startsWith("claimSetup"));
+  assert.deepEqual(claimCalls, ["claimSetup:explicit-1@example.com", "claimSetup:explicit-2@example.com"]);
 });

--- a/tests/release/src/fixtures/authenticated-actor.ts
+++ b/tests/release/src/fixtures/authenticated-actor.ts
@@ -161,6 +161,37 @@ interface OrganizationsListResponse {
 export const SYNCED_ENROLLMENT_STATUS = "synced";
 
 /**
+ * A `ReadyLocalWorld` boots ONE single-org server and runs its first-run
+ * `/setup` claim exactly once (the server correctly 404s any later claim
+ * attempt). Tier-3 scenarios loop `authenticatedActor` over multiple harness
+ * cells (claude, codex, grok, opencode, cursor) against that same world; only
+ * the first cell may claim. This cache memoizes the claim PROMISE (not just
+ * the resolved credentials) per world identity so that:
+ *
+ *   - the second+ call for the same world skips `claimSetup` /
+ *     `waitForSetupCommitted` entirely and goes straight to
+ *     `loginWithPassword` with the cached owner credentials; and
+ *   - two calls racing for the same world (sequential in practice, but
+ *     defensively guarded) await the SAME in-flight claim rather than issuing
+ *     a second `POST /setup`.
+ *
+ * A failed claim is never cached — the entry is deleted so a later call gets
+ * an honest retry-from-scratch (still surfacing the real failure, never
+ * masking it).
+ */
+const claimedOwnerByWorld = new Map<string, Promise<{ email: string; password: string }>>();
+
+/** Test-only escape hatch: clears the module-level per-world claim cache. */
+export function __resetAuthenticatedActorClaimCacheForTests(): void {
+  claimedOwnerByWorld.clear();
+}
+
+/** Stable identity for a world's single-org server (one claim per run dir). */
+function worldIdentity(world: ReadyLocalWorld): string {
+  return world.paths.runDir;
+}
+
+/**
  * Every network/filesystem side effect this fixture performs, factored out so
  * unit tests can fake the transport without a real Server/filesystem. The
  * default (`defaultAuthenticatedActorTransport`) is what production wiring
@@ -281,26 +312,50 @@ export async function authenticatedActor(
     throw new Error(`authenticatedActor: unsupported role "${role}" (only "owner" is implemented).`);
   }
 
-  const setupTokenPath = options.setupTokenPath ?? path.join(world.paths.runDir, "setup-token");
-  const setupToken = await transport.readSetupToken(setupTokenPath);
+  const worldKey = worldIdentity(world);
+  const explicitEmail = options.email;
+  const setupCommitTimeoutMs = options.setupCommitTimeoutMs ?? 10_000;
+  const setupCommitPollMs = options.setupCommitPollMs ?? 250;
 
-  // NOTE: a real, non-reserved TLD is required. `normalize_account_email`
-  // (server/proliferate/server/setup/accounts.py) rejects the special-use TLDs
-  // `.invalid`/`.test`/`.local`/`.localhost` with a 400, so the claim uses a
-  // syntactically valid `example.com` address (no mail is ever sent).
-  const email = options.email ?? `qual-owner-${world.run.run_id}-${world.run.shard_id}@example.com`;
-  const password = randomBytes(24).toString("hex");
-  const organizationName = options.organizationName ?? `local-world-smoke-${world.run.run_id}`;
+  let claim: Promise<{ email: string; password: string }>;
+  if (explicitEmail !== undefined) {
+    // A caller-provided email opts out of the shared per-world owner cache
+    // (it wants its own, distinct claim identity); claim directly.
+    claim = performClaim(
+      world,
+      transport,
+      explicitEmail,
+      options.organizationName,
+      setupCommitTimeoutMs,
+      setupCommitPollMs,
+      options.setupTokenPath,
+    );
+  } else {
+    const cached = claimedOwnerByWorld.get(worldKey);
+    if (cached !== undefined) {
+      claim = cached;
+    } else {
+      claim = performClaim(
+        world,
+        transport,
+        undefined,
+        options.organizationName,
+        setupCommitTimeoutMs,
+        setupCommitPollMs,
+        options.setupTokenPath,
+      );
+      claimedOwnerByWorld.set(worldKey, claim);
+      claim.catch(() => {
+        // Never cache a failed claim: a later call must retry from scratch
+        // and surface the real failure honestly, not a stale rejection.
+        if (claimedOwnerByWorld.get(worldKey) === claim) {
+          claimedOwnerByWorld.delete(worldKey);
+        }
+      });
+    }
+  }
 
-  await transport.claimSetup({ apiBaseUrl: world.api.baseUrl, email, password, setupToken, organizationName });
-  // The setup POST can return before a second connection observes the committed
-  // owner row. Prove visibility explicitly, then make exactly one password-login
-  // attempt. A 401 remains a real red product failure; this is not a retry loop.
-  await transport.waitForSetupCommitted(
-    world.api.baseUrl,
-    options.setupCommitTimeoutMs ?? 10_000,
-    options.setupCommitPollMs ?? 250,
-  );
+  const { email, password } = await claim;
 
   let tokenResponse: DesktopTokenResponse;
   try {
@@ -347,6 +402,42 @@ export async function authenticatedActor(
     session,
     gatewayKey,
   };
+}
+
+/**
+ * Performs the real, one-time first-run claim for a world: read the setup
+ * token, `POST /setup`, then prove the claim is committed/visible on a fresh
+ * connection before any password-login attempt is made. Only ever called
+ * once per world (guarded by `claimedOwnerByWorld` in `authenticatedActor`)
+ * unless the caller passed an explicit `email`, which opts out of sharing.
+ */
+async function performClaim(
+  world: ReadyLocalWorld,
+  transport: AuthenticatedActorTransport,
+  explicitEmail: string | undefined,
+  organizationNameOverride: string | undefined,
+  setupCommitTimeoutMs: number,
+  setupCommitPollMs: number,
+  setupTokenPathOverride: string | undefined,
+): Promise<{ email: string; password: string }> {
+  const setupTokenPath = setupTokenPathOverride ?? path.join(world.paths.runDir, "setup-token");
+  const setupToken = await transport.readSetupToken(setupTokenPath);
+
+  // NOTE: a real, non-reserved TLD is required. `normalize_account_email`
+  // (server/proliferate/server/setup/accounts.py) rejects the special-use TLDs
+  // `.invalid`/`.test`/`.local`/`.localhost` with a 400, so the claim uses a
+  // syntactically valid `example.com` address (no mail is ever sent).
+  const email = explicitEmail ?? `qual-owner-${world.run.run_id}-${world.run.shard_id}@example.com`;
+  const password = randomBytes(24).toString("hex");
+  const organizationName = organizationNameOverride ?? `local-world-smoke-${world.run.run_id}`;
+
+  await transport.claimSetup({ apiBaseUrl: world.api.baseUrl, email, password, setupToken, organizationName });
+  // The setup POST can return before a second connection observes the committed
+  // owner row. Prove visibility explicitly, then make exactly one password-login
+  // attempt. A 401 remains a real red product failure; this is not a retry loop.
+  await transport.waitForSetupCommitted(world.api.baseUrl, setupCommitTimeoutMs, setupCommitPollMs);
+
+  return { email, password };
 }
 
 async function waitForSyncedEnrollment(


### PR DESCRIPTION
## Root cause

Tier-3 local functional scenarios (`tests/release`) boot ONE `ReadyLocalWorld` per scenario — single-org server, `SINGLE_ORG_MODE=true`, one-time `POST /setup` first-run claim — then loop over harness cells (claude, codex, grok, opencode, cursor) against that same world.

`authenticatedActor` (`tests/release/src/fixtures/authenticated-actor.ts`) unconditionally re-ran the first-run claim (`claimSetup` → `POST /setup`) for every cell. The first cell (claude) claims successfully; every later cell hits `POST /setup -> 404`, because the server correctly 404s a second claim attempt.

Run 29628880856 evidence: 11 cells across T3-CHAT-1 / T3-INT-1 / T3-AUTHROUTE-1 red with exactly `POST /setup -> 404`.

## Fix

Test-infrastructure only, no product/server changes.

- Added a module-level `Map` in `authenticated-actor.ts` keyed by a stable world identity (`world.paths.runDir`) that memoizes the in-flight **claim promise** (not just the resolved credentials), so sequential calls for the same world never issue a second `POST /setup`.
- First call for a world: claims → waits for commit visibility → caches `{email, password}` → logs in.
- Every subsequent call for the same world: skips `claimSetup` / `waitForSetupCommitted` entirely, goes straight to `loginWithPassword` with the cached owner credentials, then continues the normal per-harness downstream logic (route selection, enrollment) unchanged.
- A failed claim is never cached — the map entry is deleted on rejection, so a later call retries the claim honestly instead of replaying a stale error.
- An explicit `email` option (used e.g. by `cloud-provision-1.ts`) opts out of the shared cache, since it wants its own distinct claim identity — existing behavior preserved.
- No changes to `.github/workflows/release-e2e.yml` or PR #1373's preflight/candidate-reuse/concurrency logic.

## Offline proof

Added regression tests in `tests/release/src/fixtures/authenticated-actor.test.ts`:
- second `authenticatedActor` call for the same world logs in with the cached owner instead of re-claiming (asserts exactly one `claimSetup`/`waitForSetupCommitted` call across two cells, two `loginWithPassword` calls with identical credentials).
- a failed claim is not cached — a later call retries `claimSetup` from scratch.
- an explicit `email` opts out of the shared cache and always claims directly.

`cd tests/release && npm test`: 1163 pass / 5 fail — the 5 failures (`staging-workflow`, `manifest-agreement`, `tier2/evidence`, `tier2/harness`, one Tier-2-boot test) are pre-existing on `origin/main` at `7f9151db4` (confirmed via `git stash` before/after), unrelated to this change. No new failures introduced.

`npx tsc --noEmit` (via `npm run typecheck`): pre-existing unrelated errors only (`../intent/stack/billing-env.ts`, `../intent/stack/seed.ts` — missing `pg` types), same on baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)