### PR TITLE
ci(agent-catalog): protect scheduled Catalog Probe

### DIFF
--- a/.github/workflows/catalog-probe.yml
+++ b/.github/workflows/catalog-probe.yml
@@ -15,8 +15,7 @@ on:
     - cron: "0 9 * * *"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -27,18 +26,41 @@ jobs:
     name: Probe harnesses and draft catalog
     if: github.repository == 'proliferate-ai/proliferate'
     runs-on: ubuntu-latest
+    environment:
+      name: Catalog Probe
+      url: https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/operating/catalog-probe.md
     timeout-minutes: 90
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-      CODEX_AUTH_JSON_B64: ${{ secrets.CODEX_AUTH_JSON_B64 }}
+    concurrency:
+      group: catalog-probe
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Verify credential lifecycle approval
+        env:
+          CREDENTIALS_APPROVED: ${{ vars.CATALOG_PROBE_CREDENTIALS_APPROVED }}
+          CREDENTIAL_OWNER: ${{ vars.CATALOG_PROBE_CREDENTIAL_OWNER }}
+          ROTATION_DUE: ${{ vars.CATALOG_PROBE_ROTATION_DUE }}
+        run: |
+          set -euo pipefail
+          if [[ "$CREDENTIALS_APPROVED" != "true" ]]; then
+            echo "::error title=Catalog Probe credentials not approved::Complete the Catalog Probe runbook inventory, then set CATALOG_PROBE_CREDENTIALS_APPROVED=true on the Catalog Probe environment."
+            exit 2
+          fi
+          if [[ -z "$CREDENTIAL_OWNER" ]]; then
+            echo "::error title=Catalog Probe owner missing::Set CATALOG_PROBE_CREDENTIAL_OWNER on the Catalog Probe environment."
+            exit 2
+          fi
+          if [[ ! "$ROTATION_DUE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || ! rotation_epoch=$(date -u -d "$ROTATION_DUE" +%s 2>/dev/null); then
+            echo "::error title=Catalog Probe rotation date invalid::Set CATALOG_PROBE_ROTATION_DUE to the earliest credential rotation date in YYYY-MM-DD form."
+            exit 2
+          fi
+          today_epoch=$(date -u -d "$(date -u +%Y-%m-%d)" +%s)
+          if (( rotation_epoch < today_epoch )); then
+            echo "::error title=Catalog Probe credentials require rotation::The recorded rotation due date has passed; rotate or revoke the affected credentials before probing."
+            exit 2
+          fi
+          echo "Credential lifecycle approval is current for owner $CREDENTIAL_OWNER through $ROTATION_DUE."
 
       - name: Install system build dependencies
         run: |
@@ -56,6 +78,8 @@ jobs:
           workspaces: anyharness
 
       - name: Materialize isolated Codex OAuth input
+        env:
+          CODEX_AUTH_JSON_B64: ${{ secrets.CATALOG_PROBE_CODEX_AUTH_JSON_B64 }}
         run: |
           if [[ -n "${CODEX_AUTH_JSON_B64:-}" ]]; then
             auth_path="$RUNNER_TEMP/codex-auth.json"
@@ -65,7 +89,19 @@ jobs:
           fi
 
       - name: Resolve, install, probe, and finalize catalog
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CATALOG_PROBE_ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CATALOG_PROBE_CLAUDE_CODE_OAUTH_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.CATALOG_PROBE_OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.CATALOG_PROBE_GEMINI_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.CATALOG_PROBE_OPENCODE_API_KEY }}
+          XAI_API_KEY: ${{ secrets.CATALOG_PROBE_XAI_API_KEY }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.CATALOG_PROBE_AWS_BEARER_TOKEN_BEDROCK }}
         run: make catalog-update
+
+      - name: Remove isolated OAuth input
+        if: always()
+        run: rm -f "${PROBE_CODEX_OAUTH_AUTH_JSON:-}"
 
       - name: Summarize probe completeness
         if: always()
@@ -87,6 +123,33 @@ jobs:
           path: scripts/agent-catalog/catalog.html
           if-no-files-found: ignore
 
