### PR TITLE
fix(product-client): suggest a valid api-key env var for opencode

### DIFF
--- a/apps/packages/product-client/src/config/harness-env-vars.test.ts
+++ b/apps/packages/product-client/src/config/harness-env-vars.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isValidEnvVarName } from "#product/lib/domain/settings/harness-auth-sources";
+import {
+  getHarnessEnvVarSuggestions,
+  PROVIDER_REGISTRY,
+} from "#product/config/harness-env-vars";
+
+describe("getHarnessEnvVarSuggestions", () => {
+  it("suggests a valid, anthropic-hinted env var for opencode first", () => {
+    const suggestions = getHarnessEnvVarSuggestions("opencode");
+    expect(suggestions.length).toBeGreaterThan(0);
+    const [first] = suggestions;
+    expect(isValidEnvVarName(first.envVarName)).toBe(true);
+    expect(first.envVarName).toBe("ANTHROPIC_API_KEY");
+    expect(first.providerHint).toBe("anthropic");
+  });
+
+  it("never surfaces a suggestion whose env-var name fails validation, even in the registry fallback", () => {
+    // Sanity-check the fixture actually contains an invalid-looking entry
+    // (e.g. a provider id starting with a digit) so this test would catch a
+    // regression rather than vacuously passing.
+    const hasInvalidRegistryEntry = PROVIDER_REGISTRY.some((provider) =>
+      provider.envVarNames.some((name) => !isValidEnvVarName(name)),
+    );
+    expect(hasInvalidRegistryEntry).toBe(true);
+
+    const suggestions = getHarnessEnvVarSuggestions("opencode");
+    for (const suggestion of suggestions) {
+      expect(isValidEnvVarName(suggestion.envVarName)).toBe(true);
+    }
+  });
+
+  it("keeps the other harnesses' hardcoded single suggestion", () => {
+    expect(getHarnessEnvVarSuggestions("claude")).toEqual([
+      { envVarName: "ANTHROPIC_API_KEY", providerHint: "anthropic" },
+    ]);
+    expect(getHarnessEnvVarSuggestions("codex")).toEqual([
+      { envVarName: "OPENAI_API_KEY", providerHint: "openai" },
+    ]);
+    expect(getHarnessEnvVarSuggestions("grok")).toEqual([
+      { envVarName: "XAI_API_KEY", providerHint: "xai" },
+    ]);
+  });
+
+  it("returns nothing for an unknown harness", () => {
+    expect(getHarnessEnvVarSuggestions("cursor")).toEqual([]);
+  });
+});

--- a/apps/packages/product-client/src/config/harness-env-vars.ts
+++ b/apps/packages/product-client/src/config/harness-env-vars.ts
@@ -2,6 +2,7 @@
 // for the "Add variable" row in each harness's auth pane — it has zero
 // bearing on server-side validation (server/proliferate/server/cloud/
 // agent_gateway/selection_rules.py is the actual source of truth there).
+import { isValidEnvVarName } from "../lib/domain/settings/harness-auth-sources";
 import providerRegistry from "./provider-registry.generated.json";
 
 export interface ProviderRegistryEntry {
@@ -27,21 +28,33 @@ const STATIC_HARNESS_ENV_VARS: Readonly<Record<string, readonly HarnessEnvVarSug
   claude: [{ envVarName: "ANTHROPIC_API_KEY", providerHint: "anthropic" }],
   codex: [{ envVarName: "OPENAI_API_KEY", providerHint: "openai" }],
   grok: [{ envVarName: "XAI_API_KEY", providerHint: "xai" }],
+  // OpenCode fronts every provider in the vendored registry, but its own
+  // catalog auth contexts (catalogs/agents/catalog.json -> opencode.authContexts)
+  // list anthropic-api / ANTHROPIC_API_KEY first as the canonical default, so
+  // lead with that rather than the first registry entry — which is ordered
+  // arbitrarily and can be an env-var name that's invalid on arrival (e.g.
+  // "302AI_API_KEY" starts with a digit and never passes ENV_VAR_NAME_RE).
+  opencode: [{ envVarName: "ANTHROPIC_API_KEY", providerHint: "anthropic" }],
 };
 
