### PR TITLE
fix(product-client): honor cloud-only default branches

### DIFF
--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-repository-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-repository-selection.ts
@@ -95,8 +95,18 @@ export function useHomeNextRepositorySelection({
       repoRootDefaultBranch: selectedRepoRoot?.defaultBranch
         ?? selectedRepository?.defaultBranch
         ?? null,
+      // A cloud-only repository intentionally has no local repo root or branch
+      // query. Its server-validated cloud environment default is therefore the
+      // authoritative base branch instead of a value to cross-check locally.
+      acceptRepoDefaultWithoutLocalBranch: selectedRepositoryIsCloudOnly,
     })
-  ), [branchRefs, repoConfigs, selectedRepoRoot?.defaultBranch, selectedRepository]);
+  ), [
+    branchRefs,
+    repoConfigs,
+    selectedRepoRoot?.defaultBranch,
+    selectedRepository,
+    selectedRepositoryIsCloudOnly,
+  ]);
   const branchOptions = useMemo(() => {
     const localBranches = localBranchNames(branchRefs);
     if (localBranches.length > 0 || !selectedRepositoryIsCloudOnly || !defaultBranchName) {

--- a/apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts
@@ -113,6 +113,15 @@ describe("home-next branch helpers", () => {
     })).toBe("trunk");
   });
 
+  it("uses the configured cloud-only default when no local branch inventory exists", () => {
+    expect(resolveHomeNextDefaultBranchName({
+      branchRefs: [],
+      savedDefaultBranch: "stale-local-preference",
+      repoRootDefaultBranch: "main",
+      acceptRepoDefaultWithoutLocalBranch: true,
+    })).toBe("main");
+  });
+
   it("falls back to git default and then the first local branch without inventing main", () => {
     expect(resolveHomeNextDefaultBranchName({
       branchRefs: [branch({ name: "zebra" }), branch({ name: "alpha", isDefault: true })],

--- a/apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts
@@ -122,6 +122,13 @@ describe("home-next branch helpers", () => {
     })).toBe("main");
   });
 
+  it("does not trust a configured default without the cloud-only opt-in", () => {
+    expect(resolveHomeNextDefaultBranchName({
+      branchRefs: [],
+      repoRootDefaultBranch: "main",
+    })).toBeNull();
+  });
+
   it("falls back to git default and then the first local branch without inventing main", () => {
     expect(resolveHomeNextDefaultBranchName({
       branchRefs: [branch({ name: "zebra" }), branch({ name: "alpha", isDefault: true })],

--- a/apps/packages/product-client/src/lib/domain/home/home-next-launch.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-next-launch.ts
@@ -201,6 +201,7 @@ export function resolveHomeNextDefaultBranchName(input: {
   branchRefs: GitBranchRef[];
   savedDefaultBranch?: string | null;
   repoRootDefaultBranch?: string | null;
+  acceptRepoDefaultWithoutLocalBranch?: boolean;
 }): string | null {
   const branchNames = localBranchNames(input.branchRefs);
   const branchNameSet = new Set(branchNames);
@@ -210,7 +211,10 @@ export function resolveHomeNextDefaultBranchName(input: {
   }
 
   const repoRootDefaultBranch = input.repoRootDefaultBranch?.trim();
-  if (repoRootDefaultBranch && branchNameSet.has(repoRootDefaultBranch)) {
+  if (
+    repoRootDefaultBranch
+    && (branchNameSet.has(repoRootDefaultBranch) || input.acceptRepoDefaultWithoutLocalBranch)
+  ) {
     return repoRootDefaultBranch;
   }
 


### PR DESCRIPTION
## Summary

- let the home launch-target resolver accept the server-configured repository default when a cloud-only repository intentionally has no local branch inventory
- preserve local/worktree behavior: saved and repository defaults still must occur in the fetched local branch set
- add the regression caught by managed-cloud Tier 3

## Root cause and evidence

Exact-head strict run https://github.com/proliferate-ai/proliferate/actions/runs/29634664304 reached a healthy managed-cloud world and selected the covered cloud-only repository plus Cloud runtime. The API evidence carried `defaultBranch: "main"`, but the composer stayed disabled at `Choose a base branch`.

`useHomeNextRepositorySelection` correctly skips the local branch query for cloud-only repositories. `resolveHomeNextDefaultBranchName` then rejected the configured default because it was absent from that intentionally empty local branch set. This repair makes that trust decision explicit only for cloud-only repositories.

Closes #1394.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/home/home-next-launch.test.ts` — 20\/20 green
- `pnpm --filter @proliferate/product-client typecheck` — green
- `git diff --check origin/main...HEAD` — green

## Scope

No release-harness behavior, server API, provider cleanup, or stable ingress/TLS change.