### PR TITLE
test(release): snapshot pre-send sessions before the route-change new chat

### DIFF
--- a/tests/release/src/scenarios/local/chat-authroute.test.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.test.ts
@@ -126,7 +126,13 @@ function fakeWorld(overrides: Partial<ReadyLocalWorld> = {}): ReadyLocalWorld {
       desktopRenderer: { artifact_id: "desktop-renderer/browser", version: "1", sha256: "d".repeat(64), path: "/tmp/renderer" },
     },
     api: undefined as never,
-    runtime: undefined as never,
+    // LOCAL-6's orchestrator (`runLocal6RouteChangeCell`) calls
+    // `snapshotLocalWorkspaceSessionIds` directly (not through the mocked
+    // driver) immediately before `switchSelectedRouteToGateway`, so the fake
+    // world needs a minimal runtime client: no workspace exists yet, so the
+    // real resolver returns an empty pre-existing-sessions snapshot, matching
+    // what a fresh world would report.
+    runtime: { client: { listWorkspaces: async () => [], listSessions: async () => [] } } as never,
     renderer: undefined as never,
     gateway: undefined as never,
     paths: undefined as never,

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -175,6 +175,7 @@ export interface LocalRouteDriver {
     page: ProductPage,
     expectedRoute: LocalRoute,
     repoPath: string,
+    existingSessionIds?: ReadonlySet<string>,
   ): Promise<{ workspaceId: string; sessionId: string; reply: string }>;
 
   reopenAndVerify(
@@ -366,13 +367,24 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     return { route, modelId, providerId: directProviderId(modelId) };
   },
   selectModelInUi: (page, modelId) => defaultLocalWorldSmokeDriver.selectModelInUi(page, modelId),
