### PR TITLE
feat(product): polish Markdown presentation

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -11,30 +11,6 @@
   font-display: swap;
 }
 
-/* Transcript Markdown owns one scoped semantic type contract. The body scale
-   comes from its surrounding message (or the secondary-chat fallback), while
-   the hierarchy derives from runtime appearance tokens instead of frozen px
-   values. This keeps prose, inline code, and fenced code synchronized at every
-   UI size without leaking presentation rules into plan/editor surfaces. */
-.chat-markdown {
-  --markdown-font-size: var(--prose-text-size, var(--text-chat));
-  --markdown-line-height: var(--prose-text-line-height, var(--text-chat--line-height));
-  --markdown-h1-font-size: var(--text-title);
-  --markdown-h2-font-size: calc((var(--text-title) + var(--markdown-font-size)) / 2);
-  --markdown-h3-font-size: calc(var(--markdown-font-size) * 1.1667);
-  --markdown-h4-font-size: calc(var(--markdown-font-size) * 1.0833);
-  --markdown-h5-font-size: var(--markdown-font-size);
-  --markdown-h6-font-size: var(--markdown-font-size);
-}
-
-.chat-markdown ul ul {
-  list-style-type: circle;
-}
-
-.chat-markdown ul ul ul {
-  list-style-type: square;
-}
-
 @font-face {
   font-family: "Geist Mono";
   src: url("/node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2") format("woff2");

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -11,6 +11,30 @@
   font-display: swap;
 }
 
+/* Transcript Markdown owns one scoped semantic type contract. The body scale
+   comes from its surrounding message (or the secondary-chat fallback), while
+   the hierarchy derives from runtime appearance tokens instead of frozen px
+   values. This keeps prose, inline code, and fenced code synchronized at every
+   UI size without leaking presentation rules into plan/editor surfaces. */
+.chat-markdown {
+  --markdown-font-size: var(--prose-text-size, var(--text-chat));
+  --markdown-line-height: var(--prose-text-line-height, var(--text-chat--line-height));
+  --markdown-h1-font-size: var(--text-title);
+  --markdown-h2-font-size: calc((var(--text-title) + var(--markdown-font-size)) / 2);
+  --markdown-h3-font-size: calc(var(--markdown-font-size) * 1.1667);
+  --markdown-h4-font-size: calc(var(--markdown-font-size) * 1.0833);
+  --markdown-h5-font-size: var(--markdown-font-size);
+  --markdown-h6-font-size: var(--markdown-font-size);
+}
+
+.chat-markdown ul ul {
+  list-style-type: circle;
+}
+
+.chat-markdown ul ul ul {
+  list-style-type: square;
+}
+
 @font-face {
   font-family: "Geist Mono";
   src: url("/node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2") format("woff2");

--- a/apps/packages/product-client/src/app/authenticated-markdown-cascade.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-markdown-cascade.test.ts
@@ -1,0 +1,246 @@
+import { fileURLToPath } from "node:url";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CodeBlock } from "@proliferate/product-ui/code/CodeBlock";
+import { MarkdownBody } from "@proliferate/product-ui/chat/transcript/MarkdownBody";
+import { PlanMarkdownBody } from "@proliferate/product-ui/chat/transcript/PlanMarkdownBody";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Plugin, type ViteDevServer } from "vite";
+
+const WEB_ROOT = fileURLToPath(new URL("../../../../web/", import.meta.url));
+const WEB_VITE_CONFIG = fileURLToPath(
+  new URL("../../../../web/vite.config.ts", import.meta.url),
+);
+const AUTHENTICATED_CSS = fileURLToPath(
+  new URL("./authenticated.css", import.meta.url),
+);
+
+const MARKDOWN_FIXTURE = [
+  "# Transcript title",
+  "",
+  "## Section heading",
+  "",
+  "### Supporting heading",
+  "",
+  "Prose with `inline code`.",
+  "",
+  "```ts",
+  "const parity = true;",
+  "```",
+  "",
+  "| Surface | Long value |",
+  "| --- | --- |",
+  "| Transcript | " +
+    "this_unbroken_value_forces_table_local_horizontal_overflow_without_widening_the_fixture |",
+].join("\n");
+
+const PROPOSAL_FIXTURE = [
+  "# Proposal title",
+  "",
+  "## Proposal section",
+  "",
+  "### Proposal micro-label",
+  "",
+  "Proposal prose.",
+].join("\n");
+
+let viteServer: ViteDevServer;
+let browser: Browser;
+let fixtureUrl: string;
+
+beforeAll(async () => {
+  const html = renderFixtureHtml();
+  viteServer = await createServer({
+    configFile: WEB_VITE_CONFIG,
+    root: WEB_ROOT,
+    logLevel: "silent",
+    plugins: [fixtureRoute(html)],
+    server: {
+      host: "127.0.0.1",
+      port: 0,
+      strictPort: false,
+    },
+  });
+  await viteServer.listen();
+  const baseUrl = viteServer.resolvedUrls?.local[0];
+  if (!baseUrl) {
+    throw new Error("Markdown cascade fixture did not receive a Vite URL.");
+  }
+  fixtureUrl = new URL("__markdown-cascade", baseUrl).href;
+  browser = await chromium.launch({ headless: true });
+}, 60_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await viteServer?.close();
+});
+
+describe("authenticated Markdown stylesheet cascade", () => {
+  it("preserves transcript semantics and explicit proposal hierarchy", async () => {
+    const page = await browser.newPage({ viewport: { width: 900, height: 1200 } });
+    try {
+      await page.goto(fixtureUrl, { waitUntil: "networkidle" });
+
+      const result = await page.evaluate(() => {
+        const px = (element: Element | null) => {
+          if (!element) throw new Error("Expected fixture element was not rendered.");
+          return Number.parseFloat(getComputedStyle(element).fontSize);
+        };
+        const metrics = (id: string) => {
+          const container = document.querySelector<HTMLElement>(`#${id}`);
+          const root = container?.querySelector<HTMLElement>(".chat-markdown");
+          if (!container || !root) throw new Error(`${id} fixture was not rendered.`);
+          return {
+            prose: px(root.querySelector("p")),
+            inlineCode: px(root.querySelector('[data-markdown-inline-code="true"]')),
+            fencedCode: px(root.querySelector('[data-markdown-code-content="true"]')),
+            headings: [
+              px(root.querySelector("h1")),
+              px(root.querySelector("h2")),
+              px(root.querySelector("h3")),
+            ],
+          };
+        };
+        const headings = (id: string) => {
+          const root = document.querySelector<HTMLElement>(`#${id} .chat-markdown`);
+          if (!root) throw new Error(`${id} fixture was not rendered.`);
+          return [
+            px(root.querySelector("h1")),
+            px(root.querySelector("h2")),
+            px(root.querySelector("h3")),
+          ];
+        };
+
+        const tableRoot = document.querySelector<HTMLElement>("#ordinary-default .chat-markdown");
+        const tableShell = tableRoot?.querySelector<HTMLElement>(
+          '[data-markdown-table-shell="true"]',
+        );
+        const tableScroller = tableShell?.querySelector<HTMLElement>("div");
+        if (!tableRoot || !tableShell || !tableScroller) {
+          throw new Error("Table overflow fixture was not rendered.");
+        }
+
+        return {
+          stylesheets: Array.from(
+            document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'),
+          ).map((link) => link.dataset.sheet),
+          defaultTranscript: metrics("ordinary-default"),
+          largeTranscript: metrics("ordinary-large"),
+          highlightedDefault: metrics("highlighted-default"),
+          highlightedLarge: metrics("highlighted-large"),
+          proposalHeadings: headings("proposal-default"),
+          table: {
+            rootWidth: tableRoot.clientWidth,
+            shellWidth: tableShell.clientWidth,
+            clientWidth: tableScroller.clientWidth,
+            scrollWidth: tableScroller.scrollWidth,
+            overflowX: getComputedStyle(tableScroller).overflowX,
+          },
+        };
+      });
+
+      expect(result.stylesheets).toEqual(["eager", "authenticated"]);
+      expect(result.defaultTranscript.headings).toEqual([18, 15, 14.0004]);
+      expect(result.largeTranscript.headings).toEqual([19, 16, 15.1671]);
+      expect(result.proposalHeadings).toEqual([11, 11, 10]);
+
+      expect(result.defaultTranscript.prose).toBe(12);
+      expect(result.defaultTranscript.inlineCode).toBe(12);
+      expect(result.defaultTranscript.fencedCode).toBe(12);
+      expect(result.highlightedDefault.fencedCode).toBe(12);
+
+      expect(result.largeTranscript.prose).toBe(13);
+      expect(result.largeTranscript.inlineCode).toBe(13);
+      expect(result.largeTranscript.fencedCode).toBe(13);
+      expect(result.highlightedLarge.fencedCode).toBe(13);
+
+      expect(result.table.shellWidth).toBeLessThanOrEqual(result.table.rootWidth);
+      expect(result.table.scrollWidth).toBeGreaterThan(result.table.clientWidth);
+      expect(result.table.overflowX).toBe("auto");
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+});
+
+function renderFixtureHtml(): string {
+  const fallback = renderToStaticMarkup(createElement(MarkdownBody, {
+    content: MARKDOWN_FIXTURE,
+  }));
+  const highlighted = renderToStaticMarkup(createElement(MarkdownBody, {
+    content: MARKDOWN_FIXTURE,
+    renderCodeBlock: ({ code, language }) => createElement(CodeBlock, {
+      code,
+      label: language,
+      tokens: [[{ content: code }]],
+    }),
+  }));
+  const proposal = renderToStaticMarkup(createElement(PlanMarkdownBody, {
+    content: PROPOSAL_FIXTURE,
+    presentation: "proposal",
+  }));
+  const sheetPath = `/@fs${AUTHENTICATED_CSS}`;
+
+  return `<!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" data-sheet="eager" href="/src/index.css" />
+        <link rel="stylesheet" data-sheet="authenticated" href="${sheetPath}" />
+        <style>
+          body { overflow: auto; padding: 24px; }
+          section { margin-bottom: 24px; width: 320px; }
+          .default-scale {
+            --text-ui: 11px;
+            --text-ui-sm: 10px;
+            --text-chat: 10px;
+            --text-chat--line-height: 18px;
+            --text-title: 18px;
+            --prose-text-size: 12px;
+            --prose-text-line-height: 20px;
+          }
+          .large-scale {
+            --text-ui: 12px;
+            --text-ui-sm: 11px;
+            --text-chat: 11px;
+            --text-chat--line-height: 19px;
+            --text-title: 19px;
+            --prose-text-size: 13px;
+            --prose-text-line-height: 21px;
+          }
+          .proposal-scale {
+            --text-ui: 11px;
+            --text-ui-sm: 10px;
+            --text-chat: 10px;
+            --text-chat--line-height: 18px;
+            --text-title: 18px;
+          }
+        </style>
+      </head>
+      <body>
+        <section id="ordinary-default" class="default-scale">${fallback}</section>
+        <section id="ordinary-large" class="large-scale">${fallback}</section>
+        <section id="highlighted-default" class="default-scale">${highlighted}</section>
+        <section id="highlighted-large" class="large-scale">${highlighted}</section>
+        <section id="proposal-default" class="proposal-scale">${proposal}</section>
+      </body>
+    </html>`;
+}
+
+function fixtureRoute(html: string): Plugin {
+  return {
+    name: "markdown-cascade-fixture",
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        if (request.url !== "/__markdown-cascade") {
+          next();
+          return;
+        }
+        response.statusCode = 200;
+        response.setHeader("Content-Type", "text/html; charset=utf-8");
+        response.end(html);
+      });
+    },
+  };
+}

