### PR TITLE
fix(sessions): adopt recovered runtime session ids

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.test.ts
@@ -85,6 +85,7 @@ describe("pending empty-session creation", () => {
         workspaceId: ENTRY.workspaceId,
         clientSessionId: ENTRY.clientSessionId,
         runtimeSessionId: ENTRY.runtimeSessionId,
+        adoptMaterializedSessionId: true,
         agentKind: ENTRY.agentKind,
         modelId: ENTRY.modelId,
         resolvedModeId: ENTRY.modeId,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.ts
@@ -366,6 +366,7 @@ export async function resumePendingEmptySessionCreations(
         workspaceId,
         clientSessionId: entry.clientSessionId,
         runtimeSessionId: entry.runtimeSessionId,
+        adoptMaterializedSessionId: true,
         agentKind: entry.agentKind,
         modelId: entry.modelId,
         resolvedModeId: entry.modeId,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts
@@ -1,8 +1,11 @@
 import { batchSessionStoreWrites } from "#product/lib/infra/scheduling/react-batching";
 import {
+  getSessionRecord,
   patchSessionRecord,
+  putSessionRecord,
   removeSessionRecord,
 } from "#product/stores/sessions/session-records";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
 
@@ -18,6 +21,46 @@ export function materializeSessionRecord(
       materializedSessionId,
     });
   });
