### PR TITLE
test(release): evict the claimed-owner cache when a local world closes

### DIFF
--- a/tests/release/src/fixtures/authenticated-actor.test.ts
+++ b/tests/release/src/fixtures/authenticated-actor.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, test } from "node:test";
 import {
   authenticatedActor,
   toStoredSession,
+  evictClaimedOwner,
   __resetAuthenticatedActorClaimCacheForTests,
   type AuthenticatedActorTransport,
 } from "./authenticated-actor.js";
@@ -294,6 +295,52 @@ test("authenticatedActor does not cache a failed claim: a later call for the sam
   assert.equal(claimAttempts, 2);
   assert.equal(actor.role, "owner");
   assert.equal(calls.filter((call) => call.startsWith("claimSetup")).length, 2);
+});
+
+test("evictClaimedOwner: after eviction, a new actor for the same runDir claims again instead of logging in with stale credentials", async () => {
+  // Regression for run 29631868610 (T3-AUTHROUTE-1, route=change 401): two
+  // successive worlds sharing the same worldRoot/runDir must never share a
+  // cached owner. Simulates world close (which evicts) followed by a fresh
+  // world reusing the same runDir.
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+
+  const first = await authenticatedActor(world, "owner", {}, transport);
+  evictClaimedOwner(world.paths.runDir);
+
+  const { transport: secondTransport, calls: secondCalls } = fakeTransport();
+  const second = await authenticatedActor(world, "owner", {}, secondTransport);
+
+  assert.equal(
+    calls.filter((call) => call.startsWith("claimSetup")).length,
+    1,
+    "the first world claims once",
+  );
+  assert.equal(
+    secondCalls.filter((call) => call.startsWith("claimSetup")).length,
+    1,
+    "after eviction, the next call for the same runDir claims again rather than reusing the stale cache",
+  );
+  assert.equal(first.role, "owner");
+  assert.equal(second.role, "owner");
+});
+
+test("evictClaimedOwner: claim-once-per-world behavior still holds within one world's lifetime (no eviction call)", async () => {
+  const world = fakeWorld();
+  const { transport, calls } = fakeTransport();
+
+  await authenticatedActor(world, "owner", { harnessKind: "claude" }, transport);
+  await authenticatedActor(world, "owner", { harnessKind: "codex" }, transport);
+
+  assert.equal(
+    calls.filter((call) => call.startsWith("claimSetup")).length,
+    1,
+    "without eviction, the cache still serves the second call from the same world",
+  );
+});
+
+test("evictClaimedOwner: evicting an unknown runDir is a harmless no-op", () => {
+  assert.doesNotThrow(() => evictClaimedOwner("/tmp/never-cached"));
 });
 
 test("authenticatedActor: an explicit email opts out of the shared per-world claim cache and always claims directly", async () => {

--- a/tests/release/src/fixtures/authenticated-actor.ts
+++ b/tests/release/src/fixtures/authenticated-actor.ts
@@ -186,6 +186,25 @@ export function __resetAuthenticatedActorClaimCacheForTests(): void {
   claimedOwnerByWorld.clear();
 }
 
+/**
+ * Evicts the claimed-owner cache entry for a world's `runDir`. MUST be called
+ * on every teardown path of a world booted against that `runDir` (see
+ * `bootLocalFunctionalWorld` in `../scenarios/local/world-boot.ts`).
+ *
+ * The cache is keyed by `world.paths.runDir`, and a single scenario can boot
+ * MULTIPLE successive worlds under the same run dir (e.g. `T3-AUTHROUTE-1`
+ * boots one world for its batch collector, then a fresh world for its
+ * `route=change` collector, both deriving the same `worldRoot` from the
+ * shared scenario id). Without eviction, a torn-down world's cached owner
+ * credentials leak into the next world that reuses the same path; that next
+ * world's database has no such owner, so password login 401s. Evicting on
+ * close makes that leak structurally impossible no matter how many worlds a
+ * scenario boots against the same run dir.
+ */
+export function evictClaimedOwner(runDir: string): void {
+  claimedOwnerByWorld.delete(runDir);
+}
+
 /** Stable identity for a world's single-org server (one claim per run dir). */
 function worldIdentity(world: ReadyLocalWorld): string {
   return world.paths.runDir;

--- a/tests/release/src/scenarios/local/world-boot.test.ts
+++ b/tests/release/src/scenarios/local/world-boot.test.ts
@@ -16,6 +16,10 @@ import type { CandidateBuildMapV1 } from "../../artifacts/build-map.js";
 import type { EnvResolution } from "../../config/env-resolution.js";
 import type { ReadyLocalWorld } from "../../worlds/local-workspace/world.js";
 import type { LocalWorldCleanupEvidence } from "../../worlds/local-workspace/cleanup.js";
+import { authenticatedActor, __resetAuthenticatedActorClaimCacheForTests } from "../../fixtures/authenticated-actor.js";
+import { ApiClient } from "../../fixtures/http.js";
+import type { AuthenticatedActorTransport } from "../../fixtures/authenticated-actor.js";
+import type { ActorKeyIdentity } from "../../services/qualification-litellm.js";
 
 // ── Fakes (offline: no world, browser, container, or network) ────────────────
 
@@ -246,4 +250,134 @@ test("bootLocalFunctionalWorld: releases the mutex when construction throws", as
   });
   assert.equal(constructed, true);
   await world.close();
+});
+
+// ── claim-cache eviction on close (regression: run 29631868610, T3-AUTHROUTE-1
+//    route=change 401 — stale owner leaking from a torn-down world into a
+//    second world reusing the same worldRoot) ─────────────────────────────────
+
+function fakeAuthTransport(overrides: Partial<AuthenticatedActorTransport> = {}): {
+  transport: AuthenticatedActorTransport;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const transport: AuthenticatedActorTransport = {
+    readSetupToken: async (setupTokenPath) => {
+      calls.push(`readSetupToken:${setupTokenPath}`);
+      return "the-setup-token";
+    },
+    claimSetup: async (params) => {
+      calls.push(`claimSetup:${params.email}`);
+    },
+    waitForSetupCommitted: async () => {
+      calls.push("waitForSetupCommitted");
+    },
+    loginWithPassword: async (_apiBaseUrl, email) => {
+      calls.push(`loginWithPassword:${email}`);
+      return {
+        access_token: "access-1",
+        refresh_token: "refresh-1",
+        token_type: "bearer",
+        expires_in: 3600,
+        user: { id: "user-1", email, display_name: "Owner", github_login: null, avatar_url: null },
+      };
+    },
+    listOrganizations: async () => {
+      calls.push("listOrganizations");
+      return { organizations: [{ id: "org-1" }] };
+    },
+    getEnrollment: async () => {
+      calls.push("getEnrollment");
+      return {
+        id: "enrollment-1",
+        subjectKind: "user",
+        litellmTeamId: "team-1",
+        syncStatus: "synced",
+        lastErrorCode: null,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      };
+    },
+    putGatewaySelection: async (_api, harnessKind, surface) => {
+      calls.push(`putGatewaySelection:${harnessKind}:${surface}`);
+    },
+    ...overrides,
+  };
+  return { transport, calls };
+}
+
+function fakeAuthActorWorld(runDir: string): ReadyLocalWorld {
+  return {
+    kind: "local-workspace",
+    run: {
+      run_id: "local-run-1",
+      shard_id: "local-0",
+      attempt: 1,
+      source_sha: "a".repeat(40),
+      origin: { kind: "local", github_run_id: null, github_job: null },
+    },
+    artifacts: {
+      server: { artifact_id: "server/linux-amd64", version: "1", sha256: "s".repeat(64), path: "/tmp/server" },
+      anyharness: { artifact_id: "anyharness/x86_64", version: "1", sha256: "a".repeat(64), path: "/tmp/anyharness" },
+      desktopRenderer: {
+        artifact_id: "desktop-renderer/browser",
+        version: "1",
+        sha256: "d".repeat(64),
+        path: "/tmp/renderer",
+      },
+    },
+    api: { baseUrl: "http://127.0.0.1:9001", client: new ApiClient({ baseUrl: "http://127.0.0.1:9001" }) },
+    runtime: { baseUrl: "http://127.0.0.1:9002", client: undefined as never },
+    renderer: { baseUrl: "http://127.0.0.1:9003", browser: undefined as never },
+    gateway: {
+      resolveActorKey: async ({ userId, enrollmentId }: { userId: string; enrollmentId: string }) =>
+        ({
+          userId,
+          enrollmentId,
+          teamId: "team-1",
+          litellmUserId: "litellm-user-1",
+          keyAlias: `vk-user-${userId}-${enrollmentId.slice(0, 8)}`,
+          tokenId: "token-1",
+          tokenIdHash: "hash-1",
+        }) satisfies ActorKeyIdentity,
+    } as unknown as ReadyLocalWorld["gateway"],
+    paths: { runDir, runtimeHome: `${runDir}/runtime-home`, repositoriesDir: `${runDir}/repositories` },
+    db: { databaseUrl: "postgresql+asyncpg://proliferate:localdev@127.0.0.1:5599/proliferate" },
+    close: async () => ({}) as LocalWorldCleanupEvidence,
+  };
+}
+
+test("bootLocalFunctionalWorld: closing a world evicts the authenticatedActor claim cache for its worldRoot, so a second world reusing the same runDir claims again instead of reusing the stale owner", async () => {
+  __resetAuthenticatedActorClaimCacheForTests();
+  const runDir = "/tmp/run-shared-authroute";
+  const inputs = fakeWorldInputs(runDir);
+  // T3-AUTHROUTE-1's batch collector, then its route=change collector: two
+  // DIFFERENT scenario ids, but `worldDirSlug` collapses to the same subdir
+  // when both pass the same underlying scenario id (as production code does).
+  const scenarioId = "T3-AUTHROUTE-1";
+
+  const world1 = await bootLocalFunctionalWorld(inputs, scenarioId, async (opts) =>
+    fakeAuthActorWorld(opts.worldRoot!),
+  );
+  const { transport: transport1, calls: calls1 } = fakeAuthTransport();
+  await authenticatedActor(world1, "owner", {}, transport1);
+  await world1.close(); // MUST evict the claim cache entry for this worldRoot
+
+  const world2 = await bootLocalFunctionalWorld(inputs, scenarioId, async (opts) =>
+    fakeAuthActorWorld(opts.worldRoot!),
+  );
+  const { transport: transport2, calls: calls2 } = fakeAuthTransport();
+  await authenticatedActor(world2, "owner", {}, transport2);
+  await world2.close();
+
+  assert.equal(
+    calls1.filter((call) => call.startsWith("claimSetup")).length,
+    1,
+    "the first world claims once",
+  );
+  assert.equal(
+    calls2.filter((call) => call.startsWith("claimSetup")).length,
+    1,
+    "the second world, reusing the same runDir, must claim again rather than reuse world 1's stale owner cache",
+  );
 });

