### PR TITLE
test(release): type gateway-unsupported and no-eligible-model outcomes consistently

### DIFF
--- a/tests/release/src/fixtures/gateway-unsupported-harnesses.test.ts
+++ b/tests/release/src/fixtures/gateway-unsupported-harnesses.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GATEWAY_UNSUPPORTED_HARNESSES, gatewayUnsupportedMessage } from "./gateway-unsupported-harnesses.js";
+
+test("GATEWAY_UNSUPPORTED_HARNESSES contains exactly cursor (the only harness with no gateway auth slot)", () => {
+  assert.ok(GATEWAY_UNSUPPORTED_HARNESSES.has("cursor"));
+  assert.equal(GATEWAY_UNSUPPORTED_HARNESSES.size, 1);
+});
+
+test("gatewayUnsupportedMessage names the harness and the caller's context, without dropping the account-key fact", () => {
+  const message = gatewayUnsupportedMessage("cursor", "its LOCAL-4 baseline turn cannot run on the gateway-enrolled world");
+  assert.match(message, /^\[cursor\]/);
+  assert.match(message, /its LOCAL-4 baseline turn cannot run on the gateway-enrolled world/);
+  assert.match(message, /account key, not a provider key/);
+});

--- a/tests/release/src/fixtures/gateway-unsupported-harnesses.ts
+++ b/tests/release/src/fixtures/gateway-unsupported-harnesses.ts
@@ -1,0 +1,33 @@
+import type { LocalHarnessKind } from "../evidence/schema.js";
+
+/**
+ * Harness kinds that ship with NO managed-gateway auth slot in the candidate
+ * catalog (audit ruling #2, registry/catalog verified). Cursor carries an
+ * account key, not a provider key, so it can never take a gateway selection —
+ * this is a genuine product design fact (server `selection_rules.py`'s
+ * `NATIVE_ONLY_HARNESSES`), not a test gap; the server's 400 on a cursor
+ * gateway-selection PUT is CORRECT by design and must never be worked around.
+ *
+ * Every LOCAL-* collector that drives a gateway-route cell per harness
+ * (LOCAL-2/T3-CHAT-1, LOCAL-4/T3-CFG-1, LOCAL-7/T3-INT-1) must short-circuit
+ * these harnesses to a typed `blocked` outcome BEFORE attempting any gateway
+ * selection or gateway-enrolled actor — never green-required, never silently
+ * dropped, and never a hard `failed` from the server's correct 400. Single-
+ * sourced here so the set and its message stay consistent across collectors
+ * instead of drifting as independent ad-hoc copies.
+ */
+export const GATEWAY_UNSUPPORTED_HARNESSES: ReadonlySet<LocalHarnessKind> = new Set<LocalHarnessKind>(["cursor"]);
+
+/**
+ * The shared typed-unsupported message body for a gateway-unsupported
+ * harness. `context` names the specific cell/journey action that cannot run
+ * (e.g. "its LOCAL-4 baseline turn cannot run on the gateway-enrolled world"),
+ * so each collector's message stays truthful and specific while sharing the
+ * same underlying fact and wording pattern.
+ */
+export function gatewayUnsupportedMessage(harness: LocalHarnessKind, context: string): string {
+  return (
+    `[${harness}] ships with no gateway auth slot; ${context} (typed unsupported: it carries an account key, ` +
+    "not a provider key)"
+  );
+}

--- a/tests/release/src/scenarios/local/chat-authroute.test.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.test.ts
@@ -7,6 +7,7 @@ import {
   GATEWAY_PROVIDER_ID,
   HARNESSES_WITHOUT_GATEWAY_AUTH_SLOT,
   LOCAL6_REPRESENTATIVE_HARNESS,
+  NoEligibleGatewayModelError,
   assertOpencodeProviderSource,
   buildLocalRouteTurnEvidence,
   collectLocal2GatewayCells,
@@ -360,6 +361,22 @@ test("LOCAL-2: an empty assistant reply fails the cell and still closes the worl
   assert.ok(calls.includes("closeWorld"));
 });
 