+      - name: Upload sanitized catalog output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: catalog-probe-output
+          path: |
+            catalogs/agents/catalog.json
+            scripts/agent-catalog/catalog.draft.json
+            scripts/agent-catalog/generated/*.probe.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Open a catalog PR when the draft changed
+    needs: probe
+    if: needs.probe.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: catalog-probe-output
+          path: .
+
       - name: Open catalog PR when the draft changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -106,3 +169,35 @@ jobs:
             --title "chore(catalog): probe run $(date -u +%Y-%m-%d)" \
             --label "release:maintenance" --label "area:anyharness" \
             --body "Automated exact-pin catalog probe run. Every promoted agent was resolved, installed, and probed in the same run. Review the per-context diffs in \`scripts/agent-catalog/generated/\` and the draft; download the catalog-viewer artifact from the workflow run for the rendered diff vs main. Cursor remains at its prior pin because scheduled runners do not have the required machine-local login."
+
+  alert:
+    name: Alert on a scheduled Catalog Probe failure
+    needs: [probe, publish]
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (needs.probe.result == 'failure' || needs.publish.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create or update the operational alert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="ops(agent-catalog): Catalog Probe scheduled failure"
+          issue_number=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "\"$title\" in:title" --json number,title \
+            --jq ".[] | select(.title == \"$title\") | .number" | head -1)
+          message="Catalog Probe failed on the default-branch schedule: $RUN_URL
+
+          Follow the [Catalog Probe runbook](https://github.com/$GITHUB_REPOSITORY/blob/main/specs/developing/operating/catalog-probe.md). Inspect only sanitized run state and credential names; never copy credential values into this issue or workflow logs."
+          if [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body "$message"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$message" \
+              --assignee pablonyx --label "release:maintenance" \
+              --label "area:anyharness" --label "area:release"
+          fi

--- a/.github/workflows/catalog-probe.yml
+++ b/.github/workflows/catalog-probe.yml
@@ -101,7 +101,10 @@ jobs:
 
       - name: Remove isolated OAuth input
         if: always()
-        run: rm -f "${PROBE_CODEX_OAUTH_AUTH_JSON:-}"
+        run: |
+          if [[ -n "${PROBE_CODEX_OAUTH_AUTH_JSON:-}" ]]; then
+            rm -f "$PROBE_CODEX_OAUTH_AUTH_JSON"
+          fi
 
       - name: Summarize probe completeness
         if: always()
@@ -197,7 +200,13 @@ jobs:
           if [[ -n "$issue_number" ]]; then
             gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body "$message"
           else
-            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$message" \
-              --assignee pablonyx --label "release:maintenance" \
+            issue_url=$(gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$message" \
+              --label "release:maintenance" \
               --label "area:anyharness" --label "area:release"
+            )
+            created_issue_number="${issue_url##*/}"
+            if ! gh issue edit "$created_issue_number" --repo "$GITHUB_REPOSITORY" \
+              --add-assignee pablonyx; then
+              echo "::warning title=Catalog Probe alert assignment failed::Issue $created_issue_number was created but could not be assigned to pablonyx; route it through the workflow CODEOWNER."
+            fi
           fi

--- a/scripts/agent-catalog/catalog-probe-workflow.test.mjs
+++ b/scripts/agent-catalog/catalog-probe-workflow.test.mjs
@@ -55,12 +55,20 @@ test("only sanitized catalog outputs cross into the publish job", () => {
   assert.match(workflow, /name: catalog-probe-output/);
   assert.match(workflow, /scripts\/agent-catalog\/generated\/\*\.probe\.json/);
   assert.doesNotMatch(workflow, /path:[^\n]*\.probe-logs/);
-  assert.match(workflow, /Remove isolated OAuth input/);
+  assert.match(
+    workflow,
+    /if \[\[ -n "\$\{PROBE_CODEX_OAUTH_AUTH_JSON:-\}" \]\]; then\n\s+rm -f "\$PROBE_CODEX_OAUTH_AUTH_JSON"/,
+  );
 });
 
 test("scheduled failures have a deduplicated owned issue path", () => {
   assert.match(workflow, /github\.event_name == 'schedule'/);
   assert.match(workflow, /issues: write/);
   assert.match(workflow, /ops\(agent-catalog\): Catalog Probe scheduled failure/);
-  assert.match(workflow, /--assignee pablonyx/);
+  const createIndex = workflow.indexOf("issue_url=$(gh issue create");
+  const assignIndex = workflow.indexOf("if ! gh issue edit");
+  assert.notEqual(createIndex, -1);
+  assert.ok(assignIndex > createIndex, "alert issue must exist before assignment is attempted");
+  assert.match(workflow, /--add-assignee pablonyx/);
+  assert.doesNotMatch(workflow.slice(createIndex, assignIndex), /--assignee/);
 });

