### PR TITLE
test(release): return LOCAL-4 batch to Home between cells

### DIFF
--- a/tests/release/src/scenarios/local/config-session.ts
+++ b/tests/release/src/scenarios/local/config-session.ts
@@ -927,19 +927,29 @@ async function ensureHarnessReady(world: ReadyLocalWorld, page: ProductPage, har
 
 async function selectRepoAndWorkLocally(page: ProductPage, repo: PreparedRepository): Promise<void> {
   const p = page.page;
-  // `ensureHarnessReady`'s preceding reload re-mounts the home screen; its
-  // generic composer/tab-strip wait settles for DOM presence but not for the
-  // Project-menu trigger's own mount, so an immediate click here can race
-  // that mount (run 29631868610: 30s "locator.click" timeout on this button,
-  // with ERR_ABORTED launch-options/reconcile polls in the network log
-  // showing they were cancelled by the reload — a pure collector settle
-  // race, not a product defect: HomeNextScreen renders the Project button
-  // unconditionally). Wait for the trigger to be visible AND enabled before
-  // clicking, with a timeout aligned to the harness-ready budget instead of
-  // Playwright's 30s click-actionability default.
   const projectTrigger = p.getByRole("button", { name: /^Project:/ }).first();
-  await projectTrigger.waitFor({ state: "visible", timeout: HARNESS_READY_TIMEOUT_MS });
-  await waitForEnabled(projectTrigger, HARNESS_READY_TIMEOUT_MS, "Project: trigger");
+
+  // LOCAL-4 deliberately reuses one renderer page across the harness matrix.
+  // After the first cell creates a workspace, `ensureHarnessReady` reloads that
+  // active workspace shell; it does not return to Home. The old collector then
+  // waited five minutes for a Project trigger that only exists on Home (run
+  // 29631868610's captured HTML has `data-workspace-shell` and the chat
+  // composer, with no Project trigger). Use the real sidebar navigation before
+  // selecting the next cell's repository. This preserves the real renderer and
+  // Worker/enrollment boundary; it only restores the UI surface the collector
+  // requires.
+  if (!await projectTrigger.isVisible().catch(() => false)) {
+    const newChatNav = p.locator("nav").getByRole("button", { name: "New chat" }).first();
+    await newChatNav.waitFor({ state: "visible", timeout: 30_000 });
+    await newChatNav.click();
+    await p
+      .locator("[data-home-composer-editor]")
+      .first()
+      .waitFor({ state: "visible", timeout: 30_000 });
+  }
+
+  await projectTrigger.waitFor({ state: "visible", timeout: 30_000 });
+  await waitForEnabled(projectTrigger, 30_000, "Project: trigger");
   await projectTrigger.click();
   const repoRow = p.locator(`[data-repo-source-root="${cssAttr(repo.path)}"]`).first();
   await repoRow.waitFor({ state: "visible", timeout: 20_000 });


### PR DESCRIPTION
## Root cause

`collectLocal4ConfigCells` deliberately reuses one renderer page across the harness matrix. After the first (Claude) cell materializes a workspace, `ensureHarnessReady` reloads that active workspace shell. The next cell then waited for the Home-only `Project:` trigger.

Run 29631868610 captured the exact state for codex/grok/opencode: `data-workspace-shell="true"` plus `data-chat-composer-editor`, and no `Project:` trigger. This is not a late mount or a Worker/readiness shortcut; the collector was on the wrong genuine product surface.

## Fix

When the `Project:` trigger is absent, `selectRepoAndWorkLocally` now clicks the real sidebar `New chat` navigation and waits for the real Home composer before selecting the repository and `Work locally`. The renderer, worker enrollment, route sync, model probe, and launch readiness all remain real.

The old five-minute Project-trigger wait is reduced to the normal bounded 30-second UI settle after the correct surface is established.

## Verification

- `pnpm exec tsx --test src/scenarios/local/config-session.test.ts` — 27/27 pass.
- `pnpm exec tsc --noEmit` from `tests/release` — pass.
- `git diff --check` — pass.

The current post-#1388 diagnostic run 29633821275 is still in flight; this PR remains draft until its artifact confirms the same signature on that exact head.