### PR TITLE
fix(web): lazy-load authenticated chat styles

### DIFF
--- a/apps/packages/design/src/css/dom.css
+++ b/apps/packages/design/src/css/dom.css
@@ -121,24 +121,6 @@ body {
   background-clip: content-box;
 }
 
-@property --top-fade {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0;
-}
-
-@property --bottom-fade {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0;
-}
-
-@property --edge-fade-distance {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 1.5rem;
-}
-
 /* Static two-edge fallback for browsers without scroll-driven animations. */
 .vertical-scroll-fade-mask {
   --edge-fade-distance: 1.5rem;
@@ -156,43 +138,6 @@ body {
     black calc(100% - var(--edge-fade-distance)),
     transparent 100%
   );
-}
-
-@keyframes vertical-scroll-edge-fade {
-  0%,
-  1% {
-    --top-fade: 0;
-    --bottom-fade: var(--edge-fade-distance);
-  }
-
-  99%,
-  100% {
-    --top-fade: var(--edge-fade-distance);
-    --bottom-fade: 0;
-  }
-}
-
-/* Codex-style edge ownership: at the top only the bottom edge fades; after
-   scrolling both edges fade; at the bottom only the top edge fades. */
-@supports (animation-timeline: scroll()) {
-  .vertical-scroll-fade-mask {
-    mask-image: linear-gradient(
-      to bottom,
-      transparent,
-      black var(--top-fade) calc(100% - var(--bottom-fade)),
-      transparent
-    );
-    -webkit-mask-image: linear-gradient(
-      to bottom,
-      transparent,
-      black var(--top-fade) calc(100% - var(--bottom-fade)),
-      transparent
-    );
-    animation-name: vertical-scroll-edge-fade;
-    animation-timing-function: linear;
-    animation-fill-mode: both;
-    animation-timeline: scroll(self y);
-  }
 }
 
 /* Codex composer chrome (UX_SPEC §5): no border — a 0.5px stroke painted in

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -837,67 +837,6 @@ mark.codex-thread-find-active {
  * NON-THEME STYLES
  * ======================================================================== */
 