-// OpenCode has no single known key: it fronts every provider in the vendored
-// registry, so its suggestions are derived rather than hardcoded.
-const OPENCODE_ENV_VAR_SUGGESTIONS: readonly HarnessEnvVarSuggestion[] = PROVIDER_REGISTRY.flatMap(
+// Fallback suggestions derived from the vendored provider registry, used once
+// the harness-specific defaults above are exhausted (e.g. opencode after its
+// first row is taken). Suggestions whose env-var name would never pass
+// server-side validation are filtered out so a bad suggestion never surfaces.
+const REGISTRY_ENV_VAR_SUGGESTIONS: readonly HarnessEnvVarSuggestion[] = PROVIDER_REGISTRY.flatMap(
   (provider) =>
-    provider.envVarNames.map((envVarName) => ({
-      envVarName,
-      providerHint: provider.id,
-    })),
+    provider.envVarNames
+      .filter((envVarName) => isValidEnvVarName(envVarName))
+      .map((envVarName) => ({
+        envVarName,
+        providerHint: provider.id,
+      })),
 );
 
 export function getHarnessEnvVarSuggestions(harnessKind: string): readonly HarnessEnvVarSuggestion[] {
+  const staticSuggestions = STATIC_HARNESS_ENV_VARS[harnessKind] ?? [];
   if (harnessKind === "opencode") {
-    return OPENCODE_ENV_VAR_SUGGESTIONS;
+    return [...staticSuggestions, ...REGISTRY_ENV_VAR_SUGGESTIONS];
   }
-  return STATIC_HARNESS_ENV_VARS[harnessKind] ?? [];
+  return staticSuggestions;
 }


### PR DESCRIPTION
## Bug

opencode's BYOK api-key modal suggests an env var that can never validate (Tier-3 run 29631868610, cell T3-AUTHROUTE-1/local/harness=opencode; UI evidence confirmed):

- `harness-env-vars.ts` flat-maps **every** provider from `provider-registry.generated.json` in file order to build opencode's suggestions, unlike claude/codex/grok which have a hardcoded default.
- `use-harness-auth-editor.ts` picks the first unused suggestion.
- The first registry entry is `302ai` → `302AI_API_KEY`, which starts with a digit and permanently fails `ENV_VAR_NAME_RE` (`harness-auth-sources.ts`). Result: `[data-api-key-save]` stays disabled forever with a "Use SCREAMING_SNAKE_CASE" error.

## Fix

1. Give opencode a proper first suggestion: `ANTHROPIC_API_KEY` / `providerHint: "anthropic"`. Verified against `catalogs/agents/catalog.json` — opencode's own `authContexts` list `anthropic-api` (env `ANTHROPIC_API_KEY`) first, so this matches the harness's actual canonical default rather than an arbitrary registry entry.
2. Filtered the registry-derived fallback suggestions (used once opencode's static default is exhausted) through the same `isValidEnvVarName` check used for row validation, so an invalid env-var name can never surface as a suggestion in the first place.

## Tests

Added `apps/packages/product-client/src/config/harness-env-vars.test.ts`:
- opencode's first suggestion is `ANTHROPIC_API_KEY` and passes `ENV_VAR_NAME_RE`.
- the registry fallback never yields an invalid suggestion (asserts the fixture actually contains an invalid entry like `302AI_API_KEY`, so the test isn't vacuous).
- other harnesses' single hardcoded suggestion is unchanged.

`pnpm test` in `apps/packages/product-client` passes for both touched test files (`harness-env-vars.test.ts`, `harness-auth-sources.test.ts`). Full-suite `pnpm test`/`tsc --noEmit` show pre-existing unrelated failures from unbuilt workspace deps (`@proliferate/cloud-sdk`, `@anyharness/sdk`, etc.) — none touch the files in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)