+}
+
+/**
+ * A recovered empty-session create is the one materialization path that begins
+ * in a fresh renderer with a durable client alias. Once its caller-selected
+ * runtime id is acknowledged, that alias has no remaining ownership: promote
+ * the directory, transcript, queued intents, and active selection together so
+ * the renderer converges to the same identity a normal reload would expose.
+ */
+export function promoteMaterializedSessionIdentity(clientSessionId: string): string {
+  const record = getSessionRecord(clientSessionId);
+  const materializedSessionId = record?.materializedSessionId ?? null;
+  if (!record || !materializedSessionId || materializedSessionId === clientSessionId) {
+    return clientSessionId;
+  }
+
+  batchSessionStoreWrites(() => {
+    removeSessionRecord(clientSessionId);
+    putSessionRecord({
+      ...record,
+      sessionId: materializedSessionId,
+      materializedSessionId,
+      transcript: {
+        ...record.transcript,
+        sessionMeta: {
+          ...record.transcript.sessionMeta,
+          sessionId: materializedSessionId,
+        },
+      },
+    });
+    useSessionIntentStore.getState().reassignClientSession(
+      clientSessionId,
+      materializedSessionId,
+    );
+    const selection = useSessionSelectionStore.getState();
+    if (selection.activeSessionId === clientSessionId) {
+      selection.setActiveSessionId(materializedSessionId);
+    }
+  });
+  return materializedSessionId;
 }
 
 export function removeSessionRecordAndClearSelection(sessionId: string): void {

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts
@@ -36,21 +36,24 @@ export function promoteMaterializedSessionIdentity(clientSessionId: string): str
   if (!record || !materializedSessionId || materializedSessionId === clientSessionId) {
     return clientSessionId;
   }
+  const authoritativeRecord = getSessionRecord(materializedSessionId);
 
   batchSessionStoreWrites(() => {
     removeSessionRecord(clientSessionId);
-    putSessionRecord({
-      ...record,
-      sessionId: materializedSessionId,
-      materializedSessionId,
-      transcript: {
-        ...record.transcript,
-        sessionMeta: {
-          ...record.transcript.sessionMeta,
-          sessionId: materializedSessionId,
+    putSessionRecord(
+      authoritativeRecord ?? {
+        ...record,
+        sessionId: materializedSessionId,
+        materializedSessionId,
+        transcript: {
+          ...record.transcript,
+          sessionMeta: {
+            ...record.transcript.sessionMeta,
+            sessionId: materializedSessionId,
+          },
         },
       },
-    });
+    );
     useSessionIntentStore.getState().reassignClientSession(
       clientSessionId,
       materializedSessionId,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-recovered-identity.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-recovered-identity.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { adoptRecoveredSessionIdentity } from "#product/hooks/sessions/workflows/session-creation-recovered-identity";
+import { materializeSessionRecord } from "#product/hooks/sessions/workflows/session-creation-local-state";
+import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+describe("recovered session identity adoption", () => {
+  beforeEach(() => {
+    useSessionSelectionStore.getState().clearSelection();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
+    useWorkspaceUiStore.setState({
+      activeShellTabKeyByWorkspace: {},
+      shellActivationEpochByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
+      shellTabOrderByWorkspace: {},
+      visibleChatSessionIdsByWorkspace: {},
+      manualChatGroupsByWorkspace: {},
+    });
+  });
+
+  it("writes completion to the captured shell owner after selection changes", () => {
+    const clientSessionId = "client-session:codex:recovered";
+    const runtimeSessionId = "21234567-89ab-4def-8123-456789abcdef";
+    const selection = useSessionSelectionStore.getState();
+    selection.activateWorkspace({
+      logicalWorkspaceId: "logical-workspace-a",
+      workspaceId: "runtime-workspace-a",
+      initialActiveSessionId: clientSessionId,
+    });
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      workspaceId: "runtime-workspace-a",
+      materializedSessionId: null,
+    }));
+    const initialWrite = writeChatShellIntentForSession({
+      workspaceId: "runtime-workspace-a",
+      sessionId: clientSessionId,
+    });
+    expect(initialWrite?.shellWorkspaceId).toBe("logical-workspace-a");
+    const workspaceUi = useWorkspaceUiStore.getState();
+    workspaceUi.setShellTabOrderForWorkspace("logical-workspace-a", [
+      chatWorkspaceShellTabKey(clientSessionId),
+    ]);
+    workspaceUi.setVisibleChatSessionIdsForWorkspace(
+      "logical-workspace-a",
+      [clientSessionId],
+    );
+    materializeSessionRecord(
+      clientSessionId,
+      runtimeSessionId,
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "runtime-workspace-a",
+        materializedSessionId: runtimeSessionId,
+      }),
+    );
+
+    selection.activateWorkspace({
+      logicalWorkspaceId: "logical-workspace-b",
+      workspaceId: "runtime-workspace-b",
+      initialActiveSessionId: "other-session",
+    });
+    writeChatShellIntentForSession({
+      workspaceId: "runtime-workspace-b",
+      sessionId: "other-session",
+    });
+    let completionOwner: string | null | undefined;
+
+    const adoptedSessionId = adoptRecoveredSessionIdentity({
+      clientSessionId,
+      materializedWorkspaceId: "runtime-workspace-a",
+      ownedShellWorkspaceId: initialWrite?.shellWorkspaceId ?? null,
+      resolvedSessionId: clientSessionId,
+      writeOwnedShellIntent: (sessionId, shellWorkspaceId) => {
+        completionOwner = shellWorkspaceId;
+        writeChatShellIntentForSession({
+          workspaceId: "runtime-workspace-a",
+          shellWorkspaceId,
+          sessionId,
+        });
+      },
+    });
+
+    const promotedUi = useWorkspaceUiStore.getState();
+    expect(adoptedSessionId).toBe(runtimeSessionId);
+    expect(completionOwner).toBe("logical-workspace-a");
+    expect(promotedUi.activeShellTabKeyByWorkspace["logical-workspace-a"])
+      .toBe(chatWorkspaceShellTabKey(runtimeSessionId));
+    expect(promotedUi.activeShellTabKeyByWorkspace["logical-workspace-b"])
+      .toBe(chatWorkspaceShellTabKey("other-session"));
+    expect(promotedUi.shellTabOrderByWorkspace["logical-workspace-a"])
+      .toEqual([chatWorkspaceShellTabKey(runtimeSessionId)]);
+    expect(promotedUi.visibleChatSessionIdsByWorkspace["logical-workspace-a"])
+      .toEqual([runtimeSessionId]);
+    expect(useSessionSelectionStore.getState().selectedWorkspaceId)
+      .toBe("runtime-workspace-b");
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe("other-session");
+    expect(getSessionRecord(clientSessionId)).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-recovered-identity.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-recovered-identity.ts
@@ -1,0 +1,28 @@
+import { promoteMaterializedSessionIdentity } from "#product/hooks/sessions/workflows/session-creation-local-state";
+import { replaceSessionIdInShellPreferences } from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
+
+export function adoptRecoveredSessionIdentity(input: {
+  clientSessionId: string;
+  materializedWorkspaceId: string;
+  ownedShellWorkspaceId: string | null;
+  resolvedSessionId: string;
+  writeOwnedShellIntent: (
+    sessionId: string,
+    shellWorkspaceId?: string | null,
+  ) => void;
+}): string {
+  const adoptedSessionId = promoteMaterializedSessionIdentity(input.clientSessionId);
+  if (adoptedSessionId === input.clientSessionId) {
+    return input.resolvedSessionId;
+  }
+  if (input.ownedShellWorkspaceId) {
+    replaceSessionIdInShellPreferences({
+      shellWorkspaceId: input.ownedShellWorkspaceId,
+      materializedWorkspaceId: input.materializedWorkspaceId,
+      replacedSessionId: input.clientSessionId,
+      replacementSessionId: adoptedSessionId,
+    });
+  }
+  input.writeOwnedShellIntent(adoptedSessionId, input.ownedShellWorkspaceId);
+  return adoptedSessionId;
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-types.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-types.ts
@@ -24,6 +24,11 @@ export interface CreateSessionWithResolvedConfigOptions {
   clientSessionId?: string | null;
   /** Stable server session UUID used to resume an interrupted empty create. */
   runtimeSessionId?: string | null;
+  /**
+   * Fresh-renderer recovery only: once the replayed create materializes, move
+   * the shell from the stale optimistic alias to the authoritative runtime id.
+   */
+  adoptMaterializedSessionId?: boolean;
   /** Subagent preference frozen before an interrupted empty create. */
   subagentsEnabled?: boolean;
   reuseInFlightEmptySession?: boolean;
@@ -53,6 +58,8 @@ export interface CreateEmptySessionWithResolvedConfigOptions {
   clientSessionId?: string | null;
   /** Stable server session UUID used to resume an interrupted empty create. */
   runtimeSessionId?: string | null;
+  /** Promote a recovered optimistic shell to its runtime id after materialization. */
+  adoptMaterializedSessionId?: boolean;
   subagentsEnabled?: boolean;
   reuseInFlightEmptySession?: boolean;
   preserveProjectedSessionOnCreateFailure?: boolean;

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createManualChatGroupId } from "#product/lib/domain/workspaces/tabs/manual-groups";
 import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
-import { beginReplacementShellPreferences } from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
+import {
+  beginReplacementShellPreferences,
+  replaceSessionIdInShellPreferences,
+} from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
 
 describe("replacement shell preferences", () => {
   beforeEach(() => {
@@ -118,6 +121,32 @@ describe("replacement shell preferences", () => {
         .toEqual(["old", "other"]);
       expect(rolledBack.manualChatGroupsByWorkspace[workspaceId]?.[0]?.sessionIds)
         .toEqual(["old", "other"]);
+    }
+  });
+
+  it("promotes a recovered alias across logical and materialized workspace keys", () => {
+    seedPreferences("workspace-logical");
+    seedPreferences("workspace-runtime");
+
+    replaceSessionIdInShellPreferences({
+      shellWorkspaceId: "workspace-logical",
+      materializedWorkspaceId: "workspace-runtime",
+      replacedSessionId: "old",
+      replacementSessionId: "runtime-session-id",
+    });
+
+    const promoted = useWorkspaceUiStore.getState();
+    for (const workspaceId of ["workspace-logical", "workspace-runtime"]) {
+      expect(promoted.shellTabOrderByWorkspace[workspaceId]).toContain(
+        chatWorkspaceShellTabKey("runtime-session-id"),
+      );
+      expect(promoted.shellTabOrderByWorkspace[workspaceId]).not.toContain(
+        chatWorkspaceShellTabKey("old"),
+      );
+      expect(promoted.visibleChatSessionIdsByWorkspace[workspaceId])
+        .toEqual(["runtime-session-id", "other"]);
+      expect(promoted.manualChatGroupsByWorkspace[workspaceId]?.[0]?.sessionIds)
+        .toEqual(["runtime-session-id", "other"]);
     }
   });
 });

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts
@@ -33,114 +33,91 @@ export function beginReplacementShellPreferences(input: {
   const snapshots: ReplacementShellPreferenceSnapshot[] = [];
 
   for (const workspaceId of workspaceIds) {
-    const state = useWorkspaceUiStore.getState();
-    const beforeOrder = ownArray(state.shellTabOrderByWorkspace, workspaceId);
-    const beforeVisible = ownArray(
-      state.visibleChatSessionIdsByWorkspace,
-      workspaceId,
-    );
-    const beforeManualGroups = ownManualGroups(
-      state.manualChatGroupsByWorkspace,
-      workspaceId,
-    );
-    const afterOrder = beforeOrder
-      ? replaceSessionIdInShellTabOrder(
-        beforeOrder,
-        input.replacedSessionId,
-        input.replacementSessionId,
-      )
-      : null;
-    const afterVisible = beforeVisible
-      ? replaceSessionIdInOrderedList(
-        beforeVisible,
-        input.replacedSessionId,
-        input.replacementSessionId,
-      )
-      : null;
-    const afterManualGroups = beforeManualGroups
-      ? replaceSessionIdInManualChatGroups(
-        beforeManualGroups,
-        input.replacedSessionId,
-        input.replacementSessionId,
-      )
-      : null;
-    const changedOrder = !!afterOrder
-      && !sameStringList(beforeOrder ?? [], afterOrder);
-    const changedVisible = !!afterVisible
-      && !sameStringList(beforeVisible ?? [], afterVisible);
-    const changedManualGroups = !!afterManualGroups
-      && !sameManualChatGroups(beforeManualGroups ?? [], afterManualGroups);
-
-    if (changedOrder && afterOrder) {
-      state.setShellTabOrderForWorkspace(workspaceId, afterOrder);
-    }
-    if (changedVisible && afterVisible) {
-      state.setVisibleChatSessionIdsForWorkspace(workspaceId, afterVisible);
-    }
-    if (changedManualGroups && afterManualGroups) {
-      state.setManualChatGroupsForWorkspace(workspaceId, afterManualGroups);
-    }
+    replaceSessionIdInShellPreferencesForWorkspace(workspaceId, input);
     snapshots.push({ workspaceId });
   }
 
   return {
     rollback: () => {
       for (const snapshot of snapshots) {
-        const state = useWorkspaceUiStore.getState();
-        const currentOrder = ownArray(
-          state.shellTabOrderByWorkspace,
-          snapshot.workspaceId,
-        );
-        const nextOrder = currentOrder
-          ? replaceSessionIdInShellTabOrder(
-            currentOrder,
-            input.replacementSessionId,
-            input.replacedSessionId,
-          )
-          : null;
-        if (nextOrder && !sameStringList(currentOrder ?? [], nextOrder)) {
-          state.setShellTabOrderForWorkspace(snapshot.workspaceId, nextOrder);
-        }
-        const currentVisible = ownArray(
-          state.visibleChatSessionIdsByWorkspace,
-          snapshot.workspaceId,
-        );
-        const nextVisible = currentVisible
-          ? replaceSessionIdInOrderedList(
-            currentVisible,
-            input.replacementSessionId,
-            input.replacedSessionId,
-          )
-          : null;
-        if (nextVisible && !sameStringList(currentVisible ?? [], nextVisible)) {
-          state.setVisibleChatSessionIdsForWorkspace(
-            snapshot.workspaceId,
-            nextVisible,
-          );
-        }
-        const currentManualGroups = ownManualGroups(
-          state.manualChatGroupsByWorkspace,
-          snapshot.workspaceId,
-        );
-        const nextManualGroups = currentManualGroups
-          ? replaceSessionIdInManualChatGroups(
-            currentManualGroups,
-            input.replacementSessionId,
-            input.replacedSessionId,
-          )
-          : null;
-        if (
-          nextManualGroups
-          && !sameManualChatGroups(currentManualGroups ?? [], nextManualGroups)
-        ) {
-          state.setManualChatGroupsForWorkspace(
-            snapshot.workspaceId,
-            nextManualGroups,
-          );
-        }
+        replaceSessionIdInShellPreferencesForWorkspace(snapshot.workspaceId, {
+          replacedSessionId: input.replacementSessionId,
+          replacementSessionId: input.replacedSessionId,
+        });
       }
     },
   };
+}
+
+/** One-way identity promotion after a recovered session has materialized. */
+export function replaceSessionIdInShellPreferences(input: {
+  shellWorkspaceId: string;
+  materializedWorkspaceId: string;
+  replacedSessionId: string;
+  replacementSessionId: string;
+}): void {
+  for (const workspaceId of new Set([
+    input.shellWorkspaceId,
+    input.materializedWorkspaceId,
+  ])) {
+    replaceSessionIdInShellPreferencesForWorkspace(workspaceId, input);
+  }
+}
+
+function replaceSessionIdInShellPreferencesForWorkspace(
+  workspaceId: string,
+  input: {
+    replacedSessionId: string;
+    replacementSessionId: string;
+  },
+): void {
+  const state = useWorkspaceUiStore.getState();
+  const beforeOrder = ownArray(state.shellTabOrderByWorkspace, workspaceId);
+  const beforeVisible = ownArray(
+    state.visibleChatSessionIdsByWorkspace,
+    workspaceId,
+  );
+  const beforeManualGroups = ownManualGroups(
+    state.manualChatGroupsByWorkspace,
+    workspaceId,
+  );
+  const afterOrder = beforeOrder
+    ? replaceSessionIdInShellTabOrder(
+      beforeOrder,
+      input.replacedSessionId,
+      input.replacementSessionId,
+    )
+    : null;
+  const afterVisible = beforeVisible
+    ? replaceSessionIdInOrderedList(
+      beforeVisible,
+      input.replacedSessionId,
+      input.replacementSessionId,
+    )
+    : null;
+  const afterManualGroups = beforeManualGroups
+    ? replaceSessionIdInManualChatGroups(
+      beforeManualGroups,
+      input.replacedSessionId,
+      input.replacementSessionId,
+    )
+    : null;
+  const changedOrder = !!afterOrder
+    && !sameStringList(beforeOrder ?? [], afterOrder);
+  const changedVisible = !!afterVisible
+    && !sameStringList(beforeVisible ?? [], afterVisible);
+  const changedManualGroups = !!afterManualGroups
+    && !sameManualChatGroups(beforeManualGroups ?? [], afterManualGroups);
+
+  if (changedOrder && afterOrder) {
+    state.setShellTabOrderForWorkspace(workspaceId, afterOrder);
+  }
+  if (changedVisible && afterVisible) {
+    state.setVisibleChatSessionIdsForWorkspace(workspaceId, afterVisible);
+  }
+  if (changedManualGroups && afterManualGroups) {
+    state.setManualChatGroupsForWorkspace(workspaceId, afterManualGroups);
+  }
 }
 
 function ownArray<T>(source: Record<string, T[]>, workspaceId: string): T[] | null {

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { buildModelAvailabilityRetryOptions } from "#product/lib/domain/sessions/creation/retry-options";
 import {
   materializeSessionRecord,
+  promoteMaterializedSessionIdentity,
   removeSessionRecordAndClearSelection,
 } from "#product/hooks/sessions/workflows/session-creation-local-state";
 import {
@@ -12,11 +13,16 @@ import {
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+import {
+  getSessionIntentsForSession,
+  useSessionIntentStore,
+} from "#product/stores/sessions/session-intent-store";
 
 beforeEach(() => {
   useSessionSelectionStore.getState().clearSelection();
   useSessionDirectoryStore.getState().clearEntries();
   useSessionTranscriptStore.getState().clearEntries();
+  useSessionIntentStore.getState().clear();
 });
 
 describe("projected session materialization", () => {
@@ -69,6 +75,64 @@ describe("projected session materialization", () => {
     expect(useSessionSelectionStore.getState().activeSessionId).toBeNull();
     expect(getSessionRecord("pending-codex")).toBeNull();
     expect(useSessionSelectionStore.getState().activeSessionVersion).toBe(versionBefore + 1);
+  });
+
+  it("promotes a recovered shell and its queued work to the authoritative runtime id", () => {
+    const clientSessionId = "client-session:codex:recovered";
+    const runtimeSessionId = "01234567-89ab-4def-8123-456789abcdef";
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "workspace-1",
+      workspaceId: "workspace-1",
+    });
+    putSessionRecord(
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: null,
+      }),
+    );
+    useSessionSelectionStore.getState().setActiveSessionId(clientSessionId);
+    useSessionIntentStore.getState().enqueueConfig({
+      clientSessionId,
+      workspaceId: "workspace-1",
+      configId: "reasoning_effort",
+      value: "high",
+    });
+
+    materializeSessionRecord(
+      clientSessionId,
+      runtimeSessionId,
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: runtimeSessionId,
+      }),
+    );
+    useSessionIntentStore.getState().bindMaterializedSession(
+      clientSessionId,
+      runtimeSessionId,
+    );
+
+    expect(promoteMaterializedSessionIdentity(clientSessionId)).toBe(runtimeSessionId);
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe(runtimeSessionId);
+    expect(getSessionRecord(clientSessionId)).toBeNull();
+    expect(getSessionRecord(runtimeSessionId)).toMatchObject({
+      sessionId: runtimeSessionId,
+      materializedSessionId: runtimeSessionId,
+      transcript: {
+        sessionMeta: { sessionId: runtimeSessionId },
+      },
+    });
+    expect(
+      useSessionDirectoryStore.getState()
+        .clientSessionIdByMaterializedSessionId[runtimeSessionId],
+    ).toBe(runtimeSessionId);
+    expect(getSessionIntentsForSession(clientSessionId)).toEqual([]);
+    expect(getSessionIntentsForSession(runtimeSessionId)).toEqual([
+      expect.objectContaining({
+        clientSessionId: runtimeSessionId,
+        materializedSessionId: runtimeSessionId,
+        kind: "update_config",
+      }),
+    ]);
   });
 });
 

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts
@@ -134,6 +134,75 @@ describe("projected session materialization", () => {
       }),
     ]);
   });
+
+  it("preserves an already loaded authoritative runtime record during promotion", () => {
+    const clientSessionId = "client-session:codex:collision";
+    const runtimeSessionId = "11234567-89ab-4def-8123-456789abcdef";
+    putSessionRecord(
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: null,
+        title: "Recovered replay snapshot",
+      }),
+    );
+    materializeSessionRecord(
+      clientSessionId,
+      runtimeSessionId,
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: runtimeSessionId,
+        title: "Recovered replay snapshot",
+      }),
+    );
+    const authoritativeRecord = createEmptySessionRecord(runtimeSessionId, "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: runtimeSessionId,
+      title: "Authoritative runtime state",
+    });
+    const authoritativeTranscript = {
+      ...authoritativeRecord.transcript,
+      sessionMeta: {
+        ...authoritativeRecord.transcript.sessionMeta,
+        title: "Authoritative transcript",
+      },
+    };
+    putSessionRecord({
+      ...authoritativeRecord,
+      transcript: authoritativeTranscript,
+      transcriptHydrated: true,
+    });
+    useSessionSelectionStore.getState().setActiveSessionId(clientSessionId);
+    useSessionIntentStore.getState().enqueueConfig({
+      clientSessionId,
+      workspaceId: "workspace-1",
+      configId: "reasoning_effort",
+      value: "high",
+    });
+    useSessionIntentStore.getState().bindMaterializedSession(
+      clientSessionId,
+      runtimeSessionId,
+    );
+
+    expect(promoteMaterializedSessionIdentity(clientSessionId)).toBe(runtimeSessionId);
+
+    const promoted = getSessionRecord(runtimeSessionId);
+    expect(promoted?.title).toBe("Authoritative runtime state");
+    expect(promoted?.transcript).toBe(authoritativeTranscript);
+    expect(promoted?.transcriptHydrated).toBe(true);
+    expect(getSessionRecord(clientSessionId)).toBeNull();
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe(runtimeSessionId);
+    expect(getSessionIntentsForSession(clientSessionId)).toEqual([]);
+    expect(getSessionIntentsForSession(runtimeSessionId)).toEqual([
+      expect.objectContaining({
+        clientSessionId: runtimeSessionId,
+        materializedSessionId: runtimeSessionId,
+      }),
+    ]);
+    expect(
+      useSessionDirectoryStore.getState()
+        .clientSessionIdByMaterializedSessionId[runtimeSessionId],
+    ).toBe(runtimeSessionId);
+  });
 });
 
 describe("buildModelAvailabilityRetryOptions", () => {

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -53,8 +53,12 @@ import {
 import { registerSessionCreation } from "#product/hooks/sessions/workflows/session-creation-supersession";
 import {
   beginReplacementShellPreferences,
+  replaceSessionIdInShellPreferences,
   type ReplacementShellPreferencesTransaction,
 } from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
+import {
+  promoteMaterializedSessionIdentity,
+} from "#product/hooks/sessions/workflows/session-creation-local-state";
 import { cleanupSessionCreationFailure } from "#product/hooks/sessions/workflows/session-creation-failure-cleanup";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
@@ -394,6 +398,22 @@ export function useSessionCreationActions() {
       // A superseded materializer can settle without issuing the POST. Its
       // durable intent must not be resurrected by the next bootstrap.
       await pendingCreationLifecycle.current?.clear();
+      if (options.adoptMaterializedSessionId === true) {
+        const adoptedSessionId = promoteMaterializedSessionIdentity(pendingSessionId);
+        if (adoptedSessionId !== pendingSessionId) {
+          if (currentOwnedShellWorkspaceId) {
+            replaceSessionIdInShellPreferences({
+              shellWorkspaceId: currentOwnedShellWorkspaceId,
+              materializedWorkspaceId: workspaceId,
+              replacedSessionId: pendingSessionId,
+              replacementSessionId: adoptedSessionId,
+            });
+          }
+          writeOwnedShellIntent(adoptedSessionId);
+          currentOwnedSessionId = adoptedSessionId;
+          return adoptedSessionId;
+        }
+      }
       return resolvedSessionId;
     }).finally(unregisterSessionCreation);
 
@@ -478,6 +498,7 @@ export function useSessionCreationActions() {
       latencyFlowId: options.latencyFlowId,
       clientSessionId: options.clientSessionId,
       runtimeSessionId: options.runtimeSessionId,
+      adoptMaterializedSessionId: options.adoptMaterializedSessionId,
       subagentsEnabled: options.subagentsEnabled,
       reuseInFlightEmptySession: options.reuseInFlightEmptySession,
       preserveProjectedSessionOnCreateFailure: options.preserveProjectedSessionOnCreateFailure,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -53,12 +53,9 @@ import {
 import { registerSessionCreation } from "#product/hooks/sessions/workflows/session-creation-supersession";
 import {
   beginReplacementShellPreferences,
-  replaceSessionIdInShellPreferences,
   type ReplacementShellPreferencesTransaction,
 } from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
-import {
-  promoteMaterializedSessionIdentity,
-} from "#product/hooks/sessions/workflows/session-creation-local-state";
+import { adoptRecoveredSessionIdentity } from "#product/hooks/sessions/workflows/session-creation-recovered-identity";
 import { cleanupSessionCreationFailure } from "#product/hooks/sessions/workflows/session-creation-failure-cleanup";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
@@ -230,8 +227,8 @@ export function useSessionCreationActions() {
     let currentOwnedShellEpoch: number | null = null;
     let currentOwnedShellWorkspaceId: string | null = null;
     let currentOwnedSessionId: string | null = null;
-    const writeOwnedShellIntent = (sessionId: string): void => {
-      const write = writeChatShellIntentForSession({ workspaceId, sessionId });
+    const writeOwnedShellIntent = (sessionId: string, shellWorkspaceId?: string | null): void => {
+      const write = writeChatShellIntentForSession({ workspaceId, shellWorkspaceId, sessionId });
       if (!write) {
         return;
       }
@@ -399,20 +396,13 @@ export function useSessionCreationActions() {
       // durable intent must not be resurrected by the next bootstrap.
       await pendingCreationLifecycle.current?.clear();
       if (options.adoptMaterializedSessionId === true) {
-        const adoptedSessionId = promoteMaterializedSessionIdentity(pendingSessionId);
-        if (adoptedSessionId !== pendingSessionId) {
-          if (currentOwnedShellWorkspaceId) {
-            replaceSessionIdInShellPreferences({
-              shellWorkspaceId: currentOwnedShellWorkspaceId,
-              materializedWorkspaceId: workspaceId,
-              replacedSessionId: pendingSessionId,
-              replacementSessionId: adoptedSessionId,
-            });
-          }
-          writeOwnedShellIntent(adoptedSessionId);
-          currentOwnedSessionId = adoptedSessionId;
-          return adoptedSessionId;
-        }
+        return adoptRecoveredSessionIdentity({
+          clientSessionId: pendingSessionId,
+          materializedWorkspaceId: workspaceId,
+          ownedShellWorkspaceId: currentOwnedShellWorkspaceId,
+          resolvedSessionId,
+          writeOwnedShellIntent,
+        });
       }
       return resolvedSessionId;
     }).finally(unregisterSessionCreation);
@@ -482,29 +472,11 @@ export function useSessionCreationActions() {
     storageContext,
   ]);
 
-  const createEmptySessionWithResolvedConfig = useCallback(async (
+  const createEmptySessionWithResolvedConfig = useCallback((
     options: CreateEmptySessionWithResolvedConfigOptions,
-  ): Promise<string> => {
-    return createSessionWithResolvedConfig({
-      text: "",
-      agentKind: options.agentKind,
-      modelId: options.modelId,
-      modeId: options.modeId,
-      resolvedModeId: options.resolvedModeId,
-      unattendedModeId: options.unattendedModeId,
-      launchControlValues: options.launchControlValues,
-      frozenLiveControlValues: options.frozenLiveControlValues,
-      workspaceId: options.workspaceId,
-      latencyFlowId: options.latencyFlowId,
-      clientSessionId: options.clientSessionId,
-      runtimeSessionId: options.runtimeSessionId,
-      adoptMaterializedSessionId: options.adoptMaterializedSessionId,
-      subagentsEnabled: options.subagentsEnabled,
-      reuseInFlightEmptySession: options.reuseInFlightEmptySession,
-      preserveProjectedSessionOnCreateFailure: options.preserveProjectedSessionOnCreateFailure,
-      replacesSessionId: options.replacesSessionId,
-    });
-  }, [createSessionWithResolvedConfig]);
+  ): Promise<string> => createSessionWithResolvedConfig({ ...options, text: "" }), [
+    createSessionWithResolvedConfig,
+  ]);
 
   return { createEmptySessionWithResolvedConfig, createSessionWithResolvedConfig };
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/session-replacement.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/session-replacement.test.ts
@@ -36,4 +36,28 @@ describe("session replacement tab identity", () => {
       sessionIds: ["new", "other"],
     }]);
   });
+
+  it("keeps one deterministic group owner when the runtime id already exists", () => {
+    expect(replaceSessionIdInManualChatGroups([{
+      id: createManualChatGroupId("runtime-group"),
+      label: "Existing runtime group",
+      colorId: "blue",
+      sessionIds: ["new", "runtime-peer"],
+    }, {
+      id: createManualChatGroupId("alias-group"),
+      label: "Recovered alias group",
+      colorId: "magenta",
+      sessionIds: ["old", "alias-peer"],
+    }], "old", "new")).toEqual([{
+      id: createManualChatGroupId("runtime-group"),
+      label: "Existing runtime group",
+      colorId: "blue",
+      sessionIds: ["runtime-peer"],
+    }, {
+      id: createManualChatGroupId("alias-group"),
+      label: "Recovered alias group",
+      colorId: "magenta",
+      sessionIds: ["new", "alias-peer"],
+    }]);
+  });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/session-replacement.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/session-replacement.ts
@@ -41,12 +41,36 @@ export function replaceSessionIdInManualChatGroups(
   replacedSessionId: string,
   replacementSessionId: string,
 ): ManualChatGroup[] {
-  return groups.map((group) => ({
+  const replacementOwnerIndex = groups.findIndex((group) =>
+    group.sessionIds.includes(replacedSessionId)
+  );
+  const mappedGroups = groups.map((group) => ({
     ...group,
     sessionIds: replaceSessionIdInOrderedList(
       group.sessionIds,
       replacedSessionId,
       replacementSessionId,
     ),
+  }));
+  if (replacementOwnerIndex < 0) {
+    return mappedGroups;
+  }
+
+  const assignedSessionIds = new Set<string>();
+  return mappedGroups.map((group, groupIndex) => ({
+    ...group,
+    sessionIds: group.sessionIds.filter((sessionId) => {
+      if (
+        sessionId === replacementSessionId
+        && groupIndex !== replacementOwnerIndex
+      ) {
+        return false;
+      }
+      if (assignedSessionIds.has(sessionId)) {
+        return false;
+      }
+      assignedSessionIds.add(sessionId);
+      return true;
+    }),
   }));
 }

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
@@ -53,6 +53,7 @@ interface SessionIntentStoreState extends SessionIntentStateShape {
   patchIntent: (intentId: string, patch: Partial<SessionIntent>) => void;
   removeIntent: (intentId: string) => void;
   bindMaterializedSession: (clientSessionId: string, materializedSessionId: string) => void;
+  reassignClientSession: (clientSessionId: string, nextClientSessionId: string) => void;
   reconcileFromEnvelopes: (
     clientSessionId: string,
     envelopes: readonly SessionEventEnvelope[],
@@ -207,6 +208,33 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         materializedSessionId,
       }, debugStartedAtMs);
       return next;
+    });
+  },
+
+  reassignClientSession: (clientSessionId, nextClientSessionId) => {
+    if (clientSessionId === nextClientSessionId) {
+      return;
+    }
+    const debugStartedAtMs = startSessionIntentStoreActionTrace();
+    set((state) => {
+      const intents = sessionIntentsForSession(state, clientSessionId);
+      if (intents.length === 0) {
+        return state;
+      }
+      let next: SessionIntentStateShape = state;
+      for (const intent of intents) {
+        next = removeSessionIntent(next, intent.intentId);
+        next = upsertSessionIntent(next, {
+          ...intent,
+          clientSessionId: nextClientSessionId,
+        });
+      }
+      const versionedNext = withDispatchVersion(state, next);
+      recordSessionIntentStoreAction("reassignClientSession", state, versionedNext, {
+        clientSessionId,
+        nextClientSessionId,
+      }, debugStartedAtMs);
+      return versionedNext;
     });
   },
 

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -348,7 +348,11 @@ the materializer retires the created runtime or retains it honestly rather than
 publishing an unowned replay entry. If a reload interrupts the request before
 the response is observed, workspace bootstrap resumes the entry with both
 original ids and frozen inputs before it considers opening a default empty
-session. The runtime UUID is the idempotency identity: resume may repeat that
+session. The fresh renderer keeps the original client alias only while that
+replay is unresolved. Once the replay materializes, it atomically promotes the
+session record, queued intents, active selection, and shell preferences to the
+runtime UUID; a successful replay must not leave a `client-session:*` tab
+behind. The runtime UUID is the idempotency identity: resume may repeat that
 exact request, but must never probe by agent/model and must never mint a new
 UUID as a fallback. This ledger is limited to empty session creation;
 prompt-bearing projected sessions retain their existing inspectable


### PR DESCRIPTION
## Summary

- resume interrupted empty-session creation with the original client alias only while replay remains unresolved
- after successful materialization, promote alias-owned state to the authoritative runtime UUID
- preserve an already loaded authoritative runtime record/transcript on collision
- preserve the captured owning workspace across concurrent selection changes
- enforce deterministic one-group ownership across manual tab groups
- preserve the durable idempotency ledger and strict Tier 3 reconciliation/cleanup evidence

## Root cause

The earlier interrupted-create repair made the runtime UUID idempotent, but fresh-renderer recovery still materialized the server session into a record keyed by the optimistic `client-session:*` alias. The real session existed while the active tab continued to own the stale alias, matching local Tier 3 run 29661799394.

## Exact custody

- Base: `1dd3710dc6b903ec1286e50d8a4263e3e2c2b2a8`
- Final head: `cec037674f4112c214e98c37d4b10e51ff5efec1`
- Independent verdict: `CONTROL_CLEAN / CODE_MERGE_READY` at comment 5013415983
- Prior findings `BLOCKER-1414-01..04`: resolved

## Proof

- focused session recovery suite: 39/39 green
- independent delta proof: 11/11 green
- ProductClient typecheck: green
- frontend boundaries and strict structure: green, `TOTAL: 0`
- max-lines, docs, and diff checks: green
- exact-head GitHub CI, CodeQL, Intent Tests, metadata, and smoke checks: green

No collector or cleanup acceptance was weakened. Strict live local replay remains separate world-acceptance evidence.

Fixes #1375
