### PR TITLE
fix(release): isolate manual qualification worlds

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -31,6 +31,20 @@ name: Release E2E (tier 3)
 on:
   workflow_dispatch:
     inputs:
+      manual_world:
+        description: >-
+          Manual qualification world to run. "all" preserves the historical
+          fan-out; choose one world to prevent unrelated jobs from consuming
+          credentials, providers, and incompatible scenario selectors.
+        default: all
+        required: false
+        type: choice
+        options:
+          - all
+          - local
+          - managed-cloud
+          - tier2
+          - staging
       lane:
         description: Runtime target lane the runner points at.
         default: local
@@ -315,6 +329,10 @@ jobs:
   # it never runs Tier-2, controller-local, self-host, or Tier-4 bodies here.
   release-e2e-staging:
     name: tier-3 staging lane (provisional)
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.manual_world == 'all' || inputs.manual_world == 'staging'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -401,7 +419,9 @@ jobs:
   # `BootedStack` machinery.
   qualification-tier2:
     name: tier-2 billing/auth (manual, strict)
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.manual_world == 'all' || inputs.manual_world == 'tier2')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -508,7 +528,9 @@ jobs:
   # unrelated managed-cloud, self-host, Tier-2, or Tier-4 run cannot replace it.
   release-e2e-local-functional:
     name: local smoke + functional (manual, build once)
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.manual_world == 'all' || inputs.manual_world == 'local')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
@@ -900,7 +922,9 @@ jobs:
   # step.
   release-e2e-managed-cloud:
     name: cloud-provision-1 (manual, strict)
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.manual_world == 'all' || inputs.manual_world == 'managed-cloud')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -35,11 +35,24 @@ test("release qualification has stable independent concurrency groups by world",
   assert.match(job(selfhost, "artifact-chain"), /group: release-e2e-tier4/);
   assert.match(job(selfhost, "provisioning"), /group: release-e2e-self-host/);
   assert.match(job(release, "release-e2e-local"), /if: github\.event_name == 'schedule'/);
-  assert.match(job(release, "release-e2e-local-functional"), /if: github\.event_name == 'workflow_dispatch'/);
+  assert.match(job(release, "release-e2e-local-functional"), /inputs\.manual_world == 'local'/);
 
   for (const source of [release, selfhost]) {
     assert.doesNotMatch(source, /cancel-in-progress: true/);
   }
+});
+
+test("manual dispatch can isolate one qualification world", () => {
+  const workflowHeader = release.slice(0, release.indexOf("\njobs:"));
+  assert.match(workflowHeader, /manual_world:/);
+  for (const world of ["all", "local", "managed-cloud", "tier2", "staging"]) {
+    assert.match(workflowHeader, new RegExp(`- ${world}`));
+  }
+
+  assert.match(job(release, "release-e2e-local-functional"), /inputs\.manual_world == 'local'/);
+  assert.match(job(release, "release-e2e-managed-cloud"), /inputs\.manual_world == 'managed-cloud'/);
+  assert.match(job(release, "qualification-tier2"), /inputs\.manual_world == 'tier2'/);
+  assert.match(job(release, "release-e2e-staging"), /inputs\.manual_world == 'staging'/);
 });
 
 test("the manual local world builds and publishes once, then reuses exact candidates", () => {


### PR DESCRIPTION
## Summary

- add an explicit `manual_world` selector to the shared Release E2E workflow
- gate local, managed-cloud, Tier 2, and staging jobs to their selected world while preserving the historical `all` fan-out
- prevent a world-specific `scenarios` input from reaching incompatible jobs and consuming unrelated credentials/providers

## Evidence

Run 29660623018 dispatched managed-cloud scenarios but also launched the local-functional job. Local smoke passed 1/1; the functional phase then stopped before cell execution because `CLOUD-PROVISION-1` cannot form local cells. This change makes a manual dispatch world-scoped.

Offline proof on head `8a0172290`:

- `actionlint .github/workflows/release-e2e.yml`
- focused workflow tests: 7/7 green
- `python3 scripts/check_max_lines.py`
- `git diff --check`

No live provider or Release E2E run was dispatched by this PR.