### PR TITLE
fix(cloud): commit workspace creation before response

### DIFF
--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -73,7 +73,11 @@ async def list_cloud_workspaces_endpoint(
 async def create_cloud_workspace_endpoint(
     body: CreateCloudWorkspaceRequest,
     user: User = Depends(current_product_user),
-    db: AsyncSession = Depends(get_async_session),
+    # Workspace provisioning performs remote work before its final Cloud row
+    # write. Commit that final request transaction before the response starts so
+    # a caller disconnect cannot observe success while dependency teardown rolls
+    # the workspace back.
+    db: AsyncSession = Depends(get_async_session, scope="function"),
 ) -> WorkspaceDetail:
     try:
         return await create_cloud_workspace_for_user(db, user, body)

--- a/server/tests/unit/test_cloud_workspace_transaction.py
+++ b/server/tests/unit/test_cloud_workspace_transaction.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from starlette.types import Message, Receive, Scope, Send
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.server.cloud.workspaces import api
+from proliferate.server.cloud.workspaces.models import (
+    RepoRef,
+    WorkspaceDetail,
+    WorkspaceRuntimeSummary,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_commit_finishes_before_response_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful create is durable before the caller can observe it."""
+    app = FastAPI()
+    app.include_router(api.router, prefix="/v1/cloud")
+    commits_finished = 0
+    commits_at_response_start: list[int] = []
+
+    async def observed_session() -> AsyncGenerator[object, None]:
+        nonlocal commits_finished
+        yield object()
+        commits_finished += 1
+
+    async def product_user() -> SimpleNamespace:
+        return SimpleNamespace(id="00000000-0000-0000-0000-000000000001")
+
+    async def create_workspace(*_args: object, **_kwargs: object) -> WorkspaceDetail:
+        return WorkspaceDetail(
+            id="00000000-0000-0000-0000-000000000002",
+            workspace_kind="repositoryWorktree",
+            repo_environment_id="00000000-0000-0000-0000-000000000003",
+            display_name="workspace",
+            repo=RepoRef(
+                provider="github",
+                owner="owner",
+                name="repo",
+                branch="workspace",
+                base_branch="main",
+            ),
+            status="ready",
+            workspace_status="ready",
+            product_lifecycle="active",
+            runtime=WorkspaceRuntimeSummary(status="running"),
+            anyharness_workspace_id="runtime-workspace",
+        )
+
+    app.dependency_overrides[get_async_session] = observed_session
+    app.dependency_overrides[current_product_user] = product_user
+    monkeypatch.setattr(api, "create_cloud_workspace_for_user", create_workspace)
+
+    async def observed_app(scope: Scope, receive: Receive, send: Send) -> None:
+        async def observe_response_start(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                commits_at_response_start.append(commits_finished)
+            await send(message)
+
+        await app(scope, receive, observe_response_start)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=observed_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/v1/cloud/workspaces",
+            json={
+                "gitOwner": "owner",
+                "gitRepoName": "repo",
+                "branchName": "workspace",
+            },
+        )
+
+    assert response.status_code == 200
+    assert commits_at_response_start == [1]

--- a/specs/codebase/platforms/product/workspace-provisioning.md
+++ b/specs/codebase/platforms/product/workspace-provisioning.md
@@ -194,7 +194,13 @@ performs the current synchronous flow:
 11. when this is an exact-ref Desktop source flow, require the local descriptor
     to match the independently verified HEAD and record the owned local
     association (a conflict fails the request rather than reporting success);
-12. commit the request transaction after the handler returns successfully.
+12. commit the final request transaction after the handler returns successfully
+    and before the HTTP response starts.
+
+The create route uses a function-scoped request session for that last boundary.
+This matters because repository materialization and AnyHarness creation can
+outlive a caller or proxy connection: a success response is never started until
+the Cloud workspace id and managed materialization are durable.
 
 Desktop clone and open-on-Mac use caller-supplied idempotency ledgers in
 AnyHarness. Clone operation ids are scoped to the chosen destination and reused


### PR DESCRIPTION
## Summary

- commit Cloud workspace creation before the success response starts
- prevent a caller or proxy disconnect from rolling back a successfully provisioned workspace
- add an ASGI-boundary regression and document the durable transaction contract

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `DEBUG=true uv run --extra dev pytest -q tests/unit/test_cloud_workspace_provisioning.py tests/unit/test_cloud_workspace_status.py tests/unit/test_cloud_workspace_materialization_summaries.py tests/unit/test_cloud_workspace_transaction.py` (25 passed)
- `DEBUG=true uv run --extra dev ruff check proliferate/server/cloud/workspaces/api.py tests/unit/test_cloud_workspace_transaction.py`
- `DEBUG=true uv run --extra dev mypy proliferate/server/cloud/workspaces/api.py tests/unit/test_cloud_workspace_transaction.py`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`