### PR TITLE
fix(release): wait for local sidebar navigation readiness

### DIFF
--- a/tests/release/src/scenarios/local/config-session.ts
+++ b/tests/release/src/scenarios/local/config-session.ts
@@ -25,6 +25,7 @@ import {
   GATEWAY_UNSUPPORTED_HARNESSES,
   gatewayUnsupportedMessage,
 } from "../../fixtures/gateway-unsupported-harnesses.js";
+import { waitForSidebarControlReady } from "./sidebar-control-readiness.js";
 
 /**
  * LOCAL-4 (live configuration matrix, per harness) under `T3-CFG-1/local`, and
@@ -940,7 +941,7 @@ async function selectRepoAndWorkLocally(page: ProductPage, repo: PreparedReposit
   // requires.
   if (!await projectTrigger.isVisible().catch(() => false)) {
     const newChatNav = p.locator("nav").getByRole("button", { name: "New chat" }).first();
-    await newChatNav.waitFor({ state: "visible", timeout: 30_000 });
+    await waitForSidebarControlReady(p, newChatNav);
     await newChatNav.click();
     await p
       .locator("[data-home-composer-editor]")

--- a/tests/release/src/scenarios/local/sidebar-control-readiness.test.ts
+++ b/tests/release/src/scenarios/local/sidebar-control-readiness.test.ts
@@ -7,6 +7,7 @@ import { waitForSidebarControlReady } from "./sidebar-control-readiness.js";
 
 interface FakeControlOptions {
   topAtCenter: Array<"overlay" | "target">;
+  clippingAncestorRight?: number;
 }
 
 function fakeCollapsedSidebar(options: FakeControlOptions): {
@@ -15,9 +16,28 @@ function fakeCollapsedSidebar(options: FakeControlOptions): {
   calls: string[];
 } {
   const calls: string[] = [];
+  const clippingAncestorRight = options.clippingAncestorRight;
+  const clippingAncestor = clippingAncestorRight === undefined
+    ? null
+    : {
+        clientHeight: 80,
+        clientLeft: 0,
+        clientTop: 0,
+        clientWidth: clippingAncestorRight - 20,
+        getBoundingClientRect: () => ({
+          left: 20,
+          top: 0,
+          right: clippingAncestorRight,
+          bottom: 80,
+          width: clippingAncestorRight - 20,
+          height: 80,
+        }),
+        parentElement: null,
+      };
   const target = {
     getBoundingClientRect: () => ({ left: 20, top: 20, right: 120, bottom: 60, width: 100, height: 40 }),
     contains: (node: unknown) => node === target,
+    parentElement: clippingAncestor,
   };
   const overlay = {};
   let hitTest = 0;
@@ -34,7 +54,13 @@ function fakeCollapsedSidebar(options: FakeControlOptions): {
       const previousRaf = globalThis.requestAnimationFrame;
       let now = 0;
       Object.assign(globalThis, {
-        window: { innerWidth: 1024, innerHeight: 768 },
+        window: {
+          innerWidth: 1024,
+          innerHeight: 768,
+          getComputedStyle: (element: unknown) => element === clippingAncestor
+            ? { overflowX: "hidden", overflowY: "hidden" }
+            : { overflowX: "visible", overflowY: "visible" },
+        },
         document: {
           elementFromPoint: () => options.topAtCenter[Math.min(hitTest++, options.topAtCenter.length - 1)] === "target"
             ? target
@@ -107,4 +133,16 @@ test("does not accept stable geometry while an overlay owns the hit target", asy
   await waitForSidebarControlReady(page, control);
 
   assert.equal(calls.filter((call) => call === "control.evaluate").length, 1);
+});
+
+test("does not accept a control clipped by an overflow ancestor", async () => {
+  const { page, control } = fakeCollapsedSidebar({
+    topAtCenter: ["target"],
+    clippingAncestorRight: 70,
+  });
+
+  await assert.rejects(
+    waitForSidebarControlReady(page, control),
+    /sidebar control did not settle into an interactable layout/,
+  );
 });

--- a/tests/release/src/scenarios/local/sidebar-control-readiness.test.ts
+++ b/tests/release/src/scenarios/local/sidebar-control-readiness.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { Locator, Page } from "playwright";
+
+import { waitForSidebarControlReady } from "./sidebar-control-readiness.js";
+
+interface FakeControlOptions {
+  topAtCenter: Array<"overlay" | "target">;
+}
+
+function fakeCollapsedSidebar(options: FakeControlOptions): {
+  page: Page;
+  control: Locator;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const target = {
+    getBoundingClientRect: () => ({ left: 20, top: 20, right: 120, bottom: 60, width: 100, height: 40 }),
+    contains: (node: unknown) => node === target,
+  };
+  const overlay = {};
+  let hitTest = 0;
+
+  const control = {
+    waitFor: async () => {
+      calls.push("control.waitFor");
+    },
+    evaluate: async (callback: (node: unknown, args: unknown) => Promise<void>, args: unknown) => {
+      calls.push("control.evaluate");
+      const previousWindow = globalThis.window;
+      const previousDocument = globalThis.document;
+      const previousPerformance = globalThis.performance;
+      const previousRaf = globalThis.requestAnimationFrame;
+      let now = 0;
+      Object.assign(globalThis, {
+        window: { innerWidth: 1024, innerHeight: 768 },
+        document: {
+          elementFromPoint: () => options.topAtCenter[Math.min(hitTest++, options.topAtCenter.length - 1)] === "target"
+            ? target
+            : overlay,
+        },
+        performance: { now: () => now },
+        requestAnimationFrame: (run: (timestamp: number) => void) => {
+          now += 50;
+          run(now);
+          return now;
+        },
+      });
+      try {
+        await callback(target, args);
+      } finally {
+        Object.assign(globalThis, {
+          window: previousWindow,
+          document: previousDocument,
+          performance: previousPerformance,
+          requestAnimationFrame: previousRaf,
+        });
+      }
+    },
+  } as unknown as Locator;
+
+  const hide = {
+    first: () => hide,
+    waitFor: async () => {
+      calls.push("hide.waitFor");
+    },
+  };
+  const combined = {
+    first: () => combined,
+    waitFor: async () => {
+      calls.push("toggle.waitFor");
+    },
+  };
+  const show = {
+    first: () => show,
+    or: () => combined,
+    isVisible: async () => true,
+    click: async () => {
+      calls.push("show.click");
+    },
+  };
+  const page = {
+    getByRole: (_role: string, query: { name: string }) => query.name === "Show sidebar" ? show : hide,
+  } as unknown as Page;
+
+  return { page, control, calls };
+}
+
+test("expands the sidebar and proves the control is settled before returning", async () => {
+  const { page, control, calls } = fakeCollapsedSidebar({ topAtCenter: ["target"] });
+
+  await waitForSidebarControlReady(page, control);
+
+  assert.deepEqual(calls, [
+    "toggle.waitFor",
+    "show.click",
+    "hide.waitFor",
+    "control.waitFor",
+    "control.evaluate",
+  ]);
+});
+
+test("does not accept stable geometry while an overlay owns the hit target", async () => {
+  const { page, control, calls } = fakeCollapsedSidebar({ topAtCenter: ["overlay", "target"] });
+
+  await waitForSidebarControlReady(page, control);
+
+  assert.equal(calls.filter((call) => call === "control.evaluate").length, 1);
+});

--- a/tests/release/src/scenarios/local/sidebar-control-readiness.ts
+++ b/tests/release/src/scenarios/local/sidebar-control-readiness.ts
@@ -9,9 +9,10 @@ const SIDEBAR_SETTLE_ATTEMPTS = 50;
  *
  * Playwright considers a control visible even while an overflow-hidden parent
  * still clips it. The sidebar's width transition can therefore leave a role
- * locator attached and visible while its center is outside the viewport or an
- * overlay receives the click. Readiness requires stable geometry across a
- * sample wider than the transition plus a successful center-point hit test.
+ * locator attached and visible while an overflow ancestor clips it, its center
+ * is outside the viewport, or an overlay receives the click. Readiness requires
+ * stable geometry across a sample wider than the transition, full containment
+ * by every overflow-clipping ancestor, and a successful center-point hit test.
  */
 export async function waitForSidebarControlReady(
   page: Page,
@@ -32,6 +33,27 @@ export async function waitForSidebarControlReady(
     async (node, options) => {
       const nextFrame = () =>
         new Promise<number>((resolve) => requestAnimationFrame(() => resolve(performance.now())));
+      const fullyInsideOverflowClips = (rect: DOMRect) => {
+        for (let ancestor = node.parentElement; ancestor; ancestor = ancestor.parentElement) {
+          const style = window.getComputedStyle(ancestor);
+          const clipsX = style.overflowX !== "visible";
+          const clipsY = style.overflowY !== "visible";
+          if (!clipsX && !clipsY) continue;
+
+          const ancestorRect = ancestor.getBoundingClientRect();
+          const clipLeft = ancestorRect.left + ancestor.clientLeft;
+          const clipTop = ancestorRect.top + ancestor.clientTop;
+          const clipRight = clipLeft + ancestor.clientWidth;
+          const clipBottom = clipTop + ancestor.clientHeight;
+          if (
+            (clipsX && (rect.left < clipLeft || rect.right > clipRight)) ||
+            (clipsY && (rect.top < clipTop || rect.bottom > clipBottom))
+          ) {
+            return false;
+          }
+        }
+        return true;
+      };
 
       for (let attempt = 0; attempt < options.attempts; attempt += 1) {
         const first = node.getBoundingClientRect();
@@ -51,7 +73,8 @@ export async function waitForSidebarControlReady(
           second.left >= 0 &&
           second.top >= 0 &&
           second.right <= window.innerWidth &&
-          second.bottom <= window.innerHeight;
+          second.bottom <= window.innerHeight &&
+          fullyInsideOverflowClips(second);
         if (!stableAndInViewport) continue;
 
         const centerX = second.left + second.width / 2;

--- a/tests/release/src/scenarios/local/sidebar-control-readiness.ts
+++ b/tests/release/src/scenarios/local/sidebar-control-readiness.ts
@@ -1,0 +1,67 @@
+import type { Locator, Page } from "playwright";
+
+const SIDEBAR_TRANSITION_SETTLE_MS = 200;
+const SIDEBAR_SETTLE_ATTEMPTS = 50;
+
+/**
+ * Expands the animated workspace sidebar when necessary, then proves the
+ * requested control is genuinely interactable before its caller clicks it.
+ *
+ * Playwright considers a control visible even while an overflow-hidden parent
+ * still clips it. The sidebar's width transition can therefore leave a role
+ * locator attached and visible while its center is outside the viewport or an
+ * overlay receives the click. Readiness requires stable geometry across a
+ * sample wider than the transition plus a successful center-point hit test.
+ */
+export async function waitForSidebarControlReady(
+  page: Page,
+  control: Locator,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const showSidebar = page.getByRole("button", { name: "Show sidebar" }).first();
+  const hideSidebar = page.getByRole("button", { name: "Hide sidebar" }).first();
+
+  await showSidebar.or(hideSidebar).first().waitFor({ state: "visible", timeout: timeoutMs });
+  if (await showSidebar.isVisible().catch(() => false)) {
+    await showSidebar.click({ timeout: timeoutMs });
+    await hideSidebar.waitFor({ state: "visible", timeout: timeoutMs });
+  }
+
+  await control.waitFor({ state: "visible", timeout: timeoutMs });
+  await control.evaluate(
+    async (node, options) => {
+      const nextFrame = () =>
+        new Promise<number>((resolve) => requestAnimationFrame(() => resolve(performance.now())));
+
+      for (let attempt = 0; attempt < options.attempts; attempt += 1) {
+        const first = node.getBoundingClientRect();
+        const startedAt = await nextFrame();
+        let now = startedAt;
+        while (now - startedAt < options.settleMs) {
+          now = await nextFrame();
+        }
+        const second = node.getBoundingClientRect();
+        const stableAndInViewport =
+          first.width > 0 &&
+          first.height > 0 &&
+          Math.abs(first.left - second.left) < 0.5 &&
+          Math.abs(first.top - second.top) < 0.5 &&
+          Math.abs(first.width - second.width) < 0.5 &&
+          Math.abs(first.height - second.height) < 0.5 &&
+          second.left >= 0 &&
+          second.top >= 0 &&
+          second.right <= window.innerWidth &&
+          second.bottom <= window.innerHeight;
+        if (!stableAndInViewport) continue;
+
+        const centerX = second.left + second.width / 2;
+        const centerY = second.top + second.height / 2;
+        const topAtCenter = document.elementFromPoint(centerX, centerY);
+        if (topAtCenter && (topAtCenter === node || node.contains(topAtCenter))) return;
+      }
+
+      throw new Error("sidebar control did not settle into an interactable layout");
+    },
+    { attempts: SIDEBAR_SETTLE_ATTEMPTS, settleMs: SIDEBAR_TRANSITION_SETTLE_MS },
+  );
+}


### PR DESCRIPTION
## Outcome

Repairs the shared `T3-CFG-1` navigation failure observed on exact-main strict run 29661799394. When a reused renderer is still on the workspace shell, the collector now expands the animated sidebar and proves the `New chat` control has stable in-viewport geometry, remains inside every overflow-clipping ancestor's client area, and owns its center hit target before clicking once.

This does not force clicks, retry product actions, or convert any product failure to green.

## Exact custody

- Base: `6fdec94eba59192bf17fd46435b1da5069127c3f`
- Final head: `f80205dbf20e160c308841a4a97826f8a5af9951`
- Evidence source: Actions run 29661799394, artifact `local-functional-evidence` ID 8434895810
- Independent verdict: `CONTROL_CLEAN / CODE_MERGE_READY` at comment 5013223869

## Offline proof

- focused config/sidebar tests: 30/30 green
- independent delta regression: 3/3 green
- `npm run typecheck`: green
- `python3 scripts/check_max_lines.py`: green
- `git diff --check`: green
- exact-head repository CI: fully green

No Rust build, Docker, provider call, or live qualification run was performed for the repair. Strict live `T3-CFG-1` replay remains separate acceptance evidence. Product/configuration failures remain separately tracked in #1375, #1410, and #1411.