+test("LOCAL-2: no eligible gateway model (live probe ∩ allowlist empty) maps to a typed blocked cell, not failed", async () => {
+  const { driver, calls } = fakeDriver();
+  driver.resolveRouteModel = async (_w, _p, harness, route) => {
+    calls.push(`resolveRouteModel:${harness}:${route}`);
+    throw new NoEligibleGatewayModelError(
+      `[${harness}] no eligible non-Fable gateway model in the intersection of the qualification allowlist ` +
+        "and AnyHarness's live gateway probe",
+    );
+  };
+  const [outcome] = await collectLocal2GatewayCells(fakeCtx(), [cell("T3-CHAT-1", { harness: "grok" })], driver);
+  assert.equal(outcome.status, "blocked");
+  assert.equal(outcome.reason?.code, "scenario_blocked");
+  assert.match(outcome.reason?.message ?? "", /no eligible non-Fable gateway model/);
+  assert.ok(calls.includes("closeWorld"));
+});
+
 // ── LOCAL-3 (user-key per harness) ─────────────────────────────────────────────
 
 test("LOCAL-3: a user-key harness is green with route=user_key, zero-isolation, and no gateway spend", async () => {
@@ -455,6 +472,26 @@ test("LOCAL-6: a route switch that reuses the same session id fails (route not p
   const outcome = await collectLocal6RouteChangeCell(fakeCtx(), cell("T3-AUTHROUTE-1", { route: "change" }), driver);
   assert.equal(outcome.status, "failed");
   assert.match(outcome.reason?.message ?? "", /new session/i);
+});
+
+test("LOCAL-6: no eligible gateway model on the route=change gateway leg maps to a typed blocked cell, not failed", async () => {
+  const { driver, calls } = fakeDriver();
+  driver.resolveRouteModel = async (_w, _p, harness, route) => {
+    calls.push(`resolveRouteModel:${harness}:${route}`);
+    if (route === "gateway") {
+      throw new NoEligibleGatewayModelError(
+        `[${harness}] no eligible non-Fable gateway model in the intersection of the qualification allowlist ` +
+          "and AnyHarness's live gateway probe",
+      );
+    }
+    return { route, modelId: "claude-haiku-4-5", providerId: "anthropic" };
+  };
+  const outcome = await collectLocal6RouteChangeCell(fakeCtx(), cell("T3-AUTHROUTE-1", { route: "change" }), driver);
+  assert.equal(outcome.status, "blocked");
+  assert.equal(outcome.reason?.code, "scenario_blocked");
+  assert.match(outcome.reason?.message ?? "", /no eligible non-Fable gateway model/);
+  // The user-key leg ran first and succeeded before the gateway leg's block.
+  assert.ok(calls.includes("sendBoundedTurn:user_key"));
 });
 
 // ── Batch lifecycle: world construction, cleanup, non-world-backed ────────────

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -29,6 +29,10 @@ import type {
   LocalRoute,
   LocalRouteTurnEvidenceV1,
 } from "../../evidence/schema.js";
+import {
+  GATEWAY_UNSUPPORTED_HARNESSES,
+  gatewayUnsupportedMessage,
+} from "../../fixtures/gateway-unsupported-harnesses.js";
 
 /**
  * LOCAL-2 (managed gateway turn per harness), LOCAL-3 (user API-key turn per
@@ -98,9 +102,7 @@ export const GATEWAY_PROVIDER_ID = "proliferate";
  * matrix their cell is the truthful typed `blocked` (unsupported) result — never
  * green-required, never dropped. Cursor is the only such kind today.
  */
-export const HARNESSES_WITHOUT_GATEWAY_AUTH_SLOT: ReadonlySet<LocalHarnessKind> = new Set<LocalHarnessKind>([
-  "cursor",
-]);
+export const HARNESSES_WITHOUT_GATEWAY_AUTH_SLOT: ReadonlySet<LocalHarnessKind> = GATEWAY_UNSUPPORTED_HARNESSES;
 
 /**
  * How a harness selects its model on each route (BRIEF §"BYOK input mapping"):
@@ -348,7 +350,7 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
         probe.map((model) => model.id),
       );
       if (!modelId) {
-        throw new Error(
+        throw new NoEligibleGatewayModelError(
           `[${harness}] no eligible non-Fable gateway model in the intersection of the qualification ` +
             "allowlist and AnyHarness's live gateway probe",
         );
@@ -682,10 +684,11 @@ async function runLocal2GatewayCell(
       status: "blocked",
       reason: {
         code: "scenario_blocked",
-        message:
-          `[${harness}] the candidate catalog ships no managed-gateway auth slot for this harness, so the ` +
-          "managed gateway route is unsupported (it carries an account key, not a provider key); this cell is " +
-          "the truthful typed-unsupported result and is never green-required",
+        message: gatewayUnsupportedMessage(
+          harness,
+          "the managed gateway route (LOCAL-2) is unsupported for it; this cell is the truthful typed-unsupported " +
+            "result and is never green-required",
+        ),
       },
     };
   }
@@ -1023,6 +1026,14 @@ function harnessOf(cell: PlannedCellV1): LocalHarnessKind {
 }
 
 function failedPending(cell: PlannedCellV1, error: unknown): PendingRouteCell {
+  if (error instanceof NoEligibleGatewayModelError) {
+    return {
+      cellId: cell.cell_id,
+      kind: "terminal",
+      status: "blocked",
+      reason: { code: "scenario_blocked", message: error.message },
+    };
+  }
   return {
     cellId: cell.cell_id,
     kind: "terminal",
@@ -1112,6 +1123,19 @@ function cssAttr(value: string): string {
  * silently-weakened assertion.
  */
 export class CloudSurfaceGatedError extends Error {}
+
+/**
+ * Thrown from `resolveRouteModel`'s gateway branch when the intersection of
+ * the qualification allowlist and AnyHarness's live gateway probe is empty
+ * for a harness. This is a live-gateway/allowlist intersection gap in the
+ * running environment — NOT an unsupported product combo (unlike
+ * `GATEWAY_UNSUPPORTED_HARNESSES`, which is permanent) — so it maps to a
+ * typed `blocked` outcome, identical in kind to `NoEligibleMcpModelError`
+ * (integration-mcp.ts) for the same underlying condition. The cell must
+ * resume running normally the instant the gateway serves eligible models
+ * again; nothing here weakens or removes the eligibility check itself.
+ */
+export class NoEligibleGatewayModelError extends Error {}
 
 /** The Agents-scope settings sidebar label for each harness (fix round 3: the
  * user-key surface lives on the per-harness settings pane, reached via the

--- a/tests/release/src/scenarios/local/config-session.ts
+++ b/tests/release/src/scenarios/local/config-session.ts
@@ -21,6 +21,10 @@ import { resolveWorldConstructionInputs } from "../local-world-smoke-1.js";
 import { bootLocalFunctionalWorld, type LocalFunctionalWorldInputs } from "./world-boot.js";
 import { captureLocalDriverFailure } from "./debug-capture.js";
 import { resolveLocalWorkspaceSessionId } from "./local-session.js";
+import {
+  GATEWAY_UNSUPPORTED_HARNESSES,
+  gatewayUnsupportedMessage,
+} from "../../fixtures/gateway-unsupported-harnesses.js";
 
 /**
  * LOCAL-4 (live configuration matrix, per harness) under `T3-CFG-1/local`, and
@@ -57,11 +61,6 @@ export const BASELINE_PROMPT = "Reply with exactly the word: pong";
  * to a second shipped kind so the tab/session replacement is observable. */
 export const SESSION_TABS_START_HARNESS: LocalHarnessKind = "claude";
 export const SESSION_TABS_SWITCH_HARNESS: LocalHarnessKind = "codex";
-
-/** Cursor ships with no gateway auth slot; its LOCAL-4 baseline turn cannot run
- * on the gateway-enrolled world, so its cell is the truthful typed `blocked`
- * (mirroring LOCAL-2's cursor treatment) — never green, never silently dropped. */
-const GATEWAY_UNSUPPORTED_HARNESSES: ReadonlySet<LocalHarnessKind> = new Set(["cursor"]);
 
 /** Bounded waits for the live browser flow (kept generous but finite). */
 const HARNESS_READY_TIMEOUT_MS = 300_000;
@@ -336,7 +335,10 @@ export async function collectLocal4ConfigCells(
           cell,
           outcome: {
             kind: "blocked",
-            message: `[${harness}] ships with no gateway auth slot; its LOCAL-4 baseline turn cannot run on the gateway-enrolled world (typed unsupported)`,
+            message: gatewayUnsupportedMessage(
+              harness,
+              "its LOCAL-4 baseline turn cannot run on the gateway-enrolled world",
+            ),
           },
         });
         continue;

