### PR TITLE
fix(anyharness): own handled model-gate incidents

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/cowork.rs
@@ -258,17 +258,9 @@ fn map_create_cowork_thread_error(error: CoworkCreateThreadError) -> ApiError {
                 format!("model '{model_id}' is not supported for agent '{agent_kind}'"),
                 "SESSION_MODEL_UNSUPPORTED",
             ),
-            crate::domains::sessions::runtime::CreateAndStartSessionError::ModelGated {
-                agent_kind,
-                model_id,
-                required_contexts,
-            } => ApiError::model_gated(
-                format!(
-                    "model '{model_id}' for agent '{agent_kind}' is gated behind auth contexts \
-                     {required_contexts:?}"
-                ),
-                required_contexts,
-            ),
+            crate::domains::sessions::runtime::CreateAndStartSessionError::ModelGated(context) => {
+                ApiError::model_gated(context)
+            }
             crate::domains::sessions::runtime::CreateAndStartSessionError::ModeUnsupported {
                 agent_kind,
                 mode_id,
@@ -522,6 +514,30 @@ mod tests {
     use super::CoworkCreateThreadError;
     use crate::domains::agents::route_auth::RouteAuthError;
     use crate::domains::sessions::runtime::CreateAndStartSessionError;
+    use crate::domains::sessions::service::ModelGatedContext;
+
+    #[test]
+    fn model_gate_uses_the_shared_runtime_incident_mapping() {
+        let error = CoworkCreateThreadError::CreateSession(CreateAndStartSessionError::ModelGated(
+            ModelGatedContext {
+                workspace_id: "workspace-cowork".to_string(),
+                attempted_session_id: None,
+                agent_kind: "claude".to_string(),
+                requested_model_id: "opus[1m]".to_string(),
+                canonical_model_id: "opus[1m]".to_string(),
+                active_contexts: vec!["anthropic-oauth".to_string()],
+                required_contexts: vec!["anthropic-api".to_string()],
+                catalog_version: "2026-07-18".to_string(),
+            },
+        ));
+
+        let mapped = super::map_create_cowork_thread_error(error);
+        assert_eq!(mapped.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(mapped.code(), Some("SESSION_MODEL_GATED"));
+        assert!(mapped
+            .instance()
+            .is_some_and(|instance| instance.starts_with("urn:proliferate:anyharness:incident:")));
+    }
 
     /// Materialization IO / malformed-state route-auth failures are server-side
     /// problems → 500, matching the sessions API (not a client 409).

--- a/anyharness/crates/anyharness-lib/src/api/http/error.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/error.rs
@@ -2,6 +2,10 @@ use anyharness_contract::v1::ProblemDetails;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use uuid::Uuid;
+
+use crate::domains::sessions::service::ModelGatedContext;
+use crate::observability::RUNTIME_INCIDENT_TRACING_TARGET;
 
 pub struct ApiError(StatusCode, ProblemDetails);
 
@@ -62,17 +66,41 @@ impl ApiError {
     /// (`SESSION_MODEL_GATED`) and carries the unlock condition
     /// (`required_contexts`, the model's `availability.anyOf`) as an RFC 7807
     /// extension. An unresolvable model uses `SESSION_MODEL_UNSUPPORTED`.
-    pub fn model_gated(detail: impl Into<String>, required_contexts: Vec<String>) -> Self {
+    pub fn model_gated(context: ModelGatedContext) -> Self {
+        let incident_id = Uuid::new_v4();
+        let instance = format!("urn:proliferate:anyharness:incident:{incident_id}");
+        tracing::error!(
+            target: RUNTIME_INCIDENT_TRACING_TARGET,
+            incident_id = %incident_id,
+            error_code = "SESSION_MODEL_GATED",
+            fingerprint = "anyharness:session_model_gated",
+            workspace_id = %context.workspace_id,
+            attempted_session_id = context.attempted_session_id.as_deref(),
+            agent_kind = %context.agent_kind,
+            requested_model = %context.requested_model_id,
+            canonical_model = %context.canonical_model_id,
+            active_contexts = ?context.active_contexts,
+            required_contexts = ?context.required_contexts,
+            catalog_version = %context.catalog_version,
+            selection_outcome = "model_gated",
+            effective_model = "none",
+            effective_route = "none",
+            "handled runtime incident"
+        );
+        let detail = format!(
+            "model '{}' for agent '{}' is gated behind auth contexts {:?}",
+            context.requested_model_id, context.agent_kind, context.required_contexts
+        );
         Self(
             StatusCode::BAD_REQUEST,
             ProblemDetails {
                 type_url: "about:blank".into(),
                 title: "Bad request".into(),
                 status: 400,
-                detail: Some(detail.into()),
-                instance: None,
+                detail: Some(detail),
+                instance: Some(instance),
                 code: Some("SESSION_MODEL_GATED".into()),
-                required_contexts: Some(required_contexts),
+                required_contexts: Some(context.required_contexts),
             },
         )
     }
@@ -198,6 +226,12 @@ impl ApiError {
     pub(crate) fn detail(&self) -> Option<&str> {
         self.1.detail.as_deref()
     }
+
+    /// RFC 7807 occurrence receipt, if any. Test/introspection accessor.
+    #[cfg(test)]
+    pub(crate) fn instance(&self) -> Option<&str> {
+        self.1.instance.as_deref()
+    }
 }
 
 impl IntoResponse for ApiError {
@@ -208,20 +242,124 @@ impl IntoResponse for ApiError {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
     use super::*;
 
+    const INCIDENT_INSTANCE_PREFIX: &str = "urn:proliferate:anyharness:incident:";
+
+    #[derive(Clone)]
+    struct SharedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for SharedLogWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn gated_context() -> ModelGatedContext {
+        ModelGatedContext {
+            workspace_id: "workspace-1".to_string(),
+            attempted_session_id: Some("session-1".to_string()),
+            agent_kind: "claude".to_string(),
+            requested_model_id: "long-opus".to_string(),
+            canonical_model_id: "opus[1m]".to_string(),
+            active_contexts: vec!["anthropic-oauth".to_string()],
+            required_contexts: vec!["anthropic-api".to_string(), "gateway".to_string()],
+            catalog_version: "2026-07-18".to_string(),
+        }
+    }
+
     #[test]
-    fn model_gated_carries_code_and_required_contexts() {
-        let err = ApiError::model_gated(
-            "gated",
-            vec!["anthropic-api".to_string(), "gateway".to_string()],
-        );
+    fn model_gated_carries_code_contexts_and_valid_incident_receipt() {
+        let err = ApiError::model_gated(gated_context());
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
         assert_eq!(err.1.code.as_deref(), Some("SESSION_MODEL_GATED"));
         assert_eq!(
             err.1.required_contexts.as_deref(),
             Some(&["anthropic-api".to_string(), "gateway".to_string()][..])
         );
+        let receipt = err.1.instance.as_deref().expect("incident receipt");
+        let occurrence = receipt
+            .strip_prefix(INCIDENT_INSTANCE_PREFIX)
+            .expect("owned incident receipt prefix");
+        let occurrence = Uuid::parse_str(occurrence).expect("receipt UUID");
+        assert_eq!(occurrence.get_version_num(), 4);
+    }
+
+    #[test]
+    fn model_gated_mints_a_unique_receipt_per_mapping() {
+        let first = ApiError::model_gated(gated_context());
+        let second = ApiError::model_gated(gated_context());
+
+        assert_ne!(first.1.instance, second.1.instance);
+    }
+
+    #[test]
+    fn model_gated_emits_one_authoritative_error_with_truthful_context() {
+        let log_bytes = Arc::new(Mutex::new(Vec::new()));
+        let log_writer = Arc::clone(&log_bytes);
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(true)
+            .with_writer(move || SharedLogWriter(Arc::clone(&log_writer)))
+            .finish();
+
+        let error =
+            tracing::subscriber::with_default(
+                subscriber,
+                || ApiError::model_gated(gated_context()),
+            );
+        let occurrence = error
+            .instance()
+            .and_then(|instance| instance.strip_prefix(INCIDENT_INSTANCE_PREFIX))
+            .expect("owned incident receipt");
+
+        let logged = String::from_utf8(
+            log_bytes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+        )
+        .expect("formatted log is UTF-8");
+        assert_eq!(logged.matches("handled runtime incident").count(), 1);
+        assert!(
+            logged.contains(occurrence),
+            "returned receipt must identify the emitted event: {logged}"
+        );
+        for expected in [
+            RUNTIME_INCIDENT_TRACING_TARGET,
+            "incident_id=",
+            "SESSION_MODEL_GATED",
+            "anyharness:session_model_gated",
+            "workspace-1",
+            "session-1",
+            "claude",
+            "long-opus",
+            "opus[1m]",
+            "anthropic-oauth",
+            "anthropic-api",
+            "gateway",
+            "2026-07-18",
+            "model_gated",
+            "effective_model=\"none\"",
+            "effective_route=\"none\"",
+        ] {
+            assert!(
+                logged.contains(expected),
+                "missing {expected:?} in {logged}"
+            );
+        }
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -110,17 +110,7 @@ pub(super) fn map_create_session_error(error: CreateAndStartSessionError) -> Api
             format!("model '{model_id}' is not supported for agent '{agent_kind}'"),
             "SESSION_MODEL_UNSUPPORTED",
         ),
-        CreateAndStartSessionError::ModelGated {
-            agent_kind,
-            model_id,
-            required_contexts,
-        } => ApiError::model_gated(
-            format!(
-                "model '{model_id}' for agent '{agent_kind}' is gated behind auth contexts \
-                 {required_contexts:?}"
-            ),
-            required_contexts,
-        ),
+        CreateAndStartSessionError::ModelGated(context) => ApiError::model_gated(context),
         CreateAndStartSessionError::ModeUnsupported {
             agent_kind,
             mode_id,
@@ -362,6 +352,7 @@ mod tests {
 
     use crate::domains::sessions::model::{AgentStartupExitError, RequestedModeApplyError};
     use crate::domains::sessions::runtime::{CreateAndStartSessionError, ResolveInteractionError};
+    use crate::domains::sessions::service::ModelGatedContext;
     use crate::domains::workspaces::access_gate::WorkspaceAccessError;
 
     #[test]
@@ -386,14 +377,25 @@ mod tests {
 
     #[test]
     fn model_gated_maps_to_bad_request() {
-        let response = super::map_create_session_error(CreateAndStartSessionError::ModelGated {
-            agent_kind: "claude".to_string(),
-            model_id: "opus".to_string(),
-            required_contexts: vec!["anthropic-api".to_string()],
-        })
-        .into_response();
+        let mapped = super::map_create_session_error(CreateAndStartSessionError::ModelGated(
+            ModelGatedContext {
+                workspace_id: "workspace-1".to_string(),
+                attempted_session_id: None,
+                agent_kind: "claude".to_string(),
+                requested_model_id: "opus".to_string(),
+                canonical_model_id: "opus".to_string(),
+                active_contexts: vec!["anthropic-oauth".to_string()],
+                required_contexts: vec!["anthropic-api".to_string()],
+                catalog_version: "2026-07-18".to_string(),
+            },
+        ));
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(mapped.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(mapped.code(), Some("SESSION_MODEL_GATED"));
+        assert!(mapped
+            .instance()
+            .is_some_and(|instance| instance.starts_with("urn:proliferate:anyharness:incident:")));
+        assert_eq!(mapped.into_response().status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/mod.rs
@@ -12,4 +12,6 @@ pub mod validation_pairing;
 #[cfg(test)]
 mod gateway_eligibility_tests;
 #[cfg(test)]
+mod service_model_gate_tests;
+#[cfg(test)]
 mod service_tests;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service.rs
@@ -160,10 +160,16 @@ pub enum SelectionUnsupported {
         model_id: String,
     },
     /// In the catalog, but not available under the active auth contexts.
+    /// Carries the requested spelling separately from the canonical catalog
+    /// identity so callers retain the exact rejected selection without
+    /// confusing an alias or variant with the model that owned the gate.
     /// `required_contexts` is `availability.anyOf` — the unlock condition.
     ModelGated {
-        model_id: String,
+        requested_model_id: String,
+        canonical_model_id: String,
+        active_contexts: Vec<String>,
         required_contexts: Vec<String>,
+        catalog_version: String,
     },
     UnsupportedMode {
         mode_id: String,
@@ -177,6 +183,10 @@ impl ActiveCatalog {
 
     pub fn agents(&self) -> &[AgentCatalogAgent] {
         &self.document.agents
+    }
+
+    pub fn catalog_version(&self) -> &str {
+        &self.document.catalog_version
     }
 
     pub fn agent(&self, kind: &str) -> Option<&AgentCatalogAgent> {
@@ -309,8 +319,11 @@ impl ActiveCatalog {
                 })?;
                 if !model_is_available(resolved.model, contexts) {
                     return Err(SelectionUnsupported::ModelGated {
-                        model_id: requested.to_string(),
+                        requested_model_id: requested.to_string(),
+                        canonical_model_id: resolved.model.id.clone(),
+                        active_contexts: contexts.ids().to_vec(),
                         required_contexts: resolved.model.availability.any_of.clone(),
+                        catalog_version: self.document.catalog_version.clone(),
                     });
                 }
                 Some(resolved)

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_model_gate_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_model_gate_tests.rs
@@ -1,0 +1,81 @@
+//! Incident-provenance regressions for catalog-known gated selections.
+
+use std::sync::Arc;
+
+use super::loader::parse_agent_catalog_json;
+use super::schema::draft_catalog_json;
+use super::service::{ActiveCatalog, SelectionUnsupported};
+use crate::domains::agents::auth::context::ActiveAuthContexts;
+
+fn draft_catalog() -> ActiveCatalog {
+    let document = parse_agent_catalog_json(draft_catalog_json()).expect("draft must load");
+    ActiveCatalog::new(Arc::new(document))
+}
+
+fn contexts(ids: &[&str]) -> ActiveAuthContexts {
+    ActiveAuthContexts::test_from_ids(ids.iter().copied())
+}
+
+#[test]
+fn gated_alias_preserves_requested_and_canonical_model_identity() {
+    let mut raw: serde_json::Value =
+        serde_json::from_str(draft_catalog_json()).expect("draft must parse");
+    let claude = raw["agents"]
+        .as_array_mut()
+        .expect("agents")
+        .iter_mut()
+        .find(|agent| agent["kind"] == "claude")
+        .expect("claude agent");
+    let model = claude["session"]["models"]
+        .as_array_mut()
+        .expect("models")
+        .iter_mut()
+        .find(|model| model["id"] == "opus[1m]")
+        .expect("api-only model");
+    model["aliases"] = serde_json::json!(["long-opus"]);
+    let document = parse_agent_catalog_json(&serde_json::to_string(&raw).expect("serialize"))
+        .expect("catalog with alias must load");
+    let expected_version = document.catalog_version.clone();
+    let catalog = ActiveCatalog::new(Arc::new(document));
+
+    let gated = catalog
+        .validate_launch(
+            "claude",
+            &contexts(&["anthropic-oauth"]),
+            Some("long-opus"),
+            None,
+        )
+        .expect_err("api-only alias must remain gated under oauth");
+
+    assert_eq!(
+        gated,
+        SelectionUnsupported::ModelGated {
+            requested_model_id: "long-opus".into(),
+            canonical_model_id: "opus[1m]".into(),
+            active_contexts: vec!["anthropic-oauth".into()],
+            required_contexts: vec!["anthropic-api".into()],
+            catalog_version: expected_version,
+        }
+    );
+}
+
+#[test]
+fn gated_variant_preserves_requested_and_canonical_model_identity() {
+    let catalog = draft_catalog();
+    let requested = "claude-fable-5[thinking=true,context=300k,effort=high]";
+
+    let gated = catalog
+        .validate_launch("cursor", &contexts(&[]), Some(requested), None)
+        .expect_err("cursor-login variant must be gated without that context");
+
+    assert_eq!(
+        gated,
+        SelectionUnsupported::ModelGated {
+            requested_model_id: requested.to_string(),
+            canonical_model_id: "claude-fable-5".to_string(),
+            active_contexts: vec![],
+            required_contexts: vec!["cursor-login".to_string()],
+            catalog_version: catalog.catalog_version().to_string(),
+        }
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/service_tests.rs
@@ -347,13 +347,7 @@ fn validate_launch_rejects_gated_and_unknown_models() {
             None,
         )
         .expect_err("api-only model must be gated under oauth");
-    assert_eq!(
-        gated,
-        SelectionUnsupported::ModelGated {
-            model_id: "opus[1m]".into(),
-            required_contexts: vec!["anthropic-api".into()],
-        }
-    );
+    assert!(matches!(gated, SelectionUnsupported::ModelGated { .. }));
 
     let unknown = catalog
         .validate_launch("claude", &contexts(&["anthropic-api"]), Some("nope"), None)

--- a/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
@@ -119,7 +119,7 @@ impl AgentRuntime {
         })
     }
 
-    #[tracing::instrument(skip_all, err, fields(
+    #[tracing::instrument(skip_all, fields(
         agent = %kind,
         reinstall = request.reinstall,
         native_version = ?request.native_version,
@@ -141,7 +141,7 @@ impl AgentRuntime {
         let install_runtime_home = self.runtime_home.clone();
         let install_descriptor = descriptor.clone();
         let catalog_pins = self.catalog_service.pin_overrides(kind);
-        let installed_artifacts = tokio::task::spawn_blocking(move || {
+        let install_result = tokio::task::spawn_blocking(move || {
             installer::install_agent_with_pins(
                 &install_descriptor,
                 &install_runtime_home,
@@ -149,8 +149,26 @@ impl AgentRuntime {
                 catalog_pins.as_ref(),
             )
         })
-        .await
-        .map_err(AgentRuntimeError::InstallTaskFailed)??;
+        .await;
+        let installed_artifacts = match install_result {
+            Ok(Ok(installed_artifacts)) => installed_artifacts,
+            Ok(Err(error)) => {
+                tracing::error!(
+                    agent_kind = %kind,
+                    error_kind = install_error_kind(&error),
+                    "agent install failed"
+                );
+                return Err(AgentRuntimeError::Install(error));
+            }
+            Err(error) => {
+                tracing::error!(
+                    agent_kind = %kind,
+                    error_kind = "task_join",
+                    "agent install failed"
+                );
+                return Err(AgentRuntimeError::InstallTaskFailed(error));
+            }
+        };
 
         self.seed_store.refresh_from_state(&self.runtime_home);
         let agent = resolve_agent(&descriptor, &self.runtime_home);
@@ -306,4 +324,35 @@ impl AgentRuntime {
 
 fn descriptor_for_kind(kind: &str) -> Result<AgentDescriptor, AgentRuntimeError> {
     super::registry::descriptor(kind).ok_or_else(|| AgentRuntimeError::NotFound(kind.to_string()))
+}
+
+fn install_error_kind(error: &InstallError) -> &'static str {
+    match error {
+        InstallError::NotInstallable => "not_installable",
+        InstallError::UnsupportedPlatform => "unsupported_platform",
+        InstallError::InvalidInstallSpec(_) => "invalid_install_spec",
+        InstallError::CommandFailed { .. } => "command_failed",
+        InstallError::MissingManagedArtifact(_) => "missing_managed_artifact",
+        InstallError::FetchFailed { .. } => "fetch_failed",
+        InstallError::RegistryFailed(_) => "registry_failed",
+        InstallError::ChecksumMismatch { .. } => "checksum_mismatch",
+        InstallError::NoPinForPlatform(_) => "no_pin_for_platform",
+        InstallError::Io(_) => "io",
+    }
+}
+
+#[cfg(test)]
+mod telemetry_tests {
+    use super::{install_error_kind, InstallError};
+
+    #[test]
+    fn install_errors_emit_only_stable_classifications() {
+        let error = InstallError::CommandFailed {
+            program: "provider-installer".to_string(),
+            message: "Bearer raw-provider-secret at /Users/customer/private".to_string(),
+        };
+
+        assert_eq!(install_error_kind(&error), "command_failed");
+        assert!(!install_error_kind(&error).contains("raw-provider-secret"));
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
@@ -347,15 +347,9 @@ fn map_create_session_service_error(
             agent_kind,
             model_id,
         },
-        crate::domains::sessions::service::CreateSessionError::ModelGated {
-            agent_kind,
-            model_id,
-            required_contexts,
-        } => CreateAndStartSessionError::ModelGated {
-            agent_kind,
-            model_id,
-            required_contexts,
-        },
+        crate::domains::sessions::service::CreateSessionError::ModelGated(context) => {
+            CreateAndStartSessionError::ModelGated(context)
+        }
         crate::domains::sessions::service::CreateSessionError::ModeUnsupported {
             agent_kind,
             mode_id,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -16,7 +16,7 @@ use super::mcp_bindings::model::SessionMcpServer;
 use super::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
 use super::model::SessionRecord;
 use super::plan_references::{PlanInteractionLinkResolver, PlanReferenceResolver};
-use super::service::SessionService;
+use super::service::{ModelGatedContext, SessionService};
 use crate::domains::agents::route_auth::{GatewayModelResolve, RouteAuthError};
 use crate::domains::sessions::extensions::SessionExtension;
 use crate::domains::workspaces::access_gate::{WorkspaceAccessError, WorkspaceAccessGate};
@@ -89,11 +89,7 @@ pub enum CreateAndStartSessionError {
     /// A known model is gated behind inactive auth contexts. Carries the
     /// unlock condition (`required_contexts`) for the API layer; an
     /// unresolvable model uses `ModelUnsupported` instead.
-    ModelGated {
-        agent_kind: String,
-        model_id: String,
-        required_contexts: Vec<String>,
-    },
+    ModelGated(ModelGatedContext),
     ModeUnsupported {
         agent_kind: String,
         mode_id: String,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/create.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/create.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use uuid::Uuid;
 
-use super::{CreateSessionError, CreateSessionOutcome, SessionService};
+use super::{CreateSessionError, CreateSessionOutcome, ModelGatedContext, SessionService};
 use crate::domains::agents::auth::context::classify;
 use crate::domains::agents::auth::launch_facts::collect_launch_env_facts;
 use crate::domains::agents::catalog::service::{ActiveCatalog, SelectionUnsupported};
@@ -147,6 +147,8 @@ impl SessionService {
         let (resolved_model_id, resolved_mode_id, agent_auth_contexts) = resolve_selection(
             &catalog,
             &descriptor,
+            workspace_id,
+            preselected_session_id.as_deref(),
             agent_kind,
             model_id,
             mode_id,
@@ -275,6 +277,8 @@ fn replay_existing_session(
 fn resolve_selection(
     catalog: &ActiveCatalog,
     descriptor: &AgentDescriptor,
+    workspace_id: &str,
+    attempted_session_id: Option<&str>,
     agent_kind: &str,
     model_id: Option<&str>,
     mode_id: Option<&str>,
@@ -286,7 +290,9 @@ fn resolve_selection(
     let active = classify(descriptor, contexts, &facts);
     let selection = catalog
         .validate_launch(agent_kind, &active, model_id, mode_id)
-        .map_err(|unsupported| map_selection_unsupported(agent_kind, unsupported))?;
+        .map_err(|unsupported| {
+            map_selection_unsupported(workspace_id, attempted_session_id, agent_kind, unsupported)
+        })?;
     let provenance = serde_json::to_string(active.ids())
         .map_err(|error| CreateSessionError::Internal(error.into()))?;
     Ok((
@@ -297,6 +303,8 @@ fn resolve_selection(
 }
 
 fn map_selection_unsupported(
+    workspace_id: &str,
+    attempted_session_id: Option<&str>,
     agent_kind: &str,
     unsupported: SelectionUnsupported,
 ) -> CreateSessionError {
@@ -309,20 +317,33 @@ fn map_selection_unsupported(
             model_id,
         },
         SelectionUnsupported::ModelGated {
-            model_id,
+            requested_model_id,
+            canonical_model_id,
+            active_contexts,
             required_contexts,
+            catalog_version,
         } => {
             tracing::info!(
+                workspace_id,
+                attempted_session_id,
                 agent_kind,
-                model_id = %model_id,
+                requested_model_id = %requested_model_id,
+                canonical_model_id = %canonical_model_id,
+                active_contexts = ?active_contexts,
                 required_contexts = ?required_contexts,
+                catalog_version = %catalog_version,
                 "session create rejected: model gated behind inactive auth contexts"
             );
-            CreateSessionError::ModelGated {
+            CreateSessionError::ModelGated(ModelGatedContext {
+                workspace_id: workspace_id.to_string(),
+                attempted_session_id: attempted_session_id.map(ToOwned::to_owned),
                 agent_kind: agent_kind.to_string(),
-                model_id,
+                requested_model_id,
+                canonical_model_id,
+                active_contexts,
                 required_contexts,
-            }
+                catalog_version,
+            })
         }
         SelectionUnsupported::UnsupportedMode { mode_id } => CreateSessionError::ModeUnsupported {
             agent_kind: agent_kind.to_string(),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/create_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/create_tests.rs
@@ -1,3 +1,5 @@
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use uuid::Uuid;
@@ -6,8 +8,58 @@ use super::{CreateSessionError, CreateSessionOutcome};
 use crate::app::{test_support, AppState};
 use crate::domains::agents::installer::seed::AgentSeedStore;
 use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+use crate::domains::sessions::runtime::CreateAndStartSessionError;
 use crate::origin::OriginContext;
 use crate::persistence::Db;
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new(label: &str) -> Self {
+        let path = std::env::temp_dir().join(format!("{label}-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&path).expect("create test directory");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct EnvVarGuard {
+    name: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &OsStr) -> Self {
+        let original = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self { name, original }
+    }
+
+    fn remove(name: &'static str) -> Self {
+        let original = std::env::var_os(name);
+        std::env::remove_var(name);
+        Self { name, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(original) = &self.original {
+            std::env::set_var(self.name, original);
+        } else {
+            std::env::remove_var(self.name);
+        }
+    }
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn idempotent_create_reuses_only_the_original_workspace_and_agent() {
@@ -120,6 +172,97 @@ async fn idempotent_create_reuses_only_the_original_workspace_and_agent() {
         dismissed_conflict,
         CreateSessionError::SessionIdConflict { session_id: id } if id == session_id
     ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn gated_create_preserves_context_without_a_session_row_or_live_process() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env mutex");
+    let _bearer_guard = test_support::set_bearer_token_env(None);
+    let _data_key_guard = test_support::set_data_key_env(None);
+    let runtime_home = TestDir::new("anyharness-gated-session-create");
+    let empty_home = TestDir::new("anyharness-gated-session-home");
+    let workspace_path = runtime_home.path().join("workspace");
+    std::fs::create_dir_all(&workspace_path).expect("create workspace directory");
+    let agent_auth_dir = runtime_home.path().join("agent-auth");
+    std::fs::create_dir_all(&agent_auth_dir).expect("create agent-auth directory");
+    std::fs::write(
+        agent_auth_dir.join("state.json"),
+        r#"{"version":2,"revision":1,"harnesses":[{"harness_kind":"grok","sources":[{"kind":"gateway","base_url":"https://gw","key":"sk-vk"}]}]}"#,
+    )
+    .expect("write gateway route state");
+
+    let test_executable = std::env::current_exe().expect("current test executable");
+    let _program_guard =
+        EnvVarGuard::set("ANYHARNESS_GROK_AGENT_PROGRAM", test_executable.as_os_str());
+    let _home_guard = EnvVarGuard::set("HOME", empty_home.path().as_os_str());
+    let _xai_guard = EnvVarGuard::remove("XAI_API_KEY");
+    let _grok_guard = EnvVarGuard::remove("GROK_API_KEY");
+
+    let state = AppState::new(
+        runtime_home.path().to_path_buf(),
+        "http://127.0.0.1:8457".to_string(),
+        Db::open_in_memory().expect("open in-memory db"),
+        false,
+        AgentSeedStore::not_configured_dev(),
+    )
+    .expect("create app state");
+    test_support::seed_workspace_with_repo_root(
+        &state.db,
+        "workspace-gated",
+        "local",
+        &workspace_path.to_string_lossy(),
+    );
+    let attempted_session_id = "01234567-89ab-4def-8123-456789abcdef";
+
+    let error = state
+        .session_runtime
+        .create_and_start_session_with_id(
+            "workspace-gated",
+            "grok",
+            Some(attempted_session_id),
+            Some("grok-4.3"),
+            None,
+            None,
+            vec![],
+            None,
+            true,
+            OriginContext::api_local_runtime(),
+        )
+        .await
+        .expect_err("xai-only model must be gated on a gateway route");
+
+    let CreateAndStartSessionError::ModelGated(context) = error else {
+        panic!("expected model-gated context, got {error:?}");
+    };
+    assert_eq!(context.workspace_id, "workspace-gated");
+    assert_eq!(
+        context.attempted_session_id.as_deref(),
+        Some(attempted_session_id)
+    );
+    assert_eq!(context.agent_kind, "grok");
+    assert_eq!(context.requested_model_id, "grok-4.3");
+    assert_eq!(context.canonical_model_id, "grok-4.3");
+    assert_eq!(context.active_contexts, vec!["gateway".to_string()]);
+    assert_eq!(context.required_contexts, vec!["xai-api".to_string()]);
+    assert_eq!(
+        context.catalog_version,
+        state.catalog_sync_service.catalog_version()
+    );
+    assert!(state
+        .session_service
+        .store()
+        .list_by_workspace("workspace-gated")
+        .expect("list sessions")
+        .is_empty());
+    assert!(
+        !state
+            .session_runtime
+            .has_live_session(attempted_session_id)
+            .await
+    );
 }
 
 fn session_record(id: &str) -> SessionRecord {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/mod.rs
@@ -38,6 +38,21 @@ impl CreateSessionOutcome {
     }
 }
 
+/// Complete provenance for a catalog-known model rejected by the active auth
+/// context. The service constructs this before returning so the API boundary
+/// can emit one authoritative incident without reconstructing lost context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelGatedContext {
+    pub workspace_id: String,
+    pub attempted_session_id: Option<String>,
+    pub agent_kind: String,
+    pub requested_model_id: String,
+    pub canonical_model_id: String,
+    pub active_contexts: Vec<String>,
+    pub required_contexts: Vec<String>,
+    pub catalog_version: String,
+}
+
 #[derive(Debug)]
 pub enum CreateSessionError {
     WorkspaceNotFound(String),
@@ -56,11 +71,7 @@ pub enum CreateSessionError {
     /// are not active. Distinct from `ModelUnsupported` (unresolvable model):
     /// the client can unlock it by satisfying one of
     /// `required_contexts` (the model's `availability.anyOf`).
-    ModelGated {
-        agent_kind: String,
-        model_id: String,
-        required_contexts: Vec<String>,
-    },
+    ModelGated(ModelGatedContext),
     ModeUnsupported {
         agent_kind: String,
         mode_id: String,

--- a/anyharness/crates/anyharness-lib/src/observability/latency.rs
+++ b/anyharness/crates/anyharness-lib/src/observability/latency.rs
@@ -18,6 +18,8 @@ const FLOW_KIND_HEADER: &str = "x-anyharness-flow-kind";
 const FLOW_SOURCE_HEADER: &str = "x-anyharness-flow-source";
 const PROMPT_ID_HEADER: &str = "x-anyharness-prompt-id";
 const MEASUREMENT_OPERATION_ID_HEADER: &str = "x-proliferate-measurement-operation-id";
+const MAX_CORRELATION_ID_BYTES: usize = 160;
+const MAX_CORRELATION_SLUG_BYTES: usize = 64;
 
 /// The flow fields a client may attach to a request for latency tracing.
 /// Parsed at the transport edge and recorded once on a `session_flow` span.
@@ -33,11 +35,11 @@ pub struct FlowHeaders {
 impl FlowHeaders {
     pub fn from_headers(headers: &HeaderMap) -> Self {
         Self {
-            flow_id: header_value(headers, FLOW_ID_HEADER),
-            flow_kind: header_value(headers, FLOW_KIND_HEADER),
-            flow_source: header_value(headers, FLOW_SOURCE_HEADER),
-            prompt_id: header_value(headers, PROMPT_ID_HEADER),
-            measurement_operation_id: header_value(headers, MEASUREMENT_OPERATION_ID_HEADER),
+            flow_id: correlation_id_header(headers, FLOW_ID_HEADER),
+            flow_kind: correlation_slug_header(headers, FLOW_KIND_HEADER),
+            flow_source: correlation_slug_header(headers, FLOW_SOURCE_HEADER),
+            prompt_id: correlation_id_header(headers, PROMPT_ID_HEADER),
+            measurement_operation_id: measurement_operation_header(headers),
         }
     }
 
@@ -55,21 +57,73 @@ impl FlowHeaders {
     }
 }
 
-fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
-    headers
-        .get(name)?
-        .to_str()
-        .ok()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
+fn raw_header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name)?.to_str().ok().map(str::trim)
+}
+
+fn correlation_id_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    raw_header_value(headers, name)
+        .filter(|value| safe_correlation_id(value))
         .map(ToOwned::to_owned)
+}
+
+fn correlation_slug_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    raw_header_value(headers, name)
+        .filter(|value| safe_correlation_slug(value))
+        .map(ToOwned::to_owned)
+}
+
+fn measurement_operation_header(headers: &HeaderMap) -> Option<String> {
+    raw_header_value(headers, MEASUREMENT_OPERATION_ID_HEADER)
+        .filter(|value| {
+            value.starts_with("mop_")
+                && safe_ascii_identifier(value, MAX_CORRELATION_ID_BYTES, true)
+        })
+        .map(ToOwned::to_owned)
+}
+
+fn safe_correlation_id(value: &str) -> bool {
+    safe_ascii_identifier(value, MAX_CORRELATION_ID_BYTES, true)
+}
+
+fn safe_correlation_slug(value: &str) -> bool {
+    safe_ascii_identifier(value, MAX_CORRELATION_SLUG_BYTES, false)
+}
+
+fn safe_ascii_identifier(value: &str, max_bytes: usize, allow_colon: bool) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && !looks_like_secret(value)
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'_' | b'-' | b'.')
+                || (allow_colon && byte == b':')
+        })
+}
+
+fn looks_like_secret(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    [
+        "sk-",
+        "sk_",
+        "ghp_",
+        "github_pat_",
+        "xoxb-",
+        "xoxp-",
+        "npm_",
+        "akia",
+        "bearer",
+        "basic",
+    ]
+    .iter()
+    .any(|prefix| normalized.starts_with(prefix))
 }
 
 #[cfg(test)]
 mod tests {
     use axum::http::{HeaderMap, HeaderValue};
 
-    use super::FlowHeaders;
+    use super::{FlowHeaders, MAX_CORRELATION_ID_BYTES};
 
     #[test]
     fn parses_flow_headers() {
@@ -110,5 +164,78 @@ mod tests {
 
         assert!(flow.flow_id.is_none());
         assert!(flow.prompt_id.is_none());
+    }
+
+    #[test]
+    fn rejects_content_secret_and_oversized_flow_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-anyharness-flow-id",
+            HeaderValue::from_static("customer@example.com"),
+        );
+        headers.insert(
+            "x-anyharness-flow-kind",
+            HeaderValue::from_static("prompt submit"),
+        );
+        headers.insert(
+            "x-anyharness-flow-source",
+            HeaderValue::from_static("sk-ant-private"),
+        );
+        headers.insert(
+            "x-anyharness-prompt-id",
+            HeaderValue::from_str(&"p".repeat(MAX_CORRELATION_ID_BYTES + 1))
+                .expect("valid oversized header"),
+        );
+        headers.insert(
+            "x-proliferate-measurement-operation-id",
+            HeaderValue::from_static("operation-without-prefix"),
+        );
+
+        let flow = FlowHeaders::from_headers(&headers);
+
+        assert!(flow.flow_id.is_none());
+        assert!(flow.flow_kind.is_none());
+        assert!(flow.flow_source.is_none());
+        assert!(flow.prompt_id.is_none());
+        assert!(flow.measurement_operation_id.is_none());
+    }
+
+    #[test]
+    fn preserves_canonical_flow_header_vocabularies() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-anyharness-flow-id",
+            HeaderValue::from_static("prompt_submit:1721320000000:abc123"),
+        );
+        headers.insert(
+            "x-anyharness-flow-kind",
+            HeaderValue::from_static("prompt_submit"),
+        );
+        headers.insert(
+            "x-anyharness-flow-source",
+            HeaderValue::from_static("plan-handoff-restore"),
+        );
+        headers.insert(
+            "x-anyharness-prompt-id",
+            HeaderValue::from_static("prompt-123"),
+        );
+        headers.insert(
+            "x-proliferate-measurement-operation-id",
+            HeaderValue::from_static("mop_test-123"),
+        );
+
+        let flow = FlowHeaders::from_headers(&headers);
+
+        assert_eq!(
+            flow.flow_id.as_deref(),
+            Some("prompt_submit:1721320000000:abc123")
+        );
+        assert_eq!(flow.flow_kind.as_deref(), Some("prompt_submit"));
+        assert_eq!(flow.flow_source.as_deref(), Some("plan-handoff-restore"));
+        assert_eq!(flow.prompt_id.as_deref(), Some("prompt-123"));
+        assert_eq!(
+            flow.measurement_operation_id.as_deref(),
+            Some("mop_test-123")
+        );
     }
 }

--- a/anyharness/crates/anyharness-lib/src/observability/latency.rs
+++ b/anyharness/crates/anyharness-lib/src/observability/latency.rs
@@ -112,6 +112,7 @@ fn looks_like_secret(value: &str) -> bool {
         "xoxp-",
         "npm_",
         "akia",
+        "eyj",
         "bearer",
         "basic",
     ]
@@ -198,6 +199,24 @@ mod tests {
         assert!(flow.flow_source.is_none());
         assert!(flow.prompt_id.is_none());
         assert!(flow.measurement_operation_id.is_none());
+    }
+
+    #[test]
+    fn rejects_jwt_like_flow_header_values_case_insensitively() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-anyharness-flow-id",
+            HeaderValue::from_static("eyJhbGciOiJIUzI1NiJ9.payload.signature"),
+        );
+        headers.insert(
+            "x-anyharness-prompt-id",
+            HeaderValue::from_static("eyjhbGciOiJIUzI1NiJ9.payload.signature"),
+        );
+
+        let flow = FlowHeaders::from_headers(&headers);
+
+        assert!(flow.flow_id.is_none());
+        assert!(flow.prompt_id.is_none());
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/observability/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/observability/mod.rs
@@ -6,3 +6,10 @@ pub mod transcript_phase;
 /// child-process output. Keep the target stable so vendor telemetry can
 /// exclude it while console and file logging retain the local diagnostic.
 pub const AGENT_STDERR_TRACING_TARGET: &str = "anyharness.agent_stderr";
+
+/// Handled, user-visible runtime failures that own one canonical incident.
+///
+/// Keep this target stable: the AnyHarness Sentry adapter uses it to attach
+/// the incident fingerprint and the bounded request-span context without
+/// changing ordinary runtime error grouping.
+pub const RUNTIME_INCIDENT_TRACING_TARGET: &str = "anyharness.runtime_incident";

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -1,7 +1,16 @@
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf, sync::Arc, time::Duration};
 
-use anyharness_lib::{app::default_runtime_home, observability::AGENT_STDERR_TRACING_TARGET};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
+use anyharness_lib::{
+    app::default_runtime_home,
+    observability::{AGENT_STDERR_TRACING_TARGET, RUNTIME_INCIDENT_TRACING_TARGET},
+};
+use tracing::Subscriber;
+use tracing_subscriber::{
+    layer::{Context as LayerContext, SubscriberExt},
+    registry::LookupSpan,
+    util::SubscriberInitExt,
+    Layer,
+};
 
 use crate::{
     cli::Commands,
@@ -9,7 +18,45 @@ use crate::{
     file_logging::create_file_log_sink,
 };
 
+mod scrub;
+
 const ANYHARNESS_TELEMETRY_MODE: &str = "hosted_product";
+const RUNTIME_ENV_TAG: &str = "runtime_env";
+const RUNTIME_INCIDENT_FINGERPRINT: &str = "anyharness:session_model_gated";
+
+#[derive(Clone)]
+struct ScrubbedTransportFactory;
+
+impl sentry::TransportFactory for ScrubbedTransportFactory {
+    fn create_transport_with_options(
+        &self,
+        options: sentry::TransportOptions,
+    ) -> Arc<dyn sentry::Transport> {
+        let inner = sentry::TransportFactory::create_transport_with_options(
+            &sentry::transports::DefaultTransportFactory,
+            options,
+        );
+        Arc::new(ScrubbedTransport { inner })
+    }
+}
+
+struct ScrubbedTransport {
+    inner: Arc<dyn sentry::Transport>,
+}
+
+impl sentry::Transport for ScrubbedTransport {
+    fn send_envelope(&self, envelope: sentry::Envelope) {
+        self.inner.send_envelope(scrub::envelope(envelope));
+    }
+
+    fn flush(&self, timeout: Duration) -> bool {
+        self.inner.flush(timeout)
+    }
+
+    fn shutdown(&self, timeout: Duration) -> bool {
+        self.inner.shutdown(timeout)
+    }
+}
 
 pub struct TelemetryGuards {
     _sentry: Option<sentry::ClientInitGuard>,
@@ -69,6 +116,47 @@ fn sentry_event_filter(metadata: &tracing::Metadata<'_>) -> sentry_tracing::Even
     )
 }
 
+fn sentry_event_mapper<S>(
+    event: &tracing::Event<'_>,
+    context: LayerContext<'_, S>,
+) -> sentry_tracing::EventMapping
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    let filter = sentry_event_filter(event.metadata());
+    if filter.is_empty() {
+        return sentry_tracing::EventMapping::Ignore;
+    }
+
+    // Ordinary events retain sentry-tracing's existing behavior. Only the
+    // incident target inherits active request/flow span fields, which keeps
+    // the new correlation context bounded to the canonical incident.
+    let is_runtime_incident = event.metadata().target() == RUNTIME_INCIDENT_TRACING_TARGET;
+    let span_context = is_runtime_incident.then_some(&context);
+    let mut mappings = Vec::new();
+
+    if filter.contains(sentry_tracing::EventFilter::Breadcrumb) {
+        mappings.push(sentry_tracing::EventMapping::Breadcrumb(
+            sentry_tracing::breadcrumb_from_event(event, span_context),
+        ));
+    }
+    if filter.contains(sentry_tracing::EventFilter::Event) {
+        let mut sentry_event = sentry_tracing::event_from_event(event, span_context);
+        if is_runtime_incident {
+            sentry_event.fingerprint =
+                Cow::Owned(vec![Cow::Borrowed(RUNTIME_INCIDENT_FINGERPRINT)]);
+        }
+        mappings.push(sentry_tracing::EventMapping::Event(sentry_event));
+    }
+    if filter.contains(sentry_tracing::EventFilter::Log) {
+        mappings.push(sentry_tracing::EventMapping::Log(
+            sentry_tracing::log_from_event(event, span_context),
+        ));
+    }
+
+    sentry_tracing::EventMapping::Combined(mappings.into())
+}
+
 fn runtime_home_from_serve(args: &ServeArgs) -> PathBuf {
     args.runtime_home
         .as_ref()
@@ -105,9 +193,17 @@ pub fn init(command: &Commands) -> TelemetryGuards {
                 environment: Some(
                     env_or_default("ANYHARNESS_SENTRY_ENVIRONMENT", "trusted-beta").into(),
                 ),
-                release: Some(env_or_default("ANYHARNESS_SENTRY_RELEASE", &default_release()).into()),
+                release: Some(
+                    env_or_default("ANYHARNESS_SENTRY_RELEASE", &default_release()).into(),
+                ),
                 traces_sample_rate: sample_rate("ANYHARNESS_SENTRY_TRACES_SAMPLE_RATE", 1.0),
                 attach_stacktrace: true,
+                send_default_pii: false,
+                server_name: Some(scrub::SAFE_SERVER_NAME.into()),
+                before_send: Some(Arc::new(scrub::event)),
+                before_breadcrumb: Some(Arc::new(scrub::breadcrumb)),
+                before_send_log: Some(Arc::new(scrub::log)),
+                transport: Some(Arc::new(ScrubbedTransportFactory)),
                 ..Default::default()
             },
         ))
@@ -129,7 +225,7 @@ pub fn init(command: &Commands) -> TelemetryGuards {
 
     tracing_subscriber::registry()
         .with(console_layer)
-        .with(sentry_tracing::layer().event_filter(sentry_event_filter))
+        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper))
         .with(file_sink.as_ref().map(|sink| {
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
@@ -186,8 +282,8 @@ fn sentry_scope_tags() -> Vec<(&'static str, String)> {
         ("telemetry_mode", ANYHARNESS_TELEMETRY_MODE.to_string()),
     ];
 
-    let runtime_env = std::env::var("PROLIFERATE_RUNTIME_ENV")
-        .unwrap_or_else(|_| "local".to_string());
+    let runtime_env =
+        std::env::var("PROLIFERATE_RUNTIME_ENV").unwrap_or_else(|_| "local".to_string());
     tags.push(("runtime_env", runtime_env));
 
     if let Ok(org_id) = std::env::var("PROLIFERATE_ORG_ID") {
@@ -215,170 +311,4 @@ fn sentry_scope_tags() -> Vec<(&'static str, String)> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        default_release, log_path_for_command, runtime_home_from_install, runtime_home_from_serve,
-        sentry_event_filter, sentry_event_filter_for_target, sentry_scope_tags,
-        sentry_user_from_id, stamped_git_sha,
-    };
-    use crate::{
-        cli::Commands,
-        commands::{install_agents::InstallAgentsArgs, serve::ServeArgs},
-    };
-    use anyharness_lib::observability::AGENT_STDERR_TRACING_TARGET;
-
-    #[test]
-    fn tracing_error_reaches_the_sentry_client() {
-        // Regression (B2 amendment): PR #684 bumped `sentry` to 0.48 while
-        // `sentry-tracing` stayed at 0.47, linking two `sentry-core` instances.
-        // The tracing layer then captured events into the 0.47 Hub — which has
-        // no client — so every runtime ERROR event was silently dropped in
-        // production from 2026-06-14. This test binds a test client to the same
-        // `sentry-core` the layer uses; it fails (0 events) whenever the two
-        // crates diverge again.
-        use tracing_subscriber::layer::SubscriberExt;
-        let subscriber = tracing_subscriber::registry()
-            .with(sentry_tracing::layer().event_filter(sentry_event_filter));
-        let events = sentry::test::with_captured_events(|| {
-            tracing::subscriber::with_default(subscriber, || {
-                tracing::error!("sentry emission regression probe");
-            });
-        });
-        assert_eq!(events.len(), 1, "tracing ERROR must reach the Sentry client");
-        assert_eq!(events[0].level, sentry::Level::Error);
-    }
-
-    #[test]
-    fn agent_stderr_stays_out_of_sentry_while_runtime_errors_remain_visible() {
-        use tracing_subscriber::layer::SubscriberExt;
-        let subscriber = tracing_subscriber::registry()
-            .with(sentry_tracing::layer().event_filter(sentry_event_filter));
-        let events = sentry::test::with_captured_events(|| {
-            tracing::subscriber::with_default(subscriber, || {
-                tracing::error!(
-                    target: AGENT_STDERR_TRACING_TARGET,
-                    "raw child-process stderr"
-                );
-                tracing::error!("ordinary runtime failure");
-            });
-        });
-
-        assert_eq!(events.len(), 1, "agent stderr must be ignored by Sentry");
-        assert_eq!(
-            events[0].message.as_deref(),
-            Some("ordinary runtime failure")
-        );
-    }
-
-    #[test]
-    fn agent_stderr_filter_ignores_every_sentry_signal_type() {
-        let all_signal_types = sentry_tracing::EventFilter::Event
-            | sentry_tracing::EventFilter::Breadcrumb
-            | sentry_tracing::EventFilter::Log;
-
-        let filter = sentry_event_filter_for_target(AGENT_STDERR_TRACING_TARGET, all_signal_types);
-
-        assert!(
-            filter.is_empty(),
-            "agent stderr must map to EventFilter::Ignore"
-        );
-    }
-
-    #[test]
-    fn sentry_scope_tags_include_runtime_surface_and_mode() {
-        let tags = sentry_scope_tags();
-        assert!(tags.iter().any(|(k, v)| *k == "surface" && v == "anyharness_runtime"));
-        assert!(tags.iter().any(|(k, v)| *k == "telemetry_mode" && v == "hosted_product"));
-        assert!(tags.iter().any(|(k, v)| *k == "runtime_env" && !v.is_empty()));
-    }
-
-    #[test]
-    fn default_release_is_canonical_for_this_component() {
-        let release = default_release();
-        assert!(release.starts_with("anyharness@"), "{release}");
-        let expected = match stamped_git_sha() {
-            Some(sha) => {
-                assert_eq!(sha.len(), 12);
-                format!("anyharness@{}+{sha}", env!("PROLIFERATE_STAMPED_VERSION"))
-            }
-            None => format!("anyharness@{}", env!("PROLIFERATE_STAMPED_VERSION")),
-        };
-        assert_eq!(release, expected);
-    }
-
-    #[test]
-    fn sentry_user_context_is_id_only_and_trimmed() {
-        let user = sentry_user_from_id(Some("  user-1  ")).expect("user present");
-        assert_eq!(user.id.as_deref(), Some("user-1"));
-        assert!(user.email.is_none());
-        assert!(sentry_user_from_id(None).is_none());
-        assert!(sentry_user_from_id(Some("   ")).is_none());
-    }
-
-    #[test]
-    fn serve_runtime_home_uses_override_when_present() {
-        let args = ServeArgs {
-            host: "127.0.0.1".to_string(),
-            port: 8457,
-            runtime_home: Some("/tmp/anyharness-test".to_string()),
-            require_bearer_auth: false,
-            disable_cors: false,
-        };
-
-        assert_eq!(
-            runtime_home_from_serve(&args).to_string_lossy(),
-            "/tmp/anyharness-test"
-        );
-    }
-
-    #[test]
-    fn install_runtime_home_uses_override_when_present() {
-        let args = InstallAgentsArgs {
-            runtime_home: Some("/tmp/anyharness-install".to_string()),
-            reinstall: false,
-            agents: Vec::new(),
-        };
-
-        assert_eq!(
-            runtime_home_from_install(&args).to_string_lossy(),
-            "/tmp/anyharness-install"
-        );
-    }
-
-    #[test]
-    fn print_openapi_has_no_file_log_path() {
-        assert!(log_path_for_command(&Commands::PrintOpenapi).is_none());
-    }
-
-    #[test]
-    fn serve_command_log_path_lands_under_runtime_home_logs() {
-        let path = log_path_for_command(&Commands::Serve(ServeArgs {
-            host: "127.0.0.1".to_string(),
-            port: 8457,
-            runtime_home: Some("/tmp/anyharness-serve".to_string()),
-            require_bearer_auth: false,
-            disable_cors: false,
-        }))
-        .expect("serve should use file logging");
-
-        assert_eq!(
-            path.to_string_lossy(),
-            "/tmp/anyharness-serve/logs/anyharness.log"
-        );
-    }
-
-    #[test]
-    fn install_command_log_path_lands_under_runtime_home_logs() {
-        let path = log_path_for_command(&Commands::InstallAgents(InstallAgentsArgs {
-            runtime_home: Some("/tmp/anyharness-install".to_string()),
-            reinstall: false,
-            agents: Vec::new(),
-        }))
-        .expect("install should use file logging");
-
-        assert_eq!(
-            path.to_string_lossy(),
-            "/tmp/anyharness-install/logs/anyharness.log"
-        );
-    }
-}
+mod tests;

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -128,9 +128,10 @@ where
         return sentry_tracing::EventMapping::Ignore;
     }
 
-    // Ordinary events retain sentry-tracing's existing behavior. Only the
-    // incident target inherits active request/flow span fields, which keeps
-    // the new correlation context bounded to the canonical incident.
+    // The prior event-filter layer left span-attribute inheritance disabled,
+    // so ordinary events continue without parent span fields; Sentry's active
+    // scope still supplies their trace context. Only the incident target opts
+    // into bounded request/flow fields from active spans.
     let is_runtime_incident = event.metadata().target() == RUNTIME_INCIDENT_TRACING_TARGET;
     let span_context = is_runtime_incident.then_some(&context);
     let mut mappings = Vec::new();

--- a/anyharness/crates/anyharness/src/telemetry/scrub.rs
+++ b/anyharness/crates/anyharness/src/telemetry/scrub.rs
@@ -1,0 +1,280 @@
+use std::borrow::Cow;
+
+use sentry::protocol::{
+    Breadcrumb, Context as SentryContext, EnvelopeItem, Event, Frame, Log, LogEntry, Span,
+    Stacktrace, ThreadId, Transaction, Value,
+};
+use sentry::Envelope;
+
+mod redact;
+
+use self::redact::{
+    explicitly_safe_key, safe_string_value_for_key, safe_value_for_key, scrub_bounded_text,
+};
+
+const MAX_DIAGNOSTIC_STRING_BYTES: usize = 512;
+const MAX_DIAGNOSTIC_COLLECTION_ITEMS: usize = 32;
+const MAX_TRANSACTION_SPANS: usize = 128;
+const MAX_CORRELATION_ID_BYTES: usize = 160;
+const MAX_CORRELATION_SLUG_BYTES: usize = 64;
+pub(super) const SAFE_SERVER_NAME: &str = "anyharness-runtime";
+
+fn scrub_value(value: &mut Value) {
+    match value {
+        Value::String(text) => *text = scrub_bounded_text(text),
+        Value::Array(items) => {
+            items.truncate(MAX_DIAGNOSTIC_COLLECTION_ITEMS);
+            for item in items {
+                scrub_value(item);
+            }
+        }
+        Value::Object(map) => map.retain(|key, value| {
+            if !explicitly_safe_key(key) || !safe_value_for_key(key, value) {
+                return false;
+            }
+            scrub_value(value);
+            true
+        }),
+        _ => {}
+    }
+}
+
+fn scrub_value_map(map: &mut std::collections::BTreeMap<String, Value>) {
+    map.retain(|key, value| {
+        if !explicitly_safe_key(key) || !safe_value_for_key(key, value) {
+            return false;
+        }
+        scrub_value(value);
+        true
+    });
+}
+
+fn scrub_optional_text(value: &mut Option<String>) {
+    if let Some(text) = value {
+        *text = scrub_bounded_text(text);
+    }
+}
+
+fn scrub_log_entry(logentry: &mut Option<LogEntry>) {
+    if let Some(logentry) = logentry {
+        logentry.message = scrub_bounded_text(&logentry.message);
+        logentry.params.clear();
+    }
+}
+
+fn scrub_thread_id(thread_id: &mut Option<ThreadId>) {
+    if let Some(ThreadId::String(value)) = thread_id {
+        *value = scrub_bounded_text(value);
+    }
+}
+
+fn scrub_breadcrumb(breadcrumb: &mut Breadcrumb) {
+    breadcrumb.ty = scrub_bounded_text(&breadcrumb.ty);
+    scrub_optional_text(&mut breadcrumb.category);
+    scrub_optional_text(&mut breadcrumb.message);
+    scrub_value_map(&mut breadcrumb.data);
+}
+
+fn scrub_frame(frame: &mut Frame) {
+    scrub_optional_text(&mut frame.function);
+    scrub_optional_text(&mut frame.symbol);
+    scrub_optional_text(&mut frame.module);
+    scrub_optional_text(&mut frame.package);
+    scrub_optional_text(&mut frame.filename);
+    scrub_optional_text(&mut frame.abs_path);
+    scrub_optional_text(&mut frame.addr_mode);
+    frame.context_line = None;
+    frame.pre_context.clear();
+    frame.post_context.clear();
+    frame.vars.clear();
+}
+
+fn scrub_stacktrace(stacktrace: &mut Option<Stacktrace>) {
+    if let Some(stacktrace) = stacktrace {
+        for frame in &mut stacktrace.frames {
+            scrub_frame(frame);
+        }
+        stacktrace.registers.clear();
+    }
+}
+
+fn scrub_context(context: &mut SentryContext) -> bool {
+    match context {
+        SentryContext::Other(values) => {
+            scrub_value_map(values);
+            !values.is_empty()
+        }
+        SentryContext::Trace(trace) => {
+            trace.op = None;
+            trace.description = None;
+            trace.origin = None;
+            scrub_value_map(&mut trace.data);
+            true
+        }
+        SentryContext::Response(response) => {
+            response.cookies = None;
+            response.headers.clear();
+            response.data = None;
+            true
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn breadcrumb(mut breadcrumb: Breadcrumb) -> Option<Breadcrumb> {
+    scrub_breadcrumb(&mut breadcrumb);
+    Some(breadcrumb)
+}
+
+pub(super) fn event(mut event: Event<'static>) -> Option<Event<'static>> {
+    scrub_optional_text(&mut event.message);
+    scrub_optional_text(&mut event.culprit);
+    scrub_optional_text(&mut event.transaction);
+    scrub_log_entry(&mut event.logentry);
+    scrub_optional_text(&mut event.logger);
+    event.fingerprint = Cow::Owned(
+        event
+            .fingerprint
+            .iter()
+            .take(MAX_DIAGNOSTIC_COLLECTION_ITEMS)
+            .map(|value| Cow::Owned(scrub_bounded_text(value)))
+            .collect(),
+    );
+
+    if let Some(user) = &mut event.user {
+        if let Some(id) = &mut user.id {
+            *id = scrub_bounded_text(id);
+        }
+        user.email = None;
+        user.username = None;
+        user.ip_address = None;
+        user.other.clear();
+    }
+
+    event.request = None;
+    event.server_name = Some(Cow::Borrowed(SAFE_SERVER_NAME));
+
+    for breadcrumb in &mut event.breadcrumbs.values {
+        scrub_breadcrumb(breadcrumb);
+    }
+    for exception in &mut event.exception.values {
+        exception.ty = scrub_bounded_text(&exception.ty);
+        scrub_optional_text(&mut exception.value);
+        scrub_optional_text(&mut exception.module);
+        if let Some(mechanism) = &mut exception.mechanism {
+            mechanism.ty = scrub_bounded_text(&mechanism.ty);
+            scrub_optional_text(&mut mechanism.description);
+            mechanism.help_link = None;
+            scrub_value_map(&mut mechanism.data);
+        }
+        scrub_thread_id(&mut exception.thread_id);
+        scrub_stacktrace(&mut exception.stacktrace);
+        scrub_stacktrace(&mut exception.raw_stacktrace);
+    }
+    scrub_stacktrace(&mut event.stacktrace);
+    if let Some(template) = &mut event.template {
+        scrub_optional_text(&mut template.filename);
+        scrub_optional_text(&mut template.abs_path);
+        template.context_line = None;
+        template.pre_context.clear();
+        template.post_context.clear();
+    }
+    for thread in &mut event.threads.values {
+        scrub_thread_id(&mut thread.id);
+        scrub_optional_text(&mut thread.name);
+        scrub_stacktrace(&mut thread.stacktrace);
+        scrub_stacktrace(&mut thread.raw_stacktrace);
+    }
+    event.contexts.retain(|_, context| scrub_context(context));
+    scrub_value_map(&mut event.extra);
+    event.tags.retain(|key, value| {
+        if !explicitly_safe_key(key) || !safe_string_value_for_key(key, value) {
+            return false;
+        }
+        *value = scrub_bounded_text(value);
+        true
+    });
+
+    Some(event)
+}
+
+pub(super) fn log(mut log: Log) -> Option<Log> {
+    log.body = scrub_bounded_text(&log.body);
+    log.attributes.retain(|key, attribute| {
+        if !explicitly_safe_key(key) || !safe_value_for_key(key, &attribute.0) {
+            return false;
+        }
+        scrub_value(&mut attribute.0);
+        true
+    });
+    Some(log)
+}
+
+fn scrub_span(span: &mut Span) {
+    scrub_optional_text(&mut span.op);
+    scrub_optional_text(&mut span.description);
+    span.tags.retain(|key, value| {
+        if !explicitly_safe_key(key) || !safe_string_value_for_key(key, value) {
+            return false;
+        }
+        *value = scrub_bounded_text(value);
+        true
+    });
+    scrub_value_map(&mut span.data);
+}
+
+/// Sentry Rust 0.48 has event/log callbacks but no transaction callback. The
+/// transport wrapper invokes this equivalent before every transaction envelope
+/// is delegated to the HTTP transport.
+pub(super) fn before_send_transaction(
+    mut transaction: Transaction<'static>,
+) -> Transaction<'static> {
+    scrub_optional_text(&mut transaction.name);
+    if let Some(user) = &mut transaction.user {
+        if let Some(id) = &mut user.id {
+            *id = scrub_bounded_text(id);
+        }
+        user.email = None;
+        user.username = None;
+        user.ip_address = None;
+        user.other.clear();
+    }
+    transaction.tags.retain(|key, value| {
+        if !explicitly_safe_key(key) || !safe_string_value_for_key(key, value) {
+            return false;
+        }
+        *value = scrub_bounded_text(value);
+        true
+    });
+    scrub_value_map(&mut transaction.extra);
+    transaction
+        .contexts
+        .retain(|_, context| scrub_context(context));
+    transaction.request = None;
+    transaction.server_name = Some(Cow::Borrowed(SAFE_SERVER_NAME));
+    transaction.spans.truncate(MAX_TRANSACTION_SPANS);
+    for span in &mut transaction.spans {
+        scrub_span(span);
+    }
+    transaction
+}
+
+pub(super) fn envelope(envelope: Envelope) -> Envelope {
+    if envelope.items().next().is_none() {
+        return envelope;
+    }
+    let headers = envelope.headers().clone();
+    let mut scrubbed = Envelope::new().with_headers(headers);
+    for item in envelope.into_items() {
+        match item {
+            EnvelopeItem::Transaction(transaction) => {
+                scrubbed.add_item(before_send_transaction(transaction));
+            }
+            other => scrubbed.add_item(other),
+        }
+    }
+    scrubbed
+}
+
+#[cfg(test)]
+mod tests;

--- a/anyharness/crates/anyharness/src/telemetry/scrub/redact.rs
+++ b/anyharness/crates/anyharness/src/telemetry/scrub/redact.rs
@@ -1,0 +1,442 @@
+use sentry::protocol::Value;
+
+use super::super::RUNTIME_ENV_TAG;
+use super::{MAX_CORRELATION_ID_BYTES, MAX_CORRELATION_SLUG_BYTES, MAX_DIAGNOSTIC_STRING_BYTES};
+
+/// Incident and correlation keys whose values are bounded identifiers or
+/// finite catalog vocabulary. These remain visible even when their names
+/// contain a normally-sensitive word such as `prompt` or `fingerprint`.
+const SAFE_DIAGNOSTIC_KEYS: &[&str] = &[
+    "incident_id",
+    "error_code",
+    "error_kind",
+    "fingerprint",
+    "request_id",
+    "flow_id",
+    "flow_kind",
+    "flow_source",
+    "prompt_id",
+    "measurement_operation_id",
+    "workspace_id",
+    "attempted_session_id",
+    "session_id",
+    "agent_kind",
+    "requested_model",
+    "canonical_model",
+    "active_contexts",
+    "required_contexts",
+    "catalog_version",
+    "selection_outcome",
+    "effective_model",
+    "effective_route",
+    "surface",
+    "telemetry_mode",
+    RUNTIME_ENV_TAG,
+    "org_id",
+    "sandbox_id",
+    "user_id",
+    "target_id",
+];
+
+fn diagnostic_key_leaf(key: &str) -> String {
+    let normalized = key.to_ascii_lowercase();
+    normalized
+        .rsplit(|character| matches!(character, ':' | '.'))
+        .next()
+        .unwrap_or(normalized.as_str())
+        .to_string()
+}
+
+pub(super) fn explicitly_safe_key(key: &str) -> bool {
+    SAFE_DIAGNOSTIC_KEYS.contains(&diagnostic_key_leaf(key).as_str())
+}
+
+pub(super) fn safe_value_for_key(key: &str, value: &Value) -> bool {
+    match value {
+        Value::String(value) => safe_string_value_for_key(key, value),
+        _ => !matches!(
+            diagnostic_key_leaf(key).as_str(),
+            "request_id"
+                | "flow_id"
+                | "prompt_id"
+                | "measurement_operation_id"
+                | "flow_kind"
+                | "flow_source"
+        ),
+    }
+}
+
+pub(super) fn safe_string_value_for_key(key: &str, value: &str) -> bool {
+    let leaf = diagnostic_key_leaf(key);
+    match leaf.as_str() {
+        "request_id" | "flow_id" | "prompt_id" => {
+            safe_ascii_identifier(value, MAX_CORRELATION_ID_BYTES, true)
+        }
+        "measurement_operation_id" => {
+            value.starts_with("mop_")
+                && safe_ascii_identifier(value, MAX_CORRELATION_ID_BYTES, true)
+        }
+        "flow_kind" | "flow_source" => {
+            safe_ascii_identifier(value, MAX_CORRELATION_SLUG_BYTES, false)
+        }
+        _ => true,
+    }
+}
+
+fn safe_ascii_identifier(value: &str, max_bytes: usize, allow_colon: bool) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && !looks_like_secret(value)
+        && redact_sensitive_text(value) == value
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'_' | b'-' | b'.')
+                || (allow_colon && byte == b':')
+        })
+}
+
+fn looks_like_secret(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    [
+        "sk-",
+        "sk_",
+        "ghp_",
+        "github_pat_",
+        "xoxb-",
+        "xoxp-",
+        "npm_",
+        "akia",
+        "bearer",
+        "basic",
+    ]
+    .iter()
+    .any(|prefix| normalized.starts_with(prefix))
+}
+
+fn scrub_text(value: &str) -> String {
+    redact_absolute_paths(&strip_query_segments(&redact_sensitive_text(value)))
+}
+
+pub(super) fn scrub_bounded_text(value: &str) -> String {
+    let mut scrubbed = scrub_text(value);
+    if scrubbed.len() > MAX_DIAGNOSTIC_STRING_BYTES {
+        let mut end = MAX_DIAGNOSTIC_STRING_BYTES;
+        while !scrubbed.is_char_boundary(end) {
+            end -= 1;
+        }
+        scrubbed.truncate(end);
+    }
+    scrubbed
+}
+
+fn redact_sensitive_text(value: &str) -> String {
+    let without_pem = redact_pem_blocks(value);
+    let without_auth = redact_auth_schemes(&without_pem);
+    let without_assignments = redact_secret_assignments(&without_auth);
+    redact_prefixed_secrets(&without_assignments)
+}
+
+fn redact_pem_blocks(value: &str) -> String {
+    let mut output = String::new();
+    let mut remaining = value;
+    while let Some(index) = find_ascii_case_insensitive(remaining, "-----begin ") {
+        output.push_str(&remaining[..index]);
+        output.push_str("[redacted-secret]");
+        let block = &remaining[index..];
+        let end = find_ascii_case_insensitive(block, "-----end ")
+            .and_then(|end_marker| {
+                block[end_marker + "-----end ".len()..]
+                    .find("-----")
+                    .map(|suffix| end_marker + "-----end ".len() + suffix + "-----".len())
+            })
+            .unwrap_or(block.len());
+        remaining = &block[end..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn redact_auth_schemes(value: &str) -> String {
+    let mut output = String::new();
+    let mut remaining = value;
+    while let Some((index, marker_len)) = earliest_ascii_marker(remaining, &["bearer", "basic"]) {
+        let mut credential_start = index + marker_len;
+        if !token_boundary_before(remaining, index)
+            || !remaining[credential_start..]
+                .chars()
+                .next()
+                .is_some_and(char::is_whitespace)
+        {
+            output.push_str(&remaining[..index + marker_len]);
+            remaining = &remaining[index + marker_len..];
+            continue;
+        }
+        while let Some(character) = remaining[credential_start..].chars().next() {
+            if character.is_whitespace() || matches!(character, '\'' | '"') {
+                credential_start += character.len_utf8();
+            } else {
+                break;
+            }
+        }
+        output.push_str(&remaining[..index]);
+        output.push_str("[redacted-token]");
+        let credential_end = secret_token_end(remaining, credential_start);
+        remaining = &remaining[credential_end..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn redact_secret_assignments(value: &str) -> String {
+    let mut output = String::new();
+    let mut remaining = value;
+    while let Some((start, end)) = find_secret_assignment(remaining) {
+        output.push_str(&remaining[..start]);
+        output.push_str("[redacted-secret]");
+        remaining = &remaining[end..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn find_secret_assignment(value: &str) -> Option<(usize, usize)> {
+    const KEYS: &[&str] = &[
+        "authorization",
+        "access_token",
+        "access-token",
+        "refresh_token",
+        "refresh-token",
+        "auth_token",
+        "auth-token",
+        "api_key",
+        "api-key",
+        "apikey",
+        "client_secret",
+        "client-secret",
+        "private_key",
+        "private-key",
+        "token",
+        "key",
+        "secret",
+        "password",
+        "credential",
+    ];
+    let normalized = value.to_ascii_lowercase();
+    let mut best: Option<(usize, usize)> = None;
+    for (index, _) in value.char_indices() {
+        if !token_boundary_before(value, index) {
+            continue;
+        }
+        for key in KEYS {
+            if !normalized[index..].starts_with(key) {
+                continue;
+            }
+            let mut cursor = index + key.len();
+            if matches!(normalized[cursor..].chars().next(), Some('\'' | '"')) {
+                cursor += 1;
+            }
+            while let Some(character) = normalized[cursor..].chars().next() {
+                if character.is_whitespace() {
+                    cursor += character.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            let Some(delimiter) = normalized[cursor..].chars().next() else {
+                continue;
+            };
+            if !matches!(delimiter, '=' | ':') {
+                continue;
+            }
+            cursor += delimiter.len_utf8();
+            while let Some(character) = normalized[cursor..].chars().next() {
+                if character.is_whitespace() || matches!(character, '\'' | '"') {
+                    cursor += character.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            if cursor >= value.len() {
+                continue;
+            }
+            let end = secret_token_end(value, cursor);
+            if end > cursor && best.map_or(true, |(best_start, _)| index < best_start) {
+                best = Some((index, end));
+            }
+        }
+    }
+    best
+}
+
+fn redact_prefixed_secrets(value: &str) -> String {
+    const PREFIXES: &[&str] = &[
+        "github_pat_",
+        "ghp_",
+        "xoxb-",
+        "xoxp-",
+        "npm_",
+        "sk-",
+        "sk_",
+        "akia",
+        "eyj",
+    ];
+    let normalized = value.to_ascii_lowercase();
+    let mut output = String::new();
+    let mut cursor = 0;
+    while cursor < value.len() {
+        let found = PREFIXES
+            .iter()
+            .filter_map(|prefix| {
+                normalized[cursor..]
+                    .find(prefix)
+                    .map(|offset| (cursor + offset, *prefix))
+            })
+            .filter(|(index, _)| token_boundary_before(value, *index))
+            .min_by_key(|(index, _)| *index);
+        let Some((index, prefix)) = found else {
+            output.push_str(&value[cursor..]);
+            break;
+        };
+        let end = secret_token_end(value, index);
+        if end.saturating_sub(index) <= prefix.len() {
+            let next = index + prefix.len();
+            output.push_str(&value[cursor..next]);
+            cursor = next;
+            continue;
+        }
+        output.push_str(&value[cursor..index]);
+        output.push_str("[redacted-secret]");
+        cursor = end;
+    }
+    output
+}
+
+fn earliest_ascii_marker(value: &str, markers: &[&str]) -> Option<(usize, usize)> {
+    markers
+        .iter()
+        .filter_map(|marker| {
+            find_ascii_case_insensitive(value, marker).map(|index| (index, marker.len()))
+        })
+        .min_by_key(|(index, _)| *index)
+}
+
+fn find_ascii_case_insensitive(value: &str, needle: &str) -> Option<usize> {
+    value
+        .to_ascii_lowercase()
+        .find(&needle.to_ascii_lowercase())
+}
+
+fn token_boundary_before(value: &str, index: usize) -> bool {
+    index == 0
+        || value[..index]
+            .chars()
+            .next_back()
+            .is_some_and(|character| !character.is_ascii_alphanumeric())
+}
+
+fn secret_token_end(value: &str, start: usize) -> usize {
+    value[start..]
+        .char_indices()
+        .find_map(|(offset, character)| {
+            (character.is_whitespace()
+                || matches!(
+                    character,
+                    '"' | '\'' | ',' | ';' | ')' | ']' | '}' | '<' | '>'
+                ))
+            .then_some(start + offset)
+        })
+        .unwrap_or(value.len())
+}
+
+fn strip_query_segments(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let mut output = String::new();
+    let mut index = 0;
+    while index < chars.len() {
+        if chars[index] == '?' && preceding_token_is_urlish(&output) {
+            index += 1;
+            while index < chars.len()
+                && !chars[index].is_whitespace()
+                && !matches!(chars[index], '"' | '\'' | ')' | '<' | '>')
+            {
+                index += 1;
+            }
+            continue;
+        }
+        output.push(chars[index]);
+        index += 1;
+    }
+    output
+}
+
+fn preceding_token_is_urlish(value: &str) -> bool {
+    let token = value
+        .rsplit(|character: char| {
+            character.is_whitespace() || matches!(character, '"' | '\'' | '(' | '<' | '>')
+        })
+        .next()
+        .unwrap_or_default();
+    token.contains("://")
+        || token.starts_with('/')
+        || token.starts_with("./")
+        || token.starts_with("../")
+}
+
+fn redact_absolute_paths(value: &str) -> String {
+    let mut output = String::new();
+    let mut index = 0;
+    while index < value.len() {
+        let rest = &value[index..];
+        if rest.starts_with("/Users/")
+            || rest.starts_with("/home/")
+            || rest.starts_with("/private/var/mobile/")
+            || rest.starts_with("/var/mobile/")
+            || rest.starts_with("/data/user/")
+            || rest.starts_with("/data/data/")
+            || starts_with_posix_absolute_path(value, index)
+            || starts_with_windows_path(rest)
+        {
+            output.push_str("[redacted-path]");
+            index += rest
+                .find(|character: char| {
+                    character.is_whitespace()
+                        || matches!(character, '"' | '\'' | ',' | ')' | '<' | '>')
+                })
+                .unwrap_or(rest.len());
+            continue;
+        }
+        let character = rest.chars().next().expect("non-empty rest");
+        output.push(character);
+        index += character.len_utf8();
+    }
+    output
+}
+
+fn starts_with_posix_absolute_path(value: &str, index: usize) -> bool {
+    let rest = &value[index..];
+    if !rest.starts_with('/') || rest.starts_with("//") {
+        return false;
+    }
+    match value[..index].chars().next_back() {
+        None => true,
+        Some(character) => {
+            character.is_whitespace()
+                || matches!(character, '"' | '\'' | '(' | '=' | ',' | ':' | '<' | '>')
+        }
+    }
+}
+
+fn starts_with_windows_path(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(drive) = chars.next() else {
+        return false;
+    };
+    if !drive.is_ascii_alphabetic() || chars.next() != Some(':') {
+        return false;
+    }
+    match chars.next() {
+        Some('\\') => true,
+        Some('/') => chars.next() != Some('/'),
+        _ => false,
+    }
+}

--- a/anyharness/crates/anyharness/src/telemetry/scrub/tests.rs
+++ b/anyharness/crates/anyharness/src/telemetry/scrub/tests.rs
@@ -1,0 +1,527 @@
+use std::{collections::BTreeMap, time::SystemTime};
+
+use sentry::protocol::{
+    Breadcrumb, Context as SentryContext, EnvelopeItem, Event, Exception, Frame, Log, LogEntry,
+    LogLevel, Request, Span, Stacktrace, Transaction, User, Value,
+};
+use sentry::Envelope;
+
+use super::{
+    breadcrumb, envelope, event, log, scrub_bounded_text, MAX_CORRELATION_ID_BYTES,
+    MAX_DIAGNOSTIC_COLLECTION_ITEMS, MAX_DIAGNOSTIC_STRING_BYTES, MAX_TRANSACTION_SPANS,
+    SAFE_SERVER_NAME,
+};
+
+fn string_field<'a>(fields: &'a BTreeMap<String, Value>, key: &str) -> &'a str {
+    match fields.get(key) {
+        Some(Value::String(value)) => value,
+        other => panic!("expected string field {key}, got {other:?}"),
+    }
+}
+
+#[test]
+fn free_text_redaction_is_case_insensitive_bounded_and_covers_secret_shapes() {
+    let raw = format!(
+        "bEaReR   lower-bearer-secret BaSiC\tbasic-secret \
+         API_KEY=assignment-secret \
+         \"access_token\":\"json-secret\" \
+         ANTHROPIC_API_KEY=environment-secret \
+         ghp_prefixed-secret \
+         -----BEGIN PRIVATE KEY-----\npem-secret\n-----END PRIVATE KEY----- \
+         /Users/customer/private/file \
+         https://runtime.invalid/start?credential=query-secret {}",
+        "x".repeat(MAX_DIAGNOSTIC_STRING_BYTES + 64)
+    );
+
+    let scrubbed = scrub_bounded_text(&raw);
+
+    for secret in [
+        "lower-bearer-secret",
+        "basic-secret",
+        "assignment-secret",
+        "json-secret",
+        "environment-secret",
+        "prefixed-secret",
+        "pem-secret",
+        "/Users/customer",
+        "query-secret",
+    ] {
+        assert!(!scrubbed.contains(secret), "leaked {secret}: {scrubbed}");
+    }
+    assert!(scrubbed.len() <= MAX_DIAGNOSTIC_STRING_BYTES);
+    assert!(scrubbed.contains("[redacted-token]"));
+    assert!(scrubbed.contains("[redacted-secret]"));
+    assert!(scrubbed.contains("[redacted-path]"));
+}
+
+#[test]
+fn event_scrubber_removes_malicious_payloads_and_bounds_safe_values() {
+    let long_workspace_id = "w".repeat(MAX_DIAGNOSTIC_STRING_BYTES + 64);
+    let active_contexts = (0..MAX_DIAGNOSTIC_COLLECTION_ITEMS + 8)
+        .map(|index| Value::String(format!("context-{index}")))
+        .collect::<Vec<_>>();
+    let raw_event = Event {
+        message: Some(
+            "failure at /Users/customer/private.txt with Bearer event-secret \
+             https://runtime.invalid/start?token=query-secret"
+                .to_string(),
+        ),
+        logentry: Some(LogEntry {
+            message: "failed at /home/customer/private.txt".to_string(),
+            params: vec![Value::String("raw prompt parameter".to_string())],
+        }),
+        user: Some(User {
+            id: Some("user-1".to_string()),
+            email: Some("customer@example.com".to_string()),
+            ip_address: Some(Default::default()),
+            username: Some("customer-name".to_string()),
+            other: BTreeMap::from([(
+                "profile".to_string(),
+                Value::String("private profile".to_string()),
+            )]),
+        }),
+        request: Some(Request {
+            url: Some(
+                "https://runtime.invalid/start?token=query-secret#fragment"
+                    .parse()
+                    .expect("valid URL"),
+            ),
+            method: Some("POST".to_string()),
+            data: Some("raw request body".to_string()),
+            query_string: Some("token=query-secret".to_string()),
+            cookies: Some("session=cookie-secret".to_string()),
+            headers: BTreeMap::from([(
+                "authorization".to_string(),
+                "Bearer header-secret".to_string(),
+            )]),
+            env: BTreeMap::from([("API_TOKEN".to_string(), "env-secret".to_string())]),
+        }),
+        server_name: Some("private-customer-hostname".into()),
+        contexts: BTreeMap::from([(
+            "malicious".to_string(),
+            SentryContext::Other(BTreeMap::from([
+                (
+                    "incident_id".to_string(),
+                    Value::String("incident-1".to_string()),
+                ),
+                ("workspace_id".to_string(), Value::String(long_workspace_id)),
+                ("active_contexts".to_string(), Value::Array(active_contexts)),
+                (
+                    "authorization".to_string(),
+                    Value::String("Bearer context-secret".to_string()),
+                ),
+                (
+                    "provider_output".to_string(),
+                    Value::String("raw provider output".to_string()),
+                ),
+                (
+                    "customer_name".to_string(),
+                    Value::String("private name".to_string()),
+                ),
+                (
+                    "runtime_request:request_id".to_string(),
+                    Value::String("customer@example.com".to_string()),
+                ),
+                (
+                    "session_flow:flow_id".to_string(),
+                    Value::String("sk-ant-private".to_string()),
+                ),
+                (
+                    "session_flow:flow_kind".to_string(),
+                    Value::String("prompt_submit".to_string()),
+                ),
+                (
+                    "session_flow:flow_source".to_string(),
+                    Value::String("prompt submit".to_string()),
+                ),
+                (
+                    "session_flow:prompt_id".to_string(),
+                    Value::String("prompt-1".to_string()),
+                ),
+            ])),
+        )]),
+        breadcrumbs: vec![Breadcrumb {
+            message: Some(
+                "child output at C:\\Users\\customer\\secret.txt Bearer child-secret".to_string(),
+            ),
+            data: BTreeMap::from([
+                (
+                    "request_id".to_string(),
+                    Value::String("request-1".to_string()),
+                ),
+                (
+                    "stderr".to_string(),
+                    Value::String("raw child stderr".to_string()),
+                ),
+            ]),
+            ..Default::default()
+        }]
+        .into(),
+        exception: vec![Exception {
+            value: Some(
+                "exception at /private/var/mobile/customer.txt Bearer exception-secret".to_string(),
+            ),
+            stacktrace: Some(Stacktrace {
+                frames: vec![Frame {
+                    filename: Some("/Users/customer/source.rs".to_string()),
+                    abs_path: Some("/Users/customer/source.rs".to_string()),
+                    context_line: Some("let token = secret;".to_string()),
+                    pre_context: vec!["raw source before".to_string()],
+                    post_context: vec!["raw source after".to_string()],
+                    vars: BTreeMap::from([(
+                        "prompt".to_string(),
+                        Value::String("raw frame prompt".to_string()),
+                    )]),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]
+        .into(),
+        tags: BTreeMap::from([
+            ("runtime_env".to_string(), "e2b".to_string()),
+            ("sandbox_id".to_string(), "provider-sandbox-1".to_string()),
+            ("raw_env".to_string(), "env-secret".to_string()),
+            (
+                "route_url".to_string(),
+                "https://runtime.invalid/private".to_string(),
+            ),
+        ]),
+        extra: BTreeMap::from([
+            (
+                "catalog_version".to_string(),
+                Value::String("catalog-1".to_string()),
+            ),
+            (
+                "response_body".to_string(),
+                Value::String("raw response".to_string()),
+            ),
+        ]),
+        ..Default::default()
+    };
+
+    let event = event(raw_event).expect("event retained");
+    let message = event.message.as_deref().expect("event message");
+    assert!(!message.contains("event-secret"));
+    assert!(!message.contains("/Users/customer"));
+    assert!(!message.contains("query-secret"));
+    assert!(event.request.is_none());
+    assert_eq!(event.server_name.as_deref(), Some(SAFE_SERVER_NAME));
+
+    let user = event.user.as_ref().expect("ID-only user retained");
+    assert_eq!(user.id.as_deref(), Some("user-1"));
+    assert!(user.email.is_none());
+    assert!(user.ip_address.is_none());
+    assert!(user.username.is_none());
+    assert!(user.other.is_empty());
+
+    let fields = match event.contexts.get("malicious") {
+        Some(SentryContext::Other(fields)) => fields,
+        other => panic!("expected scrubbed context, got {other:?}"),
+    };
+    assert_eq!(string_field(fields, "incident_id"), "incident-1");
+    assert_eq!(
+        string_field(fields, "workspace_id").len(),
+        MAX_DIAGNOSTIC_STRING_BYTES
+    );
+    match fields.get("active_contexts") {
+        Some(Value::Array(values)) => {
+            assert_eq!(values.len(), MAX_DIAGNOSTIC_COLLECTION_ITEMS)
+        }
+        other => panic!("expected bounded auth contexts, got {other:?}"),
+    }
+    assert!(!fields.contains_key("authorization"));
+    assert!(!fields.contains_key("provider_output"));
+    assert!(!fields.contains_key("customer_name"));
+    assert!(!fields.contains_key("runtime_request:request_id"));
+    assert!(!fields.contains_key("session_flow:flow_id"));
+    assert_eq!(
+        string_field(fields, "session_flow:flow_kind"),
+        "prompt_submit"
+    );
+    assert!(!fields.contains_key("session_flow:flow_source"));
+    assert_eq!(string_field(fields, "session_flow:prompt_id"), "prompt-1");
+
+    assert_eq!(
+        event.tags.get("runtime_env").map(String::as_str),
+        Some("e2b")
+    );
+    assert_eq!(
+        event.tags.get("sandbox_id").map(String::as_str),
+        Some("provider-sandbox-1")
+    );
+    assert!(!event.tags.contains_key("raw_env"));
+    assert!(!event.tags.contains_key("route_url"));
+    assert_eq!(string_field(&event.extra, "catalog_version"), "catalog-1");
+    assert!(!event.extra.contains_key("response_body"));
+
+    let logentry = event.logentry.as_ref().expect("log entry retained");
+    assert!(!logentry.message.contains("/home/customer"));
+    assert!(logentry.params.is_empty());
+    let breadcrumb = &event.breadcrumbs[0];
+    assert!(!breadcrumb
+        .message
+        .as_deref()
+        .expect("breadcrumb message")
+        .contains("child-secret"));
+    assert_eq!(string_field(&breadcrumb.data, "request_id"), "request-1");
+    assert!(!breadcrumb.data.contains_key("stderr"));
+
+    let exception = &event.exception[0];
+    let exception_value = exception.value.as_deref().expect("exception value");
+    assert!(!exception_value.contains("exception-secret"));
+    assert!(!exception_value.contains("/private/var/mobile"));
+    let frame = &exception
+        .stacktrace
+        .as_ref()
+        .expect("stacktrace retained")
+        .frames[0];
+    assert_eq!(frame.filename.as_deref(), Some("[redacted-path]"));
+    assert_eq!(frame.abs_path.as_deref(), Some("[redacted-path]"));
+    assert!(frame.context_line.is_none());
+    assert!(frame.pre_context.is_empty());
+    assert!(frame.post_context.is_empty());
+    assert!(frame.vars.is_empty());
+}
+
+#[test]
+fn transaction_envelopes_are_scrubbed_before_transport() {
+    let mut spans = vec![Span {
+        op: Some("provider /Users/customer/private Basic span-secret".to_string()),
+        description: Some(
+            "request https://runtime.invalid/run?token=span-query-secret".to_string(),
+        ),
+        tags: BTreeMap::from([
+            ("runtime_env".to_string(), "e2b".to_string()),
+            ("request_id".to_string(), "customer@example.com".to_string()),
+            (
+                "flow_id".to_string(),
+                "prompt_submit:1721320000000:abc123".to_string(),
+            ),
+            ("raw_env".to_string(), "private".to_string()),
+        ]),
+        data: BTreeMap::from([
+            (
+                "prompt_id".to_string(),
+                Value::String("prompt-1".to_string()),
+            ),
+            (
+                "flow_source".to_string(),
+                Value::String("prompt submit".to_string()),
+            ),
+            (
+                "provider_output".to_string(),
+                Value::String("raw provider stderr".to_string()),
+            ),
+        ]),
+        ..Default::default()
+    }];
+    spans.extend((0..MAX_TRANSACTION_SPANS).map(|_| Span::default()));
+
+    let transaction = Transaction {
+        name: Some(format!(
+            "POST /Users/customer/private Basic transaction-secret {}",
+            "n".repeat(MAX_DIAGNOSTIC_STRING_BYTES + 64)
+        )),
+        user: Some(User {
+            id: Some("user-1".to_string()),
+            email: Some("customer@example.com".to_string()),
+            username: Some("customer".to_string()),
+            ip_address: Some(Default::default()),
+            other: BTreeMap::from([(
+                "profile".to_string(),
+                Value::String("private profile".to_string()),
+            )]),
+        }),
+        tags: BTreeMap::from([
+            ("runtime_env".to_string(), "e2b".to_string()),
+            ("flow_kind".to_string(), "prompt_submit".to_string()),
+            ("flow_source".to_string(), "sk-ant-private".to_string()),
+            ("raw_env".to_string(), "private".to_string()),
+        ]),
+        extra: BTreeMap::from([
+            (
+                "measurement_operation_id".to_string(),
+                Value::String("mop_test-123".to_string()),
+            ),
+            (
+                "request_id".to_string(),
+                Value::String("r".repeat(MAX_CORRELATION_ID_BYTES + 1)),
+            ),
+            (
+                "request_body".to_string(),
+                Value::String("raw request body".to_string()),
+            ),
+        ]),
+        contexts: BTreeMap::from([(
+            "inherited".to_string(),
+            SentryContext::Other(BTreeMap::from([
+                (
+                    "runtime_request:request_id".to_string(),
+                    Value::String("request-1".to_string()),
+                ),
+                (
+                    "session_flow:flow_id".to_string(),
+                    Value::String("customer@example.com".to_string()),
+                ),
+                (
+                    "session_flow:flow_kind".to_string(),
+                    Value::String("prompt_submit".to_string()),
+                ),
+            ])),
+        )]),
+        request: Some(Request {
+            data: Some("raw transaction request".to_string()),
+            headers: BTreeMap::from([(
+                "authorization".to_string(),
+                "Bearer request-secret".to_string(),
+            )]),
+            ..Default::default()
+        }),
+        server_name: Some("private-customer-hostname".into()),
+        spans,
+        ..Default::default()
+    };
+    let mut raw_envelope = Envelope::new();
+    raw_envelope.add_item(transaction);
+
+    let scrubbed_envelope = envelope(raw_envelope);
+    let transaction = match scrubbed_envelope.items().next() {
+        Some(EnvelopeItem::Transaction(transaction)) => transaction,
+        other => panic!("expected transaction envelope, got {other:?}"),
+    };
+
+    let name = transaction.name.as_deref().expect("transaction name");
+    assert!(name.len() <= MAX_DIAGNOSTIC_STRING_BYTES);
+    assert!(!name.contains("transaction-secret"));
+    assert!(!name.contains("/Users/customer"));
+    assert!(transaction.request.is_none());
+    assert_eq!(transaction.server_name.as_deref(), Some(SAFE_SERVER_NAME));
+
+    let user = transaction.user.as_ref().expect("ID-only user retained");
+    assert_eq!(user.id.as_deref(), Some("user-1"));
+    assert!(user.email.is_none());
+    assert!(user.username.is_none());
+    assert!(user.ip_address.is_none());
+    assert!(user.other.is_empty());
+
+    assert_eq!(
+        transaction.tags.get("runtime_env").map(String::as_str),
+        Some("e2b")
+    );
+    assert_eq!(
+        transaction.tags.get("flow_kind").map(String::as_str),
+        Some("prompt_submit")
+    );
+    assert!(!transaction.tags.contains_key("flow_source"));
+    assert!(!transaction.tags.contains_key("raw_env"));
+    assert_eq!(
+        string_field(&transaction.extra, "measurement_operation_id"),
+        "mop_test-123"
+    );
+    assert!(!transaction.extra.contains_key("request_id"));
+    assert!(!transaction.extra.contains_key("request_body"));
+
+    let inherited = match transaction.contexts.get("inherited") {
+        Some(SentryContext::Other(fields)) => fields,
+        other => panic!("expected inherited context, got {other:?}"),
+    };
+    assert_eq!(
+        string_field(inherited, "runtime_request:request_id"),
+        "request-1"
+    );
+    assert!(!inherited.contains_key("session_flow:flow_id"));
+    assert_eq!(
+        string_field(inherited, "session_flow:flow_kind"),
+        "prompt_submit"
+    );
+
+    assert_eq!(transaction.spans.len(), MAX_TRANSACTION_SPANS);
+    let span = &transaction.spans[0];
+    let op = span.op.as_deref().expect("span op");
+    assert!(!op.contains("span-secret"));
+    assert!(!op.contains("/Users/customer"));
+    assert!(!span
+        .description
+        .as_deref()
+        .expect("span description")
+        .contains("span-query-secret"));
+    assert_eq!(
+        span.tags.get("flow_id").map(String::as_str),
+        Some("prompt_submit:1721320000000:abc123")
+    );
+    assert!(!span.tags.contains_key("request_id"));
+    assert!(!span.tags.contains_key("raw_env"));
+    assert_eq!(string_field(&span.data, "prompt_id"), "prompt-1");
+    assert!(!span.data.contains_key("flow_source"));
+    assert!(!span.data.contains_key("provider_output"));
+}
+
+#[test]
+fn breadcrumb_and_log_scrubbers_keep_only_bounded_safe_fields() {
+    let breadcrumb = breadcrumb(Breadcrumb {
+        message: Some("Bearer breadcrumb-secret at /home/customer/file".to_string()),
+        data: BTreeMap::from([
+            (
+                "incident_id".to_string(),
+                Value::String("incident-1".to_string()),
+            ),
+            (
+                "content".to_string(),
+                Value::String("raw content".to_string()),
+            ),
+        ]),
+        ..Default::default()
+    })
+    .expect("breadcrumb retained");
+    assert_eq!(string_field(&breadcrumb.data, "incident_id"), "incident-1");
+    assert!(!breadcrumb.data.contains_key("content"));
+    let breadcrumb_message = breadcrumb.message.as_deref().expect("breadcrumb message");
+    assert!(!breadcrumb_message.contains("breadcrumb-secret"));
+    assert!(!breadcrumb_message.contains("/home/customer"));
+
+    let log = log(Log {
+        level: LogLevel::Error,
+        body: "Bearer log-secret at /Users/customer/file".to_string(),
+        trace_id: None,
+        timestamp: SystemTime::now(),
+        severity_number: None,
+        attributes: BTreeMap::from([
+            ("requested_model".to_string(), "haiku".to_string().into()),
+            (
+                "flow_id".to_string(),
+                "prompt_submit:1721320000000:abc123".to_string().into(),
+            ),
+            (
+                "request_id".to_string(),
+                "customer@example.com".to_string().into(),
+            ),
+            (
+                "provider_output".to_string(),
+                "raw provider output".to_string().into(),
+            ),
+            (
+                "arbitrary".to_string(),
+                "non-ID user data".to_string().into(),
+            ),
+        ]),
+    })
+    .expect("log retained");
+    assert!(!log.body.contains("log-secret"));
+    assert!(!log.body.contains("/Users/customer"));
+    match log.attributes.get("requested_model") {
+        Some(attribute) => assert_eq!(attribute.0, Value::String("haiku".to_string())),
+        None => panic!("requested model must survive"),
+    }
+    match log.attributes.get("flow_id") {
+        Some(attribute) => assert_eq!(
+            attribute.0,
+            Value::String("prompt_submit:1721320000000:abc123".to_string())
+        ),
+        None => panic!("valid flow ID must survive"),
+    }
+    assert!(!log.attributes.contains_key("request_id"));
+    assert!(!log.attributes.contains_key("provider_output"));
+    assert!(!log.attributes.contains_key("arbitrary"));
+}

--- a/anyharness/crates/anyharness/src/telemetry/tests.rs
+++ b/anyharness/crates/anyharness/src/telemetry/tests.rs
@@ -1,11 +1,11 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use sentry::protocol::{Breadcrumb, Context as SentryContext, User, Value};
+use sentry::protocol::{Breadcrumb, Context as SentryContext, SpanId, TraceId, User, Value};
 
 use super::{
     default_release, log_path_for_command, runtime_home_from_install, runtime_home_from_serve,
-    scrub, sentry_event_filter_for_target, sentry_event_mapper, sentry_scope_tags,
-    sentry_user_from_id, stamped_git_sha, RUNTIME_INCIDENT_FINGERPRINT,
+    scrub, sentry_event_filter, sentry_event_filter_for_target, sentry_event_mapper,
+    sentry_scope_tags, sentry_user_from_id, stamped_git_sha, RUNTIME_INCIDENT_FINGERPRINT,
 };
 use crate::{
     cli::Commands,
@@ -63,6 +63,83 @@ fn tracing_error_reaches_the_sentry_client() {
         .fingerprint
         .iter()
         .all(|part| part.as_ref() != RUNTIME_INCIDENT_FINGERPRINT));
+}
+
+fn emit_ordinary_error_inside_span() -> (TraceId, SpanId) {
+    let request_span = tracing::info_span!("ordinary_request", request_id = "request-1");
+    let _request_guard = request_span.enter();
+    let operation_span = tracing::info_span!("ordinary_operation", operation_id = "operation-1");
+    let _operation_guard = operation_span.enter();
+
+    let active_span = sentry::configure_scope(|scope| scope.get_span())
+        .expect("tracing span must install an active Sentry span");
+    let trace_context = active_span.get_trace_context();
+    let span_id = match &active_span {
+        sentry::TransactionOrSpan::Transaction(_) => trace_context.span_id,
+        sentry::TransactionOrSpan::Span(span) => span.get_span_id(),
+    };
+    let active_identity = (trace_context.trace_id, span_id);
+
+    tracing::error!(error_code = "ORDINARY_FAILURE", "ordinary runtime failure");
+    active_identity
+}
+
+#[test]
+fn ordinary_error_retains_pre_mapper_span_attribute_behavior() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let old_filter_subscriber = tracing_subscriber::registry()
+        .with(sentry_tracing::layer().event_filter(sentry_event_filter));
+    let mut old_active_identity = None;
+    let old_events = sentry::test::with_captured_events_options(
+        || {
+            tracing::subscriber::with_default(old_filter_subscriber, || {
+                old_active_identity = Some(emit_ordinary_error_inside_span());
+            });
+        },
+        sentry_test_options(),
+    );
+
+    let mapper_subscriber = tracing_subscriber::registry()
+        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
+    let mut mapper_active_identity = None;
+    let mapper_events = sentry::test::with_captured_events_options(
+        || {
+            tracing::subscriber::with_default(mapper_subscriber, || {
+                mapper_active_identity = Some(emit_ordinary_error_inside_span());
+            });
+        },
+        sentry_test_options(),
+    );
+
+    assert_eq!(old_events.len(), 1);
+    assert_eq!(mapper_events.len(), 1);
+    let old_trace = match old_events[0].contexts.get("trace") {
+        Some(SentryContext::Trace(trace)) => trace,
+        other => panic!("expected old-filter trace context, got {other:?}"),
+    };
+    let mapper_trace = match mapper_events[0].contexts.get("trace") {
+        Some(SentryContext::Trace(trace)) => trace,
+        other => panic!("expected mapper trace context, got {other:?}"),
+    };
+    assert_eq!(
+        (old_trace.trace_id, old_trace.span_id),
+        old_active_identity.expect("old-filter active identity")
+    );
+    assert_eq!(
+        (mapper_trace.trace_id, mapper_trace.span_id),
+        mapper_active_identity.expect("mapper active identity")
+    );
+    let old_fields = old_events[0].contexts.get("Rust Tracing Fields");
+    let mapper_fields = mapper_events[0].contexts.get("Rust Tracing Fields");
+    assert_eq!(mapper_fields, old_fields);
+    let fields = match mapper_fields {
+        Some(SentryContext::Other(fields)) => fields,
+        other => panic!("expected ordinary event fields, got {other:?}"),
+    };
+    assert_eq!(string_field(fields, "error_code"), "ORDINARY_FAILURE");
+    assert!(!fields.contains_key("ordinary_request:request_id"));
+    assert!(!fields.contains_key("ordinary_operation:operation_id"));
 }
 
 #[test]

--- a/anyharness/crates/anyharness/src/telemetry/tests.rs
+++ b/anyharness/crates/anyharness/src/telemetry/tests.rs
@@ -1,0 +1,347 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use sentry::protocol::{Breadcrumb, Context as SentryContext, User, Value};
+
+use super::{
+    default_release, log_path_for_command, runtime_home_from_install, runtime_home_from_serve,
+    scrub, sentry_event_filter_for_target, sentry_event_mapper, sentry_scope_tags,
+    sentry_user_from_id, stamped_git_sha, RUNTIME_INCIDENT_FINGERPRINT,
+};
+use crate::{
+    cli::Commands,
+    commands::{install_agents::InstallAgentsArgs, serve::ServeArgs},
+};
+use anyharness_lib::observability::{AGENT_STDERR_TRACING_TARGET, RUNTIME_INCIDENT_TRACING_TARGET};
+
+fn sentry_test_options() -> sentry::ClientOptions {
+    sentry::ClientOptions {
+        release: Some("anyharness@test".into()),
+        environment: Some("test".into()),
+        traces_sample_rate: 1.0,
+        send_default_pii: false,
+        before_send: Some(Arc::new(scrub::event)),
+        before_breadcrumb: Some(Arc::new(scrub::breadcrumb)),
+        before_send_log: Some(Arc::new(scrub::log)),
+        ..Default::default()
+    }
+}
+
+fn string_field<'a>(fields: &'a BTreeMap<String, Value>, key: &str) -> &'a str {
+    match fields.get(key) {
+        Some(Value::String(value)) => value,
+        other => panic!("expected string field {key}, got {other:?}"),
+    }
+}
+
+#[test]
+fn tracing_error_reaches_the_sentry_client() {
+    // Regression (B2 amendment): PR #684 bumped `sentry` to 0.48 while
+    // `sentry-tracing` stayed at 0.47, linking two `sentry-core` instances.
+    // The tracing layer then captured events into the 0.47 Hub — which has
+    // no client — so every runtime ERROR event was silently dropped in
+    // production from 2026-06-14. This test binds a test client to the same
+    // `sentry-core` the layer uses; it fails (0 events) whenever the two
+    // crates diverge again.
+    use tracing_subscriber::layer::SubscriberExt;
+    let subscriber = tracing_subscriber::registry()
+        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
+    let events = sentry::test::with_captured_events_options(
+        || {
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::error!("sentry emission regression probe");
+            });
+        },
+        sentry_test_options(),
+    );
+    assert_eq!(
+        events.len(),
+        1,
+        "tracing ERROR must reach the Sentry client"
+    );
+    assert_eq!(events[0].level, sentry::Level::Error);
+    assert!(events[0]
+        .fingerprint
+        .iter()
+        .all(|part| part.as_ref() != RUNTIME_INCIDENT_FINGERPRINT));
+}
+
+#[test]
+fn agent_stderr_stays_out_of_sentry_while_runtime_errors_remain_visible() {
+    use tracing_subscriber::layer::SubscriberExt;
+    let subscriber = tracing_subscriber::registry()
+        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
+    let events = sentry::test::with_captured_events_options(
+        || {
+            tracing::subscriber::with_default(subscriber, || {
+                tracing::error!(
+                    target: AGENT_STDERR_TRACING_TARGET,
+                    "raw child-process stderr"
+                );
+                tracing::error!("ordinary runtime failure");
+            });
+        },
+        sentry_test_options(),
+    );
+
+    assert_eq!(events.len(), 1, "agent stderr must be ignored by Sentry");
+    assert_eq!(
+        events[0].message.as_deref(),
+        Some("ordinary runtime failure")
+    );
+}
+
+#[test]
+fn runtime_incident_reaches_sentry_once_with_stable_scrubbed_context() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let subscriber = tracing_subscriber::registry()
+        .with(sentry_tracing::layer().event_mapper(sentry_event_mapper));
+    let events = sentry::test::with_captured_events_options(
+        || {
+            tracing::subscriber::with_default(subscriber, || {
+                sentry::configure_scope(|scope| {
+                    scope.set_tag("runtime_env", "e2b");
+                    scope.set_tag("org_id", "org-1");
+                    scope.set_tag("sandbox_id", "provider-sandbox-1");
+                    scope.set_tag("target_id", "cloud-sandbox-1");
+                    scope.set_user(Some(User {
+                        id: Some("user-1".to_string()),
+                        email: Some("private@example.com".to_string()),
+                        ..Default::default()
+                    }));
+                });
+                sentry::add_breadcrumb(Breadcrumb {
+                    message: Some(
+                        "request at /Users/customer/private.txt with Bearer breadcrumb-secret"
+                            .to_string(),
+                    ),
+                    data: BTreeMap::from([
+                        (
+                            "request_id".to_string(),
+                            Value::String("request-1".to_string()),
+                        ),
+                        (
+                            "request_body".to_string(),
+                            Value::String("raw prompt".to_string()),
+                        ),
+                    ]),
+                    ..Default::default()
+                });
+
+                let request_span = tracing::info_span!(
+                    "runtime_request",
+                    request_id = "request-1",
+                    authorization = "Bearer span-secret",
+                    request_body = "raw request prompt"
+                );
+                let _request_guard = request_span.enter();
+                let flow_span =
+                    tracing::info_span!("session_flow", flow_id = "flow-1", prompt_id = "prompt-1");
+                let _flow_guard = flow_span.enter();
+
+                tracing::error!(
+                    target: RUNTIME_INCIDENT_TRACING_TARGET,
+                    incident_id = "incident-1",
+                    error_code = "SESSION_MODEL_GATED",
+                    fingerprint = "anyharness:session_model_gated",
+                    workspace_id = "workspace-1",
+                    attempted_session_id = "session-1",
+                    agent_kind = "claude",
+                    requested_model = "haiku",
+                    canonical_model = "claude-haiku-4-5",
+                    active_contexts = "anthropic-api-key",
+                    required_contexts = "anthropic-api-key",
+                    catalog_version = "catalog-1",
+                    selection_outcome = "model_gated",
+                    effective_model = "none",
+                    effective_route = "none",
+                    provider_output = "raw provider secret",
+                    "handled runtime incident"
+                );
+            });
+        },
+        sentry_test_options(),
+    );
+
+    assert_eq!(events.len(), 1, "one request owns one runtime incident");
+    let event = &events[0];
+    assert_eq!(event.level, sentry::Level::Error);
+    assert_eq!(
+        event.logger.as_deref(),
+        Some(RUNTIME_INCIDENT_TRACING_TARGET)
+    );
+    assert_eq!(event.message.as_deref(), Some("handled runtime incident"));
+    assert_eq!(event.release.as_deref(), Some("anyharness@test"));
+    assert_eq!(event.environment.as_deref(), Some("test"));
+    assert_eq!(event.fingerprint.len(), 1);
+    assert_eq!(event.fingerprint[0].as_ref(), RUNTIME_INCIDENT_FINGERPRINT);
+
+    let fields = match event.contexts.get("Rust Tracing Fields") {
+        Some(SentryContext::Other(fields)) => fields,
+        other => panic!("expected tracing fields context, got {other:?}"),
+    };
+    assert_eq!(string_field(fields, "incident_id"), "incident-1");
+    assert_eq!(string_field(fields, "error_code"), "SESSION_MODEL_GATED");
+    assert_eq!(
+        string_field(fields, "fingerprint"),
+        RUNTIME_INCIDENT_FINGERPRINT
+    );
+    assert_eq!(string_field(fields, "workspace_id"), "workspace-1");
+    assert_eq!(string_field(fields, "attempted_session_id"), "session-1");
+    assert_eq!(string_field(fields, "requested_model"), "haiku");
+    assert_eq!(string_field(fields, "canonical_model"), "claude-haiku-4-5");
+    assert_eq!(string_field(fields, "effective_model"), "none");
+    assert_eq!(string_field(fields, "effective_route"), "none");
+    assert_eq!(
+        string_field(fields, "runtime_request:request_id"),
+        "request-1"
+    );
+    assert_eq!(string_field(fields, "session_flow:flow_id"), "flow-1");
+    assert_eq!(string_field(fields, "session_flow:prompt_id"), "prompt-1");
+    assert!(!fields.contains_key("provider_output"));
+    assert!(!fields.contains_key("runtime_request:authorization"));
+    assert!(!fields.contains_key("runtime_request:request_body"));
+
+    assert_eq!(
+        event.tags.get("runtime_env").map(String::as_str),
+        Some("e2b")
+    );
+    assert_eq!(event.tags.get("org_id").map(String::as_str), Some("org-1"));
+    assert_eq!(
+        event.tags.get("sandbox_id").map(String::as_str),
+        Some("provider-sandbox-1")
+    );
+    assert_eq!(
+        event.tags.get("target_id").map(String::as_str),
+        Some("cloud-sandbox-1")
+    );
+    let user = event.user.as_ref().expect("ID-only user context");
+    assert_eq!(user.id.as_deref(), Some("user-1"));
+    assert!(user.email.is_none());
+
+    assert_eq!(event.breadcrumbs.len(), 1);
+    let breadcrumb = &event.breadcrumbs[0];
+    let message = breadcrumb.message.as_deref().expect("breadcrumb message");
+    assert!(!message.contains("breadcrumb-secret"));
+    assert!(!message.contains("/Users/customer"));
+    assert_eq!(string_field(&breadcrumb.data, "request_id"), "request-1");
+    assert!(!breadcrumb.data.contains_key("request_body"));
+}
+
+#[test]
+fn agent_stderr_filter_ignores_every_sentry_signal_type() {
+    let all_signal_types = sentry_tracing::EventFilter::Event
+        | sentry_tracing::EventFilter::Breadcrumb
+        | sentry_tracing::EventFilter::Log;
+
+    let filter = sentry_event_filter_for_target(AGENT_STDERR_TRACING_TARGET, all_signal_types);
+
+    assert!(
+        filter.is_empty(),
+        "agent stderr must map to EventFilter::Ignore"
+    );
+}
+
+#[test]
+fn sentry_scope_tags_include_runtime_surface_and_mode() {
+    let tags = sentry_scope_tags();
+    assert!(tags
+        .iter()
+        .any(|(k, v)| *k == "surface" && v == "anyharness_runtime"));
+    assert!(tags
+        .iter()
+        .any(|(k, v)| *k == "telemetry_mode" && v == "hosted_product"));
+    assert!(tags
+        .iter()
+        .any(|(k, v)| *k == "runtime_env" && !v.is_empty()));
+}
+
+#[test]
+fn default_release_is_canonical_for_this_component() {
+    let release = default_release();
+    assert!(release.starts_with("anyharness@"), "{release}");
+    let expected = match stamped_git_sha() {
+        Some(sha) => {
+            assert_eq!(sha.len(), 12);
+            format!("anyharness@{}+{sha}", env!("PROLIFERATE_STAMPED_VERSION"))
+        }
+        None => format!("anyharness@{}", env!("PROLIFERATE_STAMPED_VERSION")),
+    };
+    assert_eq!(release, expected);
+}
+
+#[test]
+fn sentry_user_context_is_id_only_and_trimmed() {
+    let user = sentry_user_from_id(Some("  user-1  ")).expect("user present");
+    assert_eq!(user.id.as_deref(), Some("user-1"));
+    assert!(user.email.is_none());
+    assert!(sentry_user_from_id(None).is_none());
+    assert!(sentry_user_from_id(Some("   ")).is_none());
+}
+
+#[test]
+fn serve_runtime_home_uses_override_when_present() {
+    let args = ServeArgs {
+        host: "127.0.0.1".to_string(),
+        port: 8457,
+        runtime_home: Some("/tmp/anyharness-test".to_string()),
+        require_bearer_auth: false,
+        disable_cors: false,
+    };
+
+    assert_eq!(
+        runtime_home_from_serve(&args).to_string_lossy(),
+        "/tmp/anyharness-test"
+    );
+}
+
+#[test]
+fn install_runtime_home_uses_override_when_present() {
+    let args = InstallAgentsArgs {
+        runtime_home: Some("/tmp/anyharness-install".to_string()),
+        reinstall: false,
+        agents: Vec::new(),
+    };
+
+    assert_eq!(
+        runtime_home_from_install(&args).to_string_lossy(),
+        "/tmp/anyharness-install"
+    );
+}
+
+#[test]
+fn print_openapi_has_no_file_log_path() {
+    assert!(log_path_for_command(&Commands::PrintOpenapi).is_none());
+}
+
+#[test]
+fn serve_command_log_path_lands_under_runtime_home_logs() {
+    let path = log_path_for_command(&Commands::Serve(ServeArgs {
+        host: "127.0.0.1".to_string(),
+        port: 8457,
+        runtime_home: Some("/tmp/anyharness-serve".to_string()),
+        require_bearer_auth: false,
+        disable_cors: false,
+    }))
+    .expect("serve should use file logging");
+
+    assert_eq!(
+        path.to_string_lossy(),
+        "/tmp/anyharness-serve/logs/anyharness.log"
+    );
+}
+
+#[test]
+fn install_command_log_path_lands_under_runtime_home_logs() {
+    let path = log_path_for_command(&Commands::InstallAgents(InstallAgentsArgs {
+        runtime_home: Some("/tmp/anyharness-install".to_string()),
+        reinstall: false,
+        agents: Vec::new(),
+    }))
+    .expect("install should use file logging");
+
+    assert_eq!(
+        path.to_string_lossy(),
+        "/tmp/anyharness-install/logs/anyharness.log"
+    );
+}

--- a/anyharness/sdk/src/client/core.test.ts
+++ b/anyharness/sdk/src/client/core.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AnyHarnessError,
   AnyHarnessTransport,
+  hasAnyHarnessRuntimeIncidentReceipt,
   toAnyHarnessTelemetryError,
 } from "./core.js";
 
@@ -191,6 +192,133 @@ describe("AnyHarnessTransport problem details", () => {
     expect((telemetryError as Error).stack).not.toContain(rawTail);
     expect(JSON.stringify(telemetryError)).not.toContain(rawTail);
   });
+
+  it("parses an exact runtime incident receipt through a wrapping cause chain", async () => {
+    const cause = await requestError(problemResponse({
+      type: "about:blank",
+      title: "Model gated",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+      instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    }, 400));
+    const wrapper = new Error("Failed to open chat", { cause });
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(wrapper)).toBe(true);
+  });
+
+  it.each([
+    ["missing instance", undefined],
+    ["null instance", null],
+    ["legacy path instance", "/v1/sessions/session-1"],
+    [
+      "foreign namespace",
+      "urn:proliferate:server:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    ],
+    ["missing UUID", "urn:proliferate:anyharness:incident:"],
+    ["malformed UUID", "urn:proliferate:anyharness:incident:not-a-uuid"],
+    [
+      "nil UUID",
+      "urn:proliferate:anyharness:incident:00000000-0000-0000-0000-000000000000",
+    ],
+    [
+      "UUIDv1",
+      "urn:proliferate:anyharness:incident:8fd6ea9a-1246-1ef0-a526-9cc5f86ed960",
+    ],
+    [
+      "non-RFC variant",
+      "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-7526-9cc5f86ed960",
+    ],
+    [
+      "uppercase UUID",
+      "urn:proliferate:anyharness:incident:8FD6EA9A-1246-4EF0-A526-9CC5F86ED960",
+    ],
+    [
+      "receipt suffix",
+      "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960?delivered=true",
+    ],
+  ])("rejects a runtime incident receipt with %s", (_name, instance) => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Request failed",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+      ...(instance === undefined ? {} : { instance }),
+    });
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(error)).toBe(false);
+  });
+
+  it("finds a valid receipt behind a nonmatching AnyHarness error", () => {
+    const receipt = new AnyHarnessError({
+      type: "about:blank",
+      title: "Model gated",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+      instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    });
+    const outer = new AnyHarnessError({
+      type: "about:blank",
+      title: "Outer runtime failure",
+      status: 500,
+      instance: "/legacy/instance",
+    }, receipt);
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(outer)).toBe(true);
+  });
+
+  it("fails closed when a receipt-bearing cause chain contains a cycle", () => {
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Model gated",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+      instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    });
+    (error as Error & { cause?: unknown }).cause = error;
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(error)).toBe(false);
+  });
+
+  it("accepts a receipt within the bounded cause-chain depth", () => {
+    let error: Error = runtimeIncidentError();
+    for (let depth = 1; depth < 8; depth += 1) {
+      error = new Error(`wrapper ${depth}`, { cause: error });
+    }
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(error)).toBe(true);
+  });
+
+  it("fails closed when the cause chain exceeds the bounded depth", () => {
+    let error: Error = runtimeIncidentError();
+    for (let depth = 0; depth < 8; depth += 1) {
+      error = new Error(`wrapper ${depth}`, { cause: error });
+    }
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(error)).toBe(false);
+  });
+
+  it("fails closed when reading a cause throws", () => {
+    const error = runtimeIncidentError();
+    Object.defineProperty(error, "cause", {
+      configurable: true,
+      get() {
+        throw new Error("cause access failed");
+      },
+    });
+
+    expect(() => hasAnyHarnessRuntimeIncidentReceipt(error)).not.toThrow();
+    expect(hasAnyHarnessRuntimeIncidentReceipt(error)).toBe(false);
+  });
+
+  it("rejects a matching-looking receipt outside an AnyHarness error", () => {
+    const error = Object.assign(new Error("foreign failure"), {
+      problem: {
+        instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+      },
+    });
+
+    expect(hasAnyHarnessRuntimeIncidentReceipt(error)).toBe(false);
+  });
 });
 
 async function requestError(response: Response): Promise<AnyHarnessError> {
@@ -218,5 +346,15 @@ function problemResponse(
     status,
     statusText,
     headers: { "content-type": "application/problem+json" },
+  });
+}
+
+function runtimeIncidentError(): AnyHarnessError {
+  return new AnyHarnessError({
+    type: "about:blank",
+    title: "Model gated",
+    status: 400,
+    code: "SESSION_MODEL_GATED",
+    instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
   });
 }

--- a/anyharness/sdk/src/client/core.ts
+++ b/anyharness/sdk/src/client/core.ts
@@ -179,6 +179,49 @@ export class AnyHarnessError extends Error {
 }
 
 const TELEMETRY_SAFE_PROBLEM_CODE = /^[A-Z][A-Z0-9_]{0,63}$/;
+const ANYHARNESS_RUNTIME_INCIDENT_INSTANCE =
+  /^urn:proliferate:anyharness:incident:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const MAX_ERROR_CAUSE_CHAIN_DEPTH = 8;
+
+/**
+ * Whether an AnyHarness request error (or an Error wrapping one) carries the
+ * runtime-owned incident receipt returned through RFC 7807 `instance`.
+ *
+ * The receipt is correlation only: its exact namespace and canonical UUID
+ * shape identify the runtime as the exception owner, without claiming that a
+ * telemetry vendor accepted the corresponding event.
+ */
+export function hasAnyHarnessRuntimeIncidentReceipt(error: unknown): boolean {
+  let current = error;
+  let foundReceipt = false;
+  const seen = new Set<Error>();
+
+  for (let depth = 0; depth < MAX_ERROR_CAUSE_CHAIN_DEPTH; depth += 1) {
+    if (!(current instanceof Error) || seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
+
+    if (
+      current instanceof AnyHarnessError
+      && typeof current.problem.instance === "string"
+      && ANYHARNESS_RUNTIME_INCIDENT_INSTANCE.test(current.problem.instance)
+    ) {
+      foundReceipt = true;
+    }
+
+    const cause = readErrorCause(current);
+    if (!cause.ok) {
+      return false;
+    }
+    if (cause.value == null) {
+      return foundReceipt;
+    }
+    current = cause.value;
+  }
+
+  return false;
+}
 
 /**
  * Replace an AnyHarness request error (or an Error wrapping one) with a
@@ -212,7 +255,11 @@ export function toAnyHarnessTelemetryError(error: unknown): unknown {
 function findAnyHarnessError(error: unknown): AnyHarnessError | null {
   let current = error;
   const seen = new Set<unknown>();
-  for (let depth = 0; depth < 8 && current != null; depth += 1) {
+  for (
+    let depth = 0;
+    depth < MAX_ERROR_CAUSE_CHAIN_DEPTH && current != null;
+    depth += 1
+  ) {
     if (current instanceof AnyHarnessError) {
       return current;
     }
@@ -220,9 +267,26 @@ function findAnyHarnessError(error: unknown): AnyHarnessError | null {
       return null;
     }
     seen.add(current);
-    current = (current as Error & { cause?: unknown }).cause;
+    const cause = readErrorCause(current);
+    if (!cause.ok) {
+      return null;
+    }
+    current = cause.value;
   }
   return null;
+}
+
+function readErrorCause(
+  error: Error,
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return {
+      ok: true,
+      value: (error as Error & { cause?: unknown }).cause,
+    };
+  } catch {
+    return { ok: false };
+  }
 }
 
 export class AnyHarnessTransport {

--- a/anyharness/sdk/src/client/core.ts
+++ b/anyharness/sdk/src/client/core.ts
@@ -190,6 +190,10 @@ const MAX_ERROR_CAUSE_CHAIN_DEPTH = 8;
  * The receipt is correlation only: its exact namespace and canonical UUID
  * shape identify the runtime as the exception owner, without claiming that a
  * telemetry vendor accepted the corresponding event.
+ *
+ * Validation covers the entire bounded cause chain and fails closed if any
+ * later cause is not an Error, repeats, cannot be read, or exceeds the depth
+ * limit, even when an earlier error carries a valid receipt.
  */
 export function hasAnyHarnessRuntimeIncidentReceipt(error: unknown): boolean {
   let current = error;

--- a/anyharness/sdk/src/index.ts
+++ b/anyharness/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export {
   AnyHarnessClient,
   AnyHarnessError,
+  hasAnyHarnessRuntimeIncidentReceipt,
   hashTimingScope,
   setAnyHarnessTimingObserver,
   toAnyHarnessTelemetryError,

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.test.tsx
@@ -1,9 +1,9 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CoworkThread } from "@anyharness/sdk";
+import { AnyHarnessError, type CoworkThread } from "@anyharness/sdk";
 import { CoworkThreadsSection } from "#product/components/workspace/cowork/sidebar/CoworkThreadsSection";
 import {
   buildPendingWorkspaceUiKey,
@@ -153,6 +153,25 @@ describe("CoworkThreadsSection", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("consumes receipt-bearing create failures at the intentional UI boundary", async () => {
+    const rejection = Promise.reject(new AnyHarnessError({
+      type: "about:blank",
+      title: "Model is not available",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+      instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    }));
+    const catchSpy = vi.spyOn(rejection, "catch");
+    coworkState.createThread.mockReturnValueOnce(rejection);
+    render(<CoworkThreadsSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start a new thread" }));
+
+    expect(coworkState.createThread).toHaveBeenCalledOnce();
+    expect(catchSpy).toHaveBeenCalledOnce();
+    await Promise.resolve();
   });
 
   it("shows a pending cowork thread while the real thread list loads", () => {

--- a/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkThreadsSection.tsx
@@ -118,7 +118,7 @@ export function CoworkThreadsSection() {
             </SidebarActionButton>
           )}
           <SidebarActionButton
-            onClick={() => { void createThread(); }}
+            onClick={() => { void createThread().catch(() => undefined); }}
             disabled={isCreatingThread}
             title="Start a new thread"
             variant="section"

--- a/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.test.ts
@@ -27,6 +27,9 @@ const ENTRY: PendingEmptySessionCreation = {
   createdAt: 42,
 };
 
+const VALID_RUNTIME_INCIDENT_RECEIPT =
+  "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960";
+
 describe("pending empty-session creation", () => {
   it("prepares and persists the bundled-local lifecycle with frozen inputs", async () => {
     const context = memoryStorageContext();
@@ -144,6 +147,84 @@ describe("pending empty-session creation", () => {
     });
   });
 
+  it("suppresses recovery capture for a cause-wrapped runtime incident receipt", async () => {
+    const captureException = vi.fn();
+    const context = memoryStorageContext(captureException);
+    await persistPendingEmptySessionCreation(context, ENTRY);
+    const runtimeError = new AnyHarnessError({
+      type: "about:blank",
+      title: "Model is not available",
+      status: 400,
+      detail: "caller-facing gated-model detail",
+      code: "SESSION_MODEL_GATED",
+      instance: VALID_RUNTIME_INCIDENT_RECEIPT,
+    });
+    const wrappedError = Object.assign(new Error("resume failed"), {
+      cause: runtimeError,
+    });
+
+    await expect(resumePendingEmptySessionCreations(
+      context,
+      ENTRY.workspaceId,
+      () => true,
+      async () => { throw wrappedError; },
+    )).resolves.toEqual({ resumed: 0, unresolved: 1 });
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a legacy runtime without a receipt", undefined],
+    ["a malformed receipt", "urn:proliferate:anyharness:incident:not-a-uuid"],
+    [
+      "a foreign receipt",
+      "urn:proliferate:server:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    ],
+  ])("keeps sanitized recovery capture for %s", async (_name, instance) => {
+    const captureException = vi.fn();
+    const context = memoryStorageContext(captureException);
+    await persistPendingEmptySessionCreation(context, ENTRY);
+    const rawDetail = "caller-facing provider detail";
+    const runtimeError = new AnyHarnessError({
+      type: "about:blank",
+      title: "Model is not available",
+      status: 400,
+      detail: rawDetail,
+      code: "SESSION_MODEL_GATED",
+      instance,
+    });
+    const wrappedError = Object.assign(new Error("resume failed"), {
+      cause: runtimeError,
+    });
+
+    await expect(resumePendingEmptySessionCreations(
+      context,
+      ENTRY.workspaceId,
+      () => true,
+      async () => { throw wrappedError; },
+    )).resolves.toEqual({ resumed: 0, unresolved: 1 });
+
+    expect(captureException).toHaveBeenCalledOnce();
+    const [capturedError, captureContext] = captureException.mock.calls[0];
+    expect(capturedError).toMatchObject({
+      name: "AnyHarnessError",
+      message: "AnyHarness request failed (SESSION_MODEL_GATED)",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+    });
+    expect(capturedError).not.toBe(wrappedError);
+    expect("problem" in capturedError).toBe(false);
+    expect("cause" in capturedError).toBe(false);
+    expect(capturedError.stack).not.toContain(rawDetail);
+    expect(JSON.stringify(capturedError)).not.toContain(rawDetail);
+    expect(captureContext).toEqual({
+      tags: {
+        domain: "pending_empty_session_creation",
+        action: "resume",
+      },
+    });
+  });
+
   it("serializes concurrent writes so separate empty tabs are not lost", async () => {
     const context = memoryStorageContext();
     const second: PendingEmptySessionCreation = {
@@ -239,7 +320,9 @@ describe("pending empty-session creation", () => {
   });
 });
 
-function memoryStorageContext(): ProductStorageContext {
+function memoryStorageContext(
+  captureException: ProductStorageContext["captureException"] = vi.fn(),
+): ProductStorageContext {
   const values = new Map<string, string>();
   const storage: ProductStorage = {
     getItem: async (key) => values.get(key) ?? null,
@@ -250,5 +333,5 @@ function memoryStorageContext(): ProductStorageContext {
       values.delete(key);
     },
   };
-  return { storage, captureException: vi.fn() };
+  return { storage, captureException };
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/pending-empty-session-creation.ts
@@ -1,4 +1,8 @@
-import { AnyHarnessError } from "@anyharness/sdk";
+import {
+  AnyHarnessError,
+  hasAnyHarnessRuntimeIncidentReceipt,
+  toAnyHarnessTelemetryError,
+} from "@anyharness/sdk";
 import type { ProductStorageContext } from "#product/lib/infra/persistence/product-storage";
 import type { CreateEmptySessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
 import { supportsCallerSelectedSessionCreate } from "#product/lib/access/anyharness/caller-selected-session-create";
@@ -59,8 +63,11 @@ function captureStorageFailure(
   error: unknown,
   action: "read" | "write" | "remove" | "resume",
 ): void {
+  if (hasAnyHarnessRuntimeIncidentReceipt(error)) {
+    return;
+  }
   try {
-    const captured = context.captureException(error, {
+    const captured = context.captureException(toAnyHarnessTelemetryError(error), {
       tags: {
         domain: "pending_empty_session_creation",
         action,

--- a/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.test.tsx
+++ b/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.test.tsx
@@ -110,6 +110,60 @@ describe("useProductTelemetry", () => {
     });
   });
 
+  it("suppresses explicit capture when the runtime returned a valid incident receipt", () => {
+    const telemetry = spyTelemetry();
+    const { result } = renderFacade(telemetry);
+    const cause = new AnyHarnessError({
+      type: "about:blank",
+      title: "Model gated",
+      status: 400,
+      detail: "caller-visible gating detail",
+      code: "SESSION_MODEL_GATED",
+      instance: "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    });
+
+    const error = Object.assign(new Error("Failed to open chat"), { cause });
+
+    result.current.captureException(error, {
+      tags: { action: "create_session_with_resolved_config" },
+    });
+
+    expect(telemetry.captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an old runtime without a receipt", undefined],
+    ["a malformed receipt", "urn:proliferate:anyharness:incident:not-a-uuid"],
+    [
+      "a foreign receipt",
+      "urn:proliferate:server:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    ],
+  ])("keeps explicit host capture for %s", (_name, instance) => {
+    const telemetry = spyTelemetry();
+    const { result } = renderFacade(telemetry);
+    const error = new AnyHarnessError({
+      type: "about:blank",
+      title: "Model gated",
+      status: 400,
+      detail: "caller-visible gating detail",
+      code: "SESSION_MODEL_GATED",
+      ...(instance === undefined ? {} : { instance }),
+    });
+
+    result.current.captureException(error);
+
+    expect(telemetry.captureException).toHaveBeenCalledTimes(1);
+    const [capturedError] = vi.mocked(telemetry.captureException).mock.calls[0];
+    expect(capturedError).toMatchObject({
+      name: "AnyHarnessError",
+      message: "AnyHarness request failed (SESSION_MODEL_GATED)",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+    });
+    expect("problem" in (capturedError as object)).toBe(false);
+    expect("cause" in (capturedError as object)).toBe(false);
+  });
+
   it("returns a stable adapter identity while the host is unchanged", () => {
     const telemetry = spyTelemetry();
     const { result, rerender } = renderFacade(telemetry);

--- a/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.ts
+++ b/apps/packages/product-client/src/hooks/telemetry/facade/use-product-telemetry.ts
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
-import { toAnyHarnessTelemetryError } from "@anyharness/sdk";
+import {
+  hasAnyHarnessRuntimeIncidentReceipt,
+  toAnyHarnessTelemetryError,
+} from "@anyharness/sdk";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import type {
   ErrorContext,
@@ -54,6 +57,9 @@ export function useProductTelemetry(): ProductTelemetryFacade {
         });
       },
       captureException(error, context) {
+        if (hasAnyHarnessRuntimeIncidentReceipt(error)) {
+          return;
+        }
         telemetry.captureException(toAnyHarnessTelemetryError(error), context);
       },
       setUser(user) {

--- a/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
@@ -48,6 +48,20 @@ async function runFailingQuery(
   })).rejects.toBe(error);
 }
 
+function modelGatedError(instance?: string): AnyHarnessError {
+  return new AnyHarnessError({
+    type: "about:blank",
+    title: "Model gated",
+    status: 400,
+    detail: "caller-visible gating detail",
+    code: "SESSION_MODEL_GATED",
+    ...(instance === undefined ? {} : { instance }),
+  });
+}
+
+const VALID_RUNTIME_INCIDENT_RECEIPT =
+  "urn:proliferate:anyharness:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960";
+
 describe("createAppQueryClient query telemetry", () => {
   it.each([
     ["AbortError", new DOMException("Aborted", "AbortError")],
@@ -204,6 +218,49 @@ describe("createAppQueryClient query telemetry", () => {
     });
   });
 
+  it("suppresses global query capture for a cause-wrapped runtime incident receipt", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const cause = modelGatedError(VALID_RUNTIME_INCIDENT_RECEIPT);
+    const error = Object.assign(new Error("Failed to open chat"), { cause });
+    const queryKey = ["session", "create"];
+
+    await runFailingQuery(client, queryKey, error);
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(client.getQueryState(queryKey)).toMatchObject({
+      status: "error",
+      error,
+    });
+  });
+
+  it.each([
+    ["an old runtime without a receipt", undefined],
+    ["a malformed receipt", "urn:proliferate:anyharness:incident:not-a-uuid"],
+    [
+      "a foreign receipt",
+      "urn:proliferate:server:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    ],
+  ])("keeps global query capture for %s", async (_name, instance) => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const error = modelGatedError(instance);
+    const queryKey = ["session", "create", _name];
+
+    await runFailingQuery(client, queryKey, error);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [capturedError] = captureException.mock.calls[0];
+    expect(capturedError).toMatchObject({
+      name: "AnyHarnessError",
+      message: "AnyHarness request failed (SESSION_MODEL_GATED)",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+    });
+    expect("problem" in capturedError).toBe(false);
+    expect("cause" in capturedError).toBe(false);
+  });
+
   it("captures an AnyHarness mutation failure without its caller-facing detail", async () => {
     const captureException = vi.fn();
     const client = createAppQueryClient({ captureException });
@@ -246,6 +303,56 @@ describe("createAppQueryClient query telemetry", () => {
         mutation_key: hashAppQueryKey(mutationKey),
       },
     });
+  });
+
+  it("suppresses global mutation capture for a runtime incident receipt", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const error = modelGatedError(VALID_RUNTIME_INCIDENT_RECEIPT);
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey: ["session", "create"],
+      mutationFn: async () => {
+        throw error;
+      },
+      retry: false,
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toBe(error);
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an old runtime without a receipt", undefined],
+    ["a malformed receipt", "urn:proliferate:anyharness:incident:not-a-uuid"],
+    [
+      "a foreign receipt",
+      "urn:proliferate:server:incident:8fd6ea9a-1246-4ef0-a526-9cc5f86ed960",
+    ],
+  ])("keeps global mutation capture for %s", async (_name, instance) => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const error = modelGatedError(instance);
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey: ["session", "create", _name],
+      mutationFn: async () => {
+        throw error;
+      },
+      retry: false,
+    });
+
+    await expect(mutation.execute(undefined)).rejects.toBe(error);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [capturedError] = captureException.mock.calls[0];
+    expect(capturedError).toMatchObject({
+      name: "AnyHarnessError",
+      message: "AnyHarness request failed (SESSION_MODEL_GATED)",
+      status: 400,
+      code: "SESSION_MODEL_GATED",
+    });
+    expect("problem" in capturedError).toBe(false);
+    expect("cause" in capturedError).toBe(false);
   });
 
   it("preserves the explicit telemetryHandled query override", async () => {

--- a/apps/packages/product-client/src/lib/infra/query/query-client.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.ts
@@ -4,7 +4,10 @@ import {
   QueryCache,
   QueryClient,
 } from "@tanstack/react-query";
-import { toAnyHarnessTelemetryError } from "@anyharness/sdk";
+import {
+  hasAnyHarnessRuntimeIncidentReceipt,
+  toAnyHarnessTelemetryError,
+} from "@anyharness/sdk";
 import {
   isExpectedMutationTelemetryError,
   isExpectedQueryTelemetryError,
@@ -99,11 +102,14 @@ export function hashAppQueryKey(queryKey: unknown): string {
 }
 
 export function shouldCaptureAppQueryError(error: unknown): boolean {
-  return !isCancelledError(error) && !isExpectedQueryTelemetryError(error);
+  return !hasAnyHarnessRuntimeIncidentReceipt(error)
+    && !isCancelledError(error)
+    && !isExpectedQueryTelemetryError(error);
 }
 
 export function shouldCaptureAppMutationError(error: unknown): boolean {
-  return !isExpectedMutationTelemetryError(error);
+  return !hasAnyHarnessRuntimeIncidentReceipt(error)
+    && !isExpectedMutationTelemetryError(error);
 }
 
 export function createAppQueryClient({

--- a/server/proliferate/server/cloud/materialization/sandbox_io/runtime_launch.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/runtime_launch.py
@@ -115,6 +115,7 @@ async def launch_anyharness_runtime(
             build_runtime_env(
                 runtime_token,
                 anyharness_data_key=anyharness_data_key,
+                target_id=sandbox_record.id,
                 organization_id=organization_id,
                 sandbox_id=provider_sandbox_id,
                 user_id=sandbox_record.owner_user_id,
@@ -197,6 +198,7 @@ async def _launch_supervisor_owned_runtime(
     anyharness_env = build_runtime_env(
         runtime_token,
         anyharness_data_key=anyharness_data_key,
+        target_id=sandbox_record.id,
         organization_id=organization_id,
         sandbox_id=provider_sandbox_id,
         user_id=sandbox_record.owner_user_id,

--- a/server/proliferate/server/cloud/runtime_workers/service.py
+++ b/server/proliferate/server/cloud/runtime_workers/service.py
@@ -383,6 +383,7 @@ def _build_supervisor_bridge_inputs(
         anyharness_env = build_runtime_env(
             runtime_token,
             anyharness_data_key=anyharness_data_key,
+            target_id=sandbox.id,
             organization_id=sandbox.organization_id,
             sandbox_id=sandbox.e2b_sandbox_id,
             user_id=sandbox.owner_user_id,

--- a/server/tests/integration/test_cloud_sandbox_desired_versions.py
+++ b/server/tests/integration/test_cloud_sandbox_desired_versions.py
@@ -504,6 +504,11 @@ class TestSupervisorBridgeDelivery:
         assert "anyharness_update_enabled = false" in bridge["workerConfigToml"]
         # The supervisor config carries the runtime env (mailbox drain target).
         assert "update_request_dir" in bridge["supervisorConfigToml"]
+        assert f'ANYHARNESS_RUNTIME_TARGET_ID = "{sandbox.id}"' in bridge["supervisorConfigToml"]
+        assert (
+            f'PROLIFERATE_SANDBOX_ID = "{sandbox.provider_sandbox_id}"'
+            in bridge["supervisorConfigToml"]
+        )
 
     @pytest.mark.asyncio
     async def test_no_bridge_when_flag_off(

--- a/server/tests/integration/test_cloud_supervisor_owned_launch.py
+++ b/server/tests/integration/test_cloud_supervisor_owned_launch.py
@@ -90,7 +90,10 @@ class _FakeProvider:
         return _CommandResult(exit_code=0)
 
 
-def _install_stubs(monkeypatch: pytest.MonkeyPatch, provider: _FakeProvider) -> list[str]:
+def _install_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: _FakeProvider,
+) -> tuple[list[str], list[dict[str, object]]]:
     """Installs the same stubs as the reconnect self-heal suite, plus a
     ``launch_worker_sidecar`` spy so tests can assert it was (not) called."""
     monkeypatch.setattr(connect_module, "get_sandbox_provider", lambda _ref: provider)
@@ -99,7 +102,13 @@ def _install_stubs(monkeypatch: pytest.MonkeyPatch, provider: _FakeProvider) -> 
         "build_runtime_launch_script",
         lambda *a, **k: "#!/bin/bash\ntrue\n",
     )
-    monkeypatch.setattr(runtime_launch_module, "build_runtime_env", lambda *a, **k: {})
+    runtime_env_calls: list[dict[str, object]] = []
+
+    def _capture_runtime_env(*_args: object, **kwargs: object) -> dict[str, str]:
+        runtime_env_calls.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(runtime_launch_module, "build_runtime_env", _capture_runtime_env)
     monkeypatch.setattr(
         runtime_launch_module,
         "worker_cloud_base_url",
@@ -133,7 +142,7 @@ def _install_stubs(monkeypatch: pytest.MonkeyPatch, provider: _FakeProvider) -> 
     monkeypatch.setattr(runtime_launch_module, "verify_runtime_auth_enforced", _ok_auth)
     monkeypatch.setattr(runtime_launch_module, "launch_worker_sidecar", _spy_sidecar)
     monkeypatch.setattr(connect_module, "assert_cloud_sandbox_resume_allowed", _resume_allowed)
-    return sidecar_calls
+    return sidecar_calls, runtime_env_calls
 
 
 async def _seed_sandbox(db: AsyncSession) -> CloudSandbox:
@@ -174,7 +183,7 @@ async def test_flag_off_keeps_legacy_launch_unchanged(
 ) -> None:
     monkeypatch.setattr(settings, "supervisor_owned_runtime", False)
     provider = _FakeProvider(db_session)
-    sidecar_calls = _install_stubs(monkeypatch, provider)
+    sidecar_calls, runtime_env_calls = _install_stubs(monkeypatch, provider)
     sandbox = await _seed_sandbox(db_session)
     value = await sandbox_store.load_personal_cloud_sandbox(db_session, sandbox.owner_user_id)
     assert value is not None
@@ -188,6 +197,9 @@ async def test_flag_off_keeps_legacy_launch_unchanged(
     assert launch_command in provider.commands
     assert supervisor_command not in provider.commands
     assert sidecar_calls == ["called"]
+    assert [(call["target_id"], call["sandbox_id"]) for call in runtime_env_calls] == [
+        (sandbox.id, sandbox.provider_sandbox_id)
+    ]
     assert worker_config_path(runtime_context) not in provider.written_files
     assert supervisor_config_path(runtime_context) not in provider.written_files
     assert provider.runtime_io_transactions
@@ -201,7 +213,7 @@ async def test_flag_on_launches_supervisor_first_no_sidecar(
 ) -> None:
     monkeypatch.setattr(settings, "supervisor_owned_runtime", True)
     provider = _FakeProvider(db_session)
-    sidecar_calls = _install_stubs(monkeypatch, provider)
+    sidecar_calls, runtime_env_calls = _install_stubs(monkeypatch, provider)
     sandbox = await _seed_sandbox(db_session)
     value = await sandbox_store.load_personal_cloud_sandbox(db_session, sandbox.owner_user_id)
     assert value is not None
@@ -223,6 +235,9 @@ async def test_flag_on_launches_supervisor_first_no_sidecar(
     assert launch_command not in provider.commands
     # The Supervisor spawns the Worker itself: no separate sidecar launch.
     assert sidecar_calls == []
+    assert [(call["target_id"], call["sandbox_id"]) for call in runtime_env_calls] == [
+        (sandbox.id, sandbox.provider_sandbox_id)
+    ]
     assert worker_config_path(runtime_context) in provider.written_files
     assert supervisor_config_path(runtime_context) in provider.written_files
 

--- a/server/tests/unit/test_runtime_version_pin.py
+++ b/server/tests/unit/test_runtime_version_pin.py
@@ -7,6 +7,8 @@ env must carry exactly what the pin advertises so heartbeats report what runs.
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 
 from proliferate.server.cloud.runtime.bootstrap import build_runtime_env
@@ -31,6 +33,18 @@ class TestRuntimeVersionPin:
 
 
 class TestRuntimeLaunchEnvExport:
+    def test_exports_logical_target_identity_separately_from_provider_sandbox(self) -> None:
+        target_id = uuid.uuid4()
+        env = build_runtime_env(
+            "tok",
+            anyharness_data_key="key",
+            target_id=target_id,
+            sandbox_id="e2b-provider-sandbox",
+        )
+
+        assert env["ANYHARNESS_RUNTIME_TARGET_ID"] == str(target_id)
+        assert env["PROLIFERATE_SANDBOX_ID"] == "e2b-provider-sandbox"
+
     def test_exports_pin_when_stamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("RUNTIME_VERSION", "3.4.5")
         env = build_runtime_env("tok", anyharness_data_key="key")

--- a/specs/codebase/platforms/product/agent-catalog-readiness.md
+++ b/specs/codebase/platforms/product/agent-catalog-readiness.md
@@ -102,6 +102,15 @@ is outside the active contexts returns `SESSION_MODEL_GATED` as HTTP 400, with
 `required_contexts` equal to the model's `availability.anyOf`. Unrelated errors
 do not carry `required_contexts`.
 
+Because this handled response genuinely blocks a launch, AnyHarness emits one
+runtime-owned, error-level incident while preserving the HTTP 400 contract.
+The incident records the requested and canonical model, active and required
+auth-context IDs, catalog version, and an explicit `model_gated` outcome;
+effective model and route remain `none` because no launch selection occurred.
+Its RFC 7807 `instance` receipt lets compatible clients avoid a duplicate Web,
+Desktop, or Mobile Sentry issue without changing behavior against older
+runtimes.
+
 ### Claude And Bedrock
 
 `CLAUDE_CODE_USE_BEDROCK=1` is the routing signal for the ordered Bedrock auth

--- a/specs/codebase/structures/anyharness/contract.md
+++ b/specs/codebase/structures/anyharness/contract.md
@@ -59,6 +59,12 @@ Owns shared identifier aliases used by the public API surface.
 Owns `ProblemDetails`, the canonical wire error shape returned by HTTP
 endpoints.
 
+For handled runtime incidents, `instance` is the mixed-deployment capability
+receipt. AnyHarness mints one UUID, emits one bounded runtime-owned event, and
+returns `urn:proliferate:anyharness:incident:<uuid>` in that existing field.
+Callers may suppress their duplicate capture only after exact receipt
+validation; absent, malformed, or foreign instances retain legacy capture.
+
 ### `health.rs`
 
 Owns health-check response types.

--- a/specs/codebase/structures/frontend/guides/telemetry.md
+++ b/specs/codebase/structures/frontend/guides/telemetry.md
@@ -65,6 +65,11 @@ session replay, and telemetry-related provider and hook ownership.
 
 - Vendor exception capture (Sentry) is hosted-product only in v1.
 - Prefer one capture path per failure.
+- For a handled AnyHarness failure, suppress ProductClient capture only when
+  the cause chain contains an exact
+  `urn:proliferate:anyharness:incident:<uuid>` RFC 7807 instance. Old runtimes,
+  malformed or foreign instances, transport failures, and unrelated errors
+  retain the sanitized client capture path.
 - If a query or mutation hook captures its own exception, mark it with
   `meta.telemetryHandled = true` so the global React Query handlers do not
   report it again.

--- a/specs/codebase/systems/engineering/observability/README.md
+++ b/specs/codebase/systems/engineering/observability/README.md
@@ -45,9 +45,10 @@ renderer and native shell, hosted Web and Mobile clients, AnyHarness, and the
 managed target Worker and Supervisor. Components with explicit scrubbers may
 transmit scrubbed exceptions, stack traces, traces, breadcrumbs, component
 release/environment, surface tags, and allowlisted correlation identifiers to
-the Sentry destination selected by their configured DSN. Desktop-native and
-AnyHarness can transmit exceptions and stack traces but lack an explicit
-before-send scrubber. Server structured logs go to the deployment log sink and
+the Sentry destination selected by their configured DSN. AnyHarness applies an
+explicit before-send scrubber to its hosted-product events and breadcrumbs.
+Desktop-native can transmit exceptions and stack traces but lacks that
+explicit scrubber. Server structured logs go to the deployment log sink and
 can be queried through CloudWatch/Grafana in the hosted stack.
 
 Sentry is diagnostic telemetry, not session replay by default. Web and Mobile
@@ -59,9 +60,9 @@ runtime telemetry disable setting disables vendor telemetry as well.
 
 Known current gaps:
 
-- the Desktop-native and AnyHarness Rust adapters do not install the explicit
-  before-send scrubbers used by the server, clients, Worker, and Supervisor;
+- the Desktop-native Rust adapter does not install the explicit before-send
+  scrubber used by the server, clients, AnyHarness, Worker, and Supervisor;
 - Desktop renderer error replay can retain identifier-bearing route metadata.
 
 Do not add free-form user content or secrets to tracing events. Closing either
-source-code gap requires a separate implementation PR.
+remaining source-code gap requires a separate implementation PR.

--- a/specs/codebase/systems/engineering/observability/sentry.md
+++ b/specs/codebase/systems/engineering/observability/sentry.md
@@ -14,7 +14,7 @@ provider state and are not repository law.
 | Desktop native shell | Native telemetry mode is `hosted_product` and `PROLIFERATE_DESKTOP_SENTRY_DSN` is available at runtime or baked into the build | Native tracing failures and stack traces with Desktop-native release/environment and surface/runtime tags | Other modes or a missing DSN retain console/file logging without Sentry. |
 | Hosted Web | Telemetry is not disabled and `VITE_PROLIFERATE_SENTRY_DSN` is nonempty | Scrubbed React errors, traces, breadcrumbs, id-only user, Web release/environment, and `surface=web` | The SDK remains uninitialized when disabled or unconfigured. |
 | Hosted Mobile | Telemetry is not disabled and `EXPO_PUBLIC_PROLIFERATE_SENTRY_DSN` is nonempty | Scrubbed React Native errors, native crashes, traces, breadcrumbs, id-only user, Mobile release/environment, and `surface=mobile` | The SDK remains uninitialized when disabled or unconfigured. |
-| AnyHarness runtime | Hosted deployment/launch supplies `ANYHARNESS_SENTRY_DSN` | Rust tracing failures and stack traces, AnyHarness release/environment, runtime surface/environment, and available user/org/sandbox/target identity | A missing DSN preserves console/file logging without Sentry. Supported self-managed deployment leaves the Proliferate vendor DSN unset. |
+| AnyHarness runtime | Hosted deployment/launch supplies `ANYHARNESS_SENTRY_DSN` | Scrubbed Rust tracing failures and stack traces, AnyHarness release/environment, runtime surface/environment, and available user/org/sandbox/target identity | A missing DSN preserves console/file logging without Sentry. Supported self-managed deployment leaves the Proliferate vendor DSN unset. |
 | Managed Worker and Supervisor | Hosted bootstrap supplies `PROLIFERATE_TARGET_SENTRY_DSN` | Scrubbed Rust events/logs/breadcrumbs, component-specific release, environment, runtime surface, and available user/org/sandbox/target identity | A missing DSN preserves normal tracing without Sentry. |
 
 Source owners:
@@ -61,8 +61,8 @@ workflow.
 
 ## Privacy and replay
 
-The server, renderer clients, Worker, and Supervisor disable default PII and
-scrub sensitive keys and values before sending. The client scrubbers remove
+The server, renderer clients, AnyHarness, Worker, and Supervisor disable
+default PII and scrub sensitive keys and values before sending. The client scrubbers remove
 frame source context and variables, redact request bodies/cookies, reduce users
 to `id`, and sanitize URLs, paths, breadcrumbs, transactions, and spans. Server
 scrubbing redacts request data and cookies, removes user IP addresses, and
@@ -89,6 +89,15 @@ projection both at its explicit exception facade and its global React Query
 capture boundary while preserving the original detail for UI.
 Raw provider output is not a safe Sentry grouping key or exception message.
 
+When a handled AnyHarness problem genuinely prevents an operation, the runtime
+may emit one error-level incident before returning the truthful non-5xx
+problem. The event uses a stable message and fingerprint plus bounded,
+allowlisted launch-selection metadata; it never uses the problem detail or raw
+provider output as its message. A runtime-minted incident UUID is returned in
+the existing RFC 7807 `instance` field as a capability receipt so callers can
+avoid reporting the same failure again. The receipt attests runtime ownership,
+not successful provider delivery.
+
 Two exact, bounded fields are deliberately preserved through the scrubbers
 because they are deployment identity, not a raw process-environment map:
 
@@ -101,8 +110,9 @@ because they are deployment identity, not a raw process-environment map:
 - The `runtime_env` tag on Worker and Supervisor events, whose only allowed
   live value is `e2b`. Every other env-like tag key stays redacted.
 
-Nothing beyond user ID, sandbox ID, bounded runtime environment, deployment
-environment, release version, and source revision is added to any event.
+Outside the bounded handled-incident contract above, nothing beyond user ID,
+sandbox ID, target ID, bounded runtime environment, deployment environment,
+release version, and source revision is added to any event.
 
 Replay defaults are deliberately narrow:
 
@@ -114,11 +124,11 @@ Replay defaults are deliberately narrow:
   `[data-telemetry-block]` / `[data-telemetry-mask]` are honored.
 - Server and Rust runtime components do not initialize a replay integration.
 
-Known current privacy gaps: Desktop-native and AnyHarness attach stack traces
-but do not install explicit before-send event/breadcrumb scrubbers, and Desktop
-renderer error replay can retain identifier-bearing route metadata despite
-text/input masking. Callers must keep user content and secrets out of tracing
-fields. Worker and Supervisor do have explicit event, breadcrumb, and log
+Known current privacy gaps: Desktop-native attaches stack traces but does not
+install an explicit before-send event/breadcrumb scrubber, and Desktop renderer
+error replay can retain identifier-bearing route metadata despite text/input
+masking. Callers must keep user content and secrets out of tracing fields.
+AnyHarness, Worker, and Supervisor do have explicit event, breadcrumb, and log
 scrubbers.
 
 ## Correlation
@@ -141,6 +151,12 @@ for CloudWatch/Grafana evaluation; Sentry is the exception/trace source. The
 two surfaces correlate through release and request/product identifiers rather
 than by copying full evidence bodies between systems.
 
+Managed-cloud launch binds the logical cloud sandbox as AnyHarness `target_id`
+and the provider sandbox as `sandbox_id`; the two identifiers must remain
+distinct. A handled AnyHarness incident adds a fresh incident UUID and the
+bounded request/session selection context needed to connect its runtime event
+to the caller-visible RFC 7807 problem without copying user content.
+
 [Issue Lifecycle](../issue-lifecycle/README.md) owns polling or receiving this
 provider evidence, deduplicating it, routing it into canonical issues, and
 following up with reporters. Observability does not own tracker state.
@@ -155,6 +171,8 @@ following up with reporters. Observability does not own tracker state.
   debug file exists.
 - Provider delivery is diagnostic and must not become a product request's
   success condition.
+- An AnyHarness incident receipt proves that the runtime owned the capture
+  attempt; it does not prove that Sentry accepted or persisted the event.
 - Local file or structured logs remain the primary fallback when Sentry is
   absent or unavailable.
 - The Rust workspace's `sentry`, `sentry-anyhow`, and `sentry-tracing`


### PR DESCRIPTION
## Summary

- Keep model/auth launch rejection as the truthful typed HTTP 400 `SESSION_MODEL_GATED`, while making AnyHarness the single incident owner with a stable Sentry issue, bounded launch provenance, and a UUIDv4 correlation receipt in RFC 7807 `instance`.
- Add an explicit AnyHarness telemetry privacy boundary for events, breadcrumbs, logs, and transaction envelopes; preserve release plus logical target/provider sandbox identity while removing credentials, content, provider output, raw paths, and unbounded client correlation values.
- Validate runtime receipts in the SDK and suppress duplicate ProductClient capture only for exact receipt-bearing cause chains, including query, mutation, recovery, facade, and intentional Cowork fire-and-forget seams. Legacy, malformed, foreign, network, and unrelated failures remain client-captured.
- Export the logical managed-cloud sandbox UUID as `ANYHARNESS_RUNTIME_TARGET_ID` while preserving the provider/E2B sandbox ID as `PROLIFERATE_SANDBOX_ID` for direct, supervisor-owned, and existing-target bridge launches.

No schema migration or generated wire-contract change is required.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The private production-evidence relationship is linked through the tracker API. No tracker, report, user, support, or telemetry identity is included here.

## Verification

- `cargo test -p anyharness-lib --lib gated -j 2` (8 passed)
- `cargo test -p anyharness-lib --lib observability::latency::tests -j 2` (5 passed)
- `cargo test -p anyharness-lib --lib install_errors_emit_only_stable_classifications -j 2` (1 passed)
- `cargo test -p anyharness --bin anyharness telemetry::tests -j 2` (13 passed)
- `pnpm exec vitest run src/client/core.test.ts` in `anyharness/sdk` (30 passed)
- Focused ProductClient Vitest matrix for receipt suppression, query/mutation capture, recovery, and Cowork UI boundary (68 passed)
- `pnpm --filter @proliferate/product-client typecheck`
- Focused managed-cloud server matrix (41 passed), plus scoped Ruff check/format proof
- Full repo-shape script set, exact Alembic-head check, documentation tests/integrity, and generated-boundary checks
- Three independent adversarial reviews completed; Greptile findings were repaired and independently re-reviewed; the final hotfix-main exact head is clean at 5/5 with 41 files reviewed and zero comments; the final module-split review confirmed behavior-preserving movement






