### PR TITLE
feat(chat): render user prompts as markdown

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -1,8 +1,6 @@
-import { Fragment } from "react";
 import type { ContentPart } from "@anyharness/sdk";
 import { FileIcon, Link2, Spinner, X } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { FilePathLink } from "#product/components/content/ui/FilePathLink";
 import { FileTreeEntryIcon } from "#product/components/workspace/files/file-icons";
 import { PlanReferenceAttachmentCard } from "#product/components/workspace/chat/content/PlanReferenceAttachmentCard";
 import { usePromptAttachmentUrl } from "#product/hooks/access/anyharness/sessions/use-prompt-attachment-url";
@@ -13,9 +11,8 @@ import {
   type PromptDisplayPart,
 } from "@proliferate/product-domain/chats/composer/prompt-display-parts";
 import type { PromptDraftAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
-import { tokenizeSerializedFileLinks } from "#product/lib/domain/chat/composer/file-mention-links";
-import { useChatContentSearchPaint } from "@proliferate/product-ui/chat/transcript/ChatContentSearchContext";
-import { markSearchChildren } from "@proliferate/product-ui/chat/transcript/MarkdownContentSearchMarks";
+import { MarkdownBody } from "@proliferate/product-ui/chat/transcript/MarkdownBody";
+import { renderTranscriptLink } from "#product/components/workspace/chat/transcript/transcript-markdown";
 
 type PromptContentRendererVariant = "transcript" | "compact";
 type PromptContentRendererLayout = "stack" | "wrap" | "auto";
@@ -128,32 +125,13 @@ function PromptDisplayPartView({
 }
 
 function FileLinkedText({ text }: { text: string }) {
-  const tokens = tokenizeSerializedFileLinks(text);
-  // Chat content-search paint for user-message prose. Only applies inside a
-  // committed transcript turn row (not the composer or in-flight prompt rows,
-  // which the search index doesn't cover).
-  const paint = useChatContentSearchPaint();
-  const searchPaint = paint?.rowUnitId.startsWith("chatrow:turn:") ? paint : null;
-
   return (
-    <div className="whitespace-pre-wrap break-words text-[length:var(--prose-text-size,var(--text-chat))] leading-[var(--prose-text-line-height,var(--text-chat--line-height))]">
-      {tokens.map((token, index) => {
-        if (token.type === "text") {
-          return (
-            <Fragment key={`text-${index}`}>
-              {searchPaint
-                ? markSearchChildren(token.text, searchPaint.query, searchPaint.rowUnitId)
-                : token.text}
-            </Fragment>
-          );
-        }
-        return (
-          <FilePathLink key={`${token.path}-${index}`} rawPath={token.path}>
-            {token.label}
-          </FilePathLink>
-        );
-      })}
-    </div>
+    <MarkdownBody
+      content={text}
+      renderLink={renderTranscriptLink}
+      enableContentSearch
+      className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+    />
   );
 }
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx
@@ -1,13 +1,20 @@
 // @vitest-environment jsdom
 
 import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
 import type { ContentPart } from "@anyharness/sdk";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   PLAN_IMPLEMENT_HERE_PROMPT,
   PLAN_IMPLEMENT_HERE_ROW_LABEL,
 } from "#product/copy/plans/plan-prompts";
 import { UserMessage } from "#product/components/workspace/chat/transcript/UserMessage";
+
+vi.mock("#product/components/content/ui/FilePathLink", () => ({
+  FilePathLink: ({ rawPath, children }: { rawPath: string; children?: ReactNode }) => (
+    <span data-file-path-link={rawPath}>{children ?? rawPath}</span>
+  ),
+}));
 
 afterEach(() => {
   cleanup();
@@ -60,6 +67,36 @@ describe("UserMessage", () => {
 
     expect(container.querySelector("[data-carry-out-plan-row]")).toBeNull();
     expect(container.querySelector("[data-chat-user-message]")).toBeTruthy();
+  });
+
+  it("renders sent user prose as Markdown while preserving workspace file links", () => {
+    const { container } = render(
+      <UserMessage
+        sessionId="session-1"
+        content={"**Bold** and _italic_\n\n- first\n- second\n\n[Docs](https://example.com) and [file](src/main.ts)"}
+        contentParts={[]}
+      />,
+    );
+
+    expect(container.querySelector("strong")?.textContent).toBe("Bold");
+    expect(container.querySelector("em")?.textContent).toBe("italic");
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector('a[href="https://example.com"]')).toBeTruthy();
+    expect(container.querySelector("[data-file-path-link]")?.textContent).toContain("file");
+  });
+
+  it("does not execute raw HTML or unsafe Markdown links", () => {
+    const { container } = render(
+      <UserMessage
+        sessionId="session-1"
+        content={'<script>alert("no")</script> [unsafe](javascript:alert(1))'}
+        contentParts={[]}
+      />,
+    );
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector('a[href^="javascript:"]')).toBeNull();
+    expect(container.textContent).toContain("<script>");
   });
 });
 

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -73,6 +73,16 @@ path.
 
 ## Markdown File Mentions And Code Blocks
 
+Committed user-message prose renders through the shared `MarkdownBody` GFM
+surface rather than as plain pre-wrapped text. Bold, italic, lists, links, and
+other supported Markdown therefore render after submission. Raw HTML remains
+text and unsafe URL protocols remain blocked. Product-client injects the same
+workspace-aware link renderer used by assistant prose, so serialized workspace
+file links continue to open in the file viewer while external links retain the
+shared web-link presentation. User prose opts into transcript content-search
+painting and removes only the outer first/last Markdown margins so the existing
+message-bubble rhythm remains authoritative.
+
 Assistant markdown renders file references as clickable file mentions and code
 blocks as bordered highlighted cards. Ownership is split by package law:
 


### PR DESCRIPTION
## Summary
- render committed human-message prose through the shared GFM Markdown surface
- preserve workspace file-link routing and transcript content-search highlighting
- keep raw HTML inert and unsafe URL protocols blocked

## Proof
- `pnpm --filter @proliferate/product-client build`
- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/transcript/UserMessage.test.tsx --reporter=dot`
- `python3 scripts/check_docs.py`
- `git diff --check`

## Dependency
- Independent first slice; the rich-composer PR will stack on this branch until this PR merges.