--- a/scripts/agent-catalog/catalog-probe-workflow.test.mjs
+++ b/scripts/agent-catalog/catalog-probe-workflow.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/catalog-probe.yml", import.meta.url),
+  "utf8",
+);
+const runbook = readFileSync(
+  new URL("../../specs/developing/operating/catalog-probe.md", import.meta.url),
+  "utf8",
+);
+
+const requiredSecrets = [
+  ["CATALOG_PROBE_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"],
+  ["CATALOG_PROBE_CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"],
+  ["CATALOG_PROBE_OPENAI_API_KEY", "OPENAI_API_KEY"],
+  ["CATALOG_PROBE_CODEX_AUTH_JSON_B64", "CODEX_AUTH_JSON_B64"],
+  ["CATALOG_PROBE_AWS_BEARER_TOKEN_BEDROCK", "AWS_BEARER_TOKEN_BEDROCK"],
+  ["CATALOG_PROBE_GEMINI_API_KEY", "GEMINI_API_KEY"],
+  ["CATALOG_PROBE_OPENCODE_API_KEY", "OPENCODE_API_KEY"],
+  ["CATALOG_PROBE_XAI_API_KEY", "XAI_API_KEY"],
+];
+
+test("Catalog Probe binds credentials to the protected lifecycle gate", () => {
+  assert.match(workflow, /environment:\n\s+name: Catalog Probe\n/);
+  assert.match(workflow, /CREDENTIALS_APPROVED: \$\{\{ vars\.CATALOG_PROBE_CREDENTIALS_APPROVED \}\}/);
+  assert.match(workflow, /CREDENTIAL_OWNER: \$\{\{ vars\.CATALOG_PROBE_CREDENTIAL_OWNER \}\}/);
+  assert.match(workflow, /ROTATION_DUE: \$\{\{ vars\.CATALOG_PROBE_ROTATION_DUE \}\}/);
+
+  for (const [secret, injectedVariable] of requiredSecrets) {
+    const references = workflow.match(new RegExp(`secrets\\.${secret}`, "g")) ?? [];
+    assert.equal(references.length, 1, `${secret} must have one step-scoped reference`);
+    assert.ok(runbook.includes("`" + secret + "`"), `${secret} must be in the runbook`);
+    assert.match(workflow, new RegExp(`${injectedVariable}: \\$\\{\\{ secrets\\.${secret} \\}\\}`));
+    assert.doesNotMatch(workflow, new RegExp(`secrets\\.${injectedVariable}(?:[^A-Z0-9_]|$)`));
+  }
+});
+
+test("provider credentials and repository write permission stay in separate jobs", () => {
+  const publishStart = workflow.indexOf("\n  publish:");
+  const alertStart = workflow.indexOf("\n  alert:");
+  assert.notEqual(publishStart, -1);
+  assert.notEqual(alertStart, -1);
+
+  const probeJob = workflow.slice(0, publishStart);
+  const publishJob = workflow.slice(publishStart, alertStart);
+  assert.doesNotMatch(probeJob, /contents: write|pull-requests: write/);
+  assert.match(publishJob, /contents: write/);
+  assert.match(publishJob, /pull-requests: write/);
+  assert.doesNotMatch(publishJob, /secrets\.(ANTHROPIC|CLAUDE|OPENAI|CODEX|AWS|GEMINI|OPENCODE|XAI)/);
+});
+
+test("only sanitized catalog outputs cross into the publish job", () => {
+  assert.match(workflow, /name: catalog-probe-output/);
+  assert.match(workflow, /scripts\/agent-catalog\/generated\/\*\.probe\.json/);
+  assert.doesNotMatch(workflow, /path:[^\n]*\.probe-logs/);
+  assert.match(workflow, /Remove isolated OAuth input/);
+});
+
+test("scheduled failures have a deduplicated owned issue path", () => {
+  assert.match(workflow, /github\.event_name == 'schedule'/);
+  assert.match(workflow, /issues: write/);
+  assert.match(workflow, /ops\(agent-catalog\): Catalog Probe scheduled failure/);
+  assert.match(workflow, /--assignee pablonyx/);
+});

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -213,7 +213,7 @@ gate.
 | Workflow | Trigger and posture | Role |
 | --- | --- | --- |
 | `agent-runtime-compat.yml` | Manual | Exercise live local AnyHarness compatibility with configured agent credentials. |
