### PR TITLE
feat(product): make composer mode changes immediate

### DIFF
--- a/anyharness/sdk-react/src/hooks/sessions.test.tsx
+++ b/anyharness/sdk-react/src/hooks/sessions.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
+import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
+import { useSetSessionConfigOptionMutation } from "./sessions.js";
+
+const mocks = vi.hoisted(() => ({
+  setConfigOption: vi.fn(),
+}));
+
+vi.mock("../lib/client-cache.js", () => ({
+  getAnyHarnessClient: () => ({
+    sessions: {
+      setConfigOption: mocks.setConfigOption,
+    },
+  }),
+}));
+
+describe("sdk-react session config mutation request options", () => {
+  afterEach(() => {
+    cleanup();
+    mocks.setConfigOption.mockReset();
+  });
+
+  it("passes caller abort signals to SessionsClient.setConfigOption", async () => {
+    mocks.setConfigOption.mockResolvedValue({
+      applyState: "applied",
+      session: { id: "session-1" },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    const controller = new AbortController();
+    const { result } = renderHook(() => useSetSessionConfigOptionMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+        request: { configId: "collaboration_mode", value: "plan" },
+        requestOptions: { signal: controller.signal },
+      });
+    });
+
+    expect(mocks.setConfigOption).toHaveBeenCalledWith(
+      "session-1",
+      { configId: "collaboration_mode", value: "plan" },
+      { signal: controller.signal },
+    );
+  });
+});
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AnyHarnessRuntime runtimeUrl="http://runtime.test">
+          <AnyHarnessWorkspace
+            workspaceId="workspace-1"
+            resolveConnection={async () => ({
+              runtimeUrl: "http://runtime.test",
+              anyharnessWorkspaceId: "workspace-1",
+            })}
+          >
+            {children}
+          </AnyHarnessWorkspace>
+        </AnyHarnessRuntime>
+      </QueryClientProvider>
+    );
+  };
+}

--- a/anyharness/sdk-react/src/hooks/sessions.test.tsx
+++ b/anyharness/sdk-react/src/hooks/sessions.test.tsx
@@ -1,20 +1,22 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
 import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
-import { useSetSessionConfigOptionMutation } from "./sessions.js";
+import { useSessionQuery, useSetSessionConfigOptionMutation } from "./sessions.js";
 
 const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
   setConfigOption: vi.fn(),
 }));
 
 vi.mock("../lib/client-cache.js", () => ({
   getAnyHarnessClient: () => ({
     sessions: {
+      get: mocks.getSession,
       setConfigOption: mocks.setConfigOption,
     },
   }),
@@ -23,6 +25,7 @@ vi.mock("../lib/client-cache.js", () => ({
 describe("sdk-react session config mutation request options", () => {
   afterEach(() => {
     cleanup();
+    mocks.getSession.mockReset();
     mocks.setConfigOption.mockReset();
   });
 
@@ -57,7 +60,96 @@ describe("sdk-react session config mutation request options", () => {
       { signal: controller.signal },
     );
   });
+
+  it("can settle on transport acknowledgement while active invalidation remains deferred", async () => {
+    const refetch = deferred<{ id: string }>();
+    mocks.getSession
+      .mockResolvedValueOnce({ id: "session-1" })
+      .mockImplementationOnce(() => refetch.promise);
+    mocks.setConfigOption.mockResolvedValue({
+      applyState: "applied",
+      session: { id: "session-1" },
+    });
+    const queryClient = createQueryClient();
+    const controller = new AbortController();
+    const { result } = renderHook(() => ({
+      session: useSessionQuery("session-1"),
+      mutation: useSetSessionConfigOptionMutation(),
+    }), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.session.isSuccess).toBe(true));
+
+    await act(async () => {
+      await expect(result.current.mutation.mutateAsync({
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+        request: { configId: "collaboration_mode", value: "plan" },
+        requestOptions: { signal: controller.signal },
+        awaitInvalidations: false,
+      })).resolves.toMatchObject({ applyState: "applied" });
+    });
+
+    expect(mocks.getSession).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+    expect(controller.signal.aborted).toBe(false);
+
+    await act(async () => {
+      refetch.resolve({ id: "session-1" });
+      await refetch.promise;
+    });
+
+    expect(result.current.mutation.isSuccess).toBe(true);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it("continues to await active invalidation by default", async () => {
+    const refetch = deferred<{ id: string }>();
+    mocks.getSession
+      .mockResolvedValueOnce({ id: "session-1" })
+      .mockImplementationOnce(() => refetch.promise);
+    mocks.setConfigOption.mockResolvedValue({
+      applyState: "applied",
+      session: { id: "session-1" },
+    });
+    const queryClient = createQueryClient();
+    const { result } = renderHook(() => ({
+      session: useSessionQuery("session-1"),
+      mutation: useSetSessionConfigOptionMutation(),
+    }), { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.session.isSuccess).toBe(true));
+
+    let settled = false;
+    let mutation!: ReturnType<typeof result.current.mutation.mutateAsync>;
+    act(() => {
+      mutation = result.current.mutation.mutateAsync({
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+        request: { configId: "collaboration_mode", value: "plan" },
+      });
+      void mutation.then(() => {
+        settled = true;
+      });
+    });
+    await waitFor(() => expect(mocks.getSession).toHaveBeenCalledTimes(2));
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      refetch.resolve({ id: "session-1" });
+      await mutation;
+    });
+
+    expect(settled).toBe(true);
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+  });
 });
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+}
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -77,4 +169,12 @@ function createWrapper(queryClient: QueryClient) {
       </QueryClientProvider>
     );
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }

--- a/anyharness/sdk-react/src/hooks/sessions.ts
+++ b/anyharness/sdk-react/src/hooks/sessions.ts
@@ -39,6 +39,11 @@ interface WorkspaceQueryOptions {
 interface WorkspaceMutationInput {
   workspaceId?: string | null;
 }
+type SetSessionConfigOptionMutationInput = WorkspaceMutationInput & {
+  sessionId: string;
+  request: SetSessionConfigOptionRequest;
+  requestOptions?: AnyHarnessRequestOptions;
+};
 
 type TimedWorkspaceQueryOptions = WorkspaceQueryOptions & AnyHarnessQueryTimingOptions;
 
@@ -269,21 +274,11 @@ export function useSetSessionConfigOptionMutation(options?: { workspaceId?: stri
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (
-      input: WorkspaceMutationInput & {
-        sessionId: string;
-        request: SetSessionConfigOptionRequest;
-        requestOptions?: AnyHarnessRequestOptions;
-      },
-    ) => {
+    mutationFn: async (input: SetSessionConfigOptionMutationInput) => {
       const workspaceId = input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
       const client = getAnyHarnessClient(resolved.connection);
-      return client.sessions.setConfigOption(
-        input.sessionId,
-        input.request,
-        input.requestOptions,
-      );
+      return client.sessions.setConfigOption(input.sessionId, input.request, input.requestOptions);
     },
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;

--- a/anyharness/sdk-react/src/hooks/sessions.ts
+++ b/anyharness/sdk-react/src/hooks/sessions.ts
@@ -273,12 +273,17 @@ export function useSetSessionConfigOptionMutation(options?: { workspaceId?: stri
       input: WorkspaceMutationInput & {
         sessionId: string;
         request: SetSessionConfigOptionRequest;
+        requestOptions?: AnyHarnessRequestOptions;
       },
     ) => {
       const workspaceId = input.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
       const client = getAnyHarnessClient(resolved.connection);
-      return client.sessions.setConfigOption(input.sessionId, input.request);
+      return client.sessions.setConfigOption(
+        input.sessionId,
+        input.request,
+        input.requestOptions,
+      );
     },
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;

--- a/anyharness/sdk-react/src/hooks/sessions.ts
+++ b/anyharness/sdk-react/src/hooks/sessions.ts
@@ -43,6 +43,7 @@ type SetSessionConfigOptionMutationInput = WorkspaceMutationInput & {
   sessionId: string;
   request: SetSessionConfigOptionRequest;
   requestOptions?: AnyHarnessRequestOptions;
+  awaitInvalidations?: boolean;
 };
 
 type TimedWorkspaceQueryOptions = WorkspaceQueryOptions & AnyHarnessQueryTimingOptions;
@@ -282,17 +283,16 @@ export function useSetSessionConfigOptionMutation(options?: { workspaceId?: stri
     },
     onSuccess: async (_response, variables) => {
       const workspaceId = variables.workspaceId ?? options?.workspaceId ?? workspace.workspaceId;
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionLiveConfigKey(cacheScopeKey, workspaceId, variables.sessionId),
-        }),
-        queryClient.invalidateQueries({
-          queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
-        }),
-      ]);
+      const invalidations = Promise.all([
+        anyHarnessSessionKey(cacheScopeKey, workspaceId, variables.sessionId),
+        anyHarnessSessionLiveConfigKey(cacheScopeKey, workspaceId, variables.sessionId),
+        anyHarnessSessionsKey(cacheScopeKey, workspaceId),
+      ].map((queryKey) => queryClient.invalidateQueries({ queryKey })));
+      if (variables.awaitInvalidations === false) {
+        void invalidations.catch(() => undefined);
+        return;
+      }
+      await invalidations;
     },
   });
 }

--- a/anyharness/sdk/src/client/sessions.test.ts
+++ b/anyharness/sdk/src/client/sessions.test.ts
@@ -129,6 +129,39 @@ describe("SessionsClient.listEvents", () => {
   });
 });
 
