### PR TITLE
fix(community): replace expiring Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat" /></a>
   <a href="https://proliferate.com/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-view-0969DA?style=flat" /></a>
   <a href="https://proliferate.com"><img alt="Website" src="https://img.shields.io/badge/website-visit-0969DA?style=flat" /></a>
-  <a href="https://discord.gg/7b5afMTqW"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2?style=flat&amp;logo=discord&amp;logoColor=white" /></a>
+  <a href="https://discord.gg/2RVNNzEZnj"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2?style=flat&amp;logo=discord&amp;logoColor=white" /></a>
 </p>
 
 <br />
@@ -32,7 +32,7 @@ Move running sessions between your machine and the cloud. Works solo or across a
   &nbsp;&bull;&nbsp;
   <a href="https://proliferate.com/changelog">Changelog</a>
   &nbsp;&bull;&nbsp;
-  <a href="https://discord.gg/7b5afMTqW">Discord</a>
+  <a href="https://discord.gg/2RVNNzEZnj">Discord</a>
 </p>
 
 <img width="full" alt="Proliferate" src="./assets/readme/hero.png" />
@@ -165,7 +165,7 @@ on the way.
 
 Point the desktop app at your control plane by setting `apiBaseUrl` in
 `~/.proliferate/config.json`. Expect rough edges — [open an issue](https://github.com/proliferate-ai/proliferate/issues/new/choose) or ask in
-[Discord](https://discord.gg/7b5afMTqW) if you hit problems, and see
+[Discord](https://discord.gg/2RVNNzEZnj) if you hit problems, and see
 [SECURITY.md](./SECURITY.md) for reporting vulnerabilities.
 
 </details>
@@ -193,7 +193,7 @@ self-host experience will be polished as Cloud moves toward GA.
 
 ## Community
 
-Join our community on [Discord](https://discord.gg/7b5afMTqW)!
+Join our community on [Discord](https://discord.gg/2RVNNzEZnj)!
 
 ## Contributing
 

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.tsx
@@ -15,7 +15,7 @@ import type { SupportMenuAction } from "#product/lib/domain/support/support-menu
 import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 
 const PROLIFERATE_CHANGELOG_URL = "https://proliferate.com/changelog";
-const PROLIFERATE_DISCORD_URL = "https://discord.gg/7b5afMTqW";
+const PROLIFERATE_DISCORD_URL = "https://discord.gg/2RVNNzEZnj";
 
 export interface SidebarHelpSectionProps {
   webApp: WebAppTarget;


### PR DESCRIPTION
## Summary

- replace the four expiring Discord invite references in the repository README
- update the shared ProductClient help menu used by Desktop and Web
- point every source reference at the verified permanent Proliferate invite

## Root cause and impact

The repository and shipped help menu referenced an invite scheduled to expire, which would leave community links dead after that date. The replacement invite resolves to the Proliferate server, lands in `#announcements`, and reports no expiration through Discord's public invite endpoint.

## Verification

- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `pnpm --filter @proliferate/product-client build`
- `pnpm --filter @proliferate/product-client test` (578 files, 3,470 tests)
- Discord public invite metadata: guild `1510104281787662466` (`Proliferate`), `expires_at: null`

Fixes #1126