### PR TITLE
fix(chat): align composer placeholder padding

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -45,6 +45,16 @@ beforeEach(() => {
 });
 
 describe("ComposerRichTextEditor", () => {
+  it("anchors the placeholder to the editor's local positioning frame", async () => {
+    const harness = renderEditor({ value: "" });
+    await harness.ready();
+
+    const frame = harness.root.closest<HTMLElement>("[data-chat-composer-editor-frame]");
+    expect(frame).toBeTruthy();
+    expect(frame?.classList.contains("relative")).toBe(true);
+    expect(frame?.textContent).toBe("Message");
+  });
+
   it("toggles bold and italic for future typing from command-key shortcuts", async () => {
     const harness = renderEditor();
     await harness.ready();

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -125,38 +125,40 @@ export function ComposerRichTextEditor({
   };
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <RichTextPlugin
-        contentEditable={(
-          <ContentEditable
-            data-chat-composer-editor
-            data-home-composer-editor={surface === "home" ? true : undefined}
-            data-telemetry-mask
-            ref={rootRef}
-            aria-placeholder={placeholder}
-            placeholder={<></>}
-            spellCheck={false}
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === "Tab" || event.defaultPrevented) return;
-              onKeyDown?.(event);
-            }}
-            onPaste={(event) => {
-              if (isComposerLinkPaste(event.clipboardData.getData("text/plain"))) {
-                event.stopPropagation();
-              }
-            }}
-            className={`relative w-full resize-none bg-transparent text-[length:var(--text-composer)] leading-[var(--text-composer--line-height)] text-foreground outline-none ${disabled ? "opacity-60" : ""} ${className}`}
-          />
-        )}
-        placeholder={(
-          <div className="pointer-events-none absolute inset-x-0 top-0 truncate text-[length:var(--text-composer)] leading-[var(--text-composer--line-height)] text-muted-foreground">
-            {placeholder}
-          </div>
-        )}
-        ErrorBoundary={LexicalErrorBoundary}
-      />
+      <div data-chat-composer-editor-frame className="relative min-h-[inherit]">
+        <RichTextPlugin
+          contentEditable={(
+            <ContentEditable
+              data-chat-composer-editor
+              data-home-composer-editor={surface === "home" ? true : undefined}
+              data-telemetry-mask
+              ref={rootRef}
+              aria-placeholder={placeholder}
+              placeholder={<></>}
+              spellCheck={false}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === "Tab" || event.defaultPrevented) return;
+                onKeyDown?.(event);
+              }}
+              onPaste={(event) => {
+                if (isComposerLinkPaste(event.clipboardData.getData("text/plain"))) {
+                  event.stopPropagation();
+                }
+              }}
+              className={`relative w-full resize-none bg-transparent text-[length:var(--text-composer)] leading-[var(--text-composer--line-height)] text-foreground outline-none ${disabled ? "opacity-60" : ""} ${className}`}
+            />
+          )}
+          placeholder={(
+            <div className="pointer-events-none absolute inset-x-0 top-0 truncate text-[length:var(--text-composer)] leading-[var(--text-composer--line-height)] text-muted-foreground">
+              {placeholder}
+            </div>
+          )}
+          ErrorBoundary={LexicalErrorBoundary}
+        />
+      </div>
       <HistoryPlugin />
       <ListPlugin />
       <MarkdownShortcutPlugin transformers={INPUT_TRANSFORMERS} />


### PR DESCRIPTION
## Summary
- anchor the Lexical placeholder to the same local positioning frame as the editable surface
- preserve the existing composer typography, padding tokens, and one-pixel replacement caret
- add a regression test for placeholder positioning ownership

## Validation
- `pnpm exec vitest run src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx --reporter=dot`
- `pnpm --filter @proliferate/product-client build`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- authenticated desktop Home composer visual verification