--- a/tests/release/src/scenarios/local/world-boot.ts
+++ b/tests/release/src/scenarios/local/world-boot.ts
@@ -10,6 +10,7 @@ import {
   type ReadyLocalWorld,
 } from "../../worlds/local-workspace/world.js";
 import { resolveWorldConstructionInputs, type QualificationLiteLlmConfigLike } from "../local-world-smoke-1.js";
+import { evictClaimedOwner } from "../../fixtures/authenticated-actor.js";
 
 /**
  * Shared local-functional world boot (BRIEF §"World lifecycle").
@@ -143,6 +144,7 @@ export async function bootLocalFunctionalWorld(
   construct: ConstructLocalWorldFn = constructLocalWorld,
 ): Promise<ReadyLocalWorld> {
   const release = await worldBootMutex.acquire();
+  const worldRoot = path.join(inputs.runDir, "worlds", worldDirSlug(worldId));
   let world: ReadyLocalWorld;
   try {
     // Identical world construction to `LOCAL-WORLD-SMOKE-1`'s `buildWorld`
@@ -155,7 +157,7 @@ export async function bootLocalFunctionalWorld(
       map: inputs.map,
       litellm: inputs.litellm,
       runDir: inputs.runDir,
-      worldRoot: path.join(inputs.runDir, "worlds", worldDirSlug(worldId)),
+      worldRoot,
       ports: inputs.ports,
     });
   } catch (error) {
@@ -166,12 +168,19 @@ export async function bootLocalFunctionalWorld(
   }
 
   // Hold the mutex until this world is fully torn down. Wrap `close()` so the
-  // release happens exactly once, whether close resolves or throws.
+  // release happens exactly once, whether close resolves or throws. Also
+  // evict the claim-once cache entry for this world's run dir on every
+  // teardown path: a scenario may boot a SECOND, freshly-constructed world
+  // against this exact same `worldRoot` (e.g. T3-AUTHROUTE-1's batch
+  // collector followed by its route=change collector), and without eviction
+  // that next world would inherit this world's now-stale owner credentials
+  // from `authenticatedActor`'s per-world claim cache and 401 on login.
   const realClose = world.close.bind(world);
   let released = false;
   const releaseOnce = (): void => {
     if (!released) {
       released = true;
+      evictClaimedOwner(worldRoot);
       release();
     }
   };


### PR DESCRIPTION
## Regression lineage

PR #1376 introduced `authenticatedActor`'s per-world claim-once cache
(`tests/release/src/fixtures/authenticated-actor.ts:163-190`), keyed by
`world.paths.runDir` (= worldRoot, `path.join(runDir, "worlds", worldDirSlug(worldId))`,
`tests/release/src/scenarios/local/world-boot.ts:158`).

`T3-AUTHROUTE-1` (`tests/release/src/scenarios/t3-authroute-1.ts:84-95`) boots
**two successive worlds** under the same `worldId`/scenario id — a LOCAL-3
batch collector, then a LOCAL-6 `route=change` collector — both deriving the
identical `worldRoot`, hence the identical cache key.

- World 1 claims setup and caches the owner credentials.
- World 1 is torn down.
- World 2 (a fresh server, fresh database, `/setup` still open) hits the
  stale cache entry, skips its own claim, and logs in with credentials that
  don't exist in the new database.
- `POST /auth/desktop/password/login -> 401` (run 29631868610, cell
  `T3-AUTHROUTE-1/local/route=change`; `auth-failure-diag` confirmed
  `setupStillOpen: true`, i.e. the claim never happened in world 2).

## Fix

Evict on world close (fixes the general hazard, not just this one scenario):

1. `authenticated-actor.ts`: added `evictClaimedOwner(runDir)`, which deletes
   that key from the module-level claim-promise cache. Kept
   `__resetAuthenticatedActorClaimCacheForTests` working as-is.
2. `world-boot.ts`: `bootLocalFunctionalWorld`'s `close()` wrapper now calls
   `evictClaimedOwner(worldRoot)` from inside `releaseOnce()`, which already
   runs in a `finally` around the real `close()` — so eviction happens on
   every teardown path (normal close and close-that-throws), exactly once,
   before the mutex is released for the next serialized world boot.

## Proof

- `cd tests/release && npx tsc --noEmit` — clean except the pre-existing
  `pg` module-resolution noise in `../intent/stack/{billing-env,seed}.ts`
  (unrelated, present on main).
- `npm test` — 1175 tests, 1170 pass, 5 fail. The 5 failures are the known
  pre-existing ones on main (`staging-workflow.test.ts`,
  `manifest-agreement.test.ts`, `tier2/evidence.test.ts`,
  `tier2/harness.test.ts`, and the "failed Tier-2 boot" case) — identical
  failure set before and after this change, no new failures.
- Added regressions:
  - `authenticated-actor.test.ts`: after `evictClaimedOwner`, a new actor for
    the same `runDir` claims again instead of reusing stale credentials;
    without eviction, the existing claim-once-per-world behavior is
    unchanged; evicting an unknown `runDir` is a no-op.
  - `world-boot.test.ts`: an end-to-end regression that boots two
    `bootLocalFunctionalWorld` instances against the same `runDir`/scenario
    id (mirroring `T3-AUTHROUTE-1`'s two-collector pattern), closes world 1,
    and asserts world 2 claims setup again rather than replaying world 1's
    cached owner — this is the exact shape of the run 29631868610 failure,
    now green.

## Out of scope

No changes to `release-e2e.yml`/#1373 logic, no assertion deletions, no
product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)