### PR TITLE
feat(product): preview composer and transcript attachments

### DIFF
--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -151,9 +151,3 @@
 .turn-document-reference-trigger:is(:hover, :focus-visible) .turn-document-open-label {
   opacity: 1;
 }
-
-.prompt-attachment-card:hover .prompt-attachment-remove,
-.prompt-attachment-remove:focus-visible {
-  pointer-events: auto;
-  opacity: 1;
-}

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -151,3 +151,9 @@
 .turn-document-reference-trigger:is(:hover, :focus-visible) .turn-document-open-label {
   opacity: 1;
 }
+
+.prompt-attachment-card:hover .prompt-attachment-remove,
+.prompt-attachment-remove:focus-visible {
+  pointer-events: auto;
+  opacity: 1;
+}

--- a/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.css
+++ b/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.css
@@ -1,0 +1,3 @@
+.playground-attachment-preview-aside {
+  width: 26rem;
+}

--- a/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
@@ -187,7 +187,10 @@ export function PlaygroundAttachmentPreviewAside() {
   }, []);
 
   return (
-    <aside className="flex w-[26rem] shrink-0 flex-col border-l border-sidebar-border bg-sidebar-background">
+    <aside
+      className="flex shrink-0 flex-col border-l border-sidebar-border bg-sidebar-background"
+      style={{ width: "26rem" }}
+    >
       {target?.kind === "promptAttachment" ? (
         <>
           <div className="right-panel-tab-system flex h-10 shrink-0 items-stretch border-b border-sidebar-border">

--- a/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
@@ -93,7 +93,8 @@ export function PlaygroundAttachmentComposerSurface({
   controlRow: ReactNode;
 }) {
   const [attachments, setAttachments] = useState(INITIAL_DRAFT_ATTACHMENTS);
-  const { closeDraftAttachmentPreview } = usePromptAttachmentPreviewActions();
+  const { openAttachmentPreview, closeDraftAttachmentPreview } =
+    usePromptAttachmentPreviewActions();
   return (
     <ChatComposerSurface overflowMode="clip">
       <form className="relative flex flex-col" data-focus-zone="chat">
@@ -105,6 +106,11 @@ export function PlaygroundAttachmentComposerSurface({
               current.filter((attachment) => attachment.id !== id)
             ));
           }}
+          onOpenAttachment={(part) => openAttachmentPreview({
+            part,
+            origin: "draft",
+            sessionId: null,
+          })}
         />
         <ComposerTextareaFrame topInset="none">
           <ComposerTextarea

--- a/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import type { ContentPart } from "@anyharness/sdk";
+import { useQueryClient } from "@tanstack/react-query";
+import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
+import { ComposerTextarea } from "@proliferate/ui/primitives/ComposerTextarea";
+import { ComposerTextareaFrame } from "@proliferate/ui/primitives/ComposerTextareaFrame";
+import { DraftAttachmentPreviewList } from "#product/components/workspace/chat/content/PromptContentRenderer";
+import { UserMessage } from "#product/components/workspace/chat/transcript/UserMessage";
+import { PromptAttachmentViewer } from "#product/components/workspace/files/PromptAttachmentViewer";
+import { ViewerHeaderButton } from "#product/components/workspace/shell/right-panel/ViewerHeaderButton";
+import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
+import type { PromptAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
+import {
+  viewerTargetKey,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
+import { focusChatInput } from "#product/lib/domain/focus-zone";
+import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
+
+const PLAYGROUND_ATTACHMENT_SESSION_ID = "playground-attachment-session";
+const PLAYGROUND_IMAGE_ID = "playground-attachment-image";
+const PLAYGROUND_TEXT_ID = "playground-attachment-text";
+const IMAGE_DATA_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(`
+  <svg xmlns="http://www.w3.org/2000/svg" width="640" height="420" viewBox="0 0 640 420">
+    <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#fb7185"/><stop offset="1" stop-color="#7c3aed"/></linearGradient></defs>
+    <rect width="640" height="420" rx="32" fill="#171717"/>
+    <rect x="28" y="28" width="584" height="364" rx="24" fill="url(#g)" opacity=".92"/>
+    <circle cx="188" cy="180" r="76" fill="#fff" opacity=".18"/>
+    <path d="M92 330l118-112 80 70 66-58 192 100H92z" fill="#fff" opacity=".72"/>
+    <text x="52" y="78" fill="#fff" font-family="system-ui" font-size="28" font-weight="700">Attachment preview</text>
+  </svg>
+`)}`;
+const TEXT_DATA_URL = `data:text/plain;charset=utf-8,${encodeURIComponent(
+  "Draft attachment preview\n\nThis text stays in memory and never becomes a workspace file.\n",
+)}`;
+
+const INITIAL_DRAFT_ATTACHMENTS: PromptAttachmentDescriptor[] = [
+  {
+    id: "draft-image",
+    name: "attachment-preview.png",
+    mimeType: "image/png",
+    size: 245_760,
+    kind: "image",
+    source: "upload",
+    objectUrl: IMAGE_DATA_URL,
+  },
+  {
+    id: "draft-paste",
+    name: "paste-2026-07-18.txt",
+    mimeType: "text/plain",
+    size: 3_824,
+    kind: "text_resource",
+    source: "paste",
+    objectUrl: TEXT_DATA_URL,
+  },
+  {
+    id: "draft-file",
+    name: "interaction-notes.md",
+    mimeType: "text/markdown",
+    size: 8_192,
+    kind: "text_resource",
+    source: "upload",
+    objectUrl: TEXT_DATA_URL,
+  },
+];
+
+const SENT_ATTACHMENT_PARTS: ContentPart[] = [
+  {
+    type: "text",
+    text: "Compare the screenshot and interaction notes before updating the composer.",
+  },
+  {
+    type: "image",
+    attachmentId: PLAYGROUND_IMAGE_ID,
+    name: "attachment-preview.png",
+    mimeType: "image/png",
+    size: 245_760,
+    source: "upload",
+  },
+  {
+    type: "resource",
+    attachmentId: PLAYGROUND_TEXT_ID,
+    uri: "file://interaction-notes.md",
+    name: "interaction-notes.md",
+    mimeType: "text/markdown",
+    size: 8_192,
+    source: "upload",
+  },
+];
+
+export function PlaygroundAttachmentComposerSurface({
+  controlRow,
+}: {
+  controlRow: ReactNode;
+}) {
+  const [attachments, setAttachments] = useState(INITIAL_DRAFT_ATTACHMENTS);
+  const { closeDraftAttachmentPreview } = usePromptAttachmentPreviewActions();
+  return (
+    <ChatComposerSurface overflowMode="clip">
+      <form className="relative flex flex-col" data-focus-zone="chat">
+        <DraftAttachmentPreviewList
+          attachments={attachments}
+          onRemove={(id) => {
+            closeDraftAttachmentPreview(id);
+            setAttachments((current) => (
+              current.filter((attachment) => attachment.id !== id)
+            ));
+          }}
+        />
+        <ComposerTextareaFrame topInset="none">
+          <ComposerTextarea
+            data-chat-composer-editor
+            data-telemetry-mask
+            rows={2}
+            value="Use these references to tighten the attachment interaction."
+            spellCheck={false}
+            readOnly
+          />
+        </ComposerTextareaFrame>
+        {controlRow}
+      </form>
+    </ChatComposerSurface>
+  );
+}
+
+export function PlaygroundAttachmentTranscript() {
+  const queryClient = useQueryClient();
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    queryClient.setQueryData(
+      ["prompt-attachment", PLAYGROUND_ATTACHMENT_SESSION_ID, PLAYGROUND_IMAGE_ID],
+      svgDataUrlBlob(IMAGE_DATA_URL),
+    );
+    queryClient.setQueryData(
+      ["prompt-attachment", PLAYGROUND_ATTACHMENT_SESSION_ID, PLAYGROUND_TEXT_ID],
+      new Blob([
+        "Submitted attachment preview\n\nThis content is fetched through the session attachment cache.\n",
+      ], { type: "text/markdown" }),
+    );
+    setReady(true);
+    return () => {
+      queryClient.removeQueries({
+        queryKey: ["prompt-attachment", PLAYGROUND_ATTACHMENT_SESSION_ID],
+      });
+    };
+  }, [queryClient]);
+
+  if (!ready) {
+    return null;
+  }
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        Submitted attachments
+      </div>
+      <UserMessage
+        sessionId={PLAYGROUND_ATTACHMENT_SESSION_ID}
+        content="Compare the screenshot and interaction notes before updating the composer."
+        contentParts={SENT_ATTACHMENT_PARTS}
+      />
+    </div>
+  );
+}
+
+export function PlaygroundAttachmentPreviewAside() {
+  const openTargets = useWorkspaceViewerTabsStore((state) => state.openTargets);
+  const activeTargetKey = useWorkspaceViewerTabsStore((state) => state.activeTargetKey);
+  const closeTarget = useWorkspaceViewerTabsStore((state) => state.closeTarget);
+  const setActiveTarget = useWorkspaceViewerTabsStore((state) => state.setActiveTarget);
+  const target = useMemo(() => openTargets.find((candidate) => (
+    viewerTargetKey(candidate) === activeTargetKey
+    && candidate.kind === "promptAttachment"
+  )), [activeTargetKey, openTargets]);
+
+  useEffect(() => () => {
+    const state = useWorkspaceViewerTabsStore.getState();
+    state.openTargets.forEach((candidate) => {
+      if (candidate.kind === "promptAttachment") {
+        state.closeTarget(viewerTargetKey(candidate));
+      }
+    });
+  }, []);
+
+  return (
+    <aside className="flex w-[26rem] shrink-0 flex-col border-l border-sidebar-border bg-sidebar-background">
+      {target?.kind === "promptAttachment" ? (
+        <>
+          <div className="right-panel-tab-system flex h-10 shrink-0 items-stretch border-b border-sidebar-border">
+            <ViewerHeaderButton
+              target={target}
+              isActive
+              isDirty={false}
+              isDiff={false}
+              isDragging={false}
+              shouldSuppressClick={() => false}
+              onSelect={() => setActiveTarget(viewerTargetKey(target))}
+              onClose={() => {
+                closeTarget(viewerTargetKey(target));
+                focusChatInput();
+              }}
+            />
+          </div>
+          <div className="min-h-0 flex-1">
+            <PromptAttachmentViewer target={target} />
+          </div>
+        </>
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
+          Select a draft or submitted attachment to preview it here.
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function svgDataUrlBlob(dataUrl: string): Blob {
+  const encoded = dataUrl.split(",", 2)[1] ?? "";
+  return new Blob([decodeURIComponent(encoded)], { type: "image/svg+xml" });
+}

--- a/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx
@@ -15,6 +15,7 @@ import {
 } from "#product/lib/domain/workspaces/viewer/viewer-target";
 import { focusChatInput } from "#product/lib/domain/focus-zone";
 import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
+import "./PlaygroundAttachmentFixtures.css";
 
 const PLAYGROUND_ATTACHMENT_SESSION_ID = "playground-attachment-session";
 const PLAYGROUND_IMAGE_ID = "playground-attachment-image";
@@ -187,10 +188,7 @@ export function PlaygroundAttachmentPreviewAside() {
   }, []);
 
   return (
-    <aside
-      className="flex shrink-0 flex-col border-l border-sidebar-border bg-sidebar-background"
-      style={{ width: "26rem" }}
-    >
+    <aside className="playground-attachment-preview-aside flex shrink-0 flex-col border-l border-sidebar-border bg-sidebar-background">
       {target?.kind === "promptAttachment" ? (
         <>
           <div className="right-panel-tab-system flex h-10 shrink-0 items-stretch border-b border-sidebar-border">

--- a/apps/packages/product-client/src/components/playground/PlaygroundComposer.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundComposer.tsx
@@ -17,6 +17,7 @@ interface PlaygroundComposerProps {
   lowerBackdropTopPx: number | null;
   selection: PlaygroundScenarioSelection;
   replay: PlaygroundReplayState;
+  rightInsetPx?: number;
 }
 
 export function PlaygroundComposer({
@@ -24,6 +25,7 @@ export function PlaygroundComposer({
   lowerBackdropTopPx,
   selection,
   replay,
+  rightInsetPx = 0,
 }: PlaygroundComposerProps) {
   const replaySlots = useComposerDockSlots();
   const scenario = selection.kind === "fixture" ? selection.key : null;
@@ -32,7 +34,10 @@ export function PlaygroundComposer({
   const attachedSlot = scenario ? renderAttachedSlot(scenario) : replaySlots.attachedSlot;
 
   return (
-    <div className="pointer-events-none absolute inset-0 z-10">
+    <div
+      className="pointer-events-none absolute inset-y-0 left-0 z-10"
+      style={{ right: rightInsetPx }}
+    >
       <ChatComposerDock
         ref={dockRef}
         outboundSlot={outboundSlot ?? undefined}

--- a/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
@@ -33,6 +33,7 @@ import {
   createPlaygroundEnvironmentAdvancedControls,
   createPlaygroundEnvironmentTargetState,
 } from "#product/lib/domain/chat/__fixtures__/playground/environment-fixtures";
+import { PlaygroundAttachmentComposerSurface } from "#product/components/playground/PlaygroundAttachmentFixtures";
 
 export function renderComposerSurfaceForScenario(scenario: ScenarioKey): ReactNode {
   switch (scenario) {
@@ -40,6 +41,12 @@ export function renderComposerSurfaceForScenario(scenario: ScenarioKey): ReactNo
       return <PlaygroundLongInputComposerSurface />;
     case "composer-ultra":
       return <PlaygroundComposerSurface ultra />;
+    case "attachment-previews":
+      return (
+        <PlaygroundAttachmentComposerSurface
+          controlRow={<PlaygroundComposerControlRow />}
+        />
+      );
     case "workspace-status-card":
       return <PlaygroundComposerSurface statusControl={<PlaygroundWorkspaceStatusControl />} />;
     case "status-live-stream":

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundTranscript.tsx
@@ -6,6 +6,7 @@ import { renderPlaygroundPlanTranscript } from "#product/components/playground/t
 import { renderPlaygroundStatusTranscript } from "#product/components/playground/transcript/PlaygroundStatusTranscript";
 import { renderPlaygroundToolTranscript } from "#product/components/playground/transcript/PlaygroundToolTranscript";
 import { PlaygroundLoadingStates } from "#product/components/playground/loading/PlaygroundLoadingStates";
+import { PlaygroundAttachmentTranscript } from "#product/components/playground/PlaygroundAttachmentFixtures";
 
 interface PlaygroundTranscriptProps {
   stickyBottomInsetPx: number;
@@ -33,6 +34,9 @@ export function PlaygroundTranscript({
   const scenario = selection.key;
   if (scenario === "loading-states") {
     return <PlaygroundLoadingStates />;
+  }
+  if (scenario === "attachment-previews") {
+    return <PlaygroundAttachmentTranscript />;
   }
 
   const planTranscript = renderPlaygroundPlanTranscript(scenario);

--- a/apps/packages/product-client/src/components/workspace/chat/ChatView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/ChatView.tsx
@@ -42,6 +42,7 @@ import {
   readFileDragInput,
 } from "#product/lib/domain/chat/composer/prompt-attachment-drag";
 import type { WorkspaceRenderSurface } from "#product/lib/domain/workspaces/tabs/shell-activation";
+import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
 
 function ChatContent({
   dockSafeAreaPx,
@@ -154,10 +155,14 @@ export const ChatView = memo(function ChatView({
     hasActiveSession: !suppressComposerActiveSessionState && !!activeSessionId,
     supportsAttachments,
   });
+  const { closeDraftAttachmentPreviews } = usePromptAttachmentPreviewActions();
   const promptAttachments = useChatPromptAttachments({
     scopeKey: workspaceUiKey,
     promptCapabilities,
     canAttachFiles: canAcceptFileDrop,
+    onBeforeReleaseAttachments: (attachments) => {
+      closeDraftAttachmentPreviews(attachments.map((attachment) => attachment.id));
+    },
   });
   const [fileDragOver, setFileDragOver] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.css
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.css
@@ -3,6 +3,11 @@
   height: 52px;
 }
 
+.prompt-card-image-draft {
+  width: 5rem;
+  height: 5rem;
+}
+
 .prompt-card:hover .prompt-card-remove,
 .prompt-card-remove:focus-visible {
   pointer-events: auto;

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.css
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.css
@@ -1,10 +1,10 @@
-.prompt-attachment-card-draft-file {
+.prompt-card-file {
   width: 210px;
   height: 52px;
 }
 
-.prompt-attachment-card:hover .prompt-attachment-remove,
-.prompt-attachment-remove:focus-visible {
+.prompt-card:hover .prompt-card-remove,
+.prompt-card-remove:focus-visible {
   pointer-events: auto;
   opacity: 1;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.css
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.css
@@ -1,0 +1,10 @@
+.prompt-attachment-card-draft-file {
+  width: 210px;
+  height: 52px;
+}
+
+.prompt-attachment-card:hover .prompt-attachment-remove,
+.prompt-attachment-remove:focus-visible {
+  pointer-events: auto;
+  opacity: 1;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.styles.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.styles.test.tsx
@@ -28,16 +28,13 @@ describe("PromptAttachmentCard style ownership", () => {
     expect(componentSource).not.toContain("h-[52px]");
     expect(componentSource).not.toContain("w-[210px]");
     expect(componentCss).toMatch(
-      /\.prompt-attachment-card-draft-file\s*\{[^}]*width:\s*210px;[^}]*height:\s*52px;/su,
+      /\.prompt-card-file\s*\{[^}]*width:\s*210px;[^}]*height:\s*52px;/su,
     );
-    expect(componentCss).toContain(
-      ".prompt-attachment-card:hover .prompt-attachment-remove,",
-    );
-    expect(componentCss).toContain(".prompt-attachment-remove:focus-visible");
+    expect(componentCss).toContain(".prompt-card:hover .prompt-card-remove,");
+    expect(componentCss).toContain(".prompt-card-remove:focus-visible");
     expect(componentCss).toContain("pointer-events: auto;");
     expect(componentCss).toContain("opacity: 1;");
-    expect(authenticatedCss).not.toContain("prompt-attachment-card");
-    expect(authenticatedCss).not.toContain("prompt-attachment-remove");
+    expect(authenticatedCss).not.toContain("prompt-card");
 
     const html = renderToStaticMarkup(
       <PromptAttachmentCard
@@ -56,9 +53,9 @@ describe("PromptAttachmentCard style ownership", () => {
         onRemove={vi.fn()}
       />,
     );
-    expect(html).toContain("prompt-attachment-card-draft-file");
+    expect(html).toContain("prompt-card-file");
     expect(html).toContain("max-w-full");
-    expect(html).toContain("prompt-attachment-remove");
+    expect(html).toContain("prompt-card-remove");
     expect(html).toContain("pointer-events-none");
     expect(html).toContain("opacity-0");
     expect(html).not.toContain("style=");

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.styles.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.styles.test.tsx
@@ -27,8 +27,12 @@ describe("PromptAttachmentCard style ownership", () => {
     expect(componentSource).not.toContain("style={isDraft && !isImage");
     expect(componentSource).not.toContain("h-[52px]");
     expect(componentSource).not.toContain("w-[210px]");
+    expect(componentSource).not.toContain(["size", "20"].join("-"));
     expect(componentCss).toMatch(
       /\.prompt-card-file\s*\{[^}]*width:\s*210px;[^}]*height:\s*52px;/su,
+    );
+    expect(componentCss).toMatch(
+      /\.prompt-card-image-draft\s*\{[^}]*width:\s*5rem;[^}]*height:\s*5rem;/su,
     );
     expect(componentCss).toContain(".prompt-card:hover .prompt-card-remove,");
     expect(componentCss).toContain(".prompt-card-remove:focus-visible");

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.styles.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.styles.test.tsx
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { PromptAttachmentCard } from "#product/components/workspace/chat/content/PromptAttachmentCard";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const componentSource = readFileSync(resolve(testDir, "PromptAttachmentCard.tsx"), "utf8");
+const componentCss = readFileSync(resolve(testDir, "PromptAttachmentCard.css"), "utf8");
+const authenticatedCss = readFileSync(
+  resolve(testDir, "../../../../app/authenticated.css"),
+  "utf8",
+);
+const playgroundSource = readFileSync(
+  resolve(testDir, "../../../playground/PlaygroundAttachmentFixtures.tsx"),
+  "utf8",
+);
+const playgroundCss = readFileSync(
+  resolve(testDir, "../../../playground/PlaygroundAttachmentFixtures.css"),
+  "utf8",
+);
+
+describe("PromptAttachmentCard style ownership", () => {
+  it("loads fixed card and reveal styles from the component-owned chunk", () => {
+    expect(componentSource).toContain('import "./PromptAttachmentCard.css";');
+    expect(componentSource).not.toContain("style={isDraft && !isImage");
+    expect(componentSource).not.toContain("h-[52px]");
+    expect(componentSource).not.toContain("w-[210px]");
+    expect(componentCss).toMatch(
+      /\.prompt-attachment-card-draft-file\s*\{[^}]*width:\s*210px;[^}]*height:\s*52px;/su,
+    );
+    expect(componentCss).toContain(
+      ".prompt-attachment-card:hover .prompt-attachment-remove,",
+    );
+    expect(componentCss).toContain(".prompt-attachment-remove:focus-visible");
+    expect(componentCss).toContain("pointer-events: auto;");
+    expect(componentCss).toContain("opacity: 1;");
+    expect(authenticatedCss).not.toContain("prompt-attachment-card");
+    expect(authenticatedCss).not.toContain("prompt-attachment-remove");
+
+    const html = renderToStaticMarkup(
+      <PromptAttachmentCard
+        sessionId={null}
+        part={{
+          type: "file",
+          id: "draft-file",
+          name: "notes.md",
+          mimeType: "text/markdown",
+          size: 2048,
+          sizeLabel: "2 KB",
+          objectUrl: "blob:notes",
+          source: "upload",
+        }}
+        variant="draft"
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(html).toContain("prompt-attachment-card-draft-file");
+    expect(html).toContain("max-w-full");
+    expect(html).toContain("prompt-attachment-remove");
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain("opacity-0");
+    expect(html).not.toContain("style=");
+  });
+
+  it("keeps the DEV aside width with its fixture owner", () => {
+    expect(playgroundSource).toContain('import "./PlaygroundAttachmentFixtures.css";');
+    expect(playgroundSource).toContain("playground-attachment-preview-aside");
+    expect(playgroundSource).not.toContain('style={{ width: "26rem" }}');
+    expect(playgroundSource).not.toContain("w-[26rem]");
+    expect(playgroundCss).toMatch(
+      /\.playground-attachment-preview-aside\s*\{[^}]*width:\s*26rem;/su,
+    );
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
@@ -4,6 +4,7 @@ import type { PromptDisplayAttachmentPart } from "@proliferate/product-domain/ch
 import { FileTreeEntryIcon } from "#product/components/workspace/files/file-icons";
 import { PlanReferenceAttachmentCard } from "#product/components/workspace/chat/content/PlanReferenceAttachmentCard";
 import { usePromptAttachmentUrl } from "#product/hooks/access/anyharness/sessions/use-prompt-attachment-url";
+import "./PromptAttachmentCard.css";
 
 type PromptAttachmentCardVariant = "transcript" | "compact" | "draft";
 type NonPlanPromptAttachmentPart = Exclude<
@@ -50,12 +51,7 @@ export function PromptAttachmentCard({
   const className = promptAttachmentCardClassName({ isCompact, isDraft, isImage });
 
   return (
-    <div
-      className={className}
-      data-telemetry-mask
-      style={isDraft && !isImage ? { height: 52, width: 210 } : undefined}
-      title={title}
-    >
+    <div className={className} data-telemetry-mask title={title}>
       {canPreview && onOpenAttachment ? (
         <Button
           type="button"
@@ -241,7 +237,7 @@ function promptAttachmentCardClassName(args: {
     return `prompt-attachment-card relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
   }
   if (args.isDraft) {
-    return "prompt-attachment-card relative inline-flex max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
+    return "prompt-attachment-card prompt-attachment-card-draft-file relative inline-flex max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
   }
   if (args.isCompact) {
     return "prompt-attachment-card relative inline-flex h-10 w-44 max-w-full shrink-0 overflow-visible rounded-lg border border-border/50 bg-card/70 text-foreground";

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
@@ -50,7 +50,12 @@ export function PromptAttachmentCard({
   const className = promptAttachmentCardClassName({ isCompact, isDraft, isImage });
 
   return (
-    <div className={className} data-telemetry-mask title={title}>
+    <div
+      className={className}
+      data-telemetry-mask
+      style={isDraft && !isImage ? { height: 52, width: 210 } : undefined}
+      title={title}
+    >
       {canPreview && onOpenAttachment ? (
         <Button
           type="button"
@@ -102,7 +107,7 @@ export function PromptAttachmentCard({
             event.stopPropagation();
             onRemove(part.id);
           }}
-          className="pointer-events-none absolute top-1 right-1 z-20 size-5 rounded-full border border-border bg-background/95 p-0 text-foreground opacity-0 shadow-sm transition-opacity group-hover/attachment:pointer-events-auto group-hover/attachment:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
+          className="prompt-attachment-remove pointer-events-none absolute top-1 right-1 z-20 size-5 rounded-full border border-border bg-background/95 p-0 text-foreground opacity-0 shadow-sm transition-opacity"
           aria-label={`Remove ${part.name}`}
         >
           <X className="size-3" />
@@ -233,13 +238,13 @@ function promptAttachmentCardClassName(args: {
   if (args.isImage) {
     const size = args.isDraft ? "size-20" : args.isCompact ? "size-10" : "size-14";
     const border = args.isDraft ? "border-border" : "border-border/60";
-    return `group/attachment relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
+    return `prompt-attachment-card relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
   }
   if (args.isDraft) {
-    return "group/attachment relative inline-flex h-[52px] w-[210px] max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
+    return "prompt-attachment-card relative inline-flex max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
   }
   if (args.isCompact) {
-    return "group/attachment relative inline-flex h-10 w-44 max-w-full shrink-0 overflow-visible rounded-lg border border-border/50 bg-card/70 text-foreground";
+    return "prompt-attachment-card relative inline-flex h-10 w-44 max-w-full shrink-0 overflow-visible rounded-lg border border-border/50 bg-card/70 text-foreground";
   }
-  return "group/attachment relative inline-flex h-11 w-48 max-w-full shrink-0 overflow-visible rounded-lg border border-border/60 bg-card/80 text-foreground";
+  return "prompt-attachment-card relative inline-flex h-11 w-48 max-w-full shrink-0 overflow-visible rounded-lg border border-border/60 bg-card/80 text-foreground";
 }

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
@@ -232,7 +232,11 @@ function promptAttachmentCardClassName(args: {
   isImage: boolean;
 }): string {
   if (args.isImage) {
-    const size = args.isDraft ? "size-20" : args.isCompact ? "size-10" : "size-14";
+    const size = args.isDraft
+      ? "prompt-card-image-draft"
+      : args.isCompact
+        ? "size-10"
+        : "size-14";
     const border = args.isDraft ? "border-border" : "border-border/60";
     return `prompt-card relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
   }

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
@@ -1,0 +1,245 @@
+import { FileIcon, Link2, Spinner, X } from "@proliferate/ui/icons";
+import { Button } from "@proliferate/ui/primitives/Button";
+import type { PromptDisplayAttachmentPart } from "@proliferate/product-domain/chats/composer/prompt-display-parts";
+import { FileTreeEntryIcon } from "#product/components/workspace/files/file-icons";
+import { PlanReferenceAttachmentCard } from "#product/components/workspace/chat/content/PlanReferenceAttachmentCard";
+import { usePromptAttachmentUrl } from "#product/hooks/access/anyharness/sessions/use-prompt-attachment-url";
+
+type PromptAttachmentCardVariant = "transcript" | "compact" | "draft";
+type NonPlanPromptAttachmentPart = Exclude<
+  PromptDisplayAttachmentPart,
+  { type: "plan_reference" }
+>;
+
+export function PromptAttachmentCard({
+  sessionId,
+  part,
+  variant,
+  onRemove,
+  onOpenAttachment,
+}: {
+  sessionId: string | null;
+  part: PromptDisplayAttachmentPart;
+  variant: PromptAttachmentCardVariant;
+  onRemove?: (id: string) => void;
+  onOpenAttachment?: (part: Exclude<
+    PromptDisplayAttachmentPart,
+    { type: "link" | "plan_reference" }
+  >) => void;
+}) {
+  if (part.type === "plan_reference") {
+    return (
+      <PlanReferenceAttachmentCard
+        plan={part}
+        variant={variant}
+        onRemove={onRemove}
+      />
+    );
+  }
+
+  const isDraft = variant === "draft";
+  const isCompact = variant === "compact";
+  const isImage = part.type === "image";
+  const canPreview = part.type === "image" || part.type === "file";
+  const metadata = [attachmentTypeLabel(part), part.sizeLabel]
+    .filter(Boolean)
+    .join(" · ");
+  const title = [part.name, metadata, part.type === "link" ? part.uri : null]
+    .filter(Boolean)
+    .join("\n");
+  const className = promptAttachmentCardClassName({ isCompact, isDraft, isImage });
+
+  return (
+    <div className={className} data-telemetry-mask title={title}>
+      {canPreview && onOpenAttachment ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-chat-transcript-ignore
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenAttachment(part);
+          }}
+          className="absolute inset-0 z-0 h-full w-full rounded-[inherit] bg-transparent p-0 hover:bg-foreground/[0.045] focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset"
+          aria-label={`Preview ${part.name}`}
+        />
+      ) : null}
+      <div className={isImage
+        ? "pointer-events-none relative z-10 size-full overflow-hidden rounded-[inherit]"
+        : "pointer-events-none relative z-10 flex size-full min-w-0 items-center gap-2 p-2 pr-7"}
+      >
+        <PromptAttachmentPreview
+          sessionId={sessionId}
+          part={part}
+          variant={variant}
+        />
+        {!isImage ? (
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium text-foreground">
+              {part.name}
+            </div>
+            {metadata ? (
+              <div className="truncate text-xs leading-4 text-muted-foreground">
+                {metadata}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {isDraft && onRemove && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          data-chat-transcript-ignore
+          onPointerDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onRemove(part.id);
+          }}
+          className="pointer-events-none absolute top-1 right-1 z-20 size-5 rounded-full border border-border bg-background/95 p-0 text-foreground opacity-0 shadow-sm transition-opacity group-hover/attachment:pointer-events-auto group-hover/attachment:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
+          aria-label={`Remove ${part.name}`}
+        >
+          <X className="size-3" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function PromptAttachmentPreview({
+  sessionId,
+  part,
+  variant,
+}: {
+  sessionId: string | null;
+  part: NonPlanPromptAttachmentPart;
+  variant: PromptAttachmentCardVariant;
+}) {
+  if (part.type === "image") {
+    return (
+      <PromptImagePreview
+        sessionId={sessionId}
+        attachmentId={part.attachmentId}
+        objectUrl={part.objectUrl}
+        name={part.name}
+        variant={variant}
+      />
+    );
+  }
+
+  return (
+    <div className={previewFrameClassName(variant)}>
+      {part.type === "link" ? (
+        <Link2 className="size-3.5 text-muted-foreground" />
+      ) : (
+        <FileTreeEntryIcon
+          name={part.name}
+          path={part.uri ?? part.name}
+          kind="file"
+          className="size-3.5 text-muted-foreground"
+        />
+      )}
+    </div>
+  );
+}
+
+function PromptImagePreview({
+  sessionId,
+  attachmentId,
+  objectUrl,
+  name,
+  variant,
+}: {
+  sessionId: string | null;
+  attachmentId?: string;
+  objectUrl?: string | null;
+  name: string;
+  variant: PromptAttachmentCardVariant;
+}) {
+  const image = usePromptAttachmentUrl(
+    objectUrl ? null : sessionId,
+    objectUrl ? null : attachmentId,
+  );
+  const src = objectUrl ?? image.data ?? null;
+
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className={imageClassName(variant)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={previewFrameClassName(variant)}
+      title={image.isError ? "Image unavailable" : "Loading image"}
+    >
+      {image.isLoading ? (
+        <Spinner className="size-4 text-muted-foreground" />
+      ) : (
+        <FileIcon className="size-4 text-muted-foreground" />
+      )}
+    </div>
+  );
+}
+
+function previewFrameClassName(variant: PromptAttachmentCardVariant): string {
+  return variant === "compact"
+    ? "flex size-7 shrink-0 items-center justify-center rounded-md bg-muted/70"
+    : "flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted/70";
+}
+
+function imageClassName(variant: PromptAttachmentCardVariant): string {
+  return variant === "compact"
+    ? "size-full object-cover opacity-90"
+    : "size-full object-cover";
+}
+
+function attachmentTypeLabel(part: PromptDisplayAttachmentPart): string {
+  switch (part.type) {
+    case "image":
+      return "Image";
+    case "file":
+      if (part.source === "paste") {
+        return "Pasted text";
+      }
+      return attachmentExtension(part.name) ?? "Text file";
+    case "link":
+      return "Link";
+    case "plan_reference":
+      return "Plan";
+  }
+}
+
+function attachmentExtension(name: string): string | null {
+  const extension = name.split(".").pop();
+  return extension && extension !== name ? extension.toUpperCase() : null;
+}
+
+function promptAttachmentCardClassName(args: {
+  isCompact: boolean;
+  isDraft: boolean;
+  isImage: boolean;
+}): string {
+  if (args.isImage) {
+    const size = args.isDraft ? "size-20" : args.isCompact ? "size-10" : "size-14";
+    const border = args.isDraft ? "border-border" : "border-border/60";
+    return `group/attachment relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
+  }
+  if (args.isDraft) {
+    return "group/attachment relative inline-flex h-[52px] w-[210px] max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
+  }
+  if (args.isCompact) {
+    return "group/attachment relative inline-flex h-10 w-44 max-w-full shrink-0 overflow-visible rounded-lg border border-border/50 bg-card/70 text-foreground";
+  }
+  return "group/attachment relative inline-flex h-11 w-48 max-w-full shrink-0 overflow-visible rounded-lg border border-border/60 bg-card/80 text-foreground";
+}

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptAttachmentCard.tsx
@@ -103,7 +103,7 @@ export function PromptAttachmentCard({
             event.stopPropagation();
             onRemove(part.id);
           }}
-          className="prompt-attachment-remove pointer-events-none absolute top-1 right-1 z-20 size-5 rounded-full border border-border bg-background/95 p-0 text-foreground opacity-0 shadow-sm transition-opacity"
+          className="prompt-card-remove pointer-events-none absolute top-1 right-1 z-20 size-5 rounded-full border border-border bg-background/95 p-0 text-foreground opacity-0 shadow-sm transition-opacity"
           aria-label={`Remove ${part.name}`}
         >
           <X className="size-3" />
@@ -234,13 +234,13 @@ function promptAttachmentCardClassName(args: {
   if (args.isImage) {
     const size = args.isDraft ? "size-20" : args.isCompact ? "size-10" : "size-14";
     const border = args.isDraft ? "border-border" : "border-border/60";
-    return `prompt-attachment-card relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
+    return `prompt-card relative inline-flex ${size} shrink-0 overflow-visible rounded-lg border ${border} bg-card text-foreground`;
   }
   if (args.isDraft) {
-    return "prompt-attachment-card prompt-attachment-card-draft-file relative inline-flex max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
+    return "prompt-card prompt-card-file relative inline-flex max-w-full shrink-0 overflow-visible rounded-lg border border-border bg-card text-foreground";
   }
   if (args.isCompact) {
-    return "prompt-attachment-card relative inline-flex h-10 w-44 max-w-full shrink-0 overflow-visible rounded-lg border border-border/50 bg-card/70 text-foreground";
+    return "prompt-card relative inline-flex h-10 w-44 max-w-full shrink-0 overflow-visible rounded-lg border border-border/50 bg-card/70 text-foreground";
   }
-  return "prompt-attachment-card relative inline-flex h-11 w-48 max-w-full shrink-0 overflow-visible rounded-lg border border-border/60 bg-card/80 text-foreground";
+  return "prompt-card relative inline-flex h-11 w-48 max-w-full shrink-0 overflow-visible rounded-lg border border-border/60 bg-card/80 text-foreground";
 }

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.test.tsx
@@ -8,15 +8,6 @@ import {
   PromptContentRenderer,
 } from "#product/components/workspace/chat/content/PromptContentRenderer";
 
-const previewActions = vi.hoisted(() => ({
-  openAttachmentPreview: vi.fn(),
-  closeDraftAttachmentPreview: vi.fn(),
-}));
-
-vi.mock("#product/hooks/chat/workflows/use-prompt-attachment-preview-actions", () => ({
-  usePromptAttachmentPreviewActions: () => previewActions,
-}));
-
 vi.mock("#product/hooks/access/anyharness/sessions/use-prompt-attachment-url", () => ({
   usePromptAttachmentUrl: () => ({
     data: null,
@@ -35,15 +26,13 @@ vi.mock("#product/components/workspace/chat/content/PlanReferenceAttachmentCard"
 }));
 
 describe("PromptContentRenderer attachment cards", () => {
-  beforeEach(() => {
-    previewActions.openAttachmentPreview.mockReset();
-    previewActions.closeDraftAttachmentPreview.mockReset();
-  });
+  beforeEach(() => vi.clearAllMocks());
 
   afterEach(cleanup);
 
   it("shows useful draft thumbnails and compact file metadata", () => {
     const onRemove = vi.fn();
+    const onOpenAttachment = vi.fn();
     render(<DraftAttachmentPreviewList
       attachments={[
         {
@@ -66,6 +55,7 @@ describe("PromptContentRenderer attachment cards", () => {
         },
       ]}
       onRemove={onRemove}
+      onOpenAttachment={onOpenAttachment}
     />);
 
     expect(screen.getByRole("img", { name: "reference.png" }).classList.contains("size-full"))
@@ -73,25 +63,24 @@ describe("PromptContentRenderer attachment cards", () => {
     expect(screen.queryByText("Pasted text · 3 KB")).not.toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Preview reference.png" }));
-    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
-      origin: "draft",
-      sessionId: null,
-      part: expect.objectContaining({ id: "attachment:image", type: "image" }),
+    expect(onOpenAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      id: "attachment:image",
+      type: "image",
     }));
 
     fireEvent.click(screen.getByRole("button", { name: "Preview paste.txt" }));
-    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
-      origin: "draft",
-      sessionId: null,
-      part: expect.objectContaining({ id: "attachment:paste", type: "file" }),
+    expect(onOpenAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      id: "attachment:paste",
+      type: "file",
     }));
 
     fireEvent.click(screen.getByRole("button", { name: "Remove paste.txt" }));
     expect(onRemove).toHaveBeenCalledWith("attachment:paste");
-    expect(previewActions.openAttachmentPreview).toHaveBeenCalledTimes(2);
+    expect(onOpenAttachment).toHaveBeenCalledTimes(2);
   });
 
   it("opens a submitted resource through a session-backed preview target", () => {
+    const onOpenAttachment = vi.fn();
     const parts: ContentPart[] = [
       {
         type: "image",
@@ -117,26 +106,29 @@ describe("PromptContentRenderer attachment cards", () => {
       includeText={false}
       variant="transcript"
       layout="wrap"
+      onOpenAttachment={onOpenAttachment}
     />);
 
     expect(screen.queryByText("MD · 1.5 KB")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Preview reference.png" }));
-    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
-      origin: "session",
-      sessionId: "session-1",
-      part: expect.objectContaining({
-        attachmentId: "attachment:image-sent",
-        type: "image",
-      }),
+    expect(onOpenAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      attachmentId: "attachment:image-sent",
+      type: "image",
     }));
     fireEvent.click(screen.getByRole("button", { name: "Preview notes.md" }));
-    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
-      origin: "session",
-      sessionId: "session-1",
-      part: expect.objectContaining({
-        attachmentId: "attachment:sent",
-        type: "file",
-      }),
+    expect(onOpenAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      attachmentId: "attachment:sent",
+      type: "file",
     }));
+  });
+
+  it("renders text without a ProductHost or preview workflow", () => {
+    render(<PromptContentRenderer
+      sessionId={null}
+      parts={[{ type: "text", text: "text-only renderer" }]}
+    />);
+
+    expect(screen.queryByText("text-only renderer")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /Preview/u })).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import type { ContentPart } from "@anyharness/sdk";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DraftAttachmentPreviewList,
+  PromptContentRenderer,
+} from "#product/components/workspace/chat/content/PromptContentRenderer";
+
+const previewActions = vi.hoisted(() => ({
+  openAttachmentPreview: vi.fn(),
+  closeDraftAttachmentPreview: vi.fn(),
+}));
+
+vi.mock("#product/hooks/chat/workflows/use-prompt-attachment-preview-actions", () => ({
+  usePromptAttachmentPreviewActions: () => previewActions,
+}));
+
+vi.mock("#product/hooks/access/anyharness/sessions/use-prompt-attachment-url", () => ({
+  usePromptAttachmentUrl: () => ({
+    data: null,
+    blob: null,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("#product/components/workspace/chat/transcript/transcript-markdown", () => ({
+  renderTranscriptLink: () => null,
+}));
+
+vi.mock("#product/components/workspace/chat/content/PlanReferenceAttachmentCard", () => ({
+  PlanReferenceAttachmentCard: () => null,
+}));
+
+describe("PromptContentRenderer attachment cards", () => {
+  beforeEach(() => {
+    previewActions.openAttachmentPreview.mockReset();
+    previewActions.closeDraftAttachmentPreview.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it("shows useful draft thumbnails and compact file metadata", () => {
+    const onRemove = vi.fn();
+    render(<DraftAttachmentPreviewList
+      attachments={[
+        {
+          id: "attachment:image",
+          name: "reference.png",
+          mimeType: "image/png",
+          size: 2048,
+          kind: "image",
+          source: "upload",
+          objectUrl: "blob:reference-image",
+        },
+        {
+          id: "attachment:paste",
+          name: "paste.txt",
+          mimeType: "text/plain",
+          size: 3072,
+          kind: "text_resource",
+          source: "paste",
+          objectUrl: "blob:pasted-text",
+        },
+      ]}
+      onRemove={onRemove}
+    />);
+
+    expect(screen.getByRole("img", { name: "reference.png" }).classList.contains("size-full"))
+      .toBe(true);
+    expect(screen.queryByText("Pasted text · 3 KB")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview reference.png" }));
+    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
+      origin: "draft",
+      sessionId: null,
+      part: expect.objectContaining({ id: "attachment:image", type: "image" }),
+    }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview paste.txt" }));
+    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
+      origin: "draft",
+      sessionId: null,
+      part: expect.objectContaining({ id: "attachment:paste", type: "file" }),
+    }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove paste.txt" }));
+    expect(onRemove).toHaveBeenCalledWith("attachment:paste");
+    expect(previewActions.openAttachmentPreview).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens a submitted resource through a session-backed preview target", () => {
+    const parts: ContentPart[] = [
+      {
+        type: "image",
+        attachmentId: "attachment:image-sent",
+        name: "reference.png",
+        mimeType: "image/png",
+        size: 2048,
+        source: "upload",
+      },
+      {
+        type: "resource",
+        attachmentId: "attachment:sent",
+        uri: "file://notes.md",
+        name: "notes.md",
+        mimeType: "text/markdown",
+        size: 1536,
+        source: "upload",
+      },
+    ];
+    render(<PromptContentRenderer
+      sessionId="session-1"
+      parts={parts}
+      includeText={false}
+      variant="transcript"
+      layout="wrap"
+    />);
+
+    expect(screen.queryByText("MD · 1.5 KB")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Preview reference.png" }));
+    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
+      origin: "session",
+      sessionId: "session-1",
+      part: expect.objectContaining({
+        attachmentId: "attachment:image-sent",
+        type: "image",
+      }),
+    }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.md" }));
+    expect(previewActions.openAttachmentPreview).toHaveBeenCalledWith(expect.objectContaining({
+      origin: "session",
+      sessionId: "session-1",
+      part: expect.objectContaining({
+        attachmentId: "attachment:sent",
+        type: "file",
+      }),
+    }));
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -10,10 +10,14 @@ import {
 import type { PromptDraftAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
 import { MarkdownBody } from "@proliferate/product-ui/chat/transcript/MarkdownBody";
 import { renderTranscriptLink } from "#product/components/workspace/chat/transcript/transcript-markdown";
-import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
 
 type PromptContentRendererVariant = "transcript" | "compact";
 type PromptContentRendererLayout = "stack" | "wrap" | "auto";
+export type PromptAttachmentPreviewPart = Exclude<
+  PromptDisplayAttachmentPart,
+  { type: "link" | "plan_reference" }
+>;
+export type PromptAttachmentPreviewHandler = (part: PromptAttachmentPreviewPart) => void;
 
 export interface PromptContentRendererProps {
   sessionId: string | null;
@@ -24,6 +28,7 @@ export interface PromptContentRendererProps {
   includeText?: boolean;
   includeAttachments?: boolean;
   layout?: PromptContentRendererLayout;
+  onOpenAttachment?: PromptAttachmentPreviewHandler;
 }
 
 export function PromptContentRenderer({
@@ -35,8 +40,8 @@ export function PromptContentRenderer({
   includeText = true,
   includeAttachments = true,
   layout = "stack",
+  onOpenAttachment,
 }: PromptContentRendererProps) {
-  const { openAttachmentPreview } = usePromptAttachmentPreviewActions();
   const displayParts = normalizeContentParts(parts, fallbackText);
   const visibleParts = displayParts.filter((part) => (
     part.type === "text" ? includeText : includeAttachments
@@ -56,11 +61,7 @@ export function PromptContentRenderer({
           sessionId={sessionId}
           part={part}
           variant={resolvedVariant}
-          onOpenAttachment={(attachment) => openAttachmentPreview({
-            part: attachment,
-            origin: "session",
-            sessionId,
-          })}
+          onOpenAttachment={onOpenAttachment}
         />
       ))}
     </div>
@@ -70,13 +71,14 @@ export function PromptContentRenderer({
 export interface DraftAttachmentPreviewListProps {
   attachments: readonly PromptDraftAttachmentDescriptor[];
   onRemove: (id: string) => void;
+  onOpenAttachment?: PromptAttachmentPreviewHandler;
 }
 
 export function DraftAttachmentPreviewList({
   attachments,
   onRemove,
+  onOpenAttachment,
 }: DraftAttachmentPreviewListProps) {
-  const { openAttachmentPreview } = usePromptAttachmentPreviewActions();
   const displayParts = normalizeDraftAttachments(attachments);
 
   if (displayParts.length === 0) {
@@ -92,11 +94,7 @@ export function DraftAttachmentPreviewList({
           part={part}
           variant="draft"
           onRemove={onRemove}
-          onOpenAttachment={(attachment) => openAttachmentPreview({
-            part: attachment,
-            origin: "draft",
-            sessionId: null,
-          })}
+          onOpenAttachment={onOpenAttachment}
         />
       ))}
     </div>
@@ -112,10 +110,7 @@ function PromptDisplayPartView({
   sessionId: string | null;
   part: PromptDisplayPart;
   variant: PromptContentRendererVariant;
-  onOpenAttachment: (part: Exclude<
-    PromptDisplayAttachmentPart,
-    { type: "link" | "plan_reference" }
-  >) => void;
+  onOpenAttachment?: PromptAttachmentPreviewHandler;
 }) {
   if (part.type === "text") {
     return <FileLinkedText text={part.text} />;

--- a/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
@@ -1,9 +1,6 @@
 import type { ContentPart } from "@anyharness/sdk";
-import { FileIcon, Link2, Spinner, X } from "@proliferate/ui/icons";
-import { Button } from "@proliferate/ui/primitives/Button";
-import { FileTreeEntryIcon } from "#product/components/workspace/files/file-icons";
 import { PlanReferenceAttachmentCard } from "#product/components/workspace/chat/content/PlanReferenceAttachmentCard";
-import { usePromptAttachmentUrl } from "#product/hooks/access/anyharness/sessions/use-prompt-attachment-url";
+import { PromptAttachmentCard } from "#product/components/workspace/chat/content/PromptAttachmentCard";
 import {
   normalizeContentParts,
   normalizeDraftAttachments,
@@ -13,14 +10,10 @@ import {
 import type { PromptDraftAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
 import { MarkdownBody } from "@proliferate/product-ui/chat/transcript/MarkdownBody";
 import { renderTranscriptLink } from "#product/components/workspace/chat/transcript/transcript-markdown";
+import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
 
 type PromptContentRendererVariant = "transcript" | "compact";
 type PromptContentRendererLayout = "stack" | "wrap" | "auto";
-type PromptAttachmentCardVariant = PromptContentRendererVariant | "draft";
-type NonPlanPromptAttachmentPart = Exclude<
-  PromptDisplayAttachmentPart,
-  { type: "plan_reference" }
->;
 
 export interface PromptContentRendererProps {
   sessionId: string | null;
@@ -43,6 +36,7 @@ export function PromptContentRenderer({
   includeAttachments = true,
   layout = "stack",
 }: PromptContentRendererProps) {
+  const { openAttachmentPreview } = usePromptAttachmentPreviewActions();
   const displayParts = normalizeContentParts(parts, fallbackText);
   const visibleParts = displayParts.filter((part) => (
     part.type === "text" ? includeText : includeAttachments
@@ -62,6 +56,11 @@ export function PromptContentRenderer({
           sessionId={sessionId}
           part={part}
           variant={resolvedVariant}
+          onOpenAttachment={(attachment) => openAttachmentPreview({
+            part: attachment,
+            origin: "session",
+            sessionId,
+          })}
         />
       ))}
     </div>
@@ -77,6 +76,7 @@ export function DraftAttachmentPreviewList({
   attachments,
   onRemove,
 }: DraftAttachmentPreviewListProps) {
+  const { openAttachmentPreview } = usePromptAttachmentPreviewActions();
   const displayParts = normalizeDraftAttachments(attachments);
 
   if (displayParts.length === 0) {
@@ -84,7 +84,7 @@ export function DraftAttachmentPreviewList({
   }
 
   return (
-    <div className="flex w-full flex-wrap items-center justify-start gap-1 px-2 py-1.5" data-telemetry-mask>
+    <div className="flex w-full flex-wrap items-start justify-start gap-2 px-2 pt-2 pb-1" data-telemetry-mask>
       {displayParts.map((part) => (
         <PromptAttachmentCard
           key={part.id}
@@ -92,6 +92,11 @@ export function DraftAttachmentPreviewList({
           part={part}
           variant="draft"
           onRemove={onRemove}
+          onOpenAttachment={(attachment) => openAttachmentPreview({
+            part: attachment,
+            origin: "draft",
+            sessionId: null,
+          })}
         />
       ))}
     </div>
@@ -102,10 +107,15 @@ function PromptDisplayPartView({
   sessionId,
   part,
   variant,
+  onOpenAttachment,
 }: {
   sessionId: string | null;
   part: PromptDisplayPart;
   variant: PromptContentRendererVariant;
+  onOpenAttachment: (part: Exclude<
+    PromptDisplayAttachmentPart,
+    { type: "link" | "plan_reference" }
+  >) => void;
 }) {
   if (part.type === "text") {
     return <FileLinkedText text={part.text} />;
@@ -120,6 +130,7 @@ function PromptDisplayPartView({
       sessionId={sessionId}
       part={part}
       variant={variant}
+      onOpenAttachment={onOpenAttachment}
     />
   );
 }
@@ -133,173 +144,6 @@ function FileLinkedText({ text }: { text: string }) {
       className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
     />
   );
-}
-
-function PromptAttachmentCard({
-  sessionId,
-  part,
-  variant,
-  onRemove,
-}: {
-  sessionId: string | null;
-  part: PromptDisplayAttachmentPart;
-  variant: PromptAttachmentCardVariant;
-  onRemove?: (id: string) => void;
-}) {
-  if (part.type === "plan_reference") {
-    return (
-      <PlanReferenceAttachmentCard
-        plan={part}
-        variant={variant}
-        onRemove={onRemove}
-      />
-    );
-  }
-
-  const isDraft = variant === "draft";
-  const isCompact = variant === "compact";
-  const metadata = [attachmentKindLabel(part), part.mimeType, part.sizeLabel]
-    .filter(Boolean)
-    .join(" - ");
-  const title = [part.name, metadata, part.type === "link" ? part.uri : null]
-    .filter(Boolean)
-    .join("\n");
-  const className = isDraft
-    ? "group relative inline-flex max-w-[240px] items-center gap-1 rounded-full border border-border bg-card px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent"
-    : isCompact
-      ? "inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-border/70 bg-card px-2 py-1.5 text-xs text-foreground transition-colors hover:bg-accent"
-      : "inline-flex min-w-0 max-w-[240px] items-center gap-1 rounded-full border border-border bg-card px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-accent";
-
-  return (
-    <div className={className} data-telemetry-mask title={title}>
-      <PromptAttachmentPreview
-        sessionId={sessionId}
-        part={part}
-        variant={variant}
-      />
-      <div className={isDraft ? "relative min-w-0 flex-1 truncate pr-5 font-medium" : "relative min-w-0 flex-1 truncate pr-1 font-medium"}>
-        <div className="truncate text-foreground">
-          {part.name}
-        </div>
-      </div>
-      {isDraft && onRemove && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          data-chat-transcript-ignore
-          onClick={() => onRemove(part.id)}
-          className="pointer-events-none absolute inset-y-0 right-0 h-full w-7 rounded-full bg-card/95 px-0 opacity-0 transition-opacity hover:bg-accent group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
-          aria-label={`Remove ${part.name}`}
-        >
-          <X className="size-3" />
-        </Button>
-      )}
-    </div>
-  );
-}
-
-function PromptAttachmentPreview({
-  sessionId,
-  part,
-  variant,
-}: {
-  sessionId: string | null;
-  part: NonPlanPromptAttachmentPart;
-  variant: PromptAttachmentCardVariant;
-}) {
-  if (part.type === "image") {
-    return (
-      <PromptImagePreview
-        sessionId={sessionId}
-        attachmentId={part.attachmentId}
-        objectUrl={part.objectUrl}
-        name={part.name}
-        variant={variant}
-      />
-    );
-  }
-
-  return (
-    <div className={previewFrameClassName(variant)}>
-      {part.type === "link" ? (
-        <Link2 className="size-3.5 text-muted-foreground" />
-      ) : (
-        <FileTreeEntryIcon
-          name={part.name}
-          path={part.uri ?? part.name}
-          kind="file"
-          className="size-3.5 text-muted-foreground"
-        />
-      )}
-    </div>
-  );
-}
-
-function PromptImagePreview({
-  sessionId,
-  attachmentId,
-  objectUrl,
-  name,
-  variant,
-}: {
-  sessionId: string | null;
-  attachmentId?: string;
-  objectUrl?: string | null;
-  name: string;
-  variant: PromptAttachmentCardVariant;
-}) {
-  const image = usePromptAttachmentUrl(
-    objectUrl ? null : sessionId,
-    objectUrl ? null : attachmentId,
-  );
-  const src = objectUrl ?? image.data ?? null;
-
-  if (src) {
-    return (
-      <img
-        src={src}
-        alt={name}
-        className={imageClassName(variant)}
-      />
-    );
-  }
-
-  return (
-    <div className={previewFrameClassName(variant)} title={image.isError ? "Image unavailable" : "Loading image"}>
-      {image.isLoading ? (
-        <Spinner className="size-4 text-muted-foreground" />
-      ) : (
-        <FileIcon className="size-4 text-muted-foreground" />
-      )}
-    </div>
-  );
-}
-
-function previewFrameClassName(variant: PromptAttachmentCardVariant): string {
-  if (variant === "compact") {
-    return "flex size-4 shrink-0 items-center justify-center";
-  }
-  return "flex size-4 shrink-0 items-center justify-center";
-}
-
-function imageClassName(variant: PromptAttachmentCardVariant): string {
-  return variant === "compact"
-    ? "size-4 shrink-0 rounded object-cover"
-    : "size-4 shrink-0 rounded object-cover";
-}
-
-function attachmentKindLabel(part: PromptDisplayAttachmentPart): string {
-  switch (part.type) {
-    case "image":
-      return "Image";
-    case "file":
-      return part.source === "paste" ? "Paste" : "File";
-    case "link":
-      return "Link";
-    case "plan_reference":
-      return "Plan";
-  }
 }
 
 function promptContentContainerClassName(

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -8,7 +8,6 @@ import {
   type ClipboardEvent,
   type MouseEvent,
 } from "react";
-import type { PromptInputBlock } from "@anyharness/sdk";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import {
   useActiveSessionId,
@@ -53,6 +52,7 @@ import { Input } from "@proliferate/ui/primitives/Input";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
 import { handlePromptAttachmentPaste } from "#product/lib/domain/chat/composer/prompt-attachment-paste";
+import type { PromptAttachmentPreviewHandler } from "#product/components/workspace/chat/content/PromptContentRenderer";
 
 const CHAT_INPUT_ATTACHMENT_ACCEPT =
   "image/*,text/*,.md,.json,.ts,.tsx,.js,.jsx,.py,.rs,.go,.java,.css,.html,.xml,.yaml,.yml,.toml,.sql,.sh";
@@ -108,7 +108,7 @@ export function ChatInput({
       ?? modeControl
       ?? null;
   const { handleSubmit, handleCancel } = useChatPromptActions();
-  const { closeDraftAttachmentPreview } = usePromptAttachmentPreviewActions();
+  const { openAttachmentPreview } = usePromptAttachmentPreviewActions();
   const { isSubmitting, run: runSubmit } = useComposerSubmitGate();
   const {
     isEditing: isEditingQueuedPrompt,
@@ -159,7 +159,7 @@ export function ChatInput({
       const blockPrepareStartedAt = performance.now();
       const attachmentSnapshots = attachments.snapshotForSubmit();
       const blocks = [
-        ...buildTextPromptBlocks(trimmedPromptText),
+        ...(trimmedPromptText ? [{ type: "text" as const, text: trimmedPromptText }] : []),
         ...planAttachments.blocks,
       ];
       recordMeasurementWorkflowStep({
@@ -188,14 +188,12 @@ export function ChatInput({
       // A harness switch can temporarily make an existing attachment
       // unsupported. Clear only attachments that were eligible for this send,
       // leaving visible incompatible drafts available for another harness.
-      attachmentSnapshots.forEach((snapshot) => closeDraftAttachmentPreview(snapshot.id));
       attachments.clearSubmittedAttachments(attachmentSnapshots);
       planAttachments.clearPlans();
     });
   }, [
     attachments,
     commitEdit,
-    closeDraftAttachmentPreview,
     effectiveIsEditingQueuedPrompt,
     getDraft,
     handleSubmit,
@@ -241,10 +239,14 @@ export function ChatInput({
   }, [attachments]);
 
   const handleRemoveDraftAttachment = useCallback((id: string) => {
-    closeDraftAttachmentPreview(id);
     attachments.removeAttachment(id);
     planAttachments.removePlan(id);
-  }, [attachments, closeDraftAttachmentPreview, planAttachments]);
+  }, [attachments, planAttachments]);
+
+  const handleOpenDraftAttachment = useCallback<PromptAttachmentPreviewHandler>(
+    (part) => openAttachmentPreview({ part, origin: "draft", sessionId: null }),
+    [openAttachmentPreview],
+  );
 
   const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
     // The editor owns formatted Markdown paste first. Once it has imported a
@@ -356,6 +358,7 @@ export function ChatInput({
               hasDraftAttachments={hasDraftAttachments}
               draftAttachments={[...attachments.attachments, ...planAttachments.attachments]}
               onRemoveDraftAttachment={handleRemoveDraftAttachment}
+              onOpenDraftAttachment={handleOpenDraftAttachment}
               overlayHostElement={composerOverlayHost}
               onCancelEdit={cancelEdit}
             />
@@ -393,8 +396,4 @@ export function ChatInput({
       </div>
     </DebugProfiler>
   );
-}
-
-function buildTextPromptBlocks(text: string): PromptInputBlock[] {
-  return text ? [{ type: "text", text }] : [];
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -51,6 +51,8 @@ import { ChatInputDraftArea } from "./ChatInputDraftArea";
 import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
 import { Input } from "@proliferate/ui/primitives/Input";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
+import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
+import { handlePromptAttachmentPaste } from "#product/lib/domain/chat/composer/prompt-attachment-paste";
 
 const CHAT_INPUT_ATTACHMENT_ACCEPT =
   "image/*,text/*,.md,.json,.ts,.tsx,.js,.jsx,.py,.rs,.go,.java,.css,.html,.xml,.yaml,.yml,.toml,.sql,.sh";
@@ -106,6 +108,7 @@ export function ChatInput({
       ?? modeControl
       ?? null;
   const { handleSubmit, handleCancel } = useChatPromptActions();
+  const { closeDraftAttachmentPreview } = usePromptAttachmentPreviewActions();
   const { isSubmitting, run: runSubmit } = useComposerSubmitGate();
   const {
     isEditing: isEditingQueuedPrompt,
@@ -185,12 +188,14 @@ export function ChatInput({
       // A harness switch can temporarily make an existing attachment
       // unsupported. Clear only attachments that were eligible for this send,
       // leaving visible incompatible drafts available for another harness.
+      attachmentSnapshots.forEach((snapshot) => closeDraftAttachmentPreview(snapshot.id));
       attachments.clearSubmittedAttachments(attachmentSnapshots);
       planAttachments.clearPlans();
     });
   }, [
     attachments,
     commitEdit,
+    closeDraftAttachmentPreview,
     effectiveIsEditingQueuedPrompt,
     getDraft,
     handleSubmit,
@@ -236,27 +241,24 @@ export function ChatInput({
   }, [attachments]);
 
   const handleRemoveDraftAttachment = useCallback((id: string) => {
+    closeDraftAttachmentPreview(id);
     attachments.removeAttachment(id);
     planAttachments.removePlan(id);
-  }, [attachments, planAttachments]);
+  }, [attachments, closeDraftAttachmentPreview, planAttachments]);
 
   const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
     // The editor owns formatted Markdown paste first. Once it has imported a
     // list or link, do not reinterpret the same clipboard text as an
     // attachment at the composer surface.
-    if (event.defaultPrevented) {
-      return;
-    }
-    if (!canAcceptPastedAttachments) {
-      return;
-    }
-    if (event.clipboardData.files.length > 0) {
-      attachments.addFiles(event.clipboardData.files);
-      event.preventDefault();
-      return;
-    }
-    const text = event.clipboardData.getData("text/plain");
-    if (text && attachments.addTextPaste(text)) {
+    const shouldPreventDefault = handlePromptAttachmentPaste({
+      defaultPrevented: event.defaultPrevented,
+      canAcceptAttachments: canAcceptPastedAttachments,
+      fileCount: event.clipboardData.files.length,
+      plainText: event.clipboardData.getData("text/plain"),
+      addFiles: () => attachments.addFiles(event.clipboardData.files),
+      addTextPaste: attachments.addTextPaste,
+    });
+    if (shouldPreventDefault) {
       event.preventDefault();
     }
   }, [attachments, canAcceptPastedAttachments]);

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.test.tsx
@@ -40,6 +40,7 @@ describe("ChatInputDraftArea", () => {
         hasDraftAttachments={false}
         draftAttachments={[]}
         onRemoveDraftAttachment={vi.fn()}
+        onOpenDraftAttachment={vi.fn()}
         overlayHostElement={null}
         onCancelEdit={vi.fn()}
       />,

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -8,6 +8,7 @@ import type {
 import {
   DraftAttachmentPreviewList,
   type DraftAttachmentPreviewListProps,
+  type PromptAttachmentPreviewHandler,
 } from "#product/components/workspace/chat/content/PromptContentRenderer";
 import { useChatDraftValue } from "#product/hooks/chat/ui/use-chat-draft-state";
 import { ComposerCommandEditor } from "#product/components/workspace/chat/input/ComposerCommandEditor";
@@ -37,6 +38,7 @@ interface ChatInputDraftAreaProps {
   hasDraftAttachments: boolean;
   draftAttachments: DraftAttachmentPreviewListProps["attachments"];
   onRemoveDraftAttachment: DraftAttachmentPreviewListProps["onRemove"];
+  onOpenDraftAttachment: PromptAttachmentPreviewHandler;
   overlayHostElement: HTMLElement | null;
   onCancelEdit: () => void;
 }
@@ -57,6 +59,7 @@ export function ChatInputDraftArea({
   hasDraftAttachments,
   draftAttachments,
   onRemoveDraftAttachment,
+  onOpenDraftAttachment,
   overlayHostElement,
   onCancelEdit,
 }: ChatInputDraftAreaProps) {
@@ -111,6 +114,7 @@ export function ChatInputDraftArea({
       <DraftAttachmentPreviewList
         attachments={draftAttachments}
         onRemove={onRemoveDraftAttachment}
+        onOpenAttachment={onOpenDraftAttachment}
       />
       <ComposerCommandEditor
         draft={draft}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.tsx
@@ -9,6 +9,7 @@ import {
   normalizeContentParts,
   type PromptDisplayPlanPart,
 } from "@proliferate/product-domain/chats/composer/prompt-display-parts";
+import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
 
 export interface UserMessageProps {
   sessionId: string | null;
@@ -39,6 +40,9 @@ export function UserMessage({
     ) ?? null
     : null;
   const hasAttachments = displayParts.some((part) => part.type !== "text");
+  const hasPreviewableAttachments = displayParts.some((part) => (
+    part.type === "image" || part.type === "file"
+  ));
   const hasTextPart = displayParts.some((part) => (
     part.type === "text" && part.text.trim().length > 0
   ));
@@ -67,13 +71,10 @@ export function UserMessage({
       <div className="flex w-full flex-col items-end justify-end gap-1">
         {hasAttachments && (
           <div className="w-full max-w-xl self-end lg:max-w-3xl" data-telemetry-mask>
-            <PromptContentRenderer
+            <UserMessageAttachmentContent
               sessionId={sessionId}
               parts={contentParts}
-              fallbackText=""
-              variant="transcript"
-              includeText={false}
-              layout="auto"
+              previewEnabled={hasPreviewableAttachments}
             />
           </div>
         )}
@@ -127,5 +128,64 @@ export function UserMessage({
         )}
       </div>
     </div>
+  );
+}
+
+function UserMessageAttachmentContent({
+  sessionId,
+  parts,
+  previewEnabled,
+}: {
+  sessionId: string | null;
+  parts: ContentPart[];
+  previewEnabled: boolean;
+}) {
+  if (previewEnabled) {
+    return <PreviewConnectedUserMessageAttachments sessionId={sessionId} parts={parts} />;
+  }
+  return <UserMessageAttachments sessionId={sessionId} parts={parts} />;
+}
+
+function PreviewConnectedUserMessageAttachments({
+  sessionId,
+  parts,
+}: {
+  sessionId: string | null;
+  parts: ContentPart[];
+}) {
+  const { openAttachmentPreview } = usePromptAttachmentPreviewActions();
+  return (
+    <PromptContentRenderer
+      sessionId={sessionId}
+      parts={parts}
+      fallbackText=""
+      variant="transcript"
+      includeText={false}
+      layout="auto"
+      onOpenAttachment={(part) => openAttachmentPreview({
+        part,
+        origin: "session",
+        sessionId,
+      })}
+    />
+  );
+}
+
+function UserMessageAttachments({
+  sessionId,
+  parts,
+}: {
+  sessionId: string | null;
+  parts: ContentPart[];
+}) {
+  return (
+    <PromptContentRenderer
+      sessionId={sessionId}
+      parts={parts}
+      fallbackText=""
+      variant="transcript"
+      includeText={false}
+      layout="auto"
+    />
   );
 }

--- a/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.identity.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.identity.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+
+import { useLayoutEffect, useRef } from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PromptAttachmentViewer } from "#product/components/workspace/files/PromptAttachmentViewer";
+import {
+  promptAttachmentViewerTarget,
+  type ViewerTarget,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
+
+const queryCache = vi.hoisted(() => new Map<string, Blob>());
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ desktop: null, cloud: { client: null } }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useFetchPromptAttachmentMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({
+    queryKey,
+    enabled,
+  }: {
+    queryKey: readonly [string, string | null, string | null];
+    enabled: boolean;
+  }) => {
+    const data = enabled
+      ? queryCache.get(queryIdentity(queryKey[1], queryKey[2]))
+      : undefined;
+    return {
+      data,
+      isLoading: enabled && !data,
+      isSuccess: !!data,
+      isError: false,
+      error: null,
+      status: data ? "success" : "pending",
+      fetchStatus: "idle",
+    };
+  },
+}));
+
+type PromptAttachmentTarget = Extract<ViewerTarget, { kind: "promptAttachment" }>;
+
+interface ViewerCommit {
+  requestedName: string;
+  imageName: string | null;
+  imageUrl: string | null;
+  isLoading: boolean;
+}
+
+describe("PromptAttachmentViewer submitted image identity", () => {
+  let imageA: Blob;
+  let imageB: Blob;
+  let imageAcrossSession: Blob;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let serial: number;
+
+  beforeEach(() => {
+    imageA = new Blob(["image-a"], { type: "image/png" });
+    imageB = new Blob(["image-b"], { type: "image/png" });
+    imageAcrossSession = new Blob(["image-a-session-2"], { type: "image/png" });
+    queryCache.clear();
+    queryCache.set(queryIdentity("session-1", "image-a"), imageA);
+    queryCache.set(queryIdentity("session-1", "image-b"), imageB);
+    queryCache.set(queryIdentity("session-2", "image-a"), imageAcrossSession);
+    serial = 0;
+    createObjectURL = vi.fn((blob: Blob) => {
+      serial += 1;
+      const identity = blob === imageA
+        ? "a"
+        : blob === imageB
+          ? "b"
+          : blob === imageAcrossSession
+            ? "session-2-a"
+            : "replacement-a";
+      return `blob:${identity}-${serial}`;
+    });
+    revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("never renders a previous cached image under the next attachment identity", async () => {
+    const commits: ViewerCommit[] = [];
+    const targetA = submittedImageTarget("session-1", "image-a", "image-a.png");
+    const targetB = submittedImageTarget("session-1", "image-b", "image-b.png");
+    const targetAcrossSession = submittedImageTarget(
+      "session-2",
+      "image-a",
+      "session-2-image-a.png",
+    );
+    const rendered = render(
+      <ViewerCommitProbe target={targetA} onCommit={(commit) => commits.push(commit)} />,
+    );
+
+    await expectImage("image-a.png", "blob:a-1");
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+    rendered.rerender(
+      <ViewerCommitProbe target={targetA} onCommit={(commit) => commits.push(commit)} />,
+    );
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+    rendered.rerender(
+      <ViewerCommitProbe target={targetB} onCommit={(commit) => commits.push(commit)} />,
+    );
+    expect(latestCommit(commits, "image-b.png")).toMatchObject({
+      imageName: null,
+      imageUrl: null,
+      isLoading: true,
+    });
+    await expectImage("image-b.png", "blob:b-2");
+    expect(revokeObjectURL.mock.calls.filter(([url]) => url === "blob:a-1")).toHaveLength(1);
+
+    rendered.rerender(
+      <ViewerCommitProbe target={targetA} onCommit={(commit) => commits.push(commit)} />,
+    );
+    expect(latestCommit(commits, "image-a.png")).toMatchObject({
+      imageName: null,
+      imageUrl: null,
+      isLoading: true,
+    });
+    await expectImage("image-a.png", "blob:a-3");
+    expect(revokeObjectURL.mock.calls.filter(([url]) => url === "blob:b-2")).toHaveLength(1);
+
+    rendered.rerender(
+      <ViewerCommitProbe
+        target={targetAcrossSession}
+        onCommit={(commit) => commits.push(commit)}
+      />,
+    );
+    expect(latestCommit(commits, "session-2-image-a.png")).toMatchObject({
+      imageName: null,
+      imageUrl: null,
+      isLoading: true,
+    });
+    await expectImage("session-2-image-a.png", "blob:session-2-a-4");
+    expect(revokeObjectURL.mock.calls.filter(([url]) => url === "blob:a-3")).toHaveLength(1);
+
+    const replacementImageA = new Blob(["replacement-a"], { type: "image/png" });
+    queryCache.set(queryIdentity("session-2", "image-a"), replacementImageA);
+    rendered.rerender(
+      <ViewerCommitProbe
+        target={targetAcrossSession}
+        onCommit={(commit) => commits.push(commit)}
+      />,
+    );
+    expect(latestCommit(commits, "session-2-image-a.png")).toMatchObject({
+      imageName: null,
+      imageUrl: null,
+      isLoading: true,
+    });
+    await expectImage("session-2-image-a.png", "blob:replacement-a-5");
+    expect(
+      revokeObjectURL.mock.calls.filter(([url]) => url === "blob:session-2-a-4"),
+    ).toHaveLength(1);
+
+    for (const commit of commits) {
+      if (commit.imageName === "image-b.png") {
+        expect(commit.imageUrl).not.toMatch(/^blob:a-/u);
+      }
+      if (commit.imageName === "image-a.png") {
+        expect(commit.imageUrl).not.toMatch(/^blob:b-/u);
+      }
+    }
+
+    rendered.unmount();
+    for (const [url] of revokeObjectURL.mock.calls) {
+      expect(revokeObjectURL.mock.calls.filter(([candidate]) => candidate === url)).toHaveLength(1);
+    }
+  });
+});
+
+function ViewerCommitProbe({
+  target,
+  onCommit,
+}: {
+  target: PromptAttachmentTarget;
+  onCommit: (commit: ViewerCommit) => void;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const image = rootRef.current?.querySelector("img") ?? null;
+    onCommit({
+      requestedName: target.name,
+      imageName: image?.getAttribute("alt") ?? null,
+      imageUrl: image?.getAttribute("src") ?? null,
+      isLoading: rootRef.current?.textContent?.includes("Loading attachment preview…") ?? false,
+    });
+  });
+  return (
+    <div ref={rootRef}>
+      <PromptAttachmentViewer target={target} />
+    </div>
+  );
+}
+
+function submittedImageTarget(
+  sessionId: string,
+  attachmentId: string,
+  name: string,
+): PromptAttachmentTarget {
+  return promptAttachmentViewerTarget({
+    origin: "session",
+    sessionId,
+    attachmentId,
+    name,
+    mimeType: "image/png",
+    attachmentKind: "image",
+    attachmentSource: "upload",
+  }) as PromptAttachmentTarget;
+}
+
+function queryIdentity(
+  sessionId: string | null,
+  attachmentId: string | null,
+): string {
+  return JSON.stringify([sessionId, attachmentId]);
+}
+
+function latestCommit(commits: ViewerCommit[], requestedName: string): ViewerCommit {
+  for (let index = commits.length - 1; index >= 0; index -= 1) {
+    const commit = commits[index];
+    if (commit?.requestedName === requestedName) {
+      return commit;
+    }
+  }
+  throw new Error(`Missing viewer commit for ${requestedName}`);
+}
+
+async function expectImage(name: string, src: string): Promise<void> {
+  await waitFor(() => {
+    expect(screen.getByRole("img", { name }).getAttribute("src")).toBe(src);
+  });
+}

--- a/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PromptAttachmentViewer } from "#product/components/workspace/files/PromptAttachmentViewer";
+import { promptAttachmentViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+
+const attachmentUrlState = vi.hoisted(() => ({
+  data: null as string | null,
+  blob: null as Blob | null,
+  isLoading: false,
+  isError: false,
+}));
+
+vi.mock("#product/hooks/access/anyharness/sessions/use-prompt-attachment-url", () => ({
+  usePromptAttachmentUrl: () => attachmentUrlState,
+}));
+
+describe("PromptAttachmentViewer", () => {
+  beforeEach(() => {
+    attachmentUrlState.data = null;
+    attachmentUrlState.blob = null;
+    attachmentUrlState.isLoading = false;
+    attachmentUrlState.isError = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders an in-memory draft image on the read-only viewer surface", () => {
+    render(<PromptAttachmentViewer target={promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "attachment:image",
+      name: "reference.png",
+      mimeType: "image/png",
+      size: 2048,
+      attachmentKind: "image",
+      attachmentSource: "upload",
+      objectUrl: "blob:reference-image",
+    }) as Extract<ReturnType<typeof promptAttachmentViewerTarget>, { kind: "promptAttachment" }>} />);
+
+    expect(screen.getByRole("img", { name: "reference.png" }).getAttribute("src"))
+      .toBe("blob:reference-image");
+    expect(screen.queryByText("image/png · 2 KB · Read only")).not.toBeNull();
+  });
+
+  it("loads pasted draft text without writing it into the workspace", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("alpha\nbeta", { status: 200 })));
+    render(<PromptAttachmentViewer target={promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "attachment:paste",
+      name: "paste.txt",
+      mimeType: "text/plain",
+      attachmentKind: "text_resource",
+      attachmentSource: "paste",
+      objectUrl: "blob:pasted-text",
+    }) as Extract<ReturnType<typeof promptAttachmentViewerTarget>, { kind: "promptAttachment" }>} />);
+
+    await waitFor(() => expect(screen.queryByText(/alpha\s+beta/u)).not.toBeNull());
+    expect(fetch).toHaveBeenCalledWith("blob:pasted-text");
+  });
+
+  it("shows a clear unavailable state when a draft resource was removed", () => {
+    render(<PromptAttachmentViewer target={promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "attachment:missing",
+      name: "missing.txt",
+      mimeType: "text/plain",
+      attachmentKind: "text_resource",
+      attachmentSource: "upload",
+      objectUrl: null,
+    }) as Extract<ReturnType<typeof promptAttachmentViewerTarget>, { kind: "promptAttachment" }>} />);
+
+    expect(screen.queryByText("Attachment preview unavailable")).not.toBeNull();
+    expect(screen.queryByText("The attachment was removed or could not be read.")).not.toBeNull();
+  });
+
+  it("renders submitted text from the fetched session attachment blob", async () => {
+    attachmentUrlState.data = "blob:session-text";
+    attachmentUrlState.blob = new Blob(["session resource"], { type: "text/plain" });
+    render(<PromptAttachmentViewer target={promptAttachmentViewerTarget({
+      origin: "session",
+      sessionId: "session-1",
+      attachmentId: "attachment:sent",
+      name: "sent.txt",
+      mimeType: "text/plain",
+      attachmentKind: "text_resource",
+      attachmentSource: "upload",
+    }) as Extract<ReturnType<typeof promptAttachmentViewerTarget>, { kind: "promptAttachment" }>} />);
+
+    await waitFor(() => expect(screen.queryByText("session resource")).not.toBeNull());
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.test.tsx
@@ -60,7 +60,10 @@ describe("PromptAttachmentViewer", () => {
     }) as Extract<ReturnType<typeof promptAttachmentViewerTarget>, { kind: "promptAttachment" }>} />);
 
     await waitFor(() => expect(screen.queryByText(/alpha\s+beta/u)).not.toBeNull());
-    expect(fetch).toHaveBeenCalledWith("blob:pasted-text");
+    expect(fetch).toHaveBeenCalledWith(
+      "blob:pasted-text",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("shows a clear unavailable state when a draft resource was removed", () => {

--- a/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { FileIcon, FileText, Spinner } from "@proliferate/ui/icons";
+import { formatPromptFileSize } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
+import { usePromptAttachmentUrl } from "#product/hooks/access/anyharness/sessions/use-prompt-attachment-url";
+import type { ViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+
+type PromptAttachmentTarget = Extract<ViewerTarget, { kind: "promptAttachment" }>;
+
+export function PromptAttachmentViewer({ target }: { target: PromptAttachmentTarget }) {
+  return target.origin === "draft"
+    ? <DraftPromptAttachmentViewer target={target} />
+    : <SessionPromptAttachmentViewer target={target} />;
+}
+
+function DraftPromptAttachmentViewer({ target }: { target: PromptAttachmentTarget }) {
+  const text = useObjectUrlText(
+    target.attachmentKind === "text_resource" ? target.objectUrl : null,
+  );
+  return (
+    <PromptAttachmentViewerSurface
+      target={target}
+      src={target.objectUrl}
+      text={text.data}
+      isLoading={text.isLoading}
+      isError={text.isError || !target.objectUrl}
+    />
+  );
+}
+
+function SessionPromptAttachmentViewer({ target }: { target: PromptAttachmentTarget }) {
+  const resource = usePromptAttachmentUrl(target.sessionId, target.attachmentId);
+  const text = useBlobText(
+    target.attachmentKind === "text_resource" ? resource.blob : null,
+  );
+  return (
+    <PromptAttachmentViewerSurface
+      target={target}
+      src={resource.data}
+      text={text.data}
+      isLoading={resource.isLoading || text.isLoading}
+      isError={resource.isError || text.isError || !target.sessionId}
+    />
+  );
+}
+
+function PromptAttachmentViewerSurface({
+  target,
+  src,
+  text,
+  isLoading,
+  isError,
+}: {
+  target: PromptAttachmentTarget;
+  src: string | null;
+  text: string | null;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const metadata = [
+    target.attachmentSource === "paste" ? "Pasted text" : target.mimeType,
+    formatPromptFileSize(target.size),
+    "Read only",
+  ].filter(Boolean).join(" · ");
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [src]);
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background text-foreground"
+      data-prompt-attachment-viewer
+      data-telemetry-mask
+    >
+      <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border/60 px-3 text-xs text-muted-foreground">
+        {target.attachmentKind === "image" ? (
+          <FileIcon className="size-3.5 shrink-0" />
+        ) : (
+          <FileText className="size-3.5 shrink-0" />
+        )}
+        <span className="truncate">{metadata}</span>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {isLoading ? (
+          <PreviewStatus icon={<Spinner className="size-5" />} label="Loading attachment preview…" />
+        ) : isError || (target.attachmentKind === "image" ? !src || imageFailed : text === null) ? (
+          <PreviewStatus
+            icon={<FileIcon className="size-5" />}
+            label="Attachment preview unavailable"
+            detail="The attachment was removed or could not be read."
+          />
+        ) : target.attachmentKind === "image" ? (
+          <div className="flex size-full items-center justify-center overflow-auto p-4">
+            <img
+              src={src!}
+              alt={target.name}
+              className="max-h-full max-w-full rounded-lg object-contain shadow-sm"
+              onError={() => setImageFailed(true)}
+            />
+          </div>
+        ) : (
+          <pre className="size-full overflow-auto p-3 font-mono text-[length:var(--readable-code-font-size)] leading-[var(--readable-code-line-height)] text-foreground">
+            <code className={target.attachmentSource === "paste" ? "whitespace-pre-wrap" : "whitespace-pre"}>
+              {text}
+            </code>
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PreviewStatus({
+  icon,
+  label,
+  detail,
+}: {
+  icon: ReactNode;
+  label: string;
+  detail?: string;
+}) {
+  return (
+    <div className="flex size-full items-center justify-center p-6 text-center">
+      <div className="flex max-w-64 flex-col items-center gap-2 text-muted-foreground">
+        {icon}
+        <div className="text-sm font-medium text-foreground">{label}</div>
+        {detail ? <div className="text-xs leading-5">{detail}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+function useObjectUrlText(objectUrl: string | null) {
+  const [state, setState] = useState<{
+    data: string | null;
+    isLoading: boolean;
+    isError: boolean;
+  }>({ data: null, isLoading: false, isError: false });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!objectUrl) {
+      setState({ data: null, isLoading: false, isError: false });
+      return;
+    }
+    setState({ data: null, isLoading: true, isError: false });
+    void fetch(objectUrl)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Attachment preview failed with ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setState({ data, isLoading: false, isError: false });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ data: null, isLoading: false, isError: true });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [objectUrl]);
+
+  return state;
+}
+
+function useBlobText(blob: Blob | null) {
+  const [state, setState] = useState<{
+    data: string | null;
+    isLoading: boolean;
+    isError: boolean;
+  }>({ data: null, isLoading: false, isError: false });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!blob) {
+      setState({ data: null, isLoading: false, isError: false });
+      return;
+    }
+    setState({ data: null, isLoading: true, isError: false });
+    void blob.text()
+      .then((data) => {
+        if (!cancelled) {
+          setState({ data, isLoading: false, isError: false });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ data: null, isLoading: false, isError: true });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [blob]);
+
+  return state;
+}

--- a/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState, type ReactNode } from "react";
 import { FileIcon, FileText, Spinner } from "@proliferate/ui/icons";
 import { formatPromptFileSize } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
 import { usePromptAttachmentUrl } from "#product/hooks/access/anyharness/sessions/use-prompt-attachment-url";
+import {
+  usePromptAttachmentBlobText,
+  usePromptAttachmentObjectUrlText,
+} from "#product/hooks/access/prompt-attachments/use-prompt-attachment-text";
 import type { ViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
 
 type PromptAttachmentTarget = Extract<ViewerTarget, { kind: "promptAttachment" }>;
@@ -13,7 +17,7 @@ export function PromptAttachmentViewer({ target }: { target: PromptAttachmentTar
 }
 
 function DraftPromptAttachmentViewer({ target }: { target: PromptAttachmentTarget }) {
-  const text = useObjectUrlText(
+  const text = usePromptAttachmentObjectUrlText(
     target.attachmentKind === "text_resource" ? target.objectUrl : null,
   );
   return (
@@ -29,7 +33,7 @@ function DraftPromptAttachmentViewer({ target }: { target: PromptAttachmentTarge
 
 function SessionPromptAttachmentViewer({ target }: { target: PromptAttachmentTarget }) {
   const resource = usePromptAttachmentUrl(target.sessionId, target.attachmentId);
-  const text = useBlobText(
+  const text = usePromptAttachmentBlobText(
     target.attachmentKind === "text_resource" ? resource.blob : null,
   );
   return (
@@ -129,76 +133,4 @@ function PreviewStatus({
       </div>
     </div>
   );
-}
-
-function useObjectUrlText(objectUrl: string | null) {
-  const [state, setState] = useState<{
-    data: string | null;
-    isLoading: boolean;
-    isError: boolean;
-  }>({ data: null, isLoading: false, isError: false });
-
-  useEffect(() => {
-    let cancelled = false;
-    if (!objectUrl) {
-      setState({ data: null, isLoading: false, isError: false });
-      return;
-    }
-    setState({ data: null, isLoading: true, isError: false });
-    void fetch(objectUrl)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`Attachment preview failed with ${response.status}`);
-        }
-        return response.text();
-      })
-      .then((data) => {
-        if (!cancelled) {
-          setState({ data, isLoading: false, isError: false });
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setState({ data: null, isLoading: false, isError: true });
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [objectUrl]);
-
-  return state;
-}
-
-function useBlobText(blob: Blob | null) {
-  const [state, setState] = useState<{
-    data: string | null;
-    isLoading: boolean;
-    isError: boolean;
-  }>({ data: null, isLoading: false, isError: false });
-
-  useEffect(() => {
-    let cancelled = false;
-    if (!blob) {
-      setState({ data: null, isLoading: false, isError: false });
-      return;
-    }
-    setState({ data: null, isLoading: true, isError: false });
-    void blob.text()
-      .then((data) => {
-        if (!cancelled) {
-          setState({ data, isLoading: false, isError: false });
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setState({ data: null, isLoading: false, isError: true });
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [blob]);
-
-  return state;
 }

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelContent.tsx
@@ -1,4 +1,5 @@
 import { FileEditorView } from "#product/components/workspace/files/FileEditorView";
+import { PromptAttachmentViewer } from "#product/components/workspace/files/PromptAttachmentViewer";
 import { GitPanel } from "#product/components/workspace/git/GitPanel";
 import { ScratchPadPanel } from "#product/components/workspace/scratch/ScratchPadPanel";
 import { RightPanelPlaceholder } from "#product/components/workspace/shell/right-panel/RightPanelPlaceholder";
@@ -83,7 +84,9 @@ export function RightPanelContent({
           )}
           {activeViewerTarget && (
             <div className="absolute inset-0">
-              {activeViewerTarget.kind === "file" ? (
+              {activeViewerTarget.kind === "promptAttachment" ? (
+                <PromptAttachmentViewer target={activeViewerTarget} />
+              ) : activeViewerTarget.kind === "file" ? (
                 <FileEditorView
                   filePath={activeViewerTarget.path}
                   targetKey={viewerTargetKey(activeViewerTarget)}

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -261,4 +261,9 @@ describe("playground scenarios", () => {
     expect(html).toContain("data-chat-composer-editor");
     expect(html).toContain("data-telemetry-mask");
   });
+
+  it("includes an attachment preview scenario for composer, transcript, and viewer iteration", () => {
+    expect(Object.keys(SCENARIOS)).toContain("attachment-previews");
+    expect(isValidElement(renderComposerSurfaceForScenario("attachment-previews"))).toBe(true);
+  });
 });

--- a/apps/packages/product-client/src/config/playground.ts
+++ b/apps/packages/product-client/src/config/playground.ts
@@ -20,6 +20,7 @@ export type ScenarioKey =
   | "pending-prompts-with-approval"
   | "composer-long-input"
   | "composer-ultra"
+  | "attachment-previews"
   | "workspace-activity-card"
   | "workspace-status-card"
   | "slash-command-search"
@@ -133,6 +134,7 @@ export const SCENARIOS: Record<ScenarioKey, Scenario> = {
   "pending-prompts-with-approval": { label: "Queue + approval" },
   "composer-long-input": { label: "Composer long input" },
   "composer-ultra": { label: "Composer ultra tier" },
+  "attachment-previews": { label: "Attachment previews" },
   "workspace-activity-card": { label: "Workspace activity cap" },
   "workspace-status-card": { label: "Workspace status (new)" },
   "slash-command-search": { label: "Slash commands" },

--- a/apps/packages/product-client/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useQuery } from "@tanstack/react-query";
 import { useFetchPromptAttachmentMutation } from "@anyharness/sdk-react";
@@ -28,20 +28,39 @@ export function usePromptAttachmentUrl(
       return blob;
     },
   });
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [objectUrlState, setObjectUrlState] = useState<PromptAttachmentObjectUrl | null>(null);
+  const activeObjectUrlRef = useRef<PromptAttachmentObjectUrl | null>(null);
+
+  const objectUrl = objectUrlState
+    && activeObjectUrlRef.current === objectUrlState
+    && objectUrlState.sessionId === sessionId
+    && objectUrlState.attachmentId === attachmentId
+    && objectUrlState.blob === query.data
+    ? objectUrlState.url
+    : null;
 
   useEffect(() => {
-    if (!query.data) {
-      setObjectUrl(null);
+    if (!sessionId || !attachmentId || !query.data) {
+      setObjectUrlState(null);
       return;
     }
 
     const nextObjectUrl = URL.createObjectURL(query.data);
-    setObjectUrl(nextObjectUrl);
+    const nextState: PromptAttachmentObjectUrl = {
+      sessionId,
+      attachmentId,
+      blob: query.data,
+      url: nextObjectUrl,
+    };
+    activeObjectUrlRef.current = nextState;
+    setObjectUrlState(nextState);
     return () => {
+      if (activeObjectUrlRef.current === nextState) {
+        activeObjectUrlRef.current = null;
+      }
       URL.revokeObjectURL(nextObjectUrl);
     };
-  }, [query.data]);
+  }, [attachmentId, query.data, sessionId]);
 
   return {
     ...query,
@@ -49,4 +68,11 @@ export function usePromptAttachmentUrl(
     blob: query.data ?? null,
     isLoading: query.isLoading || (query.isSuccess && !objectUrl),
   };
+}
+
+interface PromptAttachmentObjectUrl {
+  sessionId: string;
+  attachmentId: string;
+  blob: Blob;
+  url: string;
 }

--- a/apps/packages/product-client/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts
@@ -46,6 +46,7 @@ export function usePromptAttachmentUrl(
   return {
     ...query,
     data: objectUrl,
+    blob: query.data ?? null,
     isLoading: query.isLoading || (query.isSuccess && !objectUrl),
   };
 }

--- a/apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.test.tsx
+++ b/apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  usePromptAttachmentBlobText,
+  usePromptAttachmentObjectUrlText,
+} from "#product/hooks/access/prompt-attachments/use-prompt-attachment-text";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("prompt attachment text access", () => {
+  it("reads an object URL and reports HTTP failures", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("preview text", { status: 200 }))
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { result, rerender } = renderHook(
+      ({ objectUrl }: { objectUrl: string | null }) => (
+        usePromptAttachmentObjectUrlText(objectUrl)
+      ),
+      { initialProps: { objectUrl: "blob:first" as string | null } },
+    );
+
+    await waitFor(() => expect(result.current.data).toBe("preview text"));
+    rerender({ objectUrl: "blob:failure" });
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("aborts replaced object-URL reads and never exposes stale text", async () => {
+    const pending = new Map<string, {
+      resolve: (response: Response) => void;
+      signal: AbortSignal;
+    }>();
+    vi.stubGlobal("fetch", vi.fn((source: string, init?: RequestInit) => (
+      new Promise<Response>((resolve) => {
+        pending.set(source, { resolve, signal: init?.signal as AbortSignal });
+      })
+    )));
+    const { result, rerender, unmount } = renderHook(
+      ({ objectUrl }: { objectUrl: string | null }) => (
+        usePromptAttachmentObjectUrlText(objectUrl)
+      ),
+      { initialProps: { objectUrl: "blob:old-secret" as string | null } },
+    );
+
+    await waitFor(() => expect(pending.has("blob:old-secret")).toBe(true));
+    rerender({ objectUrl: "blob:replacement" });
+    expect(result.current.data).toBeNull();
+    expect(pending.get("blob:old-secret")?.signal.aborted).toBe(true);
+    await waitFor(() => expect(pending.has("blob:replacement")).toBe(true));
+
+    await act(async () => {
+      pending.get("blob:replacement")!.resolve(new Response("replacement text"));
+    });
+    await waitFor(() => expect(result.current.data).toBe("replacement text"));
+    await act(async () => {
+      pending.get("blob:old-secret")!.resolve(new Response("old secret"));
+    });
+    expect(result.current.data).toBe("replacement text");
+
+    unmount();
+    expect(pending.get("blob:replacement")?.signal.aborted).toBe(true);
+  });
+
+  it("cancels blob reads and clears resolved identity synchronously", async () => {
+    const oldRead = deferred<string>();
+    const replacementRead = deferred<string>();
+    const oldBlob = { text: vi.fn(() => oldRead.promise) } as unknown as Blob;
+    const replacementBlob = {
+      text: vi.fn(() => replacementRead.promise),
+    } as unknown as Blob;
+    const { result, rerender } = renderHook(
+      ({ blob }: { blob: Blob | null }) => usePromptAttachmentBlobText(blob),
+      { initialProps: { blob: oldBlob as Blob | null } },
+    );
+
+    rerender({ blob: replacementBlob });
+    expect(result.current.data).toBeNull();
+    await act(async () => replacementRead.resolve("replacement blob"));
+    await waitFor(() => expect(result.current.data).toBe("replacement blob"));
+    await act(async () => oldRead.resolve("old blob secret"));
+    expect(result.current.data).toBe("replacement blob");
+
+    rerender({ blob: null });
+    expect(result.current).toEqual({
+      data: null,
+      isLoading: false,
+      isError: false,
+    });
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.ts
+++ b/apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from "react";
+
+export interface PromptAttachmentTextState {
+  data: string | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function usePromptAttachmentObjectUrlText(
+  objectUrl: string | null,
+): PromptAttachmentTextState {
+  const readObjectUrl = useCallback(async (source: string, signal: AbortSignal) => {
+    const response = await fetch(source, { signal });
+    if (!response.ok) {
+      throw new Error(`Attachment preview failed with ${response.status}`);
+    }
+    return response.text();
+  }, []);
+  return usePromptAttachmentTextSource(objectUrl, readObjectUrl);
+}
+
+export function usePromptAttachmentBlobText(
+  blob: Blob | null,
+): PromptAttachmentTextState {
+  const readBlob = useCallback((source: Blob) => source.text(), []);
+  return usePromptAttachmentTextSource(blob, readBlob);
+}
+
+function usePromptAttachmentTextSource<Source extends string | Blob>(
+  source: Source | null,
+  read: (source: Source, signal: AbortSignal) => Promise<string>,
+): PromptAttachmentTextState {
+  const [state, setState] = useState<PromptAttachmentTextState & {
+    source: Source | null;
+  }>(() => initialState(source));
+  const visibleState = state.source === source ? state : initialState(source);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    if (!source) {
+      setState(initialState(null));
+      return () => abortController.abort();
+    }
+    setState(initialState(source));
+    void read(source, abortController.signal)
+      .then((data) => {
+        if (!abortController.signal.aborted) {
+          setState({ source, data, isLoading: false, isError: false });
+        }
+      })
+      .catch(() => {
+        if (!abortController.signal.aborted) {
+          setState({ source, data: null, isLoading: false, isError: true });
+        }
+      });
+    return () => abortController.abort();
+  }, [read, source]);
+
+  return {
+    data: visibleState.data,
+    isLoading: visibleState.isLoading,
+    isError: visibleState.isError,
+  };
+}
+
+function initialState<Source extends string | Blob>(
+  source: Source | null,
+): PromptAttachmentTextState & { source: Source | null } {
+  return {
+    source,
+    data: null,
+    isLoading: source !== null,
+    isError: false,
+  };
+}

--- a/apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.ts
+++ b/apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.ts
@@ -32,16 +32,16 @@ function usePromptAttachmentTextSource<Source extends string | Blob>(
 ): PromptAttachmentTextState {
   const [state, setState] = useState<PromptAttachmentTextState & {
     source: Source | null;
-  }>(() => initialState(source));
-  const visibleState = state.source === source ? state : initialState(source);
+  }>(() => initialState<Source>(source));
+  const visibleState = state.source === source ? state : initialState<Source>(source);
 
   useEffect(() => {
     const abortController = new AbortController();
     if (!source) {
-      setState(initialState(null));
+      setState(initialState<Source>(null));
       return () => abortController.abort();
     }
-    setState(initialState(source));
+    setState(initialState<Source>(source));
     void read(source, abortController.signal)
       .then((data) => {
         if (!abortController.signal.aborted) {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-prompt-attachments.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-prompt-attachments.ts
@@ -3,6 +3,7 @@ import type { PromptCapabilities } from "@anyharness/sdk";
 import { canAttachPromptContent } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
 import { usePromptAttachments } from "#product/hooks/chat/ui/use-prompt-attachments";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
+import type { PromptAttachmentDescriptor } from "@proliferate/product-domain/chats/composer/prompt-attachment-rules";
 
 export type PromptAttachmentController = ReturnType<typeof usePromptAttachments> & {
   canAttachFiles: boolean;
@@ -13,12 +14,18 @@ export function useChatPromptAttachments({
   scopeKey,
   promptCapabilities,
   canAttachFiles,
+  onBeforeReleaseAttachments,
 }: {
   scopeKey: string | null;
   promptCapabilities: PromptCapabilities | null;
   canAttachFiles: boolean;
+  onBeforeReleaseAttachments?: (
+    attachments: readonly PromptAttachmentDescriptor[],
+  ) => void;
 }): PromptAttachmentController {
-  const attachments = usePromptAttachments(scopeKey, promptCapabilities);
+  const attachments = usePromptAttachments(scopeKey, promptCapabilities, {
+    onBeforeReleaseAttachments,
+  });
   const supportsAttachments = canAttachPromptContent(promptCapabilities);
   const pasteAttachmentsEnabled = useUserPreferencesStore((state) => state.pasteAttachmentsEnabled);
   const addFiles = useCallback((files: Iterable<File>) => {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.test.tsx
@@ -114,6 +114,35 @@ describe("usePromptAttachments", () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 
+  it("notifies the lifetime owner before remove and submit revocation", () => {
+    const onBeforeReleaseAttachments = vi.fn();
+    const { result } = renderHook(() =>
+      usePromptAttachments("session-1", promptCapabilities, {
+        onBeforeReleaseAttachments,
+      })
+    );
+    act(() => {
+      result.current.addFiles([
+        new File(["one"], "one.txt", { type: "text/plain" }),
+        new File(["two"], "two.txt", { type: "text/plain" }),
+      ]);
+    });
+    const [first, second] = result.current.attachments;
+
+    act(() => result.current.removeAttachment(first!.id));
+    expect(onBeforeReleaseAttachments).toHaveBeenNthCalledWith(1, [first]);
+    expect(onBeforeReleaseAttachments.mock.invocationCallOrder[0])
+      .toBeLessThan(vi.mocked(URL.revokeObjectURL).mock.invocationCallOrder[0]!);
+
+    act(() => result.current.clearSubmittedAttachments([
+      { id: second!.id },
+    ]));
+    expect(onBeforeReleaseAttachments).toHaveBeenNthCalledWith(2, [second]);
+    expect(onBeforeReleaseAttachments.mock.invocationCallOrder[1])
+      .toBeLessThan(vi.mocked(URL.revokeObjectURL).mock.invocationCallOrder[1]!);
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps attachments across same-workspace harness capability changes", () => {
     const { result, rerender } = renderHook(
       ({ capabilities }: { capabilities: PromptCapabilities | null }) =>

--- a/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.test.tsx
@@ -18,7 +18,7 @@ describe("usePromptAttachments", () => {
   beforeEach(() => {
     Object.defineProperty(URL, "createObjectURL", {
       configurable: true,
-      value: vi.fn(() => "blob:prompt-attachment"),
+      value: vi.fn((blob: Blob) => `blob:prompt-attachment:${blob.size}`),
     });
     Object.defineProperty(URL, "revokeObjectURL", {
       configurable: true,
@@ -75,6 +75,45 @@ describe("usePromptAttachments", () => {
     expect(result.current.snapshotForSubmit()).toEqual([]);
   });
 
+  it("creates preview URLs for image, file, and pasted-text drafts", () => {
+    const { result } = renderHook(() =>
+      usePromptAttachments("session-1", promptCapabilities)
+    );
+    const image = new File(["image-bytes"], "image.png", { type: "image/png" });
+    const textFile = new File(["const ok = true;"], "example.ts", { type: "text/plain" });
+    const pastedText = Array.from({ length: 25 }, (_, index) => `line ${index}`).join("\n");
+
+    act(() => {
+      result.current.addFiles([image, textFile]);
+      result.current.addTextPaste(pastedText);
+    });
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(3);
+    expect(result.current.attachments).toHaveLength(3);
+    expect(result.current.attachments.every((attachment) => attachment.objectUrl)).toBe(true);
+  });
+
+  it("revokes owned preview URLs when an attachment is removed or the hook unmounts", () => {
+    const { result, unmount } = renderHook(() =>
+      usePromptAttachments("session-1", promptCapabilities)
+    );
+    const first = new File(["one"], "one.txt", { type: "text/plain" });
+    const second = new File(["two-two"], "two.txt", { type: "text/plain" });
+    act(() => {
+      result.current.addFiles([first, second]);
+    });
+    const [firstAttachment, secondAttachment] = result.current.attachments;
+
+    act(() => {
+      result.current.removeAttachment(firstAttachment!.id);
+    });
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(firstAttachment!.objectUrl);
+
+    unmount();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(secondAttachment!.objectUrl);
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps attachments across same-workspace harness capability changes", () => {
     const { result, rerender } = renderHook(
       ({ capabilities }: { capabilities: PromptCapabilities | null }) =>
@@ -124,5 +163,6 @@ describe("usePromptAttachments", () => {
 
     expect(result.current.attachments).toEqual([]);
     expect(result.current.snapshotForSubmit()).toEqual([]);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:prompt-attachment:11");
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.ts
@@ -103,7 +103,7 @@ export function usePromptAttachments(
             size: file.size,
             kind: "text_resource",
             source: "upload",
-            objectUrl: null,
+            objectUrl: URL.createObjectURL(file),
           },
         });
         remainingSlots -= 1;
@@ -139,7 +139,7 @@ export function usePromptAttachments(
         size: file.size,
         kind: "text_resource",
         source: "paste",
-        objectUrl: null,
+        objectUrl: URL.createObjectURL(file),
       },
     };
     const updated = [...entriesRef.current, entry].slice(0, MAX_PROMPT_ATTACHMENTS);

--- a/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.ts
@@ -20,6 +20,12 @@ interface AttachmentEntry {
 
 const MAX_PROMPT_ATTACHMENTS = 10;
 
+export interface PromptAttachmentLifetimeOptions {
+  onBeforeReleaseAttachments?: (
+    attachments: readonly PromptAttachmentDescriptor[],
+  ) => void;
+}
+
 function createAttachmentId(): string {
   return `attachment:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`;
 }
@@ -33,29 +39,47 @@ function revokeAttachmentObjectUrl(entry: AttachmentEntry): void {
 export function usePromptAttachments(
   scopeKey: string | null | undefined,
   capabilities: PromptCapabilities | null | undefined,
+  lifetimeOptions: PromptAttachmentLifetimeOptions = {},
 ) {
   const canAttachImages = capabilities?.image === true;
   const canAttachEmbeddedContext = capabilities?.embeddedContext === true;
   const [entries, setEntries] = useState<AttachmentEntry[]>([]);
   const entriesRef = useRef<AttachmentEntry[]>([]);
+  const onBeforeReleaseAttachmentsRef = useRef(
+    lifetimeOptions.onBeforeReleaseAttachments,
+  );
 
-  useEffect(() => () => {
-    for (const entry of entriesRef.current) {
+  useEffect(() => {
+    onBeforeReleaseAttachmentsRef.current = lifetimeOptions.onBeforeReleaseAttachments;
+  }, [lifetimeOptions.onBeforeReleaseAttachments]);
+
+  const releaseEntries = useCallback((released: readonly AttachmentEntry[]) => {
+    if (released.length === 0) {
+      return;
+    }
+    onBeforeReleaseAttachmentsRef.current?.(
+      released.map((entry) => entry.descriptor),
+    );
+    for (const entry of released) {
       revokeAttachmentObjectUrl(entry);
     }
-    entriesRef.current = [];
   }, []);
+
+  useEffect(() => () => {
+    const outgoing = entriesRef.current;
+    entriesRef.current = [];
+    releaseEntries(outgoing);
+  }, [releaseEntries]);
 
   useEffect(() => {
     if (entriesRef.current.length === 0) {
       return;
     }
-    for (const entry of entriesRef.current) {
-      revokeAttachmentObjectUrl(entry);
-    }
+    const outgoing = entriesRef.current;
     entriesRef.current = [];
     setEntries([]);
-  }, [scopeKey]);
+    releaseEntries(outgoing);
+  }, [releaseEntries, scopeKey]);
 
   const descriptors = useMemo(
     () => entries.map((entry) => entry.descriptor),
@@ -153,22 +177,21 @@ export function usePromptAttachments(
     if (!removed) {
       return;
     }
-    revokeAttachmentObjectUrl(removed);
     const updated = entriesRef.current.filter((entry) => entry.descriptor.id !== id);
     entriesRef.current = updated;
     setEntries(updated);
-  }, []);
+    releaseEntries([removed]);
+  }, [releaseEntries]);
 
   const clearAttachments = useCallback(() => {
     if (entriesRef.current.length === 0) {
       return;
     }
-    for (const entry of entriesRef.current) {
-      revokeAttachmentObjectUrl(entry);
-    }
+    const outgoing = entriesRef.current;
     entriesRef.current = [];
     setEntries([]);
-  }, []);
+    releaseEntries(outgoing);
+  }, [releaseEntries]);
 
   const clearSubmittedAttachments = useCallback((
     submitted: readonly Pick<PromptAttachmentSnapshot, "id">[],
@@ -178,16 +201,18 @@ export function usePromptAttachments(
       return;
     }
     const retained: AttachmentEntry[] = [];
+    const released: AttachmentEntry[] = [];
     for (const entry of entriesRef.current) {
       if (submittedIds.has(entry.descriptor.id)) {
-        revokeAttachmentObjectUrl(entry);
+        released.push(entry);
       } else {
         retained.push(entry);
       }
     }
     entriesRef.current = retained;
     setEntries(retained);
-  }, []);
+    releaseEntries(released);
+  }, [releaseEntries]);
 
   const snapshotForSubmit = useCallback((): PromptAttachmentSnapshot[] => {
     return entriesRef.current.flatMap((entry) => {

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.test.tsx
@@ -151,7 +151,7 @@ describe("usePromptAttachmentPreviewActions", () => {
       result.current.previewActions.openAttachmentPreview({
         origin: "draft",
         sessionId: null,
-        part: normalizeDraftAttachments([first])[0]!,
+        part: previewPart(first),
       });
     });
     const firstTargetKey = viewerTargetKey(
@@ -183,7 +183,7 @@ describe("usePromptAttachmentPreviewActions", () => {
       result.current.previewActions.openAttachmentPreview({
         origin: "draft",
         sessionId: null,
-        part: normalizeDraftAttachments([second])[0]!,
+        part: previewPart(second),
       });
     });
     const secondTargetKey = viewerTargetKey(
@@ -222,4 +222,14 @@ function createTestWrapper() {
       </ProductHostProvider>
     </QueryClientProvider>
   );
+}
+
+function previewPart(
+  attachment: Parameters<typeof normalizeDraftAttachments>[0][number],
+) {
+  const part = normalizeDraftAttachments([attachment])[0];
+  if (!part || (part.type !== "image" && part.type !== "file")) {
+    throw new Error("Expected a previewable draft attachment");
+  }
+  return part;
 }

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AnyHarnessRuntime, AnyHarnessWorkspace } from "@anyharness/sdk-react";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
+import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
+import { viewerTargetKey } from "#product/lib/domain/workspaces/viewer/viewer-target";
+import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
+
+describe("usePromptAttachmentPreviewActions", () => {
+  beforeEach(() => {
+    useSessionSelectionStore.getState().clearSelection();
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-workspace-1",
+      workspaceId: "workspace-1",
+    });
+    useWorkspaceViewerTabsStore.getState().reset();
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+      shellActivationEpochByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
+      urgentHighlightedChatSessionByWorkspace: {},
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("opens a draft in the right viewer and removes it when the draft is discarded", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <ProductHostProvider host={makeTestProductHost()}>
+          <AnyHarnessRuntime runtimeUrl={null}>
+            <AnyHarnessWorkspace
+              workspaceId="workspace-1"
+              resolveConnection={async () => ({
+                runtimeUrl: "http://127.0.0.1:1",
+                anyharnessWorkspaceId: "workspace-1",
+              })}
+            >
+              {children}
+            </AnyHarnessWorkspace>
+          </AnyHarnessRuntime>
+        </ProductHostProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => usePromptAttachmentPreviewActions(), { wrapper });
+
+    act(() => {
+      result.current.openAttachmentPreview({
+        origin: "draft",
+        sessionId: null,
+        part: {
+          type: "file",
+          id: "draft-1",
+          name: "notes.md",
+          mimeType: "text/markdown",
+          size: 128,
+          source: "paste",
+          objectUrl: "blob:draft-1",
+        },
+      });
+    });
+
+    const target = useWorkspaceViewerTabsStore.getState().openTargets[0];
+    expect(target).toMatchObject({
+      kind: "promptAttachment",
+      origin: "draft",
+      attachmentId: "draft-1",
+      objectUrl: "blob:draft-1",
+    });
+    const targetKey = viewerTargetKey(target!);
+    expect(useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace["workspace-1"])
+      .toMatchObject({ activeEntryKey: targetKey });
+    expect(useWorkspaceUiStore.getState().rightPanelDurableByWorkspace["logical-workspace-1"])
+      .toMatchObject({ open: true });
+
+    act(() => {
+      result.current.closeDraftAttachmentPreview("draft-1");
+    });
+
+    expect(useWorkspaceViewerTabsStore.getState().openTargets).toEqual([]);
+    expect(
+      useWorkspaceUiStore.getState()
+        .rightPanelMaterializedByWorkspace["workspace-1"]?.headerOrder,
+    ).not.toContain(targetKey);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.test.tsx
@@ -1,18 +1,29 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
+import type { PromptCapabilities } from "@anyharness/sdk";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AnyHarnessRuntime, AnyHarnessWorkspace } from "@anyharness/sdk-react";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
+import { usePromptAttachments } from "#product/hooks/chat/ui/use-prompt-attachments";
 import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
 import { viewerTargetKey } from "#product/lib/domain/workspaces/viewer/viewer-target";
 import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { makeTestProductHost } from "#product/test/product-host-fixtures";
+import { normalizeDraftAttachments } from "@proliferate/product-domain/chats/composer/prompt-display-parts";
+
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
+const promptCapabilities: PromptCapabilities = {
+  image: true,
+  audio: false,
+  embeddedContext: true,
+};
 
 describe("usePromptAttachmentPreviewActions", () => {
   beforeEach(() => {
@@ -29,31 +40,32 @@ describe("usePromptAttachmentPreviewActions", () => {
       pendingChatActivationByWorkspace: {},
       urgentHighlightedChatSessionByWorkspace: {},
     });
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn((blob: Blob) => (
+        `blob:${blob instanceof File ? blob.name : blob.size}`
+      )),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
   });
 
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: originalCreateObjectUrl,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: originalRevokeObjectUrl,
+    });
+  });
 
   it("opens a draft in the right viewer and removes it when the draft is discarded", () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>
-        <ProductHostProvider host={makeTestProductHost()}>
-          <AnyHarnessRuntime runtimeUrl={null}>
-            <AnyHarnessWorkspace
-              workspaceId="workspace-1"
-              resolveConnection={async () => ({
-                runtimeUrl: "http://127.0.0.1:1",
-                anyharnessWorkspaceId: "workspace-1",
-              })}
-            >
-              {children}
-            </AnyHarnessWorkspace>
-          </AnyHarnessRuntime>
-        </ProductHostProvider>
-      </QueryClientProvider>
-    );
+    const wrapper = createTestWrapper();
     const { result } = renderHook(() => usePromptAttachmentPreviewActions(), { wrapper });
 
     act(() => {
@@ -92,7 +104,122 @@ describe("usePromptAttachmentPreviewActions", () => {
     expect(useWorkspaceViewerTabsStore.getState().openTargets).toEqual([]);
     expect(
       useWorkspaceUiStore.getState()
-        .rightPanelMaterializedByWorkspace["workspace-1"]?.headerOrder,
+      .rightPanelMaterializedByWorkspace["workspace-1"]?.headerOrder,
     ).not.toContain(targetKey);
   });
+
+  it("releases scoped and unmounted draft previews before revoking each URL once", () => {
+    const wrapper = createTestWrapper();
+    const targetKeyByUrl = new Map<string, string>();
+    vi.mocked(URL.revokeObjectURL).mockImplementation((objectUrl) => {
+      const targetKey = targetKeyByUrl.get(String(objectUrl));
+      if (!targetKey) {
+        return;
+      }
+      expect(useWorkspaceViewerTabsStore.getState().openTargets.some((target) => (
+        viewerTargetKey(target) === targetKey
+      ))).toBe(false);
+      for (const panelState of Object.values(
+        useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace,
+      )) {
+        expect(panelState.headerOrder).not.toContain(targetKey);
+        expect(panelState.activeEntryKey).not.toBe(targetKey);
+      }
+    });
+    const { result, rerender, unmount } = renderHook(
+      ({ scopeKey }: { scopeKey: string }) => {
+        const previewActions = usePromptAttachmentPreviewActions();
+        const attachments = usePromptAttachments(scopeKey, promptCapabilities, {
+          onBeforeReleaseAttachments: (outgoing) => {
+            previewActions.closeDraftAttachmentPreviews(
+              outgoing.map((attachment) => attachment.id),
+            );
+          },
+        });
+        return { attachments, previewActions };
+      },
+      { initialProps: { scopeKey: "logical-workspace-1" }, wrapper },
+    );
+
+    act(() => {
+      result.current.attachments.addFiles([
+        new File(["first"], "first.txt", { type: "text/plain" }),
+      ]);
+    });
+    const first = result.current.attachments.attachments[0]!;
+    act(() => {
+      result.current.previewActions.openAttachmentPreview({
+        origin: "draft",
+        sessionId: null,
+        part: normalizeDraftAttachments([first])[0]!,
+      });
+    });
+    const firstTargetKey = viewerTargetKey(
+      useWorkspaceViewerTabsStore.getState().openTargets[0]!,
+    );
+    targetKeyByUrl.set(first.objectUrl!, firstTargetKey);
+
+    act(() => {
+      useSessionSelectionStore.getState().activateWorkspace({
+        logicalWorkspaceId: "logical-workspace-2",
+        workspaceId: "workspace-2",
+      });
+    });
+    rerender({ scopeKey: "logical-workspace-2" });
+
+    expect(useWorkspaceViewerTabsStore.getState().openTargets).toEqual([]);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(first.objectUrl);
+    expect(vi.mocked(URL.revokeObjectURL).mock.calls.filter(
+      ([objectUrl]) => objectUrl === first.objectUrl,
+    )).toHaveLength(1);
+
+    act(() => {
+      result.current.attachments.addFiles([
+        new File(["second"], "second.txt", { type: "text/plain" }),
+      ]);
+    });
+    const second = result.current.attachments.attachments[0]!;
+    act(() => {
+      result.current.previewActions.openAttachmentPreview({
+        origin: "draft",
+        sessionId: null,
+        part: normalizeDraftAttachments([second])[0]!,
+      });
+    });
+    const secondTargetKey = viewerTargetKey(
+      useWorkspaceViewerTabsStore.getState().openTargets[0]!,
+    );
+    targetKeyByUrl.set(second.objectUrl!, secondTargetKey);
+
+    unmount();
+
+    expect(useWorkspaceViewerTabsStore.getState().openTargets).toEqual([]);
+    expect(vi.mocked(URL.revokeObjectURL).mock.calls.filter(
+      ([objectUrl]) => objectUrl === second.objectUrl,
+    )).toHaveLength(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
 });
+
+function createTestWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ProductHostProvider host={makeTestProductHost()}>
+        <AnyHarnessRuntime runtimeUrl={null}>
+          <AnyHarnessWorkspace
+            workspaceId="workspace-1"
+            resolveConnection={async () => ({
+              runtimeUrl: "http://127.0.0.1:1",
+              anyharnessWorkspaceId: "workspace-1",
+            })}
+          >
+            {children}
+          </AnyHarnessWorkspace>
+        </AnyHarnessRuntime>
+      </ProductHostProvider>
+    </QueryClientProvider>
+  );
+}

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.ts
@@ -5,10 +5,13 @@ import type {
 import { focusChatInput } from "#product/lib/domain/focus-zone";
 import { useWorkspaceShellActivation } from "#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
 import { removeViewerTargetFromRightPanelState } from "#product/lib/domain/workspaces/shell/right-panel-state";
+import { parseRightPanelHeaderEntryKey } from "#product/lib/domain/workspaces/shell/right-panel-model";
 import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import {
   promptAttachmentViewerTarget,
   viewerTargetKey,
+  type ViewerTarget,
+  type ViewerTargetKey,
 } from "#product/lib/domain/workspaces/viewer/viewer-target";
 import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
@@ -64,33 +67,78 @@ export function usePromptAttachmentPreviewActions() {
     focusChatInput();
   }, [activateViewerTarget, materializedWorkspaceId, openViewerTarget, workspaceUiKey]);
 
-  const closeDraftAttachmentPreview = useCallback((attachmentId: string) => {
-    const targets = useWorkspaceViewerTabsStore.getState().openTargets.filter((target) => (
-      target.kind === "promptAttachment"
-      && target.origin === "draft"
-      && target.attachmentId === attachmentId
-    ));
-    for (const target of targets) {
-      const targetKey = viewerTargetKey(target);
-      closeViewerTarget(targetKey);
-      if (materializedWorkspaceId) {
-        setRightPanelMaterializedForWorkspace(
-          materializedWorkspaceId,
-          (previous) => removeViewerTargetFromRightPanelState(previous, targetKey, true),
-        );
+  const closeDraftAttachmentPreviews = useCallback((attachmentIds: readonly string[]) => {
+    const outgoingIds = new Set(attachmentIds);
+    if (outgoingIds.size === 0) {
+      return;
+    }
+    const targetKeys = new Set<ViewerTargetKey>();
+    for (const target of useWorkspaceViewerTabsStore.getState().openTargets) {
+      if (isOutgoingDraftAttachmentTarget(target, outgoingIds)) {
+        targetKeys.add(viewerTargetKey(target));
       }
     }
-    if (targets.length > 0) {
+    const materializedByWorkspace = useWorkspaceUiStore.getState()
+      .rightPanelMaterializedByWorkspace;
+    for (const panelState of Object.values(materializedByWorkspace)) {
+      for (const entryKey of new Set([
+        panelState.activeEntryKey,
+        ...panelState.headerOrder,
+      ])) {
+        const entry = parseRightPanelHeaderEntryKey(entryKey);
+        if (entry?.kind === "viewer"
+          && isOutgoingDraftAttachmentTarget(entry.target, outgoingIds)) {
+          targetKeys.add(entry.targetKey);
+        }
+      }
+    }
+    if (targetKeys.size === 0) {
+      return;
+    }
+    for (const targetKey of targetKeys) {
+      closeViewerTarget(targetKey);
+    }
+    for (const [workspaceId, panelState] of Object.entries(materializedByWorkspace)) {
+      if (!panelState.headerOrder.some((entryKey) => targetKeys.has(
+        entryKey as ViewerTargetKey,
+      )) && !targetKeys.has(panelState.activeEntryKey as ViewerTargetKey)) {
+        continue;
+      }
+      setRightPanelMaterializedForWorkspace(workspaceId, (previous) => (
+        [...targetKeys].reduce(
+          (next, targetKey) => removeViewerTargetFromRightPanelState(
+            next,
+            targetKey,
+            true,
+          ),
+          previous,
+        )
+      ));
+    }
+    if (targetKeys.size > 0) {
       focusChatInput();
     }
   }, [
     closeViewerTarget,
-    materializedWorkspaceId,
     setRightPanelMaterializedForWorkspace,
   ]);
+
+  const closeDraftAttachmentPreview = useCallback((attachmentId: string) => {
+    closeDraftAttachmentPreviews([attachmentId]);
+  }, [closeDraftAttachmentPreviews]);
 
   return {
     openAttachmentPreview,
     closeDraftAttachmentPreview,
+    closeDraftAttachmentPreviews,
   };
+}
+
+function isOutgoingDraftAttachmentTarget(
+  target: ViewerTarget,
+  attachmentIds: ReadonlySet<string>,
+): boolean {
+  return target.kind === "promptAttachment"
+    && target.origin === "draft"
+    && attachmentIds.has(target.attachmentId);
 }

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.ts
@@ -1,0 +1,96 @@
+import { useCallback } from "react";
+import type {
+  PromptDisplayAttachmentPart,
+} from "@proliferate/product-domain/chats/composer/prompt-display-parts";
+import { focusChatInput } from "#product/lib/domain/focus-zone";
+import { useWorkspaceShellActivation } from "#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
+import { removeViewerTargetFromRightPanelState } from "#product/lib/domain/workspaces/shell/right-panel-state";
+import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
+import {
+  promptAttachmentViewerTarget,
+  viewerTargetKey,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
+import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+type PreviewablePromptAttachmentPart = Exclude<
+  PromptDisplayAttachmentPart,
+  { type: "link" | "plan_reference" }
+>;
+
+export function usePromptAttachmentPreviewActions() {
+  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const { workspaceUiKey, materializedWorkspaceId } = resolveSelectedWorkspaceIdentity({
+    selectedLogicalWorkspaceId,
+    materializedWorkspaceId: selectedWorkspaceId,
+  });
+  const openViewerTarget = useWorkspaceViewerTabsStore((state) => state.openTarget);
+  const closeViewerTarget = useWorkspaceViewerTabsStore((state) => state.closeTarget);
+  const setRightPanelMaterializedForWorkspace = useWorkspaceUiStore(
+    (state) => state.setRightPanelMaterializedForWorkspace,
+  );
+  const { activateViewerTarget } = useWorkspaceShellActivation();
+
+  const openAttachmentPreview = useCallback((args: {
+    part: PreviewablePromptAttachmentPart;
+    origin: "draft" | "session";
+    sessionId: string | null;
+  }) => {
+    const target = promptAttachmentViewerTarget({
+      origin: args.origin,
+      sessionId: args.origin === "session" ? args.sessionId : null,
+      attachmentId: args.part.attachmentId ?? args.part.id,
+      name: args.part.name,
+      mimeType: args.part.mimeType
+        ?? (args.part.type === "image" ? "image/png" : "text/plain"),
+      size: args.part.size ?? null,
+      attachmentKind: args.part.type === "image" ? "image" : "text_resource",
+      attachmentSource: args.part.source ?? "upload",
+      objectUrl: args.origin === "draft" ? args.part.objectUrl ?? null : null,
+    });
+    openViewerTarget(target);
+    if (materializedWorkspaceId) {
+      activateViewerTarget({
+        workspaceId: materializedWorkspaceId,
+        shellWorkspaceId: workspaceUiKey,
+        target,
+        mode: "open-or-focus",
+      });
+    }
+    focusChatInput();
+  }, [activateViewerTarget, materializedWorkspaceId, openViewerTarget, workspaceUiKey]);
+
+  const closeDraftAttachmentPreview = useCallback((attachmentId: string) => {
+    const targets = useWorkspaceViewerTabsStore.getState().openTargets.filter((target) => (
+      target.kind === "promptAttachment"
+      && target.origin === "draft"
+      && target.attachmentId === attachmentId
+    ));
+    for (const target of targets) {
+      const targetKey = viewerTargetKey(target);
+      closeViewerTarget(targetKey);
+      if (materializedWorkspaceId) {
+        setRightPanelMaterializedForWorkspace(
+          materializedWorkspaceId,
+          (previous) => removeViewerTargetFromRightPanelState(previous, targetKey, true),
+        );
+      }
+    }
+    if (targets.length > 0) {
+      focusChatInput();
+    }
+  }, [
+    closeViewerTarget,
+    materializedWorkspaceId,
+    setRightPanelMaterializedForWorkspace,
+  ]);
+
+  return {
+    openAttachmentPreview,
+    closeDraftAttachmentPreview,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useRightPanelViewerActions } from "#product/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions";
+import {
+  promptAttachmentViewerTarget,
+  viewerTargetKey,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
+
+const focusChatInput = vi.hoisted(() => vi.fn());
+
+vi.mock("#product/lib/domain/focus-zone", () => ({ focusChatInput }));
+
+describe("useRightPanelViewerActions", () => {
+  it("closes a prompt attachment without clearing file buffers and recovers composer focus", () => {
+    const target = promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "draft-1",
+      name: "notes.md",
+      mimeType: "text/markdown",
+      attachmentKind: "text_resource",
+      attachmentSource: "upload",
+      objectUrl: "blob:draft-1",
+    });
+    const targetKey = viewerTargetKey(target);
+    const state = {
+      activeEntryKey: targetKey,
+      headerOrder: ["tool:scratch" as const, "tool:git" as const, targetKey],
+    };
+    const updateState = vi.fn();
+    const closeViewerTarget = vi.fn();
+    const setActiveViewerTarget = vi.fn();
+    const clearBuffer = vi.fn();
+    focusChatInput.mockReset();
+
+    const { result } = renderHook(() => useRightPanelViewerActions({
+      state,
+      isCloudWorkspaceSelected: true,
+      openViewerTargets: [target],
+      buffersByPath: {},
+      updateState,
+      closeViewerTarget,
+      setActiveViewerTarget,
+      clearBuffer,
+    }));
+
+    act(() => {
+      result.current.handleCloseViewer(targetKey);
+    });
+
+    expect(closeViewerTarget).toHaveBeenCalledWith(targetKey);
+    expect(clearBuffer).not.toHaveBeenCalled();
+    expect(setActiveViewerTarget).not.toHaveBeenCalled();
+    expect(focusChatInput).toHaveBeenCalledOnce();
+    const update = updateState.mock.calls[0]?.[0];
+    expect(typeof update).toBe("function");
+    expect(update(state)).toEqual({
+      activeEntryKey: "tool:git",
+      headerOrder: ["tool:scratch", "tool:git"],
+    });
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions.ts
@@ -17,6 +17,7 @@ import {
   type ViewerTargetKey,
 } from "#product/lib/domain/workspaces/viewer/viewer-target";
 import type { WorkspaceFileBuffer } from "#product/stores/editor/workspace-file-buffers-store";
+import { focusChatInput } from "#product/lib/domain/focus-zone";
 
 type RightPanelStateUpdater = (value: SetStateAction<RightPanelWorkspaceState>) => void;
 
@@ -99,6 +100,9 @@ export function useRightPanelViewerActions({
         isCloudWorkspaceSelected,
       )
     );
+    if (target.kind === "promptAttachment") {
+      focusChatInput();
+    }
   }, [
     buffersByPath,
     clearBuffer,

--- a/apps/packages/product-client/src/lib/domain/chat/composer/prompt-attachment-paste.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/prompt-attachment-paste.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { handlePromptAttachmentPaste } from "#product/lib/domain/chat/composer/prompt-attachment-paste";
+
+describe("handlePromptAttachmentPaste", () => {
+  it("never duplicates a rich Markdown paste already owned by the editor", () => {
+    const addFiles = vi.fn();
+    const addTextPaste = vi.fn(() => true);
+
+    expect(handlePromptAttachmentPaste({
+      defaultPrevented: true,
+      canAcceptAttachments: true,
+      fileCount: 1,
+      plainText: "- **first**\n- second",
+      addFiles,
+      addTextPaste,
+    })).toBe(false);
+    expect(addFiles).not.toHaveBeenCalled();
+    expect(addTextPaste).not.toHaveBeenCalled();
+  });
+
+  it("gives files precedence and reports when the surface should prevent default", () => {
+    const addFiles = vi.fn();
+    const addTextPaste = vi.fn(() => true);
+
+    expect(handlePromptAttachmentPaste({
+      defaultPrevented: false,
+      canAcceptAttachments: true,
+      fileCount: 2,
+      plainText: "clipboard fallback",
+      addFiles,
+      addTextPaste,
+    })).toBe(true);
+    expect(addFiles).toHaveBeenCalledOnce();
+    expect(addTextPaste).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/chat/composer/prompt-attachment-paste.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/prompt-attachment-paste.ts
@@ -1,0 +1,17 @@
+export function handlePromptAttachmentPaste(args: {
+  defaultPrevented: boolean;
+  canAcceptAttachments: boolean;
+  fileCount: number;
+  plainText: string;
+  addFiles: () => void;
+  addTextPaste: (text: string) => boolean;
+}): boolean {
+  if (args.defaultPrevented || !args.canAcceptAttachments) {
+    return false;
+  }
+  if (args.fileCount > 0) {
+    args.addFiles();
+    return true;
+  }
+  return !!args.plainText && args.addTextPaste(args.plainText);
+}

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-right-panel.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persisted-right-panel.ts
@@ -1,11 +1,15 @@
 import {
   clampRightPanelWidth,
   normalizeRightPanelDurableState,
+  parseRightPanelHeaderEntryKey,
   type RightPanelDurableState,
   type RightPanelMaterializedState,
 } from "#product/lib/domain/workspaces/shell/right-panel-model";
 import { normalizeRightPanelMaterializedState } from "#product/lib/domain/workspaces/shell/right-panel-state-normalization";
 import { migrateLegacyRightPanelWorkspaceState } from "#product/lib/domain/workspaces/shell/right-panel-migration";
+import {
+  isPersistableViewerTarget,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
 
 export function migrateLegacyRightPanelPreferences(args: {
   rightPanelByWorkspace?: Record<string, unknown>;
@@ -71,12 +75,25 @@ export function sanitizeRightPanelMaterializedByWorkspace(
     if (typeof rawState !== "object" || rawState === null) {
       continue;
     }
+    const input = rawState as Partial<RightPanelMaterializedState>;
+    const headerOrder = Array.isArray(input.headerOrder)
+      ? input.headerOrder.filter(isPersistableRightPanelEntry)
+      : undefined;
+    const activeEntryKey = input.activeEntryKey
+      && isPersistableRightPanelEntry(input.activeEntryKey)
+      ? input.activeEntryKey
+      : undefined;
     next[workspaceId] = normalizeRightPanelMaterializedState(
-      rawState as Partial<RightPanelMaterializedState>,
+      { ...input, activeEntryKey, headerOrder },
       { isCloudWorkspaceSelected: true },
     );
   }
   return next;
+}
+
+function isPersistableRightPanelEntry(value: unknown): boolean {
+  const entry = parseRightPanelHeaderEntryKey(value);
+  return !!entry && (entry.kind !== "viewer" || isPersistableViewerTarget(entry.target));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persistence.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persistence.test.ts
@@ -9,6 +9,11 @@ import {
   isNonPersistedWorkspaceUiStateKey,
   selectPersistedWorkspaceUiState,
 } from "#product/lib/domain/preferences/workspace-ui/persistence";
+import {
+  fileViewerTarget,
+  promptAttachmentViewerTarget,
+  viewerTargetKey,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
 
 describe("workspace UI state persistence", () => {
   it("sanitizes persisted chat slices and excludes non-persisted runtime state", () => {
@@ -101,5 +106,37 @@ describe("workspace UI state persistence", () => {
     expect(isNonPersistedWorkspaceUiStateKey("pendingChatActivationByWorkspace")).toBe(true);
     expect(isNonPersistedWorkspaceUiStateKey("urgentHighlightedChatSessionByWorkspace")).toBe(true);
     expect(isNonPersistedWorkspaceUiStateKey("sidebarOpen")).toBe(false);
+  });
+
+  it("strips attachment preview targets from every persisted viewer surface", () => {
+    const attachmentKey = viewerTargetKey(promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "attachment:one",
+      name: "paste.txt",
+      mimeType: "text/plain",
+      attachmentKind: "text_resource",
+      attachmentSource: "paste",
+      objectUrl: "blob:attachment-one",
+    }));
+    const fileKey = viewerTargetKey(fileViewerTarget("README.md"));
+
+    const selected = selectPersistedWorkspaceUiState({
+      ...WORKSPACE_UI_DEFAULTS,
+      activeShellTabKeyByWorkspace: { w1: attachmentKey },
+      shellTabOrderByWorkspace: { w1: [attachmentKey, fileKey] },
+      rightPanelMaterializedByWorkspace: {
+        w1: {
+          activeEntryKey: attachmentKey,
+          headerOrder: [attachmentKey, fileKey],
+        },
+      },
+    });
+
+    expect(selected.activeShellTabKeyByWorkspace).toEqual({});
+    expect(selected.shellTabOrderByWorkspace).toEqual({ w1: [fileKey] });
+    expect(selected.rightPanelMaterializedByWorkspace.w1).toEqual({
+      activeEntryKey: "tool:scratch",
+      headerOrder: [fileKey, "tool:scratch", "tool:git"],
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persistence.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/persistence.ts
@@ -15,6 +15,9 @@ import {
   type PersistedWorkspaceUiState,
   type WorkspaceUiChangeTrackedState,
 } from "#product/lib/domain/preferences/workspace-ui/model";
+import {
+  sanitizeRightPanelMaterializedByWorkspace,
+} from "#product/lib/domain/preferences/workspace-ui/persisted-right-panel";
 
 export function selectPersistedWorkspaceUiState(
   state: PersistedWorkspaceUiState,
@@ -29,7 +32,9 @@ export function selectPersistedWorkspaceUiState(
     sidebarOpen: state.sidebarOpen,
     sidebarWidth: state.sidebarWidth,
     rightPanelDurableByWorkspace: state.rightPanelDurableByWorkspace,
-    rightPanelMaterializedByWorkspace: state.rightPanelMaterializedByWorkspace,
+    rightPanelMaterializedByWorkspace: sanitizeRightPanelMaterializedByWorkspace(
+      state.rightPanelMaterializedByWorkspace,
+    ),
     activeShellTabKeyByWorkspace: sanitizeActiveShellTabKeysByWorkspace(
       state.activeShellTabKeyByWorkspace,
     ),

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-file-seed.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-file-seed.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { fileViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+import {
+  fileViewerTarget,
+  promptAttachmentViewerTarget,
+  viewerTargetKey,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
 import { fileWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
 import { deriveWorkspaceFileTabSeed } from "#product/lib/domain/workspaces/tabs/shell-file-seed";
 
@@ -35,5 +39,28 @@ describe("deriveWorkspaceFileTabSeed", () => {
         activeShellTabKey,
       }).initialActiveTargetKey).toBeNull();
     }
+  });
+
+  it("does not restore session-local attachment preview targets", () => {
+    const attachmentKey = viewerTargetKey(promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "attachment:one",
+      name: "notes.txt",
+      mimeType: "text/plain",
+      attachmentKind: "text_resource",
+      attachmentSource: "paste",
+      objectUrl: "blob:attachment-one",
+    }));
+
+    expect(deriveWorkspaceFileTabSeed({
+      shellOrderKeys: ["chat:s1", attachmentKey, "file:README.md"],
+      activeShellTabKey: attachmentKey,
+      rightPanelHeaderOrderKeys: [attachmentKey],
+      rightPanelActiveEntryKey: attachmentKey,
+    })).toEqual({
+      shellOrderKeys: ["chat:s1", fileWorkspaceShellTabKey("README.md")],
+      initialOpenTargets: [fileViewerTarget("README.md")],
+      initialActiveTargetKey: null,
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-file-seed.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-file-seed.ts
@@ -3,7 +3,11 @@ import {
   parseWorkspaceShellTabKey,
   type WorkspaceShellTabKey,
 } from "#product/lib/domain/workspaces/tabs/shell-tabs";
-import { viewerTargetKey, type ViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+import {
+  isPersistableViewerTarget,
+  viewerTargetKey,
+  type ViewerTarget,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
 
 export interface WorkspaceFileTabSeed {
   shellOrderKeys: WorkspaceShellTabKey[];
@@ -19,7 +23,7 @@ export function sanitizeWorkspaceShellTabKeys(
 
   for (const key of keys ?? []) {
     const parsed = parseWorkspaceShellTabKey(key);
-    if (!parsed) {
+    if (!parsed || (parsed.kind === "viewer" && !isPersistableViewerTarget(parsed.target))) {
       continue;
     }
     const canonicalKey = getWorkspaceShellTabKey(parsed);

--- a/apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.test.ts
@@ -5,8 +5,10 @@ import {
   defaultFileViewerMode,
   fileDiffViewerTarget,
   fileViewerTarget,
+  isPersistableViewerTarget,
   pathIsWithinWorkspaceEntry,
   parseViewerTargetKey,
+  promptAttachmentViewerTarget,
   remapPathWithinWorkspaceEntry,
   remapViewerTargetPathWithinWorkspaceEntry,
   viewerTargetEditablePath,
@@ -47,6 +49,23 @@ describe("viewer target keys", () => {
       v: 2,
       target: fileViewerTarget("README.md"),
     }))}`)).toBeNull();
+  });
+
+  it("round-trips session-local attachment targets without making them durable", () => {
+    const draftTarget = promptAttachmentViewerTarget({
+      origin: "draft",
+      attachmentId: "attachment:one",
+      name: "notes.md",
+      mimeType: "text/markdown",
+      size: 128,
+      attachmentKind: "text_resource",
+      attachmentSource: "upload",
+      objectUrl: "blob:attachment-one",
+    });
+
+    expect(parseViewerTargetKey(viewerTargetKey(draftTarget))).toEqual(draftTarget);
+    expect(isPersistableViewerTarget(draftTarget)).toBe(false);
+    expect(isPersistableViewerTarget(fileViewerTarget("notes.md"))).toBe(true);
   });
 
   it("normalizes legacy working_tree all-changes payloads to composite scope", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.ts
@@ -9,6 +9,9 @@ export type FileViewerMode = "source" | "rendered" | "diff" | "edit";
 export type DiffViewerLayout = "unified" | "split";
 export type FileDiffViewerScope = Exclude<GitDiffScope, "working_tree" | "base_worktree">;
 export type AllChangesViewerScope = FileDiffViewerScope | "working_tree_composite";
+export type PromptAttachmentViewerOrigin = "draft" | "session";
+export type PromptAttachmentViewerKind = "image" | "text_resource";
+export type PromptAttachmentViewerSource = "upload" | "paste";
 
 export type ViewerTarget =
   | { kind: "file"; path: string }
@@ -27,6 +30,18 @@ export type ViewerTarget =
     baseRef: string | null;
     baseOid: string | null;
     headOid: string | null;
+  }
+  | {
+    kind: "promptAttachment";
+    origin: PromptAttachmentViewerOrigin;
+    sessionId: string | null;
+    attachmentId: string;
+    name: string;
+    mimeType: string;
+    size: number | null;
+    attachmentKind: PromptAttachmentViewerKind;
+    attachmentSource: PromptAttachmentViewerSource;
+    objectUrl: string | null;
   };
 
 export type ViewerTargetKey = `viewer:${string}`;
@@ -73,6 +88,31 @@ export function allChangesViewerTarget(args: {
     baseRef: args.baseRef ?? null,
     baseOid: args.baseOid ?? null,
     headOid: args.headOid ?? null,
+  });
+}
+
+export function promptAttachmentViewerTarget(args: {
+  origin: PromptAttachmentViewerOrigin;
+  sessionId?: string | null;
+  attachmentId: string;
+  name: string;
+  mimeType: string;
+  size?: number | null;
+  attachmentKind: PromptAttachmentViewerKind;
+  attachmentSource: PromptAttachmentViewerSource;
+  objectUrl?: string | null;
+}): ViewerTarget {
+  return canonicalizeViewerTarget({
+    kind: "promptAttachment",
+    origin: args.origin,
+    sessionId: args.sessionId ?? null,
+    attachmentId: args.attachmentId,
+    name: args.name,
+    mimeType: args.mimeType,
+    size: args.size ?? null,
+    attachmentKind: args.attachmentKind,
+    attachmentSource: args.attachmentSource,
+    objectUrl: args.objectUrl ?? null,
   });
 }
 
@@ -125,6 +165,48 @@ export function canonicalizeViewerTarget(target: ViewerTarget): ViewerTarget {
       headOid: normalizeNullableTargetPart(target.headOid),
     };
   }
+  if (target.kind === "promptAttachment") {
+    const origin = target.origin === "draft" || target.origin === "session"
+      ? target.origin
+      : null;
+    const attachmentKind = target.attachmentKind === "image"
+      || target.attachmentKind === "text_resource"
+      ? target.attachmentKind
+      : null;
+    const attachmentSource = target.attachmentSource === "upload"
+      || target.attachmentSource === "paste"
+      ? target.attachmentSource
+      : null;
+    const attachmentId = normalizeRequiredTargetPart(target.attachmentId);
+    const name = normalizeRequiredTargetPart(target.name);
+    const mimeType = normalizeRequiredTargetPart(target.mimeType);
+    const sessionId = normalizeNullableTargetPart(target.sessionId);
+    const objectUrl = normalizeNullableTargetPart(target.objectUrl);
+    if (
+      !origin
+      || !attachmentKind
+      || !attachmentSource
+      || !attachmentId
+      || !name
+      || !mimeType
+      || (origin === "draft" && sessionId)
+      || (origin === "session" && objectUrl)
+    ) {
+      throw new Error("Invalid prompt attachment viewer target");
+    }
+    return {
+      kind: "promptAttachment",
+      origin,
+      sessionId,
+      attachmentId,
+      name,
+      mimeType,
+      size: normalizeNullableTargetSize(target.size),
+      attachmentKind,
+      attachmentSource,
+      objectUrl,
+    };
+  }
   return {
     kind: "allChanges",
     scope: normalizeAllChangesScope(target.scope),
@@ -138,6 +220,10 @@ export function isFileViewerTarget(
   target: ViewerTarget,
 ): target is Extract<ViewerTarget, { kind: "file" }> {
   return target.kind === "file";
+}
+
+export function isPersistableViewerTarget(target: ViewerTarget): boolean {
+  return target.kind !== "promptAttachment";
 }
 
 export function viewerTargetEditablePath(target: ViewerTarget): string | null {
@@ -203,6 +289,9 @@ export function viewerTargetLabel(target: ViewerTarget): string {
   if (target.kind === "allChanges") {
     return target.scope === "working_tree_composite" ? "All changes" : "All branch changes";
   }
+  if (target.kind === "promptAttachment") {
+    return target.name;
+  }
   return "Viewer";
 }
 
@@ -227,4 +316,12 @@ function normalizeAllChangesScope(
 function normalizeNullableTargetPart(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+function normalizeRequiredTargetPart(value: string | null | undefined): string | null {
+  return normalizeNullableTargetPart(value);
+}
+
+function normalizeNullableTargetSize(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }

--- a/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
+++ b/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
@@ -10,6 +10,7 @@ import {
 import { CHAT_COLUMN_CLASSNAME, CHAT_SURFACE_GUTTER_CLASSNAME } from "#product/config/chat-layout";
 import { useChatDockInset } from "#product/hooks/chat/ui/use-chat-dock-inset";
 import { useReplaySession } from "#product/hooks/playground/lifecycle/use-replay-session";
+import { PlaygroundAttachmentPreviewAside } from "#product/components/playground/PlaygroundAttachmentFixtures";
 
 export function ChatPlaygroundPage() {
   const [params, setParams] = useSearchParams();
@@ -25,6 +26,8 @@ export function ChatPlaygroundPage() {
   );
   const showSidebarGitDiff =
     selection.kind === "fixture" && selection.key === "git-diff-panel";
+  const showAttachmentPreview =
+    selection.kind === "fixture" && selection.key === "attachment-previews";
 
   const handleSelectFixture = (key: ScenarioKey) => {
     const next = new URLSearchParams(params);
@@ -68,12 +71,14 @@ export function ChatPlaygroundPage() {
           lowerBackdropTopPx={lowerBackdropTopPx}
           selection={selection}
           replay={replay}
+          rightInsetPx={showAttachmentPreview ? 416 : 0}
         />
         {showSidebarGitDiff && (
           <aside className="hidden w-[22rem] shrink-0 border-l border-sidebar-border bg-sidebar-background lg:block">
             <PlaygroundSidebarGitDiff />
           </aside>
         )}
+        {showAttachmentPreview && <PlaygroundAttachmentPreviewAside />}
       </main>
       <footer className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
         <code className="font-mono">?s={selection.raw}</code>

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -61,18 +61,48 @@ The durable right-panel tool id remains `git`; “Changes” is a display label.
 ## Viewer Targets
 
 Center tabs use `ViewerTarget`, owned by
-`apps/desktop/src/lib/domain/workspaces/viewer-target.ts`.
+`apps/packages/product-client/src/lib/domain/workspaces/viewer/viewer-target.ts`.
 
 Supported targets:
 
 - `file`: editable/readable file view
 - `fileDiff`: one file diff for `unstaged`, `staged`, or `branch`
 - `allChanges`: a scoped multi-file review view
+- `promptAttachment`: an ephemeral read-only image or text-resource preview
+  originating from a composer draft or submitted session prompt
 
 Shell-tab keys are `viewer:<base64url-json>`. The encoded payload is canonical:
 optional fields normalize to `null`, refs are trimmed, and UTF-8 paths are
 encoded through the shared base64url helper. Legacy persisted `file:<path>`
 keys are read as file viewer targets and written back as `viewer:*`.
+
+`promptAttachment` identity includes its `draft` or `session` origin,
+attachment id, display name, MIME type, optional size, image/text-resource
+kind, and upload/paste source. Draft targets may include an in-memory object
+URL and must not include a session id. Session targets never include an object
+URL; they resolve the attachment through the existing session resource access
+path and may temporarily have no usable session id while queued or optimistic
+identity is incomplete, in which case the viewer shows an unavailable state.
+
+Prompt-attachment targets are session-local UI state and are never persisted.
+Shell-tab seeding and right-panel preference sanitization discard them on
+write and restore. Draft object URLs must never be copied into durable state,
+logs, workspace files, or submitted session targets. Their lifetime is owned
+by
+`apps/packages/product-client/src/hooks/chat/ui/use-prompt-attachments.ts`:
+removal, submission, scope
+change, and unmount first remove every matching viewer target and materialized
+right-panel header through
+`apps/packages/product-client/src/hooks/chat/workflows/use-prompt-attachment-preview-actions.ts`,
+then revoke
+each owned URL exactly once. Closing the viewer alone leaves the draft and its
+URL intact. Submitted attachment blobs and derived object URLs remain owned by
+`apps/packages/product-client/src/hooks/access/anyharness/sessions/use-prompt-attachment-url.ts`;
+draft and
+session text reads, cancellation, and identity reset are owned by
+`apps/packages/product-client/src/hooks/access/prompt-attachments/use-prompt-attachment-text.ts`.
+The read-only presentation surface is
+`apps/packages/product-client/src/components/workspace/files/PromptAttachmentViewer.tsx`.
 
 `working_tree_composite` is UI-only. It is never passed to git diff queries.
 It renders separate unstaged and staged sections, and rows open `fileDiff`


### PR DESCRIPTION
## What this changes

The **chat attachment preview flow** lets people recognize, remove, and preview image and text attachments in the composer and reopen them from the transcript.

**Surface:** composer and transcript attachment cards through their read-only right-pane preview.  
**Non-goals:** ordinary file-tree/path actions, Markdown paste parsing, transport schemas, the composer control row, durable attachment storage, adjacent cleanup, and every other numbered UI slice.

## Before / after

- **Before:** Draft and submitted attachments did not share a clear, reliable preview experience, and draft removal was difficult to discover with a pointer or keyboard.
- **After:** Attachments appear as readable image or file cards, reveal removal on hover or keyboard focus, and open the correct content in the existing right-side preview without briefly showing a previous attachment.

## When this matters

This is a routine path when someone adds a screenshot or text file to a prompt, checks it before sending, or reopens the attachment later from the transcript; keep the user flow narrowly scoped as implemented.

## Demo

[Open the verified hosted Web preview](https://proliferate-web-git-codex-ui-attachment-previews-getonyx.vercel.app/) — exact head `98c6fbd25cf1fb4a91edde470aad6b984efbf065`; Vercel production Web build, not packaged Desktop; verified HTTP 200 on 2026-07-19; authentication may be required.

## Current disposition

**Merged** — squash-merged into `main` as `7a6d97f36b379ed631228dea691375ab14975789`; no further action.

## Founder decision needed

None. On 2026-07-19, founder accepted option 1: the existing exact-head implementation-state proof is sufficient for this already-built PR. No new proof or retroactive mock was manufactured.

## Design reference

**Primary reference only:** Codex Desktop `26.715.31925` (build `5551`), dark composer, specifically draft image thumbnails, draft file cards, whole-card preview activation, hover removal, and keyboard focus. Conductor was not used as a reference.

**Reference viewport and provenance:** the reusable clean-composer replay is `1440×1000` at 1× scale. It contains no attachment nodes. Attachment geometry and interaction rules were derived read-only from the packaged Codex renderer source, which has no live capture viewport.

**Elements and interactions matched:**

- `80×80` draft image thumbnails above the editor;
- compact named file cards with quiet type/size context;
- full-card pointer and keyboard preview activation;
- absolutely positioned remove controls that reveal on hover/focus without layout shift;
- quiet hover treatment and visible inset keyboard focus;
- smaller, quieter attachment presentation after send.

**Intentional Proliferate-specific divergences:**

- previews open in Proliferate’s existing right file-viewing pane, not Codex’s image-modal treatment;
- draft file cards use a fixed `210×52` footprint rather than Codex’s content-sized card with a `256px` maximum;
- transcript variants use Proliferate’s existing message hierarchy and smaller card/image sizes;
- colors, borders, radii, icons, and typography use Proliferate design tokens rather than copying Codex renderer styling literally;
- draft text and files can render through Proliferate’s plain/code viewers, while submitted attachments include Proliferate-specific loading and unavailable states;
- draft object-URL lifetime, session-resource access, focus recovery, and right-pane close behavior follow Proliferate’s workspace ownership model.

**Accepted proof limitation:** no live Codex attachment-populated composer or transcript capture was available, so exact card rhythm, hover appearance, and sent-state presentation were not compared in the same meaningful state. The Codex replay is `1440×1000`; the exact-head Proliferate proof is `1386×901`. The current proof verifies genuine Proliferate states but is not a direct reference-vs-implementation visual comparison. Founder accepted this truthful limitation for this already-built PR on 2026-07-19.

---

## Engineering evidence

Frozen base: `c91d6f9275cd6e21723f9b83388df2ac8a697389`  
Current exact head: `98c6fbd25cf1fb4a91edde470aad6b984efbf065`  
Frozen contract: UI 07 revision 2  
Squash merge SHA: `7a6d97f36b379ed631228dea691375ab14975789`

### Scope delivered

- Add Codex-informed draft and submitted attachment cards for images and text resources, including type/size metadata, hover/focus remove controls, and full-card keyboard/pointer preview activation.
- Open draft object URLs and submitted session resources in the existing right-side viewer, keep previews ephemeral across persistence/restore, and recover composer focus when attachment previews close.
- Preserve rich-editor paste ownership while adding deterministic image, pasted-text, uploaded-file, and submitted-resource states to the real ProductClient playground for visual review.
- Founder accepted the proof, the PR was marked ready, and the exact accepted head was squash-merged as `7a6d97f36b379ed631228dea691375ab14975789`.

### Review repairs

- `PR1434-B1` resolved: the generic `PromptContentRenderer` remains provider-neutral; the owning transcript boundary connects previews only for image/file content. Provider-free text/plan render regressions are covered.
- `PR1434-B2` resolved: remove, successful submit, scope change, and unmount retire every matching draft target/header before exactly-once object-URL revocation.
- `PR1434-B3` resolved: submitted image object-URL state is bound to the current session, attachment, and Blob/query identity. Identity changes synchronously expose loading/null, stale A URLs never render under B metadata, and cleanup revokes once without duplicate URL creation. Cached A→B, rapid A→B→A, cross-session, and Blob-replacement cases are covered.
- `PR1434-B4` resolved: canonical ViewerTarget documentation now records promptAttachment identity, draft/session lifetime, object-URL restrictions, non-persistability, and owner paths.
- `PR1434-B5` resolved: 52×210 card sizing and hover/focus reveal styling live in component-owned CSS imported by `PromptAttachmentCard`; the 26rem DEV aside width lives in fixture-owned CSS. The direct playground loads both owners without `authenticated.css`.
- `PR1434-D1` resolved: exact-head implementation-state proof is complete under frozen spec revision 2, and founder accepted the documented source-derived reference limitation for this already-built PR on 2026-07-19.
- `PR1434-F1` resolved without raising the JS/CSS caps. A final 11-byte remote CSS overage at the prior repair head was addressed by moving the unique draft-image `size-20` rule out of global Tailwind generation and into the existing component-owned CSS. Exact-head and merge-ref CI both pass at JS `483,556 / 485,000` and CSS `65,993 / 66,000` gzip bytes.

### Verification

- `pnpm --filter @proliferate/product-client test` — 601 files / 3,583 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build` — passed; production emits a separate `AuthenticatedProductClient-*.css` chunk.
- `node scripts/measure-login-runtime-budget.mjs --no-build` — exact head `98c6fbd2…`; JS `482,618 / 485,000`, CSS `65,854 / 66,000`, no font/image/audio first-load bytes; passed.
- Remote exact-head budget — tested `98c6fbd25cf1fb4a91edde470aad6b984efbf065`; JS `483,556 / 485,000`, CSS `65,993 / 66,000`; passed.
- Remote merge-ref budget — tested `3a49e6e3b718aff4b0382789d448e2e5585fd9fb`; JS `483,556 / 485,000`, CSS `65,993 / 66,000`; passed.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- `python3 scripts/report_frontend_structure.py --strict --summary-only` — 0 findings.
- `python3 scripts/check_docs.py` — all 220 Markdown files passed.
- `git diff --check` — passed.
- Current PR merge-ref CI: https://github.com/proliferate-ai/proliferate/actions/runs/29676717269
- Current exact-head CI: https://github.com/proliferate-ai/proliferate/actions/runs/29676800103
- All required PR checks, including full ProductClient/shared-package tests, Web/Desktop builds, CodeQL, intent tests, smoke, metadata, and Vercel deployment, pass at the current head.

### Exact-head visual proof

Capture environment: ProductClient DEV attachment playground (Web-dev, not packaged Desktop); app `0.3.43`; reserved profile `ui-07-attachments` (the minimal playground does not load profile state); HMR active; `1386×901`; `http://127.0.0.1:5757/playground?s=attachment-previews`. The local preview was stopped after capture.

Real Chrome pointer/keyboard input produced and computed-state assertions verified:

- default remove state: opacity `0`, pointer events `none`;
- genuine pointer hover: card matched `:hover`, remove opacity `1`, pointer events `auto`;
- genuine keyboard focus: remove control matched `:focus-visible`, opacity `1`, pointer events `auto`;
- draft image and in-memory text preview targets rendered under the correct identities;
- removal deleted the draft image card, cleared its active preview target/header, and left the submitted image intact.

Artifacts (local review bundle, intentionally ignored by Git):

- `reference/proliferate/composer-attachment-previews-exact-head/01-default.png`
- `reference/proliferate/composer-attachment-previews-exact-head/02-hover.png`
- `reference/proliferate/composer-attachment-previews-exact-head/03-keyboard-focus.png`
- `reference/proliferate/composer-attachment-previews-exact-head/04-image-preview.png`
- `reference/proliferate/composer-attachment-previews-exact-head/05-text-preview.png`
- `reference/proliferate/composer-attachment-previews-exact-head/06-removal.png`
- `reference/proliferate/composer-attachment-previews-exact-head/contact-sheet.png`
- `reference/proliferate/composer-attachment-previews-exact-head/ui-07-derived-still-sequence.mp4`
- `reference/proliferate/composer-attachment-previews-exact-head/metadata.json` and `analysis.md`

The MP4 is explicitly a **derived still sequence; no motion/timing evidence**. Its first slate says so, every state is visibly captioned, and the exact SHA is visible. Native continuous capture was unavailable without including unrelated shared Chrome UI, so no native-motion claim is made. The obsolete byte-identical fake hover artifact was removed.

Reference provenance:

- `reference/codex/composer-attachments-source/` — Codex Desktop `26.715.31925` packaged renderer source-derived attachment rules; no live populated state or viewport.
- `reference/codex/composer-attachments-before/` — `1440×1000` clean-composer replay; no attachment nodes.
- `reference/proliferate/composer-attachment-previews-exact-head/` — live exact-head Proliferate interaction states at `1386×901`.

### Ownership and assumptions

- Draft object URLs remain owned by the attachment hook. Closing a preview is non-destructive; removal, submission, scope change, and unmount retire target/header state before revocation.
- A queued/session attachment without a usable session identity remains selectable but renders the existing unavailable state until its resource is resolvable.
- This slice is frontend-only. No transport schema, server, runtime, Rust, Docker, or neighboring numbered UI slice changed.
