### PR TITLE
feat(chat): unify rich composer surfaces

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -19,6 +19,7 @@ import type {
   HomeNextModelSelection,
   ModelAvailabilityState,
 } from "#product/lib/domain/home/home-next-launch";
+import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 
 // Surfaces whose React commits are attributed to a home `composer_typing`
 // operation. If the render-isolation is working, only "home-composer" should
@@ -106,7 +107,11 @@ export function HomeComposerForm({
   // (no-op unless VITE_PROLIFERATE_DEBUG_MAIN_THREAD is enabled).
   const typingOperationRef = useRef<MeasurementOperationId | null>(null);
   const setDraft = composer.setDraft;
-  const handleDraftChange = useCallback((value: string, eventTimeStampMs?: number) => {
+  const handleDraftChange = useCallback((
+    value: string,
+    eventTimeStampMs: number | undefined,
+    snapshot: ChatComposerEditorSnapshot,
+  ) => {
     const operationId = startMeasurementOperation({
       kind: "composer_typing",
       sampleKey: "composer",
@@ -124,7 +129,7 @@ export function HomeComposerForm({
       surface: "home-composer",
       eventTimeStampMs,
     });
-    setDraft(value);
+    setDraft(value, snapshot);
   }, [setDraft]);
   useEffect(() => () => {
     finishOrCancelMeasurementOperation(typingOperationRef.current, "unmount");
@@ -152,8 +157,12 @@ export function HomeComposerForm({
             >
               <ComposerRichTextEditor
                 value={composer.draft}
+                snapshot={composer.editorSnapshot}
                 onChange={handleDraftChange}
                 onKeyDown={composer.handleKeyDown}
+                submitBehavior="home"
+                canSubmit={composer.canSubmit}
+                onSubmit={() => { void composer.submit(); }}
                 placeholder={CHAT_COMPOSER_LABELS.placeholder}
                 disabled={false}
                 surface="home"

--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -4,7 +4,7 @@ import { CHAT_COMPOSER_LABELS } from "#product/copy/chat/chat-copy";
 import { ChatComposerActions } from "#product/components/workspace/chat/input/ChatComposerActions";
 import { ChatComposerControlRowFrame } from "@proliferate/product-ui/chat/composer/ChatComposerControlRowFrame";
 import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
-import { ComposerTextarea } from "@proliferate/ui/primitives/ComposerTextarea";
+import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { useHomeNextComposerState } from "#product/hooks/home/ui/use-home-next-composer-state";
 import {
@@ -150,23 +150,14 @@ export function HomeComposerForm({
                 maxHeight: homeComposerInputMaxHeight,
               }}
             >
-              <ComposerTextarea
-                data-telemetry-mask
-                data-home-composer-editor
-                ref={composer.textareaRef}
-                rows={2}
+              <ComposerRichTextEditor
                 value={composer.draft}
-                onChange={(event) => handleDraftChange(event.target.value, event.timeStamp)}
+                onChange={handleDraftChange}
                 onKeyDown={composer.handleKeyDown}
                 placeholder={CHAT_COMPOSER_LABELS.placeholder}
-                spellCheck={false}
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                style={{
-                  minHeight: `${HOME_CHAT_COMPOSER_INPUT.minHeightRem}rem`,
-                  maxHeight: homeComposerInputMaxHeight,
-                }}
+                disabled={false}
+                surface="home"
+                className="min-h-[inherit]"
               />
             </div>
 

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import type { KeyboardEventHandler, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeNextScreen } from "#product/components/home/screen/HomeNextScreen";
@@ -154,24 +154,8 @@ vi.mock("@proliferate/product-ui/chat/composer/ChatComposerSurface", () => ({
 }));
 
 vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () => ({
-  ComposerRichTextEditor: ({
-    value,
-    onChange,
-    onKeyDown,
-    disabled,
-  }: {
-    value: string;
-    onChange: (value: string) => void;
-    onKeyDown: KeyboardEventHandler<HTMLElement>;
-    disabled: boolean;
-  }) => (
-    <textarea
-      aria-label="Prompt"
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      onKeyDown={onKeyDown}
-      disabled={disabled}
-    />
+  ComposerRichTextEditor: ({ value, onChange, onKeyDown, disabled }: any) => (
+    <textarea aria-label="Prompt" value={value} onChange={(event) => onChange(event.target.value)} onKeyDown={onKeyDown} disabled={disabled} />
   ),
 }));
 

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -154,8 +154,8 @@ vi.mock("@proliferate/product-ui/chat/composer/ChatComposerSurface", () => ({
 }));
 
 vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () => ({
-  ComposerRichTextEditor: ({ value, onChange, onKeyDown, disabled }: any) => (
-    <textarea aria-label="Prompt" value={value} onChange={(event) => onChange(event.target.value)} onKeyDown={onKeyDown} disabled={disabled} />
+  ComposerRichTextEditor: ({ value, snapshot, onChange, onKeyDown, disabled }: any) => (
+    <textarea aria-label="Prompt" data-editor-snapshot={snapshot?.payload} value={value} onChange={(event) => onChange(event.target.value, event.timeStamp, { version: 1, payload: "home-editor-snapshot" })} onKeyDown={onKeyDown} disabled={disabled} />
   ),
 }));
 
@@ -346,6 +346,7 @@ describe("HomeNextScreen model availability notices", () => {
     fail();
     const prompt = submitPrompt("keep this draft");
     await waitFor(() => expect(prompt.value).toBe("keep this draft"));
+    expect(prompt.dataset.editorSnapshot).toBe("home-editor-snapshot");
     expect(document.querySelector("[data-home-submit-preview]")).toBeNull();
   });
 

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import type { ReactNode, TextareaHTMLAttributes } from "react";
+import type { KeyboardEventHandler, ReactNode } from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeNextScreen } from "#product/components/home/screen/HomeNextScreen";
@@ -153,9 +153,25 @@ vi.mock("@proliferate/product-ui/chat/composer/ChatComposerSurface", () => ({
   ),
 }));
 
-vi.mock("@proliferate/ui/primitives/ComposerTextarea", () => ({
-  ComposerTextarea: (props: TextareaHTMLAttributes<HTMLTextAreaElement>) => (
-    <textarea aria-label="Prompt" {...props} />
+vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () => ({
+  ComposerRichTextEditor: ({
+    value,
+    onChange,
+    onKeyDown,
+    disabled,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    onKeyDown: KeyboardEventHandler<HTMLElement>;
+    disabled: boolean;
+  }) => (
+    <textarea
+      aria-label="Prompt"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={onKeyDown}
+      disabled={disabled}
+    />
   ),
 }));
 
@@ -282,7 +298,6 @@ describe("HomeNextScreen model availability notices", () => {
     const expectedMaxHeight =
       `calc(var(--text-composer--line-height) * ${HOME_CHAT_COMPOSER_INPUT.maxRows})`;
 
-    expect(textarea.style.maxHeight).toBe(expectedMaxHeight);
     expect(textarea.parentElement?.style.maxHeight).toBe(expectedMaxHeight);
   });
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -9,10 +9,6 @@ import {
   type MouseEvent,
 } from "react";
 import type { PromptInputBlock } from "@anyharness/sdk";
-import {
-  CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
-  WORKSPACE_CHAT_COMPOSER_INPUT,
-} from "#product/config/chat";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import {
   useActiveSessionId,
@@ -32,7 +28,6 @@ import {
   useEditLastQueuedPrompt,
   useQueuedPromptEdit,
 } from "#product/hooks/chat/ui/use-queued-prompt-edit";
-import { useComposerTextareaAutosize } from "#product/hooks/chat/ui/use-composer-textarea-autosize";
 import { focusChatInput } from "#product/lib/domain/focus-zone";
 import { serializeChatDraftToPrompt } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import { promptAttachmentSnapshotsToContentParts } from "@proliferate/product-domain/chats/composer/prompt-attachment-snapshot";
@@ -79,7 +74,7 @@ export function ChatInput({
   hasSessionTurns?: boolean;
 }) {
   useDebugRenderCount("chat-composer");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const textareaRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [composerOverlayHost, setComposerOverlayHost] = useState<HTMLDivElement | null>(null);
   const workspaceSelectionNonce = useSessionSelectionStore((state) => state.workspaceSelectionNonce);
@@ -145,15 +140,6 @@ export function ChatInput({
     && !areRuntimeControlsDisabled
     && !isSubmitting
     && attachments.canAttachFiles;
-  useComposerTextareaAutosize({
-    textareaRef,
-    value: editDraft,
-    lineHeightRem: CHAT_COMPOSER_INPUT_LINE_HEIGHT_REM,
-    minRows: WORKSPACE_CHAT_COMPOSER_INPUT.minRows,
-    maxRows: WORKSPACE_CHAT_COMPOSER_INPUT.maxRows,
-    minHeightRem: WORKSPACE_CHAT_COMPOSER_INPUT.minHeightRem,
-  });
-
   const onSubmit = useCallback(async () => {
     // End the typing burst NOW so the transcript renders urgently: the
     // composer clearing and the sent message appearing must be one frame.

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -115,6 +115,7 @@ export function ChatInput({
   const { isSubmitting, run: runSubmit } = useComposerSubmitGate();
   const {
     isEditing: isEditingQueuedPrompt,
+    editingSeq,
     editDraft,
     setEditDraftText,
     cancelEdit,
@@ -340,6 +341,7 @@ export function ChatInput({
             <ChatInputDraftArea
               hasSessionTurns={hasSessionTurns}
               isEditingQueuedPrompt={effectiveIsEditingQueuedPrompt}
+              editingQueueSeq={effectiveIsEditingQueuedPrompt ? editingSeq : null}
               editDraft={editDraft}
               onEditDraftChange={setEditDraftText}
               textareaRef={textareaRef}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WORKSPACE_CHAT_COMPOSER_INPUT } from "#product/config/chat";
+import { ChatInputDraftArea } from "#product/components/workspace/chat/input/ChatInputDraftArea";
+
+vi.mock("#product/hooks/chat/ui/use-chat-draft-state", () => ({
+  useChatDraftValue: () => ({ nodes: [] }),
+}));
+vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () => ({
+  ComposerRichTextEditor: () => <div data-testid="queue-rich-editor" />,
+}));
+vi.mock("@proliferate/ui/primitives/ComposerTextareaFrame", () => ({
+  ComposerTextareaFrame: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("#product/components/workspace/chat/input/QueuedPromptEditBanner", () => ({
+  QueuedPromptEditBanner: () => <div />,
+}));
+
+afterEach(cleanup);
+
+describe("ChatInputDraftArea", () => {
+  it("caps a queued rich editor at the workspace composer height", () => {
+    render(
+      <ChatInputDraftArea
+        hasSessionTurns
+        isEditingQueuedPrompt
+        editingQueueSeq={7}
+        editDraft="queued prompt"
+        onEditDraftChange={vi.fn()}
+        textareaRef={{ current: null }}
+        workspaceUiKey={null}
+        onDraftChange={vi.fn()}
+        canSubmit
+        isDisabled={false}
+        onSubmit={vi.fn()}
+        onKeyDown={vi.fn()}
+        hasDraftAttachments={false}
+        draftAttachments={[]}
+        onRemoveDraftAttachment={vi.fn()}
+        overlayHostElement={null}
+        onCancelEdit={vi.fn()}
+      />,
+    );
+
+    const viewport = screen.getByTestId("queue-rich-editor").parentElement!;
+    expect(viewport.classList.contains("overflow-y-auto")).toBe(true);
+    expect(viewport.style.minHeight).toBe(`${WORKSPACE_CHAT_COMPOSER_INPUT.minHeightRem}rem`);
+    expect(viewport.style.maxHeight).toBe(
+      `calc(var(--text-composer--line-height) * ${WORKSPACE_CHAT_COMPOSER_INPUT.maxRows})`,
+    );
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -1,7 +1,10 @@
-import type { RefObject } from "react";
+import { useState, type RefObject } from "react";
 import { WORKSPACE_CHAT_COMPOSER_INPUT } from "#product/config/chat";
 import { CHAT_COMPOSER_LABELS } from "#product/copy/chat/chat-copy";
-import type { ChatComposerDraft } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import type {
+  ChatComposerDraft,
+  ChatComposerEditorSnapshot,
+} from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import {
   DraftAttachmentPreviewList,
   type DraftAttachmentPreviewListProps,
@@ -17,6 +20,7 @@ interface ChatInputDraftAreaProps {
   /** Picks the follow-up placeholder once the session transcript has turns. */
   hasSessionTurns: boolean;
   isEditingQueuedPrompt: boolean;
+  editingQueueSeq: number | null;
   editDraft: string;
   onEditDraftChange: (value: string) => void;
   textareaRef: RefObject<HTMLDivElement | null>;
@@ -40,6 +44,7 @@ interface ChatInputDraftAreaProps {
 export function ChatInputDraftArea({
   hasSessionTurns,
   isEditingQueuedPrompt,
+  editingQueueSeq,
   editDraft,
   onEditDraftChange,
   textareaRef,
@@ -55,6 +60,15 @@ export function ChatInputDraftArea({
   overlayHostElement,
   onCancelEdit,
 }: ChatInputDraftAreaProps) {
+  const [editEditorState, setEditEditorState] = useState<{
+    queueSeq: number | null;
+    value: string;
+    snapshot: ChatComposerEditorSnapshot;
+  }>();
+  const editSnapshot = editEditorState?.queueSeq === editingQueueSeq
+    && editEditorState.value === editDraft
+    ? editEditorState.snapshot
+    : undefined;
   const draft = useChatDraftValue(workspaceUiKey);
   const placeholder = hasSessionTurns
     ? CHAT_COMPOSER_LABELS.followUpPlaceholder
@@ -64,18 +78,29 @@ export function ChatInputDraftArea({
       <>
         <QueuedPromptEditBanner onCancel={onCancelEdit} />
         <ComposerTextareaFrame topInset="none">
-          <ComposerRichTextEditor
-            rootRef={textareaRef}
-            value={editDraft}
-            onChange={(value) => onEditDraftChange(value)}
-            onKeyDown={onKeyDown}
-            submitBehavior="editing"
-            canSubmit={canSubmit}
-            onSubmit={onSubmit}
-            placeholder={placeholder}
-            disabled={false}
-            className="min-h-[2.5rem]"
-          />
+          <div
+            className="relative overflow-y-auto"
+            style={{
+              minHeight: `${WORKSPACE_CHAT_COMPOSER_INPUT.minHeightRem}rem`,
+              maxHeight: `calc(var(--text-composer--line-height) * ${WORKSPACE_CHAT_COMPOSER_INPUT.maxRows})`,
+            }}
+          >
+            <ComposerRichTextEditor
+              rootRef={textareaRef}
+              value={editDraft}
+              snapshot={editSnapshot}
+              onChange={(value, _eventTimeStampMs, snapshot) => {
+                setEditEditorState({ queueSeq: editingQueueSeq, value, snapshot });
+                onEditDraftChange(value);
+              }}
+              onKeyDown={onKeyDown}
+              submitBehavior="editing"
+              canSubmit={canSubmit}
+              onSubmit={onSubmit}
+              placeholder={placeholder}
+              disabled={false}
+            />
+          </div>
         </ComposerTextareaFrame>
       </>
     );

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -8,7 +8,7 @@ import {
 } from "#product/components/workspace/chat/content/PromptContentRenderer";
 import { useChatDraftValue } from "#product/hooks/chat/ui/use-chat-draft-state";
 import { ComposerCommandEditor } from "#product/components/workspace/chat/input/ComposerCommandEditor";
-import { ComposerTextarea } from "@proliferate/ui/primitives/ComposerTextarea";
+import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import { ComposerTextareaFrame } from "@proliferate/ui/primitives/ComposerTextareaFrame";
 import { QueuedPromptEditBanner } from "#product/components/workspace/chat/input/QueuedPromptEditBanner";
 import type { ChatComposerKeyboardEvent } from "#product/hooks/chat/ui/use-chat-composer-keyboard";
@@ -19,7 +19,7 @@ interface ChatInputDraftAreaProps {
   isEditingQueuedPrompt: boolean;
   editDraft: string;
   onEditDraftChange: (value: string) => void;
-  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  textareaRef: RefObject<HTMLDivElement | null>;
   /**
    * PERF: the draft area subscribes to the live draft itself (by workspace
    * key) so keystrokes re-render only this subtree, not the whole ChatInput.
@@ -64,19 +64,17 @@ export function ChatInputDraftArea({
       <>
         <QueuedPromptEditBanner onCancel={onCancelEdit} />
         <ComposerTextareaFrame topInset="none">
-          <ComposerTextarea
-            data-chat-composer-editor
-            data-telemetry-mask
-            ref={textareaRef}
-            rows={WORKSPACE_CHAT_COMPOSER_INPUT.minRows}
+          <ComposerRichTextEditor
+            rootRef={textareaRef}
             value={editDraft}
-            onChange={(event) => onEditDraftChange(event.target.value)}
-            onKeyDown={(event) => onKeyDown(event)}
+            onChange={(value) => onEditDraftChange(value)}
+            onKeyDown={onKeyDown}
+            submitBehavior="editing"
+            canSubmit={canSubmit}
+            onSubmit={onSubmit}
             placeholder={placeholder}
-            spellCheck={false}
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
+            disabled={false}
+            className="min-h-[2.5rem]"
           />
         </ComposerTextareaFrame>
       </>

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -85,8 +85,7 @@ export interface ComposerRichTextEditorProps {
   canSubmit: boolean;
   onSubmit: () => void;
   editorRef?: (editor: LexicalEditor) => void;
-  rootRef?: Ref<HTMLDivElement>;
-  surface?: "workspace" | "home";
+  rootRef?: Ref<HTMLDivElement>; surface?: "workspace" | "home";
   placeholder: string;
   disabled: boolean;
   className?: string;
@@ -102,9 +101,7 @@ export function ComposerRichTextEditor({
   submitBehavior,
   canSubmit,
   onSubmit,
-  editorRef,
-  rootRef,
-  surface = "workspace",
+  editorRef, rootRef, surface = "workspace",
   placeholder,
   disabled,
   className = "",

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type MutableRefObject } from "react";
+import { useEffect, useRef, type MutableRefObject, type Ref } from "react";
 import {
   $createRangeSelection,
   $createTextNode,
@@ -85,6 +85,8 @@ export interface ComposerRichTextEditorProps {
   canSubmit: boolean;
   onSubmit: () => void;
   editorRef?: (editor: LexicalEditor) => void;
+  rootRef?: Ref<HTMLDivElement>;
+  surface?: "workspace" | "home";
   placeholder: string;
   disabled: boolean;
   className?: string;
@@ -101,6 +103,8 @@ export function ComposerRichTextEditor({
   canSubmit,
   onSubmit,
   editorRef,
+  rootRef,
+  surface = "workspace",
   placeholder,
   disabled,
   className = "",
@@ -131,7 +135,9 @@ export function ComposerRichTextEditor({
         contentEditable={(
           <ContentEditable
             data-chat-composer-editor
+            data-home-composer-editor={surface === "home" ? true : undefined}
             data-telemetry-mask
+            ref={rootRef}
             aria-placeholder={placeholder}
             placeholder={<></>}
             spellCheck={false}

--- a/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
+++ b/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
 import { flushSync } from "react-dom";
 import { useHomeNextLaunch } from "#product/hooks/home/workflows/use-home-next-launch";
 import { useHomeDraftHandoffStore } from "#product/stores/home/home-draft-handoff-store";
@@ -8,6 +7,8 @@ import type {
   HomeNextModelSelection,
   ModelAvailabilityState,
 } from "#product/lib/domain/home/home-next-launch";
+import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import type { ChatComposerKeyboardEvent } from "#product/hooks/chat/ui/use-chat-composer-keyboard";
 
 interface UseHomeNextComposerStateArgs {
   targetDisabledReason: string | null;
@@ -29,14 +30,18 @@ export function useHomeNextComposerState({
   launchTarget,
 }: UseHomeNextComposerStateArgs) {
   const submitInFlightRef = useRef(false);
-  const [draft, setDraft] = useState("");
+  const [draftState, setDraftState] = useState<{
+    value: string;
+    snapshot?: ChatComposerEditorSnapshot;
+  }>({ value: "" });
+  const draft = draftState.value;
   const restoredDraftText = useHomeDraftHandoffStore((state) => state.draftText);
   const clearRestoredDraftText = useHomeDraftHandoffStore((state) => state.clearDraftText);
   const { isLaunching, launch } = useHomeNextLaunch();
 
   useEffect(() => {
     if (restoredDraftText !== null) {
-      setDraft(restoredDraftText);
+      setDraftState({ value: restoredDraftText });
       clearRestoredDraftText();
     }
   }, [clearRestoredDraftText, restoredDraftText]);
@@ -52,6 +57,13 @@ export function useHomeNextComposerState({
     && !!launchTarget
     && !isLaunching;
 
+  const setDraft = useCallback((
+    value: string,
+    snapshot?: ChatComposerEditorSnapshot,
+  ) => {
+    setDraftState(snapshot ? { value, snapshot } : { value });
+  }, []);
+
   const submit = useCallback(async () => {
     if (
       !canSubmit
@@ -61,19 +73,19 @@ export function useHomeNextComposerState({
     ) return;
 
     submitInFlightRef.current = true;
-    const submittedDraft = draft;
+    const submittedDraft = draftState;
     const restoreSubmittedDraft = () => {
-      setDraft((currentDraft) => (
-        currentDraft.length === 0 ? submittedDraft : currentDraft
+      setDraftState((currentDraft) => (
+        currentDraft.value.length === 0 ? submittedDraft : currentDraft
       ));
     };
     flushSync(() => {
-      setDraft("");
+      setDraftState({ value: "" });
     });
 
     try {
       const succeeded = await launch({
-        text: submittedDraft,
+        text: submittedDraft.value,
         modelSelection,
         modeId,
         launchControlValues,
@@ -91,7 +103,7 @@ export function useHomeNextComposerState({
     }
   }, [
     canSubmit,
-    draft,
+    draftState,
     launch,
     launchControlValues,
     launchTarget,
@@ -101,12 +113,12 @@ export function useHomeNextComposerState({
 
   const cancel = useCallback(() => {
     if (!isLaunching) {
-      setDraft("");
+      setDraftState({ value: "" });
     }
   }, [isLaunching]);
 
-  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
-    if (event.nativeEvent.isComposing) return;
+  const handleKeyDown = useCallback((event: ChatComposerKeyboardEvent) => {
+    if (event.isComposing || event.nativeEvent?.isComposing) return;
     if (
       event.key === "Escape"
       && !event.shiftKey
@@ -115,22 +127,12 @@ export function useHomeNextComposerState({
       && !event.metaKey
     ) {
       cancel();
-      return;
     }
-    if (
-      event.key === "Enter"
-      && (event.metaKey || event.ctrlKey)
-      && !event.shiftKey
-      && !event.altKey
-      && canSubmit
-    ) {
-      event.preventDefault();
-      void submit();
-    }
-  }, [canSubmit, cancel, submit]);
+  }, [cancel]);
 
   return {
     draft,
+    editorSnapshot: draftState.snapshot,
     setDraft,
     submitDisabledReason,
     canSubmit,

--- a/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
+++ b/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
 import { flushSync } from "react-dom";
-import { HOME_CHAT_COMPOSER_INPUT } from "#product/config/chat";
 import { useHomeNextLaunch } from "#product/hooks/home/workflows/use-home-next-launch";
 import { useHomeDraftHandoffStore } from "#product/stores/home/home-draft-handoff-store";
 import type {
@@ -29,7 +28,6 @@ export function useHomeNextComposerState({
   launchControlValues,
   launchTarget,
 }: UseHomeNextComposerStateArgs) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const submitInFlightRef = useRef(false);
   const [draft, setDraft] = useState("");
   const restoredDraftText = useHomeDraftHandoffStore((state) => state.draftText);
@@ -53,42 +51,6 @@ export function useHomeNextComposerState({
     && !!modelSelection
     && !!launchTarget
     && !isLaunching;
-
-  // PERF: `getComputedStyle` twice per keystroke is avoidable work in the hot
-  // typing path — line-height and root font-size only change on theme/UI-scale
-  // edits, so cache them briefly. The `scrollHeight` read below still forces a
-  // reflow; that one is inherent to autosizing.
-  const fontMetricsRef = useRef<{
-    lineHeightPx: number;
-    rootFontSizePx: number;
-    measuredAtMs: number;
-  } | null>(null);
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-
-    const nowMs = Date.now();
-    let metrics = fontMetricsRef.current;
-    if (!metrics || nowMs - metrics.measuredAtMs > 1_000) {
-      const lineHeightPx = parseFloat(getComputedStyle(el).lineHeight);
-      if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0) return;
-      const rootFontSizePx = parseFloat(getComputedStyle(document.documentElement).fontSize);
-      metrics = { lineHeightPx, rootFontSizePx, measuredAtMs: nowMs };
-      fontMetricsRef.current = metrics;
-    }
-    const { lineHeightPx, rootFontSizePx } = metrics;
-
-    const homeMinHeightPx = Number.isFinite(rootFontSizePx)
-      ? rootFontSizePx * HOME_CHAT_COMPOSER_INPUT.minHeightRem
-      : lineHeightPx * HOME_CHAT_COMPOSER_INPUT.minRows;
-    const minPx = Math.max(lineHeightPx * HOME_CHAT_COMPOSER_INPUT.minRows, homeMinHeightPx);
-    const maxPx = lineHeightPx * HOME_CHAT_COMPOSER_INPUT.maxRows;
-    el.style.height = "auto";
-    const contentHeight = el.scrollHeight;
-    const next = Math.min(maxPx, Math.max(minPx, contentHeight));
-    el.style.height = `${next}px`;
-    el.style.overflowY = contentHeight > maxPx ? "auto" : "hidden";
-  }, [draft]);
 
   const submit = useCallback(async () => {
     if (
@@ -143,7 +105,7 @@ export function useHomeNextComposerState({
     }
   }, [isLaunching]);
 
-  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
     if (event.nativeEvent.isComposing) return;
     if (
       event.key === "Escape"
@@ -168,7 +130,6 @@ export function useHomeNextComposerState({
   }, [canSubmit, cancel, submit]);
 
   return {
-    textareaRef,
     draft,
     setDraft,
     submitDisabledReason,

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -37,5 +37,4 @@ apps/packages/product-client/src/host/product-host.ts 420 WDU slice 04 (G2/G4): 
 apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx 450 status-card playground fixtures pending scenario-module split (#1202 debt repair)
 apps/packages/product-client/src/lib/domain/preferences/appearance.ts 437 appearance preset model pending preset-catalog split (#1202 growth recorded in debt repair)
 apps/packages/product-client/src/components/playground/GitReviewV2Playground.tsx 445 git review playground fixtures pending scenario-module split
-apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx 410 composer input growth from workspace-status card wiring (#1210 debt repair, #1256 resources/advanced threading)
 apps/packages/product-client/src/hooks/plans/workflows/use-proposed-plan-actions.ts 405 plan decision + carry-out workflow growth (#1250); split deferred

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -70,12 +70,13 @@ Non-negotiable:
 - **The composer surface paints the seam.** There is no `flatTop` prop or alternate composer mode. Ordinary dock-region panels remain narrower attached trays above the composer. When the full-width workspace-activity cap is present, `ChatComposerDock` squares the composer's top corners with a local `:has()` selector so the cap and input read as one card; removing the cap restores the normal composer radius. The composer still paints after the dock regions so its own top outline remains visible at the seam.
 - **Composer command overlays are composer-local, not dock-region inhabitants.** The slash-command tray renders from `ChatInput` in a small host directly above `ChatComposerSurface` while a prompt-leading `/` trigger is active. It is transient editor UI and does not participate in `useComposerDockSlots` precedence.
 
-### Workspace editor behavior
+### Editor behavior
 
-`ComposerCommandEditor` uses the product-client-owned Lexical adapter for the
-workspace prompt body. The editor keeps the existing `ChatComposerDraft` and
-submitted prompt boundary as Markdown; Lexical state is an editing detail and
-must not cross the runtime or server boundary.
+The workspace, Home, and queued-prompt editors use the same
+product-client-owned Lexical adapter. Workspace drafts keep the existing
+`ChatComposerDraft`; Home and queued edits keep their existing Markdown string
+state. Every submitted prompt boundary remains Markdown, and Lexical state is
+an editing detail that must not cross the runtime or server boundary.
 
 While a workspace draft is live, `ChatComposerDraft` may carry a versioned,
 opaque editor snapshot beside its Markdown nodes. The product client uses that
@@ -88,7 +89,9 @@ line-leading unordered and ordered list shortcuts. Cmd/Ctrl-B and Cmd/Ctrl-I
 toggle marks through the rich-text command layer. Enter continues or exits a
 list and Tab/Shift-Tab indent or outdent only when the selection is inside a
 list item. Outside lists, plain Enter retains workspace submission and
-Shift-Enter inserts a newline.
+Shift-Enter inserts a newline. Home retains Cmd/Ctrl-Enter submission and
+ordinary Enter editing. Queued edits retain workspace submission behavior
+outside lists.
 
 Lexical's high-priority Enter and Tab commands own this decision before native
 editor mutation. A list selection stays Lexical-owned; otherwise the workspace,

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -82,7 +82,9 @@ While a workspace draft is live, `ChatComposerDraft` may carry a versioned,
 opaque editor snapshot beside its Markdown nodes. The product client uses that
 snapshot only to restore editor-only identity such as whether Markdown link
 syntax came from an HTTPS paste; submission still serializes only Markdown.
-Empty drafts and plain-text compatibility writes discard the snapshot.
+Home and queued-edit state retain the same opaque snapshot locally while their
+Markdown draft is live. Empty drafts, plain-text compatibility writes, and
+external draft replacements discard the snapshot.
 
 The live editor recognizes `*`/`_` emphasis, `**`/`__` strong emphasis, and
 line-leading unordered and ordered list shortcuts. Cmd/Ctrl-B and Cmd/Ctrl-I
@@ -91,7 +93,8 @@ list and Tab/Shift-Tab indent or outdent only when the selection is inside a
 list item. Outside lists, plain Enter retains workspace submission and
 Shift-Enter inserts a newline. Home retains Cmd/Ctrl-Enter submission and
 ordinary Enter editing. Queued edits retain workspace submission behavior
-outside lists.
+outside lists and use the workspace editor's minimum height, row cap, and
+overflow scrolling.
 
 Lexical's high-priority Enter and Tab commands own this decision before native
 editor mutation. A list selection stays Lexical-owned; otherwise the workspace,


### PR DESCRIPTION
## Summary
- reuse the rich Markdown editor for Home prompts and queued-prompt editing
- preserve Home Cmd/Ctrl-Enter and workspace/queue Enter semantics, including list-owned Enter
- remove textarea-only refs and autosize work from the migrated surfaces
- retain the existing Home typing-render isolation and queued-edit focus behavior

## Proof
- `pnpm exec tsc -p apps/packages/product-client/tsconfig.json --noEmit`
- `pnpm --filter @proliferate/product-client exec vitest run src/components/home/screen/HomeNextScreen.test.tsx src/components/workspace/chat/input/ComposerCommandEditor.test.tsx --reporter=dot` (27 passed)
- `python3 scripts/check_docs.py`
- `git diff --check`

## Dependency
- Stacked on #1396, which is stacked on #1393. Rebase onto `main` after the preceding slices merge.