-| `catalog-probe.yml` | Scheduled daily or manual | Probe agent/catalog pins and open an update PR when the generated catalog changes. |
+| `catalog-probe.yml` | Scheduled daily or manual | Probe agent/catalog pins through the protected `Catalog Probe` environment, pass sanitized outputs to a separate write-capable PR job, and create or update an owned GitHub issue on scheduled failure. |
 | `ci.yml` | Push to `main`, pull request, or manual | Run repository shape, configuration, candidate-handoff, Rust, SDK, client, and workflow checks. Required-check policy is external to this file. |
 | `cloud-live-webhook.yml` | Manual | Exercise a live E2B webhook through an externally reachable target. |
 | `cloud-tests.yml` | Manual | Run credentialed cloud lifecycle and runtime suites. |

--- a/specs/developing/operating/README.md
+++ b/specs/developing/operating/README.md
@@ -20,6 +20,7 @@ under [`../deploying/`](../deploying/).
 | Triage Worker enrollment, heartbeat, or version convergence after checking AnyHarness independently | [Worker enrollment failure](worker-enrollment-failure.md) |
 | Prepare for break-glass access, secret rotation, support-bundle handling, or audit closeout | [Operator security posture](operator-security-posture.md) |
 | Understand, reproduce, or roll back the six production Grafana alert-rule identities and the dark issue-tracker webhook contact point | [Production alerts](production-alerts.md) |
+| Provision, rotate, revoke, audit, or manually verify the scheduled agent catalog probe | [Catalog Probe](catalog-probe.md) |
 
 ## Procedure Rules
 