-  async sendBoundedTurn(world, page, _expectedRoute, repoPath) {
+  async sendBoundedTurn(world, page, _expectedRoute, repoPath, existingSessionIds) {
     const p = page.page;
     // Snapshot before Send. LOCAL-6 uses the same concrete workspace for both
     // routes; resolving the "latest" session after the click can otherwise
     // bind the gateway leg to the already-completed user-key session while the
     // new process is still reconciling.
-    const preSendSessionIds = await snapshotLocalWorkspaceSessionIds(world, repoPath);
+    //
+    // For LOCAL-6's gateway leg the caller passes an `existingSessionIds`
+    // snapshot taken BEFORE `switchSelectedRouteToGateway` opens the new chat
+    // tab, because that navigation itself materializes the AnyHarness session
+    // (product's `createSessionWithResolvedConfig` runs unconditionally on
+    // open, prompt or not). Snapshotting here — after that navigation — would
+    // count the just-created session as pre-existing and leave zero new
+    // candidates for `resolveLocalWorkspaceSessionAfter` to find (Actions run
+    // 29628880856, T3-AUTHROUTE-1/local/route=change). Callers that don't pass
+    // one (LOCAL-2/3, whose first turn runs from the home screen and doesn't
+    // pre-create a session) keep taking their own fresh snapshot here.
+    const preSendSessionIds = existingSessionIds ?? (await snapshotLocalWorkspaceSessionIds(world, repoPath));
     // LOCAL-2/3's first turn runs from the home screen (`[data-home-composer-editor]`);
     // LOCAL-6's gateway turn runs from a fresh in-workspace tab
     // (`[data-chat-composer-editor]`, opened by `openNewChat`). Accept either
@@ -867,12 +879,19 @@ async function runLocal6RouteChangeCell(
       // on the user-key session). The workspace/repo binding is retained by the
       // new-tab path — no repo re-selection needed (those "Project:"/"Runtime:"
       // controls exist only on the home screen).
+      // Snapshot the pre-existing sessions BEFORE `switchSelectedRouteToGateway`:
+      // its trailing `openNewChat` navigation materializes the new AnyHarness
+      // session immediately (product's create-session path runs unconditionally
+      // on open), so a snapshot taken after it would wrongly count that session
+      // as pre-existing and leave `sendBoundedTurn` unable to find a "new"
+      // candidate (Actions run 29628880856, T3-AUTHROUTE-1/local/route=change).
+      const preRouteSwitchSessionIds = await snapshotLocalWorkspaceSessionIds(world, repo.path);
       await driver.switchSelectedRouteToGateway(world, page, harness);
       const gatewaySelection = await driver.resolveRouteModel(world, page, harness, "gateway");
       await driver.selectModelInUi(page, gatewaySelection.modelId);
       const before = await driver.snapshotGatewaySpend(world, actor);
       const windowStartedAt = new Date().toISOString();
-      const gatewayTurn = await driver.sendBoundedTurn(world, page, "gateway", repo.path);
+      const gatewayTurn = await driver.sendBoundedTurn(world, page, "gateway", repo.path, preRouteSwitchSessionIds);
       if (!gatewayTurn.reply.trim()) {
         throw new Error("empty assistant reply on the gateway session");
       }

--- a/tests/release/src/scenarios/local/local-session.test.ts
+++ b/tests/release/src/scenarios/local/local-session.test.ts
@@ -211,3 +211,64 @@ test("pre-send snapshot propagates a workspace query failure", async () => {
     /workspace snapshot failed/,
   );
 });
+
+// ── Ordering contract (fix round: LOCAL-6 route-change, run 29628880856) ─────
+//
+// `openNewChat`/`switchSelectedRouteToGateway` materializes a new AnyHarness
+// session as a SIDE EFFECT of the navigation itself, before any prompt is
+// sent. `snapshotLocalWorkspaceSessionIds` must be called BEFORE that
+// navigation; calling it after (i.e. treating the just-created session as
+// pre-existing) makes `resolveLocalWorkspaceSessionAfter` unable to find any
+// "new" candidate and it times out, which is exactly the observed failure
+// (`pre-send sessions=2, new candidates=0`).
+
+test("ordering contract: a snapshot taken BEFORE session creation lets resolution find the new session", async () => {
+  // Snapshot taken while only the pre-existing (user-key) session exists.
+  const preNavigationWorld = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [{ id: "session-user-key", workspaceId: RAW_WORKSPACE_ID }],
+  );
+  const existingSessionIds = await snapshotLocalWorkspaceSessionIds(preNavigationWorld, REPO_PATH);
+  assert.deepEqual(existingSessionIds, new Set(["session-user-key"]));
+
+  // The navigation (openNewChat) has since materialized the gateway session.
+  const postNavigationWorld = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [
+      { id: "session-user-key", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-gateway", workspaceId: RAW_WORKSPACE_ID },
+    ],
+  );
+
+  assert.equal(
+    await resolveLocalWorkspaceSessionAfter(postNavigationWorld, REPO_PATH, 2_000, {
+      existingSessionIds,
+      activeSessionAlias: null,
+    }),
+    "session-gateway",
+  );
+});
+
+test("ordering contract: a snapshot taken AFTER session creation makes the new session invisible (the reported bug)", async () => {
+  // The navigation has ALREADY materialized the gateway session by the time
+  // the snapshot is taken (the bug: snapshotting after `openNewChat`).
+  const postNavigationWorld = fakeWorld(
+    [{ id: RAW_WORKSPACE_ID, kind: "local", path: REPO_PATH }],
+    [
+      { id: "session-user-key", workspaceId: RAW_WORKSPACE_ID },
+      { id: "session-gateway", workspaceId: RAW_WORKSPACE_ID },
+    ],
+  );
+  const existingSessionIds = await snapshotLocalWorkspaceSessionIds(postNavigationWorld, REPO_PATH);
+  // Both sessions are now (wrongly) captured as "pre-existing".
+  assert.deepEqual(existingSessionIds, new Set(["session-user-key", "session-gateway"]));
+
+  await assert.rejects(
+    () =>
+      resolveLocalWorkspaceSessionAfter(postNavigationWorld, REPO_PATH, 1, {
+        existingSessionIds,
+        activeSessionAlias: null,
+      }),
+    /no unambiguous new AnyHarness session/,
+  );
+});


### PR DESCRIPTION
## Root cause

Actions run 29628880856, cell `T3-AUTHROUTE-1/local/route=change`:

- `runLocal6RouteChangeCell` (`tests/release/src/scenarios/local/chat-authroute.ts`, ~line 870) calls `driver.switchSelectedRouteToGateway(...)`, which ends with `openNewChat(p)` (~line 305) — clicking `data-chat-new-tab-button`.
- That click **immediately materializes a real AnyHarness session**: the product's `createSessionWithResolvedConfig` unconditionally materializes a session on open, regardless of whether a prompt has been sent yet.
- `sendBoundedTurn` (~line 369) then took its `preSendSessionIds = await snapshotLocalWorkspaceSessionIds(...)` snapshot **after** that navigation, so the just-created gateway session was counted as pre-existing.
- The send then posts into that session, but `resolveLocalWorkspaceSessionAfter` truthfully reports zero "new" candidates until the 90s timeout:
  `no unambiguous new AnyHarness session ... (pre-send sessions=2, new candidates=0, active alias present=true)`.

## Fix (collector-only, no product changes)

- `sendBoundedTurn` now accepts an optional `existingSessionIds?: ReadonlySet<string>` parameter. When omitted it takes its own fresh snapshot exactly as before, preserving LOCAL-2/3 behavior unchanged.
- `runLocal6RouteChangeCell` now snapshots `snapshotLocalWorkspaceSessionIds(world, repo.path)` **immediately before** `switchSelectedRouteToGateway` — i.e. before the session-creating `openNewChat` navigation runs — and passes that snapshot into the gateway-leg `sendBoundedTurn` call.
- All other `sendBoundedTurn` call sites (LOCAL-2, LOCAL-3, and the LOCAL-6 user-key leg) are unchanged; they still take their own snapshot at send time.

## Offline proof

- `tests/release/src/scenarios/local/local-session.test.ts` gets two new unit tests encoding the ordering contract directly against `resolveLocalWorkspaceSessionAfter`/`snapshotLocalWorkspaceSessionIds`:
  - a snapshot taken **before** the session-creating navigation lets the resolver find the new session;
  - a snapshot taken **after** it (the reported bug) makes the new session invisible and the resolver times out with the exact `no unambiguous new AnyHarness session` message.
- `tests/release/src/scenarios/local/chat-authroute.test.ts`'s fake world gained a minimal `runtime.client` stub so the LOCAL-6 orchestrator's direct (non-driver-mocked) `snapshotLocalWorkspaceSessionIds` call resolves cleanly; both existing LOCAL-6 offline tests still pass green.

`cd tests/release && npx tsc --noEmit` shows only pre-existing, unrelated `pg` module-resolution errors in `../intent/stack/*` that reproduce identically on `origin/main` before this change. `npm test`: 1162/1167 pass; the 5 remaining failures reproduce identically against `origin/main` before this change (confirmed via `git stash`) and are unrelated to this fix.

## Deviations

None from the assigned scope — no product changes, no touches to `release-e2e.yml` or #1373 logic, `local-session.ts` helper semantics unchanged (only a new optional parameter added to `sendBoundedTurn`'s signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)