--- a/apps/packages/product-client/src/app/authenticated-markdown-cascade.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-markdown-cascade.test.ts
@@ -68,7 +68,7 @@ beforeAll(async () => {
     throw new Error("Markdown cascade fixture did not receive a Vite URL.");
   }
   fixtureUrl = new URL("__markdown-cascade", baseUrl).href;
-  browser = await chromium.launch({ headless: true });
+  browser = await chromium.launch({ channel: "chrome", headless: true });
 }, 60_000);
 
 afterAll(async () => {

--- a/apps/packages/product-client/src/app/authenticated-markdown-cascade.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-markdown-cascade.test.ts
@@ -136,6 +136,7 @@ describe("authenticated Markdown stylesheet cascade", () => {
             clientWidth: tableScroller.clientWidth,
             scrollWidth: tableScroller.scrollWidth,
             overflowX: getComputedStyle(tableScroller).overflowX,
+            overscrollBehaviorX: getComputedStyle(tableScroller).overscrollBehaviorX,
           },
         };
       });
@@ -158,6 +159,7 @@ describe("authenticated Markdown stylesheet cascade", () => {
       expect(result.table.shellWidth).toBeLessThanOrEqual(result.table.rootWidth);
       expect(result.table.scrollWidth).toBeGreaterThan(result.table.clientWidth);
       expect(result.table.overflowX).toBe("auto");
+      expect(result.table.overscrollBehaviorX).toBe("none");
     } finally {
       await page.close();
     }

--- a/apps/packages/product-client/src/app/authenticated-markdown-css.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-markdown-css.test.ts
@@ -14,6 +14,8 @@ describe("authenticated Markdown CSS ownership", () => {
   it("keeps the semantic presentation contract behind the authenticated boundary", () => {
     expect(AUTHENTICATED_CSS).toContain(".chat-markdown {");
     expect(AUTHENTICATED_CSS).toContain("font-size: var(--markdown-font-size)");
+    expect(AUTHENTICATED_CSS).toContain(":where(.chat-markdown) :where(h1)");
+    expect(AUTHENTICATED_CSS).not.toContain(".chat-markdown h1");
     expect(AUTHENTICATED_CSS).toContain('[data-markdown-code-content="true"]');
     expect(EAGER_PRODUCT_CSS).not.toContain(".chat-markdown");
   });

--- a/apps/packages/product-client/src/app/authenticated-markdown-css.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-markdown-css.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const AUTHENTICATED_CSS = readFileSync(
+  new URL("./authenticated.css", import.meta.url),
+  "utf8",
+);
+const EAGER_PRODUCT_CSS = readFileSync(
+  new URL("../../../design/src/css/product.css", import.meta.url),
+  "utf8",
+);
+
+describe("authenticated Markdown CSS ownership", () => {
+  it("keeps the semantic presentation contract behind the authenticated boundary", () => {
+    expect(AUTHENTICATED_CSS).toContain(".chat-markdown {");
+    expect(AUTHENTICATED_CSS).toContain("font-size: var(--markdown-font-size)");
+    expect(AUTHENTICATED_CSS).toContain('[data-markdown-code-content="true"]');
+    expect(EAGER_PRODUCT_CSS).not.toContain(".chat-markdown");
+  });
+});

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -1,6 +1,71 @@
 /* Authenticated-only interaction styles stay behind the lazy product boundary
  * so chat affordances do not consume the public login shell's CSS budget. */
 
+/* Transcript Markdown owns one scoped semantic type contract. The body scale
+   comes from its surrounding message (or the secondary-chat fallback), while
+   the hierarchy derives from runtime appearance tokens instead of frozen px
+   values. This keeps prose, inline code, and fenced code synchronized at every
+   UI size without leaking presentation rules into plan/editor surfaces. */
+.chat-markdown {
+  --markdown-font-size: var(--prose-text-size, var(--text-chat));
+  --markdown-line-height: var(--prose-text-line-height, var(--text-chat--line-height));
+  --markdown-h1-font-size: var(--text-title);
+  --markdown-h2-font-size: calc((var(--text-title) + var(--markdown-font-size)) / 2);
+  --markdown-h3-font-size: calc(var(--markdown-font-size) * 1.1667);
+  --markdown-h4-font-size: calc(var(--markdown-font-size) * 1.0833);
+  --markdown-h5-font-size: var(--markdown-font-size);
+  --markdown-h6-font-size: var(--markdown-font-size);
+  font-size: var(--markdown-font-size);
+  line-height: var(--markdown-line-height);
+}
+
+.chat-markdown h1 { font-size: var(--markdown-h1-font-size); }
+.chat-markdown h2 { font-size: var(--markdown-h2-font-size); }
+.chat-markdown h3 { font-size: var(--markdown-h3-font-size); }
+.chat-markdown h4 { font-size: var(--markdown-h4-font-size); }
+.chat-markdown h5 { font-size: var(--markdown-h5-font-size); }
+.chat-markdown h6 { font-size: var(--markdown-h6-font-size); }
+
+.chat-markdown blockquote {
+  border-color: var(--color-prose-border, var(--color-border));
+  border-left-width: 3px;
+  padding-block: 0.25rem;
+}
+
+.chat-markdown blockquote > p:last-child {
+  margin-bottom: 0;
+}
+
+.chat-markdown [data-markdown-inline-code="true"] {
+  font-size: var(--markdown-font-size);
+  line-height: inherit;
+  padding-block: 0.125rem;
+}
+
+.chat-markdown [data-markdown-code-block="true"],
+.chat-markdown [data-markdown-table-shell="true"],
+.chat-markdown [data-markdown-table-shell="true"] :is(th, td) {
+  border-color: var(--color-prose-border, var(--color-border));
+}
+
+.chat-markdown [data-markdown-code-content="true"] {
+  font-size: var(--markdown-font-size);
+  line-height: 1.55;
+}
+
+.chat-markdown [data-markdown-code-content="true"] :is(pre, code) {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.chat-markdown ul ul {
+  list-style-type: circle;
+}
+
+.chat-markdown ul ul ul {
+  list-style-type: square;
+}
+
 @property --top-fade {
   syntax: "<length>";
   inherits: false;

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -19,12 +19,16 @@
   line-height: var(--markdown-line-height);
 }
 
-.chat-markdown h1 { font-size: var(--markdown-h1-font-size); }
-.chat-markdown h2 { font-size: var(--markdown-h2-font-size); }
-.chat-markdown h3 { font-size: var(--markdown-h3-font-size); }
-.chat-markdown h4 { font-size: var(--markdown-h4-font-size); }
-.chat-markdown h5 { font-size: var(--markdown-h5-font-size); }
-.chat-markdown h6 { font-size: var(--markdown-h6-font-size); }
+/* Keep semantic hierarchy as the default, while allowing proposal/editor/plan
+   surfaces with an explicit heading utility contract to win the cascade. */
+@layer components {
+  :where(.chat-markdown) :where(h1) { font-size: var(--markdown-h1-font-size); }
+  :where(.chat-markdown) :where(h2) { font-size: var(--markdown-h2-font-size); }
+  :where(.chat-markdown) :where(h3) { font-size: var(--markdown-h3-font-size); }
+  :where(.chat-markdown) :where(h4) { font-size: var(--markdown-h4-font-size); }
+  :where(.chat-markdown) :where(h5) { font-size: var(--markdown-h5-font-size); }
+  :where(.chat-markdown) :where(h6) { font-size: var(--markdown-h6-font-size); }
+}
 
 .chat-markdown blockquote {
   border-color: var(--color-prose-border, var(--color-border));

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundMarkdownTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundMarkdownTranscript.tsx
@@ -1,0 +1,71 @@
+import { AssistantMessage } from "#product/components/workspace/chat/transcript/AssistantMessage";
+import {
+  renderTranscriptCodeBlock,
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
+import type { ScenarioKey } from "#product/config/playground";
+import { TranscriptPreviewShell } from "#product/components/playground/transcript/PlaygroundTranscriptShell";
+
+export const MARKDOWN_PRESENTATION_FIXTURE = `# Markdown presentation
+
+This settled response demonstrates **strong emphasis**, *italic emphasis*, and a [web link](https://github.com/proliferate-ai/proliferate) without changing the source text.
+
+## Hierarchy and rhythm
+
+### Lists stay legible
+
+- Unordered item with \`inline code\`
+- Nested structure
+  - Second-level item
+    - Third-level item
+- File references keep their renderer: [MarkdownBody.tsx](/Users/pablohansen/proliferate/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx)
+
+1. First ordered item
+2. Second ordered item
+   1. Nested ordered item
+   2. Another nested item
+
+#### Blockquotes and code
+
+> Presentation should make structure easier to scan while preserving selection, copying, and the original Markdown semantics.
+
+Inline \`const readable = true\` keeps a monospace face at the surrounding prose size.
+
+\`\`\`ts
+export function presentation(value: string): string {
+  return value.trim();
+}
+\`\`\`
+
+##### Wide tables
+
+| Surface | Presentation owner | Font contract | Overflow contract | Copy affordance | Link behavior |
+| --- | --- | --- | --- | --- | --- |
+| Assistant transcript | product-ui MarkdownBody | prose-sized inline and fenced code | table scrolls inside the message | code button stays visible | workspace files keep file renderer |
+| Hosted web transcript | shared product-ui renderer | semantic UI-size tokens | chat column never widens | plain highlighted fallback | external links keep provider renderer |
+
+###### Supporting detail
+
+The smallest heading remains distinct but restrained, and the final paragraph closes the fixture without extra outer spacing.`;
+
+export function renderPlaygroundMarkdownTranscript(
+  scenario: ScenarioKey,
+) {
+  if (scenario !== "markdown-presentation") {
+    return null;
+  }
+
+  return (
+    <TranscriptPreviewShell>
+      <div data-markdown-presentation-fixture="settled">
+        <AssistantMessage
+          content={MARKDOWN_PRESENTATION_FIXTURE}
+          renderLink={renderTranscriptLink}
+          renderInlineCode={renderTranscriptInlineCode}
+          renderCodeBlock={renderTranscriptCodeBlock}
+        />
+      </div>
+    </TranscriptPreviewShell>
+  );
+}

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundTranscript.tsx
@@ -2,6 +2,7 @@ import type { PlaygroundScenarioSelection } from "#product/config/playground";
 import type { PlaygroundReplayState } from "#product/hooks/playground/lifecycle/use-replay-session";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { PlaygroundRecordingTranscript } from "#product/components/playground/transcript/PlaygroundRecordingTranscript";
+import { renderPlaygroundMarkdownTranscript } from "#product/components/playground/transcript/PlaygroundMarkdownTranscript";
 import { renderPlaygroundPlanTranscript } from "#product/components/playground/transcript/PlaygroundPlanTranscript";
 import { renderPlaygroundStatusTranscript } from "#product/components/playground/transcript/PlaygroundStatusTranscript";
 import { renderPlaygroundToolTranscript } from "#product/components/playground/transcript/PlaygroundToolTranscript";
@@ -37,6 +38,11 @@ export function PlaygroundTranscript({
   }
   if (scenario === "attachment-previews") {
     return <PlaygroundAttachmentTranscript />;
+  }
+
+  const markdownTranscript = renderPlaygroundMarkdownTranscript(scenario);
+  if (markdownTranscript) {
+    return markdownTranscript;
   }
 
   const planTranscript = renderPlaygroundPlanTranscript(scenario);

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -114,6 +114,10 @@ function visibleText(html: string): string {
 }
 
 describe("playground scenarios", () => {
+  it("includes the complete Markdown presentation fixture", () => {
+    expect(Object.keys(SCENARIOS)).toContain("markdown-presentation");
+  });
+
   it("includes user-input card scenarios for visual iteration", () => {
     expect(Object.keys(SCENARIOS)).toEqual(expect.arrayContaining(USER_INPUT_SCENARIOS));
   });

--- a/apps/packages/product-client/src/config/playground.ts
+++ b/apps/packages/product-client/src/config/playground.ts
@@ -1,5 +1,6 @@
 export type ScenarioKey =
   | "clean"
+  | "markdown-presentation"
   | "todos-short"
   | "todos-mid"
   | "todos-long"
@@ -114,6 +115,7 @@ interface Scenario {
 
 export const SCENARIOS: Record<ScenarioKey, Scenario> = {
   "clean": { label: "Clean" },
+  "markdown-presentation": { label: "Markdown presentation" },
   "todos-short": { label: "Todos (3)" },
   "todos-mid": { label: "Todos (5)" },
   "todos-long": { label: "Todos (12)" },

--- a/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
+++ b/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
@@ -3,6 +3,9 @@ import { PlaygroundComposer } from "#product/components/playground/PlaygroundCom
 import { PlaygroundScenarioBar } from "#product/components/playground/PlaygroundScenarioBar";
 import { PlaygroundSidebarGitDiff } from "#product/components/playground/PlaygroundSidebarGitDiff";
 import { PlaygroundTranscript } from "#product/components/playground/transcript/PlaygroundTranscript";
+// This dev-only route sits outside AuthenticatedProductClient, so load the
+// authenticated presentation rules explicitly for direct playground URLs.
+import "../app/authenticated.css";
 import {
   resolvePlaygroundScenarioSelection,
   type ScenarioKey,

--- a/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
+++ b/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
@@ -28,6 +28,10 @@ export function ChatPlaygroundPage() {
     selection.kind === "fixture" && selection.key === "git-diff-panel";
   const showAttachmentPreview =
     selection.kind === "fixture" && selection.key === "attachment-previews";
+  const focusMarkdownPresentation =
+    selection.kind === "fixture"
+    && selection.key === "markdown-presentation"
+    && params.get("focus") === "1";
 
   const handleSelectFixture = (key: ScenarioKey) => {
     const next = new URLSearchParams(params);
@@ -43,12 +47,14 @@ export function ChatPlaygroundPage() {
 
   return (
     <div className="chat-selection-root flex h-screen flex-col bg-background text-foreground">
-      <PlaygroundScenarioBar
-        selection={selection}
-        replay={replay}
-        onSelectFixture={handleSelectFixture}
-        onSelectRecording={handleSelectRecording}
-      />
+      {!focusMarkdownPresentation && (
+        <PlaygroundScenarioBar
+          selection={selection}
+          replay={replay}
+          onSelectFixture={handleSelectFixture}
+          onSelectRecording={handleSelectRecording}
+        />
+      )}
       <main className="relative flex flex-1 overflow-hidden">
         <div
           className="flex-1 overflow-y-auto pt-6"
@@ -80,11 +86,13 @@ export function ChatPlaygroundPage() {
         )}
         {showAttachmentPreview && <PlaygroundAttachmentPreviewAside />}
       </main>
-      <footer className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
-        <code className="font-mono">?s={selection.raw}</code>
-        <span className="mx-2">·</span>
-        Dev only · import.meta.env.DEV
-      </footer>
+      {!focusMarkdownPresentation && (
+        <footer className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          <code className="font-mono">?s={selection.raw}</code>
+          <span className="mx-2">·</span>
+          Dev only · import.meta.env.DEV
+        </footer>
+      )}
     </div>
   );
 }

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
@@ -1,0 +1,121 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { CodeBlock } from "../../code/CodeBlock";
+import {
+  ChatContentSearchQueryContext,
+  ChatTranscriptRowProvider,
+} from "./ChatContentSearchContext";
+import {
+  MarkdownBody,
+  type MarkdownLinkRenderInput,
+} from "./MarkdownBody";
+
+const COMPLETE_MARKDOWN = `# Heading one
+
+## Heading two
+
+### Heading three
+
+#### Heading four
+
+##### Heading five
+
+###### Heading six
+
+Paragraph with **strong**, *emphasis*, [web](https://example.com), and \`inline code\`.
+
+- First
+  - Second
+    - Third
+
+1. Ordered
+   1. Nested ordered
+
+> A quoted paragraph.
+
+\`\`\`ts
+const readable = true;
+\`\`\`
+
+| First column | Second column |
+| --- | --- |
+| One | Two |`;
+
+function renderMarkdown(
+  content: string,
+  props: Partial<Parameters<typeof MarkdownBody>[0]> = {},
+): string {
+  return renderToStaticMarkup(createElement(MarkdownBody, {
+    content,
+    ...props,
+  }));
+}
+
+describe("MarkdownBody presentation", () => {
+  it("renders the complete presentation fixture without rewriting its source", () => {
+    const source = COMPLETE_MARKDOWN;
+    const html = renderMarkdown(source);
+
+    expect(source).toBe(COMPLETE_MARKDOWN);
+    expect(html).toContain('data-markdown-body="true"');
+    expect(html).toMatch(/<h1[^>]*>Heading one<\/h1>/);
+    expect(html).toMatch(/<h6[^>]*>Heading six<\/h6>/);
+    expect(html).toContain("<strong");
+    expect(html).toContain("<em");
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("<ol");
+    expect(html).toContain("<ul");
+    expect(html).toContain('data-markdown-inline-code="true"');
+    expect(html).toContain('data-markdown-code-block="true"');
+    expect(html).toContain('data-markdown-table-shell="true"');
+    expect(html).toContain('data-markdown-table-scroll="true"');
+  });
+
+  it("keeps inline, fallback fenced, and highlighted code on the prose-size contract", () => {
+    const html = renderMarkdown("Text with `value`.\n\n```ts\nconst value = true;\n```");
+    const highlightedHtml = renderToStaticMarkup(createElement(CodeBlock, {
+      code: "const value = true;",
+      label: "ts",
+      tokens: [[{ content: "const value = true;" }]],
+    }));
+
+    expect(html).toContain("--markdown-font-size");
+    expect(html).not.toContain("calc(var(--text-chat)-1px)");
+    expect(highlightedHtml).toContain("--markdown-font-size");
+  });
+
+  it("preserves injected workspace links while stabilizing only the render copy", () => {
+    const source = "Open [config](/tmp/project/config";
+    const renderLink = vi.fn(({ href }: MarkdownLinkRenderInput) => (
+      <span data-workspace-file={href}>config</span>
+    ));
+    const html = renderMarkdown(source, { isStreaming: true, renderLink });
+
+    expect(source).toBe("Open [config](/tmp/project/config");
+    expect(renderLink).toHaveBeenCalledWith(expect.objectContaining({
+      href: "/tmp/project/config",
+    }));
+    expect(html).toContain('data-workspace-file="/tmp/project/config"');
+    expect(html).not.toContain("(/tmp/project/config");
+  });
+
+  it("keeps content-search marks inside the presentation DOM", () => {
+    const html = renderToStaticMarkup(
+      <ChatContentSearchQueryContext.Provider value="readable">
+        <ChatTranscriptRowProvider value={{ rowUnitId: "assistant-1", rowIndex: 0 }}>
+          <MarkdownBody content="Readable Markdown remains searchable." enableContentSearch />
+        </ChatTranscriptRowProvider>
+      </ChatContentSearchQueryContext.Provider>,
+    );
+
+    expect(html).toContain('class="codex-thread-find-match"');
+    expect(html).toContain('data-content-search-row="assistant-1"');
+  });
+
+  it("continues to strip executable URL schemes", () => {
+    const html = renderMarkdown("[unsafe](javascript:alert(1))");
+
+    expect(html).not.toContain("javascript:");
+  });
+});

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
@@ -80,9 +80,9 @@ describe("MarkdownBody presentation", () => {
       tokens: [[{ content: "const value = true;" }]],
     }));
 
-    expect(html).toContain("--markdown-font-size");
+    expect(html).toContain('data-markdown-code-content="true"');
     expect(html).not.toContain("calc(var(--text-chat)-1px)");
-    expect(highlightedHtml).toContain("--markdown-font-size");
+    expect(highlightedHtml).toContain('data-markdown-code-content="true"');
   });
 
   it("preserves injected workspace links while stabilizing only the render copy", () => {

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
@@ -70,6 +70,8 @@ describe("MarkdownBody presentation", () => {
     expect(html).toContain('data-markdown-code-block="true"');
     expect(html).toContain('data-markdown-table-shell="true"');
     expect(html).toContain('data-markdown-table-scroll="true"');
+    expect(html).toContain("overflow-x-auto overscroll-x-none");
+    expect(html).not.toContain("overscroll-x-contain");
   });
 
   it("keeps inline, fallback fenced, and highlighted code on the prose-size contract", () => {

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -121,7 +121,7 @@ type MdCodeProps = MdElementProps & {
 // unset, so the fallback keeps that secondary chrome on --text-chat while
 // conversation bodies grow to match the composer.
 const PROSE_TEXT =
-  "text-[length:var(--prose-text-size,var(--text-chat))] leading-[var(--prose-text-line-height,var(--text-chat--line-height))]";
+  "text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[var(--markdown-line-height,var(--prose-text-line-height,var(--text-chat--line-height)))]";
 
 const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
 
@@ -142,12 +142,12 @@ function mdComponent(tag: MdTag, className: string) {
 }
 
 const STATIC_MARKDOWN_COMPONENTS = {
-  h1: mdComponent("h1", "mb-2.5 mt-5 text-[24px] font-semibold leading-[1.25] text-foreground"),
-  h2: mdComponent("h2", "mb-2.5 mt-5 text-[20px] font-semibold leading-[1.25] text-foreground"),
-  h3: mdComponent("h3", "mb-2.5 mt-5 text-[17px] font-semibold leading-[22px] text-foreground"),
-  h4: mdComponent("h4", "mb-2 mt-4 text-[15px] font-semibold leading-[1.3] text-foreground"),
-  h5: mdComponent("h5", "mb-1.5 mt-4 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground"),
-  h6: mdComponent("h6", "mb-1.5 mt-4 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground"),
+  h1: mdComponent("h1", "mb-2.5 mt-5 text-[length:var(--markdown-h1-font-size)] font-semibold leading-[1.25] text-foreground"),
+  h2: mdComponent("h2", "mb-2.5 mt-5 text-[length:var(--markdown-h2-font-size)] font-semibold leading-[1.3] text-foreground"),
+  h3: mdComponent("h3", "mb-2.5 mt-5 text-[length:var(--markdown-h3-font-size)] font-semibold leading-[1.35] text-foreground"),
+  h4: mdComponent("h4", "mb-2 mt-4 text-[length:var(--markdown-h4-font-size)] font-semibold leading-[1.4] text-foreground"),
+  h5: mdComponent("h5", "mb-1.5 mt-4 text-[length:var(--markdown-h5-font-size)] font-semibold uppercase tracking-wide text-muted-foreground"),
+  h6: mdComponent("h6", "mb-1.5 mt-4 text-[length:var(--markdown-h6-font-size)] font-semibold uppercase tracking-wide text-muted-foreground"),
   strong: mdComponent("strong", "font-semibold"),
   em: mdComponent("em", "italic"),
   del: mdComponent("del", "line-through"),
@@ -155,25 +155,29 @@ const STATIC_MARKDOWN_COMPONENTS = {
   ul: mdComponent("ul", `mb-[0.6875rem] mt-0 list-disc pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
   ol: mdComponent("ol", `mb-[0.6875rem] mt-0 list-decimal pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
   li: mdComponent("li", LI_CLASSNAME),
-  blockquote: mdComponent("blockquote", `my-3 border-l-2 border-border pl-4 ${PROSE_TEXT} italic text-foreground`),
+  blockquote: mdComponent("blockquote", `my-3 border-l-[3px] border-[var(--color-prose-border,var(--color-border))] py-1 pl-4 ${PROSE_TEXT} text-foreground`),
   hr: () => <hr className="my-3 border-border" />,
   table: (props: MdElementProps) => (
     <div
-      className="my-4 overflow-hidden rounded-lg border border-border"
+      className="my-4 min-w-0 max-w-full overflow-hidden rounded-lg border border-[var(--color-prose-border,var(--color-border))]"
+      data-markdown-table-shell="true"
       data-wide-markdown-block="true"
       data-wide-markdown-block-kind="table"
     >
-      <div className="overflow-x-auto">
+      <div
+        className="max-w-full overflow-x-auto overscroll-x-contain"
+        data-markdown-table-scroll="true"
+      >
         {mdHtmlElement(
           "table",
-          `w-max min-w-full border-collapse ${PROSE_TEXT} [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.02] [&_tbody_tr:last-child_td]:border-b-0`,
+          `w-max min-w-full max-w-none border-collapse ${PROSE_TEXT} [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.018] [&_tbody_tr:last-child_td]:border-b-0`,
           props,
         )}
       </div>
     </div>
   ),
-  th: mdComponent("th", `border-b border-border bg-foreground/5 px-2.5 py-1.5 text-left ${PROSE_TEXT} font-semibold text-foreground`),
-  td: mdComponent("td", `border-b border-border px-2.5 py-1.5 align-top ${PROSE_TEXT}`),
+  th: mdComponent("th", `border-b border-[var(--color-prose-border,var(--color-border))] bg-foreground/[0.035] px-3 py-2 text-left ${PROSE_TEXT} font-medium text-foreground`),
+  td: mdComponent("td", `border-b border-[var(--color-prose-border,var(--color-border))] px-3 py-2 align-top ${PROSE_TEXT}`),
   pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
     if (dangerouslySetInnerHTML) {
       return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
@@ -331,7 +335,7 @@ export const MarkdownBody = memo(function MarkdownBody({
     [content, isStreaming],
   );
   const markdownClassName = [
-    `${PROSE_TEXT} text-foreground break-words`,
+    `chat-markdown ${PROSE_TEXT} min-w-0 max-w-full text-foreground break-words`,
     "[&_li>p]:my-0",
     "[&_li>ol]:mt-2 [&_li>ol]:mb-0",
     "[&_li>ul]:mt-2 [&_li>ul]:mb-0",
@@ -341,6 +345,7 @@ export const MarkdownBody = memo(function MarkdownBody({
     "[&_ul.contains-task-list]:list-none [&>ul.contains-task-list]:pl-0",
     "[&_li.task-list-item]:pl-0",
     "[&_li.task-list-item_input]:mr-2 [&_li.task-list-item_input]:size-3.5 [&_li.task-list-item_input]:align-middle [&_li.task-list-item_input]:accent-link-foreground",
+    "[&_blockquote>p:last-child]:mb-0",
     className,
   ].filter(Boolean).join(" ");
 
@@ -364,7 +369,7 @@ export const MarkdownBody = memo(function MarkdownBody({
 
   const body = (
     <MarkdownRevealContext.Provider value={revealState}>
-      <div className={markdownClassName}>
+      <div className={markdownClassName} data-markdown-body="true">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           urlTransform={markdownUrlTransform}
@@ -403,7 +408,8 @@ function MarkdownCode({
     return (
       <code
         {...rest}
-        className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1.5 py-0.5 align-baseline font-mono text-[length:calc(var(--text-chat)-1px)] leading-none text-foreground"
+        className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1 py-[0.125rem] align-baseline font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[inherit] text-foreground"
+        data-markdown-inline-code="true"
         dangerouslySetInnerHTML={dangerouslySetInnerHTML}
       />
     );
@@ -425,7 +431,8 @@ function MarkdownCode({
   return (
     <code
       {...rest}
-      className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1.5 py-0.5 align-baseline font-mono text-[length:calc(var(--text-chat)-1px)] leading-none text-foreground"
+      className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1 py-[0.125rem] align-baseline font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[inherit] text-foreground"
+      data-markdown-inline-code="true"
     >
       {children}
     </code>

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -119,11 +119,9 @@ type MdCodeProps = MdElementProps & {
 // wrappers set to --text-message (the composer size). Every other MarkdownBody
 // context — tool-row detail bodies, plan cards, work history — leaves the var
 // unset, so the fallback keeps that secondary chrome on --text-chat while
-// conversation bodies grow to match the composer.
-const PROSE_TEXT =
-  "text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[var(--markdown-line-height,var(--prose-text-line-height,var(--text-chat--line-height)))]";
-
-const LI_CLASSNAME = `pl-0.5 ${PROSE_TEXT}`;
+// conversation bodies grow to match the composer. Authenticated CSS owns the
+// scoped font-size and line-height so chat rules stay out of the login bundle.
+const LI_CLASSNAME = "pl-0.5";
 
 // Markdown component overrides are the React element *types* for every
 // rendered node. They must be referentially stable across renders: a fresh
@@ -142,24 +140,24 @@ function mdComponent(tag: MdTag, className: string) {
 }
 
 const STATIC_MARKDOWN_COMPONENTS = {
-  h1: mdComponent("h1", "mb-2.5 mt-5 text-[length:var(--markdown-h1-font-size)] font-semibold leading-[1.25] text-foreground"),
-  h2: mdComponent("h2", "mb-2.5 mt-5 text-[length:var(--markdown-h2-font-size)] font-semibold leading-[1.3] text-foreground"),
-  h3: mdComponent("h3", "mb-2.5 mt-5 text-[length:var(--markdown-h3-font-size)] font-semibold leading-[1.35] text-foreground"),
-  h4: mdComponent("h4", "mb-2 mt-4 text-[length:var(--markdown-h4-font-size)] font-semibold leading-[1.4] text-foreground"),
-  h5: mdComponent("h5", "mb-1.5 mt-4 text-[length:var(--markdown-h5-font-size)] font-semibold uppercase tracking-wide text-muted-foreground"),
-  h6: mdComponent("h6", "mb-1.5 mt-4 text-[length:var(--markdown-h6-font-size)] font-semibold uppercase tracking-wide text-muted-foreground"),
+  h1: mdComponent("h1", "mb-2.5 mt-5 font-semibold leading-[1.25] text-foreground"),
+  h2: mdComponent("h2", "mb-2.5 mt-5 font-semibold leading-[1.3] text-foreground"),
+  h3: mdComponent("h3", "mb-2.5 mt-5 font-semibold leading-[1.35] text-foreground"),
+  h4: mdComponent("h4", "mb-2 mt-4 font-semibold leading-[1.4] text-foreground"),
+  h5: mdComponent("h5", "mb-1.5 mt-4 font-semibold uppercase tracking-wide text-muted-foreground"),
+  h6: mdComponent("h6", "mb-1.5 mt-4 font-semibold uppercase tracking-wide text-muted-foreground"),
   strong: mdComponent("strong", "font-semibold"),
   em: mdComponent("em", "italic"),
   del: mdComponent("del", "line-through"),
-  p: mdComponent("p", `mb-[0.6875rem] mt-0 ${PROSE_TEXT} text-foreground`),
-  ul: mdComponent("ul", `mb-[0.6875rem] mt-0 list-disc pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
-  ol: mdComponent("ol", `mb-[0.6875rem] mt-0 list-decimal pl-[1.3125rem] ${PROSE_TEXT} text-foreground [&>li+li]:mt-2`),
+  p: mdComponent("p", "mb-[0.6875rem] mt-0 text-foreground"),
+  ul: mdComponent("ul", "mb-[0.6875rem] mt-0 list-disc pl-[1.3125rem] text-foreground [&>li+li]:mt-2"),
+  ol: mdComponent("ol", "mb-[0.6875rem] mt-0 list-decimal pl-[1.3125rem] text-foreground [&>li+li]:mt-2"),
   li: mdComponent("li", LI_CLASSNAME),
-  blockquote: mdComponent("blockquote", `my-3 border-l-[3px] border-[var(--color-prose-border,var(--color-border))] py-1 pl-4 ${PROSE_TEXT} text-foreground`),
+  blockquote: mdComponent("blockquote", "my-3 border-l pl-4 text-foreground"),
   hr: () => <hr className="my-3 border-border" />,
   table: (props: MdElementProps) => (
     <div
-      className="my-4 min-w-0 max-w-full overflow-hidden rounded-lg border border-[var(--color-prose-border,var(--color-border))]"
+      className="my-4 min-w-0 max-w-full overflow-hidden rounded-lg border"
       data-markdown-table-shell="true"
       data-wide-markdown-block="true"
       data-wide-markdown-block-kind="table"
@@ -170,14 +168,14 @@ const STATIC_MARKDOWN_COMPONENTS = {
       >
         {mdHtmlElement(
           "table",
-          `w-max min-w-full max-w-none border-collapse ${PROSE_TEXT} [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.018] [&_tbody_tr:last-child_td]:border-b-0`,
+          "w-max min-w-full max-w-none border-collapse [&_tbody_tr:nth-child(2n)]:bg-foreground/[0.018] [&_tbody_tr:last-child_td]:border-b-0",
           props,
         )}
       </div>
     </div>
   ),
-  th: mdComponent("th", `border-b border-[var(--color-prose-border,var(--color-border))] bg-foreground/[0.035] px-3 py-2 text-left ${PROSE_TEXT} font-medium text-foreground`),
-  td: mdComponent("td", `border-b border-[var(--color-prose-border,var(--color-border))] px-3 py-2 align-top ${PROSE_TEXT}`),
+  th: mdComponent("th", "border-b bg-foreground/[0.035] px-3 py-2 text-left font-medium text-foreground"),
+  td: mdComponent("td", "border-b px-3 py-2 align-top"),
   pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
     if (dangerouslySetInnerHTML) {
       return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
@@ -335,7 +333,7 @@ export const MarkdownBody = memo(function MarkdownBody({
     [content, isStreaming],
   );
   const markdownClassName = [
-    `chat-markdown ${PROSE_TEXT} min-w-0 max-w-full text-foreground break-words`,
+    "chat-markdown min-w-0 max-w-full text-foreground break-words",
     "[&_li>p]:my-0",
     "[&_li>ol]:mt-2 [&_li>ol]:mb-0",
     "[&_li>ul]:mt-2 [&_li>ul]:mb-0",
@@ -345,7 +343,6 @@ export const MarkdownBody = memo(function MarkdownBody({
     "[&_ul.contains-task-list]:list-none [&>ul.contains-task-list]:pl-0",
     "[&_li.task-list-item]:pl-0",
     "[&_li.task-list-item_input]:mr-2 [&_li.task-list-item_input]:size-3.5 [&_li.task-list-item_input]:align-middle [&_li.task-list-item_input]:accent-link-foreground",
-    "[&_blockquote>p:last-child]:mb-0",
     className,
   ].filter(Boolean).join(" ");
 
@@ -408,7 +405,7 @@ function MarkdownCode({
     return (
       <code
         {...rest}
-        className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1 py-[0.125rem] align-baseline font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[inherit] text-foreground"
+        className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1 align-baseline font-mono text-foreground"
         data-markdown-inline-code="true"
         dangerouslySetInnerHTML={dangerouslySetInnerHTML}
       />
@@ -431,7 +428,7 @@ function MarkdownCode({
   return (
     <code
       {...rest}
-      className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1 py-[0.125rem] align-baseline font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[inherit] text-foreground"
+      className="rounded-sm bg-[var(--color-code-block-background,var(--color-muted))] px-1 align-baseline font-mono text-foreground"
       data-markdown-inline-code="true"
     >
       {children}

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.tsx
@@ -163,7 +163,7 @@ const STATIC_MARKDOWN_COMPONENTS = {
       data-wide-markdown-block-kind="table"
     >
       <div
-        className="max-w-full overflow-x-auto overscroll-x-contain"
+        className="max-w-full overflow-x-auto overscroll-x-none"
         data-markdown-table-scroll="true"
       >
         {mdHtmlElement(

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
@@ -32,7 +32,7 @@ export function MarkdownCodeBlockShell({
 
   return (
     <div
-      className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-[var(--color-prose-border,var(--color-border))] bg-[var(--color-code-block-background,var(--color-card))]"
+      className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]"
       data-markdown-code-block="true"
     >
       <div className="flex select-none items-center justify-between gap-2 py-1 pl-2 pr-1.5 text-[length:var(--text-chat-meta,11px)] text-muted-foreground">
@@ -48,10 +48,13 @@ export function MarkdownCodeBlockShell({
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>
       </div>
-      <div className="overflow-x-auto overflow-y-auto p-3 font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55] [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!bg-transparent [&_code]:text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] [&_code]:leading-[1.55]">
+      <div
+        className="overflow-x-auto overflow-y-auto p-3 font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!bg-transparent [&_code]:text-[length:var(--text-chat)] [&_code]:leading-[1.5]"
+        data-markdown-code-content="true"
+      >
         {children ?? (
           <pre className="m-0 p-0">
-            <code className="whitespace-pre font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55] text-foreground">
+            <code className="whitespace-pre font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] text-foreground">
               {code}
             </code>
           </pre>

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
@@ -31,7 +31,10 @@ export function MarkdownCodeBlockShell({
   }
 
   return (
-    <div className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]">
+    <div
+      className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-[var(--color-prose-border,var(--color-border))] bg-[var(--color-code-block-background,var(--color-card))]"
+      data-markdown-code-block="true"
+    >
       <div className="flex select-none items-center justify-between gap-2 py-1 pl-2 pr-1.5 text-[length:var(--text-chat-meta,11px)] text-muted-foreground">
         {label ? <span className="min-w-0 flex-1 truncate">{label}</span> : <span className="min-w-0 flex-1" />}
         <Button
@@ -45,10 +48,10 @@ export function MarkdownCodeBlockShell({
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>
       </div>
-      <div className="overflow-x-auto overflow-y-auto p-2 font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!bg-transparent [&_code]:text-[length:var(--text-chat)] [&_code]:leading-[1.5]">
+      <div className="overflow-x-auto overflow-y-auto p-3 font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55] [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!bg-transparent [&_code]:text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] [&_code]:leading-[1.55]">
         {children ?? (
           <pre className="m-0 p-0">
-            <code className="whitespace-pre font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] text-foreground">
+            <code className="whitespace-pre font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55] text-foreground">
               {code}
             </code>
           </pre>

--- a/apps/packages/product-ui/src/code/CodeBlock.tsx
+++ b/apps/packages/product-ui/src/code/CodeBlock.tsx
@@ -50,7 +50,7 @@ export function CodeBlock({
 
   return (
     <div
-      className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-[var(--color-prose-border,var(--color-border))] bg-[var(--color-code-block-background,var(--color-card))]"
+      className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]"
       data-markdown-code-block="true"
     >
       <div className="flex select-none items-center justify-between gap-2 py-1 pl-2 pr-1.5 text-[length:var(--text-chat-meta,11px)] text-muted-foreground">
@@ -70,18 +70,21 @@ export function CodeBlock({
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>
       </div>
-      <div className="overflow-x-auto overflow-y-auto p-3 font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55]">
+      <div
+        className="overflow-x-auto overflow-y-auto p-3 font-mono text-[length:var(--text-chat)] font-normal leading-[1.5]"
+        data-markdown-code-content="true"
+      >
         {children ?? (tokens ? (
           <CodeBlockTokenContent
             lines={tokens}
             renderToken={renderToken}
             showLineNumbers={showLineNumbers}
             lineNumberStart={lineNumberStart}
-            className="text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[1.55] text-foreground"
+            className="text-[length:var(--text-chat)] leading-[1.5] text-foreground"
           />
         ) : (
           <pre className="m-0 p-0">
-            <code className="whitespace-pre font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55] text-foreground">
+            <code className="whitespace-pre font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] text-foreground">
               {code}
             </code>
           </pre>

--- a/apps/packages/product-ui/src/code/CodeBlock.tsx
+++ b/apps/packages/product-ui/src/code/CodeBlock.tsx
@@ -49,7 +49,10 @@ export function CodeBlock({
   }
 
   return (
-    <div className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]">
+    <div
+      className="relative my-[14px] w-full min-w-0 overflow-clip rounded-lg border border-[var(--color-prose-border,var(--color-border))] bg-[var(--color-code-block-background,var(--color-card))]"
+      data-markdown-code-block="true"
+    >
       <div className="flex select-none items-center justify-between gap-2 py-1 pl-2 pr-1.5 text-[length:var(--text-chat-meta,11px)] text-muted-foreground">
         {label ? (
           <span className="min-w-0 flex-1 truncate">{label}</span>
@@ -67,18 +70,18 @@ export function CodeBlock({
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </Button>
       </div>
-      <div className="overflow-x-auto overflow-y-auto p-2 font-mono text-[length:var(--text-chat)] font-normal leading-[1.5]">
+      <div className="overflow-x-auto overflow-y-auto p-3 font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55]">
         {children ?? (tokens ? (
           <CodeBlockTokenContent
             lines={tokens}
             renderToken={renderToken}
             showLineNumbers={showLineNumbers}
             lineNumberStart={lineNumberStart}
-            className="text-[length:var(--text-chat)] leading-[1.5] text-foreground"
+            className="text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] leading-[1.55] text-foreground"
           />
         ) : (
           <pre className="m-0 p-0">
-            <code className="whitespace-pre font-mono text-[length:var(--text-chat)] font-normal leading-[1.5] text-foreground">
+            <code className="whitespace-pre font-mono text-[length:var(--markdown-font-size,var(--prose-text-size,var(--text-chat)))] font-normal leading-[1.55] text-foreground">
               {code}
             </code>
           </pre>


### PR DESCRIPTION
## What this changes

**Surface:** Chat transcript Markdown presentation for settled and streaming-stabilized assistant responses. Long responses now have a clear heading hierarchy, prose-sized code, and wide tables that scroll inside the message without stretching or horizontally bouncing the session.

**Explicit non-goals:** Rich-paste parsing, editor serialization, reveal timing or motion, tool-call rows, global font-token values, proposal-plan content semantics, and adjacent Markdown/editor cleanup.

## Before / after

Before, long Markdown responses looked flatter, code could appear smaller than surrounding prose, and a wide table could widen or hand horizontal edge motion to the conversation. After, headings step down visibly, inline and fenced code track the selected text size, the table alone owns horizontal scrolling, and repeated scrolling at its edge leaves the session fixed; proposal plans remain compact.

## When this matters

When an agent posts a long implementation plan or report with several sections, code snippets, and a wide comparison table—a normal reachable workflow—the response stays readable and the conversation column remains stable while the table is inspected.

## Design reference (reference contract)

1. **Primary reference:** Codex desktop main chat. Conductor was not used.
2. **Exact states inspected:** Codex desktop dark-theme settled assistant Markdown in `reference/codex/main_chat_view.html` and `reference/codex/styles.css`, including paragraphs, headings, inline and fenced code, copy controls, and a wide table. The live prose/list reveal was captured at `2306×1862`; the historical settled DOM capture omitted viewport metadata and is therefore used for structure and rendered rules rather than pixel geometry.
3. **Intentionally matched:** Clear heading hierarchy, compact paragraph/list rhythm, nested-list markers, normal-style blockquotes, restrained table treatment, table-local horizontal scrolling, and a highlighted monospace code shell with a copy affordance.
4. **Intentional Proliferate divergences:** Proliferate keeps its semantic colors, type scale, spacing tokens, link/path renderers, search marks, streaming stabilization, and reduced-motion contract. Code matches Proliferate prose size, proposal headings stay compact, and the table scroller explicitly suppresses horizontal edge chaining so the shared web/Desktop transcript stays fixed.
5. **Mock approval:** Not required. The named Codex evidence, frozen specification, and founder-requested table-edge behavior fully determine this already-built slice; no retroactive mock was manufactured.

## Demo

[Inspect the exact-head hosted preview](https://proliferate-web-git-codex-ui-markdown-presentation-getonyx.vercel.app) — reviewed head `4f6e49ce3720f1acd4092de151e0f0774c226b70`, Vercel web production build (not packaged Desktop), deployment successful and `/login` verified HTTP 200 on 2026-07-19. The temporary local profile is stopped.

## Current disposition

Merged — squash commit `f7827d61f46c36ff3d94d41b89f36fccf50c35d8` is on `main`; no further action is required for UI 02.

## Founder decision needed

None.

---

## Engineering evidence

### Scope and ownership

- Frozen base: `c91d6f9275cd6e21723f9b83388df2ac8a697389`
- Final reviewed head: `4f6e49ce3720f1acd4092de151e0f0774c226b70`
- Squash merge commit: `f7827d61f46c36ff3d94d41b89f36fccf50c35d8`
- Branch: `codex/ui-markdown-presentation`
- Rebase base immediately before merge: `aacd494b03b67e262ad6f79be4a7ec139d0507af`
- The sole rebase conflict was the dev-only `ChatPlaygroundPage.tsx`; the resolution preserved both current-main attachment-preview behavior and UI 02's focused Markdown fixture.
- UI 01 subsequently landed as `0e50751bb270e0ef9d64e25f1a929a3fd1517406` on top of the UI 02 squash. A final integration inspection confirmed the lazy authenticated rules, proposal cascade regression, focused playground state, and `overscroll-x-none` table contract remain present on `main`.
- Transcript Markdown presentation CSS remains owned by the lazy authenticated stylesheet and absent from the anonymous `/login` sheet.
- Semantic heading defaults use zero-specificity `:where()` selectors in the `components` cascade layer. Explicit proposal/editor/preview utilities retain ownership in the later `utilities` layer.
- The table wrapper remains the only horizontal scroller. Its `overscroll-behavior-x: none` prevents edge chaining/bounce without changing vertical transcript scrolling.

### Review findings

- `B-1428-01` — **Resolved.** Transcript presentation rules remain outside eager login CSS, preserving the founder-owned login budget.
- `B-1428-02` — **Resolved.** Low-specificity transcript heading defaults preserve proposal H1/H2/H3 at `11 / 11 / 10px`.
- Independent review round 3 accepted head `c0cfff3f37bc19c4e36f46d420d37a5e169d23c5` with no new Blocker, Decision, or Follow-up.
- Canonical exact-head review of `4f6e49ce3720f1acd4092de151e0f0774c226b70` — **PASS.** The only post-acceptance production delta changes the existing table scroller from horizontal containment to horizontal overscroll suppression; focused markup and real-browser cascade tests cover the contract. No code finding remains.
- Founder explicitly authorized advancing and force squash-merging UI 02 after rebasing onto current `main`; the admin squash merge completed successfully.

### Computed and interaction evidence

- Ordinary Default transcript headings: `18 / 15 / 14.0004 / 12.9996 / 12 / 12px`; Large H1/H2/H3: `19 / 16 / 15.1671px`.
- Proposal H1/H2/H3: `11 / 11 / 10px`.
- Default prose and every inline/fenced/highlighted code path: `12px`; Large prose and code paths: `13px`.
- At `620×1000`, the table scroller measured `586px` client width and `1,157px` scroll width, computed `overflow-x: auto` and `overscroll-behavior-x: none`, and reached `scrollLeft 571.5px` while the document remained `620/620px` and the session remained at `scrollLeft 0` after an additional edge scroll.
- Pre-rebase interaction screenshot: `reference/proliferate/markdown-presentation/overscroll-none-after.png`; final exact-head proof is the hosted Demo above.

### Budget evidence

- Final rebased head `4f6e49ce3720f1acd4092de151e0f0774c226b70`: JS `484,100 / 485,000 B`; CSS `65,827 / 66,000 B`; zero eager font/image/audio bytes; pass (JS headroom `900 B`, CSS headroom `173 B`).
- The squash merge content is identical to the reviewed rebased head relative to base `aacd494b03b67e262ad6f79be4a7ec139d0507af`.

### Validation matrix

- `pnpm --filter @proliferate/product-ui test` — 38 files / 220 tests passed on the rebased head.
- `pnpm --filter @proliferate/product-client test` — full suite passed on the rebased head, including the real Chrome eager-plus-authenticated cascade regression.
- Product UI and product client typechecks passed.
- `python3 scripts/check_frontend_boundaries.py` passed.
- `python3 scripts/report_frontend_structure.py --strict --summary-only` — 0 violations across 2,276 non-test frontend files.
- PR metadata validation and `git diff --check` passed.
- Exact-head GitHub metadata and Vercel deployment checks passed. The founder explicitly authorized the admin merge without waiting for the remaining GitHub matrix; those jobs continue against the immutable merged head.

### Capture record

- Primary final surface: hosted Vercel web production build at the Demo link; not packaged Desktop.
- Exact hosted head: `4f6e49ce3720f1acd4092de151e0f0774c226b70`; HMR does not apply to the production build.
- Supporting local capture used profile `ui-02-markdown`, Proliferate `0.3.43`, renderer `127.0.0.1:5495`, viewport `620×1000`, and fresh settled HMR; temporary local preview stopped.
- Local evidence bundle: `reference/proliferate/markdown-presentation/overscroll-none-*`.

### Readiness

- [x] Frozen UI 02 scope is preserved; no neighboring slice or unrelated cleanup was absorbed.
- [x] Founder-facing brief names the sole surface, non-goals, primary reference, divergences, exact-head demo, and disposition.
- [x] Exact-head behavior, focused/full relevant tests, typechecks, boundaries, strict structure, diff, metadata, budget, and visual/computed proof pass.
- [x] Rebased onto current `main`, resolved the sole integration conflict, and repeated the exact-head review.
- [x] Squash-merged into `main` as `f7827d61f46c36ff3d94d41b89f36fccf50c35d8` under explicit founder authorization.

### Support and attribution

No support relationship applies. No tracker, report, user, support, or private source data is included.