--- a/specs/developing/operating/catalog-probe.md
+++ b/specs/developing/operating/catalog-probe.md
@@ -1,0 +1,134 @@
+# Catalog Probe Operations
+
+Status: current procedure
+
+Use this runbook to provision, rotate, revoke, audit, or manually verify the
+daily `Catalog Probe` workflow. The durable catalog producer contract lives in
+[Agent Catalog And Readiness](../../codebase/platforms/product/agent-catalog-readiness.md),
+and the workflow's delivery role lives in the
+[Delivery system](../../codebase/systems/engineering/delivery/README.md).
+
+## Ownership And Boundaries
+
+- `.github/workflows/catalog-probe.yml` is owned by the workflow CODEOWNER,
+  `@pablonyx`. The `Catalog Probe` environment variable
+  `CATALOG_PROBE_CREDENTIAL_OWNER` names the current lifecycle owner.
+- Provider credentials belong only to the protected `Catalog Probe` GitHub
+  Environment. Its deployment branch policy permits `main` only. Do not put
+  these values at repository scope or in `Production`, `staging`,
+  `Qualification`, a developer profile, or a personal workstation export.
+- The environment must contain dedicated organization-owned automation
+  credentials. Production application credentials, release-qualification
+  credentials, and personal OAuth sessions are not substitutes.
+- The probe job has read-only repository permission. Secret references exist
+  only on the two first-party steps that materialize OAuth input and run the
+  probe. A separate job without provider credentials owns branch pushes and PR
+  creation.
+- Cursor stays excluded because its supported authentication is an interactive
+  machine-local login. The scheduled environment must not contain copied
+  Cursor session material.
+
+## Required Credential Inventory
+
+The lifecycle owner must prove every row before setting
+`CATALOG_PROBE_CREDENTIALS_APPROVED=true`. Record the provider account or
+workspace, credential owner, creation date, last rotation, next rotation,
+billing/quota cap, and revocation location in the organization credential
+manager. Those records may contain provider identifiers, so they do not belong
+in GitHub issues, PRs, workflow logs, or this repository.
+
+| Environment secret | Injected probe variable | Required probe contexts | Least-privilege and billing guardrail | Rotation and revocation |
+| --- | --- | --- | --- | --- |
+| `CATALOG_PROBE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY` | `claude.anthropic-api`, `opencode.anthropic-api` | Dedicated probe project/workspace; inference only; provider-native monthly spend cap or automatic quota stop sized for one daily probe. | Rotate at most every 90 days. Revoke in the dedicated provider project, delete the environment secret, and set approval false. |
+| `CATALOG_PROBE_CLAUDE_CODE_OAUTH_TOKEN` | `CLAUDE_CODE_OAUTH_TOKEN` | `claude.anthropic-oauth` | Dedicated organization automation identity; no personal subscription or workstation dependency; no administrative scope; bounded organization usage. | Prove non-interactive refresh at least every 30 days. On expiry or compromise, revoke the identity/session, delete the secret, and set approval false. |
+| `CATALOG_PROBE_OPENAI_API_KEY` | `OPENAI_API_KEY` | `codex.openai-api`, `opencode.openai-api` | Dedicated probe project; model/inference access only; provider-native project budget cap or automatic quota stop. | Rotate at most every 90 days. Revoke in the probe project, delete the environment secret, and set approval false. |
+| `CATALOG_PROBE_CODEX_AUTH_JSON_B64` | `CODEX_AUTH_JSON_B64` | `codex.openai-oauth` | Base64 of the complete auth document for a dedicated organization automation identity; must refresh without a personal workstation. The workflow decodes it only into a mode-`0600` runner-temporary file and deletes that file after probing. | Prove refresh at least every 30 days. Revoke the automation session, delete the environment secret, and set approval false. |
+| `CATALOG_PROBE_AWS_BEARER_TOKEN_BEDROCK` | `AWS_BEARER_TOKEN_BEDROCK` | `claude.bedrock`, `codex.bedrock` | Dedicated Bedrock automation principal/token; model invocation only for the probed models and region; no general AWS control-plane permission; automatic budget/quota enforcement. | Rotate at most every 90 days or the provider maximum, whichever is shorter. Revoke the token/principal, delete the environment secret, and set approval false. |
+| `CATALOG_PROBE_GEMINI_API_KEY` | `GEMINI_API_KEY` | `opencode.gemini-api` | Dedicated probe project; Generative Language/model invocation only; API and project restrictions plus an automatic quota stop. | Rotate at most every 90 days. Revoke in the dedicated project, delete the environment secret, and set approval false. |
+| `CATALOG_PROBE_OPENCODE_API_KEY` | `OPENCODE_API_KEY` | `opencode.opencode-zen` | Dedicated probe account/project; inference only; provider-native spend cap or automatic quota stop. | Rotate at most every 90 days. Revoke in the dedicated provider account, delete the environment secret, and set approval false. |
+| `CATALOG_PROBE_XAI_API_KEY` | `XAI_API_KEY` | `grok.xai-api` | Dedicated probe team/project; inference only; provider-native spend cap or automatic quota stop. | Rotate at most every 90 days. Revoke in the dedicated project, delete the environment secret, and set approval false. |
+
+A provider budget alert without automatic enforcement is evidence, not a cap.
+If a provider cannot enforce a cap or quota stop, keep approval false until the
+lifecycle owner records an explicitly authorized bounded-spend alternative.
+
+## Environment Guard
+
+Configure these non-secret variables on the `Catalog Probe` environment:
+
+| Variable | Value |
+| --- | --- |
+| `CATALOG_PROBE_CREDENTIAL_OWNER` | GitHub login or team that owns rotation, billing, failure triage, and revocation. |
+| `CATALOG_PROBE_CREDENTIALS_APPROVED` | `true` only after all eight dedicated rows are present and the inventory above is proven; otherwise `false`. |
+| `CATALOG_PROBE_ROTATION_DUE` | Earliest next rotation date across the eight credentials, in `YYYY-MM-DD` UTC form. |
+
+The workflow validates these variables before referencing any provider secret.
+An absent approval, owner, invalid date, or passed rotation date fails closed.
+When any credential is rotated, revoked, expired, over budget, or of uncertain
+ownership, first set approval to `false`; restore `true` only after every row is
+healthy and update the earliest due date.
+
+## Provision Or Rotate
+
+Required access: repository environment administration plus provider access
+for the dedicated automation project/account. Never put a value in a CLI
+argument. Use the GitHub UI or a secret-store-backed authenticated tool that
+accepts the value through protected standard input.
+
+1. Set `CATALOG_PROBE_CREDENTIALS_APPROVED=false`.
+2. Confirm the environment allows only `main` and has no inherited repository,
+   staging, Qualification, or Production provider credentials.
+3. In each provider's organization console, confirm the owner, dedicated
+   project/account, exact scope, billing/quota enforcement, and revocation
+   control. Create or rotate only credentials already authorized by the
+   organization; this procedure does not authorize a new billable account.
+4. Store each value under the exact `CATALOG_PROBE_*` environment secret name
+   in the table. The unique prefix prevents GitHub from silently satisfying a
+   missing environment value from a generic repository or organization secret.
+   For `CATALOG_PROBE_CODEX_AUTH_JSON_B64`, encode the whole dedicated auth
+   document without printing it and send the encoded bytes directly to the
+   environment secret.
+5. Prove both OAuth credentials can refresh without a personal workstation.
+6. Update the owner and earliest rotation date, then set approval to `true`.
+7. Manually dispatch `Catalog Probe` from `main`. Do not use a PR branch.
+
+## Verify A Manual Probe
+
+The run is complete only when:
+
+1. `Verify credential lifecycle approval` passes.
+2. `Resolve, install, probe, and finalize catalog` records `complete=true` and
+   every required non-Cursor context as `passed=` in the sanitized step
+   summary.
+3. The viewer and sanitized catalog-output artifacts upload successfully.
+4. The separate publish job reaches `Open catalog PR when the draft changed`;
+   either it reports no diff or opens the expected catalog PR.
+5. No raw credential, auth document, provider identifier, prompt, response, or
+   probe log appears in the summary, artifacts, issue alert, or PR.
+
+Inspect only the step names, conclusions, sanitized `run.state`, and generated
+catalog outputs. Do not paste raw logs into an issue. A failed scheduled run
+creates or updates the deduplicated
+`ops(agent-catalog): Catalog Probe scheduled failure` issue and assigns the
+workflow owner.
+
+## Revoke Or Respond To Failure
+
+1. Set `CATALOG_PROBE_CREDENTIALS_APPROVED=false` before investigating a
+   suspected compromise, ownership ambiguity, expired refresh path, passed
+   rotation date, or billing breach.
+2. Revoke the affected credential at its dedicated provider project/account,
+   then delete the corresponding GitHub environment secret. Do not begin by
+   deleting the secret if that would leave a still-valid provider credential.
+3. Inspect the failing workflow's sanitized state to identify the affected
+   context. Confirm provider status, quota, and refresh health in the owning
+   console without copying values or raw responses.
+4. Rotate or repair only with the authority described above. Re-run the full
+   non-Cursor matrix; a focused or partial diagnostic is not promotion proof.
+5. Close the operational alert only after the full manual verification passes
+   and the next scheduled run has an owned response path.
+
+If any credential owner, scope, cap, refresh path, or revocation control cannot
+be proven, leave the workflow blocked and hand the exact missing secret names
+and metadata fields to the lifecycle owner. Never fall back to Production,
+Qualification, staging, or personal credentials.

