### PR TITLE
test(release): wait for the Project picker to settle after harness-ready reload

### DIFF
--- a/tests/release/src/scenarios/local/config-session.ts
+++ b/tests/release/src/scenarios/local/config-session.ts
@@ -851,6 +851,23 @@ function cssAttr(value: string): string {
   return value.replace(/["\\]/g, "\\$&");
 }
 
+/**
+ * Waits for a locator to report itself enabled (not `disabled`), polling
+ * rather than relying on Playwright's default 30s click-actionability
+ * timeout — used where a trigger's mount can race a preceding reload and the
+ * scenario's own budget is far larger than 30s.
+ */
+async function waitForEnabled(locator: ReturnType<Page["locator"]>, timeoutMs: number, what: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await locator.isEnabled().catch(() => false)) {
+      return;
+    }
+    await sleep(250);
+  }
+  throw new Error(`waitForEnabled: ${what} did not become enabled within ${timeoutMs}ms`);
+}
+
 // ── Production UI/runtime driver bodies ──────────────────────────────────────
 //
 // These drive the real Desktop renderer + candidate AnyHarness through the
@@ -908,7 +925,20 @@ async function ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, har
 
 async function selectRepoAndWorkLocally(page: ProductPage, repo: PreparedRepository): Promise<void> {
   const p = page.page;
-  await p.getByRole("button", { name: /^Project:/ }).first().click();
+  // `ensureHarnessReady`'s preceding reload re-mounts the home screen; its
+  // generic composer/tab-strip wait settles for DOM presence but not for the
+  // Project-menu trigger's own mount, so an immediate click here can race
+  // that mount (run 29631868610: 30s "locator.click" timeout on this button,
+  // with ERR_ABORTED launch-options/reconcile polls in the network log
+  // showing they were cancelled by the reload — a pure collector settle
+  // race, not a product defect: HomeNextScreen renders the Project button
+  // unconditionally). Wait for the trigger to be visible AND enabled before
+  // clicking, with a timeout aligned to the harness-ready budget instead of
+  // Playwright's 30s click-actionability default.
+  const projectTrigger = p.getByRole("button", { name: /^Project:/ }).first();
+  await projectTrigger.waitFor({ state: "visible", timeout: HARNESS_READY_TIMEOUT_MS });
+  await waitForEnabled(projectTrigger, HARNESS_READY_TIMEOUT_MS, "Project: trigger");
+  await projectTrigger.click();
   const repoRow = p.locator(`[data-repo-source-root="${cssAttr(repo.path)}"]`).first();
   await repoRow.waitFor({ state: "visible", timeout: 20_000 });
   await repoRow.click();


### PR DESCRIPTION
## Root cause

Run 29631868610 (T3-CFG-1, codex/grok/opencode): `collectLocal4ConfigCells` reuses one page across the harness batch. `ensureHarnessReady` reloads the page (`page.page.reload({waitUntil:"domcontentloaded"})`) and then only waits for a generic composer selector (`[data-home-composer-editor], [data-chat-composer-editor], [data-workspace-tab-strip]`) to settle. The immediately following `selectRepoAndWorkLocally` clicks `getByRole('button', {name:/^Project:/}).first()` and hit Playwright's default 30s click-actionability timeout — the click was racing the home-screen Project-menu mount after the reload. The network log for the failing run shows a storm of `ERR_ABORTED` launch-options/reconcile polls cancelled by the reload, consistent with a collector settle race rather than a product defect: HomeNextScreen renders the Project button unconditionally, and Claude passes in the same run only because it goes first (no prior-cell reload churn to race against).

## Fix

`selectRepoAndWorkLocally` now explicitly waits for the `Project:` trigger to be visible and enabled before clicking, with a timeout aligned to the scenario's harness-ready budget (`HARNESS_READY_TIMEOUT_MS`, 300s) instead of Playwright's 30s default. No unconditional sleeps, no weakened assertions; the failure message names what was being waited for if the bound is ever exceeded.

Only one copy of `selectRepoAndWorkLocally` exists in the release-test tree (`tests/release/src/scenarios/local/config-session.ts`); there is no second copy sharing the defect.

## Proof

```
cd tests/release && npx tsc --noEmit
# 2 pre-existing unrelated errors (pg module types), unrelated to this change

npm test
# 1171 tests: 1166 pass, 5 fail — same 5 pre-existing failures as main
#   (a failed Tier-2 boot ..., staging-workflow.test.ts, manifest-agreement.test.ts,
#    tier2/evidence.test.ts, tier2/harness.test.ts)

npx tsx --test src/scenarios/local/config-session.test.ts
# 27/27 pass (unchanged — the wait lives in the production driver body,
# which per this file's existing comments is not exercisable offline)
```

No new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)