--- a/tests/release/src/scenarios/local/integration-mcp.test.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.test.ts
@@ -178,8 +178,8 @@ test("runLocal7McpCellsAgainstWorld: a per-cell failure does not affect its sibl
   const driver: LocalMcpDriver = {
     ...base,
     runIntegrationTurn: async (_world, _page, harness) => {
-      if (harness === "cursor") {
-        throw new Error("cursor turn errored");
+      if (harness === "grok") {
+        throw new Error("grok turn errored");
       }
       return {
         workspaceId: `ws-${harness}`,
@@ -190,13 +190,35 @@ test("runLocal7McpCellsAgainstWorld: a per-cell failure does not affect its sibl
       };
     },
   };
-  const cells = [fakeCell("claude"), fakeCell("cursor")];
+  const cells = [fakeCell("claude"), fakeCell("grok")];
 
   const outcomes = await runLocal7McpCellsAgainstWorld(world, cells, driver);
 
   assert.equal(outcomes[0]!.status, "green");
   assert.equal(outcomes[1]!.status, "failed");
-  assert.match(outcomes[1]!.reason!.message, /cursor turn errored/);
+  assert.match(outcomes[1]!.reason!.message, /grok turn errored/);
+});
+
+test("runLocal7McpCellsAgainstWorld: cursor is short-circuited to blocked before any gateway selection PUT (createActor never called)", async () => {
+  const closed = { value: 0 };
+  const world = fakeWorld();
+  const base = greenDriver(closed);
+  let createActorCalled = false;
+  const driver: LocalMcpDriver = {
+    ...base,
+    createActor: async (_world, harness) => {
+      createActorCalled = true;
+      return fakeActor(harness);
+    },
+  };
+  const cells = [fakeCell("cursor")];
+
+  const outcomes = await runLocal7McpCellsAgainstWorld(world, cells, driver);
+
+  assert.equal(outcomes[0]!.status, "blocked");
+  assert.equal(outcomes[0]!.reason!.code, "scenario_blocked");
+  assert.match(outcomes[0]!.reason!.message, /no gateway auth slot/);
+  assert.equal(createActorCalled, false);
 });
 
 test("runLocal7McpCellsAgainstWorld: a real audit query failure stays failed", async () => {

--- a/tests/release/src/scenarios/local/integration-mcp.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.ts
@@ -35,6 +35,10 @@ import type {
   LocalHarnessKind,
   LocalMcpIntegrationEvidenceV1,
 } from "../../evidence/schema.js";
+import {
+  GATEWAY_UNSUPPORTED_HARNESSES,
+  gatewayUnsupportedMessage,
+} from "../../fixtures/gateway-unsupported-harnesses.js";
 
 /**
  * LOCAL-7 (Product MCP integration for every harness) under `T3-INT-1/local/
@@ -381,6 +385,22 @@ export async function runLocal7McpCellsAgainstWorld(
 
   for (const cell of cells) {
     const harness = (cell.dimensions.harness ?? "claude") as LocalHarnessKind;
+    if (GATEWAY_UNSUPPORTED_HARNESSES.has(harness)) {
+      // Short-circuit BEFORE createActor: `authenticatedActor` unconditionally
+      // PUTs a gateway selection for the requested harness, and the server
+      // correctly 400s that PUT for a gateway-unsupported harness (cursor
+      // carries an account key, not a provider key — see
+      // gateway-unsupported-harnesses.ts). That 400 is by design, not a
+      // failure to mask; type this cell blocked the same way LOCAL-2/LOCAL-4
+      // already do for the identical fact.
+      entries.push({
+        cell,
+        ok: false,
+        status: "blocked",
+        message: gatewayUnsupportedMessage(harness, "its LOCAL-7 MCP integration turn cannot run on the gateway-enrolled world"),
+      });
+      continue;
+    }
     try {
       const actor = await driver.createActor(world, harness);
       await world.trackActorSubjects?.(actor.gatewayKey);


### PR DESCRIPTION
## Both defects (run 29631868610)

**T3-INT-1 cursor cell hard-fails (400) instead of typed-blocked.** `runLocal7McpCellsAgainstWorld` (integration-mcp.ts) calls `authenticatedActor(world,"owner",{harnessKind: harness})` for every cell including cursor. That fixture unconditionally PUTs a gateway selection, and the server correctly 400s it — `NATIVE_ONLY_HARNESSES=("cursor",)` in `selection_rules.py` means cursor can never take a gateway route (it carries an account key, not a provider key). This is correct server behavior, not a test gap; CFG-1 (config-session.ts) and CHAT-1 (chat-authroute.ts) already type cursor as `blocked` for the identical fact. Not a regression of #1376/#1378 — the setup-404 bug (fixed by #1376) was previously masking this.

**T3-CHAT-1 classifies the same no-eligible-model condition as `failed` where T3-INT-1 classifies it `blocked`.** integration-mcp.ts's `NoEligibleMcpModelError` (thrown when the qualification allowlist ∩ AnyHarness's live gateway probe is empty) is caught and mapped to `blocked`. chat-authroute.ts's `resolveRouteModel` gateway branch threw a plain `Error` for the identical condition, which fell into `failedPending` → `failed`. This is an environment-probe gap (blocked is truthful), not a permanently-unsupported combo — the cell must resume running the moment the gateway serves eligible models again.

## Fixes

1. Added `tests/release/src/fixtures/gateway-unsupported-harnesses.ts`: single-sourced `GATEWAY_UNSUPPORTED_HARNESSES` set + `gatewayUnsupportedMessage()` helper, now referenced by `config-session.ts`, `chat-authroute.ts` (`HARNESSES_WITHOUT_GATEWAY_AUTH_SLOT`), and `integration-mcp.ts` — replacing three independent ad-hoc copies.
2. `integration-mcp.ts`: short-circuit cursor cells to a typed `blocked` outcome BEFORE `driver.createActor` — no gateway-selection PUT is ever attempted for cursor.
3. `chat-authroute.ts`: added `NoEligibleGatewayModelError`, thrown from `resolveRouteModel`'s gateway branch instead of a plain `Error`; `failedPending` now maps it to `blocked` (`scenario_blocked`), covering both `runLocal2GatewayCell` and the LOCAL-6 `route=change` gateway leg. `services/qualification-litellm.ts` eligibility logic is untouched.

## Proof

- No server code touched (`selection_rules.py` untrue behavior confirmed correct by design).
- No `release-e2e.yml` / #1373 changes.
- Did not touch `authenticated-actor.ts` or `world-boot.ts` (avoided per instructions — another in-flight PR edits those for claim-cache eviction).
- No assertions deleted; new regressions added:
  - cursor-in-INT-1 → `blocked`, `createActor` never called (proves no selection PUT attempted)
  - `NoEligibleGatewayModelError` → `blocked` in LOCAL-2 and LOCAL-6's gateway leg
  - new `gateway-unsupported-harnesses.test.ts` for the shared module
- `cd tests/release && npx tsc --noEmit && npm test`:
  - `tsc --noEmit`: only pre-existing unrelated `pg` module errors in `../intent/stack/*.ts` (confirmed present on `origin/main` before this change, outside `tests/release`'s own tree)
  - `npm test`: 1176 tests, 1171 pass, 5 fail — the same 5 pre-existing failures as before this change (`staging-workflow.test.ts`, `manifest-agreement.test.ts`, `tier2/evidence.test.ts`, `tier2/harness.test.ts`, one Tier-2-boot subtest), none touching the files in this PR. No NEW failures.
  - Isolated run of the 4 touched/new test files: 62/62 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)