### PR TITLE
perf(chat): smooth assistant streaming and composer input

### DIFF
--- a/apps/packages/design/scripts/generate-theme.mjs
+++ b/apps/packages/design/scripts/generate-theme.mjs
@@ -69,14 +69,19 @@ ${shadowLines}
   }
 }
 
-.proliferate-spinner {
-  animation: proliferate-spinner-rotate 1.1s linear infinite;
+/* Keep the inline layout box stationary. Rotating it changes its transformed
+   bounding box throughout the cycle and makes compact tab/sidebar spinners
+   appear to orbit instead of spinning in place. */
+.proliferate-spinner > svg {
+  display: block;
+  animation: proliferate-spinner-rotate 1.4s linear infinite;
+  transform-box: view-box;
   transform-origin: center;
   will-change: transform;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .proliferate-spinner {
+  .proliferate-spinner > svg {
     animation: none;
     transform: rotate(22deg);
   }

--- a/apps/packages/design/src/css/dom.css
+++ b/apps/packages/design/src/css/dom.css
@@ -16,7 +16,7 @@
   --text-ui--line-height: 16px;       /* font size + 5px */
   --text-ui-sm: 10px;                 /* descriptions, secondary labels, notices, meta */
   --text-ui-sm--line-height: 14px;    /* font size + 4px */
-  --text-composer: 12px;              /* composer input text only */
+  --text-composer: 12px;              /* composer input and message text */
   --text-composer--line-height: 20px; /* font size + 8px */
   --text-title: 18px;                 /* page/settings titles (SettingsPageHeader pairing) */
   --text-title--line-height: 22px;    /* 1.2 × font size */
@@ -150,6 +150,29 @@ body {
   backdrop-filter: var(--color-composer-backdrop-filter);
 }
 
+/* The composer uses a fail-safe one-pixel visual caret because current macOS
+   WebKit paints its redesigned native caret at two CSS pixels. Layout-critical
+   styles are inline on the overlay; this rule is the native fallback whenever
+   the overlay cannot resolve a valid collapsed selection. */
+[data-chat-composer-editor] {
+  caret-color: currentColor;
+}
+
+@keyframes chat-composer-caret-blink {
+  0%, 54% { opacity: 1; }
+  55%, 100% { opacity: 0; }
+}
+
+[data-chat-composer-caret] {
+  animation: chat-composer-caret-blink 1s steps(1, end) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-chat-composer-caret] {
+    animation: none;
+  }
+}
+
 /* ---- Skeleton shimmer (codex block shimmer) ----
    Loading blocks share one motion family with the thinking-text sweep in
    product.css: a soft gradient band travelling left→right via transform
@@ -232,19 +255,17 @@ body {
   }
 }
 
-/* ---- Stream word reveal ----
-   Word-level opacity fade for the live streaming tail. Each word mounts at
-   near-invisible and fades to full over 200ms. Opacity-only: cannot cause
-   layout shift, preserving the anchor invariant (newest content occupies its
-   final position instantly). Starts at 0.05 (not 0) so the bottom-most line
-   never looks empty while animating. */
+/* ---- Streaming prose reveal ----
+   Each recent word owns an opacity-only animation. Existing word spans retain
+   their class and source-order key for the entire fade window, so a later word
+   can begin before earlier words reach full opacity. */
 @keyframes stream-word-in {
-  from { opacity: 0.05; }
+  from { opacity: 0.08; }
   to { opacity: 1; }
 }
 
 .stream-word {
-  animation: stream-word-in 0.2s cubic-bezier(0.37, 0.55, 0.86, 0.88) both;
+  animation: stream-word-in 320ms linear both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -1624,27 +1624,6 @@ body {
 .animate-snake-11 { opacity: 0; animation: snake-n11 2.08s linear infinite; }
 .animate-snake-12 { opacity: 0; animation: snake-n12 2.08s linear infinite; }
 
-/* ---- Compact spinner ----
-   Shared current-color spinner for small controls. */
-@keyframes proliferate-spinner-rotate {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.proliferate-spinner {
-  animation: proliferate-spinner-rotate 1.4s linear infinite;
-  transform-origin: center;
-  will-change: transform;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .proliferate-spinner {
-    animation: none;
-    transform: rotate(22deg);
-  }
-}
-
 /* ---- Braille sweep loading text ----
    Retained as a CSS-driven auth-only mark. */
 @keyframes braille-sweep-content {

--- a/apps/packages/product-client/package.json
+++ b/apps/packages/product-client/package.json
@@ -66,6 +66,7 @@
     "@lexical/list": "^0.48.0",
     "@lexical/markdown": "^0.48.0",
     "@lexical/react": "^0.48.0",
+    "@lexical/selection": "^0.48.0",
     "@lezer/common": "^1.2.3",
     "@lezer/highlight": "^1.2.3",
     "@monaco-editor/react": "^4",

--- a/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { FileReferenceBadge } from "#product/components/workspace/file-references/FileReferenceBadge";
 
 interface FilePathLinkProps {
@@ -21,8 +21,11 @@ interface FilePathLinkProps {
  * Style: Codex-style local file/doc link in `text-link-foreground`, no pill,
  * no border, underline on hover only.
  */
-export function FilePathLink({ rawPath, children }: FilePathLinkProps) {
+export const FilePathLink = memo(function FilePathLink({
+  rawPath,
+  children,
+}: FilePathLinkProps) {
   return (
     <FileReferenceBadge rawPath={rawPath} label={children} variant="inline" />
   );
-}
+});

--- a/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
@@ -40,6 +40,8 @@ export function renderComposerSurfaceForScenario(scenario: ScenarioKey): ReactNo
       return <PlaygroundComposerSurface ultra />;
     case "workspace-status-card":
       return <PlaygroundComposerSurface statusControl={<PlaygroundWorkspaceStatusControl />} />;
+    case "status-live-stream":
+      return <PlaygroundComposerSurface interactive />;
     case "slash-command-search":
       return <PlaygroundSlashCommandComposerSurface commands={PLAYGROUND_SLASH_COMMANDS} />;
     case "slash-command-empty":
@@ -51,11 +53,14 @@ export function renderComposerSurfaceForScenario(scenario: ScenarioKey): ReactNo
 
 export function PlaygroundComposerSurface({
   ultra = false,
+  interactive = false,
   statusControl,
 }: {
   ultra?: boolean;
+  interactive?: boolean;
   statusControl?: ReactNode;
 }) {
+  const [draft, setDraft] = useState("");
   return (
     <ChatComposerSurface>
       <form className="relative flex flex-col">
@@ -64,11 +69,14 @@ export function PlaygroundComposerSurface({
           style={{ minHeight: "3.5rem" }}
         >
           <Textarea
+            data-chat-composer-editor
             variant="ghost"
             rows={2}
-            placeholder="Playground composer (read-only)"
+            value={draft}
+            onChange={interactive ? (event) => setDraft(event.target.value) : undefined}
+            placeholder={interactive ? "Type while the response renders" : "Playground composer (read-only)"}
             spellCheck={false}
-            readOnly
+            readOnly={!interactive}
             className="min-h-0 px-0 py-0 text-base leading-relaxed text-foreground placeholder:text-muted-foreground/70"
           />
         </div>

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundStatusTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundStatusTranscript.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { CircleAlert } from "@proliferate/ui/icons";
 import type { GoalTranscriptEvent } from "@proliferate/product-domain/activity/goal-transcript-events";
 import { AssistantMessage } from "#product/components/workspace/chat/transcript/AssistantMessage";
@@ -232,9 +232,11 @@ A couple of useful confirmations: the worktree is detached with unrelated local 
 function LiveStreamPreview() {
   const [visibleLength, setVisibleLength] = useState(0);
   const [cycle, setCycle] = useState(0);
+  const [revealComplete, setRevealComplete] = useState(false);
 
   useEffect(() => {
     setVisibleLength(0);
+    setRevealComplete(false);
     const interval = window.setInterval(() => {
       setVisibleLength((current) => {
         if (current >= LIVE_STREAM_TEXT.length) {
@@ -250,12 +252,23 @@ function LiveStreamPreview() {
     };
   }, [cycle]);
 
+  const handleRevealStateChange = useCallback(
+    (state: { complete: boolean }) => setRevealComplete(state.complete),
+    [],
+  );
+
   const content = LIVE_STREAM_TEXT.slice(0, visibleLength);
   const isStreaming = visibleLength < LIVE_STREAM_TEXT.length;
   return (
     <>
-      {content && <AssistantMessage content={content} isStreaming={isStreaming} />}
-      {!isStreaming && (
+      {content && (
+        <AssistantMessage
+          content={content}
+          isStreaming={isStreaming}
+          onRevealStateChange={handleRevealStateChange}
+        />
+      )}
+      {!isStreaming && revealComplete && (
         <TransientStatusRow text="Reading workspace flow entry points" />
       )}
     </>

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.tsx
@@ -1,0 +1,268 @@
+import { useEffect } from "react";
+import { createDOMRange } from "@lexical/selection";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from "lexical";
+
+interface ComposerCaretMeasurement {
+  color: string;
+  height: number;
+  left: number;
+  top: number;
+}
+
+const CARET_WIDTH_PX = 1;
+
+/**
+ * Replaces WebKit's two-CSS-pixel redesigned insertion caret with a one-pixel
+ * visual caret. The browser selection remains authoritative; this plugin only
+ * paints its collapsed position and immediately restores the native caret when
+ * it cannot prove that the replacement is visible.
+ */
+export function ComposerCaretPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    let caretElement: HTMLSpanElement | null = null;
+    let rootElement: HTMLElement | null = null;
+    let rootCleanup: (() => void) | null = null;
+    let isComposing = false;
+    let scheduledFrame: number | null = null;
+    let previousCaretColor = "";
+    let previousCaretColorPriority = "";
+
+    const restoreNativeCaret = () => {
+      if (rootElement === null) return;
+      if (previousCaretColor) {
+        rootElement.style.setProperty(
+          "caret-color",
+          previousCaretColor,
+          previousCaretColorPriority,
+        );
+      } else {
+        rootElement.style.removeProperty("caret-color");
+      }
+    };
+
+    const hideReplacementCaret = () => {
+      if (caretElement !== null) {
+        caretElement.style.display = "none";
+      }
+      restoreNativeCaret();
+    };
+
+    const destroyReplacementCaret = () => {
+      hideReplacementCaret();
+      caretElement?.remove();
+      caretElement = null;
+    };
+
+    const ensureReplacementCaret = (root: HTMLElement): HTMLSpanElement | null => {
+      const ownerDocument = root.ownerDocument;
+      if (caretElement !== null && caretElement.ownerDocument === ownerDocument) {
+        return caretElement;
+      }
+
+      caretElement?.remove();
+      const body = ownerDocument.body;
+      if (body === null) return null;
+
+      const nextCaret = ownerDocument.createElement("span");
+      nextCaret.setAttribute("aria-hidden", "true");
+      nextCaret.setAttribute("data-chat-composer-caret", "");
+      nextCaret.style.backgroundColor = "currentColor";
+      nextCaret.style.display = "none";
+      nextCaret.style.pointerEvents = "none";
+      nextCaret.style.position = "fixed";
+      nextCaret.style.width = `${CARET_WIDTH_PX}px`;
+      nextCaret.style.zIndex = "2147483647";
+      body.appendChild(nextCaret);
+      caretElement = nextCaret;
+      return nextCaret;
+    };
+
+    const rootHasFocus = (root: HTMLElement): boolean => {
+      const activeElement = root.ownerDocument.activeElement;
+      return activeElement !== null && root.contains(activeElement);
+    };
+
+    const measureCaret = (
+      activeEditor: LexicalEditor,
+      root: HTMLElement,
+    ): ComposerCaretMeasurement | null => {
+      const range = activeEditor.getEditorState().read((): Range | null => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
+        const anchor = selection.anchor;
+        const anchorNode = anchor.getNode();
+        return createDOMRange(
+          activeEditor,
+          anchorNode,
+          anchor.offset,
+          anchorNode,
+          anchor.offset,
+        );
+      });
+
+      if (range === null) return null;
+      const rangeRect = range.getBoundingClientRect();
+      const measuredHeight = rangeRect.height;
+      if (
+        !Number.isFinite(rangeRect.left)
+        || !Number.isFinite(rangeRect.top)
+        || !Number.isFinite(measuredHeight)
+        || measuredHeight <= 0
+      ) return null;
+
+      const ownerWindow = root.ownerDocument.defaultView;
+      const computedStyle = ownerWindow?.getComputedStyle(root);
+      const fontSize = Number.parseFloat(computedStyle?.fontSize ?? "");
+      const proportionalHeight = Number.isFinite(fontSize) && fontSize > 0
+        ? fontSize * 1.25
+        : measuredHeight;
+      const height = Math.min(measuredHeight, proportionalHeight);
+      const deviceScale = ownerWindow?.devicePixelRatio || 1;
+      const snap = (value: number) => Math.round(value * deviceScale) / deviceScale;
+
+      return {
+        color: computedStyle?.color || "currentColor",
+        height: snap(height),
+        left: snap(rangeRect.left),
+        top: snap(rangeRect.top + ((measuredHeight - height) / 2)),
+      };
+    };
+
+    const positionReplacementCaret = () => {
+      if (scheduledFrame !== null && rootElement !== null) {
+        rootElement.ownerDocument.defaultView?.cancelAnimationFrame(scheduledFrame);
+        scheduledFrame = null;
+      }
+
+      const root = rootElement;
+      if (root === null || isComposing || !rootHasFocus(root)) {
+        hideReplacementCaret();
+        return;
+      }
+
+      try {
+        const measurement = measureCaret(editor, root);
+        const caret = measurement === null ? null : ensureReplacementCaret(root);
+        if (measurement === null || caret === null) {
+          hideReplacementCaret();
+          return;
+        }
+
+        caret.style.backgroundColor = measurement.color;
+        caret.style.height = `${measurement.height}px`;
+        caret.style.left = `${measurement.left}px`;
+        caret.style.opacity = "1";
+        caret.style.top = `${measurement.top}px`;
+        caret.style.display = "block";
+
+        if (
+          !caret.isConnected
+          || caret.style.display === "none"
+          || caret.style.width !== `${CARET_WIDTH_PX}px`
+          || measurement.height <= 0
+        ) {
+          hideReplacementCaret();
+          return;
+        }
+
+        root.style.setProperty("caret-color", "transparent");
+        if (typeof caret.getAnimations === "function") {
+          for (const animation of caret.getAnimations()) {
+            animation.currentTime = 0;
+            animation.play();
+          }
+        }
+      } catch {
+        hideReplacementCaret();
+      }
+    };
+
+    const scheduleReplacementCaret = () => {
+      const root = rootElement;
+      const ownerWindow = root?.ownerDocument.defaultView;
+      if (root === null || ownerWindow === null || ownerWindow === undefined) {
+        hideReplacementCaret();
+        return;
+      }
+      if (scheduledFrame !== null) return;
+      scheduledFrame = ownerWindow.requestAnimationFrame(() => {
+        scheduledFrame = null;
+        positionReplacementCaret();
+      });
+    };
+
+    // Lexical may publish several updates in one input turn. Measure once on
+    // the next display frame so typing never synchronously forces layout.
+    const unregisterUpdate = editor.registerUpdateListener(() => {
+      scheduleReplacementCaret();
+    });
+
+    const unregisterRoot = editor.registerRootListener((nextRoot) => {
+      rootCleanup?.();
+      rootCleanup = null;
+      destroyReplacementCaret();
+      rootElement = nextRoot;
+      isComposing = false;
+
+      if (nextRoot === null) return;
+      previousCaretColor = nextRoot.style.getPropertyValue("caret-color");
+      previousCaretColorPriority = nextRoot.style.getPropertyPriority("caret-color");
+      const ownerDocument = nextRoot.ownerDocument;
+      const ownerWindow = ownerDocument.defaultView;
+
+      const handleFocus = () => scheduleReplacementCaret();
+      const handleBlur = () => queueMicrotask(() => {
+        if (!rootHasFocus(nextRoot)) hideReplacementCaret();
+      });
+      const handleCompositionStart = () => {
+        isComposing = true;
+        hideReplacementCaret();
+      };
+      const handleCompositionEnd = () => {
+        isComposing = false;
+        scheduleReplacementCaret();
+      };
+
+      nextRoot.addEventListener("focus", handleFocus);
+      nextRoot.addEventListener("blur", handleBlur);
+      nextRoot.addEventListener("compositionstart", handleCompositionStart);
+      nextRoot.addEventListener("compositionend", handleCompositionEnd);
+      ownerDocument.addEventListener("selectionchange", scheduleReplacementCaret);
+      ownerWindow?.addEventListener("resize", scheduleReplacementCaret);
+      ownerWindow?.addEventListener("scroll", scheduleReplacementCaret, true);
+
+      rootCleanup = () => {
+        nextRoot.removeEventListener("focus", handleFocus);
+        nextRoot.removeEventListener("blur", handleBlur);
+        nextRoot.removeEventListener("compositionstart", handleCompositionStart);
+        nextRoot.removeEventListener("compositionend", handleCompositionEnd);
+        ownerDocument.removeEventListener("selectionchange", scheduleReplacementCaret);
+        ownerWindow?.removeEventListener("resize", scheduleReplacementCaret);
+        ownerWindow?.removeEventListener("scroll", scheduleReplacementCaret, true);
+        if (scheduledFrame !== null) {
+          ownerWindow?.cancelAnimationFrame(scheduledFrame);
+          scheduledFrame = null;
+        }
+      };
+
+      scheduleReplacementCaret();
+    });
+
+    return () => {
+      unregisterUpdate();
+      unregisterRoot();
+      rootCleanup?.();
+      destroyReplacementCaret();
+      rootElement = null;
+    };
+  }, [editor]);
+
+  return null;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import type { SessionSlashCommandViewModel } from "#product/lib/domain/chat/composer/session-slash-command-policy";
 import { ComposerCommandEditor } from "#product/components/workspace/chat/input/ComposerCommandEditor";
-import { isExactHttpsComposerPaste } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+import {
+  isComposerLinkPaste,
+  isExactHttpsComposerPaste,
+} from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 
 const slashCommandMock = vi.hoisted(() => ({
   commands: [] as SessionSlashCommandViewModel[],
@@ -176,11 +179,15 @@ describe("ComposerCommandEditor", () => {
     expect(textarea.querySelector("ul li")?.textContent).toContain("item");
   });
 
-  it("recognizes only exact HTTPS paste values and keeps typed Markdown links literal", () => {
+  it("recognizes exact HTTPS URLs and complete pasted Markdown HTTPS links", () => {
     expect(isExactHttpsComposerPaste("https://example.com/path?q=1")).toBe(true);
     expect(isExactHttpsComposerPaste("http://example.com")).toBe(false);
     expect(isExactHttpsComposerPaste(" https://example.com")).toBe(false);
     expect(isExactHttpsComposerPaste("https://example.com extra")).toBe(false);
+    expect(isComposerLinkPaste("[Docs](https://example.com)")).toBe(true);
+    expect(isComposerLinkPaste("See [Docs](https://example.com) now")).toBe(true);
+    expect(isComposerLinkPaste("[Docs](https://example.com")).toBe(false);
+    expect(isComposerLinkPaste("[Docs](http://example.com)")).toBe(false);
 
     const { textarea: typed } = renderEditor({
       draft: createTextDraft("[Docs](https://example.com)"),

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -20,9 +20,28 @@ import {
 } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 
-afterEach(cleanup);
+let originalRangeRectDescriptor: PropertyDescriptor | undefined;
+
+afterEach(() => {
+  cleanup();
+  if (originalRangeRectDescriptor === undefined) {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  } else {
+    Object.defineProperty(
+      Range.prototype,
+      "getBoundingClientRect",
+      originalRangeRectDescriptor,
+    );
+  }
+  vi.restoreAllMocks();
+});
 beforeEach(() => {
+  originalRangeRectDescriptor = Object.getOwnPropertyDescriptor(
+    Range.prototype,
+    "getBoundingClientRect",
+  );
   vi.stubGlobal("DragEvent", class DragEvent extends Event {});
+  vi.stubGlobal("ClipboardEvent", class ClipboardEvent extends Event {});
 });
 
 describe("ComposerRichTextEditor", () => {
@@ -81,7 +100,7 @@ describe("ComposerRichTextEditor", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("creates bare and selected HTTPS links while typed Markdown stays literal", async () => {
+  it("creates bare and selected HTTPS links", async () => {
     const bare = renderEditor();
     await bare.ready();
     act(() => resetText(bare.editor, ""));
@@ -100,11 +119,33 @@ describe("ComposerRichTextEditor", () => {
     });
     await waitFor(() => expect(selected.root.querySelector("a")?.textContent).toBe("Docs"));
 
+  });
+
+  it("formats complete Markdown HTTPS links only when pasted", async () => {
+    const onChange = vi.fn();
+    const pasted = renderEditor({ onChange });
+    await pasted.ready();
+    act(() => resetText(pasted.editor, ""));
+    onChange.mockClear();
+
+    const completePaste = pasteEvent("Read [Docs](https://example.com/docs) or [Help](https://example.com/help). ");
+    act(() => { pasted.editor.dispatchCommand(PASTE_COMMAND, completePaste); });
+
+    await waitFor(() => expect(pasted.root.querySelectorAll("a")).toHaveLength(2));
+    expect(completePaste.defaultPrevented).toBe(true);
+    expect(pasted.root.textContent).toBe("Read Docs or Help. ");
+    expect(pasted.root.querySelector('a[href="https://example.com/docs"]')?.textContent).toBe("Docs");
+    expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0]).toBe(
+      "Read [Docs](https://example.com/docs) or [Help](https://example.com/help). ",
+    );
+
     cleanup();
-    const typed = renderEditor({ value: "[Docs](https://example.com)" });
+    const typed = renderEditor();
     await typed.ready();
+    act(() => resetText(typed.editor, ""));
+    await typeCharacters(typed.editor, "[Docs](https://example.com)");
     expect(typed.root.querySelector("a")).toBeNull();
-    expect(typed.root.textContent).toContain("[Docs](https://example.com)");
+    expect(typed.root.textContent).toBe("[Docs](https://example.com)");
   });
 
   it("restores pasted-link identity from the controlled snapshot", async () => {
@@ -172,6 +213,74 @@ describe("ComposerRichTextEditor", () => {
     });
     expect(homeSubmit).toHaveBeenCalledTimes(1);
   });
+
+  it("shows a one-pixel replacement caret only after valid geometry", async () => {
+    mockRangeRect({ height: 15, left: 24, top: 18 });
+    const harness = renderEditor();
+    await harness.ready();
+
+    act(() => {
+      harness.root.focus();
+      resetText(harness.editor, "caret");
+    });
+
+    const caret = await waitFor(() => {
+      const nextCaret = document.body.querySelector<HTMLElement>(
+        "[data-chat-composer-caret]",
+      );
+      expect(nextCaret?.style.display).toBe("block");
+      return nextCaret!;
+    });
+    expect(caret.style.width).toBe("1px");
+    expect(caret.style.height).toBe("15px");
+    expect(caret.style.left).toBe("24px");
+    expect(harness.root.style.caretColor).toBe("transparent");
+
+    fireEvent.compositionStart(harness.root);
+    expect(caret.style.display).toBe("none");
+    expect(harness.root.style.caretColor).toBe("");
+
+    fireEvent.compositionEnd(harness.root);
+    act(() => insertText(harness.editor, "!"));
+    await waitFor(() => expect(caret.style.display).toBe("block"));
+
+    act(() => {
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes()[0]?.select(0, 1);
+      }, { discrete: true });
+    });
+    await waitFor(() => expect(caret.style.display).toBe("none"));
+    expect(harness.root.style.caretColor).toBe("");
+
+    act(() => harness.root.blur());
+    await waitFor(() => expect(harness.root.style.caretColor).toBe(""));
+
+    act(() => {
+      harness.root.focus();
+      insertText(harness.editor, "!");
+    });
+    await waitFor(() => expect(harness.root.style.caretColor).toBe("transparent"));
+    harness.unmount();
+    expect(harness.root.style.caretColor).toBe("");
+    expect(caret.isConnected).toBe(false);
+  });
+
+  it("keeps the native caret when replacement geometry is invalid", async () => {
+    mockRangeRect({ height: 0, left: 24, top: 18 });
+    const harness = renderEditor();
+    await harness.ready();
+
+    act(() => {
+      harness.root.focus();
+      resetText(harness.editor, "fallback");
+    });
+
+    await waitFor(() => expect(harness.root.style.caretColor).toBe(""));
+    expect(
+      document.body.querySelector<HTMLElement>("[data-chat-composer-caret]")
+        ?.style.display,
+    ).not.toBe("block");
+  });
 });
 
 function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
@@ -197,6 +306,7 @@ function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
       props = { ...props, ...next };
       rendered.rerender(<ComposerRichTextEditor {...props} />);
     },
+    unmount: rendered.unmount,
   };
 }
 
@@ -228,9 +338,34 @@ function keyEvent(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
 }
 
 function pasteEvent(text: string): ClipboardEvent {
-  const event = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+  const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
   Object.defineProperty(event, "clipboardData", {
     value: { getData: (type: string) => type === "text/plain" ? text : "" },
   });
   return event;
+}
+
+function mockRangeRect({
+  height,
+  left,
+  top,
+}: {
+  height: number;
+  left: number;
+  top: number;
+}) {
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: vi.fn(() => ({
+      bottom: top + height,
+      height,
+      left,
+      right: left,
+      toJSON: () => ({}),
+      top,
+      width: 0,
+      x: left,
+      y: top,
+    } satisfies DOMRect)),
+  });
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -41,6 +41,7 @@ import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { ComposerCaretPlugin } from "#product/components/workspace/chat/input/ComposerCaretPlugin";
 import type { ComposerKeyboardEventLike } from "#product/lib/domain/chat/composer/composer-keyboard";
 import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 
@@ -56,6 +57,7 @@ const INPUT_TRANSFORMERS: Transformer[] = [
 ];
 const OUTPUT_TRANSFORMERS: Transformer[] = [...INPUT_TRANSFORMERS, LINK];
 const EXACT_HTTPS_URL = /^https:\/\/[^\s]+$/u;
+const MARKDOWN_HTTPS_LINK = /\[([^\]\r\n]+)\]\((https:\/\/[^\s)\r\n]+)\)/gu;
 const EXTERNAL_VALUE_TAG = "external-composer-value";
 
 type ComposerNativeKeyboardEvent = KeyboardEvent & ComposerKeyboardEventLike;
@@ -68,6 +70,37 @@ export interface ComposerEditorContext {
 
 export function isExactHttpsComposerPaste(value: string): boolean {
   return EXACT_HTTPS_URL.test(value);
+}
+
+type ComposerPastePart =
+  | { kind: "text"; value: string }
+  | { kind: "link"; label: string; url: string };
+
+export function parseMarkdownHttpsComposerPaste(value: string): ComposerPastePart[] | null {
+  const parts: ComposerPastePart[] = [];
+  let cursor = 0;
+  let containsLink = false;
+
+  for (const match of value.matchAll(MARKDOWN_HTTPS_LINK)) {
+    const matchIndex = match.index;
+    const label = match[1];
+    const url = match[2];
+    if (matchIndex === undefined || label === undefined || url === undefined) continue;
+    if (matchIndex > cursor) {
+      parts.push({ kind: "text", value: value.slice(cursor, matchIndex) });
+    }
+    parts.push({ kind: "link", label, url });
+    containsLink = true;
+    cursor = matchIndex + match[0].length;
+  }
+
+  if (!containsLink) return null;
+  if (cursor < value.length) parts.push({ kind: "text", value: value.slice(cursor) });
+  return parts;
+}
+
+export function isComposerLinkPaste(value: string): boolean {
+  return isExactHttpsComposerPaste(value) || parseMarkdownHttpsComposerPaste(value) !== null;
 }
 
 export interface ComposerRichTextEditorProps {
@@ -146,7 +179,7 @@ export function ComposerRichTextEditor({
               onKeyDown?.(event);
             }}
             onPaste={(event) => {
-              if (isExactHttpsComposerPaste(event.clipboardData.getData("text/plain"))) {
+              if (isComposerLinkPaste(event.clipboardData.getData("text/plain"))) {
                 event.stopPropagation();
               }
             }}
@@ -170,7 +203,8 @@ export function ComposerRichTextEditor({
         onKeyDown={onKeyDown}
         onCommandKey={onCommandKey}
       />
-      <HttpsPastePlugin />
+      <ComposerLinkPastePlugin />
+      <ComposerCaretPlugin />
       <ComposerNativeEventTimestampPlugin eventTimeStampRef={eventTimeStampRef} />
       <ComposerEditorBridge
         value={value}
@@ -226,19 +260,30 @@ function ComposerEditorBridge({
 }) {
   const [editor] = useLexicalComposerContext();
   const lastDocumentPayloadRef = useRef(JSON.stringify(editor.getEditorState().toJSON()));
+  const lastMarkdownRef = useRef(value);
 
   useEffect(() => { editor.setEditable(!disabled); }, [disabled, editor]);
   useEffect(() => { editorRef?.(editor); }, [editor, editorRef]);
 
   useEffect(() => {
+    if (
+      value === lastMarkdownRef.current
+      && (snapshot?.version !== 1 || snapshot.payload === lastDocumentPayloadRef.current)
+    ) return;
+
     const currentPayload = JSON.stringify(editor.getEditorState().toJSON());
     if (snapshot?.version === 1 && snapshot.payload !== currentPayload) {
+      lastMarkdownRef.current = value;
       editor.setEditorState(editor.parseEditorState(snapshot.payload), { tag: EXTERNAL_VALUE_TAG });
       return;
     }
     let currentMarkdown = "";
     editor.getEditorState().read(() => { currentMarkdown = $convertToMarkdownString(OUTPUT_TRANSFORMERS); });
-    if (currentMarkdown === value) return;
+    if (currentMarkdown === value) {
+      lastMarkdownRef.current = value;
+      return;
+    }
+    lastMarkdownRef.current = value;
     editor.update(() => {
       $getRoot().clear();
       if (value) $convertFromMarkdownString(value, INPUT_TRANSFORMERS);
@@ -256,8 +301,10 @@ function ComposerEditorBridge({
       if (tags.has(EXTERNAL_VALUE_TAG)) return;
       const eventTimeStampMs = eventTimeStampRef.current;
       eventTimeStampRef.current = undefined;
+      const markdown = $convertToMarkdownString(OUTPUT_TRANSFORMERS);
+      lastMarkdownRef.current = markdown;
       onChange(
-        $convertToMarkdownString(OUTPUT_TRANSFORMERS),
+        markdown,
         eventTimeStampMs,
         { version: 1, payload },
       );
@@ -309,23 +356,38 @@ function ComposerBehaviorPlugin({
   return null;
 }
 
-function HttpsPastePlugin() {
+function ComposerLinkPastePlugin() {
   const [editor] = useLexicalComposerContext();
   useEffect(() => editor.registerCommand(PASTE_COMMAND, (event) => {
     const clipboard = "clipboardData" in event ? event.clipboardData : null;
-    const url = clipboard?.getData("text/plain") ?? "";
-    if (!isExactHttpsComposerPaste(url)) return false;
+    const value = clipboard?.getData("text/plain") ?? "";
+    const markdownParts = parseMarkdownHttpsComposerPaste(value);
+    const isExactUrl = isExactHttpsComposerPaste(value);
+    if (!isExactUrl && markdownParts === null) return false;
     const selection = $getSelection();
     if (!$isRangeSelection(selection)) return false;
     event.preventDefault();
-    if (!selection.isCollapsed()) {
-      $toggleLink(url);
-    } else {
-      const link = $createLinkNode(url);
-      link.append($createTextNode(url));
+
+    if (isExactUrl) {
+      if (!selection.isCollapsed()) {
+        $toggleLink(value);
+        return true;
+      }
+      const link = $createLinkNode(value);
+      link.append($createTextNode(value));
       $insertNodes([link]);
       link.selectEnd();
+      return true;
     }
+
+    const nodes = markdownParts!.map((part) => {
+      if (part.kind === "text") return $createTextNode(part.value);
+      const link = $createLinkNode(part.url);
+      link.append($createTextNode(part.label));
+      return link;
+    });
+    $insertNodes(nodes);
+    nodes[nodes.length - 1]?.selectEnd();
     return true;
   }, COMMAND_PRIORITY_HIGH), [editor]);
   return null;

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessage.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessage.tsx
@@ -1,4 +1,6 @@
 export {
   AssistantMessage,
   type AssistantMessageProps,
+  type AssistantMessageRevealPhase,
+  type AssistantMessageRevealState,
 } from "@proliferate/product-ui/chat/transcript/AssistantMessage";

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
@@ -2,6 +2,7 @@ import type {
   TranscriptItem,
   TranscriptState,
 } from "@anyharness/sdk";
+import { useCallback } from "react";
 import { ReasoningBlock } from "#product/components/workspace/chat/tool-calls/ReasoningBlock";
 import type { PromptPlanAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-plan-attachments";
 import {
@@ -21,7 +22,14 @@ import {
 } from "@proliferate/product-domain/chats/transcript/transcript-action-time";
 import type { TranscriptOpenSessionRole } from "@proliferate/product-domain/chats/transcript/transcript-open-target";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
-import { AssistantMessage } from "#product/components/workspace/chat/transcript/AssistantMessage";
+import {
+  AssistantMessage,
+  type AssistantMessageRevealState,
+} from "#product/components/workspace/chat/transcript/AssistantMessage";
+import {
+  getAssistantRevealProgress,
+  recordAssistantRevealProgress,
+} from "#product/components/workspace/chat/transcript/assistant-reveal-progress";
 import {
   renderTranscriptCodeBlock,
   renderTranscriptInlineCode,
@@ -50,6 +58,8 @@ export function TranscriptItemBlock({
   item,
   transcript,
   animateActivityEntry = false,
+  animateAssistantReveal = false,
+  onAssistantRevealStateChange,
   workspaceId,
   onOpenArtifact,
   onHandOffPlanToNewSession,
@@ -57,6 +67,11 @@ export function TranscriptItemBlock({
   item: TranscriptItem;
   transcript: TranscriptState;
   animateActivityEntry?: boolean;
+  animateAssistantReveal?: boolean;
+  onAssistantRevealStateChange?: (
+    itemId: string,
+    state: AssistantMessageRevealState,
+  ) => void;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
@@ -66,6 +81,10 @@ export function TranscriptItemBlock({
   const openSession = useTranscriptOpenSession();
   const canOpenSession = useTranscriptCanOpenSession();
   const recordRelationshipHint = useSessionDirectoryStore((state) => state.recordRelationshipHint);
+  const reportAssistantRevealState = useCallback((state: AssistantMessageRevealState) => {
+    recordAssistantRevealProgress(item.itemId, state);
+    onAssistantRevealStateChange?.(item.itemId, state);
+  }, [item.itemId, onAssistantRevealStateChange]);
 
   switch (item.kind) {
     case "user_message": {
@@ -168,6 +187,13 @@ export function TranscriptItemBlock({
             <AssistantMessage
               content={item.text}
               isStreaming={item.isStreaming}
+              animateReveal={animateAssistantReveal}
+              initialVisibleLength={animateAssistantReveal
+                ? getAssistantRevealProgress(item.itemId)?.visibleLength
+                : undefined}
+              onRevealStateChange={animateAssistantReveal && onAssistantRevealStateChange
+                ? reportAssistantRevealState
+                : undefined}
               renderLink={renderTranscriptLink}
               renderInlineCode={renderTranscriptInlineCode}
               renderCodeBlock={renderTranscriptCodeBlock}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx
@@ -4,6 +4,7 @@ import { isSubagentItem } from "#product/components/workspace/chat/transcript/Tr
 import { TranscriptActivityBlock } from "#product/components/workspace/chat/transcript/TranscriptActivityBlock";
 import { TranscriptItemBlock } from "#product/components/workspace/chat/transcript/TranscriptItemBlock";
 import { TranscriptToolCallGroupBlock } from "#product/components/workspace/chat/transcript/TranscriptToolCallGroupBlock";
+import type { AssistantMessageRevealState } from "#product/components/workspace/chat/transcript/AssistantMessage";
 
 type PlanHandoffHandler = (plan: PromptPlanAttachmentDescriptor) => void;
 
@@ -12,6 +13,8 @@ export function TranscriptTreeNode({
   transcript,
   childrenByParentId,
   animateActivityEntry = false,
+  animateAssistantReveal = false,
+  onAssistantRevealStateChange,
   workspaceId,
   onOpenArtifact,
   onHandOffPlanToNewSession,
@@ -20,6 +23,11 @@ export function TranscriptTreeNode({
   transcript: TranscriptState;
   childrenByParentId: Map<string, string[]>;
   animateActivityEntry?: boolean;
+  animateAssistantReveal?: boolean;
+  onAssistantRevealStateChange?: (
+    itemId: string,
+    state: AssistantMessageRevealState,
+  ) => void;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
@@ -44,6 +52,8 @@ export function TranscriptTreeNode({
               transcript={transcript}
               childrenByParentId={childrenByParentId}
               animateActivityEntry={animateActivityEntry}
+              animateAssistantReveal={false}
+              onAssistantRevealStateChange={onAssistantRevealStateChange}
               workspaceId={workspaceId}
               onOpenArtifact={onOpenArtifact}
               onHandOffPlanToNewSession={onHandOffPlanToNewSession}
@@ -59,6 +69,8 @@ export function TranscriptTreeNode({
       item={item}
       transcript={transcript}
       animateActivityEntry={animateActivityEntry}
+      animateAssistantReveal={animateAssistantReveal}
+      onAssistantRevealStateChange={onAssistantRevealStateChange}
       workspaceId={workspaceId}
       onOpenArtifact={onOpenArtifact}
       onHandOffPlanToNewSession={onHandOffPlanToNewSession}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  isRecentAssistantCompletion,
+  RECENT_ASSISTANT_REVEAL_WINDOW_MS,
   resolveTurnAssistantFooterMode,
   resolveTranscriptTurnDiffPanelKind,
+  shouldHoldAssistantRevealFrontier,
   shouldRenderStandaloneStoppedNotice,
 } from "#product/components/workspace/chat/transcript/TranscriptTurnRow";
 import { resolveCompletedHistoryDisclosureLabel } from "#product/components/workspace/chat/transcript/TurnItemSequence";
@@ -51,6 +54,7 @@ describe("resolveTurnAssistantFooterMode", () => {
       rowIsLastTurnRow: true,
       turnCompleted: true,
       hasAssistantCopyContent: false,
+      assistantRevealComplete: true,
     })).toBe("reserved");
   });
 
@@ -59,12 +63,66 @@ describe("resolveTurnAssistantFooterMode", () => {
       rowIsLastTurnRow: true,
       turnCompleted: true,
       hasAssistantCopyContent: true,
+      assistantRevealComplete: true,
     })).toBe("copy");
     expect(resolveTurnAssistantFooterMode({
       rowIsLastTurnRow: false,
       turnCompleted: true,
       hasAssistantCopyContent: true,
+      assistantRevealComplete: true,
     })).toBe("none");
+  });
+
+  it("keeps completion controls reserved until the reveal fully settles", () => {
+    expect(resolveTurnAssistantFooterMode({
+      rowIsLastTurnRow: true,
+      turnCompleted: true,
+      hasAssistantCopyContent: true,
+      assistantRevealComplete: false,
+    })).toBe("reserved");
+  });
+});
+
+describe("recent completed assistant reveal", () => {
+  const nowMs = Date.parse("2026-07-18T08:00:00.000Z");
+
+  it("includes atomic short completions inside the reveal window", () => {
+    expect(isRecentAssistantCompletion(
+      new Date(nowMs - RECENT_ASSISTANT_REVEAL_WINDOW_MS).toISOString(),
+      nowMs,
+    )).toBe(true);
+  });
+
+  it("does not replay hydrated history or future timestamps", () => {
+    expect(isRecentAssistantCompletion(
+      new Date(nowMs - RECENT_ASSISTANT_REVEAL_WINDOW_MS - 1).toISOString(),
+      nowMs,
+    )).toBe(false);
+    expect(isRecentAssistantCompletion(
+      new Date(nowMs + 1).toISOString(),
+      nowMs,
+    )).toBe(false);
+    expect(isRecentAssistantCompletion(null, nowMs)).toBe(false);
+  });
+});
+
+describe("assistant reveal frontier", () => {
+  it("stays claimed while the final word fade is still settling", () => {
+    expect(shouldHoldAssistantRevealFrontier({
+      itemId: "assistant-item",
+      hasUnrevealedText: false,
+      cachedRevealComplete: false,
+      eligibleOrigin: true,
+    })).toBe(true);
+  });
+
+  it("releases only a settled frontier with no buffered text", () => {
+    expect(shouldHoldAssistantRevealFrontier({
+      itemId: "assistant-item",
+      hasUnrevealedText: false,
+      cachedRevealComplete: true,
+      eligibleOrigin: true,
+    })).toBe(false);
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -2,7 +2,7 @@ import type {
   TranscriptState,
   TurnRecord,
 } from "@anyharness/sdk";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import { useRevertGitPatchesMutation } from "@anyharness/sdk-react";
 import { TurnDiffPanel } from "#product/components/workspace/chat/transcript/TurnDiffPanel";
 import { TranscriptPatchTurnDiffPanel } from "#product/components/workspace/chat/transcript/TranscriptPatchTurnDiffPanel";
@@ -42,8 +42,19 @@ import type { TurnDisplayBlock } from "@proliferate/product-domain/chats/transcr
 import type { PromptPlanAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-plan-attachments";
 import type { SessionViewState } from "@proliferate/product-domain/sessions/activity";
 import { useToastStore } from "#product/stores/toast/toast-store";
+import type { AssistantMessageRevealState } from "#product/components/workspace/chat/transcript/AssistantMessage";
+import {
+  getAssistantRevealProgress,
+} from "#product/components/workspace/chat/transcript/assistant-reveal-progress";
+import { logDevAssistantRevealState } from "#product/lib/infra/debug/dev-assistant-reveal-log";
 
 type PlanHandoffHandler = (plan: PromptPlanAttachmentDescriptor) => void;
+type AssistantRevealClaim = {
+  itemId: string;
+  targetLength: number;
+};
+
+export const RECENT_ASSISTANT_REVEAL_WINDOW_MS = 60_000;
 
 export function TranscriptTurnRow({
   row,
@@ -82,24 +93,7 @@ export function TranscriptTurnRow({
     () => latestCompletedTurn(transcript)?.turnId ?? null,
     [transcript],
   );
-  const diffPanelKind = resolveTranscriptTurnDiffPanelKind({
-    rowIsLastTurnRow: row.isLastTurnRow,
-    turnCompleted: !!turn.completedAt,
-    turnId: turn.turnId,
-    latestCompletedTurnId,
-    hasFileBadges: turn.fileBadges.length > 0,
-  });
-  const isLatestCompletedTurnRow = diffPanelKind === "current";
-  // Fix 2/3: the transcript's single final completed AI message. Its action
-  // row is sticky (not hover-gated) and hosts the inline goal-met marker.
-  const isFinalCompletedTurn = row.isLastTurnRow
-    && !!turn.completedAt
-    && turn.turnId === latestCompletedTurnId;
   const sessionGoal = useSessionGoal();
-  const metMarker = isFinalCompletedTurn
-    && sessionGoal?.goal?.status === "met"
-    ? <TurnGoalMetMarker label={goalMetMarkerLabel(sessionGoal.goal)} />
-    : null;
   const presentation = row.presentation;
   const renderPresentation = row.renderPresentation;
   const liveExplorationBlock = isLatestTurn ? latestLiveExplorationBlock : null;
@@ -113,6 +107,82 @@ export function TranscriptTurnRow({
   );
   const tailAssistantItem = tailAssistantProseRootId
     ? transcript.itemsById[tailAssistantProseRootId]
+    : null;
+  const revealOriginRef = useRef({
+    turnId: turn.turnId,
+    wasLive: !turn.completedAt,
+  });
+  if (revealOriginRef.current.turnId !== turn.turnId) {
+    revealOriginRef.current = {
+      turnId: turn.turnId,
+      wasLive: !turn.completedAt,
+    };
+  } else if (!turn.completedAt) {
+    revealOriginRef.current.wasLive = true;
+  }
+  const [assistantRevealClaim, setAssistantRevealClaim] =
+    useState<AssistantRevealClaim | null>(null);
+  const cachedAssistantReveal = getAssistantRevealProgress(
+    tailAssistantProseRootId,
+  );
+  const claimedVisibleLength =
+    assistantRevealClaim?.itemId === tailAssistantProseRootId
+      ? assistantRevealClaim.targetLength
+      : cachedAssistantReveal?.visibleLength ?? 0;
+  const tailAssistantTextLength = tailAssistantCopyContent?.length ?? 0;
+  const hasUnrevealedAssistantText = tailAssistantTextLength > claimedVisibleLength;
+  const shouldAnimateAssistantReveal = shouldHoldAssistantRevealFrontier({
+    itemId: tailAssistantProseRootId,
+    hasUnrevealedText: hasUnrevealedAssistantText,
+    cachedRevealComplete: cachedAssistantReveal?.complete ?? null,
+    eligibleOrigin: (
+      revealOriginRef.current.wasLive
+      || cachedAssistantReveal !== null
+      || (
+        isLatestTurn
+        && isRecentAssistantCompletion(turn.completedAt)
+      )
+    ),
+  });
+  const animateAssistantRevealItemId = shouldAnimateAssistantReveal
+    ? tailAssistantProseRootId
+    : null;
+  const assistantRevealComplete = !shouldAnimateAssistantReveal;
+  const handleAssistantRevealStateChange = useCallback((
+    itemId: string,
+    state: AssistantMessageRevealState,
+  ) => {
+    logDevAssistantRevealState({ turnId: turn.turnId, itemId, state });
+    if (!state.complete) {
+      return;
+    }
+    setAssistantRevealClaim((current) => {
+      if (
+        current?.itemId === itemId
+        && current.targetLength >= state.targetLength
+      ) {
+        return current;
+      }
+      return { itemId, targetLength: state.targetLength };
+    });
+  }, [turn.turnId]);
+  const visualTurnCompleted = !!turn.completedAt && assistantRevealComplete;
+  const diffPanelKind = resolveTranscriptTurnDiffPanelKind({
+    rowIsLastTurnRow: row.isLastTurnRow,
+    turnCompleted: visualTurnCompleted,
+    turnId: turn.turnId,
+    latestCompletedTurnId,
+    hasFileBadges: turn.fileBadges.length > 0,
+  });
+  const isLatestCompletedTurnRow = diffPanelKind === "current";
+  // Completion chrome follows the assistant handoff point. The final word can
+  // still be finishing its opacity settle while the next transcript item starts.
+  const isFinalCompletedTurn = row.isLastTurnRow
+    && visualTurnCompleted
+    && turn.turnId === latestCompletedTurnId;
+  const metMarker = isFinalCompletedTurn
+    && sessionGoal?.goal?.status === "met"
+    ? <TurnGoalMetMarker label={goalMetMarkerLabel(sessionGoal.goal)} />
     : null;
   const tailAssistantActionTime = resolveAssistantTurnActionTime({
     assistantItem: tailAssistantItem?.kind === "assistant_prose" ? tailAssistantItem : null,
@@ -154,6 +224,7 @@ export function TranscriptTurnRow({
     rowIsLastTurnRow: row.isLastTurnRow,
     turnCompleted: !!turn.completedAt,
     hasAssistantCopyContent: !!tailAssistantCopyContent,
+    assistantRevealComplete,
   });
   const revertPatchesMutation = useRevertGitPatchesMutation({ workspaceId: selectedWorkspaceId });
   const showToast = useToastStore((state) => state.show);
@@ -226,15 +297,18 @@ export function TranscriptTurnRow({
           tailAssistantProseRootId={tailAssistantProseRootId}
           completedHistoryLabel={stoppedNotice}
           animateActivityEntry={isLatestTurnInProgress}
+          animateAssistantRevealItemId={animateAssistantRevealItemId}
+          onAssistantRevealStateChange={handleAssistantRevealStateChange}
           showCompletedArtifactFallback={row.isLastTurnRow}
           workspaceId={selectedWorkspaceId}
           onOpenArtifact={onOpenArtifact}
           onHandOffPlanToNewSession={onHandOffPlanToNewSession}
         />
-        {trailingStatus && (
+        {assistantRevealComplete && trailingStatus && (
           <div data-turn-frontier-status>{trailingStatus}</div>
         )}
-        {shouldRenderStandaloneStoppedNotice(stoppedNotice, hasCompletedHistoryDisclosure) && (
+        {assistantRevealComplete
+          && shouldRenderStandaloneStoppedNotice(stoppedNotice, hasCompletedHistoryDisclosure) && (
           <div className="flex flex-col items-start gap-2 text-chat text-foreground/60">
             <span>{stoppedNotice}</span>
             <div className="w-full border-t border-current/20" />
@@ -275,18 +349,50 @@ export function resolveTurnAssistantFooterMode({
   rowIsLastTurnRow,
   turnCompleted,
   hasAssistantCopyContent,
+  assistantRevealComplete,
 }: {
   rowIsLastTurnRow: boolean;
   turnCompleted: boolean;
   hasAssistantCopyContent: boolean;
+  assistantRevealComplete: boolean;
 }): "none" | "reserved" | "copy" {
   if (!rowIsLastTurnRow) {
     return "none";
   }
-  if (turnCompleted && hasAssistantCopyContent) {
+  if (turnCompleted && hasAssistantCopyContent && assistantRevealComplete) {
     return "copy";
   }
   return "reserved";
+}
+
+export function isRecentAssistantCompletion(
+  completedAt: string | null | undefined,
+  nowMs = Date.now(),
+): boolean {
+  if (!completedAt) {
+    return false;
+  }
+  const completedAtMs = Date.parse(completedAt);
+  const ageMs = nowMs - completedAtMs;
+  return Number.isFinite(completedAtMs)
+    && ageMs >= 0
+    && ageMs <= RECENT_ASSISTANT_REVEAL_WINDOW_MS;
+}
+
+export function shouldHoldAssistantRevealFrontier({
+  itemId,
+  hasUnrevealedText,
+  cachedRevealComplete,
+  eligibleOrigin,
+}: {
+  itemId: string | null;
+  hasUnrevealedText: boolean;
+  cachedRevealComplete: boolean | null;
+  eligibleOrigin: boolean;
+}): boolean {
+  return itemId !== null
+    && eligibleOrigin
+    && (hasUnrevealedText || cachedRevealComplete === false);
 }
 
 export function shouldRenderStandaloneStoppedNotice(

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
@@ -11,10 +11,12 @@ import {
 import { buildTurnPresentation } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
 import {
   CompletedHistorySequence,
+  constrainTurnItemSequencePresentation,
   resolveTurnItemFrontierBlockKey,
   shouldRenderCompletedArtifactCards,
   TurnItemSequence,
 } from "#product/components/workspace/chat/transcript/TurnItemSequence";
+import type { TurnPresentation } from "@proliferate/product-domain/chats/transcript/transcript-presentation";
 
 vi.mock("./TranscriptTreeNode", () => ({
   TranscriptTreeNode: ({ itemId }: { itemId: string }) => (
@@ -113,6 +115,28 @@ describe("completed-work transition", () => {
   });
 });
 
+describe("assistant visual frontier", () => {
+  it("withholds following thinking and tool blocks until prose settles", () => {
+    const presentation = {
+      rootIds: ["answer", "thought", "command"],
+      childrenByParentId: new Map(),
+      displayBlocks: [
+        { kind: "item", itemId: "answer" },
+        { kind: "item", itemId: "thought" },
+        { kind: "collapsed_actions", blockId: "command-command", itemIds: ["command"] },
+      ],
+      finalAssistantItemId: null,
+      completedHistoryRootIds: [],
+      completedHistorySummary: null,
+    } as TurnPresentation;
+
+    expect(
+      constrainTurnItemSequencePresentation(presentation, "answer").displayBlocks,
+    ).toEqual([{ kind: "item", itemId: "answer" }]);
+    expect(constrainTurnItemSequencePresentation(presentation, null)).toBe(presentation);
+  });
+});
+
 function renderTurnItemSequence({
   turn,
   transcript,
@@ -141,6 +165,7 @@ function turnItemSequence({
       tailAssistantProseRootId={presentation.finalAssistantItemId}
       completedHistoryLabel={null}
       animateActivityEntry={false}
+      animateAssistantRevealItemId={null}
       showCompletedArtifactFallback={false}
       workspaceId={null}
       onOpenArtifact={vi.fn()}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -30,6 +30,7 @@ import {
   formatCollapsedSummary,
 } from "#product/components/workspace/chat/transcript/TranscriptToolGroupUtils";
 import { TURN_ITEM_GAP_CLASS } from "#product/components/workspace/chat/transcript/TranscriptTurnChrome";
+import type { AssistantMessageRevealState } from "#product/components/workspace/chat/transcript/AssistantMessage";
 
 type PlanHandoffHandler = (plan: PromptPlanAttachmentDescriptor) => void;
 
@@ -42,6 +43,8 @@ export function TurnItemSequence({
   tailAssistantProseRootId,
   completedHistoryLabel,
   animateActivityEntry,
+  animateAssistantRevealItemId,
+  onAssistantRevealStateChange,
   showCompletedArtifactFallback,
   workspaceId,
   onOpenArtifact,
@@ -55,23 +58,32 @@ export function TurnItemSequence({
   tailAssistantProseRootId: string | null;
   completedHistoryLabel?: string | null;
   animateActivityEntry: boolean;
+  animateAssistantRevealItemId: string | null;
+  onAssistantRevealStateChange?: (
+    itemId: string,
+    state: AssistantMessageRevealState,
+  ) => void;
   showCompletedArtifactFallback: boolean;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
+  const visiblePresentation = constrainTurnItemSequencePresentation(
+    presentation,
+    animateAssistantRevealItemId,
+  );
   const artifactToolCalls = collectTurnCoworkArtifactToolCalls(turn, transcript);
   const animateCompletedHistory = useCompletedHistoryTransition(
-    isTurnComplete && presentation.completedHistorySummary !== null,
+    isTurnComplete && visiblePresentation.completedHistorySummary !== null,
   );
   const completedArtifactToolCalls = isTurnComplete
     ? artifactToolCalls.filter((item) => item.status === "completed")
     : [];
-  const completedHistoryRootIdSet = new Set(presentation.completedHistoryRootIds);
-  const frontierBlockKey = resolveTurnItemFrontierBlockKey(presentation);
+  const completedHistoryRootIdSet = new Set(visiblePresentation.completedHistoryRootIds);
+  const frontierBlockKey = resolveTurnItemFrontierBlockKey(visiblePresentation);
   const shouldRenderCompletedArtifacts = shouldRenderCompletedArtifactCards({
     completedArtifactCount: completedArtifactToolCalls.length,
-    presentation,
+    presentation: visiblePresentation,
     tailAssistantProseRootId,
     showCompletedArtifactFallback,
   });
@@ -87,7 +99,7 @@ export function TurnItemSequence({
     )
     : null;
   const completedHistoryOwnsPrelude = frontierPrelude !== null
-    && presentation.completedHistorySummary !== null
+    && visiblePresentation.completedHistorySummary !== null
     && tailAssistantProseRootId !== null;
   const standaloneFrontierPrelude = frontierPrelude && !completedHistoryOwnsPrelude
     ? (
@@ -105,11 +117,11 @@ export function TurnItemSequence({
 
   return (
     <>
-      {presentation.displayBlocks.map((block) => {
+      {visiblePresentation.displayBlocks.map((block) => {
         const blockKey = getTurnDisplayBlockKey(block);
         let renderedBlock: ReactNode;
         if (
-          presentation.completedHistorySummary
+          visiblePresentation.completedHistorySummary
           && blockBelongsToCompletedHistory(block, completedHistoryRootIdSet)
         ) {
           if (hasRenderedCompletedHistory) {
@@ -119,13 +131,13 @@ export function TurnItemSequence({
           renderedBlock = (
             <ToolCallSummary
               label={resolveCompletedHistoryDisclosureLabel(turn, completedHistoryLabel)}
-              summary={formatCollapsedSummary(presentation.completedHistorySummary)}
+              summary={formatCollapsedSummary(visiblePresentation.completedHistorySummary)}
               showWorkDivider={tailAssistantProseRootId !== null}
               completionContent={completedHistoryOwnsPrelude ? frontierPrelude : null}
               animateCompletion={animateCompletedHistory}
               renderChildren={() => (
                 <CompletedHistorySequence>
-                  {presentation.displayBlocks
+                  {visiblePresentation.displayBlocks
                     .filter((historyBlock) =>
                       blockBelongsToCompletedHistory(historyBlock, completedHistoryRootIdSet)
                     )
@@ -140,8 +152,10 @@ export function TurnItemSequence({
                           <TranscriptFragment
                             itemId={itemId}
                             transcript={transcript}
-                            childrenByParentId={presentation.childrenByParentId}
+                            childrenByParentId={visiblePresentation.childrenByParentId}
                             animateActivityEntry={false}
+                            animateAssistantRevealItemId={null}
+                            onAssistantRevealStateChange={onAssistantRevealStateChange}
                             workspaceId={workspaceId}
                             onOpenArtifact={onOpenArtifact}
                             onHandOffPlanToNewSession={onHandOffPlanToNewSession}
@@ -164,8 +178,10 @@ export function TurnItemSequence({
                 <TranscriptFragment
                   itemId={itemId}
                   transcript={transcript}
-                  childrenByParentId={presentation.childrenByParentId}
+                  childrenByParentId={visiblePresentation.childrenByParentId}
                   animateActivityEntry={animateActivityEntry}
+                  animateAssistantRevealItemId={animateAssistantRevealItemId}
+                  onAssistantRevealStateChange={onAssistantRevealStateChange}
                   workspaceId={workspaceId}
                   onOpenArtifact={onOpenArtifact}
                   onHandOffPlanToNewSession={onHandOffPlanToNewSession}
@@ -185,6 +201,28 @@ export function TurnItemSequence({
       {frontierBlockKey === null ? standaloneFrontierPrelude : null}
     </>
   );
+}
+
+export function constrainTurnItemSequencePresentation(
+  presentation: TurnPresentation,
+  assistantRevealItemId: string | null,
+): TurnPresentation {
+  if (!assistantRevealItemId) {
+    return presentation;
+  }
+  const frontierIndex = presentation.displayBlocks.findIndex(
+    (block) => block.kind === "item" && block.itemId === assistantRevealItemId,
+  );
+  if (
+    frontierIndex < 0
+    || frontierIndex === presentation.displayBlocks.length - 1
+  ) {
+    return presentation;
+  }
+  return {
+    ...presentation,
+    displayBlocks: presentation.displayBlocks.slice(0, frontierIndex + 1),
+  };
 }
 
 function useCompletedHistoryTransition(eligible: boolean): boolean {
@@ -271,6 +309,8 @@ function TranscriptFragment({
   transcript,
   childrenByParentId,
   animateActivityEntry,
+  animateAssistantRevealItemId,
+  onAssistantRevealStateChange,
   workspaceId,
   onOpenArtifact,
   onHandOffPlanToNewSession,
@@ -279,6 +319,11 @@ function TranscriptFragment({
   transcript: TranscriptState;
   childrenByParentId: Map<string, string[]>;
   animateActivityEntry: boolean;
+  animateAssistantRevealItemId: string | null;
+  onAssistantRevealStateChange?: (
+    itemId: string,
+    state: AssistantMessageRevealState,
+  ) => void;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
@@ -290,6 +335,8 @@ function TranscriptFragment({
         transcript={transcript}
         childrenByParentId={childrenByParentId}
         animateActivityEntry={animateActivityEntry}
+        animateAssistantReveal={itemId === animateAssistantRevealItemId}
+        onAssistantRevealStateChange={onAssistantRevealStateChange}
         workspaceId={workspaceId}
         onOpenArtifact={onOpenArtifact}
         onHandOffPlanToNewSession={onHandOffPlanToNewSession}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/assistant-reveal-progress.test.ts
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/assistant-reveal-progress.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearAssistantRevealProgressForTests,
+  getAssistantRevealProgress,
+  recordAssistantRevealProgress,
+} from "#product/components/workspace/chat/transcript/assistant-reveal-progress";
+
+afterEach(clearAssistantRevealProgressForTests);
+
+describe("assistant reveal progress", () => {
+  it("retains an incomplete visible frontier across row remounts", () => {
+    recordAssistantRevealProgress("assistant-item", {
+      complete: false,
+      phase: "active",
+      visibleLength: 27,
+      targetLength: 81,
+      isStreaming: true,
+    });
+
+    expect(getAssistantRevealProgress("assistant-item")).toEqual({
+      complete: false,
+      phase: "active",
+      visibleLength: 27,
+      targetLength: 81,
+      isStreaming: true,
+    });
+  });
+
+  it("keeps completed progress so revisiting a row cannot replay it", () => {
+    recordAssistantRevealProgress("assistant-item", {
+      complete: true,
+      phase: "idle",
+      visibleLength: 81,
+      targetLength: 81,
+      isStreaming: false,
+    });
+
+    expect(getAssistantRevealProgress("assistant-item")?.visibleLength).toBe(81);
+    expect(getAssistantRevealProgress("assistant-item")?.complete).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/assistant-reveal-progress.ts
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/assistant-reveal-progress.ts
@@ -1,0 +1,33 @@
+import type { AssistantMessageRevealState } from "#product/components/workspace/chat/transcript/AssistantMessage";
+
+const MAX_CACHED_ASSISTANT_REVEALS = 500;
+
+const revealProgressByItemId = new Map<string, AssistantMessageRevealState>();
+
+export function getAssistantRevealProgress(
+  itemId: string | null,
+): AssistantMessageRevealState | null {
+  return itemId ? revealProgressByItemId.get(itemId) ?? null : null;
+}
+
+export function recordAssistantRevealProgress(
+  itemId: string,
+  state: AssistantMessageRevealState,
+): void {
+  // Refresh insertion order so the bounded map behaves as a tiny LRU. This
+  // state exists only to bridge React row remounts; the transcript remains the
+  // source of truth for content.
+  revealProgressByItemId.delete(itemId);
+  revealProgressByItemId.set(itemId, state);
+  while (revealProgressByItemId.size > MAX_CACHED_ASSISTANT_REVEALS) {
+    const oldestItemId = revealProgressByItemId.keys().next().value;
+    if (typeof oldestItemId !== "string") {
+      break;
+    }
+    revealProgressByItemId.delete(oldestItemId);
+  }
+}
+
+export function clearAssistantRevealProgressForTests(): void {
+  revealProgressByItemId.clear();
+}

--- a/apps/packages/product-client/src/lib/infra/debug/dev-assistant-reveal-log.ts
+++ b/apps/packages/product-client/src/lib/infra/debug/dev-assistant-reveal-log.ts
@@ -1,0 +1,75 @@
+import type { AssistantMessageRevealState } from "#product/components/workspace/chat/transcript/AssistantMessage";
+
+export interface DevAssistantRevealRecord extends AssistantMessageRevealState {
+  turnId: string;
+  itemId: string;
+  recordedAt: string;
+  visibleDelta: number | null;
+  targetDelta: number | null;
+  elapsedMs: number | null;
+}
+
+export function logDevAssistantRevealState({
+  turnId,
+  itemId,
+  state,
+}: {
+  turnId: string;
+  itemId: string;
+  state: AssistantMessageRevealState;
+}): void {
+  if (!import.meta.env.DEV || !isDevAssistantRevealLoggingEnabled()) {
+    return;
+  }
+
+  const debugGlobal = globalThis as typeof globalThis & {
+    __PROLIFERATE_ASSISTANT_REVEALS__?: DevAssistantRevealRecord[];
+    __PROLIFERATE_ASSISTANT_REVEAL_LAST__?: Record<string, DevAssistantRevealRecord>;
+    __PROLIFERATE_ASSISTANT_REVEAL_CONSOLE__?: boolean;
+  };
+  const existing = debugGlobal.__PROLIFERATE_ASSISTANT_REVEALS__ ?? [];
+  const lastByItemId = debugGlobal.__PROLIFERATE_ASSISTANT_REVEAL_LAST__ ?? {};
+  const previous = lastByItemId[itemId] ?? null;
+  const recordedAt = new Date().toISOString();
+  const record: DevAssistantRevealRecord = {
+    ...state,
+    turnId,
+    itemId,
+    recordedAt,
+    visibleDelta: previous ? state.visibleLength - previous.visibleLength : null,
+    targetDelta: previous ? state.targetLength - previous.targetLength : null,
+    elapsedMs: previous
+      ? Date.parse(recordedAt) - Date.parse(previous.recordedAt)
+      : null,
+  };
+
+  existing.push(record);
+  if (existing.length > 1_000) {
+    existing.splice(0, 500);
+  }
+  lastByItemId[itemId] = record;
+  debugGlobal.__PROLIFERATE_ASSISTANT_REVEALS__ = existing;
+  debugGlobal.__PROLIFERATE_ASSISTANT_REVEAL_LAST__ = lastByItemId;
+  if (debugGlobal.__PROLIFERATE_ASSISTANT_REVEAL_CONSOLE__ === true) {
+    console.debug("[assistant-reveal]", record);
+  }
+}
+
+let devAssistantRevealQueryEnabled: boolean | null = null;
+
+function isDevAssistantRevealLoggingEnabled(): boolean {
+  const debugGlobal = globalThis as typeof globalThis & {
+    __PROLIFERATE_ASSISTANT_PERFORMANCE_ENABLED__?: boolean;
+  };
+  if (debugGlobal.__PROLIFERATE_ASSISTANT_PERFORMANCE_ENABLED__ === true) {
+    return true;
+  }
+  if (typeof window === "undefined") {
+    return false;
+  }
+  if (devAssistantRevealQueryEnabled === null) {
+    devAssistantRevealQueryEnabled =
+      new URLSearchParams(window.location.search).get("debugAssistantPerformance") === "1";
+  }
+  return devAssistantRevealQueryEnabled;
+}

--- a/apps/packages/product-ui/src/chat/transcript/AssistantMessage.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/AssistantMessage.test.tsx
@@ -1,0 +1,349 @@
+// @vitest-environment jsdom
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AssistantMessage,
+  MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND,
+  selectVisibleTarget,
+  STREAM_REVEAL_COMMIT_INTERVAL_MS,
+  STREAM_REVEAL_FADE_MS,
+  STREAM_REVEAL_HANDOFF_DELAY_MS,
+  STREAM_REVEAL_SETTLE_MS,
+} from "./AssistantMessage";
+
+let nextFrameId = 0;
+let frameTimestamp = 0;
+let pendingFrames = new Map<number, FrameRequestCallback>();
+
+beforeEach(() => {
+  nextFrameId = 0;
+  frameTimestamp = 0;
+  pendingFrames = new Map();
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const id = ++nextFrameId;
+    pendingFrames.set(id, callback);
+    return id;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    pendingFrames.delete(id);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function flushNextFrame() {
+  const entry = pendingFrames.entries().next().value as
+    | [number, FrameRequestCallback]
+    | undefined;
+  expect(entry).toBeDefined();
+  const [id, callback] = entry!;
+  pendingFrames.delete(id);
+  frameTimestamp += 17;
+  act(() => callback(frameTimestamp));
+}
+
+describe("AssistantMessage streaming reveal", () => {
+  it("renders mounted history immediately without replaying it", () => {
+    const content = "A previously loaded answer that must already be settled.";
+    const { container } = render(<AssistantMessage content={content} />);
+
+    expect(container.textContent).toBe(content);
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it("paces the first live chunk instead of mounting it as a visible jump", () => {
+    const content = "The first live chunk should enter through the frontier.";
+    const { container } = render(
+      <AssistantMessage content={content} isStreaming />,
+    );
+
+    expect(container.textContent).toBe("");
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1);
+    flushNextFrame();
+    expect(container.textContent?.length).toBeGreaterThan(0);
+    expect(container.textContent?.length).toBeLessThan(content.length);
+  });
+
+  it("reveals one source-order prefix so the next line waits for the frontier", () => {
+    const firstParagraph =
+      "The first paragraph has enough text to remain visible on its own.";
+    const secondParagraph = "Second line begins only after its reveal starts.";
+    const content = `${firstParagraph}\n\n${secondParagraph}`;
+    const { container, rerender } = render(
+      <AssistantMessage content="" isStreaming />,
+    );
+
+    rerender(<AssistantMessage content={content} isStreaming />);
+    expect(container.textContent).toBe("");
+
+    flushNextFrame();
+    expect(container.textContent).not.toContain("Second line");
+
+    let safety = 0;
+    while (!container.textContent?.includes("Second") && safety < 30) {
+      flushNextFrame();
+      safety += 1;
+    }
+
+    expect(container.textContent).toContain(firstParagraph);
+    expect(container.textContent).toContain("Second");
+    expect(
+      container.querySelector('[data-streaming-reveal="active"]'),
+    ).not.toBeNull();
+    expect(container.textContent?.indexOf("Second")).toBeGreaterThan(
+      container.textContent?.indexOf(firstParagraph) ?? -1,
+    );
+  });
+
+  it("never snaps a large initial or reconnect delivery into view", () => {
+    const content = "x".repeat(1_000);
+    const { container, rerender } = render(
+      <AssistantMessage content="" isStreaming />,
+    );
+
+    rerender(<AssistantMessage content={content} isStreaming />);
+    expect(container.textContent).toBe("");
+
+    for (let frame = 0; frame < 10; frame += 1) {
+      flushNextFrame();
+    }
+    const elapsedMs = 16 + (9 * 17);
+    const maximumVisible = Math.ceil(
+      (elapsedMs * MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND) / 1_000,
+    );
+    expect(container.textContent?.length).toBeLessThanOrEqual(maximumVisible);
+  });
+
+  it("rewinds a corrected stream to its common prefix instead of snapping", () => {
+    const initial = "old answer that is still arriving";
+    const { container, rerender } = render(
+      <AssistantMessage content={initial} isStreaming />,
+    );
+    flushNextFrame();
+    expect(container.textContent?.length).toBeGreaterThan(0);
+    expect(container.textContent?.length).toBeLessThan(initial.length);
+    expect(initial.startsWith(container.textContent ?? "")).toBe(true);
+
+    const corrected = "new answer delivered as one large corrected batch";
+    rerender(<AssistantMessage content={corrected} isStreaming />);
+    expect(container.textContent).toBe("");
+
+    flushNextFrame();
+    expect(container.textContent?.length).toBeLessThan(corrected.length);
+  });
+
+  it("resumes a remounted reveal from the exact prior visible prefix", () => {
+    const content = "A remounted transcript row must continue without a buffered phrase jump.";
+    const firstRender = render(
+      <AssistantMessage content={content} animateReveal />,
+    );
+
+    for (let frame = 0; frame < 4; frame += 1) {
+      flushNextFrame();
+    }
+    const priorVisibleText = firstRender.container.textContent ?? "";
+    expect(priorVisibleText.length).toBeGreaterThan(0);
+    expect(priorVisibleText.length).toBeLessThan(content.length);
+    firstRender.unmount();
+
+    const resumedRender = render(
+      <AssistantMessage
+        content={content}
+        animateReveal
+        initialVisibleLength={priorVisibleText.length}
+      />,
+    );
+    expect(resumedRender.container.textContent).toBe(priorVisibleText);
+    expect(resumedRender.container.querySelectorAll(".stream-word")).toHaveLength(0);
+
+    flushNextFrame();
+    const maximumFirstFrameGrowth = Math.ceil(
+      (16 * MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND) / 1_000,
+    );
+    expect(
+      (resumedRender.container.textContent?.length ?? 0) - priorVisibleText.length,
+    ).toBeLessThanOrEqual(maximumFirstFrameGrowth);
+  });
+
+  it("never re-fades prose that settled before a paused stream resumes", () => {
+    const settledContent = "one two";
+    const { container, rerender } = render(
+      <AssistantMessage content={settledContent} animateReveal={false} />,
+    );
+
+    rerender(
+      <AssistantMessage
+        content={`${settledContent} three four`}
+        animateReveal
+      />,
+    );
+    flushNextFrame();
+
+    const animatedWords = Array.from(
+      container.querySelectorAll(".stream-word"),
+      (word) => word.textContent,
+    );
+    expect(animatedWords.length).toBeGreaterThan(0);
+    expect(animatedWords).not.toContain("one");
+    expect(animatedWords).not.toContain("two");
+  });
+
+  it("drains the complete answer at the capped rate when streaming ends", () => {
+    vi.useFakeTimers();
+    const content = "Final answer ".repeat(30);
+    const { container, rerender } = render(
+      <AssistantMessage content="" isStreaming />,
+    );
+
+    rerender(<AssistantMessage content={content} isStreaming />);
+    flushNextFrame();
+    expect(container.textContent?.length).toBeLessThan(content.length);
+
+    rerender(<AssistantMessage content={content} isStreaming={false} />);
+    expect(container.textContent?.length).toBeLessThan(content.length);
+    expect(
+      container.querySelector('[data-streaming-reveal="active"]'),
+    ).not.toBeNull();
+
+    let safety = 0;
+    while ((container.textContent?.length ?? 0) < content.trimEnd().length && safety < 300) {
+      flushNextFrame();
+      safety += 1;
+    }
+
+    expect(container.textContent).toBe(content.trimEnd());
+    expect(
+      container.querySelector('[data-streaming-reveal="active"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-streaming-reveal="settling"]'),
+    ).not.toBeNull();
+
+    act(() => vi.advanceTimersByTime(STREAM_REVEAL_SETTLE_MS));
+    expect(container.querySelector("[data-streaming-reveal]")).toBeNull();
+  });
+
+  it("paces even a short already-completed answer before reporting it settled", () => {
+    vi.useFakeTimers();
+    const onRevealStateChange = vi.fn();
+    const content = "Done.";
+    const { container } = render(
+      <AssistantMessage
+        content={content}
+        animateReveal
+        onRevealStateChange={onRevealStateChange}
+      />,
+    );
+
+    expect(container.textContent).toBe("");
+    expect(onRevealStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ complete: false, visibleLength: 0 }),
+    );
+
+    while ((container.textContent?.length ?? 0) < content.length) {
+      flushNextFrame();
+    }
+    expect(container.textContent).toBe(content);
+    expect(onRevealStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ complete: false, phase: "settling" }),
+    );
+
+    act(() => vi.advanceTimersByTime(STREAM_REVEAL_FADE_MS));
+    expect(onRevealStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ complete: false, phase: "settling" }),
+    );
+
+    act(() => vi.advanceTimersByTime(STREAM_REVEAL_HANDOFF_DELAY_MS));
+    expect(onRevealStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        complete: true,
+        phase: "idle",
+        visibleLength: content.length,
+        targetLength: content.length,
+      }),
+    );
+  });
+
+  it("advances by a bounded prefix on each frame", () => {
+    const content = "abcdefghijklmnopqrstuvwxyz";
+    const first = selectVisibleTarget(content, 0, 3);
+    const second = selectVisibleTarget(content, first.length, 2);
+
+    expect(first).toBe("abc");
+    expect(second).toBe("abcde");
+    expect(content.startsWith(first)).toBe(true);
+    expect(second.startsWith(first)).toBe(true);
+  });
+
+  it("keeps independent word fades alive long enough to overlap", () => {
+    const cssPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../../design/src/css/dom.css",
+    );
+    const css = readFileSync(cssPath, "utf8");
+    const start = css.indexOf("/* ---- Streaming prose reveal ----");
+    const end = css.indexOf("/* Thinking indicator", start);
+    const section = css.slice(start, end);
+
+    expect(section).toContain("@keyframes stream-word-in");
+    expect(section).toContain(".stream-word");
+    expect(section).toContain("animation: stream-word-in 320ms linear both");
+    expect(section).toContain("from { opacity: 0.08; }");
+    expect(section).not.toContain("mask-image");
+    expect(STREAM_REVEAL_FADE_MS).toBe(320);
+    expect(STREAM_REVEAL_SETTLE_MS).toBe(
+      STREAM_REVEAL_FADE_MS + STREAM_REVEAL_HANDOFF_DELAY_MS,
+    );
+    expect(STREAM_REVEAL_COMMIT_INTERVAL_MS).toBe(32);
+    expect(section).toContain("@media (prefers-reduced-motion: reduce)");
+
+    const generatedCssPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../../design/dist/css/dom.css",
+    );
+    if (existsSync(generatedCssPath)) {
+      expect(readFileSync(generatedCssPath, "utf8")).toContain(
+        "animation: stream-word-in 320ms linear both",
+      );
+    }
+  });
+
+  it("routes an incomplete streaming file link through the link renderer", () => {
+    const renderLink = vi.fn(({ children }) => (
+      <span data-rendered-file-link>{children}</span>
+    ));
+    const { container } = render(
+      <AssistantMessage
+        content="[config](/Users/pablo/.codex/conf"
+        isStreaming
+        renderLink={renderLink}
+      />,
+    );
+
+    let safety = 0;
+    while (
+      !renderLink.mock.calls.some(
+        ([input]) => input.href === "/Users/pablo/.codex/conf",
+      ) &&
+      safety < 40
+    ) {
+      flushNextFrame();
+      safety += 1;
+    }
+
+    expect(renderLink).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "/Users/pablo/.codex/conf" }),
+    );
+    expect(
+      container.querySelector("[data-rendered-file-link]")?.textContent,
+    ).toBe("config");
+    expect(container.textContent).not.toContain("/Users/pablo");
+  });
+});

--- a/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/AssistantMessage.tsx
@@ -1,10 +1,25 @@
-import { useEffect, useMemo, useRef } from "react";
+import {
+  Profiler,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ProfilerOnRenderCallback,
+} from "react";
 import {
   MarkdownBody,
   type MarkdownCodeBlockRenderer,
   type MarkdownInlineCodeRenderer,
   type MarkdownLinkRenderer,
 } from "./MarkdownBody";
+import {
+  flushDevAssistantPerformanceBridge,
+  isDevAssistantPerformanceEnabled,
+  recordDevAssistantPerformance,
+} from "./dev-assistant-performance";
 
 export type {
   MarkdownCodeBlockRenderInput,
@@ -18,83 +33,383 @@ export type {
 export interface AssistantMessageProps {
   content: string;
   isStreaming?: boolean;
+  /** Force a newly completed response through the reveal instead of treating it as history. */
+  animateReveal?: boolean;
+  /** Resume a remounted live message from its last painted source prefix. */
+  initialVisibleLength?: number;
+  onRevealStateChange?: (state: AssistantMessageRevealState) => void;
   renderLink?: MarkdownLinkRenderer;
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
 }
 
-export function AssistantMessage({
+export interface AssistantMessageRevealState {
+  complete: boolean;
+  phase: AssistantMessageRevealPhase;
+  visibleLength: number;
+  targetLength: number;
+  isStreaming: boolean;
+}
+
+const STREAM_FLUSH_MS = 16;
+export const STREAM_REVEAL_COMMIT_INTERVAL_MS = 32;
+const STREAM_REVEAL_IDLE_MS = 240;
+export const STREAM_REVEAL_FADE_MS = 320;
+export const STREAM_REVEAL_HANDOFF_DELAY_MS = 160;
+export const STREAM_REVEAL_SETTLE_MS =
+  STREAM_REVEAL_FADE_MS + STREAM_REVEAL_HANDOFF_DELAY_MS;
+export const MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND = 360;
+
+export type AssistantMessageRevealPhase = "idle" | "active" | "settling";
+
+export const AssistantMessage = memo(function AssistantMessage({
   content,
   isStreaming = false,
+  animateReveal,
+  initialVisibleLength,
+  onRevealStateChange,
   renderLink,
   renderInlineCode,
   renderCodeBlock,
 }: AssistantMessageProps) {
-  return (
+  const debugProfilerId = useId();
+  const debugPerformanceEnabled = isDevAssistantPerformanceEnabled();
+  const wasStreamingRef = useRef(isStreaming);
+  if (isStreaming) {
+    wasStreamingRef.current = true;
+  }
+  const shouldAnimateReveal = animateReveal ?? wasStreamingRef.current;
+  const reportDebugRender = useCallback<ProfilerOnRenderCallback>((
+    id,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+  ) => {
+    recordDevAssistantPerformance({
+      kind: "react-commit",
+      id,
+      phase,
+      durationMs: actualDuration,
+      baseDurationMs: baseDuration,
+      startTimeMs: startTime,
+      commitTimeMs: commitTime,
+    });
+  }, []);
+
+  const message = (
     // Opt this message body into the composer-matched prose size. Both the
     // stable and live MarkdownBody below inherit --prose-text-size from here,
     // so the reserved height is identical between streaming and settled states.
     <div className="[--prose-text-size:var(--text-message)] [--prose-text-line-height:var(--text-message--line-height)] text-[length:var(--prose-text-size)] leading-[var(--prose-text-line-height)] select-text text-foreground">
       <AssistantMessageContent
+        debugPerformanceEnabled={debugPerformanceEnabled}
         content={content}
         isStreaming={isStreaming}
+        animateReveal={shouldAnimateReveal}
+        initialVisibleLength={initialVisibleLength}
+        onRevealStateChange={onRevealStateChange}
         renderLink={renderLink}
         renderInlineCode={renderInlineCode}
         renderCodeBlock={renderCodeBlock}
       />
     </div>
   );
-}
 
-// ANCHOR INVARIANT (owner rule): the newest content must occupy its final
-// layout position the INSTANT it exists. The word-level fade (revealText) is
-// opacity-only — layout commits instantly — and React's positional
-// reconciliation keeps previously-mounted word spans stable, so only
-// newly-appended words mount fresh and animate; nothing replays. The
-// stable/live split is kept for markdown-parse efficiency (the stable prefix
-// parses once; only the small live tail re-parses per stream batch).
-//
-// BLIP FIX: `revealedUpTo` tracks how much of the live content was already
-// rendered in a prior frame. When the markdown structure changes (e.g. `**bo`
-// completing to `**bold**`), React may remount word spans. The offset ensures
-// remounted spans for already-seen text render WITHOUT the animation class,
-// preventing the visible opacity blip.
+  return debugPerformanceEnabled
+    ? (
+      <Profiler id={`assistant-message:${debugProfilerId}`} onRender={reportDebugRender}>
+        {message}
+      </Profiler>
+    )
+    : message;
+});
+
+// STREAMING INVARIANT: assistant prose has one source-ordered reveal frontier.
+// The visible content is always a prefix, so a later wrapped/source line cannot
+// appear before the frontier reaches it. Recent words keep independent opacity
+// animations, allowing the next word to begin before earlier fades finish.
+// Hydrated history opts out and is visible immediately;
+// newly generated text always starts at zero and follows the same maximum rate,
+// even when the transport delivers a large initial or reconnect batch. The
+// stable/live split keeps high-frequency Markdown parsing bounded to the active
+// paragraph.
 function AssistantMessageContent({
+  debugPerformanceEnabled,
   content,
   isStreaming,
+  animateReveal,
+  initialVisibleLength,
+  onRevealStateChange,
   renderLink,
   renderInlineCode,
   renderCodeBlock,
 }: {
+  debugPerformanceEnabled: boolean;
   content: string;
   isStreaming?: boolean;
+  animateReveal: boolean;
+  initialVisibleLength?: number;
+  onRevealStateChange?: (state: AssistantMessageRevealState) => void;
   renderLink?: MarkdownLinkRenderer;
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
 }) {
-  // Track previous total content length to compute revealedUpTo for the live
-  // tree. Since rows are keyed by message id, this component mounts fresh per
-  // message — no cross-message reset needed.
-  const prevContentLengthRef = useRef(0);
+  const [visibleContent, setVisibleContent] = useState(() =>
+    initialVisibleContent(content, animateReveal, initialVisibleLength),
+  );
+  const visibleContentRef = useRef(visibleContent);
+  // A transport pause, row remount, or completed→live transition must never
+  // put already-painted prose back into fresh opacity animations. This
+  // absolute source frontier only moves backward when the source is corrected.
+  const settledVisibleLengthRef = useRef(
+    animateReveal ? visibleContent.length : content.length,
+  );
+  const targetContentRef = useRef(content);
+  const isStreamingRef = useRef(Boolean(isStreaming));
+  const flushFrameRef = useRef<number | null>(null);
+  const lastFlushAtRef = useRef(0);
+  const lastVisibleCommitAtRef = useRef(0);
+  const revealCharacterBudgetRef = useRef(0);
+  const [revealPhase, setRevealPhase] = useState<AssistantMessageRevealPhase>(() =>
+    visibleContent.length < content.length ? "active" : "idle",
+  );
+  const revealPhaseRef = useRef(revealPhase);
+  const settleDelayRef = useRef<number | null>(null);
+  const settleFinishRef = useRef<number | null>(null);
+
+  const commitRevealPhase = (phase: AssistantMessageRevealPhase) => {
+    revealPhaseRef.current = phase;
+    setRevealPhase(phase);
+  };
+
+  const cancelFlush = () => {
+    if (flushFrameRef.current === null) {
+      return;
+    }
+    window.cancelAnimationFrame(flushFrameRef.current);
+    flushFrameRef.current = null;
+  };
+
+  const commitVisibleContent = (nextContent: string) => {
+    visibleContentRef.current = nextContent;
+    setVisibleContent(nextContent);
+  };
+
+  const cancelSettle = () => {
+    if (settleDelayRef.current !== null) {
+      window.clearTimeout(settleDelayRef.current);
+      settleDelayRef.current = null;
+    }
+    if (settleFinishRef.current !== null) {
+      window.clearTimeout(settleFinishRef.current);
+      settleFinishRef.current = null;
+    }
+  };
+
+  const beginSettle = () => {
+    cancelSettle();
+    if (revealPhaseRef.current === "idle") {
+      return;
+    }
+    commitRevealPhase("settling");
+    settleFinishRef.current = window.setTimeout(() => {
+      settleFinishRef.current = null;
+      settledVisibleLengthRef.current = Math.max(
+        settledVisibleLengthRef.current,
+        visibleContentRef.current.length,
+      );
+      commitRevealPhase("idle");
+    }, STREAM_REVEAL_SETTLE_MS);
+  };
+
+  const scheduleSettle = () => {
+    if (settleDelayRef.current !== null || revealPhaseRef.current === "idle") {
+      return;
+    }
+    settleDelayRef.current = window.setTimeout(() => {
+      settleDelayRef.current = null;
+      beginSettle();
+    }, STREAM_REVEAL_IDLE_MS);
+  };
+
+  const scheduleFlush = () => {
+    if (flushFrameRef.current !== null) {
+      return;
+    }
+    flushFrameRef.current = window.requestAnimationFrame((timestamp) => {
+      flushFrameRef.current = null;
+      const elapsedMs =
+        lastFlushAtRef.current === 0
+          ? STREAM_FLUSH_MS
+          : Math.min(32, Math.max(0, timestamp - lastFlushAtRef.current));
+      lastFlushAtRef.current = timestamp;
+      revealCharacterBudgetRef.current +=
+        (elapsedMs * MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND) / 1_000;
+      const revealCharacters = Math.floor(revealCharacterBudgetRef.current);
+      const commitElapsedMs = timestamp - lastVisibleCommitAtRef.current;
+      if (
+        revealCharacters < 1
+        || (
+          lastVisibleCommitAtRef.current !== 0
+          && commitElapsedMs < STREAM_REVEAL_COMMIT_INTERVAL_MS
+        )
+      ) {
+        scheduleFlush();
+        return;
+      }
+
+      revealCharacterBudgetRef.current -= revealCharacters;
+      const target = targetContentRef.current;
+      const nextVisible = selectVisibleTarget(
+        target,
+        visibleContentRef.current.length,
+        revealCharacters,
+      );
+      if (nextVisible.length !== visibleContentRef.current.length) {
+        lastVisibleCommitAtRef.current = timestamp;
+        commitVisibleContent(nextVisible);
+      }
+      if (visibleContentRef.current.length < targetContentRef.current.length) {
+        scheduleFlush();
+      } else if (!isStreamingRef.current) {
+        beginSettle();
+      } else {
+        scheduleSettle();
+      }
+    });
+  };
+
+  useEffect(() => {
+    targetContentRef.current = content;
+    isStreamingRef.current = Boolean(isStreaming);
+
+    let visible = visibleContentRef.current;
+    const reducedMotion =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const contentWasRewritten = !content.startsWith(visible);
+
+    if (!animateReveal || reducedMotion) {
+      cancelFlush();
+      cancelSettle();
+      lastFlushAtRef.current = 0;
+      lastVisibleCommitAtRef.current = 0;
+      revealCharacterBudgetRef.current = 0;
+      settledVisibleLengthRef.current = content.length;
+      if (visible !== content) {
+        commitVisibleContent(content);
+      }
+      commitRevealPhase("idle");
+      return;
+    }
+
+    if (contentWasRewritten) {
+      cancelFlush();
+      cancelSettle();
+      lastFlushAtRef.current = 0;
+      lastVisibleCommitAtRef.current = 0;
+      revealCharacterBudgetRef.current = 0;
+      const commonPrefixLength = findCommonPrefixLength(visible, content);
+      settledVisibleLengthRef.current = Math.min(
+        settledVisibleLengthRef.current,
+        commonPrefixLength,
+      );
+      visible = content.slice(0, commonPrefixLength);
+      commitVisibleContent(visible);
+    }
+
+    if (!isStreaming) {
+      if (visible !== content) {
+        cancelSettle();
+        commitRevealPhase("active");
+        scheduleFlush();
+        return cancelFlush;
+      }
+      // The visual frontier has caught the transport. Keep its measured word
+      // mask mounted through the fade, so the final word reaches full opacity
+      // before downstream transcript rows are released.
+      if (revealPhaseRef.current !== "idle") {
+        beginSettle();
+      }
+      return;
+    }
+
+    if (content.length === visible.length) {
+      scheduleSettle();
+      return;
+    }
+
+    cancelSettle();
+    if (revealPhaseRef.current === "idle") {
+      lastFlushAtRef.current = 0;
+      lastVisibleCommitAtRef.current = 0;
+      revealCharacterBudgetRef.current = 0;
+    }
+    commitRevealPhase("active");
+
+    scheduleFlush();
+
+    return cancelFlush;
+  }, [animateReveal, content, isStreaming]);
+
+  useEffect(
+    () => () => {
+      cancelFlush();
+      cancelSettle();
+    },
+    [],
+  );
 
   const splitContent = useMemo(
-    () => splitAssistantContent(content),
-    [content],
+    () => splitAssistantContent(visibleContent),
+    [visibleContent],
   );
-
-  // revealedUpTo in live-local coordinates: everything from the live tree that
-  // was already rendered in the previous frame. Handles the live→stable
-  // boundary migration because stableContent.length grows by exactly what
-  // migrated out of the live tree.
-  const revealedUpTo = Math.max(
-    0,
-    prevContentLengthRef.current - splitContent.stableContent.length,
+  const isRevealing = visibleContent.length < content.length;
+  const showRevealTail =
+    splitContent.animateLiveContent &&
+    splitContent.liveContent.length > 0 &&
+    revealPhase !== "idle";
+  const revealWindowCharacters = Math.ceil(
+    (MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND * STREAM_REVEAL_FADE_MS) / 1_000,
   );
+  const revealedLiveSourceUpTo = Math.max(
+    Math.max(
+      0,
+      splitContent.liveContent.length - revealWindowCharacters,
+    ),
+    Math.max(
+      0,
+      Math.min(
+        splitContent.liveContent.length,
+        settledVisibleLengthRef.current - splitContent.stableContent.length,
+      ),
+    ),
+  );
+  const revealComplete =
+    revealPhase === "idle" && visibleContent.length >= content.length;
 
-  // Update the ref AFTER render so next render sees the current length.
   useEffect(() => {
-    prevContentLengthRef.current = content.length;
-  });
+    onRevealStateChange?.({
+      complete: revealComplete,
+      phase: revealPhase,
+      visibleLength: visibleContent.length,
+      targetLength: content.length,
+      isStreaming: Boolean(isStreaming),
+    });
+    if (debugPerformanceEnabled && revealComplete) {
+      flushDevAssistantPerformanceBridge();
+    }
+  }, [
+    content.length,
+    debugPerformanceEnabled,
+    isStreaming,
+    onRevealStateChange,
+    revealComplete,
+    revealPhase,
+    visibleContent.length,
+  ]);
 
   const stableClassName = splitContent.liveContent
     ? "[&>*:first-child]:mt-0"
@@ -116,15 +431,18 @@ function AssistantMessageContent({
         />
       )}
       {splitContent.liveContent && (
-        <div>
+        <div
+          data-streaming-reveal={showRevealTail ? revealPhase : undefined}
+        >
           <MarkdownBody
             content={splitContent.liveContent}
             className={liveClassName}
             renderLink={renderLink}
             renderInlineCode={renderInlineCode}
             renderCodeBlock={renderCodeBlock}
-            revealText={isStreaming}
-            revealedUpTo={revealedUpTo}
+            isStreaming={isStreaming || isRevealing}
+            revealText={showRevealTail}
+            revealedUpTo={revealedLiveSourceUpTo}
             enableContentSearch
           />
         </div>
@@ -136,26 +454,30 @@ function AssistantMessageContent({
 function splitAssistantContent(content: string): {
   stableContent: string;
   liveContent: string;
+  animateLiveContent: boolean;
 } {
   if (!content) {
-    return { stableContent: "", liveContent: "" };
+    return { stableContent: "", liveContent: "", animateLiveContent: false };
   }
 
   // Always split at the last safe paragraph boundary — including for plain
   // prose. The live MarkdownBody re-parses on every reveal flush; without a
   // split, a long prose message re-parses in its entirety at the flush rate,
   // which starves the main thread and lags composer typing.
+  const structuredTail = hasOpenCodeFence(content) || hasTrailingTable(content);
   const boundary = findStableBoundary(content);
   if (boundary < 0 || boundary + 2 >= content.length) {
     return {
       stableContent: "",
       liveContent: content,
+      animateLiveContent: !structuredTail,
     };
   }
 
   return {
     stableContent: content.slice(0, boundary + 2),
     liveContent: content.slice(boundary + 2),
+    animateLiveContent: !structuredTail,
   };
 }
 
@@ -177,3 +499,47 @@ function hasOpenCodeFence(content: string): boolean {
   return (content.match(/```/g)?.length ?? 0) % 2 === 1;
 }
 
+function hasTrailingTable(content: string): boolean {
+  const lines = content.trimEnd().split("\n");
+  if (lines.length < 2) return false;
+  const tail = lines.slice(-3);
+  const tableLikeLines = tail.filter((line) => {
+    const trimmed = line.trim();
+    return trimmed.startsWith("|") && trimmed.endsWith("|");
+  });
+  return tableLikeLines.length >= 2;
+}
+
+export function selectVisibleTarget(
+  content: string,
+  currentLength: number,
+  maximumCharacters = 1,
+): string {
+  if (content.length <= currentLength) {
+    return content;
+  }
+  return content.slice(
+    0,
+    Math.min(content.length, currentLength + Math.max(1, maximumCharacters)),
+  );
+}
+
+function findCommonPrefixLength(left: string, right: string): number {
+  const maximumLength = Math.min(left.length, right.length);
+  let index = 0;
+  while (index < maximumLength && left[index] === right[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function initialVisibleContent(
+  content: string,
+  animateReveal: boolean,
+  initialVisibleLength = 0,
+): string {
+  if (!animateReveal) {
+    return content;
+  }
+  return content.slice(0, Math.max(0, Math.min(content.length, initialVisibleLength)));
+}

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -6,17 +6,11 @@ import {
   memo,
   useContext,
   useMemo,
+  type ContextType,
   type HTMLAttributes,
   type ReactElement,
   type ReactNode,
 } from "react";
-import {
-  type HastNode,
-  type MarkdownRevealState,
-  MarkdownRevealContext,
-  REVEAL_DISABLED,
-  revealChildren,
-} from "./MarkdownRevealText";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ProviderLinkMention } from "./ProviderLinkMention";
@@ -27,6 +21,12 @@ import {
   type ChatContentSearchPaint,
 } from "./ChatContentSearchContext";
 import { markSearchChildren } from "./MarkdownContentSearchMarks";
+import { stabilizeStreamingMarkdown } from "./streaming-markdown";
+import {
+  type HastNode,
+  MarkdownRevealContext,
+  revealChildren,
+} from "./MarkdownRevealText";
 
 interface MarkdownBodyProps {
   content: string;
@@ -35,8 +35,11 @@ interface MarkdownBodyProps {
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
   taskListItems?: MarkdownTaskListItemPresentation;
+  /** Parse an incomplete live tail defensively while source text is streaming. */
+  isStreaming?: boolean;
+  /** Fade words in the live source suffix independently. */
   revealText?: boolean;
-  /** Character offset into the source string: text before this was already rendered. */
+  /** Live-source offset before which word fades have completed. */
   revealedUpTo?: number;
   /**
    * Opt this body into the chat content-search paint layer. Only the
@@ -88,6 +91,8 @@ type MdElementProps = HTMLAttributes<HTMLElement> & {
 
 type MdTag =
   | "blockquote"
+  | "del"
+  | "em"
   | "h1"
   | "h2"
   | "h3"
@@ -97,6 +102,7 @@ type MdTag =
   | "li"
   | "ol"
   | "p"
+  | "strong"
   | "table"
   | "td"
   | "th"
@@ -123,18 +129,15 @@ const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
 // rendered node. They must be referentially stable across renders: a fresh
 // arrow function per render is a new component type, which makes React
 // unmount and remount the whole markdown DOM (visible as transcript jumps
-// while streams/sends re-render rows). The reveal context is read inside each
-// component via useContext — the component identity stays stable, and the
-// context value flows from MarkdownBody's provider without rebuilding the map.
+// while streams/sends re-render rows).
 
-// Factory: creates a stable component that reads reveal + search context and
-// delegates. Both are read via useContext so the component identity stays
-// stable across renders (see the identity comment above).
+// Factory: creates a stable component that reads the search context and
+// delegates without rebuilding the components map (see the identity comment).
 function mdComponent(tag: MdTag, className: string) {
   return (props: MdElementProps) => {
-    const ctx = useContext(MarkdownRevealContext);
+    const revealState = useContext(MarkdownRevealContext);
     const searchPaint = useChatContentSearchPaint();
-    return mdHtmlElement(tag, className, props, ctx, searchPaint);
+    return mdHtmlElement(tag, className, props, revealState, searchPaint);
   };
 }
 
@@ -145,6 +148,9 @@ const STATIC_MARKDOWN_COMPONENTS = {
   h4: mdComponent("h4", "mb-2 mt-4 text-[15px] font-semibold leading-[1.3] text-foreground"),
   h5: mdComponent("h5", "mb-1.5 mt-4 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground"),
   h6: mdComponent("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground"),
+  strong: mdComponent("strong", "font-semibold"),
+  em: mdComponent("em", "italic"),
+  del: mdComponent("del", "line-through"),
   p: mdComponent("p", `mb-[0.6875rem] mt-0 ${PROSE_TEXT} text-foreground`),
   ul: mdComponent("ul", `mb-[0.6875rem] mt-0 list-disc pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
   ol: mdComponent("ol", `mb-[0.6875rem] mt-0 list-decimal pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
@@ -315,10 +321,15 @@ export const MarkdownBody = memo(function MarkdownBody({
   renderInlineCode,
   renderCodeBlock,
   taskListItems = "inline",
+  isStreaming = false,
   revealText = false,
   revealedUpTo = 0,
   enableContentSearch = false,
 }: MarkdownBodyProps) {
+  const parsedContent = useMemo(
+    () => (isStreaming ? stabilizeStreamingMarkdown(content) : content),
+    [content, isStreaming],
+  );
   const markdownClassName = [
     `${PROSE_TEXT} text-foreground break-words`,
     "[&_li>p]:my-0",
@@ -346,11 +357,8 @@ export const MarkdownBody = memo(function MarkdownBody({
     ),
   }), [renderCodeBlock, renderInlineCode, renderLink, taskListItems]);
 
-  // Build reveal context value. Memoized so a re-render that changes neither
-  // flag nor offset doesn't push a fresh object through context; the disabled
-  // case shares one module-level reference.
-  const revealState: MarkdownRevealState | null = useMemo(
-    () => (revealText ? { enabled: true, revealedUpTo } : REVEAL_DISABLED),
+  const revealState = useMemo(
+    () => revealText ? { enabled: true, revealedUpTo } : null,
     [revealText, revealedUpTo],
   );
 
@@ -362,7 +370,7 @@ export const MarkdownBody = memo(function MarkdownBody({
           urlTransform={markdownUrlTransform}
           components={components}
         >
-          {content}
+          {parsedContent}
         </ReactMarkdown>
       </div>
     </MarkdownRevealContext.Provider>
@@ -435,14 +443,12 @@ function markdownUrlTransform(value: string): string {
 export { MarkdownCodeBlockShell } from "./MarkdownCodeBlock";
 
 // mdHtmlElement is called from within STATIC_MARKDOWN_COMPONENTS entries,
-// which ARE React component functions (hooks-valid call site). Each entry
-// calls useContext(MarkdownRevealContext) and passes the context state so
-// word spans can be applied without rebuilding the components map per render.
+// which ARE React component functions (hooks-valid call site).
 function mdHtmlElement(
   tag: MdTag,
   baseClassName: string,
   props: MdElementProps,
-  ctx: MarkdownRevealState | null = null,
+  revealState: ContextType<typeof MarkdownRevealContext> = null,
   searchPaint: ChatContentSearchPaint | null = null,
 ) {
   const {
@@ -461,13 +467,8 @@ function mdHtmlElement(
       dangerouslySetInnerHTML,
     });
   }
-  // Content-search highlighting takes precedence over the streaming reveal:
-  // search runs on settled content, so the reveal fade is irrelevant while a
-  // query is active.
   const finalChildren = searchPaint
     ? markSearchChildren(children, searchPaint.query, searchPaint.rowUnitId)
-    : ctx?.enabled
-      ? revealChildren(children, node as HastNode | undefined, ctx)
-      : children;
+    : revealChildren(children, node as HastNode | undefined, revealState);
   return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
 }

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.test.tsx
@@ -1,129 +1,59 @@
 // @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { AssistantMessage } from "./AssistantMessage";
 import { MarkdownBody } from "./MarkdownBody";
 
-describe("MarkdownRevealText blip prevention", () => {
-  afterEach(cleanup);
+afterEach(cleanup);
 
-  it("words before revealedUpTo render without stream-word class", () => {
-    // Simulate: first render had "some **bo" (incomplete bold), second render
-    // has "some **bold** more" (completed bold). The first 9 characters
-    // ("some **bo") were already shown, so after the stable/live split those
-    // words must not re-animate.
-    const content = "some **bold** more";
-    // revealedUpTo = 9 means characters 0..8 were already rendered.
+describe("overlapping Markdown word reveal", () => {
+  it("keeps several recent words independently animated", () => {
     const { container } = render(
       <MarkdownBody
-        content={content}
-        revealText={true}
-        revealedUpTo={9}
-      />,
-    );
-
-    const streamWords = container.querySelectorAll(".stream-word");
-    const allSpans = container.querySelectorAll("span");
-
-    // "more" should be animated (it's new text past offset 9).
-    const animatedTexts = Array.from(streamWords).map((el) => el.textContent);
-    expect(animatedTexts).toContain("more");
-
-    // "some" should NOT have stream-word class (it was already revealed).
-    const someSpan = Array.from(allSpans).find((el) => el.textContent === "some");
-    expect(someSpan).toBeTruthy();
-    expect(someSpan!.classList.contains("stream-word")).toBe(false);
-  });
-
-  it("with revealedUpTo=0 all words animate (first render)", () => {
-    const content = "hello world";
-    const { container } = render(
-      <MarkdownBody
-        content={content}
-        revealText={true}
+        content="one **two** three"
+        revealText
         revealedUpTo={0}
       />,
     );
 
-    const streamWords = container.querySelectorAll(".stream-word");
-    const texts = Array.from(streamWords).map((el) => el.textContent);
-    expect(texts).toContain("hello");
-    expect(texts).toContain("world");
-  });
-
-  it("with revealText=false no words get stream-word class", () => {
-    const content = "hello world";
-    const { container } = render(
-      <MarkdownBody
-        content={content}
-        revealText={false}
-      />,
-    );
-
-    const streamWords = container.querySelectorAll(".stream-word");
-    expect(streamWords.length).toBe(0);
-  });
-
-  it("structure change from plain to bold does not re-animate settled words", () => {
-    // First render: "Check this bo" (no bold yet, 13 chars)
-    // Second render: "Check this **bold** end" (bold completed)
-    // revealedUpTo=13 means first 13 chars were rendered previously.
-    const content = "Check this **bold** end";
-    const { container } = render(
-      <MarkdownBody
-        content={content}
-        revealText={true}
-        revealedUpTo={13}
-      />,
-    );
-
-    const streamWords = container.querySelectorAll(".stream-word");
-    const animatedTexts = Array.from(streamWords).map((el) => el.textContent);
-
-    // "Check" and "this" should NOT be animated — they were settled.
-    expect(animatedTexts).not.toContain("Check");
-    expect(animatedTexts).not.toContain("this");
-
-    // "end" is new text and should be animated.
-    expect(animatedTexts).toContain("end");
-  });
-
-  it("fully settled element renders children as plain text (no spans)", () => {
-    // Content is 11 chars; revealedUpTo > content length means everything settled.
-    const content = "hello world";
-    const { container } = render(
-      <MarkdownBody
-        content={content}
-        revealText={true}
-        revealedUpTo={100}
-      />,
-    );
-
-    const spans = container.querySelectorAll("span");
-    // No word spans at all — children rendered as plain text.
-    expect(spans.length).toBe(0);
-  });
-
-  // The actual regression shape: stream two batches through AssistantMessage
-  // (which derives revealedUpTo from the previous render's content length) and
-  // assert the structure change does not re-animate already-seen words.
-  it("streaming rerender with completing bold does not re-animate seen words", () => {
-    const { container, rerender } = render(
-      <AssistantMessage content="Check this **bo" isStreaming />,
-    );
-    // First batch: all words are new and animate.
     expect(
-      Array.from(container.querySelectorAll(".stream-word")).map((el) => el.textContent),
-    ).toContain("Check");
+      Array.from(container.querySelectorAll(".stream-word"), (word) =>
+        word.textContent
+      ),
+    ).toEqual(["one", "two", "three"]);
+  });
 
-    // Second batch completes the bold and appends — hast restructures the
-    // paragraph, remounting spans. Seen words must render static.
-    rerender(<AssistantMessage content="Check this **bold** end" isStreaming />);
-    const animated = Array.from(container.querySelectorAll(".stream-word")).map(
-      (el) => el.textContent,
+  it("preserves existing word nodes while later words arrive", () => {
+    const { container, rerender } = render(
+      <MarkdownBody content="one two" revealText revealedUpTo={0} />,
     );
-    expect(animated).not.toContain("Check");
-    expect(animated).not.toContain("this");
-    expect(animated).toContain("end");
+    const firstWord = Array.from(container.querySelectorAll(".stream-word"))
+      .find((word) => word.textContent === "one");
+
+    rerender(
+      <MarkdownBody content="one two three" revealText revealedUpTo={0} />,
+    );
+
+    const firstWordAfterUpdate = Array.from(
+      container.querySelectorAll(".stream-word"),
+    ).find((word) => word.textContent === "one");
+    expect(firstWordAfterUpdate).toBe(firstWord);
+  });
+
+  it("drops the animation only after a word leaves the fade window", () => {
+    const { container } = render(
+      <MarkdownBody
+        content="one two three"
+        revealText
+        revealedUpTo={4}
+      />,
+    );
+
+    const animatedWords = Array.from(
+      container.querySelectorAll(".stream-word"),
+      (word) => word.textContent,
+    );
+    expect(animatedWords).not.toContain("one");
+    expect(animatedWords).toEqual(["two", "three"]);
+    expect(container.textContent).toBe("one two three");
   });
 });

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownRevealText.tsx
@@ -1,247 +1,140 @@
 import { createContext, type ReactNode } from "react";
 
-/**
- * Reveal context value. `null` = disabled (no animation). When enabled,
- * `revealedUpTo` is the character offset into the live content string:
- * everything before it was already rendered in a prior frame and must render
- * static (no animation class); words at/after it are new and animate.
- */
 export interface MarkdownRevealState {
   enabled: boolean;
+  /** Live-markdown source offset before which words have finished fading. */
   revealedUpTo: number;
 }
 
-/** Stable default for non-reveal renders — avoids re-creating context value. */
-const DISABLED: MarkdownRevealState | null = null;
+export const MarkdownRevealContext =
+  createContext<MarkdownRevealState | null>(null);
 
-export const MarkdownRevealContext = createContext<MarkdownRevealState | null>(
-  DISABLED,
-);
-
-/** Convenience: create a disabled context value without allocation. */
-export const REVEAL_DISABLED = DISABLED;
-
-/**
- * Hast Element node shape (subset used for position offsets).
- * react-markdown passes the hast `node` in props for custom components.
- */
 export interface HastNode {
   position?: {
     start: { offset?: number };
     end: { offset?: number };
   };
-  children?: Array<{ type: string; value?: string; position?: HastNode["position"]; children?: HastNode["children"] }>;
+  children?: HastNode[];
 }
 
 /**
- * Transform children for word-level reveal animation. Splits string children
- * on whitespace boundaries: whitespace segments pass through as plain strings,
- * non-whitespace segments get wrapped in `<span className="stream-word">` if
- * their estimated source offset is >= revealedUpTo (new text). Words before
- * revealedUpTo render as plain `<span>` without animation class, preserving
- * positional key parity so React doesn't remount animated siblings.
- *
- * Non-string children (elements like strong/em/code) pass through untouched —
- * their OWN inner strings will get wrapped when they render through
- * mdHtmlElement recursively.
+ * Wrap only the live suffix's words. A word keeps its animation class for the
+ * entire reveal window, so a later word can begin while earlier animations are
+ * still running. Stable source-order keys let React preserve those animations
+ * across the controller's paced content commits.
  */
 export function revealChildren(
   children: ReactNode,
   node: HastNode | undefined,
-  ctx: MarkdownRevealState | null,
+  state: MarkdownRevealState | null,
 ): ReactNode {
-  // Fast path: no reveal context or disabled — return children as-is.
-  if (!ctx || !ctx.enabled) {
+  if (!state?.enabled) {
     return children;
   }
 
-  const elementStartOffset = node?.position?.start?.offset ?? undefined;
-  const elementEndOffset = node?.position?.end?.offset ?? undefined;
-
-  // If the entire element is before revealedUpTo, return children as plain
-  // text — no spans at all, zero overhead for settled elements.
-  if (
-    elementEndOffset !== undefined &&
-    elementEndOffset <= ctx.revealedUpTo
-  ) {
+  const elementStart = node?.position?.start.offset ?? 0;
+  const elementEnd = node?.position?.end.offset;
+  if (elementEnd !== undefined && elementEnd <= state.revealedUpTo) {
     return children;
   }
 
-  // If the entire element is new (starts at or after revealedUpTo), animate
-  // all words.
-  if (
-    elementStartOffset !== undefined &&
-    elementStartOffset >= ctx.revealedUpTo
-  ) {
-    return wrapAllAnimated(children);
-  }
-
-  // Element straddles the boundary. Walk children and estimate offsets.
-  return wrapStraddling(children, node, ctx);
+  return wrapChildren(children, elementStart, state.revealedUpTo);
 }
 
-/**
- * All words in these children are new — wrap with stream-word class.
- */
-function wrapAllAnimated(children: ReactNode): ReactNode {
-  if (typeof children === "string") {
-    return splitIntoWordSpans(children, true);
-  }
-  if (Array.isArray(children)) {
-    return children.map((child) => {
-      if (typeof child === "string") {
-        return splitIntoWordSpans(child, true);
-      }
-      return child;
-    });
-  }
-  return children;
-}
-
-/**
- * Element straddles the revealedUpTo boundary. Estimate per-word offsets
- * relative to the source string and decide animate vs. static.
- */
-function wrapStraddling(
+function wrapChildren(
   children: ReactNode,
-  node: HastNode | undefined,
-  ctx: MarkdownRevealState,
+  elementStart: number,
+  revealedUpTo: number,
 ): ReactNode {
-  const elementStart = node?.position?.start?.offset ?? 0;
-  let charAccumulator = elementStart;
-
   if (typeof children === "string") {
-    return splitIntoWordSpansWithOffset(children, charAccumulator, ctx.revealedUpTo);
+    return splitWords(children, elementStart, revealedUpTo);
+  }
+  if (!Array.isArray(children)) {
+    return children;
   }
 
-  if (Array.isArray(children)) {
-    return children.map((child) => {
-      if (typeof child === "string") {
-        const result = splitIntoWordSpansWithOffset(child, charAccumulator, ctx.revealedUpTo);
-        charAccumulator += child.length;
-        return result;
-      }
-      // Non-string child (React element): advance accumulator by its source
-      // extent if available, else estimate via textContent. The textContent
-      // fallback UNDERcounts source length (markdown syntax chars, entities),
-      // which keeps drift on the safe side of the `< revealedUpTo` bias: too-low
-      // offsets can only classify new words as settled (a skipped fade, invisible)
-      // — never make an already-seen word look new and re-blip.
-      const childNode = getHastNodeFromElement(child);
-      if (childNode?.position?.end?.offset !== undefined) {
-        charAccumulator = childNode.position.end.offset;
-      } else {
-        charAccumulator += estimateTextLength(child);
-      }
-      return child;
-    });
-  }
+  let sourceOffset = elementStart;
+  return children.map((child) => {
+    if (typeof child === "string") {
+      const wrapped = splitWords(child, sourceOffset, revealedUpTo);
+      sourceOffset += child.length;
+      return wrapped;
+    }
 
-  return children;
+    const childNode = getHastNode(child);
+    const childEnd = childNode?.position?.end.offset;
+    sourceOffset = childEnd ?? sourceOffset + estimateTextLength(child);
+    return child;
+  });
 }
 
-/**
- * Split a string into word spans with offset-aware animation decisions.
- * Words whose estimated start offset < revealedUpTo render static (span
- * without animation class). Words at/after render animated.
- */
-function splitIntoWordSpansWithOffset(
+function splitWords(
   text: string,
-  startOffset: number,
+  sourceStart: number,
   revealedUpTo: number,
 ): ReactNode[] {
   if (/^\s*$/.test(text)) {
     return [text];
   }
+
   const parts = text.split(/(\s+)/);
   let localOffset = 0;
-  return parts.map((part, index) => {
-    if (/^\s+$/.test(part)) {
-      localOffset += part.length;
-      return part;
-    }
-    if (part === "") {
-      return null;
-    }
-    const wordStartOffset = startOffset + localOffset;
+  let animatedStart = text.length;
+  for (const part of parts) {
+    const partOffset = localOffset;
     localOffset += part.length;
-    // Bias toward static: use < (not <=) so words exactly at boundary are
-    // treated as new, but any drift from markdown syntax chars means some
-    // new-ish words render static — acceptable (invisible vs. blip).
-    const isSettled = wordStartOffset < revealedUpTo;
-    return (
-      <span className={isSettled ? undefined : "stream-word"} key={index}>
-        {part}
-      </span>
-    );
-  });
-}
+    if (part && !/^\s+$/.test(part) && sourceStart + partOffset >= revealedUpTo) {
+      animatedStart = partOffset;
+      break;
+    }
+  }
 
-function splitIntoWordSpans(text: string, animate: boolean): ReactNode[] {
-  // Whitespace-only strings pass through untouched.
-  if (/^\s*$/.test(text)) {
+  if (animatedStart >= text.length) {
     return [text];
   }
-  const parts = text.split(/(\s+)/);
-  return parts.map((part, index) => {
-    // Whitespace segments stay as plain text (no span).
-    if (/^\s+$/.test(part)) {
-      return part;
-    }
-    if (part === "") {
-      return null;
-    }
-    if (animate) {
-      return (
-        <span className="stream-word" key={index}>
+
+  const result: ReactNode[] = [];
+  if (animatedStart > 0) {
+    result.push(text.slice(0, animatedStart));
+  }
+
+  localOffset = animatedStart;
+  for (const part of text.slice(animatedStart).split(/(\s+)/)) {
+    const sourceOffset = sourceStart + localOffset;
+    localOffset += part.length;
+    if (!part || /^\s+$/.test(part)) {
+      result.push(part);
+    } else {
+      result.push(
+        <span className="stream-word" key={sourceOffset}>
           {part}
-        </span>
+        </span>,
       );
     }
-    return (
-      <span key={index}>
-        {part}
-      </span>
+  }
+  return result;
+}
+
+function getHastNode(value: unknown): HastNode | undefined {
+  if (!value || typeof value !== "object" || !("props" in value)) {
+    return undefined;
+  }
+  return (value as { props?: { node?: HastNode } }).props?.node;
+}
+
+function estimateTextLength(value: unknown): number {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).length;
+  }
+  if (!value || typeof value !== "object" || !("props" in value)) {
+    return 0;
+  }
+  const children = (value as { props?: { children?: unknown } }).props?.children;
+  if (Array.isArray(children)) {
+    return children.reduce(
+      (total: number, child: unknown) => total + estimateTextLength(child),
+      0,
     );
-  });
-}
-
-/**
- * Extract hast node from a React element's props (react-markdown passes it as
- * `node` prop on custom components).
- */
-function getHastNodeFromElement(element: unknown): HastNode | undefined {
-  if (
-    element &&
-    typeof element === "object" &&
-    "props" in element &&
-    (element as { props?: { node?: HastNode } }).props?.node
-  ) {
-    return (element as { props: { node: HastNode } }).props.node;
   }
-  return undefined;
-}
-
-/**
- * Cheap recursive textContent estimate for a React element (used when hast
- * position is unavailable on a child element).
- */
-function estimateTextLength(element: unknown): number {
-  if (typeof element === "string") return element.length;
-  if (typeof element === "number") return String(element).length;
-  if (!element || typeof element !== "object") return 0;
-  if ("props" in element) {
-    const props = (element as { props?: { children?: unknown } }).props;
-    if (!props?.children) return 0;
-    const children = props.children;
-    if (typeof children === "string") return children.length;
-    if (Array.isArray(children)) {
-      return children.reduce(
-        (sum: number, child: unknown) => sum + estimateTextLength(child),
-        0,
-      );
-    }
-    return estimateTextLength(children);
-  }
-  return 0;
+  return estimateTextLength(children);
 }

--- a/apps/packages/product-ui/src/chat/transcript/dev-assistant-performance.ts
+++ b/apps/packages/product-ui/src/chat/transcript/dev-assistant-performance.ts
@@ -1,0 +1,86 @@
+export interface DevAssistantPerformanceRecord {
+  kind: "react-commit";
+  id: string;
+  phase: string;
+  durationMs: number;
+  baseDurationMs: number;
+  startTimeMs: number;
+  commitTimeMs: number;
+  recordedAtMs?: number;
+}
+
+const ASSISTANT_PERFORMANCE_OUTPUT_ID =
+  "proliferate-assistant-performance-data";
+
+let devAssistantPerformanceQueryEnabled: boolean | null = null;
+
+export function recordDevAssistantPerformance(
+  record: DevAssistantPerformanceRecord,
+): void {
+  if (!isDevAssistantPerformanceEnabled()) return;
+
+  const debugGlobal = globalThis as typeof globalThis & {
+    __PROLIFERATE_ASSISTANT_PERFORMANCE__?: DevAssistantPerformanceRecord[];
+    __PROLIFERATE_ASSISTANT_PERFORMANCE_CONSOLE__?: boolean;
+  };
+  installDevAssistantPerformanceBridge();
+  const records = debugGlobal.__PROLIFERATE_ASSISTANT_PERFORMANCE__ ?? [];
+  const nextRecord = { ...record, recordedAtMs: performance.now() };
+  records.push(nextRecord);
+  if (records.length > 2_000) {
+    records.splice(0, 1_000);
+  }
+  debugGlobal.__PROLIFERATE_ASSISTANT_PERFORMANCE__ = records;
+  if (debugGlobal.__PROLIFERATE_ASSISTANT_PERFORMANCE_CONSOLE__ === true) {
+    console.debug("[assistant-performance]", nextRecord);
+  }
+}
+
+export function flushDevAssistantPerformanceBridge(): void {
+  const debugGlobal = globalThis as typeof globalThis & {
+    __PROLIFERATE_ASSISTANT_PERFORMANCE__?: DevAssistantPerformanceRecord[];
+  };
+  const output = document.getElementById(ASSISTANT_PERFORMANCE_OUTPUT_ID);
+  if (output) {
+    output.textContent = JSON.stringify(
+      debugGlobal.__PROLIFERATE_ASSISTANT_PERFORMANCE__ ?? [],
+    );
+  }
+}
+
+export function isDevAssistantPerformanceEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const hostname = window.location.hostname;
+  const isLocalDevelopmentOrigin = hostname === "localhost"
+    || hostname.endsWith(".localhost")
+    || hostname === "127.0.0.1"
+    || hostname === "::1";
+  if (!isLocalDevelopmentOrigin) return false;
+
+  const debugGlobal = globalThis as typeof globalThis & {
+    __PROLIFERATE_ASSISTANT_PERFORMANCE_ENABLED__?: boolean;
+  };
+  if (debugGlobal.__PROLIFERATE_ASSISTANT_PERFORMANCE_ENABLED__ === true) {
+    return true;
+  }
+  if (devAssistantPerformanceQueryEnabled === null) {
+    devAssistantPerformanceQueryEnabled =
+      new URLSearchParams(window.location.search).get(
+        "debugAssistantPerformance",
+      ) === "1";
+  }
+  return devAssistantPerformanceQueryEnabled;
+}
+
+function installDevAssistantPerformanceBridge(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(ASSISTANT_PERFORMANCE_OUTPUT_ID)) return;
+
+  const output = document.createElement("script");
+  output.id = ASSISTANT_PERFORMANCE_OUTPUT_ID;
+  output.type = "application/json";
+  output.hidden = true;
+  output.textContent = "[]";
+  document.head.append(output);
+}

--- a/apps/packages/product-ui/src/chat/transcript/streaming-markdown.test.ts
+++ b/apps/packages/product-ui/src/chat/transcript/streaming-markdown.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { stabilizeStreamingMarkdown } from "./streaming-markdown";
+
+describe("stabilizeStreamingMarkdown", () => {
+  it.each([
+    ["[config](/Users/pablo/.codex/conf", "[config](/Users/pablo/.codex/conf)"],
+    [
+      "[config](file:///Users/pablo/.codex/conf",
+      "[config](file:///Users/pablo/.codex/conf)",
+    ],
+    ["[config](../.codex/conf", "[config](../.codex/conf)"],
+    [
+      "[config](<file:///Users/pablo/My%20Project/conf",
+      "[config](<file:///Users/pablo/My%20Project/conf>)",
+    ],
+    [
+      "[config](<file:///Users/pablo/My%20Project/conf>",
+      "[config](<file:///Users/pablo/My%20Project/conf>)",
+    ],
+    ["[config](C:\\Users\\pablo\\conf", "[config](C:\\Users\\pablo\\conf)"],
+  ])("temporarily closes an incomplete local-file link", (input, expected) => {
+    expect(stabilizeStreamingMarkdown(input)).toBe(expected);
+  });
+
+  it.each([
+    "[site](https://example.com/part",
+    "[asset](//cdn.example.com/part",
+    "![preview](/Users/pablo/image.png",
+    "[config](/Users/pablo/.codex/config.toml)",
+    "plain [unfinished label",
+  ])("leaves non-target markdown untouched", (content) => {
+    expect(stabilizeStreamingMarkdown(content)).toBe(content);
+  });
+});

--- a/apps/packages/product-ui/src/chat/transcript/streaming-markdown.ts
+++ b/apps/packages/product-ui/src/chat/transcript/streaming-markdown.ts
@@ -1,0 +1,41 @@
+const TRAILING_INCOMPLETE_INLINE_LINK = /\[([^\]\n]+)\]\(([^)\n]*)$/;
+
+/**
+ * Keep a trailing local-file link parseable while its destination is still
+ * streaming. The synthetic closing delimiter exists only in the render copy;
+ * the authoritative transcript content remains untouched.
+ *
+ * Without this, react-markdown exposes the entire unfinished source token —
+ * including an absolute destination — until the real `)` arrives. Closing the
+ * render copy lets the injected file-link renderer paint the final mention
+ * immediately, so later destination chunks update behavior without replacing
+ * a long raw path on screen.
+ */
+export function stabilizeStreamingMarkdown(content: string): string {
+  const match = TRAILING_INCOMPLETE_INLINE_LINK.exec(content);
+  if (!match || (match.index > 0 && content[match.index - 1] === "!")) {
+    return content;
+  }
+
+  const destination = match[2]?.trim() ?? "";
+  const unwrappedDestination = destination.startsWith("<")
+    ? destination.slice(1)
+    : destination;
+  if (!looksLikeLocalFileDestination(unwrappedDestination)) {
+    return content;
+  }
+
+  if (destination.startsWith("<") && !destination.endsWith(">")) {
+    return `${content}>)`;
+  }
+  return `${content})`;
+}
+
+function looksLikeLocalFileDestination(destination: string): boolean {
+  return (destination.startsWith("/") && !destination.startsWith("//"))
+    || destination.startsWith("~/")
+    || destination.startsWith("./")
+    || destination.startsWith("../")
+    || destination.startsWith("file:")
+    || /^[a-zA-Z]:[\\/]/.test(destination);
+}

--- a/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.test.tsx
@@ -34,7 +34,7 @@ describe("useLatestTranscriptLiveStatus — continuous working feedback", () => 
     expect(result.current.latestLiveStatus).toBe("TAIL");
   });
 
-  it("shows status after a quiet streaming gap and hides it on the next token", () => {
+  it("does not insert a working status into a quiet streaming-prose gap", () => {
     vi.useFakeTimers();
     let state = transcriptWithAssistantProse(true, 1);
     const renderTurnTrailingStatus = vi.fn(() => "TAIL");
@@ -49,17 +49,38 @@ describe("useLatestTranscriptLiveStatus — continuous working feedback", () => 
       renderTurnTrailingStatus,
     }));
 
-    act(() => vi.advanceTimersByTime(499));
+    act(() => vi.advanceTimersByTime(5_000));
     expect(result.current.latestLiveStatus).toBeNull();
-    act(() => vi.advanceTimersByTime(1));
-    expect(result.current.latestLiveStatus).toBe("TAIL");
 
     state = transcriptWithAssistantProse(true, 2);
     rerender();
     expect(result.current.latestLiveStatus).toBeNull();
 
-    act(() => vi.advanceTimersByTime(500));
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(result.current.latestLiveStatus).toBeNull();
+  });
+
+  it("removes a visible working status as soon as prose starts streaming", () => {
+    vi.useFakeTimers();
+    let state = transcriptWithAssistantProse(false, 1);
+    const renderTurnTrailingStatus = vi.fn(() => "TAIL");
+
+    const { result, rerender } = renderHook(() => useLatestTranscriptLiveStatus({
+      latestTurnId: state.turn.turnId,
+      latestTurn: state.turn,
+      transcript: state.transcript,
+      virtualRows: buildRows(state.transcript, state.turn),
+      outboxStartedAtByPromptId: new Map(),
+      sessionViewState: "working",
+      renderTurnTrailingStatus,
+    }));
+
+    act(() => vi.advanceTimersByTime(150));
     expect(result.current.latestLiveStatus).toBe("TAIL");
+
+    state = transcriptWithAssistantProse(true, 2);
+    rerender();
+    expect(result.current.latestLiveStatus).toBeNull();
   });
 });
 

--- a/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.ts
+++ b/apps/packages/product-ui/src/chat/transcript/useLatestTranscriptLiveStatus.ts
@@ -29,9 +29,10 @@ import {
 } from "./ChatTranscriptViewRules";
 
 const LIVE_STATUS_GRACE_MS = 150;
-// Quiet period before "Thinking…" RETURNS after yielding to tool/command work
+// Quiet period before "Thinking…" returns after yielding to tool/command work
 // — long enough that back-to-back commands never get a status flash between
-// them.
+// them. Actively streaming prose never uses this reappearance path: the answer
+// itself owns the frontier through short provider/network gaps.
 const LIVE_STATUS_REAPPEAR_GRACE_MS = 500;
 
 export interface LatestTranscriptLiveStatus {
@@ -99,6 +100,7 @@ export function useLatestTranscriptLiveStatus({
     && !latestLiveWorkBlock
     && !latestTurnHasActiveToolWork
     && sessionViewState === "working"
+    && streamingAssistantProseRevision === null
     && shouldAllowTurnTrailingStatus({
       turn: latestTurn,
       transcript,
@@ -108,7 +110,6 @@ export function useLatestTranscriptLiveStatus({
     shouldShowDelayedLatestLiveStatus
     && latestTurnTiming?.isOutboxStartedAt === true;
   const [showDelayedLatestLiveStatus, setShowDelayedLatestLiveStatus] = useState(false);
-  const [quietStreamingProseRevision, setQuietStreamingProseRevision] = useState<string | null>(null);
   const shownForTurnIdRef = useRef<string | null>(null);
 
   // The grace ref resets ONLY when the turn changes — NOT when the status
@@ -155,35 +156,6 @@ export function useLatestTranscriptLiveStatus({
     showDelayedLatestLiveStatus,
   ]);
 
-  // Assistant prose owns the live tail while tokens are arriving. If the
-  // stream goes quiet, return the working indicator so a several-second gap
-  // can never look like the agent stopped. Keying the timer to the item's
-  // revision makes the next token hide the indicator synchronously and arm a
-  // fresh quiet period.
-  useEffect(() => {
-    if (
-      !latestTurnInProgress
-      || sessionViewState !== "working"
-      || streamingAssistantProseRevision === null
-    ) {
-      setQuietStreamingProseRevision(null);
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setQuietStreamingProseRevision(streamingAssistantProseRevision);
-    }, LIVE_STATUS_REAPPEAR_GRACE_MS);
-    return () => window.clearTimeout(timeout);
-  }, [
-    latestTurnInProgress,
-    sessionViewState,
-    streamingAssistantProseRevision,
-  ]);
-  const showQuietStreamingProseStatus = latestTurnInProgress
-    && sessionViewState === "working"
-    && streamingAssistantProseRevision !== null
-    && quietStreamingProseRevision === streamingAssistantProseRevision;
-
   // SINGLE-SHIMMER RULE: a live exploration/work block (or any active tool)
   // renders its own CollapsedActions shimmer. The delayed-visibility state
   // above lags one render behind the synchronous eligibility, so a freshly
@@ -221,10 +193,10 @@ export function useLatestTranscriptLiveStatus({
   const latestLiveStatus = latestNeedsInputStatus
     ?? (latestTurn
       && !hasCompetingLiveShimmer
+      && shouldShowDelayedLatestLiveStatus
       && (
         showDelayedLatestLiveStatus
         || shouldShowImmediateOutboxLiveStatus
-        || showQuietStreamingProseStatus
       )
         ? renderTurnTrailingStatus?.({
             startedAt: latestTurnTiming?.startedAt ?? latestTurn.startedAt,

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
@@ -191,7 +191,7 @@ export function ProductSidebarWorkspaceRow({
 
             {trailingStatus ? (
               <div
-                className={`col-start-1 row-start-1 flex size-5 items-center justify-center transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
+                className={`col-start-1 row-start-1 flex h-5 items-center justify-end transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
                     ? "opacity-0"
                     : "group-hover:opacity-0 group-focus-within:opacity-0"
                   }`}
@@ -201,7 +201,7 @@ export function ProductSidebarWorkspaceRow({
             ) : unreadDot ? (
               <Tooltip
                 content="Unseen activity"
-                className={`col-start-1 row-start-1 flex size-5 items-center justify-center transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
+                className={`col-start-1 row-start-1 flex h-5 items-center justify-end transition-opacity duration-150 ${shortcutLabel && shortcutRevealVisible
                     ? "opacity-0"
                     : "group-hover:opacity-0 group-focus-within:opacity-0"
                   }`}

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarThreads.tsx
@@ -79,7 +79,7 @@ export function ProductSidebarThreadRow({
 
         <div className="flex shrink-0 items-center gap-1">
           {trailingStatus ? (
-            <div className="flex size-5 items-center justify-center transition-opacity duration-150 group-focus-within:opacity-0 group-hover:opacity-0">
+            <div className="flex h-5 items-center justify-end transition-opacity duration-150 group-focus-within:opacity-0 group-hover:opacity-0">
               {trailingStatus}
             </div>
           ) : trailingLabel && !active && !expandControl ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
       '@lexical/react':
         specifier: ^0.48.0
         version: 0.48.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(yjs@13.6.31)
+      '@lexical/selection':
+        specifier: ^0.48.0
+        version: 0.48.0(typescript@5.9.3)
       '@lezer/common':
         specifier: ^1.2.3
         version: 1.5.2

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -102,13 +102,25 @@ Home, or queued-edit surface applies its own submit contract exactly once. The
 same native `beforeinput`, `keydown`, or `paste` event timestamp is forwarded to
 typing measurement when that event changes the document.
 
-Link creation is deliberately paste-only: an exact `https://` clipboard value
+The editable surface keeps WebKit's native selection and browser-owned editing
+semantics. On macOS, where current WebKit paints its redesigned insertion caret
+at two CSS pixels, the product client paints a one-pixel visual caret at the
+collapsed Lexical selection. The visual caret uses Lexical's DOM-range mapping,
+does not mutate editor content, and hides the native caret only after it has a
+valid attached rectangle. Failed measurement, blur, a non-collapsed selection,
+IME composition, and unmount restore the native caret immediately. Its height
+scales from the independent composer appearance tokens; composer font size and
+line height remain unchanged, including user-selected scale changes.
+
+Link creation is deliberately paste-only. An exact `https://` clipboard value
 becomes a link, wrapping a non-collapsed selection or inserting the URL when
-the selection is collapsed. Typed URLs, typed Markdown link syntax, `http://`,
-and clipboard values containing surrounding or additional text remain literal
-editor text. The Markdown exporter still serializes an actual pasted link, so
-the existing prompt submission and sent-message Markdown renderer need no
-special link transport.
+the selection is collapsed. Complete Markdown HTTPS links in pasted text also
+become links while preserving all surrounding clipboard text, and a single
+paste may contain multiple links. Typed URLs, typed Markdown link syntax,
+`http://` destinations, and incomplete pasted Markdown link syntax remain
+literal editor text. The Markdown exporter still serializes an actual pasted
+link, so the existing prompt submission and sent-message Markdown renderer
+need no special link transport.
 
 Slash-command discovery remains prompt-leading and composer-local. IME
 composition bypasses submission and command keyboard handling. The editor root

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -117,6 +117,10 @@ Rules:
 
 - Detection happens at render time from raw markdown; do not store parsed file
   references in transcript items.
+- While prose is streaming, a trailing incomplete local-file link is closed
+  only in the Markdown render copy so its file mention appears as soon as the
+  destination begins. Never persist the synthetic delimiter or expose the raw
+  partial absolute destination while waiting for the real closing delimiter.
 - Mention labels display the workspace-relative path plus a `(line N)` suffix;
   raw absolute hrefs must not be shown as label text.
 - External/web link hrefs render as a shared inline provider-icon mention
@@ -367,14 +371,49 @@ Additional dependencies:
 - `latestStreamingAssistantProseRevision` controls whether the trailing
   status renders. Only prose that is *actively streaming* suppresses the
   indicator: while text streams, the growing prose is the placeholder. The
-  moment prose completes with the turn still in progress (thinking or
-  preparing a tool call), the trailing indicator becomes eligible again. If
-  active prose receives no delta for 500ms, the indicator returns during that
-  quiet gap; the next `(itemId, lastUpdatedSeq)` revision hides it
-  synchronously and re-arms the quiet timer. A completed-looking transcript
-  with silent background work is never acceptable.
+  moment transport prose completes with the turn still in progress (thinking
+  or preparing a tool call), the trailing indicator becomes eligible only
+  after the prose's visual reveal and final opacity settle complete.
+  Never insert the generic working indicator into a quiet gap inside actively
+  streaming prose; the answer retains frontier ownership until its prose item
+  completes visually. A following thought or live tool/action row also remains
+  withheld behind that visual frontier, then takes ownership when the reveal
+  settles; transport arrival alone must not overlap it with buffered prose.
+  Inferred silence alone never creates another frontier row.
   The indicator is a frontier row above the assistant footer; it must never
   occupy the footer itself.
+- Streaming prose uses one paced, source-ordered reveal frontier. Completed
+  words stay fully opaque; each recent word receives its own uniform opacity
+  fade, and a later line must not render until the frontier reaches it. A later
+  word begins fading before earlier word fades finish, rather than replacing
+  or prematurely completing them. The reveal must not sweep a gradient through
+  the individual letters of a word. Once a source prefix has settled, a
+  transport pause, completion transition, or transcript-row remount must never
+  place that prefix back into fresh fade spans; only newly revealed source may
+  animate.
+  Pace the frontier behind a small token reserve so
+  transport batches do not read as alternating bursts and pauses, with a hard
+  maximum of 360 source characters per second; accumulated ordinary batches
+  must never trigger an adaptive catch-up jump. Initial live chunks, reconnect
+  batches, and newly completed short answers all enter through the same capped
+  frontier; a corrected stream rewinds to its shared source prefix before
+  resuming at the cap. Presentation or virtual-row key changes may remount the
+  prose component; retain a bounded item-level visible-prefix claim so the new
+  instance begins at exactly the prior painted source length and continues at
+  the cap. A remount must never replay from zero or expose the buffered suffix
+  in one paint. Only hydrated history opts out and renders immediately. When
+  transport streaming completes, continue draining any
+  buffered suffix at the same capped speed. Then finish the newest word's fade
+  and leave all prose fully opaque; never strand the last word halfway through
+  its fade. Reveal commits are cadence-bounded (32ms) so Markdown parse,
+  and reconciliation do not run on every display frame. After the 320ms
+  final-opacity fade, retain the completed prose
+  frontier for a 160ms quiet handoff before releasing a following thought,
+  tool, or status row.
+  Completion-only chrome (copy/timestamp, goal marker, stopped notice, and turn
+  diff) stays hidden or reserved until that final opacity settle reports
+  complete. Reduced-motion preferences render the complete available prefix
+  without reveal motion.
 - `TurnAssistantActionRow` renders its fixed footer when `reserveSlot` is true
   even before assistant prose exists. The latest materialized turn and pending
   prompt both reserve it; a completion without copyable prose keeps it reserved.


### PR DESCRIPTION
## Summary

- pace assistant prose behind a source-ordered frontier with overlapping word fades, bounded render cadence, remount-safe progress, and no end-of-stream jump
- keep thinking/tool rows and completion controls behind the final visual settle; stabilize incomplete streaming file links
- add paste-only Markdown link formatting and a fail-safe one-pixel composer caret without changing appearance font tokens
- anchor sidebar/tab spinners and right-side status indicators

## Review fixes

The final audit also:
- reduced reveal reconciliation from every display frame to the documented 32ms cadence
- fixed a race that could release tool/footer chrome while the last word was still fading
- moved caret measurement onto the animation-frame scheduler to avoid synchronous layout during typing
- isolated the local-only performance bridge from the shared presentation component

## Validation

- `pnpm --filter @proliferate/product-client build`
- complete `@proliferate/product-ui` Vitest suite (212 tests)
- complete `@proliferate/product-client` Vitest suite
- focused streaming/composer regression suites (74 tests)
- `python3 scripts/check_docs.py`
- `git diff --check`
- founder visual acceptance in the live Desktop playground
