### PR TITLE
test(server): align gateway tests with bound sessions

### DIFF
--- a/server/tests/integration/test_cloud_integration_gateway_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_api.py
@@ -139,7 +139,7 @@ async def test_gateway_initialize_and_tools_list(
     )
     assert init.status_code == 200, init.text
     assert init.json()["result"]["serverInfo"]["name"] == "proliferate_integrations"
-    assert init.headers[MCP_SESSION_HEADER].startswith("v1.")
+    assert init.headers[MCP_SESSION_HEADER]
 
     tools = await client.post(
         GATEWAY_URL,
@@ -163,7 +163,7 @@ async def test_invalid_gateway_session_returns_reinitialize_signal(
 
     stale = await client.post(
         GATEWAY_URL,
-        headers={**headers, MCP_SESSION_HEADER: "v1.invalid.invalid"},
+        headers={**headers, MCP_SESSION_HEADER: "not-a-session"},
         json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
     )
     assert stale.status_code == 404
@@ -175,7 +175,7 @@ async def test_invalid_gateway_session_returns_reinitialize_signal(
         json={"jsonrpc": "2.0", "id": 2, "method": "initialize"},
     )
     assert recovered.status_code == 200
-    assert recovered.headers[MCP_SESSION_HEADER].startswith("v1.")
+    assert recovered.headers[MCP_SESSION_HEADER]
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
@@ -28,6 +28,8 @@ from tests.integration.test_cloud_integration_gateway_api import (
 )
 
 MCP_SESSION_HEADER = "Mcp-Session-Id"
+WORKSPACE_HEADER = "Proliferate-Workspace-Id"
+ANYHARNESS_SESSION_HEADER = "Proliferate-Session-Id"
 
 
 @pytest.fixture(autouse=True)
@@ -44,9 +46,14 @@ async def _first_worker(db_session: AsyncSession) -> CloudRuntimeWorker:
 async def _initialized_gateway_headers(
     client: AsyncClient,
     *,
-    bearer: str,
+    authorization: str,
 ) -> dict[str, str]:
-    headers = {"Authorization": f"Bearer {bearer}"}
+    identity = uuid.uuid4().hex
+    headers = {
+        "Authorization": authorization,
+        WORKSPACE_HEADER: f"workspace-{identity}",
+        ANYHARNESS_SESSION_HEADER: f"session-{identity}",
+    }
     initialized = await client.post(
         GATEWAY_URL,
         headers=headers,
@@ -149,7 +156,10 @@ async def test_every_known_slack_mutation_returns_typed_approval_required(
     bearer = await _gateway_bearer(client, db_session, prefix="gw-slack-policy-write")
     worker = await _first_worker(db_session)
     await _seed_ready_slack_account(db_session, user_id=worker.owner_user_id)
-    gateway_headers = await _initialized_gateway_headers(client, bearer=bearer)
+    gateway_headers = await _initialized_gateway_headers(
+        client,
+        authorization=f"Bearer {bearer}",
+    )
 
     async def unexpected_call_tool(**_kwargs: object) -> dict[str, object]:
         raise AssertionError("Slack mutation reached the upstream MCP")
@@ -341,18 +351,13 @@ async def test_worker_token_and_gateway_arguments_cannot_bypass_policy(
 
     gateway_authorization = enrolled.json()["integrationGateway"]["authorization"]
     await _seed_ready_slack_account(db_session, user_id=uuid.UUID(auth.user_id))
-    initialized = await client.post(
-        GATEWAY_URL,
-        headers={"Authorization": gateway_authorization},
-        json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+    gateway_headers = await _initialized_gateway_headers(
+        client,
+        authorization=gateway_authorization,
     )
-    assert initialized.status_code == 200
     result = await _tool_call(
         client,
-        {
-            "Authorization": gateway_authorization,
-            MCP_SESSION_HEADER: initialized.headers[MCP_SESSION_HEADER],
-        },
+        gateway_headers,
         name="integrations.call_tool",
         arguments={
             "provider": "slack",


### PR DESCRIPTION
## Summary

- treat integration-gateway session identifiers as opaque in API integration tests
- initialize Slack write-policy tests with the workspace and AnyHarness session identity required by the current fail-closed contract
- preserve the production v2 token and approval enforcement behavior unchanged

## Root cause

The durable external-action approval change upgraded gateway sessions to a workspace/session-bound v2 token, while four older integration tests still asserted the v1 representation or initialized an unbound write session. This made current `main` Server CI fail even though the production security behavior was correct.

## Impact

This is test-only. It restores the Server CI gate needed for staging deployment without weakening gateway authentication or write approval policy.

## Verification

- `uv run --extra dev ruff check tests/integration/test_cloud_integration_gateway_api.py tests/integration/test_cloud_integration_gateway_tool_policy_api.py`
- `uv run --extra dev ruff format --check tests/integration/test_cloud_integration_gateway_api.py tests/integration/test_cloud_integration_gateway_tool_policy_api.py`
- focused reproduction: 4 passed
- both complete affected files: 20 passed