+describe("SessionsClient.setConfigOption", () => {
+  it("forwards request options to the config mutation transport", async () => {
+    const calls: Array<{
+      body: unknown;
+      options: AnyHarnessRequestOptions | undefined;
+      path: string;
+    }> = [];
+    const transport = {
+      post: async (path: string, body: unknown, options?: AnyHarnessRequestOptions) => {
+        calls.push({ path, body, options });
+        return {
+          applyState: "applied",
+          session: sessionResponse(),
+        };
+      },
+    } as unknown as AnyHarnessTransport;
+    const client = new SessionsClient(transport);
+    const controller = new AbortController();
+
+    await client.setConfigOption(
+      "session-1",
+      { configId: "collaboration_mode", value: "plan" },
+      { signal: controller.signal },
+    );
+
+    expect(calls).toEqual([{
+      path: "/v1/sessions/session-1/config-options",
+      body: { configId: "collaboration_mode", value: "plan" },
+      options: { signal: controller.signal },
+    }]);
+  });
+});
+
 describe("SessionsClient.reorderPendingPrompts", () => {
   it("sends both expected and desired queue order for CAS", async () => {
     const calls: Array<{ path: string; body: unknown }> = [];

--- a/anyharness/sdk/src/client/sessions.ts
+++ b/anyharness/sdk/src/client/sessions.ts
@@ -213,10 +213,12 @@ export class SessionsClient {
   async setConfigOption(
     sessionId: string,
     input: SetSessionConfigOptionRequest,
+    options?: AnyHarnessRequestOptions,
   ): Promise<SetSessionConfigOptionResponse> {
     const response = await this.transport.post<SetSessionConfigOptionResponse>(
       `/v1/sessions/${encodeURIComponent(sessionId)}/config-options`,
       input,
+      options,
     );
     if (!response.liveConfig) {
       return {

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -1270,33 +1270,32 @@ body {
   }
 }
 
-/* Reasoning-level label swap (ComposerReasoningEffortBars): when the level
-   steps, the new label slides in from above while the old one slides out
-   below, clipped by the swap container. Compositor rule: transform/opacity
-   only. */
+/* Composer control value swap: when a selection changes, the new value slides
+   in from above while the old value slides out below, clipped by the swap
+   container. Compositor rule: transform/opacity only. */
 /* display block, not inline-block: an inline-block with overflow hidden
    baseline-aligns on its bottom edge, which would hoist the label a few px
    the moment the swap wrapper first mounts. */
-.composer-reasoning-level-swap {
+.composer-value-swap {
   position: relative;
   display: block;
   overflow: hidden;
 }
 
-.composer-reasoning-level-enter {
+.composer-value-enter {
   display: inline-block;
-  animation: composer-reasoning-level-enter 240ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: composer-value-enter 240ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-.composer-reasoning-level-exit {
+.composer-value-exit {
   position: absolute;
   inset: 0;
   display: inline-block;
   white-space: nowrap;
-  animation: composer-reasoning-level-exit 240ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
+  animation: composer-value-exit 240ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
 }
 
-@keyframes composer-reasoning-level-enter {
+@keyframes composer-value-enter {
   0% {
     transform: translateY(-100%);
     opacity: 0;
@@ -1307,7 +1306,7 @@ body {
   }
 }
 
-@keyframes composer-reasoning-level-exit {
+@keyframes composer-value-exit {
   0% {
     transform: translateY(0);
     opacity: 1;
@@ -1342,12 +1341,12 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .composer-reasoning-level-enter,
-  .composer-reasoning-level-exit {
+  .composer-value-enter,
+  .composer-value-exit {
     animation: none;
   }
 
-  .composer-reasoning-level-exit {
+  .composer-value-exit {
     display: none;
   }
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -172,7 +172,7 @@ describe("ChatInputControlRow", () => {
     expect(mode.querySelector("svg")).toBeNull();
   });
 
-  it("orders model, reasoning bars, working mode, and fast mode in the visible row", () => {
+  it("orders model, working mode, reasoning bars, and fast mode in the visible row", () => {
     renderControlRow();
 
     const model = screen.getByRole("button", { name: "Model: Opus 4.1" });
@@ -180,11 +180,11 @@ describe("ChatInputControlRow", () => {
     const mode = screen.getByRole("button", { name: "Mode: Default" });
     const fast = screen.getByRole("button", { name: "Fast mode: Slow" });
 
-    expect(model.compareDocumentPosition(reasoning) & Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(model.compareDocumentPosition(mode) & Node.DOCUMENT_POSITION_FOLLOWING)
       .toBeTruthy();
-    expect(reasoning.compareDocumentPosition(mode) & Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(mode.compareDocumentPosition(reasoning) & Node.DOCUMENT_POSITION_FOLLOWING)
       .toBeTruthy();
-    expect(mode.compareDocumentPosition(fast) & Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(reasoning.compareDocumentPosition(fast) & Node.DOCUMENT_POSITION_FOLLOWING)
       .toBeTruthy();
   });
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -139,6 +139,7 @@ describe("ChatInputControlRow", () => {
     renderControlRow();
     const reasoning = screen.getByRole("button", { name: "Reasoning: Medium" });
     expect(reasoning.getAttribute("title")?.startsWith("Reasoning: Medium")).toBe(true);
+    expect(reasoning.className).toContain("!gap-0.5");
     // The level name is a visible label beside the bars, not sr-only.
     expect(screen.getByText("Medium").className).not.toContain("sr-only");
   });

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.tsx
@@ -48,7 +48,7 @@ export interface ComposerLeadingControlsProps {
 }
 
 /**
- * The leading control cluster (model selector, reasoning bars, mode, fast mode,
+ * The leading control cluster (model selector, mode, reasoning bars, fast mode,
  * goal, integrations). Shared verbatim between the in-session chat composer
  * (ChatInputControlRow) and the home/new-chat composer (HomeNextScreen slot):
  * home feeds it launch-time control descriptors instead of live-session
@@ -84,21 +84,7 @@ export function ComposerLeadingControls({
         <ComposerModelSelectorControl modelSelectorProps={modelSelectorProps} />
       </div>
 
-      {/* 2. Reasoning/effort bars */}
-      {controlGroups.reasoningEffortControl && (
-        <span
-          className={`inline-flex shrink-0 ${
-            runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
-          }`}
-        >
-          <ComposerReasoningEffortBars
-            control={controlGroups.reasoningEffortControl}
-            agentKind={agentKind}
-          />
-        </span>
-      )}
-
-      {/* 3. Primary working mode control (bypass/plan/etc) */}
+      {/* 2. Primary working mode control (bypass/plan/etc) */}
       {controlGroups.modeControl && (
         <span
           className={`inline-flex min-w-0 ${
@@ -109,6 +95,20 @@ export function ComposerLeadingControls({
             agentKind={agentKind}
             control={controlGroups.modeControl}
             triggerStyle="value"
+          />
+        </span>
+      )}
+
+      {/* 3. Reasoning/effort bars */}
+      {controlGroups.reasoningEffortControl && (
+        <span
+          className={`inline-flex shrink-0 ${
+            runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
+          }`}
+        >
+          <ComposerReasoningEffortBars
+            control={controlGroups.reasoningEffortControl}
+            agentKind={agentKind}
           />
         </span>
       )}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -91,7 +91,7 @@ export function ComposerReasoningEffortBars({
         onStep={(nextValue: string) => control.onSelect(nextValue)}
         label={labelNode}
         emphasis="none"
-        className={`!gap-2 ${toneClass} ${chipClass}`}
+        className={`!gap-0.5 ${toneClass} ${chipClass}`}
         disabled={!control.settable}
         title={tooltip}
         aria-label={ariaLabel}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import {
   reasoningLadderTopsOutAtUltra,
   resolveReasoningEffortPresentation,
@@ -9,6 +9,7 @@ import { resolveSessionControlTooltip } from "#product/lib/domain/chat/session-c
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import { LevelBarsButton } from "@proliferate/ui/primitives/LevelBarsButton";
+import { AnimatedSwapText } from "@proliferate/ui/primitives/AnimatedSwapText";
 
 // Tier-label tint ladder for ultra-capable ladders. Ultra keeps the
 // codex-convention purple (same hue as --color-pr-merged); max keeps the app
@@ -72,39 +73,15 @@ export function ComposerReasoningEffortBars({
   const chipClass = isUltraTier ? "composer-reasoning-ultra-chip" : "";
   const toneClass = isUltraLadder ? TIER_TONE_CLASSES[tierTone] : "";
 
-  // Label swap: when the level steps, the new label slides in from above
-  // while the outgoing one slides down and fades (render-phase derived state;
-  // the exit span unmounts on animationend). The initial render keeps a plain
-  // string so nothing animates on mount.
-  const swapKeyRef = useRef(0);
-  const lastLevelRef = useRef(currentLevel);
-  const [exitingLevel, setExitingLevel] = useState<string | null>(null);
-  if (lastLevelRef.current !== currentLevel) {
-    setExitingLevel(lastLevelRef.current);
-    lastLevelRef.current = currentLevel;
-    swapKeyRef.current += 1;
-  }
   const levelText = isSolUltra
     ? <span className="composer-reasoning-ultra-sol">{currentLevel}</span>
     : currentLevel;
-  const labelNode = swapKeyRef.current === 0
-    ? levelText
-    : (
-      <span className="composer-reasoning-level-swap">
-        <span key={swapKeyRef.current} className="composer-reasoning-level-enter">
-          {levelText}
-        </span>
-        {exitingLevel !== null && (
-          <span
-            aria-hidden="true"
-            className="composer-reasoning-level-exit"
-            onAnimationEnd={() => setExitingLevel(null)}
-          >
-            {exitingLevel}
-          </span>
-        )}
-      </span>
-    );
+  const labelNode = (
+    <AnimatedSwapText
+      valueKey={currentOption?.value ?? currentLevel}
+      value={levelText}
+    />
+  );
 
   return (
     <Tooltip content={tooltip}>
@@ -114,7 +91,7 @@ export function ComposerReasoningEffortBars({
         onStep={(nextValue: string) => control.onSelect(nextValue)}
         label={labelNode}
         emphasis="none"
-        className={`!gap-1.5 ${toneClass} ${chipClass}`}
+        className={`!gap-2 ${toneClass} ${chipClass}`}
         disabled={!control.settable}
         title={tooltip}
         aria-label={ariaLabel}

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.test.tsx
@@ -9,7 +9,7 @@ import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/sess
 afterEach(cleanup);
 
 describe("SessionModeControl", () => {
-  it("updates through the control callback and closes the menu on pointer selection", () => {
+  it("cycles compact mode values on click without opening a menu", () => {
     const onSelect = vi.fn();
 
     function Harness() {
@@ -25,6 +25,7 @@ describe("SessionModeControl", () => {
         options: [
           { value: "default", label: "Default", selected: selectedValue === "default" },
           { value: "plan", label: "Plan", selected: selectedValue === "plan" },
+          { value: "bypass", label: "Bypass", selected: selectedValue === "bypass" },
         ],
         onSelect: (value) => {
           onSelect(value);
@@ -42,10 +43,40 @@ describe("SessionModeControl", () => {
 
     render(<Harness />);
     fireEvent.click(screen.getByRole("button", { name: "Mode: Default" }));
-    fireEvent.click(screen.getByRole("button", { name: "Plan" }));
-
     expect(onSelect).toHaveBeenCalledWith("plan");
     expect(screen.getByRole("button", { name: "Mode: Plan" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Default" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mode: Plan" }));
+    expect(onSelect).toHaveBeenLastCalledWith("bypass");
+    expect(screen.getByRole("button", { name: "Mode: Bypass" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mode: Bypass" }));
+    expect(onSelect).toHaveBeenLastCalledWith("default");
+    expect(screen.getByRole("button", { name: "Mode: Default" })).toBeTruthy();
+  });
+
+  it("keeps the full settings control as an explicit option menu", () => {
+    const onSelect = vi.fn();
+    const control: LiveSessionControlDescriptor & { key: "collaboration_mode" } = {
+      key: "collaboration_mode",
+      label: "Mode",
+      detail: "Default",
+      rawConfigId: "collaboration_mode",
+      settable: true,
+      pendingState: null,
+      kind: "select",
+      options: [
+        { value: "default", label: "Default", selected: true },
+        { value: "plan", label: "Plan", selected: false },
+      ],
+      onSelect,
+    };
+
+    render(<SessionModeControl agentKind="codex" control={control} />);
+    fireEvent.click(screen.getByRole("button", { name: "Mode: Default" }));
+    fireEvent.click(screen.getByRole("button", { name: "Plan" }));
+
+    expect(onSelect).toHaveBeenCalledWith("plan");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionModeControl } from "#product/components/workspace/chat/input/SessionModeControl";
+import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
+
+afterEach(cleanup);
+
+describe("SessionModeControl", () => {
+  it("updates through the control callback and closes the menu on pointer selection", () => {
+    const onSelect = vi.fn();
+
+    function Harness() {
+      const [selectedValue, setSelectedValue] = useState("default");
+      const control: LiveSessionControlDescriptor & { key: "collaboration_mode" } = {
+        key: "collaboration_mode",
+        label: "Mode",
+        detail: selectedValue === "plan" ? "Plan" : "Default",
+        rawConfigId: "collaboration_mode",
+        settable: true,
+        pendingState: selectedValue === "plan" ? "submitting" : null,
+        kind: "select",
+        options: [
+          { value: "default", label: "Default", selected: selectedValue === "default" },
+          { value: "plan", label: "Plan", selected: selectedValue === "plan" },
+        ],
+        onSelect: (value) => {
+          onSelect(value);
+          setSelectedValue(value);
+        },
+      };
+      return (
+        <SessionModeControl
+          agentKind="codex"
+          control={control}
+          triggerStyle="value"
+        />
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Mode: Default" }));
+    fireEvent.click(screen.getByRole("button", { name: "Plan" }));
+
+    expect(onSelect).toHaveBeenCalledWith("plan");
+    expect(screen.getByRole("button", { name: "Mode: Plan" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Default" })).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
@@ -9,6 +9,7 @@ import { POPOVER_SURFACE_CLASS, PopoverButton } from "@proliferate/ui/primitives
 import { Check } from "@proliferate/ui/icons";
 import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { ComposerControlButton } from "@proliferate/ui/primitives/ComposerControlButton";
+import { AnimatedSwapText } from "@proliferate/ui/primitives/AnimatedSwapText";
 import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
 
 type ModeControlDescriptor = LiveSessionControlDescriptor & {
@@ -36,6 +37,14 @@ export function SessionModeControl({
   const currentDetail = currentPresentation.shortLabel ?? currentOption?.label ?? control.detail;
   const triggerLabel = triggerStyle === "value" ? currentDetail ?? control.label : control.label;
   const triggerDetail = triggerStyle === "value" ? null : currentDetail;
+  const animatedValue = (
+    <AnimatedSwapText
+      valueKey={currentValue ?? String(currentDetail ?? control.label)}
+      value={triggerStyle === "value" ? triggerLabel : triggerDetail}
+    />
+  );
+  const visibleTriggerLabel = triggerStyle === "value" ? animatedValue : triggerLabel;
+  const visibleTriggerDetail = triggerStyle === "value" ? null : animatedValue;
   const compactTrigger = triggerStyle === "value";
   const triggerIcon = compactTrigger
     ? undefined
@@ -52,8 +61,8 @@ export function SessionModeControl({
         disabled
         emphasizeLabel={triggerStyle === "value"}
         icon={triggerIcon}
-        label={triggerLabel}
-        detail={triggerDetail}
+        label={visibleTriggerLabel}
+        detail={visibleTriggerDetail}
         trailing={triggerTrailing}
         className="max-w-[12rem]"
         data-session-mode-trigger=""
@@ -68,8 +77,8 @@ export function SessionModeControl({
         <ComposerControlButton
           emphasizeLabel={triggerStyle === "value"}
           icon={triggerIcon}
-          label={triggerLabel}
-          detail={triggerDetail}
+          label={visibleTriggerLabel}
+          detail={visibleTriggerDetail}
           trailing={triggerTrailing}
           title={`${CHAT_MODE_CONTROL_LABELS.cycleHint} (${CHAT_MODE_CONTROL_LABELS.shortcut})`}
           aria-label={`${control.label}: ${currentOption?.label ?? currentDetail ?? ""}`}

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
@@ -1,5 +1,6 @@
 import { CHAT_MODE_CONTROL_LABELS } from "#product/copy/chat/chat-copy";
 import {
+  getNextSessionModeValue,
   resolveSessionControlPresentation,
 } from "#product/lib/domain/chat/session-controls/session-mode-control";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
@@ -46,11 +47,12 @@ export function SessionModeControl({
   const visibleTriggerLabel = triggerStyle === "value" ? animatedValue : triggerLabel;
   const visibleTriggerDetail = triggerStyle === "value" ? null : animatedValue;
   const compactTrigger = triggerStyle === "value";
+  const nextValue = getNextSessionModeValue(control.options, currentValue);
   const triggerIcon = compactTrigger
     ? undefined
     : <SessionControlIcon icon={currentPresentation.icon} className="size-3.5" />;
-  // No disclosure chevron on the compact trigger: the mode name alone is the
-  // whole affordance; the popover still opens on click.
+  // No disclosure chevron on the compact trigger: the mode name itself steps
+  // immediately to the next runtime-provided value.
   const triggerTrailing = control.pendingState
     ? <PendingConfigIndicator pendingState={control.pendingState} />
     : null;
@@ -71,22 +73,32 @@ export function SessionModeControl({
     );
   }
 
+  const trigger = (
+    <ComposerControlButton
+      emphasizeLabel={triggerStyle === "value"}
+      icon={triggerIcon}
+      label={visibleTriggerLabel}
+      detail={visibleTriggerDetail}
+      trailing={triggerTrailing}
+      title={`${CHAT_MODE_CONTROL_LABELS.cycleHint} (${CHAT_MODE_CONTROL_LABELS.shortcut})`}
+      aria-label={`${control.label}: ${currentOption?.label ?? currentDetail ?? ""}`}
+      className="max-w-[12rem]"
+      data-session-mode-trigger=""
+      data-session-mode-selected={currentValue ?? ""}
+      data-session-mode-next={nextValue ?? ""}
+      onClick={compactTrigger && nextValue
+        ? () => control.onSelect(nextValue)
+        : undefined}
+    />
+  );
+
+  if (compactTrigger) {
+    return trigger;
+  }
+
   return (
     <PopoverButton
-      trigger={
-        <ComposerControlButton
-          emphasizeLabel={triggerStyle === "value"}
-          icon={triggerIcon}
-          label={visibleTriggerLabel}
-          detail={visibleTriggerDetail}
-          trailing={triggerTrailing}
-          title={`${CHAT_MODE_CONTROL_LABELS.cycleHint} (${CHAT_MODE_CONTROL_LABELS.shortcut})`}
-          aria-label={`${control.label}: ${currentOption?.label ?? currentDetail ?? ""}`}
-          className="max-w-[12rem]"
-          data-session-mode-trigger=""
-          data-session-mode-selected={currentValue ?? ""}
-        />
-      }
+      trigger={trigger}
       side="top"
       className={`w-56 ${POPOVER_SURFACE_CLASS}`}
     >

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-keyboard.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-keyboard.test.ts
@@ -3,6 +3,7 @@
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useChatComposerKeyboard } from "#product/hooks/chat/ui/use-chat-composer-keyboard";
+import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 
 function keyboardEvent(overrides: Partial<{
   key: string;
@@ -191,5 +192,36 @@ describe("useChatComposerKeyboard", () => {
 
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(onEditLastQueued).not.toHaveBeenCalled();
+  });
+
+  it("cycles working mode through the control transition on Shift+Tab", () => {
+    const onSelect = vi.fn();
+    const modeControl: LiveSessionControlDescriptor = {
+      key: "collaboration_mode",
+      label: "Mode",
+      detail: "Plan",
+      rawConfigId: "collaboration_mode",
+      settable: true,
+      pendingState: null,
+      kind: "select",
+      options: [
+        { value: "default", label: "Default", selected: false },
+        { value: "plan", label: "Plan", selected: true },
+      ],
+      onSelect,
+    };
+    const { result } = renderHook(() => useChatComposerKeyboard({
+      handleSubmit: vi.fn(),
+      handleCancel: vi.fn(),
+      isRunning: false,
+      canSubmit: true,
+      modeControl,
+    }));
+    const event = keyboardEvent({ key: "Tab", code: "Tab", shiftKey: true });
+
+    result.current.handleKeyDown(event as never);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("default");
   });
 });

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
@@ -125,7 +125,54 @@ describe("dispatchConfigIntent", () => {
     expect(onFailure).not.toHaveBeenCalled();
     expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
       requestOptions: { signal: expect.any(AbortSignal) },
+      awaitInvalidations: false,
     }));
+  });
+
+  it("accepts the POST acknowledgement without timing out on later invalidations", async () => {
+    vi.useFakeTimers();
+    const intent = useSessionIntentStore.getState().enqueueConfig({
+      intentId: "config-plan",
+      clientSessionId: "session-1",
+      materializedSessionId: "runtime-session-1",
+      workspaceId: "workspace-1",
+      configId: "collaboration_mode",
+      value: "plan",
+    });
+    const invalidation = deferred<void>();
+    const onFailure = vi.fn();
+    const deps = createDeps(onFailure);
+    let signal: AbortSignal | undefined;
+    mocks.mutateAsync.mockImplementation(async (input) => {
+      signal = input.requestOptions?.signal;
+      if (input.awaitInvalidations !== false) {
+        await invalidation.promise;
+      }
+      return configResponse("plan");
+    });
+
+    const dispatch = dispatchConfigIntent(intent, deps);
+    await vi.advanceTimersByTimeAsync(0);
+    await dispatch;
+
+    expect(useSessionIntentStore.getState().entriesById[intent.intentId]).toMatchObject({
+      status: "accepted",
+      applyState: "applied",
+    });
+    expect(signal?.aborted).toBe(false);
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(deps.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(CONFIG_INTENT_DISPATCH_TIMEOUT_MS);
+    invalidation.resolve();
+    await Promise.resolve();
+
+    expect(signal?.aborted).toBe(false);
+    expect(useSessionIntentStore.getState().entriesById[intent.intentId]).toMatchObject({
+      status: "accepted",
+    });
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(deps.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
@@ -1,8 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SetSessionConfigOptionResponse } from "@anyharness/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  CONFIG_INTENT_DISPATCH_TIMEOUT_MS,
   dispatchConfigIntent,
   type ConfigIntentDispatchDeps,
 } from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
+import {
+  pendingConfigChangesForSessionIntents,
+} from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 
 const mocks = vi.hoisted(() => ({
@@ -17,11 +22,16 @@ vi.mock("#product/lib/access/anyharness/session-runtime", () => ({
 describe("dispatchConfigIntent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.mutateAsync.mockReset();
     useSessionIntentStore.getState().clear();
     mocks.getSessionClientAndWorkspace.mockResolvedValue({
       workspaceId: "workspace-1",
       materializedSessionId: "runtime-session-1",
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("drops the optimistic intent and reports runtime rejection language", async () => {
@@ -44,6 +54,79 @@ describe("dispatchConfigIntent", () => {
     });
     expect(onFailure).toHaveBeenCalledWith("request timed out");
   });
+
+  it("times out a stalled request, rolls back once, and ignores its late completion", async () => {
+    vi.useFakeTimers();
+    const intent = useSessionIntentStore.getState().enqueueConfig({
+      intentId: "config-plan",
+      clientSessionId: "session-1",
+      materializedSessionId: "runtime-session-1",
+      workspaceId: "workspace-1",
+      configId: "collaboration_mode",
+      value: "plan",
+    });
+    const request = deferred<SetSessionConfigOptionResponse>();
+    const onFailure = vi.fn();
+    const deps = createDeps(onFailure);
+    let signal: AbortSignal | undefined;
+    mocks.mutateAsync.mockImplementation((input) => {
+      signal = input.requestOptions?.signal;
+      return request.promise;
+    });
+
+    const dispatch = dispatchConfigIntent(intent, deps);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(CONFIG_INTENT_DISPATCH_TIMEOUT_MS);
+    await dispatch;
+
+    const failed = useSessionIntentStore.getState().entriesById[intent.intentId];
+    expect(failed).toMatchObject({
+      status: "failed",
+      errorMessage: "request timed out",
+    });
+    expect(pendingConfigChangesForSessionIntents(failed ? [failed] : []))
+      .not.toHaveProperty("collaboration_mode");
+    expect(signal?.aborted).toBe(true);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+
+    request.resolve(configResponse("plan"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deps.upsertWorkspaceSessionRecord).not.toHaveBeenCalled();
+    expect(useSessionIntentStore.getState().entriesById[intent.intentId]).toMatchObject({
+      status: "failed",
+    });
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps ordinary successful settlement intact", async () => {
+    const intent = useSessionIntentStore.getState().enqueueConfig({
+      intentId: "config-plan",
+      clientSessionId: "session-1",
+      materializedSessionId: "runtime-session-1",
+      workspaceId: "workspace-1",
+      configId: "collaboration_mode",
+      value: "plan",
+    });
+    const onFailure = vi.fn();
+    const deps = createDeps(onFailure);
+    mocks.mutateAsync.mockResolvedValue(configResponse("plan"));
+
+    await dispatchConfigIntent(intent, deps);
+
+    expect(useSessionIntentStore.getState().entriesById[intent.intentId]).toMatchObject({
+      status: "accepted",
+      applyState: "applied",
+    });
+    expect(deps.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      requestOptions: { signal: expect.any(AbortSignal) },
+    }));
+  });
 });
 
 function createDeps(onFailure: (message: string) => void): ConfigIntentDispatchDeps {
@@ -56,4 +139,29 @@ function createDeps(onFailure: (message: string) => void): ConfigIntentDispatchD
     upsertWorkspaceSessionRecord: vi.fn(),
     onFailure,
   };
+}
+
+function configResponse(modeId: string): SetSessionConfigOptionResponse {
+  return {
+    applyState: "applied",
+    session: {
+      id: "runtime-session-1",
+      workspaceId: "workspace-1",
+      agentKind: "claude",
+      modelId: "claude-sonnet-4-6",
+      modeId,
+      status: "idle",
+      title: null,
+      createdAt: "2026-07-18T00:00:00.000Z",
+      updatedAt: "2026-07-18T00:00:00.000Z",
+    },
+  } as SetSessionConfigOptionResponse;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchConfigIntent,
+  type ConfigIntentDispatchDeps,
+} from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+
+const mocks = vi.hoisted(() => ({
+  getSessionClientAndWorkspace: vi.fn(),
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock("#product/lib/access/anyharness/session-runtime", () => ({
+  getSessionClientAndWorkspace: mocks.getSessionClientAndWorkspace,
+}));
+
+describe("dispatchConfigIntent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionIntentStore.getState().clear();
+    mocks.getSessionClientAndWorkspace.mockResolvedValue({
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-session-1",
+    });
+  });
+
+  it("drops the optimistic intent and reports runtime rejection language", async () => {
+    const intent = useSessionIntentStore.getState().enqueueConfig({
+      intentId: "config-plan",
+      clientSessionId: "session-1",
+      materializedSessionId: "runtime-session-1",
+      workspaceId: "workspace-1",
+      configId: "collaboration_mode",
+      value: "plan",
+    });
+    const onFailure = vi.fn();
+    mocks.mutateAsync.mockRejectedValue(new Error("request timed out"));
+
+    await dispatchConfigIntent(intent, createDeps(onFailure));
+
+    expect(useSessionIntentStore.getState().entriesById[intent.intentId]).toMatchObject({
+      status: "failed",
+      errorMessage: "request timed out",
+    });
+    expect(onFailure).toHaveBeenCalledWith("request timed out");
+  });
+});
+
+function createDeps(onFailure: (message: string) => void): ConfigIntentDispatchDeps {
+  return {
+    cloudClient: null,
+    getWorkspaceSurface: vi.fn(),
+    setSessionConfigOptionMutation: {
+      mutateAsync: mocks.mutateAsync,
+    } as unknown as ConfigIntentDispatchDeps["setSessionConfigOptionMutation"],
+    upsertWorkspaceSessionRecord: vi.fn(),
+    onFailure,
+  };
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -27,6 +27,8 @@ import { logLatency } from "#product/lib/infra/measurement/measurement-port";
 
 type SetSessionConfigOptionMutation = ReturnType<typeof useSetSessionConfigOptionMutation>;
 
+export const CONFIG_INTENT_DISPATCH_TIMEOUT_MS = 15_000;
+
 export interface ConfigIntentDispatchDeps {
   ssh?: DesktopSshBridge | null;
   cloudClient: CloudSandboxGatewayUrlSource | null;
@@ -38,6 +40,7 @@ export interface ConfigIntentDispatchDeps {
     workspaceId: string,
     session: Session,
   ) => void;
+  timeoutMs?: number;
   onFailure?: (message: string) => void;
 }
 
@@ -49,10 +52,11 @@ export async function dispatchConfigIntent(
   if (!current || current.kind !== "update_config" || current.status !== "queued") {
     return;
   }
+  const dispatchedAt = new Date().toISOString();
   useSessionIntentStore.getState().patchIntent(intent.intentId, {
     status: "dispatching",
     errorMessage: null,
-    dispatchedAt: new Date().toISOString(),
+    dispatchedAt,
   });
   try {
     const { workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(
@@ -64,11 +68,18 @@ export async function dispatchConfigIntent(
       intent.clientSessionId,
       materializedSessionId,
     );
-    const response = await deps.setSessionConfigOptionMutation.mutateAsync({
-      workspaceId,
-      sessionId: materializedSessionId,
-      request: { configId: intent.configId, value: intent.value },
-    });
+    const response = await runConfigMutationWithTimeout(
+      deps.timeoutMs ?? CONFIG_INTENT_DISPATCH_TIMEOUT_MS,
+      (signal) => deps.setSessionConfigOptionMutation.mutateAsync({
+        workspaceId,
+        sessionId: materializedSessionId,
+        request: { configId: intent.configId, value: intent.value },
+        requestOptions: { signal },
+      }),
+    );
+    if (!isCurrentConfigDispatch(intent.intentId, dispatchedAt)) {
+      return;
+    }
     if (workspaceId) {
       deps.upsertWorkspaceSessionRecord(workspaceId, response.session);
     }
@@ -154,11 +165,45 @@ export async function dispatchConfigIntent(
       applyState: response.applyState,
     });
   } catch (error) {
+    if (!isCurrentConfigDispatch(intent.intentId, dispatchedAt)) {
+      return;
+    }
     const message = error instanceof Error ? error.message : String(error);
     useSessionIntentStore.getState().patchIntent(intent.intentId, {
       status: "failed",
       errorMessage: message,
     });
     deps.onFailure?.(message);
+  }
+}
+
+function isCurrentConfigDispatch(intentId: string, dispatchedAt: string): boolean {
+  const current = useSessionIntentStore.getState().entriesById[intentId];
+  return current?.kind === "update_config"
+    && current.status === "dispatching"
+    && current.dispatchedAt === dispatchedAt;
+}
+
+async function runConfigMutationWithTimeout<T>(
+  timeoutMs: number,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  const timeoutError = new Error("request timed out");
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      reject(timeoutError);
+      controller.abort(timeoutError);
+    }, timeoutMs);
+  });
+  try {
+    const request = run(controller.signal);
+    request.catch(() => undefined);
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
   }
 }

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -38,6 +38,7 @@ export interface ConfigIntentDispatchDeps {
     workspaceId: string,
     session: Session,
   ) => void;
+  onFailure?: (message: string) => void;
 }
 
 export async function dispatchConfigIntent(
@@ -153,9 +154,11 @@ export async function dispatchConfigIntent(
       applyState: response.applyState,
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     useSessionIntentStore.getState().patchIntent(intent.intentId, {
       status: "failed",
-      errorMessage: error instanceof Error ? error.message : String(error),
+      errorMessage: message,
     });
+    deps.onFailure?.(message);
   }
 }

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -59,23 +59,30 @@ export async function dispatchConfigIntent(
     dispatchedAt,
   });
   try {
-    const { workspaceId, materializedSessionId } = await getSessionClientAndWorkspace(
-      intent.clientSessionId,
-      deps.ssh ?? null,
-      deps.cloudClient,
-    );
-    useSessionIntentStore.getState().bindMaterializedSession(
-      intent.clientSessionId,
-      materializedSessionId,
-    );
-    const response = await runConfigMutationWithTimeout(
+    const { response, workspaceId } = await runConfigDispatchWithTimeout(
       deps.timeoutMs ?? CONFIG_INTENT_DISPATCH_TIMEOUT_MS,
-      (signal) => deps.setSessionConfigOptionMutation.mutateAsync({
-        workspaceId,
-        sessionId: materializedSessionId,
-        request: { configId: intent.configId, value: intent.value },
-        requestOptions: { signal },
-      }),
+      async (signal) => {
+        const target = await getSessionClientAndWorkspace(
+          intent.clientSessionId,
+          deps.ssh ?? null,
+          deps.cloudClient,
+        );
+        if (signal.aborted || !isCurrentConfigDispatch(intent.intentId, dispatchedAt)) {
+          throw new Error(signal.aborted ? "request timed out" : "config dispatch superseded");
+        }
+        useSessionIntentStore.getState().bindMaterializedSession(
+          intent.clientSessionId,
+          target.materializedSessionId,
+        );
+        const response = await deps.setSessionConfigOptionMutation.mutateAsync({
+          workspaceId: target.workspaceId,
+          sessionId: target.materializedSessionId,
+          request: { configId: intent.configId, value: intent.value },
+          requestOptions: { signal },
+          awaitInvalidations: false,
+        });
+        return { response, workspaceId: target.workspaceId };
+      },
     );
     if (!isCurrentConfigDispatch(intent.intentId, dispatchedAt)) {
       return;
@@ -184,7 +191,7 @@ function isCurrentConfigDispatch(intentId: string, dispatchedAt: string): boolea
     && current.dispatchedAt === dispatchedAt;
 }
 
-async function runConfigMutationWithTimeout<T>(
+async function runConfigDispatchWithTimeout<T>(
   timeoutMs: number,
   run: (signal: AbortSignal) => Promise<T>,
 ): Promise<T> {
@@ -193,8 +200,8 @@ async function runConfigMutationWithTimeout<T>(
   const timeoutError = new Error("request timed out");
   const timeout = new Promise<never>((_, reject) => {
     timeoutId = globalThis.setTimeout(() => {
-      reject(timeoutError);
       controller.abort(timeoutError);
+      reject(timeoutError);
     }, timeoutMs);
   });
   try {

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher-config-timeout.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher-config-timeout.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import type {
+  NormalizedSessionControl,
+  Session,
+  SessionLiveConfigSnapshot,
+  SetSessionConfigOptionResponse,
+} from "@anyharness/sdk";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CONFIG_INTENT_DISPATCH_TIMEOUT_MS,
+} from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
+import { useSessionIntentDispatcher } from "#product/hooks/sessions/lifecycle/use-session-intent-dispatcher";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const mocks = vi.hoisted(() => ({
+  getSessionClientAndWorkspace: vi.fn(),
+  mutateAsync: vi.fn(),
+  persistDefaultSessionModePreference: vi.fn(),
+  showToast: vi.fn(),
+  upsertWorkspaceSessionRecord: vi.fn(),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    cloud: { client: null },
+    desktop: null,
+  }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useDeletePendingPromptMutation: () => ({}),
+  useEditPendingPromptMutation: () => ({}),
+  usePromptSessionMutation: () => ({}),
+  useResolveSessionInteractionMutation: () => ({}),
+  useSetSessionConfigOptionMutation: () => ({ mutateAsync: mocks.mutateAsync }),
+}));
+
+vi.mock("#product/lib/access/anyharness/session-runtime", () => ({
+  getSessionClientAndWorkspace: mocks.getSessionClientAndWorkspace,
+}));
+
+vi.mock("#product/hooks/sessions/workflows/session-mode-preferences", () => ({
+  persistDefaultSessionModePreference: mocks.persistDefaultSessionModePreference,
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/use-session-history-hydration", () => ({
+  useSessionHistoryHydration: () => ({ rehydrateSessionSlotFromHistory: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-summary-actions", () => ({
+  useSessionSummaryActions: () => ({ applySessionSummary: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-title-actions", () => ({
+  useSessionTitleActions: () => ({ maybeGenerateSessionTitle: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-name-actions", () => ({
+  useWorkspaceNameActions: () => ({ maybeGenerateWorkspaceName: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-surface-lookup", () => ({
+  useWorkspaceSurfaceLookup: () => ({ getWorkspaceSurface: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/access/anyharness/sessions/use-workspace-session-cache", () => ({
+  useWorkspaceSessionCache: () => ({
+    upsertWorkspaceSessionRecord: mocks.upsertWorkspaceSessionRecord,
+  }),
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof mocks.showToast }) => unknown) =>
+    selector({ show: mocks.showToast }),
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/session-intent-interaction-dispatch", () => ({
+  dispatchDeletePendingPromptIntent: vi.fn(),
+  dispatchEditPendingPromptIntent: vi.fn(),
+  dispatchInteractionIntent: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/lifecycle/session-intent-prompt-dispatch", () => ({
+  dispatchPromptIntent: vi.fn(),
+}));
+
+describe("useSessionIntentDispatcher config timeout", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.mutateAsync.mockReset();
+    useSessionIntentStore.getState().clear();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    mocks.getSessionClientAndWorkspace.mockResolvedValue({
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-session-1",
+    });
+    putSessionRecord(createEmptySessionRecord("session-1", "claude", {
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-session-1",
+      liveConfig: liveConfig("default", 1),
+      modeId: "default",
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("releases the session after timeout and ignores the late stale response", async () => {
+    const firstRequest = deferred<SetSessionConfigOptionResponse>();
+    let firstSignal: AbortSignal | undefined;
+    mocks.mutateAsync
+      .mockImplementationOnce((input) => {
+        firstSignal = input.requestOptions?.signal;
+        return firstRequest.promise;
+      })
+      .mockResolvedValueOnce(configResponse("bypass", 3));
+
+    renderHook(() => useSessionIntentDispatcher());
+
+    act(() => {
+      enqueueMode("config-plan", "plan");
+    });
+    await vi.waitFor(() => {
+      expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      enqueueMode("config-bypass", "bypass");
+    });
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONFIG_INTENT_DISPATCH_TIMEOUT_MS);
+    });
+    await vi.waitFor(() => {
+      expect(mocks.mutateAsync).toHaveBeenCalledTimes(2);
+    });
+    await vi.waitFor(() => {
+      expect(useSessionIntentStore.getState().entriesById["config-bypass"]).toMatchObject({
+        status: "accepted",
+        applyState: "applied",
+      });
+    });
+
+    expect(useSessionIntentStore.getState().entriesById["config-plan"]).toMatchObject({
+      status: "failed",
+      errorMessage: "request timed out",
+    });
+    expect(firstSignal?.aborted).toBe(true);
+    expect(mocks.showToast).toHaveBeenCalledTimes(1);
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      "Failed to update session config: request timed out",
+    );
+    expect(getSessionRecord("session-1")?.modeId).toBe("bypass");
+    expect(mocks.persistDefaultSessionModePreference).toHaveBeenCalledTimes(1);
+    expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstRequest.resolve(configResponse("plan", 2));
+      await firstRequest.promise;
+      await Promise.resolve();
+    });
+
+    expect(getSessionRecord("session-1")?.modeId).toBe("bypass");
+    expect(useSessionIntentStore.getState().entriesById["config-plan"]).toMatchObject({
+      status: "failed",
+    });
+    expect(mocks.showToast).toHaveBeenCalledTimes(1);
+    expect(mocks.persistDefaultSessionModePreference).toHaveBeenCalledTimes(1);
+    expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
+  });
+});
+
+function enqueueMode(intentId: string, value: string): void {
+  useSessionIntentStore.getState().enqueueConfig({
+    intentId,
+    clientSessionId: "session-1",
+    materializedSessionId: "runtime-session-1",
+    workspaceId: "workspace-1",
+    configId: "mode",
+    value,
+  });
+}
+
+function configResponse(modeId: string, sourceSeq: number): SetSessionConfigOptionResponse {
+  const snapshot = liveConfig(modeId, sourceSeq);
+  return {
+    applyState: "applied",
+    liveConfig: snapshot,
+    session: session(modeId, snapshot),
+  };
+}
+
+function session(modeId: string, snapshot: SessionLiveConfigSnapshot): Session {
+  return {
+    id: "runtime-session-1",
+    workspaceId: "workspace-1",
+    agentKind: "claude",
+    modelId: "claude-sonnet-4-6",
+    modeId,
+    status: "idle",
+    title: null,
+    createdAt: "2026-07-18T00:00:00.000Z",
+    updatedAt: "2026-07-18T00:00:00.000Z",
+    liveConfig: snapshot,
+  } as Session;
+}
+
+function liveConfig(modeId: string, sourceSeq: number): SessionLiveConfigSnapshot {
+  return {
+    updatedAt: `2026-07-18T00:00:0${sourceSeq}.000Z`,
+    sourceSeq,
+    rawConfigOptions: [],
+    promptCapabilities: { image: false, audio: false, embeddedContext: false },
+    normalizedControls: {
+      extras: [],
+      model: null,
+      mode: modeControl(modeId),
+      reasoning: null,
+      effort: null,
+      fastMode: null,
+      collaborationMode: null,
+    },
+  } as SessionLiveConfigSnapshot;
+}
+
+function modeControl(currentValue: string): NormalizedSessionControl {
+  return {
+    key: "mode",
+    rawConfigId: "mode",
+    label: "Mode",
+    settable: true,
+    currentValue,
+    values: ["default", "plan", "bypass"].map((value) => ({ value, label: value })),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher-config-timeout.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher-config-timeout.test.tsx
@@ -183,6 +183,73 @@ describe("useSessionIntentDispatcher config timeout", () => {
     expect(mocks.persistDefaultSessionModePreference).toHaveBeenCalledTimes(1);
     expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
   });
+
+  it("times out stalled target resolution, releases the queue, and blocks a late request", async () => {
+    const firstTarget = deferred<{
+      workspaceId: string;
+      materializedSessionId: string;
+    }>();
+    mocks.getSessionClientAndWorkspace
+      .mockImplementationOnce(() => firstTarget.promise)
+      .mockResolvedValueOnce({
+        workspaceId: "workspace-1",
+        materializedSessionId: "runtime-session-1",
+      });
+    mocks.mutateAsync.mockResolvedValue(configResponse("bypass", 3));
+
+    renderHook(() => useSessionIntentDispatcher());
+
+    act(() => {
+      enqueueMode("config-plan", "plan");
+    });
+    await vi.waitFor(() => {
+      expect(mocks.getSessionClientAndWorkspace).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      enqueueMode("config-bypass", "bypass");
+    });
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONFIG_INTENT_DISPATCH_TIMEOUT_MS);
+    });
+    await vi.waitFor(() => {
+      expect(mocks.getSessionClientAndWorkspace).toHaveBeenCalledTimes(2);
+      expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(useSessionIntentStore.getState().entriesById["config-bypass"]).toMatchObject({
+        status: "accepted",
+        applyState: "applied",
+      });
+    });
+
+    expect(useSessionIntentStore.getState().entriesById["config-plan"]).toMatchObject({
+      status: "failed",
+      errorMessage: "request timed out",
+    });
+    expect(mocks.showToast).toHaveBeenCalledTimes(1);
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      "Failed to update session config: request timed out",
+    );
+    expect(getSessionRecord("session-1")?.modeId).toBe("bypass");
+
+    await act(async () => {
+      firstTarget.resolve({
+        workspaceId: "workspace-1",
+        materializedSessionId: "late-runtime-session",
+      });
+      await firstTarget.promise;
+      await Promise.resolve();
+    });
+
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.showToast).toHaveBeenCalledTimes(1);
+    expect(getSessionRecord("session-1")?.modeId).toBe("bypass");
+    expect(mocks.persistDefaultSessionModePreference).toHaveBeenCalledTimes(1);
+    expect(mocks.upsertWorkspaceSessionRecord).toHaveBeenCalledTimes(1);
+  });
 });
 
 function enqueueMode(intentId: string, value: string): void {

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.test.tsx
@@ -12,7 +12,9 @@ import { useSessionIntentStore } from "#product/stores/sessions/session-intent-s
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 
 const mocks = vi.hoisted(() => ({
+  dispatchConfigIntent: vi.fn(),
   dispatchPromptIntent: vi.fn(),
+  showToast: vi.fn(),
 }));
 
 vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
@@ -55,7 +57,12 @@ vi.mock("#product/hooks/access/anyharness/sessions/use-workspace-session-cache",
 }));
 
 vi.mock("#product/hooks/sessions/lifecycle/session-intent-config-dispatch", () => ({
-  dispatchConfigIntent: vi.fn(),
+  dispatchConfigIntent: mocks.dispatchConfigIntent,
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: { show: typeof mocks.showToast }) => unknown) =>
+    selector({ show: mocks.showToast }),
 }));
 
 vi.mock("#product/hooks/sessions/lifecycle/session-intent-interaction-dispatch", () => ({
@@ -135,6 +142,34 @@ describe("useSessionIntentDispatcher", () => {
     expect(mocks.dispatchPromptIntent.mock.calls[1]?.[0]).toMatchObject({
       clientPromptId: "prompt-2",
       deliveryState: "waiting_for_session",
+    });
+  });
+
+  it("surfaces an asynchronous config rejection through existing error language", async () => {
+    mocks.dispatchConfigIntent.mockImplementation(async (intent, deps) => {
+      deps.onFailure?.("request timed out");
+      useSessionIntentStore.getState().patchIntent(intent.intentId, {
+        status: "failed",
+        errorMessage: "request timed out",
+      });
+    });
+    renderHook(() => useSessionIntentDispatcher());
+
+    act(() => {
+      useSessionIntentStore.getState().enqueueConfig({
+        intentId: "config-plan",
+        clientSessionId: "session-1",
+        materializedSessionId: "runtime-session-1",
+        workspaceId: "workspace-1",
+        configId: "collaboration_mode",
+        value: "plan",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith(
+        "Failed to update session config: request timed out",
+      );
     });
   });
 });

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
@@ -22,6 +22,7 @@ import { useWorkspaceSessionCache } from "#product/hooks/access/anyharness/sessi
 import { getSessionRecord } from "#product/stores/sessions/session-records";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
+import { useToastStore } from "#product/stores/toast/toast-store";
 import {
   dispatchConfigIntent,
 } from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
@@ -47,6 +48,7 @@ export function useSessionIntentDispatcher(): void {
   const { maybeGenerateWorkspaceName } = useWorkspaceNameActions();
   const { getWorkspaceSurface } = useWorkspaceSurfaceLookup();
   const { upsertWorkspaceSessionRecord } = useWorkspaceSessionCache();
+  const showToast = useToastStore((state) => state.show);
   const promptSessionMutation = usePromptSessionMutation();
   const setSessionConfigOptionMutation = useSetSessionConfigOptionMutation();
   const resolveInteractionMutation = useResolveSessionInteractionMutation();
@@ -95,6 +97,9 @@ export function useSessionIntentDispatcher(): void {
           ssh,
           cloudClient,
           upsertWorkspaceSessionRecord,
+          onFailure: (message) => {
+            showToast(`Failed to update session config: ${message}`);
+          },
         });
         break;
       case "resolve_interaction":
@@ -118,6 +123,7 @@ export function useSessionIntentDispatcher(): void {
     rehydrateSessionSlotFromHistory,
     resolveInteractionMutation,
     setSessionConfigOptionMutation,
+    showToast,
     ssh,
     cloudClient,
     upsertWorkspaceSessionRecord,

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-mode-control.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-mode-control.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveSessionControlPresentation } from "#product/lib/domain/chat/session-controls/session-mode-control";
+import {
+  getNextSessionModeValue,
+  resolveSessionControlPresentation,
+} from "#product/lib/domain/chat/session-controls/session-mode-control";
 
 describe("resolveSessionControlPresentation", () => {
   it.each([
@@ -10,5 +13,19 @@ describe("resolveSessionControlPresentation", () => {
     ["opencode", "plan", "opencodePlan"],
   ] as const)("uses configured icons for %s %s mode", (agentKind, value, icon) => {
     expect(resolveSessionControlPresentation(agentKind, "mode", value).icon).toBe(icon);
+  });
+
+  it("steps forward through runtime-provided modes and wraps", () => {
+    const options = [
+      { value: "default" },
+      { value: "plan" },
+      { value: "bypass" },
+    ];
+
+    expect(getNextSessionModeValue(options, "default")).toBe("plan");
+    expect(getNextSessionModeValue(options, "plan")).toBe("bypass");
+    expect(getNextSessionModeValue(options, "bypass")).toBe("default");
+    expect(getNextSessionModeValue(options, "missing")).toBe("default");
+    expect(getNextSessionModeValue([{ value: "only" }], "only")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-mode-control.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-mode-control.ts
@@ -62,6 +62,19 @@ export function getPreviousSessionModeValue(
   return options[currentIndex - 1]?.value ?? null;
 }
 
+export function getNextSessionModeValue(
+  options: ReadonlyArray<{ value: string }>,
+  currentValue: string | null,
+): string | null {
+  if (options.length < 2) {
+    return null;
+  }
+
+  const currentIndex = options.findIndex((option) => option.value === currentValue);
+  const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % options.length;
+  return options[nextIndex]?.value ?? null;
+}
+
 export {
   inferSessionControlPresentation,
   isConfiguredSessionControlKey,

--- a/apps/packages/product-domain/src/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-domain/src/sessions/intents/session-intent.test.ts
@@ -149,6 +149,45 @@ describe("session intents", () => {
     expect(pendingConfigChangesForSessionIntents([reconciled]).mode).toBeUndefined();
   });
 
+  it("projects only the latest rapid selection for the same config", () => {
+    const first = {
+      ...createUpdateConfigIntent({
+        intentId: "config-default",
+        clientSessionId: "session-1",
+        configId: "mode",
+        value: "default",
+      }),
+      status: "accepted" as const,
+      applyState: "applied" as const,
+    };
+    const latest = createUpdateConfigIntent({
+      intentId: "config-plan",
+      clientSessionId: "session-1",
+      configId: "mode",
+      value: "plan",
+    });
+
+    expect(pendingConfigChangesForSessionIntents([first, latest]).mode).toMatchObject({
+      value: "plan",
+      status: "submitting",
+    });
+  });
+
+  it("drops a failed optimistic selection so authority can roll the control back", () => {
+    const failed = {
+      ...createUpdateConfigIntent({
+        intentId: "config-plan",
+        clientSessionId: "session-1",
+        configId: "mode",
+        value: "plan",
+      }),
+      status: "failed" as const,
+      errorMessage: "request timed out",
+    };
+
+    expect(pendingConfigChangesForSessionIntents([failed]).mode).toBeUndefined();
+  });
+
   it("does not queue a prompt solely because stale session metadata says busy", () => {
     expect(resolvePromptOutboxPlacement({
       isSessionBusy: isPromptOutboxPlacementBusy({

--- a/apps/packages/ui/src/primitives/AnimatedSwapText.tsx
+++ b/apps/packages/ui/src/primitives/AnimatedSwapText.tsx
@@ -1,72 +1,80 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
-const ANIMATION_DURATION_MS = 200;
+const SWAP_DURATION_MS = 240;
 
-export function AnimatedSwapText({ value }: { value: string }) {
-  const [transition, setTransition] = useState<{
-    outgoing: string | null;
-    incoming: string;
-    active: boolean;
-  }>({
-    outgoing: null,
-    incoming: value,
-    active: false,
-  });
+interface AnimatedSwapTextProps {
+  /** Stable semantic key for the rendered value. */
+  valueKey: string;
+  value: ReactNode;
+}
 
-  useEffect(() => {
-    if (value === transition.incoming) {
+interface SwapTransition {
+  id: number;
+  outgoing: ReactNode;
+}
+
+/**
+ * Keeps the incoming value owned by the current render, so optimistic control
+ * updates are visible immediately. The previous committed value is retained
+ * only for the compositor-only exit animation.
+ */
+export function AnimatedSwapText({ valueKey, value }: AnimatedSwapTextProps) {
+  const committedValueRef = useRef({ key: valueKey, value });
+  const nextTransitionIdRef = useRef(0);
+  const [transition, setTransition] = useState<SwapTransition | null>(null);
+  const valueChanged = committedValueRef.current.key !== valueKey;
+  const visibleTransition = valueChanged
+    ? {
+        id: nextTransitionIdRef.current + 1,
+        outgoing: committedValueRef.current.value,
+      }
+    : transition;
+
+  useLayoutEffect(() => {
+    if (committedValueRef.current.key === valueKey) {
+      committedValueRef.current.value = value;
       return;
     }
 
-    const nextIncoming = value;
+    const outgoing = committedValueRef.current.value;
+    nextTransitionIdRef.current += 1;
+    committedValueRef.current = { key: valueKey, value };
     setTransition({
-      outgoing: transition.incoming,
-      incoming: nextIncoming,
-      active: false,
+      id: nextTransitionIdRef.current,
+      outgoing,
     });
+  }, [value, valueKey]);
 
-    const frame = window.requestAnimationFrame(() => {
-      setTransition((current) => ({ ...current, active: true }));
-    });
-    const timer = window.setTimeout(() => {
-      setTransition({
-        outgoing: null,
-        incoming: nextIncoming,
-        active: false,
-      });
-    }, ANIMATION_DURATION_MS);
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.clearTimeout(timer);
-    };
-  }, [transition.incoming, value]);
+  useEffect(() => {
+    if (!transition) {
+      return;
+    }
+    const transitionId = transition.id;
+    const timeout = window.setTimeout(() => {
+      setTransition((current) => current?.id === transitionId ? null : current);
+    }, SWAP_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [transition]);
 
   return (
-    <span className="relative block h-[18px] min-w-0 overflow-hidden">
-      {transition.outgoing && (
+    <span className="composer-value-swap">
+      <span
+        key={visibleTransition?.id ?? valueKey}
+        className={visibleTransition ? "composer-value-enter" : undefined}
+      >
+        {value}
+      </span>
+      {visibleTransition && (
         <span
           aria-hidden="true"
-          className={`absolute inset-0 block truncate transition-all duration-200 ${
-            transition.active
-              ? "-translate-y-3 opacity-0"
-              : "translate-y-0 opacity-100"
-          }`}
+          className="composer-value-exit"
+          onAnimationEnd={() => {
+            setTransition(null);
+          }}
         >
-          {transition.outgoing}
+          {visibleTransition.outgoing}
         </span>
       )}
-      <span
-        className={`block truncate transition-all duration-200 ${
-          transition.outgoing
-            ? transition.active
-              ? "translate-y-0 opacity-100"
-              : "translate-y-3 opacity-0"
-            : "translate-y-0 opacity-100"
-        }`}
-      >
-        {transition.incoming}
-      </span>
     </span>
   );
 }

--- a/apps/packages/ui/src/primitives/LevelBarsButton.tsx
+++ b/apps/packages/ui/src/primitives/LevelBarsButton.tsx
@@ -29,12 +29,26 @@ interface LevelBarsButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonEleme
 // "wave" (see composer-level-bar-wave in product.css) used to force a
 // repaint of the whole icon every frame. Plain <span> bars with
 // currentColor backgrounds pick up the same scaleY/opacity keyframes on
-// the compositor instead. Geometry mirrors the old SVG rendering: 2px-wide
-// pill bars (rx=1 on a 2px rect is effectively a full round-cap), 2px gaps,
-// heights stepping up to the container's 14px (size-3.5) box, bottom-aligned
-// and horizontally centered the way preserveAspectRatio="xMidYMid meet"
-// centered the old viewBox.
+// the compositor instead. Every ladder owns the same 14px icon slot. Bar
+// width adapts to the number of runtime-provided levels: short ladders get
+// heavier bars, while longer ladders stay inside the slot instead of
+// consuming the icon-to-label gap.
 const LEVEL_BAR_CONTAINER_PX = 14;
+const LEVEL_BAR_GAP_PX = 1;
+const LEVEL_BAR_MAX_WIDTH_PX = 4;
+
+function resolveLevelBarGeometry(barCount: number): { barGapPx: number; barWidthPx: number } {
+  const safeBarCount = Math.max(1, barCount);
+  const barGapPx = safeBarCount <= 1
+    ? 0
+    : Math.min(LEVEL_BAR_GAP_PX, LEVEL_BAR_CONTAINER_PX / (safeBarCount * 2));
+  const availableWidth = LEVEL_BAR_CONTAINER_PX
+    - (Math.max(0, safeBarCount - 1) * barGapPx);
+  return {
+    barGapPx,
+    barWidthPx: Math.min(LEVEL_BAR_MAX_WIDTH_PX, availableWidth / safeBarCount),
+  };
+}
 
 function LevelBarsIcon({
   levels,
@@ -48,6 +62,7 @@ function LevelBarsIcon({
   levelOptionAttribute?: string;
 }) {
   const barCount = levels.length;
+  const { barGapPx, barWidthPx } = resolveLevelBarGeometry(barCount);
 
   const bars = Array.from({ length: barCount }, (_, i) => {
     const heightPx = Math.max(2, Math.round(((i + 1) / barCount) * LEVEL_BAR_CONTAINER_PX));
@@ -61,9 +76,10 @@ function LevelBarsIcon({
       <span
         key={i}
         {...optionAttr}
-        className={`block w-[2px] shrink-0 rounded-full bg-current${wave ? " composer-level-bar-wave" : ""}`}
+        className={`block shrink-0 rounded-full bg-current${wave ? " composer-level-bar-wave" : ""}`}
         style={{
           height: `${heightPx}px`,
+          width: `${barWidthPx}px`,
           opacity: lit ? 1 : 0.3,
           animationDelay: wave ? `${i * 110}ms` : undefined,
         }}
@@ -79,9 +95,11 @@ function LevelBarsIcon({
 
   return (
     <span
-      className={`inline-flex size-3.5 shrink-0 items-end justify-center gap-[2px] ${emphasisClass}`}
+      className={`inline-flex size-3.5 shrink-0 items-end justify-center ${emphasisClass}`}
+      style={{ gap: `${barGapPx}px` }}
       aria-hidden="true"
       data-level-bars-icon
+      data-level-bars-count={barCount}
     >
       {bars}
     </span>

--- a/apps/packages/ui/test/AnimatedSwapText.test.tsx
+++ b/apps/packages/ui/test/AnimatedSwapText.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { AnimatedSwapText } from "../src/primitives/AnimatedSwapText";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("AnimatedSwapText", () => {
+  it("renders the initial value without mount animation", () => {
+    const { container } = render(
+      <AnimatedSwapText valueKey="default" value="Default" />,
+    );
+
+    expect(screen.getByText("Default")).toBeTruthy();
+    expect(container.querySelector(".composer-value-enter")).toBeNull();
+    expect(container.querySelector(".composer-value-exit")).toBeNull();
+  });
+
+  it("renders the incoming value immediately and retires the outgoing value", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(
+      <AnimatedSwapText valueKey="default" value="Default" />,
+    );
+
+    rerender(<AnimatedSwapText valueKey="plan" value="Plan" />);
+
+    expect(screen.getByText("Plan").className).toBe("composer-value-enter");
+    const outgoing = screen.getByText("Default");
+    expect(outgoing.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => {
+      vi.advanceTimersByTime(240);
+    });
+
+    expect(container.querySelector(".composer-value-exit")).toBeNull();
+    expect(screen.getByText("Plan")).toBeTruthy();
+  });
+
+  it("converges on the latest value during rapid swaps", () => {
+    const { rerender } = render(
+      <AnimatedSwapText valueKey="default" value="Default" />,
+    );
+
+    rerender(<AnimatedSwapText valueKey="plan" value="Plan" />);
+    rerender(<AnimatedSwapText valueKey="bypass" value="Bypass" />);
+
+    expect(screen.getByText("Bypass").className).toBe("composer-value-enter");
+    expect(screen.getByText("Plan").getAttribute("aria-hidden")).toBe("true");
+    expect(screen.queryByText("Default")).toBeNull();
+  });
+});

--- a/apps/packages/ui/test/LevelBarsButton.test.tsx
+++ b/apps/packages/ui/test/LevelBarsButton.test.tsx
@@ -30,6 +30,34 @@ describe("LevelBarsButton", () => {
     expect(icon?.children.length).toBe(3);
   });
 
+  it("keeps one icon slot while adapting bar width to short and long ladders", () => {
+    const onStep = vi.fn();
+    const twoLevels = levels.slice(0, 2);
+    const sixLevels = [
+      ...levels,
+      { value: "extra-high", label: "Extra High" },
+      { value: "max", label: "Max" },
+      { value: "ultra", label: "Ultra" },
+    ];
+    const { container, rerender } = render(
+      <LevelBarsButton levels={twoLevels} currentIndex={0} onStep={onStep} />,
+    );
+
+    const twoLevelIcon = container.querySelector<HTMLElement>("[data-level-bars-icon]");
+    const twoLevelBars = twoLevelIcon?.querySelectorAll<HTMLElement>(":scope > span");
+    expect(twoLevelIcon?.className).toContain("size-3.5");
+    expect(twoLevelIcon?.dataset.levelBarsCount).toBe("2");
+    expect(twoLevelBars?.[0]?.style.width).toBe("4px");
+
+    rerender(<LevelBarsButton levels={sixLevels} currentIndex={5} onStep={onStep} />);
+
+    const sixLevelIcon = container.querySelector<HTMLElement>("[data-level-bars-icon]");
+    const sixLevelBars = sixLevelIcon?.querySelectorAll<HTMLElement>(":scope > span");
+    expect(sixLevelIcon?.className).toContain("size-3.5");
+    expect(sixLevelIcon?.dataset.levelBarsCount).toBe("6");
+    expect(sixLevelBars?.[0]?.style.width).toBe("1.5px");
+  });
+
   it("can render the bars without visible level text", () => {
     const onStep = vi.fn();
     render(


### PR DESCRIPTION
## What this changes

The compact composer now puts model, mode, and reasoning controls in a predictable row, lets mode advance with one click, and keeps every reasoning ladder visually compact.

- **Owned surface:** the model/mode/reasoning cluster in the running-session and new-chat composers.
- **Explicit non-goals:** changing the existing model picker, fast-mode semantics, integrations, permission policy, runtime-provided mode/reasoning options, or the full settings selector.

## Before / after

- **Before:** the row showed model → reasoning → mode; clicking mode opened a popover; long reasoning ladders overflowed their icon slot and crowded the label.
- **After:** the row shows model → mode → reasoning; clicking compact mode immediately advances to the next runtime-provided value and wraps; reasoning keeps a fixed 14 px icon slot, uses thicker bars for short ladders and thinner bars for long ladders, and leaves an exact 2 px icon-to-label gap.
- The full settings version of the mode control remains an explicit options menu.

## When this matters

This is the normal path when someone quickly switches a running agent between Default, Plan, Bypass, or another runtime-provided mode, and when different models expose reasoning ladders ranging from two levels to Ultra.

## Reference contract (Design reference)

1. **Primary reference:** grandfathered existing-slice exception — the founder-supplied current Proliferate composer screenshot and direct founder instructions are the truthful primary reference actually used. Neither Codex nor Conductor specified this exact combined control state, and no external reference is represented as inspected.
2. **Exact states inspected:** founder screenshot showing the crowded Low reasoning control; live Proliferate composer at 1280×720/DPR 2 with Default → Plan mode cycling and Medium → High reasoning cycling; Ultra ladder settled state; two- and six-level ladder geometry in focused tests.
3. **Intentionally matched:** existing model selector; reasoning-style one-click advancement and animated label swap for compact mode; model → mode → reasoning hierarchy; a materially smaller 2 px bars-to-label gap; one fixed-width icon slot across ladder sizes.
4. **Intentionally different:** Proliferate continues to use runtime-provided option order and labels, retains its own tokens and 28 px compact triggers, and keeps the full settings selector as a popover because those are product-specific contracts rather than visual-reference details.
5. **Mock approval:** none required. This repair was fully specified by the founder screenshot, the approved live result, and the later explicit 2 px adjustment; no retroactive mock was manufactured.

## Demo

- [Open the exact-head hosted Web preview](https://proliferate-web-git-codex-ui-composer-controls-getonyx.vercel.app) — head `1621bb08e28bdd2c6a116cd7e4d91b3dc014c6b9`; Hosted Web on Vercel; app `0.3.44`; HMR off; branch preview redeploys from this exact head. Sign-in may be required. Inspect the new-chat or session composer: model → mode → reasoning, direct mode cycling with no popover, and the compact reasoning icon/label spacing.

## Current disposition

**Merged.** PR #1429 was squash-merged into `main` as `aacd494b03b67e262ad6f79be4a7ec139d0507af`; next action: none for this slice.

## Founder decision needed

None.

---

## Engineering evidence

### Scope and revisions

- Frozen spec: UI 04 Composer controls, revision 1.
- Frozen base: `c91d6f9275cd6e21723f9b83388df2ac8a697389`.
- Previously independently accepted head: `77ca62d0b621097b322e2ba01eb89e7902cd6828`.
- Current base after serialized integration: `73649d4b1303285629e7a10786c043b51e0e3d07`.
- Exact review-ready head: `1621bb08e28bdd2c6a116cd7e4d91b3dc014c6b9`.
- Squash merge commit: `aacd494b03b67e262ad6f79be4a7ec139d0507af`.
- Branch: `codex/ui-composer-controls`.

### Review verdict

- **ACCEPT** at the exact current head.
- Stable Blocker-01 remains resolved after rebase: one abortable deadline covers target resolution through POST acknowledgement; late work cannot issue stale product side effects; detached SDK invalidation cannot falsely roll back an acknowledged request.
- No open Blockers, Decisions, or Follow-ups.

### User-visible and failure-path behavior

- Compact mode computes its next value from the runtime-provided option list, advances forward, and wraps; unknown current values recover to the first option; zero/singleton lists do nothing.
- The click feeds the existing `control.onSelect` authority path, so optimistic projection, queued latest-only dispatch, source-sequence gating, rollback, and the existing one-time error toast remain unchanged.
- Full settings controls still render the options popover.
- Every reasoning ladder owns the same 14 px slot. Two levels render as 4 px bars; six levels render as 1.5 px bars; larger ladders reduce width/gap to remain bounded.
- Live computed-style proof at exact head: 14 px icon slot, 2 px CSS gap, 2 px measured gap, 1280×720/DPR 2, no Vite error overlay.

### Verification matrix

- Exact-head focused ProductClient coverage: 22/22 passed (mode cycling/wrap/menu preservation, control ordering, 2 px spacing assertion, domain presentation).
- Full `@proliferate/product-client` suite passed on the repair before the final conflict-free main rebase; exact-head ProductClient typecheck and dependency build chain passed again after rebase.
- `@proliferate/ui`: 18/18 passed; adaptive ladder focused coverage 7/7 passed.
- `@anyharness/sdk`: 108/108 passed, including contract typechecks.
- `@anyharness/sdk-react`: 29/29 passed.
- Exact-head login first-load budget passed: JS 484,029/485,000 bytes; CSS 65,837/66,000 bytes; zero eager fonts/images/audio.
- `python3 scripts/check_frontend_boundaries.py` passed.
- `python3 scripts/report_frontend_structure.py --strict --summary-only` passed with 0 violations across 2,274 frontend source files.
- `python3 scripts/check_max_lines.py` passed.
- `git diff --check` passed.
- No Rust build or Docker was run locally.

### Local visual proof

- Surface: desktop renderer playground (web development surface, not packaged Desktop).
- Profile: `ui-04-composer-controls`.
- App: `0.3.44`; HMR/no-error-overlay state clean.
- Renderer URL: `http://127.0.0.1:1680/playground?s=composer-ultra` (temporary local preview).
- Exact-head screenshot: `reference/proliferate/composer-controls-direct-cycle/founder-gap-2px-crop.png` (ignored local evidence; hosted preview above is the durable PR demo).

### Readiness

- [x] Scope remains one user-facing composer control cluster; no adjacent cleanup.
- [x] Title and labels retain the established `release:minor-feature`, `area:product`, and `area:sdk` contracts.
- [x] Branch rebased onto current `main` with no integration conflicts or patch drift.
- [x] Exact-head proof, focused tests, typechecks, structure checks, diff checks, and login budget are green locally.
- [x] Squash-merged under the founder's explicit force-merge instruction; no check had failed at merge time, while several long-running checks were still pending.