-/* Codex completion-diff stats keep their semantic ink while changed digits
-   roll vertically. Right-aligned keys preserve the column identity when the
-   number gains or loses a leading digit. */
-.diff-stat-rolling-number {
-  display: inline-flex;
-  align-items: baseline;
-  height: 1lh;
-  line-height: inherit;
-}
-
-.diff-stat-digit-column {
-  position: relative;
-  display: inline-block;
-  contain: layout paint style;
-  width: 1ch;
-  height: 1lh;
-  line-height: inherit;
-}
-
-.diff-stat-digit-column::before {
-  content: "0";
-  visibility: hidden;
-}
-
-.diff-stat-digit-clip {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-}
-
-.diff-stat-digit-stack {
-  display: flex;
-  flex-direction: column;
-  contain: layout size style;
-  height: 1lh;
-  transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
-  will-change: transform;
-}
-
-.diff-stat-digit-stack > span {
-  flex: 0 0 1lh;
-  height: 1lh;
-}
-
-.diff-stat-digit-stack-0 { transform: translateY(0); }
-.diff-stat-digit-stack-1 { transform: translateY(-1lh); }
-.diff-stat-digit-stack-2 { transform: translateY(-2lh); }
-.diff-stat-digit-stack-3 { transform: translateY(-3lh); }
-.diff-stat-digit-stack-4 { transform: translateY(-4lh); }
-.diff-stat-digit-stack-5 { transform: translateY(-5lh); }
-.diff-stat-digit-stack-6 { transform: translateY(-6lh); }
-.diff-stat-digit-stack-7 { transform: translateY(-7lh); }
-.diff-stat-digit-stack-8 { transform: translateY(-8lh); }
-.diff-stat-digit-stack-9 { transform: translateY(-9lh); }
-
-@media (prefers-reduced-motion: reduce) {
-  .diff-stat-digit-stack {
-    transition: none;
-  }
-}
-
 /* Codex composer chrome (UX_SPEC §5): no border — a 0.5px stroke painted in
    the shadow stack plus the prominent-elevation shadow pair. */
 .chat-composer-surface {

--- a/apps/packages/product-client/src/app/AuthenticatedProductClient.tsx
+++ b/apps/packages/product-client/src/app/AuthenticatedProductClient.tsx
@@ -7,6 +7,7 @@ import { RepoSetupModalHost } from "#product/components/workspace/repo-setup/Rep
 import { WorkspaceAvailabilityActionHost } from "#product/components/workspace/repo-setup/WorkspaceAvailabilityActionHost"
 import { AuthenticatedAppHost } from "#product/pages/AuthenticatedAppHost"
 import { CoworkThreadLaunchProvider } from "#product/providers/CoworkThreadLaunchProvider"
+import "./authenticated.css"
 
 /**
  * Internal, lazy-loaded authenticated product root.

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -1,0 +1,153 @@
+/* Authenticated-only interaction styles stay behind the lazy product boundary
+ * so chat affordances do not consume the public login shell's CSS budget. */
+
+@property --top-fade {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --bottom-fade {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --edge-fade-distance {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 1.5rem;
+}
+
+@keyframes vertical-scroll-edge-fade {
+  0%,
+  1% {
+    --top-fade: 0;
+    --bottom-fade: var(--edge-fade-distance);
+  }
+
+  99%,
+  100% {
+    --top-fade: var(--edge-fade-distance);
+    --bottom-fade: 0;
+  }
+}
+
+/* At the top only the bottom edge fades; after scrolling both edges fade; at
+ * the bottom only the top edge fades. dom.css retains the static fallback. */
+@supports (animation-timeline: scroll()) {
+  .vertical-scroll-fade-mask {
+    mask-image: linear-gradient(
+      to bottom,
+      transparent,
+      black var(--top-fade) calc(100% - var(--bottom-fade)),
+      transparent
+    );
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      transparent,
+      black var(--top-fade) calc(100% - var(--bottom-fade)),
+      transparent
+    );
+    animation-name: vertical-scroll-edge-fade;
+    animation-timing-function: linear;
+    animation-fill-mode: both;
+    animation-timeline: scroll(self y);
+  }
+}
+
+/* Completion-diff stats keep their semantic ink while changed digits roll. */
+.diff-stat-rolling-number {
+  display: inline-flex;
+  align-items: baseline;
+  height: 1lh;
+  line-height: inherit;
+}
+
+.diff-stat-digit-column {
+  position: relative;
+  display: inline-block;
+  contain: layout paint style;
+  width: 1ch;
+  height: 1lh;
+  line-height: inherit;
+}
+
+.diff-stat-digit-column::before {
+  content: "0";
+  visibility: hidden;
+}
+
+.diff-stat-digit-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.diff-stat-digit-stack {
+  display: flex;
+  flex-direction: column;
+  contain: layout size style;
+  height: 1lh;
+  transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+}
+
+.diff-stat-digit-stack > span {
+  flex: 0 0 1lh;
+  height: 1lh;
+}
+
+.diff-stat-digit-stack-0 { transform: translateY(0); }
+.diff-stat-digit-stack-1 { transform: translateY(-1lh); }
+.diff-stat-digit-stack-2 { transform: translateY(-2lh); }
+.diff-stat-digit-stack-3 { transform: translateY(-3lh); }
+.diff-stat-digit-stack-4 { transform: translateY(-4lh); }
+.diff-stat-digit-stack-5 { transform: translateY(-5lh); }
+.diff-stat-digit-stack-6 { transform: translateY(-6lh); }
+.diff-stat-digit-stack-7 { transform: translateY(-7lh); }
+.diff-stat-digit-stack-8 { transform: translateY(-8lh); }
+.diff-stat-digit-stack-9 { transform: translateY(-9lh); }
+
+@media (prefers-reduced-motion: reduce) {
+  .diff-stat-digit-stack {
+    transition: none;
+  }
+}
+
+[data-edit-action-row]:is(:hover, :focus-within) .activity-file-change-stat-additions {
+  color: var(--color-git-green);
+}
+
+[data-edit-action-row]:is(:hover, :focus-within) .activity-file-change-stat-deletions {
+  color: var(--color-git-red);
+}
+
+[data-edit-action-row]:is(:hover, :focus-within) .edit-action-row-open,
+[data-chat-diff-wrap-context-trigger="file-header"]:is(:hover, :focus-within) .turn-diff-file-open {
+  opacity: 1;
+}
+
+[data-chat-diff-wrap-context-trigger="turn-header"]:is(:hover, :focus-within) .turn-diff-default-subtitle {
+  display: none;
+}
+
+[data-chat-diff-wrap-context-trigger="turn-header"]:is(:hover, :focus-within) .turn-diff-hover-subtitle {
+  display: inline-flex;
+}
+
+[data-chat-diff-wrap-context-trigger="turn-header"]:hover .turn-diff-review-target {
+  background: color-mix(in oklab, var(--color-list-hover) 30%, transparent);
+}
+
+.turn-document-reference-trigger:hover {
+  background: color-mix(in srgb, var(--color-foreground) 3.5%, transparent);
+}
+
+.turn-document-reference-trigger:is(:hover, :focus-visible) .turn-document-type-label {
+  opacity: 0;
+}
+
+.turn-document-reference-trigger:is(:hover, :focus-visible) .turn-document-open-label {
+  opacity: 1;
+}

--- a/apps/packages/product-client/src/components/content/ui/FileChangeStats.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FileChangeStats.tsx
@@ -30,7 +30,7 @@ export function FileChangeStats({
           value={additions}
           rolling={rolling}
           className={tone === "activity"
-            ? "text-inherit transition-colors group-hover/action-row:text-git-green group-focus-within/action-row:text-git-green"
+            ? "activity-file-change-stat-additions text-inherit transition-colors"
             : "text-git-green"}
         />
       )}
@@ -40,7 +40,7 @@ export function FileChangeStats({
           value={deletions}
           rolling={rolling}
           className={tone === "activity"
-            ? "text-inherit transition-colors group-hover/action-row:text-git-red group-focus-within/action-row:text-git-red"
+            ? "activity-file-change-stat-deletions text-inherit transition-colors"
             : "text-git-red"}
         />
       )}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -444,8 +444,7 @@ describe("CollapsedActions", () => {
     const stats = editRow?.querySelector("[data-thread-find-skip='true']");
     expect(stats?.textContent).toBe("+1-1");
     expect(stats?.querySelector("span")?.className).toContain("text-inherit");
-    expect(stats?.querySelector("span")?.className).toContain("group-hover/action-row:text-git-green");
-    expect(stats?.querySelector("span")?.className).toContain("group-focus-within/action-row:text-git-green");
+    expect(stats?.querySelector("span")?.className).toContain("activity-file-change-stat-additions");
 
     const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
     fireEvent.click(toggle);

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -78,7 +78,7 @@ function EditActionRow({
     <div
       data-edit-action-row
       onContextMenuCapture={nativeContextMenu.onContextMenuCapture}
-      className={`group/action-row relative flex min-w-0 max-w-full items-center text-left text-chat leading-[var(--text-chat--line-height)] transition-colors ${
+      className={`relative flex min-w-0 max-w-full items-center text-left text-chat leading-[var(--text-chat--line-height)] transition-colors ${
         failed
           ? "text-destructive/80 hover:text-destructive"
           : "text-foreground/60 hover:text-foreground"
@@ -128,7 +128,7 @@ function EditActionRow({
               event.stopPropagation();
               void fileActions.openPrimary();
             }}
-            className="pointer-events-auto size-5 shrink-0 rounded border-0 bg-transparent p-0 text-current opacity-0 transition-opacity hover:bg-muted focus-visible:opacity-100 focus-visible:ring-1 group-hover/action-row:opacity-100 group-focus-within/action-row:opacity-100"
+            className="edit-action-row-open pointer-events-auto size-5 shrink-0 rounded border-0 bg-transparent p-0 text-current opacity-0 transition-opacity hover:bg-muted focus-visible:opacity-100 focus-visible:ring-1"
           >
             <ArrowUpRight className="size-3" />
           </Button>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffFileRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffFileRow.tsx
@@ -29,7 +29,7 @@ export function TurnDiffFileRow({
   const header = (
     <div
       data-chat-diff-wrap-context-trigger="file-header"
-      className="group/turn-diff-file relative flex h-9 w-full min-w-0 items-center bg-background/70 text-chat leading-[var(--text-chat--line-height)] text-foreground hover:bg-list-hover/60"
+      className="relative flex h-9 w-full min-w-0 items-center bg-background/70 text-chat leading-[var(--text-chat--line-height)] text-foreground hover:bg-list-hover/60"
     >
       <Button
         type="button"
@@ -71,7 +71,7 @@ export function TurnDiffFileRow({
               event.stopPropagation();
               onOpenFile();
             }}
-            className="pointer-events-auto size-6 shrink-0 rounded-md border-0 bg-transparent p-0 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1 group-hover/turn-diff-file:opacity-100 group-focus-within/turn-diff-file:opacity-100"
+            className="turn-diff-file-open pointer-events-auto size-6 shrink-0 rounded-md border-0 bg-transparent p-0 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1"
           >
             <ArrowUpRight className="size-3.5" />
           </Button>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanel.test.tsx
@@ -123,10 +123,10 @@ describe("TurnDiffPanel", () => {
     expect(html).toContain("Edited 2 files");
     expect(html).toContain("bg-foreground/[0.0475]");
     expect(html).toContain("data-chat-diff-wrap-context-trigger=\"turn-header\"");
-    expect(html).toContain("group/turn-diff-header relative focus-within:[&amp;_.turn-diff-default-subtitle]:hidden");
+    expect(html).toContain("turn-diff-default-subtitle inline-flex");
     expect(html).toContain("bg-[var(--color-diff-chat-turn-icon-surface)]");
     expect(html).toContain("border border-border bg-foreground/[0.0475]");
-    expect(html).toContain("group/turn-diff-file relative flex h-9 w-full min-w-0 items-center bg-background/70");
+    expect(html).toContain("data-chat-diff-wrap-context-trigger=\"file-header\" class=\"relative flex h-9 w-full min-w-0 items-center bg-background/70");
     expect(html).toContain("hover:bg-list-hover/60");
     expect(html).toContain("flex flex-col border-t border-border");
     expect(html).toContain('text-git-green">+<span aria-label="4" class="diff-stat-rolling-number"');
@@ -168,9 +168,7 @@ describe("TurnDiffPanel", () => {
     expect(html).toContain("Review changes");
     expect(html).toContain("aria-label=\"Review changed files\"");
     expect(html).not.toContain("Show file in review");
-    expect(html).toContain("group-hover/turn-diff-header:bg-list-hover/30");
-    expect(html).toContain("hover:[&amp;_.turn-diff-default-subtitle]:hidden");
-    expect(html).toContain("hover:[&amp;_.turn-diff-hover-subtitle]:inline-flex");
+    expect(html).toContain("turn-diff-review-target absolute inset-0");
     expect(html).toContain("turn-diff-default-subtitle inline-flex");
     expect(html).toContain("turn-diff-hover-subtitle pointer-events-none absolute inset-0 hidden");
     expect(html).toContain("data-app-action-review-file-toggle");

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanelHeader.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanelHeader.tsx
@@ -26,7 +26,7 @@ export function TurnDiffPanelHeader({
   return (
     <div
       data-chat-diff-wrap-context-trigger="turn-header"
-      className={`group/turn-diff-header relative focus-within:[&_.turn-diff-default-subtitle]:hidden hover:[&_.turn-diff-default-subtitle]:hidden focus-within:[&_.turn-diff-hover-subtitle]:inline-flex hover:[&_.turn-diff-hover-subtitle]:inline-flex ${onOpenReviewPane ? "cursor-pointer" : ""}`}
+      className={`relative ${onOpenReviewPane ? "cursor-pointer" : ""}`}
     >
       {onOpenReviewPane && (
         <Button
@@ -36,7 +36,7 @@ export function TurnDiffPanelHeader({
           data-chat-transcript-ignore
           aria-label="Review changed files"
           onClick={onOpenReviewPane}
-          className="absolute inset-0 z-0 rounded-t-lg bg-transparent group-hover/turn-diff-header:bg-list-hover/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border"
+          className="turn-diff-review-target absolute inset-0 z-0 rounded-t-lg bg-transparent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border"
         />
       )}
       <div className="pointer-events-none relative z-10 flex min-w-0 items-center gap-2.5 px-[var(--turn-diff-row-padding-x)] py-3 text-left">

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.tsx
@@ -20,7 +20,7 @@ export function TurnDocumentReferenceCard({
         variant="unstyled"
         size="unstyled"
         onClick={() => void fileActions.openPrimary()}
-        className="group/end-resource flex w-full min-w-0 items-center justify-start gap-2.5 rounded-none px-3 py-3 text-left hover:bg-foreground/[0.035] focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+        className="turn-document-reference-trigger flex w-full min-w-0 items-center justify-start gap-2.5 rounded-none px-3 py-3 text-left focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
         aria-label={`Open preview for ${resource.displayName}`}
       >
         <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--color-diff-chat-turn-icon-surface)] text-secondary-foreground">
@@ -31,10 +31,10 @@ export function TurnDocumentReferenceCard({
             {resource.displayName}
           </span>
           <span className="relative block min-h-4 min-w-0 text-xs leading-4 text-muted-foreground">
-            <span className="block truncate transition-opacity duration-150 group-hover/end-resource:opacity-0 group-focus-visible/end-resource:opacity-0">
+            <span className="turn-document-type-label block truncate transition-opacity duration-150">
               {resource.typeLabel}
             </span>
-            <span className="pointer-events-none absolute inset-0 flex items-center opacity-0 transition-opacity duration-150 group-hover/end-resource:opacity-100 group-focus-visible/end-resource:opacity-100">
+            <span className="turn-document-open-label pointer-events-none absolute inset-0 flex items-center opacity-0 transition-opacity duration-150">
               Open preview
             </span>
           </span>


### PR DESCRIPTION
## Summary

- Move chat-only scroll fades and rolling diff-stat styles behind the lazy authenticated product boundary.
- Replace authenticated-only Tailwind interaction variants with equivalent semantic selectors in that lazy stylesheet.
- Preserve the chat visuals while removing them from the public login shell bundle.

## Root cause

PR #1423 added authenticated chat effects to eager design styles. The exact main CI measurement increased login CSS from 65,842 to 66,710 gzip bytes, exceeding the 66,000-byte cap.

## Validation

- Exact login runtime budget: CSS 65,817 / 66,000 bytes; JS 482,165 / 485,000 bytes.
- Web production build emits a separate AuthenticatedProductClient CSS chunk.
- Focused product-client tests: 3 files, 26 tests passed.
- Product-client and Web TypeScript builds passed.
- Frontend boundary, strict structure, max-lines, and diff checks passed.
