### PR TITLE
feat(product): streamline workspace pane chrome

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx
@@ -26,6 +26,14 @@ describe("ToolCallSummary", () => {
     fireEvent.click(disclosure);
     expect(screen.getByText("Work ledger")).toBeTruthy();
     const ledger = screen.getByText("Work ledger");
+    const summaryShell = container.querySelector("[data-completed-work-summary]");
+    const ledgerShell = container.querySelector("[data-completed-work-ledger]");
+    expect(summaryShell).not.toBeNull();
+    expect(ledgerShell).not.toBeNull();
+    expect(summaryShell?.className).not.toMatch(/(?:^|\s)(?:border|rounded)(?:\s|$)/);
+    expect(ledgerShell?.className).toContain("border-0");
+    expect(ledgerShell?.className).not.toMatch(/(?:^|\s)border(?:\s|$)/);
+    expect(ledgerShell?.className).not.toMatch(/(?:^|\s)rounded(?:\s|$)/);
     expect(ledger.parentElement?.className).toContain("mt-1");
     expect(ledger.parentElement?.className).not.toContain("mt-2");
     const completion = screen.getByText("Edited files");

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx
@@ -13,6 +13,7 @@ describe("ToolCallSummary", () => {
         label="Worked for 13m 25s"
         summary="2 messages, 3 tool calls"
         showWorkDivider
+        borderless
         completionContent={<div>Edited files</div>}
         renderChildren={() => <div>Work ledger</div>}
       />,
@@ -30,8 +31,10 @@ describe("ToolCallSummary", () => {
     const ledgerShell = container.querySelector("[data-completed-work-ledger]");
     expect(summaryShell).not.toBeNull();
     expect(ledgerShell).not.toBeNull();
-    expect(summaryShell?.className).not.toMatch(/(?:^|\s)(?:border|rounded)(?:\s|$)/);
-    expect(ledgerShell?.className).toContain("border-0");
+    expect(disclosure.className).toContain("border-0");
+    expect(disclosure.className).toContain("rounded-none");
+    expect(disclosure.className).not.toMatch(/(?:^|\s)border(?:\s|$)/);
+    expect(disclosure.className).not.toMatch(/(?:^|\s)rounded-md(?:\s|$)/);
     expect(ledgerShell?.className).not.toMatch(/(?:^|\s)border(?:\s|$)/);
     expect(ledgerShell?.className).not.toMatch(/(?:^|\s)rounded(?:\s|$)/);
     expect(ledger.parentElement?.className).toContain("mt-1");

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
@@ -39,6 +39,7 @@ export function ToolCallSummary({
   return (
     <div
       className={`min-w-0 ${animateCompletion ? "motion-safe:animate-status-crossfade" : ""}`}
+      data-completed-work-summary
       data-completed-work-transition={animateCompletion ? "true" : undefined}
     >
       <TurnSeparator
@@ -48,7 +49,10 @@ export function ToolCallSummary({
         onClick={() => setExpanded(!expanded)}
       />
       {expanded && (
-        <div className="mt-1 space-y-1.5">
+        <div
+          className="mt-1 space-y-1.5 border-0 bg-transparent"
+          data-completed-work-ledger
+        >
           {renderedChildren}
         </div>
       )}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
@@ -14,6 +14,8 @@ interface ToolCallSummaryProps {
   completionContent?: React.ReactNode;
   /** Fade in only when a mounted live turn becomes completed history. */
   animateCompletion?: boolean;
+  /** Removes only the outer disclosure border box; nested detail panels stay framed. */
+  borderless?: boolean;
 }
 
 export function ToolCallSummary({
@@ -26,6 +28,7 @@ export function ToolCallSummary({
   showWorkDivider = false,
   completionContent = null,
   animateCompletion = false,
+  borderless = false,
 }: ToolCallSummaryProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const renderedChildren = expanded || (itemCount !== undefined && itemCount <= 1)
@@ -47,10 +50,11 @@ export function ToolCallSummary({
         interactive
         expanded={expanded}
         onClick={() => setExpanded(!expanded)}
+        borderless={borderless}
       />
       {expanded && (
         <div
-          className="mt-1 space-y-1.5 border-0 bg-transparent"
+          className="mt-1 space-y-1.5"
           data-completed-work-ledger
         >
           {renderedChildren}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createTranscriptState } from "@anyharness/sdk";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assistantItem,
+  terminalItem,
   toolItem,
   turnRecord,
 } from "@proliferate/product-domain/chats/transcript/transcript-presentation-test-fixtures";
@@ -24,7 +26,18 @@ vi.mock("./TranscriptTreeNode", () => ({
   ),
 }));
 
-afterEach(cleanup);
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("CompletedHistorySequence", () => {
   it("restores the full conversation gap between top-level history items", () => {
@@ -39,6 +52,50 @@ describe("CompletedHistorySequence", () => {
     const sequence = container.querySelector("[data-completed-history-sequence]");
     expect(sequence?.className).toContain("flex flex-col gap-4");
     expect(sequence?.className).not.toContain("space-y-1");
+  });
+
+  it("removes only the completed-work border box and preserves ledger detail chrome", async () => {
+    const user = userEvent.setup();
+    const transcript = createTranscriptState("session-1");
+    const turn = turnRecord(["command", "command-2", "answer"], "2026-04-04T00:00:10Z");
+    transcript.itemsById = {
+      command: terminalItem("command", turn.turnId, 1, "printf proof"),
+      "command-2": terminalItem("command-2", turn.turnId, 2, "printf more"),
+      answer: assistantItem("answer", turn.turnId, 3),
+    };
+    const { container } = renderTurnItemSequence({ turn, transcript });
+
+    const completedWorkDisclosure = screen.getByRole("button", {
+      name: /Worked for 10s/,
+    });
+    expect(completedWorkDisclosure.className).toContain("border-0");
+    expect(completedWorkDisclosure.className).toContain("rounded-none");
+    expect(completedWorkDisclosure.className).not.toMatch(/(?:^|\s)border(?:\s|$)/);
+    expect(completedWorkDisclosure.className).not.toContain("rounded-md");
+
+    await user.click(completedWorkDisclosure);
+    const sequence = container.querySelector<HTMLElement>("[data-completed-history-sequence]");
+    expect(sequence).not.toBeNull();
+
+    const actionSummary = within(sequence!).getByRole("button", { expanded: false });
+    await user.click(actionSummary);
+    const ledger = container.querySelector<HTMLElement>("[data-collapsed-actions-ledger]");
+    expect(ledger).not.toBeNull();
+    expect(ledger?.className).toContain("max-h-56");
+    expect(ledger?.className).toContain("overflow-y-auto");
+    expect(ledger?.className).toContain("overflow-x-hidden");
+
+    const commandDisclosure = within(ledger!).getAllByRole("button", { expanded: false })[0]!;
+    await user.click(commandDisclosure);
+    const nestedDetailPanel = Array.from(ledger!.querySelectorAll<HTMLElement>("div"))
+      .find((node) =>
+        node.className.includes("overflow-hidden")
+        && node.className.includes("rounded-lg")
+        && node.className.includes("border-border/60")
+      );
+    expect(nestedDetailPanel).not.toBeUndefined();
+    expect(nestedDetailPanel?.className).toMatch(/(?:^|\s)border(?:\s|$)/);
+    expect(nestedDetailPanel?.className).toContain("rounded-lg");
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -137,6 +137,7 @@ export function TurnItemSequence({
               showWorkDivider={tailAssistantProseRootId !== null}
               completionContent={completedHistoryOwnsPrelude ? frontierPrelude : null}
               animateCompletion={animateCompletedHistory}
+              borderless
               renderChildren={() => (
                 <CompletedHistorySequence>
                   {visiblePresentation.displayBlocks

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnSeparator.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnSeparator.tsx
@@ -6,6 +6,8 @@ interface TurnSeparatorProps {
   interactive?: boolean;
   expanded?: boolean;
   onClick?: () => void;
+  /** Removes the disclosure's own border box without changing its focus ring. */
+  borderless?: boolean;
 }
 
 /** Left-aligned transcript disclosure used for nested or completed work. */
@@ -14,6 +16,7 @@ export function TurnSeparator({
   interactive = false,
   expanded = false,
   onClick,
+  borderless = false,
 }: TurnSeparatorProps) {
   if (interactive) {
     return (
@@ -23,7 +26,9 @@ export function TurnSeparator({
         size="sm"
         data-chat-transcript-ignore
         onClick={onClick}
-        className="group/turn-separator h-auto max-w-full justify-start gap-1 whitespace-normal rounded-md border border-transparent bg-transparent px-0 py-0 text-chat leading-[var(--text-chat--line-height)] font-normal text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className={`group/turn-separator h-auto max-w-full justify-start gap-1 whitespace-normal bg-transparent px-0 py-0 text-chat leading-[var(--text-chat--line-height)] font-normal text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          borderless ? "rounded-none border-0" : "rounded-md border border-transparent"
+        }`}
         aria-expanded={expanded}
       >
         <span className="min-w-0 truncate">{label}</span>

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +15,7 @@ function ProgrammaticPickerHarness({
 
   return (
     <>
+      <button type="button" onClick={() => setOpen(true)}>Open picker</button>
       <button type="button">Outside target</button>
       <RightPanelNewTabMenu
         open={open}
@@ -27,8 +28,39 @@ function ProgrammaticPickerHarness({
   );
 }
 
+function installAnimationFrameController() {
+  let nextFrameId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const cancelledFrameIds = new Set<number>();
+
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const frameId = nextFrameId;
+    nextFrameId += 1;
+    callbacks.set(frameId, callback);
+    return frameId;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+    cancelledFrameIds.add(frameId);
+  });
+
+  return {
+    cancelledFrameIds,
+    frameIds: () => [...callbacks.keys()],
+    run(frameId: number) {
+      const callback = callbacks.get(frameId);
+      if (!callback) {
+        throw new Error(`Unknown animation frame ${frameId}`);
+      }
+      callback(performance.now());
+    },
+  };
+}
+
 describe("RightPanelNewTabMenu", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
   it("creates exactly one terminal for each direct plus click", async () => {
     const user = userEvent.setup();
@@ -147,6 +179,91 @@ describe("RightPanelNewTabMenu", () => {
       expect(screen.queryByRole("menuitem", { name: "Terminal" })).toBeNull();
     });
     expect(document.activeElement).not.toBe(createButton);
+  });
+
+  it("invalidates an Escape restore across rapid reopen and outside dismissal", async () => {
+    const user = userEvent.setup();
+    render(<ProgrammaticPickerHarness />);
+
+    const outsideTarget = screen.getByText("Outside target").closest("button")!;
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+    const frames = installAnimationFrameController();
+
+    await user.keyboard("{Escape}");
+    const escapeFrameIds = frames.frameIds();
+    const escapeFrameId = escapeFrameIds[escapeFrameIds.length - 1];
+    expect(escapeFrameId).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Open picker" }));
+    const reopenedTerminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    reopenedTerminalItem.focus();
+    expect(document.activeElement).toBe(reopenedTerminalItem);
+
+    fireEvent.pointerDown(outsideTarget);
+    outsideTarget.focus();
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Terminal" })).toBeNull();
+    });
+
+    expect(frames.cancelledFrameIds).toContain(escapeFrameId!);
+    act(() => frames.run(escapeFrameId!));
+    expect(document.activeElement).toBe(outsideTarget);
+  });
+
+  it("makes an Escape restore harmless after rapid reopen and unmount", async () => {
+    const user = userEvent.setup();
+    const rendered = render(<ProgrammaticPickerHarness />);
+
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+    const frames = installAnimationFrameController();
+
+    await user.keyboard("{Escape}");
+    const escapeFrameIds = frames.frameIds();
+    const escapeFrameId = escapeFrameIds[escapeFrameIds.length - 1];
+    expect(escapeFrameId).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Open picker" }));
+    const reopenedTerminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    reopenedTerminalItem.focus();
+    rendered.unmount();
+
+    expect(frames.cancelledFrameIds).toContain(escapeFrameId!);
+    expect(() => act(() => frames.run(escapeFrameId!))).not.toThrow();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("allows only the latest Escape generation to restore focus", async () => {
+    const user = userEvent.setup();
+    render(<ProgrammaticPickerHarness />);
+
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+    const frames = installAnimationFrameController();
+
+    await user.keyboard("{Escape}");
+    const firstEscapeFrameIds = frames.frameIds();
+    const firstEscapeFrameId = firstEscapeFrameIds[firstEscapeFrameIds.length - 1];
+    expect(firstEscapeFrameId).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Open picker" }));
+    const reopenedTerminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    reopenedTerminalItem.focus();
+    expect(document.activeElement).toBe(reopenedTerminalItem);
+    await user.keyboard("{Escape}");
+
+    const secondEscapeFrameIds = frames.frameIds();
+    const secondEscapeFrameId = secondEscapeFrameIds[secondEscapeFrameIds.length - 1];
+    expect(secondEscapeFrameId).toBeDefined();
+    const createButton = screen.getByRole("button", { name: "New terminal" });
+
+    expect(frames.cancelledFrameIds).toContain(firstEscapeFrameId!);
+    act(() => frames.run(firstEscapeFrameId!));
+    expect(document.activeElement).not.toBe(createButton);
+
+    act(() => frames.run(secondEscapeFrameId!));
+    expect(document.activeElement).toBe(createButton);
   });
 
   it("disables terminal creation until the workspace is ready", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
@@ -1,12 +1,66 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RightPanelNewTabMenu } from "#product/components/workspace/shell/right-panel/RightPanelNewTabMenu";
 
 describe("RightPanelNewTabMenu", () => {
-
   afterEach(cleanup);
+
+  it("creates exactly one terminal for each direct plus click", () => {
+    const onCreateTerminal = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <RightPanelNewTabMenu
+        open={false}
+        defaultKind="terminal"
+        isWorkspaceReady
+        onOpenChange={onOpenChange}
+        onCreateTerminal={onCreateTerminal}
+      />,
+    );
+
+    const createButton = screen.getByRole("button", { name: "New terminal" });
+    fireEvent.click(createButton);
+    fireEvent.click(createButton);
+
+    expect(onCreateTerminal).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenNthCalledWith(1, false);
+    expect(onOpenChange).toHaveBeenNthCalledWith(2, false);
+    expect(screen.queryByRole("menuitem", { name: "Terminal" })).toBeNull();
+  });
+
+  it("keeps the explicit programmatic picker path available", async () => {
+    render(
+      <RightPanelNewTabMenu
+        open
+        defaultKind="terminal"
+        isWorkspaceReady
+        onOpenChange={vi.fn()}
+        onCreateTerminal={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("menuitem", { name: "Terminal" })).toBeTruthy();
+  });
+
+  it("disables terminal creation until the workspace is ready", () => {
+    const onCreateTerminal = vi.fn();
+    render(
+      <RightPanelNewTabMenu
+        open={false}
+        defaultKind="terminal"
+        isWorkspaceReady={false}
+        onOpenChange={vi.fn()}
+        onCreateTerminal={onCreateTerminal}
+      />,
+    );
+
+    const createButton = screen.getByRole("button", { name: "New terminal" });
+    expect((createButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(createButton);
+    expect(onCreateTerminal).not.toHaveBeenCalled();
+  });
 
   it("does not advertise a global new-tab shortcut", () => {
     const rendered = render(

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
@@ -2,8 +2,30 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RightPanelNewTabMenu } from "#product/components/workspace/shell/right-panel/RightPanelNewTabMenu";
+
+function ProgrammaticPickerHarness({
+  onCreateTerminal = vi.fn(),
+}: {
+  onCreateTerminal?: () => void;
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <>
+      <button type="button">Outside target</button>
+      <RightPanelNewTabMenu
+        open={open}
+        defaultKind="terminal"
+        isWorkspaceReady
+        onOpenChange={setOpen}
+        onCreateTerminal={onCreateTerminal}
+      />
+    </>
+  );
+}
 
 describe("RightPanelNewTabMenu", () => {
   afterEach(cleanup);
@@ -64,15 +86,7 @@ describe("RightPanelNewTabMenu", () => {
   });
 
   it("keeps the explicit programmatic picker path available", async () => {
-    const { container } = render(
-      <RightPanelNewTabMenu
-        open
-        defaultKind="terminal"
-        isWorkspaceReady
-        onOpenChange={vi.fn()}
-        onCreateTerminal={vi.fn()}
-      />,
-    );
+    const { container } = render(<ProgrammaticPickerHarness />);
 
     const trigger = container.querySelector<HTMLButtonElement>(
       "[data-slot='dropdown-menu-trigger']",
@@ -83,6 +97,56 @@ describe("RightPanelNewTabMenu", () => {
 
     const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
     await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+  });
+
+  it("returns focus to the truthful direct button after Escape", async () => {
+    const user = userEvent.setup();
+    render(<ProgrammaticPickerHarness />);
+
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+
+    await user.keyboard("{Escape}");
+
+    const createButton = await screen.findByRole("button", { name: "New terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(createButton));
+    expect(createButton.getAttribute("aria-haspopup")).toBeNull();
+    expect(createButton.getAttribute("aria-expanded")).toBeNull();
+    expect(createButton.getAttribute("data-state")).toBeNull();
+    expect(createButton.getAttribute("data-slot")).toBeNull();
+  });
+
+  it("keeps a failed picker creation on the meaningful direct button", async () => {
+    const user = userEvent.setup();
+    const onCreateTerminal = vi.fn();
+    render(<ProgrammaticPickerHarness onCreateTerminal={onCreateTerminal} />);
+
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+    await user.click(terminalItem);
+
+    const createButton = await screen.findByRole("button", { name: "New terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(createButton));
+    expect(onCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menuitem", { name: "Terminal" })).toBeNull();
+  });
+
+  it("does not steal focus on outside-pointer dismissal", async () => {
+    const { container } = render(<ProgrammaticPickerHarness />);
+
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
+
+    const outsideTarget = screen.getByText("Outside target").closest("button")!;
+    const createButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="New terminal"]',
+    )!;
+    fireEvent.pointerDown(outsideTarget);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Terminal" })).toBeNull();
+    });
+    expect(document.activeElement).not.toBe(createButton);
   });
 
   it("disables terminal creation until the workspace is ready", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.test.tsx
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RightPanelNewTabMenu } from "#product/components/workspace/shell/right-panel/RightPanelNewTabMenu";
 
 describe("RightPanelNewTabMenu", () => {
   afterEach(cleanup);
 
-  it("creates exactly one terminal for each direct plus click", () => {
+  it("creates exactly one terminal for each direct plus click", async () => {
+    const user = userEvent.setup();
     const onCreateTerminal = vi.fn();
     const onOpenChange = vi.fn();
     render(
@@ -21,8 +23,8 @@ describe("RightPanelNewTabMenu", () => {
     );
 
     const createButton = screen.getByRole("button", { name: "New terminal" });
-    fireEvent.click(createButton);
-    fireEvent.click(createButton);
+    await user.click(createButton);
+    await user.click(createButton);
 
     expect(onCreateTerminal).toHaveBeenCalledTimes(2);
     expect(onOpenChange).toHaveBeenNthCalledWith(1, false);
@@ -30,8 +32,39 @@ describe("RightPanelNewTabMenu", () => {
     expect(screen.queryByRole("menuitem", { name: "Terminal" })).toBeNull();
   });
 
-  it("keeps the explicit programmatic picker path available", async () => {
+  it("uses truthful button semantics and creates once for Enter and Space", async () => {
+    const user = userEvent.setup();
+    const onCreateTerminal = vi.fn();
+    const onOpenChange = vi.fn();
     render(
+      <RightPanelNewTabMenu
+        open={false}
+        defaultKind="terminal"
+        isWorkspaceReady
+        onOpenChange={onOpenChange}
+        onCreateTerminal={onCreateTerminal}
+      />,
+    );
+
+    const createButton = screen.getByRole("button", { name: "New terminal" });
+    expect(createButton.getAttribute("aria-haspopup")).toBeNull();
+    expect(createButton.getAttribute("aria-expanded")).toBeNull();
+    expect(createButton.getAttribute("data-state")).toBeNull();
+    expect(createButton.getAttribute("data-slot")).toBeNull();
+
+    createButton.focus();
+    await user.keyboard("{Enter}");
+    expect(onCreateTerminal).toHaveBeenCalledTimes(1);
+
+    await user.keyboard(" ");
+    expect(onCreateTerminal).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenNthCalledWith(1, false);
+    expect(onOpenChange).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("keeps the explicit programmatic picker path available", async () => {
+    const { container } = render(
       <RightPanelNewTabMenu
         open
         defaultKind="terminal"
@@ -41,7 +74,15 @@ describe("RightPanelNewTabMenu", () => {
       />,
     );
 
-    expect(await screen.findByRole("menuitem", { name: "Terminal" })).toBeTruthy();
+    const trigger = container.querySelector<HTMLButtonElement>(
+      "[data-slot='dropdown-menu-trigger']",
+    );
+    expect(trigger).not.toBeNull();
+    expect(trigger?.getAttribute("aria-haspopup")).toBe("menu");
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+
+    const terminalItem = await screen.findByRole("menuitem", { name: "Terminal" });
+    await waitFor(() => expect(document.activeElement).toBe(terminalItem));
   });
 
   it("disables terminal creation until the workspace is ready", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,6 +27,9 @@ export function RightPanelNewTabMenu({
   onOpenChange,
   onCreateTerminal,
 }: RightPanelNewTabMenuProps) {
+  const createButtonRef = useRef<HTMLButtonElement>(null);
+  const closeReasonRef = useRef<"escape" | "selection" | "outside-pointer" | null>(null);
+
   const handleMenuOpenChange = (isOpen: boolean) => {
     // A direct click owns primary terminal creation. The controlled menu only
     // opens for explicit programmatic requests routed through the header.
@@ -39,8 +43,35 @@ export function RightPanelNewTabMenu({
     onCreateTerminal();
   };
 
+  const handleSelectTerminal = () => {
+    closeReasonRef.current = "selection";
+    handleCreateTerminal();
+  };
+
+  const handleCloseAutoFocus = (event: Event) => {
+    event.preventDefault();
+    const closeReason = closeReasonRef.current;
+    closeReasonRef.current = null;
+
+    if (closeReason === "outside-pointer") {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      const activeElement = document.activeElement;
+      const shouldRestoreFocus = closeReason === "escape"
+        || activeElement === document.body
+        || !(activeElement instanceof HTMLElement)
+        || !activeElement.isConnected;
+      if (shouldRestoreFocus) {
+        createButtonRef.current?.focus();
+      }
+    });
+  };
+
   const trigger = (
     <IconButton
+      ref={createButtonRef}
       type="button"
       size="xs"
       tone="sidebar"
@@ -59,11 +90,21 @@ export function RightPanelNewTabMenu({
       {open
         ? <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         : trigger}
-      <DropdownMenuContent align="end" className="min-w-40 shadow-popover">
+      <DropdownMenuContent
+        align="end"
+        className="min-w-40 shadow-popover"
+        onEscapeKeyDown={() => {
+          closeReasonRef.current = "escape";
+        }}
+        onPointerDownOutside={() => {
+          closeReasonRef.current = "outside-pointer";
+        }}
+        onCloseAutoFocus={handleCloseAutoFocus}
+      >
         <DropdownMenuItem
           disabled={!isWorkspaceReady}
           data-autofocus={defaultKind === "terminal" || undefined}
-          onSelect={handleCreateTerminal}
+          onSelect={handleSelectTerminal}
         >
           <AppShellTerminalIcon className="size-4" />
           Terminal

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
@@ -26,23 +26,40 @@ export function RightPanelNewTabMenu({
   onOpenChange,
   onCreateTerminal,
 }: RightPanelNewTabMenuProps) {
+  const handleMenuOpenChange = (isOpen: boolean) => {
+    // A direct click owns primary terminal creation. The controlled menu only
+    // opens for explicit programmatic requests routed through the header.
+    if (!isOpen) {
+      onOpenChange(false);
+    }
+  };
+
+  const handleCreateTerminal = () => {
+    onOpenChange(false);
+    onCreateTerminal();
+  };
+
   return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+    <DropdownMenu open={open} onOpenChange={handleMenuOpenChange}>
       <DropdownMenuTrigger asChild>
         <IconButton
+          type="button"
           size="xs"
           tone="sidebar"
+          disabled={!isWorkspaceReady}
+          aria-label="New terminal"
+          title="New terminal"
+          onClick={handleCreateTerminal}
           className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger relative"
         >
           <AppShellPlusIcon className="ui-icon" />
-          <span className="sr-only">Open new tab menu</span>
         </IconButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-40 shadow-popover">
         <DropdownMenuItem
           disabled={!isWorkspaceReady}
           data-autofocus={defaultKind === "terminal" || undefined}
-          onSelect={onCreateTerminal}
+          onSelect={handleCreateTerminal}
         >
           <AppShellTerminalIcon className="size-4" />
           Terminal

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +20,8 @@ interface RightPanelNewTabMenuProps {
   onCreateTerminal: () => void;
 }
 
+type MenuCloseReason = "escape" | "selection" | "outside-pointer";
+
 export function RightPanelNewTabMenu({
   open,
   defaultKind,
@@ -28,7 +30,46 @@ export function RightPanelNewTabMenu({
   onCreateTerminal,
 }: RightPanelNewTabMenuProps) {
   const createButtonRef = useRef<HTMLButtonElement>(null);
-  const closeReasonRef = useRef<"escape" | "selection" | "outside-pointer" | null>(null);
+  const closeReasonRef = useRef<MenuCloseReason | null>(null);
+  const pendingRestoreFrameRef = useRef<number | null>(null);
+  const restoreGenerationRef = useRef(0);
+  const isMountedRef = useRef(false);
+  const isOpenRef = useRef(open);
+  isOpenRef.current = open;
+
+  const cancelPendingRestore = useCallback(() => {
+    const pendingFrame = pendingRestoreFrameRef.current;
+    if (pendingFrame !== null) {
+      window.cancelAnimationFrame(pendingFrame);
+      pendingRestoreFrameRef.current = null;
+    }
+  }, []);
+
+  const invalidatePendingRestore = useCallback(() => {
+    restoreGenerationRef.current += 1;
+    cancelPendingRestore();
+  }, [cancelPendingRestore]);
+
+  const registerCloseReason = (reason: MenuCloseReason) => {
+    invalidatePendingRestore();
+    closeReasonRef.current = reason;
+  };
+
+  useLayoutEffect(() => {
+    if (open) {
+      closeReasonRef.current = null;
+      invalidatePendingRestore();
+    }
+  }, [invalidatePendingRestore, open]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      closeReasonRef.current = null;
+      invalidatePendingRestore();
+    };
+  }, [invalidatePendingRestore]);
 
   const handleMenuOpenChange = (isOpen: boolean) => {
     // A direct click owns primary terminal creation. The controlled menu only
@@ -44,7 +85,7 @@ export function RightPanelNewTabMenu({
   };
 
   const handleSelectTerminal = () => {
-    closeReasonRef.current = "selection";
+    registerCloseReason("selection");
     handleCreateTerminal();
   };
 
@@ -57,16 +98,37 @@ export function RightPanelNewTabMenu({
       return;
     }
 
-    requestAnimationFrame(() => {
+    if (closeReason === null) {
+      invalidatePendingRestore();
+    }
+    const restoreGeneration = restoreGenerationRef.current;
+    const restoreFrame = window.requestAnimationFrame(() => {
+      if (pendingRestoreFrameRef.current !== restoreFrame) {
+        return;
+      }
+      pendingRestoreFrameRef.current = null;
+      if (
+        !isMountedRef.current
+        || restoreGenerationRef.current !== restoreGeneration
+        || isOpenRef.current
+      ) {
+        return;
+      }
+
+      const createButton = createButtonRef.current;
+      if (!createButton?.isConnected) {
+        return;
+      }
       const activeElement = document.activeElement;
       const shouldRestoreFocus = closeReason === "escape"
         || activeElement === document.body
         || !(activeElement instanceof HTMLElement)
         || !activeElement.isConnected;
       if (shouldRestoreFocus) {
-        createButtonRef.current?.focus();
+        createButton.focus();
       }
     });
+    pendingRestoreFrameRef.current = restoreFrame;
   };
 
   const trigger = (
@@ -94,10 +156,10 @@ export function RightPanelNewTabMenu({
         align="end"
         className="min-w-40 shadow-popover"
         onEscapeKeyDown={() => {
-          closeReasonRef.current = "escape";
+          registerCloseReason("escape");
         }}
         onPointerDownOutside={() => {
-          closeReasonRef.current = "outside-pointer";
+          registerCloseReason("outside-pointer");
         }}
         onCloseAutoFocus={handleCloseAutoFocus}
       >

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelNewTabMenu.tsx
@@ -39,22 +39,26 @@ export function RightPanelNewTabMenu({
     onCreateTerminal();
   };
 
+  const trigger = (
+    <IconButton
+      type="button"
+      size="xs"
+      tone="sidebar"
+      disabled={!isWorkspaceReady}
+      aria-label="New terminal"
+      title="New terminal"
+      onClick={open ? undefined : handleCreateTerminal}
+      className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger relative"
+    >
+      <AppShellPlusIcon className="ui-icon" />
+    </IconButton>
+  );
+
   return (
     <DropdownMenu open={open} onOpenChange={handleMenuOpenChange}>
-      <DropdownMenuTrigger asChild>
-        <IconButton
-          type="button"
-          size="xs"
-          tone="sidebar"
-          disabled={!isWorkspaceReady}
-          aria-label="New terminal"
-          title="New terminal"
-          onClick={handleCreateTerminal}
-          className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger relative"
-        >
-          <AppShellPlusIcon className="ui-icon" />
-        </IconButton>
-      </DropdownMenuTrigger>
+      {open
+        ? <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+        : trigger}
       <DropdownMenuContent align="end" className="min-w-40 shadow-popover">
         <DropdownMenuItem
           disabled={!isWorkspaceReady}

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx
@@ -88,6 +88,14 @@ afterEach(() => {
 });
 
 describe("GlobalHeader", () => {
+  it("renders the workspace title one restrained type step above surrounding header controls", () => {
+    renderHeader();
+
+    const title = screen.getByTitle("repo");
+    expect(title.className.split(" ")).toContain("text-sidebar-nav");
+    expect(title.className.split(" ")).not.toContain("text-ui");
+  });
+
   it("does not offer a native open action without a Desktop file bridge", () => {
     renderHeader();
 

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -107,7 +107,7 @@ export const GlobalHeader = memo(function GlobalHeader({
     <DebugProfiler id="global-header">
       <div className="flex h-full min-w-0 flex-1 items-center gap-1 px-2">
         <div
-          className="min-w-0 max-w-[220px] shrink-0 truncate px-1.5 text-ui font-medium text-foreground"
+          className="min-w-0 max-w-[220px] shrink-0 truncate px-1.5 text-sidebar-nav font-medium text-foreground"
           title={title}
           data-telemetry-mask="true"
         >

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenu.test.tsx
@@ -27,6 +27,18 @@ describe("WorkspaceActionsMenu", () => {
     nativeMenuState.show.mockReset();
   });
 
+  it("keeps the chat actions hit area flat with a keyboard-visible focus ring", () => {
+    nativeMenuState.show.mockResolvedValue(true);
+    render(<WorkspaceActions session={session} />);
+
+    const trigger = screen.getByRole("button", { name: "Chat actions" });
+    expect(trigger.className).toContain("workspace-shell-icon-button");
+    expect(trigger.className).toContain("workspace-shell-icon-button--flat");
+    expect(trigger.className).toContain("focus-ring");
+    expect(trigger.className).toContain("app-region-no-drag");
+    expect(trigger.className).not.toContain("workspace-shell-icon-button--hover-rim");
+  });
+
   it("keeps the DOM menu closed when the native menu opens", async () => {
     nativeMenuState.show.mockResolvedValue(true);
     render(<WorkspaceActions session={session} />);

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/WorkspaceActionsMenu.tsx
@@ -59,7 +59,7 @@ export function WorkspaceActions({ session }: WorkspaceActionsMenuProps) {
           size="icon-sm"
           aria-label="Chat actions"
           title="Chat actions"
-          className="workspace-shell-icon-button workspace-shell-icon-button--hover-rim app-region-no-drag shrink-0"
+          className="workspace-shell-icon-button workspace-shell-icon-button--flat focus-ring app-region-no-drag shrink-0"
         >
           <MoreHorizontal className="size-3.5" />
         </Button>

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SetStateAction } from "react";
+import {
+  DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
+  type RightPanelWorkspaceState,
+} from "#product/lib/domain/workspaces/shell/right-panel-model";
+import { useRightPanelEntryActions } from "#product/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions";
+
+const terminalActions = vi.hoisted(() => ({
+  createTab: vi.fn<(workspaceId: string) => Promise<string>>(),
+  closeTab: vi.fn(),
+  renameTab: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("#product/hooks/terminals/workflows/use-terminal-actions", () => ({
+  useTerminalActions: () => terminalActions,
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: vi.fn(() => null),
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions", () => ({
+  useRightPanelViewerActions: () => ({
+    selectViewer: vi.fn(),
+    handleCloseViewer: vi.fn(),
+  }),
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: (message: string) => void }) => unknown) =>
+    selector({ show: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useRightPanelEntryActions terminal creation", () => {
+  it("activates distinct terminals and requests focus once per creation", async () => {
+    terminalActions.createTab
+      .mockResolvedValueOnce("terminal-1")
+      .mockResolvedValueOnce("terminal-2");
+    let rightPanelState: RightPanelWorkspaceState = {
+      ...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
+      headerOrder: [...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE.headerOrder],
+    };
+    const updateState = vi.fn((value: SetStateAction<RightPanelWorkspaceState>) => {
+      rightPanelState = typeof value === "function" ? value(rightPanelState) : value;
+    });
+    const { result } = renderHook(() => useRightPanelEntryActions({
+      workspaceId: "workspace-1",
+      shouldRenderContent: true,
+      isCloudWorkspaceSelected: false,
+      state: rightPanelState,
+      repoSettingsHref: "/settings",
+      terminalsQuery: { refetch: vi.fn(async () => ({ data: [] })) },
+      activeTerminalId: null,
+      openViewerTargets: [],
+      buffersByPath: {},
+      updateState,
+      setActiveTerminalForWorkspace: vi.fn(),
+      closeViewerTarget: vi.fn(),
+      reorderViewerTargets: vi.fn(),
+      setActiveViewerTarget: vi.fn(),
+      clearBuffer: vi.fn(),
+    }));
+
+    await act(async () => {
+      expect(await result.current.createTerminal()).toBe("terminal-1");
+    });
+    expect(rightPanelState.activeEntryKey).toBe("terminal:terminal-1");
+    expect(rightPanelState.headerOrder).toContain("terminal:terminal-1");
+    expect(result.current.terminalFocusNonce).toBe(1);
+
+    await act(async () => {
+      expect(await result.current.createTerminal()).toBe("terminal-2");
+    });
+    expect(rightPanelState.activeEntryKey).toBe("terminal:terminal-2");
+    expect(rightPanelState.headerOrder).toEqual(expect.arrayContaining([
+      "terminal:terminal-1",
+      "terminal:terminal-2",
+    ]));
+    expect(new Set(rightPanelState.headerOrder).size).toBe(rightPanelState.headerOrder.length);
+    expect(result.current.terminalFocusNonce).toBe(2);
+    expect(terminalActions.createTab).toHaveBeenNthCalledWith(1, "workspace-1");
+    expect(terminalActions.createTab).toHaveBeenNthCalledWith(2, "workspace-1");
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.test.tsx
@@ -46,6 +46,48 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function renderTerminalCreationHook() {
+  let rightPanelState: RightPanelWorkspaceState = {
+    ...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
+    headerOrder: [...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE.headerOrder],
+  };
+  const updateState = vi.fn((value: SetStateAction<RightPanelWorkspaceState>) => {
+    rightPanelState = typeof value === "function" ? value(rightPanelState) : value;
+  });
+  const rendered = renderHook(() => useRightPanelEntryActions({
+    workspaceId: "workspace-1",
+    shouldRenderContent: true,
+    isCloudWorkspaceSelected: false,
+    state: rightPanelState,
+    repoSettingsHref: "/settings",
+    terminalsQuery: { refetch: vi.fn(async () => ({ data: [] })) },
+    activeTerminalId: null,
+    openViewerTargets: [],
+    buffersByPath: {},
+    updateState,
+    setActiveTerminalForWorkspace: vi.fn(),
+    closeViewerTarget: vi.fn(),
+    reorderViewerTargets: vi.fn(),
+    setActiveViewerTarget: vi.fn(),
+    clearBuffer: vi.fn(),
+  }));
+  return {
+    ...rendered,
+    getRightPanelState: () => rightPanelState,
+    updateState,
+  };
+}
+
 describe("useRightPanelEntryActions terminal creation", () => {
   it("activates distinct terminals and requests focus once per creation", async () => {
     terminalActions.createTab
@@ -95,6 +137,98 @@ describe("useRightPanelEntryActions terminal creation", () => {
     expect(result.current.terminalFocusNonce).toBe(2);
     expect(terminalActions.createTab).toHaveBeenNthCalledWith(1, "workspace-1");
     expect(terminalActions.createTab).toHaveBeenNthCalledWith(2, "workspace-1");
+  });
+
+  it("keeps final activation in click order when creations resolve in reverse", async () => {
+    const firstCreation = createDeferred<string>();
+    const secondCreation = createDeferred<string>();
+    terminalActions.createTab
+      .mockReturnValueOnce(firstCreation.promise)
+      .mockReturnValueOnce(secondCreation.promise);
+    const { result, getRightPanelState } = renderTerminalCreationHook();
+
+    let firstResult!: Promise<string | null>;
+    let secondResult!: Promise<string | null>;
+    act(() => {
+      firstResult = result.current.createTerminal();
+      secondResult = result.current.createTerminal();
+    });
+    expect(terminalActions.createTab).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      secondCreation.resolve("terminal-2");
+      await Promise.resolve();
+    });
+    firstCreation.resolve("terminal-1");
+    await act(async () => {
+      expect(await Promise.all([firstResult, secondResult])).toEqual([
+        "terminal-1",
+        "terminal-2",
+      ]);
+    });
+
+    expect(getRightPanelState().activeEntryKey).toBe("terminal:terminal-2");
+    expect(getRightPanelState().headerOrder).toEqual(expect.arrayContaining([
+      "terminal:terminal-1",
+      "terminal:terminal-2",
+    ]));
+    expect(result.current.terminalFocusNonce).toBe(2);
+  });
+
+  it("activates the latest successful click when the newer creation fails", async () => {
+    const firstCreation = createDeferred<string>();
+    const secondCreation = createDeferred<string>();
+    terminalActions.createTab
+      .mockReturnValueOnce(firstCreation.promise)
+      .mockReturnValueOnce(secondCreation.promise);
+    const { result, getRightPanelState } = renderTerminalCreationHook();
+
+    let firstResult!: Promise<string | null>;
+    let secondResult!: Promise<string | null>;
+    act(() => {
+      firstResult = result.current.createTerminal();
+      secondResult = result.current.createTerminal();
+    });
+    secondCreation.reject(new Error("second create failed"));
+    firstCreation.resolve("terminal-1");
+    await act(async () => {
+      expect(await Promise.all([firstResult, secondResult])).toEqual([
+        "terminal-1",
+        null,
+      ]);
+    });
+
+    expect(getRightPanelState().activeEntryKey).toBe("terminal:terminal-1");
+    expect(getRightPanelState().headerOrder).toContain("terminal:terminal-1");
+    expect(result.current.terminalFocusNonce).toBe(1);
+  });
+
+  it("activates the newer click when the earlier creation fails", async () => {
+    const firstCreation = createDeferred<string>();
+    const secondCreation = createDeferred<string>();
+    terminalActions.createTab
+      .mockReturnValueOnce(firstCreation.promise)
+      .mockReturnValueOnce(secondCreation.promise);
+    const { result, getRightPanelState } = renderTerminalCreationHook();
+
+    let firstResult!: Promise<string | null>;
+    let secondResult!: Promise<string | null>;
+    act(() => {
+      firstResult = result.current.createTerminal();
+      secondResult = result.current.createTerminal();
+    });
+    secondCreation.resolve("terminal-2");
+    firstCreation.reject(new Error("first create failed"));
+    await act(async () => {
+      expect(await Promise.all([firstResult, secondResult])).toEqual([
+        null,
+        "terminal-2",
+      ]);
+    });
+
+    expect(getRightPanelState().activeEntryKey).toBe("terminal:terminal-2");
+    expect(getRightPanelState().headerOrder).toContain("terminal:terminal-2");
+    expect(result.current.terminalFocusNonce).toBe(1);
   });
 
   it("does not materialize or focus a phantom terminal when creation fails", async () => {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.test.tsx
@@ -96,4 +96,41 @@ describe("useRightPanelEntryActions terminal creation", () => {
     expect(terminalActions.createTab).toHaveBeenNthCalledWith(1, "workspace-1");
     expect(terminalActions.createTab).toHaveBeenNthCalledWith(2, "workspace-1");
   });
+
+  it("does not materialize or focus a phantom terminal when creation fails", async () => {
+    terminalActions.createTab.mockRejectedValueOnce(new Error("runtime unavailable"));
+    let rightPanelState: RightPanelWorkspaceState = {
+      ...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
+      headerOrder: [...DEFAULT_RIGHT_PANEL_WORKSPACE_STATE.headerOrder],
+    };
+    const initialState = rightPanelState;
+    const updateState = vi.fn((value: SetStateAction<RightPanelWorkspaceState>) => {
+      rightPanelState = typeof value === "function" ? value(rightPanelState) : value;
+    });
+    const { result } = renderHook(() => useRightPanelEntryActions({
+      workspaceId: "workspace-1",
+      shouldRenderContent: true,
+      isCloudWorkspaceSelected: false,
+      state: rightPanelState,
+      repoSettingsHref: "/settings",
+      terminalsQuery: { refetch: vi.fn(async () => ({ data: [] })) },
+      activeTerminalId: null,
+      openViewerTargets: [],
+      buffersByPath: {},
+      updateState,
+      setActiveTerminalForWorkspace: vi.fn(),
+      closeViewerTarget: vi.fn(),
+      reorderViewerTargets: vi.fn(),
+      setActiveViewerTarget: vi.fn(),
+      clearBuffer: vi.fn(),
+    }));
+
+    await act(async () => {
+      expect(await result.current.createTerminal()).toBeNull();
+    });
+
+    expect(rightPanelState).toBe(initialState);
+    expect(updateState).not.toHaveBeenCalled();
+    expect(result.current.terminalFocusNonce).toBe(0);
+  });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useRef,
   useState,
   type SetStateAction,
 } from "react";
@@ -78,6 +79,7 @@ export function useRightPanelEntryActions({
   const showToast = useToastStore((store) => store.show);
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
   const [terminalFocusNonce, setTerminalFocusNonce] = useState(0);
+  const activationApplicationQueueRef = useRef<Promise<void>>(Promise.resolve());
   const { selectViewer, handleCloseViewer } = useRightPanelViewerActions({
     state,
     isCloudWorkspaceSelected,
@@ -118,25 +120,47 @@ export function useRightPanelEntryActions({
       return null;
     }
     const activate = options?.activate ?? true;
-    try {
-      const terminalId = await createTab(workspaceId);
-      const terminalKey = rightPanelTerminalHeaderKey(terminalId);
-      updateState((previous) => ({
-        ...previous,
-        activeEntryKey: activate ? terminalKey : previous.activeEntryKey,
-        headerOrder: previous.headerOrder.includes(terminalKey)
-          ? previous.headerOrder
-          : [...previous.headerOrder, terminalKey],
-      }));
-      if (activate) {
-        setTerminalFocusNonce((nonce) => nonce + 1);
+    // Launch every creation immediately, but apply activating results in click
+    // order so reverse promise resolution cannot give an older click final
+    // ownership of selection or focus.
+    const creationResult = createTab(workspaceId).then(
+      (terminalId) => ({ status: "created" as const, terminalId }),
+      (error: unknown) => ({ status: "failed" as const, error }),
+    );
+    const applyCreation = async () => {
+      try {
+        const result = await creationResult;
+        if (result.status === "failed") {
+          throw result.error;
+        }
+        const terminalKey = rightPanelTerminalHeaderKey(result.terminalId);
+        updateState((previous) => ({
+          ...previous,
+          activeEntryKey: activate ? terminalKey : previous.activeEntryKey,
+          headerOrder: previous.headerOrder.includes(terminalKey)
+            ? previous.headerOrder
+            : [...previous.headerOrder, terminalKey],
+        }));
+        if (activate) {
+          setTerminalFocusNonce((nonce) => nonce + 1);
+        }
+        return result.terminalId;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        showToast(`Failed to create terminal tab: ${message}`);
+        return null;
       }
-      return terminalId;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      showToast(`Failed to create terminal tab: ${message}`);
-      return null;
+    };
+
+    if (!activate) {
+      return applyCreation();
     }
+    const activationResult = activationApplicationQueueRef.current.then(applyCreation);
+    activationApplicationQueueRef.current = activationResult.then(
+      () => undefined,
+      () => undefined,
+    );
+    return activationResult;
   }, [
     createTab,
     getWorkspaceRuntimeBlockReason,


### PR DESCRIPTION
## What this changes

This updates the **Workspace header and pane chrome** surface so the workspace title reads proportionally stronger, routine actions stay visually quiet, completed work reads as a ledger, and New terminal acts immediately while the latest click keeps focus.

**Surface:** Workspace header and pane chrome—the workspace title, chat-actions control, right-pane New terminal control, and expanded completed-work ledger.

**Explicit non-goals:** No redesign of workspace/tab semantics, terminal layout, tool-detail grouping, sidebar, transcript typography, file-result cards, or neighboring UI slices; no adjacent cleanup. The final founder adjustment changes only the existing workspace-title scale.

## Before / after

**Before:** The workspace title sat nearly at the same scale as surrounding tabs and controls; chat actions carried extra button chrome, expanded Worked history sat inside another bordered card, and New terminal required an extra choice. Rapid terminal requests could also leave an older click active when responses arrived out of order.

**After:** The title moves one restrained existing type step from 11px to 12px while tabs, actions, spacing, and header geometry remain unchanged. Chat actions stay visually flat until hover, keyboard focus, or menu use; Worked history expands without an outer box while useful inner detail boundaries remain; and click, Enter, or Space on New terminal creates exactly one terminal immediately. Every rapid click still creates its own terminal, and the terminal from the last click remains active even when responses arrive in reverse order.

## When this matters

This matters whenever someone orients to a workspace, starts a terminal, or scans completed agent work. The stale-focus case requires a rare Escape → rapid reopen → outside-dismiss timing sequence; keep the narrowly scoped lifecycle guard because it preserves accessible focus ownership without changing ordinary clicks.

## Design reference

**Reference contract**

1. **Primary reference:** Codex Desktop. Conductor was not used as a co-equal reference.
2. **Exact states inspected:** Codex dark local-thread state captured 2026-07-18 at a 1256×380 settled viewport crop, backed by saved rendered DOM/CSS: the closed/idle Task actions control plus hover, focus, and menu states; the completed “Worked for 33s” disclosure with its expanded bounded ledger at the top of its scroll range; and the settled “Edited 8 files” result showing three files and “Show 5 more files.”
3. **Intentionally matched:** The quiet, transparent idle action treatment with visible hover/focus/open affordances; completed-work hierarchy without another enclosing visible card; compact vertical rhythm and readable row separation; preserved disclosure and bounded scrolling (224px / <code>max-h-56</code>); and preserved inner tool-detail boundaries.
4. **Intentional Proliferate-specific divergences:** Proliferate keeps its own color tokens, typography, workspace tab/terminal model, drag region, and existing control hit areas. The workspace title now uses Proliferate’s existing 12px primary-navigation tier after founder review of the native Desktop surface; surrounding 10px tabs/actions remain unchanged. The direct New terminal action, explicit programmatic alternate picker, independent rapid creates, click-order activation, failure handling, and focus-generation ownership come from frozen Spec 03 revision 2 rather than the Codex tool-call surface. This PR does not copy Codex file-result card styling, hover subtitle swaps, row motion, empty/error presentation, or any broader transcript redesign because those are outside this named surface.
5. **Mock approval:** None was required or obtained. This already-built slice used the real Codex reference above for visual hierarchy and chrome, while the frozen spec and the final native-Desktop founder review supplied the deliberate Proliferate behavior and title proportion; no retroactive mock was manufactured and no unresolved visual ambiguity remains.

**Comparable proof state:** The Codex reference is the 1256×380 dark settled completed-work crop in <code>reference/codex/tool-call-blocks/</code>. Final Proliferate proof is the exact-head native Desktop dark workspace at 1229×768 in <code>reference/proliferate/workspace-header-pane-chrome/after-founder-title-scale-native-head.png</code>, with measurements in <code>computed-header-title-founder-head.json</code>.

## Demo

[Verified hosted preview](https://proliferate-web-git-codex-ui-header-pane-chrome-getonyx.vercel.app) for exact head <code>1fd13144b4d907b233dfb56e575d799aff4b6e6c</code> (Vercel deployment succeeded; HTTP 200 verified 2026-07-19). The authoritative final capture is the native Desktop dev app, profile <code>ui-03-header-panes</code>, app <code>0.3.43</code>, HMR enabled, renderer <code>127.0.0.1:1676</code>, at 1229×768.

## Current disposition

**Merged.** Exact feature head <code>1fd13144b4d907b233dfb56e575d799aff4b6e6c</code> was squash-merged to <code>main</code> as <code>d5210d4e0269151964251edb683d1b84a5b18943</code>. Next action: none for UI 03.

## Founder decision needed

None. Founder approved the final title-proportion adjustment and authorized squash merge after focused verification and required CI pass. Frozen Spec 03 revision 2 already resolves overlapping terminal creation in favor of click order.

---

## Engineering evidence

### Scope and revisions

- Frozen spec: <code>03 - Workspace header and pane chrome</code>, revision 2.
- Frozen base: <code>c91d6f9275cd6e21723f9b83388df2ac8a697389</code>.
- Branch: <code>codex/ui-header-pane-chrome</code>.
- Exact final feature head: <code>1fd13144b4d907b233dfb56e575d799aff4b6e6c</code>.
- PR was squash-merged with <code>release:minor-feature</code> and <code>area:product</code>; merge SHA: <code>d5210d4e0269151964251edb683d1b84a5b18943</code>.
- No Rust source changed, no local Rust build ran, and Docker was not started.

### Final founder adjustment

- <strong>Accepted founder direction resolved:</strong> only <code>GlobalHeader</code> workspace-title typography changes, from <code>text-ui</code> (11px / 16px) to the existing <code>text-sidebar-nav</code> tier (12px / 17px).
- Tabs and actions remain 10px / 14px; header height remains 46px; title max width remains 220px; horizontal padding remains 6px; no behavior or focus logic changed.
- <code>GlobalHeader.test.tsx</code> locks the new semantic tier and rejects regression to <code>text-ui</code>.

### Stable review findings

- **UI03-B1 resolved:** the closed primary action is an ordinary native button with no Radix menu-trigger ARIA/state/key interception. Click, Enter, and Space each create exactly one terminal. Only explicit programmatic open mounts the genuine picker trigger/anchor, and Terminal receives initial focus.
- **UI03-B2 resolved:** production completed history removes the actual outer disclosure border/radius owner. The bounded action ledger, disclosure behavior, scrolling, and nested tool-detail border/radius remain unchanged.
- **UI03-B3 resolved:** Escape focus restoration owns a tracked animation frame and lifecycle generation. Every newer open, newer close reason, and unmount cancels or invalidates stale work; the callback verifies mount, generation, closed state, and a connected focus target. Escape and failed selection return to New terminal, while a later outside-pointer dismissal retains outside focus.
- **UI03-D1 resolved:** each rapid New terminal activation launches an independent create immediately, while activation application follows click order. Reverse-resolving successes finish on the last-click terminal; mixed failures activate the latest successful click and increment the focus nonce only for successful activations.

### Verification

- Final focused <code>GlobalHeader.test.tsx</code>: 1 file / 4 tests passed.
- Full ProductClient suite after final adjustment: 594 files / 3,576 tests passed.
- <code>pnpm --dir apps/packages/product-client typecheck</code>
- <code>python3 scripts/check_frontend_boundaries.py</code>
- <code>python3 scripts/report_frontend_structure.py --strict --summary-only</code> — 0 violations.
- <code>git diff --check</code>.
- PR title, release label, and area label metadata passed on the exact head.
- All 23 exact final-head checks passed before merge, including Cargo, shared frontend, Desktop/Web builds, candidate handoff, production compose smoke, CodeQL, metadata, Vercel, and both intent lanes.

### Visual and computed evidence

- Primary Codex reference bundle: <code>reference/codex/tool-call-blocks/</code> (captured 2026-07-18; dark; 1256×380 settled crop plus rendered DOM/CSS).
- Local exact-head proof bundle: <code>reference/proliferate/workspace-header-pane-chrome/</code>.
- Final native Desktop screenshot: <code>after-founder-title-scale-native-head.png</code> (1229×768, exact head <code>1fd13144b</code>).
- Final computed title proof: <code>computed-header-title-founder-head.json</code>.
- Primary lifecycle proof: <code>after-round3-click-order.jpg</code>; computed lifecycle evidence: <code>computed-focus-click-order-round3-head.json</code>.
- Worked-ledger proof: <code>before-round1-production-ledger.png</code>, <code>after-round1-production-ledger.png</code>, <code>computed-styles-round1-base.json</code>, and <code>computed-styles-round1-head.json</code>.
- Existing multi-state recording: <code>interaction-proof.mp4</code>.
- B2 computed match: Worked disclosure changes from <code>1px / 6px</code> on the frozen base to <code>0px / 0px</code> on the head; nested tool detail stays <code>1px / 8px</code>; ledger stays <code>max-height: 224px; overflow-y: auto; overflow-x: hidden</code>.
- B3/D1 rendered result: the Escape restore is invalidated with Outside target still active; reverse-resolving Terminal 2 then Terminal 1 retains both terminals, finishes on Terminal 2, and records focus nonce 2.

### Readiness and attribution

- [x] Followed the repository pull-request procedure for scope, title, labels, body, and proof.
- [x] No support relationship and no private source data.