### PR TITLE
test(release): select gateway route per harness in LOCAL-4 browser world

### DIFF
--- a/tests/release/src/scenarios/local/config-session.test.ts
+++ b/tests/release/src/scenarios/local/config-session.test.ts
@@ -204,8 +204,14 @@ function makeConfigDriver(
       calls.push("createActor");
       return fakeActor();
     },
+    selectGatewayRoute: async (_actor, harness) => {
+      calls.push(`selectGatewayRoute:${harness}`);
+    },
     prepareRepo: async () => ({ path: "/tmp/repo", repoUrl: "https://github.com/x/y.git", commit: "c", repoRootId: "rr" }) satisfies PreparedRepository,
-    openPage: async () => fakePage(),
+    openPage: async () => {
+      calls.push("openPage");
+      return fakePage();
+    },
     ensureHarnessReady: async () => undefined,
     selectRepoAndWorkLocally: async () => undefined,
     runBaselineTurn: async (_w, _p, harness) => {
@@ -240,6 +246,29 @@ test("LOCAL-4: green per-harness cells carry local_config_matrix evidence with a
   assert.equal(claude.controls[0]!.accepted_value, "high");
   assert.equal(claude.controls[0]!.rejected, false);
   assert.equal(claude.known_1063_expected_fail, false);
+});
+
+test("LOCAL-4: selects the gateway route for EVERY runnable harness before the page boots", async () => {
+  // Regression for run 29628880856: the reused owner actor only had claude's
+  // gateway route selected, so codex/grok never synced a route into AnyHarness
+  // and never became launchable. Each runnable harness must get its own
+  // selection, all before `openPage` (the real renderer syncs routes at boot).
+  const { driver, calls } = makeConfigDriver();
+  const outcomes = await collectLocal4ConfigCells(
+    fakeCtx(),
+    [cfgCell("claude"), cfgCell("grok"), cfgCell("cursor")],
+    driver,
+  );
+  for (const harness of ["claude", "grok"]) {
+    assert.ok(calls.includes(`selectGatewayRoute:${harness}`), `expected a gateway selection for ${harness}`);
+  }
+  // Cursor ships no gateway slot — it must never be selected for.
+  assert.ok(!calls.includes("selectGatewayRoute:cursor"), "cursor must not get a gateway selection");
+  // All selections happen before the page opens.
+  const firstOpen = calls.indexOf("openPage");
+  assert.ok(firstOpen === -1 || calls.filter((c) => c.startsWith("selectGatewayRoute:")).every((c) => calls.indexOf(c) < firstOpen));
+  // The claude/grok cells still finish green (cursor stays blocked).
+  assert.equal(outcomes.find((o) => (o.evidence as { harness?: string } | undefined)?.harness === "grok")?.status, "green");
 });
 
 test("LOCAL-4: cursor is typed unsupported (blocked, no evidence), never green", async () => {

--- a/tests/release/src/scenarios/local/config-session.ts
+++ b/tests/release/src/scenarios/local/config-session.ts
@@ -82,6 +82,25 @@ export interface LocalConfigDriver {
    * the world's isolated subdir (world-per-scenario, serialized). */
   buildWorld(inputs: LocalFunctionalWorldInputs, worldId: string): Promise<ReadyLocalWorld>;
   createActor(world: ReadyLocalWorld, harness: LocalHarnessKind): Promise<AuthenticatedActor>;
+  /**
+   * Selects the `gateway` route for `harness` through the genuine product
+   * selections API (`PUT /v1/cloud/agent-gateway/selections/{harness}?surface=local`
+   * — the exact call `HarnessSettingsSection` drives, and the one
+   * `authenticatedActor` itself uses for its default harness). LOCAL-4 reuses ONE
+   * owner actor across the whole harness batch, but `authenticatedActor` selects
+   * only the default harness's (claude's) route; without a selection for the
+   * other runnable harnesses the server's local-surface state.json carries no
+   * route for them, so the REAL renderer's `useLocalAuthStateSync` has nothing to
+   * push and their launch-options never populate — the codex/grok/opencode
+   * "never became launchable within 300s" red (run 29628880856). Called for every
+   * runnable harness BEFORE `openPage`, so the renderer boots once with all routes
+   * present and its worker-independent `PUT /v1/agent-auth/state` sync lands them
+   * all at startup (an out-of-band selection made after boot would not trigger the
+   * renderer's own agent-auth-state refetch). The gateway route still reaches
+   * AnyHarness only through the real product renderer path — nothing is seeded
+   * into AnyHarness world-side, and readiness is never synthesized.
+   */
+  selectGatewayRoute(actor: AuthenticatedActor, harness: LocalHarnessKind): Promise<void>;
   prepareRepo(world: ReadyLocalWorld, actor: AuthenticatedActor, cellId: string): Promise<PreparedRepository>;
   openPage(world: ReadyLocalWorld, actor: AuthenticatedActor): Promise<ProductPage>;
   ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, harness: LocalHarnessKind): Promise<void>;
@@ -173,6 +192,7 @@ export interface LocalSessionTabsDriver {
 export const defaultLocalConfigDriver: LocalConfigDriver = {
   buildWorld: (inputs, worldId) => bootLocalFunctionalWorld(inputs, worldId),
   createActor: (world) => authenticatedActor(world, "owner"),
+  selectGatewayRoute: (actor, harness) => selectGatewayRouteForHarness(actor, harness),
   prepareRepo: (world, actor, cellId) => preparedRepository(world, actor, { cellId }),
   openPage: (world, actor) => productPage(world, actor),
   ensureHarnessReady: (world, page, harness) => ensureHarnessReady(world, page, harness),
@@ -291,6 +311,17 @@ export async function collectLocal4ConfigCells(
     const representative = firstRunnableHarness(cells) ?? SESSION_TABS_START_HARNESS;
     const actor = await driver.createActor(world, representative);
     await world.trackActorSubjects?.(actor.gatewayKey);
+    // Select the gateway route for EVERY runnable harness in this batch before
+    // the page boots. `createActor` selects only the representative harness's
+    // route, but the reused actor drives baseline turns on each assigned kind;
+    // without a per-harness selection the server's local-surface state.json
+    // carries no route for the others, so the real renderer's
+    // `useLocalAuthStateSync` has nothing to sync and their launch-options never
+    // populate (codex/grok/opencode "never became launchable in 300s"). The
+    // representative's selection is idempotent, so re-selecting it is harmless.
+    for (const harness of runnableHarnesses(cells)) {
+      await driver.selectGatewayRoute(actor, harness);
+    }
     const repo = await driver.prepareRepo(world, actor, `${cells[0]?.scenario_id ?? "T3-CFG-1"}/local`);
     page = await driver.openPage(world, actor);
 
@@ -672,6 +703,34 @@ function firstRunnableHarness(cells: readonly PlannedCellV1[]): LocalHarnessKind
   return undefined;
 }
 
+/** The distinct runnable (gateway-capable) harness kinds this batch drives, in
+ * declaration order. Each needs its gateway route selected before the page boots
+ * so the real renderer syncs them all — see `LocalConfigDriver.selectGatewayRoute`. */
+function runnableHarnesses(cells: readonly PlannedCellV1[]): LocalHarnessKind[] {
+  const seen = new Set<LocalHarnessKind>();
+  for (const cell of cells) {
+    const harness = normalizeHarness(cell.dimensions.harness);
+    if (harness && !GATEWAY_UNSUPPORTED_HARNESSES.has(harness)) {
+      seen.add(harness);
+    }
+  }
+  return LOCAL_HARNESS_KINDS.filter((kind) => seen.has(kind));
+}
+
+/**
+ * Selects the `gateway` route for `harness` through the genuine product
+ * selections API — the exact endpoint `HarnessSettingsSection` and the
+ * `authenticatedActor` fixture drive. Prerequisite product state only: the real
+ * renderer's `useLocalAuthStateSync` is what actually pushes the resulting
+ * local-surface state.json to AnyHarness.
+ */
+async function selectGatewayRouteForHarness(actor: AuthenticatedActor, harness: LocalHarnessKind): Promise<void> {
+  await actor.api.put(
+    `/v1/cloud/agent-gateway/selections/${encodeURIComponent(harness)}?surface=local`,
+    { sources: [{ sourceKind: "gateway", enabled: true }] },
+  );
+}
+
 function worldArtifactIds(world: ReadyLocalWorld): string[] {
   return [
     world.artifacts.server.artifact_id,
@@ -806,8 +865,9 @@ async function ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, har
   const deadline = Date.now() + HARNESS_READY_TIMEOUT_MS;
   let triggeredInstall = false;
   let launchable = false;
+  let last: Awaited<ReturnType<typeof client.getAgent>> | undefined;
   while (Date.now() < deadline) {
-    const last = await client.getAgent(harness).catch(() => undefined);
+    last = await client.getAgent(harness).catch(() => undefined);
     const options = await client.getAgentLaunchOptions().catch(() => []);
     const entry = options.find((agent) => agent.kind === harness);
     if (entry && entry.models.length > 0) {
@@ -821,7 +881,15 @@ async function ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, har
     await sleep(2_000);
   }
   if (!launchable) {
-    throw new Error(`ensureHarnessReady: agent "${harness}" never became launchable within ${HARNESS_READY_TIMEOUT_MS}ms.`);
+    // Surface the runtime's last-seen readiness triad (as
+    // local-world-smoke-1's `ensureHarnessReady` does) so a launch-options
+    // timeout is diagnosable without a live runtime: `readiness=login_required`
+    // with an unsynced gateway route points at the route-sync path, an
+    // `installing`/`install_required` installState points at the agent build.
+    throw new Error(
+      `ensureHarnessReady: agent "${harness}" never became launchable within ${HARNESS_READY_TIMEOUT_MS}ms ` +
+        `(last: readiness=${last?.readiness}, installState=${last?.installState}, credentialState=${last?.credentialState}).`,
+    );
   }
   await page.page.reload({ waitUntil: "domcontentloaded" });
   // `ensureHarnessReady` is shared by two contexts: LOCAL-4 gates readiness from


### PR DESCRIPTION
## Root cause
T3-CFG-1/local (LOCAL-4) drives the desktop renderer in plain Playwright Chromium. Run 29628880856 red: codex/grok/opencode "never became launchable within 300s"; claude green.

The failure is NOT the Tauri desktop-worker bridge. Gateway **model routes** reach AnyHarness through the renderer's `useLocalAuthStateSync` hook, which pushes `PUT /v1/agent-auth/state` to the runtime over plain fetch (runtime URL via the browser fallback `VITE_ANYHARNESS_DEV_URL`) — fully independent of the Tauri worker. The `ensureDesktopWorker` toast seen in the screenshots is a benign fire-and-forget side effect that only governs the cloud-dispatch worker + integration-gateway MCP, which LOCAL-4 does not exercise. Proof it works in the browser: `ensureHarnessReady`'s launch-options gate can only pass via a synced gateway route (native readiness is explicitly forbidden as an ambient-credential leak), and claude passes that gate in the identical browser world.

The actual cause: `collectLocal4ConfigCells` reuses ONE owner actor across the whole harness batch, but `defaultLocalConfigDriver.createActor` selects the gateway route for the representative harness only (claude). codex/grok/opencode never get a gateway selection, so the server's local-surface `state.json` carries no route for them, the real renderer has nothing to sync, and their launch-options stay empty until the 300s timeout. This is exactly the gap already fixed for LOCAL-5's switch harness (config-session.ts createActor) and avoided by chat-authroute's per-harness `createGatewayActor`.

## Fix
Test-infra, using the genuine product path (operator option a):
- New `selectGatewayRoute` driver seam PUTs `/v1/cloud/agent-gateway/selections/{harness}?surface=local` — the exact endpoint `HarnessSettingsSection` and the `authenticatedActor` fixture drive — for **every** runnable harness in the batch, **before** `openPage`, so the real renderer boots once with all routes present and its worker-independent sync lands them all. Cursor (no gateway slot) is never selected for and stays typed-blocked. No world-side seeding into AnyHarness; no synthesized readiness; the launch-options readiness gate is untouched.
- Enriched `ensureHarnessReady`'s timeout message with `readiness/installState/credentialState` (mirroring local-world-smoke-1) so future launch-options timeouts are diagnosable.

## Proof
- `npx tsc --noEmit`: clean for changed files (the two `pg`-module errors are pre-existing worktree-env noise in `intent/stack`, absent on the main checkout).
- `npm test`: 1166 pass / 5 fail — the 5 are the known pre-existing failures on main (staging-workflow, manifest-agreement, tier2 evidence/harness, tier2 boot). No new failures.
- Added an offline regression test asserting a gateway selection is made for every runnable harness, before `openPage`, and never for cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)