--- a/specs/developing/operating/catalog-probe.md
+++ b/specs/developing/operating/catalog-probe.md
@@ -110,7 +110,9 @@ Inspect only the step names, conclusions, sanitized `run.state`, and generated
 catalog outputs. Do not paste raw logs into an issue. A failed scheduled run
 creates or updates the deduplicated
 `ops(agent-catalog): Catalog Probe scheduled failure` issue and assigns the
-workflow owner.
+workflow owner when that account remains assignable. The alert issue is created
+before assignment is attempted, so assignment drift cannot suppress the alert;
+route an unassigned alert through the workflow CODEOWNER.
 
 ## Revoke Or Respond To Failure
 


### PR DESCRIPTION
## Summary

- bind the credentialed probe to a dedicated, main-only `Catalog Probe` environment and fail closed on lifecycle approval, owner, or rotation metadata
- use uniquely prefixed environment secrets, scope them to the first-party probe steps, remove temporary OAuth material, and pass only sanitized catalog outputs to a separate write-capable PR job
- add a deduplicated scheduled-failure issue path plus an operator runbook for ownership, rotation, billing caps, revocation, and manual verification
- add workflow invariant tests that prevent shared-secret fallback, write/credential co-location, unsafe artifacts, or loss of the owned alert path

The protected environment now exists with lifecycle owner `pablonyx`, a `main`-only deployment policy, approval set to `false`, and no secrets. This deliberately does not close #1324: a manual Catalog Probe is not authorized until all eight dedicated credentials and their ownership/scope/caps/refresh paths are proven.

## Verification

- `node --test scripts/agent-catalog/*.test.mjs` (25 passed)
- `python3 scripts/check_docs.py`
- `actionlint .github/workflows/catalog-probe.yml`
- `git diff --check`
- GitHub environment/repository secret-name, protection-rule, and scheduled-run metadata audit only; no secret values were read or copied

## Operator handoff

The exact remaining inventory is documented in the runbook and issue handoff. The `Catalog Probe` environment currently has zero secrets; `CATALOG_PROBE_ROTATION_DUE` is unset; organization-level secret inventory returned HTTP 403 and therefore cannot establish a safe reuse source. Production, staging, Qualification, and personal credentials remain excluded.