### PR TITLE
test(server): align gateway policy sessions with v2 contract

### DIFF
--- a/server/tests/integration/test_cloud_integration_gateway_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_api.py
@@ -139,7 +139,7 @@ async def test_gateway_initialize_and_tools_list(
     )
     assert init.status_code == 200, init.text
     assert init.json()["result"]["serverInfo"]["name"] == "proliferate_integrations"
-    assert init.headers[MCP_SESSION_HEADER].startswith("v1.")
+    assert init.headers[MCP_SESSION_HEADER].startswith("v2.")
 
     tools = await client.post(
         GATEWAY_URL,
@@ -175,7 +175,7 @@ async def test_invalid_gateway_session_returns_reinitialize_signal(
         json={"jsonrpc": "2.0", "id": 2, "method": "initialize"},
     )
     assert recovered.status_code == 200
-    assert recovered.headers[MCP_SESSION_HEADER].startswith("v1.")
+    assert recovered.headers[MCP_SESSION_HEADER].startswith("v2.")
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
@@ -28,6 +28,8 @@ from tests.integration.test_cloud_integration_gateway_api import (
 )
 
 MCP_SESSION_HEADER = "Mcp-Session-Id"
+WORKSPACE_HEADER = "Proliferate-Workspace-Id"
+ANYHARNESS_SESSION_HEADER = "Proliferate-Session-Id"
 
 
 @pytest.fixture(autouse=True)
@@ -46,7 +48,11 @@ async def _initialized_gateway_headers(
     *,
     bearer: str,
 ) -> dict[str, str]:
-    headers = {"Authorization": f"Bearer {bearer}"}
+    headers = {
+        "Authorization": f"Bearer {bearer}",
+        WORKSPACE_HEADER: "workspace-tool-policy",
+        ANYHARNESS_SESSION_HEADER: "session-tool-policy",
+    }
     initialized = await client.post(
         GATEWAY_URL,
         headers=headers,
@@ -341,16 +347,21 @@ async def test_worker_token_and_gateway_arguments_cannot_bypass_policy(
 
     gateway_authorization = enrolled.json()["integrationGateway"]["authorization"]
     await _seed_ready_slack_account(db_session, user_id=uuid.UUID(auth.user_id))
+    launch_headers = {
+        "Authorization": gateway_authorization,
+        WORKSPACE_HEADER: "workspace-worker-bypass",
+        ANYHARNESS_SESSION_HEADER: "session-worker-bypass",
+    }
     initialized = await client.post(
         GATEWAY_URL,
-        headers={"Authorization": gateway_authorization},
+        headers=launch_headers,
         json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
     )
     assert initialized.status_code == 200
     result = await _tool_call(
         client,
         {
-            "Authorization": gateway_authorization,
+            **launch_headers,
             MCP_SESSION_HEADER: initialized.headers[MCP_SESSION_HEADER],
         },
         name="integrations.call_tool",


### PR DESCRIPTION
## Summary

- update the integration-gateway API tests to expect the published v2 MCP session token
- bind tool-policy approval tests to workspace and AnyHarness session launch identities
- preserve the published `integration_tool_approval_required` error-code contract and production fail-closed behavior

## Root cause

#1354 introduced v2 execution sessions that must be bound to both launch identity headers before an external-action approval can be created. Four tests retained v1 or unbound-session assumptions, so the server correctly returned `integration_gateway_session_required` and the assertions failed.

## Proof

- `uv run --python 3.12 --extra dev ruff check tests/integration/test_cloud_integration_gateway_api.py tests/integration/test_cloud_integration_gateway_tool_policy_api.py`
- `uv run --python 3.12 --extra dev ruff format --check tests/integration/test_cloud_integration_gateway_api.py tests/integration/test_cloud_integration_gateway_tool_policy_api.py`
- focused gateway/approval suite: 63 passed
- exact server CI pytest command: 1,914 passed, 1 skipped
- independent review: accepted with no findings

Fixes #1370