### PR TITLE
feat(product): refine sidebar navigation and footer

### DIFF
--- a/apps/packages/product-client/src/components/app/sidebar/SidebarAccountFooter.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarAccountFooter.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { CreditCard, LogOut, Settings } from "lucide-react";
+import { CreditCard, Keyboard, LogOut, Settings } from "lucide-react";
 import { Check, ChevronUpDown, Mail } from "@proliferate/ui/icons";
-import { useUsageSummary } from "@proliferate/cloud-sdk-react";
-import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ConfirmationDialog } from "@proliferate/ui/primitives/ConfirmationDialog";
 import {
@@ -14,15 +12,12 @@ import { PopoverMenuItem } from "@proliferate/ui/primitives/PopoverMenuItem";
 import { OrganizationAvatar } from "#product/components/organizations/OrganizationAvatar";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
-import { useWebAppTarget } from "#product/hooks/capabilities/derived/use-web-app-target";
 import { useAppSidebarSignOutAction } from "#product/hooks/app/workflows/use-app-sidebar-sign-out-action";
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
 import { useCurrentUserOrganizationInvitations } from "#product/hooks/access/cloud/organizations/use-current-user-organization-invitations";
 import { useOrganizationActions } from "#product/hooks/access/cloud/organizations/use-organization-actions";
 import { useJoinedOrganizationActivation } from "#product/hooks/organizations/workflows/use-joined-organization-activation";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
-import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
-import { useSupportMenuAction } from "#product/hooks/support/derived/use-support-menu-action";
 import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 import type {
   OrganizationInvitationRecord,
@@ -35,34 +30,22 @@ import {
 import { useKeyboardShortcutsDialogStore } from "#product/stores/shortcuts/keyboard-shortcuts-dialog-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
 import { OrganizationSwitchDialog } from "#product/components/app/sidebar/OrganizationSwitchDialog";
-import { SidebarAppVersionRow } from "#product/components/app/sidebar/SidebarAppVersionRow";
-import { SidebarHelpSection } from "#product/components/app/sidebar/SidebarHelpSection";
-import { ConsumptionCard } from "#product/components/app/sidebar/SidebarConsumptionCard";
+import { SidebarHelpFooter } from "#product/components/app/sidebar/SidebarHelpFooter";
+import { SidebarUsageFooter } from "#product/components/app/sidebar/SidebarUsageFooter";
 
 /**
- * The single sidebar bottom-left account block, shared verbatim by the main
- * sidebar and the settings sidebar: avatar + name/organization trigger opening
- * one popover with invitations, the organization switcher, plan, help links,
- * settings/log out and the Proliferate app-version footer.
+ * Shared sidebar footer: a wide identity/account trigger plus independent
+ * usage and help concerns. Organization behavior stays in the account surface.
  */
 export function SidebarAccountFooter() {
   const navigate = useNavigate();
   const user = useProductAuthUser();
   const authStatus = useProductAuthStatus();
-  const { openExternal } = useProductHost().links;
   const handleSignOut = useAppSidebarSignOutAction();
   const openShortcutsDialog = useKeyboardShortcutsDialogStore((state) => state.setOpen);
-  const {
-    openBug: openSupport,
-    openFeature: openPrompt,
-    disabledReason: supportDisabledReason,
-  } = useOpenSupportReportWindow({ source: "sidebar" });
-  const supportAction = useSupportMenuAction();
   const showToast = useToastStore((state) => state.show);
   const capabilities = useAppCapabilities();
-  const webApp = useWebAppTarget();
   const { data: billingPlan } = useCloudBilling();
-  const { data: usageSummary } = useUsageSummary(undefined, authStatus === "authenticated");
   const {
     activeOrganization,
     activeOrganizationId,
@@ -87,12 +70,11 @@ export function SidebarAccountFooter() {
   const planLabel = capabilities.billingEnabled && billingPlan
     ? (billingPlan.isPaidCloud ? "Pro" : "Free")
     : null;
-
-  const openExternalUrl = (url: string) => {
-    void openExternal(url).catch(() => {
-      showToast("Failed to open the link.");
-    });
-  };
+  const identityLabel = authStatus === "loading"
+    ? "Loading account…"
+    : authStatus === "authenticated"
+      ? displayName
+      : "Signed out";
 
   async function handleAcceptInvitation() {
     if (!acceptTarget) {
@@ -110,16 +92,8 @@ export function SidebarAccountFooter() {
 
   return (
     <div className="shrink-0">
-      {capabilities.usageMeteringEnabled && usageSummary ? (
-        <ConsumptionCard
-          usageSummary={usageSummary}
-          onTopUp={() => {
-            navigate("/settings?section=billing");
-          }}
-        />
-      ) : null}
-      <div aria-hidden className="h-[0.5px] bg-sidebar-border" />
-      <div className="flex items-center px-2 py-2">
+      <div aria-hidden className="mx-3 h-[0.5px] bg-sidebar-border" />
+      <div className="flex items-center gap-1 px-2 py-2">
         <PopoverButton
           align="start"
           side="top"
@@ -130,7 +104,7 @@ export function SidebarAccountFooter() {
               variant="unstyled"
               size="unstyled"
               aria-label="Open account menu"
-              className="flex h-10 w-full min-w-0 items-center gap-3 rounded-lg px-2 text-left text-sidebar-foreground hover:bg-sidebar-accent data-[state=open]:bg-sidebar-accent"
+              className="flex h-10 min-w-0 flex-1 items-center gap-3 rounded-lg px-2 text-left text-sidebar-foreground hover:bg-sidebar-accent data-[state=open]:bg-sidebar-accent"
               title={displayName}
             >
               <span className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full bg-sidebar-accent text-ui-sm font-medium text-sidebar-foreground">
@@ -158,7 +132,18 @@ export function SidebarAccountFooter() {
         >
           {(close) => (
             <div className="max-h-[28rem] overflow-y-auto">
-              {pendingInvitations.length > 0 ? (
+              <div className="px-2.5 py-2">
+                <div className="truncate text-ui font-medium text-sidebar-foreground">
+                  {identityLabel}
+                </div>
+                {authStatus === "authenticated" && user?.email && user.email !== displayName ? (
+                  <div className="truncate text-ui-sm text-sidebar-muted-foreground">
+                    {user.email}
+                  </div>
+                ) : null}
+              </div>
+
+              {authStatus === "authenticated" && pendingInvitations.length > 0 ? (
                 <div className="py-1">
                   <div className="px-2 py-1 text-ui-sm text-muted-foreground">
                     Pending invitations
@@ -180,57 +165,59 @@ export function SidebarAccountFooter() {
                 </div>
               ) : null}
 
-              <div className={`${pendingInvitations.length > 0 ? "border-t border-border-light" : ""} py-1`}>
-                {organizationsQuery.isLoading ? (
-                  <div className="px-2 py-1.5 text-ui text-muted-foreground">
-                    Loading organizations...
-                  </div>
-                ) : organizationsQuery.isError ? (
-                  <div className="px-2 py-1.5 text-ui text-muted-foreground">
-                    Organizations could not be loaded.
-                  </div>
-                ) : organizations.length > 0 ? (
-                  organizations.map((organization) => (
-                    <PopoverMenuItem
-                      key={organization.id}
-                      variant="sidebar"
-                      label={organization.name}
-                      icon={(
-                        <OrganizationAvatar
-                          name={organization.name}
-                          logoImage={organization.logoImage}
-                          className="size-5"
-                        />
-                      )}
-                      iconClassName="text-current"
-                      trailing={
-                        organization.id === activeOrganizationId
-                          ? <Check className="size-3.5" />
-                          : undefined
-                      }
-                      onClick={() => {
-                        // Org->org is semi-destructive (worker identity
-                        // rotates), so it confirms first; gaining a first
-                        // organization adopts it in place.
-                        if (organization.id !== activeOrganizationId) {
-                          if (activeOrganizationId) {
-                            setSwitchTarget(organization);
-                          } else {
-                            setActiveOrganizationId(organization.id);
-                          }
+              {authStatus === "authenticated" ? (
+                <div className={`${pendingInvitations.length > 0 ? "border-t" : ""} border-border-light py-1`}>
+                  {organizationsQuery.isLoading ? (
+                    <div className="px-2 py-1.5 text-ui text-muted-foreground">
+                      Loading organizations...
+                    </div>
+                  ) : organizationsQuery.isError ? (
+                    <div className="px-2 py-1.5 text-ui text-muted-foreground">
+                      Organizations could not be loaded.
+                    </div>
+                  ) : organizations.length > 0 ? (
+                    organizations.map((organization) => (
+                      <PopoverMenuItem
+                        key={organization.id}
+                        variant="sidebar"
+                        label={organization.name}
+                        icon={(
+                          <OrganizationAvatar
+                            name={organization.name}
+                            logoImage={organization.logoImage}
+                            className="size-5"
+                          />
+                        )}
+                        iconClassName="text-current"
+                        trailing={
+                          organization.id === activeOrganizationId
+                            ? <Check className="size-3.5" />
+                            : undefined
                         }
-                        close();
-                      }}
-                    />
-                  ))
-                ) : (
-                  <div className="px-2 py-1.5 text-ui text-muted-foreground">
-                    No organizations yet.
-                  </div>
-                )}
-              </div>
+                        onClick={() => {
+                          // Org->org is semi-destructive (worker identity
+                          // rotates), so it confirms first; gaining a first
+                          // organization adopts it in place.
+                          if (organization.id !== activeOrganizationId) {
+                            if (activeOrganizationId) {
+                              setSwitchTarget(organization);
+                            } else {
+                              setActiveOrganizationId(organization.id);
+                            }
+                          }
+                          close();
+                        }}
+                      />
+                    ))
+                  ) : (
+                    <div className="px-2 py-1.5 text-ui text-muted-foreground">
+                      No organizations yet.
+                    </div>
+                  )}
+                </div>
+              ) : null}
 
-              {planLabel ? (
+              {authStatus === "authenticated" && planLabel ? (
                 <div className="border-t border-border-light py-1">
                   <PopoverMenuItem
                     variant="sidebar"
@@ -245,18 +232,17 @@ export function SidebarAccountFooter() {
                 </div>
               ) : null}
 
-              <SidebarHelpSection
-                webApp={webApp}
-                supportAction={supportAction}
-                supportDisabledReason={supportDisabledReason}
-                openSupport={openSupport}
-                openPrompt={openPrompt}
-                openExternalUrl={openExternalUrl}
-                onShowKeyboardShortcuts={() => openShortcutsDialog(true)}
-                onClose={close}
-              />
-
               <div className="border-t border-border-light py-1">
+                <PopoverMenuItem
+                  variant="sidebar"
+                  label="Keyboard shortcuts"
+                  icon={<Keyboard className="size-4" />}
+                  trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.showKeyboardShortcuts)}</span>}
+                  onClick={() => {
+                    close();
+                    openShortcutsDialog(true);
+                  }}
+                />
                 <PopoverMenuItem
                   variant="sidebar"
                   label="Settings"
@@ -267,25 +253,23 @@ export function SidebarAccountFooter() {
                     close();
                   }}
                 />
-                <PopoverMenuItem
-                  variant="sidebar"
-                  label="Log out"
-                  icon={<LogOut className="size-4" />}
-                  onClick={() => {
-                    handleSignOut();
-                    close();
-                  }}
-                />
+                {authStatus === "authenticated" ? (
+                  <PopoverMenuItem
+                    variant="sidebar"
+                    label="Log out"
+                    icon={<LogOut className="size-4" />}
+                    onClick={() => {
+                      handleSignOut();
+                      close();
+                    }}
+                  />
+                ) : null}
               </div>
-
-              <SidebarAppVersionRow
-                connectedServerName={
-                  capabilities.isSelfManaged ? capabilities.serverDisplayName : null
-                }
-              />
             </div>
           )}
         </PopoverButton>
+        <SidebarUsageFooter />
+        <SidebarHelpFooter />
       </div>
       <ConfirmationDialog
         open={acceptTarget !== null}

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
@@ -57,22 +57,54 @@ describe("sidebar consumption", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
-  it("shows only supported billing actions and a truthful admin limit message", () => {
+  it("shows one supported Billing action without a duplicate Top up label", () => {
     const onBilling = vi.fn();
     render(
+      <ConsumptionCard
+        state={{ kind: "ready", usageSummary: usage() }}
+        actions={{ kind: "billing", onBilling }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Billing" }));
+    expect(onBilling).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps admin-managed billing singular and explains the limit owner", () => {
+    const onBilling = vi.fn();
+    const { rerender } = render(
+      <ConsumptionCard
+        state={{ kind: "ready", usageSummary: usage({ canSelfServeTopUp: false }) }}
+        actions={{
+          kind: "admin-managed",
+          message: "Billing is managed by your organization admins.",
+          onBilling,
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Billing" }));
+    expect(onBilling).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Billing is managed by your organization admins.")).not.toBeNull();
+
+    rerender(
       <ConsumptionCard
         state={{
           kind: "ready",
           usageSummary: usage({ llmRemainingUsd: 0, canSelfServeTopUp: false }),
         }}
-        actions={{ kind: "admin-managed", onBilling }}
+        actions={{
+          kind: "admin-managed",
+          message: "Billing is managed by your organization admins.",
+          onBilling,
+        }}
       />,
     );
-
-    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
     expect(screen.getByText("Ask your admin to raise your limit.")).not.toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Billing" }));
-    expect(onBilling).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Billing is managed by your organization admins.")).toBeNull();
+    expect(screen.getByRole("button", { name: "Billing" })).not.toBeNull();
   });
 
   describe.each([

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
@@ -6,6 +6,8 @@ import type { UsageSummary } from "@proliferate/cloud-sdk";
 import {
   ConsumptionCard,
   SidebarUsageMeterTrigger,
+  type SidebarConsumptionMeter,
+  type SidebarConsumptionState,
 } from "#product/components/app/sidebar/SidebarConsumptionCard";
 
 afterEach(cleanup);
@@ -73,34 +75,167 @@ describe("sidebar consumption", () => {
     expect(onBilling).toHaveBeenCalledTimes(1);
   });
 
-  it("renders zero allocations as exhausted instead of zero percent used", () => {
+  describe.each([
+    ["compute", "Compute"],
+    ["llm", "LLM"],
+  ] as const)("%s meter truthfulness", (meter, label) => {
+    it.each([
+      {
+        name: "zero allocation",
+        scenario: "zero-allocation",
+        ariaStatus: "No allocation",
+        detail: "No allocation",
+        fullRing: true,
+      },
+      {
+        name: "authoritative zero cap",
+        scenario: "zero-cap",
+        ariaStatus: "No allocation",
+        detail: "No allocation",
+        fullRing: true,
+      },
+      {
+        name: "positive exhausted usage",
+        scenario: "exhausted",
+        ariaStatus: "100% used, exhausted",
+        detail: "100% used · Exhausted",
+        fullRing: true,
+      },
+      {
+        name: "nonzero remaining usage",
+        scenario: "available",
+        ariaStatus: "10% used",
+        detail: "10% used",
+        fullRing: false,
+      },
+      {
+        name: "explicit blocked limit without usage",
+        scenario: "blocked",
+        ariaStatus: "blocked",
+        detail: "Blocked",
+        fullRing: true,
+      },
+      {
+        name: "positive explicit blocked limit",
+        scenario: "positive-blocked",
+        ariaStatus: "100% used, exhausted, blocked",
+        detail: "100% used · Exhausted · Blocked",
+        fullRing: true,
+      },
+      {
+        name: "loading",
+        scenario: "loading",
+        ariaStatus: "loading",
+        detail: "Loading usage",
+        fullRing: false,
+      },
+      {
+        name: "unavailable",
+        scenario: "unavailable",
+        ariaStatus: "unavailable",
+        detail: "Usage unavailable",
+        fullRing: false,
+      },
+    ] as const)("keeps $name visual text and ARIA aligned", ({
+      scenario,
+      ariaStatus,
+      detail,
+      fullRing,
+    }) => {
+      const state = stateForMeterScenario(meter, scenario);
+      render(
+        <>
+          <SidebarUsageMeterTrigger meter={meter} state={state} />
+          <ConsumptionCard state={state} />
+        </>,
+      );
+
+      const trigger = screen.getByRole("button", { name: new RegExp(`${label} usage`) });
+      expect(trigger.getAttribute("aria-label")).toContain(ariaStatus);
+      const dashOffset = trigger.querySelectorAll("circle")[1]?.getAttribute("stroke-dashoffset");
+      expect(dashOffset === "0").toBe(fullRing);
+
+      if (state.kind === "ready") {
+        expect(screen.getByText(label).parentElement?.textContent).toContain(detail);
+        if (scenario === "zero-allocation") {
+          expect(screen.queryByText("0% used")).toBeNull();
+        }
+      } else {
+        expect(screen.getByText(new RegExp(detail))).not.toBeNull();
+      }
+    });
+  });
+
+  it("preserves contractually supported unlimited Compute usage", () => {
     const state = {
       kind: "ready",
-      usageSummary: usage({
-        computeUsedSecondsMtd: 0,
-        computeRemainingSeconds: 0,
-        llmUsedUsdMtd: 0,
-        llmRemainingUsd: 0,
-      }),
+      usageSummary: usage({ computeRemainingSeconds: null }),
     } as const;
     render(
       <>
         <SidebarUsageMeterTrigger meter="compute" state={state} />
-        <ConsumptionCard
-          state={state}
-          actions={{ kind: "unavailable", message: "Billing unavailable." }}
-        />
+        <ConsumptionCard state={state} />
       </>,
     );
 
-    const compute = screen.getByRole("button", { name: /Compute usage, exhausted/ });
-    expect(compute).not.toBeNull();
-    expect(compute.querySelectorAll("circle")[1]?.getAttribute("stroke-dashoffset")).toBe("0");
-    expect(screen.queryByText("0% used")).toBeNull();
-    expect(screen.getAllByText("No allocation")).toHaveLength(2);
-    expect(screen.getByText("Billing unavailable.")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute usage, unlimited/ })).not.toBeNull();
+    expect(screen.getByText("Compute").parentElement?.textContent).toContain("No limit");
   });
 });
+
+type MeterScenario =
+  | "zero-allocation"
+  | "zero-cap"
+  | "exhausted"
+  | "available"
+  | "blocked"
+  | "positive-blocked"
+  | "loading"
+  | "unavailable";
+
+function stateForMeterScenario(
+  meter: SidebarConsumptionMeter,
+  scenario: MeterScenario,
+): SidebarConsumptionState {
+  if (scenario === "loading") {
+    return { kind: "loading" };
+  }
+  if (scenario === "unavailable") {
+    return { kind: "unavailable", message: "Usage service did not respond." };
+  }
+
+  const usedValue = scenario === "zero-allocation"
+    || scenario === "zero-cap"
+    || scenario === "blocked"
+    ? 0
+    : 1;
+  const remainingValue = scenario === "zero-allocation" || scenario === "exhausted" ? 0 : 9;
+  const limit = scenario === "zero-cap"
+    ? { window: "month", capValue: 0, usedValue: 0, blocked: true }
+    : scenario === "blocked" || scenario === "positive-blocked"
+      ? {
+        window: "month",
+        capValue: 10,
+        usedValue: scenario === "positive-blocked" ? 1 : 0,
+        blocked: true,
+      }
+      : null;
+
+  return {
+    kind: "ready",
+    usageSummary: usage(meter === "compute"
+      ? {
+        computeUsedSecondsMtd: usedValue,
+        computeRemainingSeconds: remainingValue,
+        computeLimit: limit,
+      }
+      : {
+        llmUsedUsdMtd: usedValue,
+        llmRemainingUsd: remainingValue,
+        llmLimit: limit,
+      }),
+  };
+}
 
 function usage(overrides: Partial<UsageSummary> = {}): UsageSummary {
   return {

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UsageSummary } from "@proliferate/cloud-sdk";
+import {
+  ConsumptionCard,
+  SidebarUsageMeterTrigger,
+} from "#product/components/app/sidebar/SidebarConsumptionCard";
+
+afterEach(cleanup);
+
+describe("sidebar consumption", () => {
+  it("renders independently labeled keyboard-focusable Compute and LLM rings", () => {
+    const onComputeOpen = vi.fn();
+    const onLlmOpen = vi.fn();
+    const state = { kind: "ready", usageSummary: usage() } as const;
+    render(
+      <>
+        <SidebarUsageMeterTrigger meter="compute" state={state} onClick={onComputeOpen} />
+        <SidebarUsageMeterTrigger meter="llm" state={state} onClick={onLlmOpen} />
+      </>,
+    );
+
+    const compute = screen.getByRole("button", { name: /Compute usage, 50% used/ });
+    const llm = screen.getByRole("button", { name: /LLM usage, 90% used/ });
+    expect(compute.getAttribute("type")).toBe("button");
+    expect(llm.getAttribute("type")).toBe("button");
+    compute.focus();
+    expect(document.activeElement).toBe(compute);
+    llm.focus();
+    expect(document.activeElement).toBe(llm);
+    fireEvent.keyDown(compute, { key: "Enter" });
+    fireEvent.keyDown(llm, { key: " " });
+    expect(onComputeOpen).toHaveBeenCalledTimes(1);
+    expect(onLlmOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps loading and unavailable states explicit", () => {
+    const { rerender } = render(
+      <ConsumptionCard state={{ kind: "loading" }} />,
+    );
+    expect(screen.getByRole("status").textContent).toContain("Loading usage");
+
+    const onRetry = vi.fn();
+    rerender(
+      <ConsumptionCard
+        state={{ kind: "unavailable", message: "Usage service did not respond." }}
+        onRetry={onRetry}
+      />,
+    );
+    expect(screen.getByText("Usage unavailable")).not.toBeNull();
+    expect(screen.getByText("Usage service did not respond.")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows only supported billing actions and a truthful admin limit message", () => {
+    const onBilling = vi.fn();
+    render(
+      <ConsumptionCard
+        state={{
+          kind: "ready",
+          usageSummary: usage({ llmRemainingUsd: 0, canSelfServeTopUp: false }),
+        }}
+        onBilling={onBilling}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
+    expect(screen.getByText("Ask your admin to raise your limit.")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Billing" }));
+    expect(onBilling).toHaveBeenCalledTimes(1);
+  });
+});
+
+function usage(overrides: Partial<UsageSummary> = {}): UsageSummary {
+  return {
+    computeUsedSecondsMtd: 3600,
+    computeRemainingSeconds: 3600,
+    llmUsedUsdMtd: 9,
+    llmRemainingUsd: 1,
+    computeLimit: null,
+    llmLimit: null,
+    canSelfServeTopUp: true,
+    ...overrides,
+  };
+}

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
@@ -63,7 +63,7 @@ describe("sidebar consumption", () => {
           kind: "ready",
           usageSummary: usage({ llmRemainingUsd: 0, canSelfServeTopUp: false }),
         }}
-        onBilling={onBilling}
+        actions={{ kind: "admin-managed", onBilling }}
       />,
     );
 
@@ -71,6 +71,34 @@ describe("sidebar consumption", () => {
     expect(screen.getByText("Ask your admin to raise your limit.")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Billing" }));
     expect(onBilling).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders zero allocations as exhausted instead of zero percent used", () => {
+    const state = {
+      kind: "ready",
+      usageSummary: usage({
+        computeUsedSecondsMtd: 0,
+        computeRemainingSeconds: 0,
+        llmUsedUsdMtd: 0,
+        llmRemainingUsd: 0,
+      }),
+    } as const;
+    render(
+      <>
+        <SidebarUsageMeterTrigger meter="compute" state={state} />
+        <ConsumptionCard
+          state={state}
+          actions={{ kind: "unavailable", message: "Billing unavailable." }}
+        />
+      </>,
+    );
+
+    const compute = screen.getByRole("button", { name: /Compute usage, exhausted/ });
+    expect(compute).not.toBeNull();
+    expect(compute.querySelectorAll("circle")[1]?.getAttribute("stroke-dashoffset")).toBe("0");
+    expect(screen.queryByText("0% used")).toBeNull();
+    expect(screen.getAllByText("No allocation")).toHaveLength(2);
+    expect(screen.getByText("Billing unavailable.")).not.toBeNull();
   });
 });
 

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
@@ -4,12 +4,18 @@ import { Button } from "@proliferate/ui/primitives/Button";
 
 type ConsumptionMeterTone = "default" | "warning" | "destructive";
 
-type ConsumptionMeterKind = "unlimited" | "available" | "blocked" | "exhausted";
+type ConsumptionMeterKind =
+  | "unlimited"
+  | "available"
+  | "blocked"
+  | "zero-allocation"
+  | "exhausted";
 
 interface ConsumptionMeterState {
   kind: ConsumptionMeterKind;
   percent: number | null;
   tone: ConsumptionMeterTone;
+  blocked: boolean;
 }
 
 export type SidebarConsumptionState =
@@ -41,34 +47,72 @@ function resolveConsumptionMeterState(
 ): ConsumptionMeterState {
   if (limit) {
     if (limit.capValue <= 0) {
-      return { kind: "exhausted", percent: 100, tone: "destructive" };
+      return limit.usedValue > 0
+        ? { kind: "exhausted", percent: 100, tone: "destructive", blocked: limit.blocked }
+        : { kind: "zero-allocation", percent: 100, tone: "destructive", blocked: limit.blocked };
+    }
+    if (limit.blocked) {
+      return limit.usedValue > 0
+        ? { kind: "exhausted", percent: 100, tone: "destructive", blocked: true }
+        : { kind: "blocked", percent: 100, tone: "destructive", blocked: true };
     }
     const percent = Math.min(100, (limit.usedValue / limit.capValue) * 100);
-    if (limit.blocked) {
-      return { kind: "blocked", percent, tone: "destructive" };
-    }
     return {
       kind: "available",
       percent,
       tone: percent >= CONSUMPTION_NEAR_LIMIT_PERCENT ? "warning" : "default",
+      blocked: false,
     };
   }
 
   if (remainingValue === null) {
-    return { kind: "unlimited", percent: null, tone: "default" };
+    return { kind: "unlimited", percent: null, tone: "default", blocked: false };
+  }
+
+  if (remainingValue <= 0) {
+    return usedValue > 0
+      ? { kind: "exhausted", percent: 100, tone: "destructive", blocked: false }
+      : { kind: "zero-allocation", percent: 100, tone: "destructive", blocked: false };
   }
 
   const total = usedValue + remainingValue;
-  if (total <= 0 || remainingValue <= 0) {
-    return { kind: "exhausted", percent: 100, tone: "destructive" };
-  }
-
   const percent = Math.min(100, (usedValue / total) * 100);
   return {
     kind: "available",
     percent,
     tone: percent >= CONSUMPTION_NEAR_LIMIT_PERCENT ? "warning" : "default",
+    blocked: false,
   };
+}
+
+function consumptionMeterAriaStatus(state: ConsumptionMeterState): string {
+  switch (state.kind) {
+    case "zero-allocation":
+      return "No allocation";
+    case "exhausted":
+      return `100% used, exhausted${state.blocked ? ", blocked" : ""}`;
+    case "blocked":
+      return "blocked";
+    case "unlimited":
+      return "unlimited";
+    case "available":
+      return `${Math.round(state.percent ?? 0)}% used`;
+  }
+}
+
+function consumptionMeterDetailLabel(state: ConsumptionMeterState): string {
+  switch (state.kind) {
+    case "zero-allocation":
+      return "No allocation";
+    case "exhausted":
+      return `100% used · Exhausted${state.blocked ? " · Blocked" : ""}`;
+    case "blocked":
+      return "Blocked";
+    case "unlimited":
+      return "No limit";
+    case "available":
+      return `${Math.round(state.percent ?? 0)}% used`;
+  }
 }
 
 function formatRemainingHours(seconds: number | null): string {
@@ -124,18 +168,12 @@ export const SidebarUsageMeterTrigger = forwardRef<
   const label = meter === "compute" ? "Compute" : "LLM";
   const shortLabel = meter === "compute" ? "C" : "L";
   const percent = meters?.[meter].percent ?? null;
-  const meterKind = meters?.[meter].kind ?? null;
   const tone = meters?.[meter].tone ?? fallbackTone;
-  const percentLabel = percent === null ? null : `${Math.round(percent)}% used`;
   const statusLabel = state.kind === "loading"
     ? "loading"
     : state.kind === "unavailable"
       ? "unavailable"
-      : meterKind === "exhausted"
-        ? "exhausted"
-        : meterKind === "blocked"
-          ? `${percentLabel}, blocked`
-          : percentLabel ?? "unlimited";
+      : consumptionMeterAriaStatus(meters![meter]);
   const dashOffset = percent === null
     ? RING_CIRCUMFERENCE
     : RING_CIRCUMFERENCE * (1 - Math.max(0, Math.min(100, percent)) / 100);
@@ -196,11 +234,7 @@ function ConsumptionDetailRow({
   state: ConsumptionMeterState;
   remainingLabel: string;
 }) {
-  const usedLabel = state.kind === "exhausted"
-    ? "No allocation"
-    : state.percent === null
-      ? "No limit"
-      : `${Math.round(state.percent)}% used`;
+  const usedLabel = consumptionMeterDetailLabel(state);
   return (
     <div className="flex items-center justify-between gap-3 px-2.5 py-1.5">
       <div>
@@ -250,8 +284,10 @@ export function ConsumptionCard({
 
   const meters = metersForState(state)!;
   const blocked = meters.compute.kind === "blocked"
+    || meters.compute.kind === "zero-allocation"
     || meters.compute.kind === "exhausted"
     || meters.llm.kind === "blocked"
+    || meters.llm.kind === "zero-allocation"
     || meters.llm.kind === "exhausted";
 
   return (

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
@@ -4,9 +4,11 @@ import { Button } from "@proliferate/ui/primitives/Button";
 
 type ConsumptionMeterTone = "default" | "warning" | "destructive";
 
+type ConsumptionMeterKind = "unlimited" | "available" | "blocked" | "exhausted";
+
 interface ConsumptionMeterState {
+  kind: ConsumptionMeterKind;
   percent: number | null;
-  blocked: boolean;
   tone: ConsumptionMeterTone;
 }
 
@@ -16,6 +18,11 @@ export type SidebarConsumptionState =
   | { kind: "ready"; usageSummary: UsageSummary };
 
 export type SidebarConsumptionMeter = "compute" | "llm";
+
+export type SidebarConsumptionActions =
+  | { kind: "self-serve"; onTopUp: () => void; onBilling: () => void }
+  | { kind: "admin-managed"; onBilling: () => void }
+  | { kind: "unavailable"; message: string };
 
 const CONSUMPTION_NEAR_LIMIT_PERCENT = 80;
 const RING_RADIUS = 8;
@@ -32,30 +39,36 @@ function resolveConsumptionMeterState(
   remainingValue: number | null,
   limit: UsageSummary["computeLimit"],
 ): ConsumptionMeterState {
-  let percent: number | null;
-  let blocked: boolean;
-
   if (limit) {
-    percent = limit.capValue > 0
-      ? Math.min(100, (limit.usedValue / limit.capValue) * 100)
-      : 100;
-    blocked = limit.blocked;
-  } else if (remainingValue !== null) {
-    const total = usedValue + remainingValue;
-    percent = total > 0 ? Math.min(100, (usedValue / total) * 100) : 0;
-    blocked = remainingValue <= 0;
-  } else {
-    percent = null;
-    blocked = false;
+    if (limit.capValue <= 0) {
+      return { kind: "exhausted", percent: 100, tone: "destructive" };
+    }
+    const percent = Math.min(100, (limit.usedValue / limit.capValue) * 100);
+    if (limit.blocked) {
+      return { kind: "blocked", percent, tone: "destructive" };
+    }
+    return {
+      kind: "available",
+      percent,
+      tone: percent >= CONSUMPTION_NEAR_LIMIT_PERCENT ? "warning" : "default",
+    };
   }
 
-  const tone: ConsumptionMeterTone = blocked
-    ? "destructive"
-    : percent !== null && percent >= CONSUMPTION_NEAR_LIMIT_PERCENT
-      ? "warning"
-      : "default";
+  if (remainingValue === null) {
+    return { kind: "unlimited", percent: null, tone: "default" };
+  }
 
-  return { percent, blocked, tone };
+  const total = usedValue + remainingValue;
+  if (total <= 0 || remainingValue <= 0) {
+    return { kind: "exhausted", percent: 100, tone: "destructive" };
+  }
+
+  const percent = Math.min(100, (usedValue / total) * 100);
+  return {
+    kind: "available",
+    percent,
+    tone: percent >= CONSUMPTION_NEAR_LIMIT_PERCENT ? "warning" : "default",
+  };
 }
 
 function formatRemainingHours(seconds: number | null): string {
@@ -111,13 +124,18 @@ export const SidebarUsageMeterTrigger = forwardRef<
   const label = meter === "compute" ? "Compute" : "LLM";
   const shortLabel = meter === "compute" ? "C" : "L";
   const percent = meters?.[meter].percent ?? null;
+  const meterKind = meters?.[meter].kind ?? null;
   const tone = meters?.[meter].tone ?? fallbackTone;
   const percentLabel = percent === null ? null : `${Math.round(percent)}% used`;
   const statusLabel = state.kind === "loading"
     ? "loading"
     : state.kind === "unavailable"
       ? "unavailable"
-      : percentLabel ?? "unlimited";
+      : meterKind === "exhausted"
+        ? "exhausted"
+        : meterKind === "blocked"
+          ? `${percentLabel}, blocked`
+          : percentLabel ?? "unlimited";
   const dashOffset = percent === null
     ? RING_CIRCUMFERENCE
     : RING_CIRCUMFERENCE * (1 - Math.max(0, Math.min(100, percent)) / 100);
@@ -178,7 +196,11 @@ function ConsumptionDetailRow({
   state: ConsumptionMeterState;
   remainingLabel: string;
 }) {
-  const usedLabel = state.percent === null ? "No limit" : `${Math.round(state.percent)}% used`;
+  const usedLabel = state.kind === "exhausted"
+    ? "No allocation"
+    : state.percent === null
+      ? "No limit"
+      : `${Math.round(state.percent)}% used`;
   return (
     <div className="flex items-center justify-between gap-3 px-2.5 py-1.5">
       <div>
@@ -198,13 +220,11 @@ function ConsumptionDetailRow({
 export function ConsumptionCard({
   state,
   onRetry,
-  onTopUp,
-  onBilling,
+  actions,
 }: {
   state: SidebarConsumptionState;
   onRetry?: () => void;
-  onTopUp?: () => void;
-  onBilling?: () => void;
+  actions?: SidebarConsumptionActions;
 }) {
   if (state.kind === "loading") {
     return (
@@ -229,7 +249,10 @@ export function ConsumptionCard({
   }
 
   const meters = metersForState(state)!;
-  const blocked = meters.compute.blocked || meters.llm.blocked;
+  const blocked = meters.compute.kind === "blocked"
+    || meters.compute.kind === "exhausted"
+    || meters.llm.kind === "blocked"
+    || meters.llm.kind === "exhausted";
 
   return (
     <div className="py-1">
@@ -246,23 +269,26 @@ export function ConsumptionCard({
         state={meters.llm}
         remainingLabel={formatRemainingUsd(state.usageSummary.llmRemainingUsd)}
       />
-      {blocked && !onTopUp ? (
+      {blocked && actions?.kind === "admin-managed" ? (
         <div className="px-2.5 py-1.5 text-ui-sm text-destructive">
           Ask your admin to raise your limit.
         </div>
       ) : null}
-      {onTopUp || onBilling ? (
+      {blocked && actions?.kind === "unavailable" ? (
+        <div className="px-2.5 py-1.5 text-ui-sm text-sidebar-muted-foreground">
+          {actions.message}
+        </div>
+      ) : null}
+      {actions?.kind === "self-serve" || actions?.kind === "admin-managed" ? (
         <div className="mt-1 flex gap-2 border-t border-border-light px-2 py-2">
-          {onTopUp ? (
-            <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={onTopUp}>
+          {actions.kind === "self-serve" ? (
+            <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={actions.onTopUp}>
               Top up
             </Button>
           ) : null}
-          {onBilling ? (
-            <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={onBilling}>
-              Billing
-            </Button>
-          ) : null}
+          <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={actions.onBilling}>
+            Billing
+          </Button>
         </div>
       ) : null}
     </div>

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
@@ -26,8 +26,8 @@ export type SidebarConsumptionState =
 export type SidebarConsumptionMeter = "compute" | "llm";
 
 export type SidebarConsumptionActions =
-  | { kind: "self-serve"; onTopUp: () => void; onBilling: () => void }
-  | { kind: "admin-managed"; onBilling: () => void }
+  | { kind: "billing"; onBilling: () => void }
+  | { kind: "admin-managed"; message: string; onBilling: () => void }
   | { kind: "unavailable"; message: string };
 
 const CONSUMPTION_NEAR_LIMIT_PERCENT = 80;
@@ -310,18 +310,18 @@ export function ConsumptionCard({
           Ask your admin to raise your limit.
         </div>
       ) : null}
-      {blocked && actions?.kind === "unavailable" ? (
+      {!blocked && actions?.kind === "admin-managed" ? (
         <div className="px-2.5 py-1.5 text-ui-sm text-sidebar-muted-foreground">
           {actions.message}
         </div>
       ) : null}
-      {actions?.kind === "self-serve" || actions?.kind === "admin-managed" ? (
+      {actions?.kind === "unavailable" ? (
+        <div className="px-2.5 py-1.5 text-ui-sm text-sidebar-muted-foreground">
+          {actions.message}
+        </div>
+      ) : null}
+      {actions?.kind === "billing" || actions?.kind === "admin-managed" ? (
         <div className="mt-1 flex gap-2 border-t border-border-light px-2 py-2">
-          {actions.kind === "self-serve" ? (
-            <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={actions.onTopUp}>
-              Top up
-            </Button>
-          ) : null}
           <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={actions.onBilling}>
             Billing
           </Button>

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
@@ -1,6 +1,6 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
 import type { UsageSummary } from "@proliferate/cloud-sdk";
 import { Button } from "@proliferate/ui/primitives/Button";
-import { ProgressBar } from "@proliferate/ui/primitives/ProgressBar";
 
 type ConsumptionMeterTone = "default" | "warning" | "destructive";
 
@@ -10,13 +10,16 @@ interface ConsumptionMeterState {
   tone: ConsumptionMeterTone;
 }
 
-const CONSUMPTION_NEAR_LIMIT_PERCENT = 80;
+export type SidebarConsumptionState =
+  | { kind: "loading" }
+  | { kind: "unavailable"; message: string }
+  | { kind: "ready"; usageSummary: UsageSummary };
 
-const CONSUMPTION_METER_INDICATOR_CLASS: Record<ConsumptionMeterTone, string> = {
-  default: "h-full rounded-full bg-primary/70",
-  warning: "h-full rounded-full bg-warning-foreground",
-  destructive: "h-full rounded-full bg-destructive",
-};
+export type SidebarConsumptionMeter = "compute" | "llm";
+
+const CONSUMPTION_NEAR_LIMIT_PERCENT = 80;
+const RING_RADIUS = 8;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
 const CONSUMPTION_METER_TEXT_CLASS: Record<ConsumptionMeterTone, string> = {
   default: "text-sidebar-muted-foreground",
@@ -24,11 +27,6 @@ const CONSUMPTION_METER_TEXT_CLASS: Record<ConsumptionMeterTone, string> = {
   destructive: "text-destructive",
 };
 
-/**
- * The tightest enabled limit (if any) wins per §3.1's `*Limit` contract; when
- * there is no limit we fall back to used/remaining balance for the bar and
- * treat an exhausted balance as blocked.
- */
 function resolveConsumptionMeterState(
   usedValue: number,
   remainingValue: number | null,
@@ -72,7 +70,106 @@ function formatRemainingUsd(usd: number): string {
   return `$${Math.max(usd, 0).toFixed(2)} left`;
 }
 
-function ConsumptionMeterRow({
+function metersForState(state: SidebarConsumptionState) {
+  if (state.kind !== "ready") {
+    return null;
+  }
+  return {
+    compute: resolveConsumptionMeterState(
+      state.usageSummary.computeUsedSecondsMtd,
+      state.usageSummary.computeRemainingSeconds,
+      state.usageSummary.computeLimit,
+    ),
+    llm: resolveConsumptionMeterState(
+      state.usageSummary.llmUsedUsdMtd,
+      state.usageSummary.llmRemainingUsd,
+      state.usageSummary.llmLimit,
+    ),
+  };
+}
+
+interface SidebarUsageMeterTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  meter: SidebarConsumptionMeter;
+  state: SidebarConsumptionState;
+}
+
+/** One independently labeled, focusable ring trigger for the usage concern. */
+export const SidebarUsageMeterTrigger = forwardRef<
+  HTMLButtonElement,
+  SidebarUsageMeterTriggerProps
+>(function SidebarUsageMeterTrigger({
+  meter,
+  state,
+  className = "",
+  onKeyDown,
+  ...buttonProps
+}, ref) {
+  const meters = metersForState(state);
+  const fallbackTone: ConsumptionMeterTone = state.kind === "unavailable"
+    ? "destructive"
+    : "default";
+  const label = meter === "compute" ? "Compute" : "LLM";
+  const shortLabel = meter === "compute" ? "C" : "L";
+  const percent = meters?.[meter].percent ?? null;
+  const tone = meters?.[meter].tone ?? fallbackTone;
+  const percentLabel = percent === null ? null : `${Math.round(percent)}% used`;
+  const statusLabel = state.kind === "loading"
+    ? "loading"
+    : state.kind === "unavailable"
+      ? "unavailable"
+      : percentLabel ?? "unlimited";
+  const dashOffset = percent === null
+    ? RING_CIRCUMFERENCE
+    : RING_CIRCUMFERENCE * (1 - Math.max(0, Math.min(100, percent)) / 100);
+
+  return (
+    <Button
+      {...buttonProps}
+      ref={ref}
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      aria-label={`${label} usage, ${statusLabel}. Open usage details`}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (!event.defaultPrevented && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          event.currentTarget.click();
+        }
+      }}
+      className={`relative flex size-7 shrink-0 items-center justify-center rounded-full text-sidebar-muted-foreground outline-none hover:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring data-[state=open]:text-sidebar-foreground ${className}`}
+    >
+      <svg viewBox="0 0 20 20" className="size-5 -rotate-90" aria-hidden="true">
+        <circle
+          cx="10"
+          cy="10"
+          r={RING_RADIUS}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="opacity-20"
+        />
+        <circle
+          cx="10"
+          cy="10"
+          r={RING_RADIUS}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeDasharray={RING_CIRCUMFERENCE}
+          strokeDashoffset={dashOffset}
+          className={CONSUMPTION_METER_TEXT_CLASS[tone]}
+        />
+      </svg>
+      <span className="pointer-events-none absolute text-[7px] font-semibold leading-none text-sidebar-foreground" aria-hidden="true">
+        {state.kind === "unavailable" ? "!" : shortLabel}
+      </span>
+    </Button>
+  );
+});
+
+function ConsumptionDetailRow({
   label,
   state,
   remainingLabel,
@@ -81,67 +178,91 @@ function ConsumptionMeterRow({
   state: ConsumptionMeterState;
   remainingLabel: string;
 }) {
+  const usedLabel = state.percent === null ? "No limit" : `${Math.round(state.percent)}% used`;
   return (
-    <div className="flex items-center gap-2 px-2.5 py-1">
-      <span className="w-20 shrink-0 text-ui-sm text-sidebar-foreground">{label}</span>
-      <ProgressBar
-        value={state.percent ?? 0}
-        className="h-1.5 flex-1 overflow-hidden rounded-full bg-sidebar-accent"
-        indicatorClassName={CONSUMPTION_METER_INDICATOR_CLASS[state.tone]}
-        aria-label={`${label} usage`}
-      />
-      <span className={`shrink-0 text-ui-sm ${CONSUMPTION_METER_TEXT_CLASS[state.tone]}`}>
+    <div className="flex items-center justify-between gap-3 px-2.5 py-1.5">
+      <div>
+        <div className="text-ui text-sidebar-foreground">{label}</div>
+        <div className={`text-ui-sm ${CONSUMPTION_METER_TEXT_CLASS[state.tone]}`}>
+          {usedLabel}
+        </div>
+      </div>
+      <div className={`text-right text-ui-sm ${CONSUMPTION_METER_TEXT_CLASS[state.tone]}`}>
         {remainingLabel}
-      </span>
+      </div>
     </div>
   );
 }
 
-/**
- * Compute + LLM usage meters, personal scope only (an admin's org-wide view
- * lives in Usage & limits settings — spec decision). Rendered always-visible
- * in the sidebar directly above the account footer, not inside its popover.
- */
+/** Usage detail surface opened by the circular footer meters. */
 export function ConsumptionCard({
-  usageSummary,
+  state,
+  onRetry,
   onTopUp,
+  onBilling,
 }: {
-  usageSummary: UsageSummary;
-  onTopUp: () => void;
+  state: SidebarConsumptionState;
+  onRetry?: () => void;
+  onTopUp?: () => void;
+  onBilling?: () => void;
 }) {
-  const computeState = resolveConsumptionMeterState(
-    usageSummary.computeUsedSecondsMtd,
-    usageSummary.computeRemainingSeconds,
-    usageSummary.computeLimit,
-  );
-  const llmState = resolveConsumptionMeterState(
-    usageSummary.llmUsedUsdMtd,
-    usageSummary.llmRemainingUsd,
-    usageSummary.llmLimit,
-  );
-  const blocked = computeState.blocked || llmState.blocked;
+  if (state.kind === "loading") {
+    return (
+      <div className="px-3 py-3 text-ui text-sidebar-muted-foreground" role="status">
+        Loading usage…
+      </div>
+    );
+  }
+
+  if (state.kind === "unavailable") {
+    return (
+      <div className="space-y-2 px-3 py-3">
+        <div className="text-ui text-sidebar-foreground">Usage unavailable</div>
+        <div className="text-ui-sm text-sidebar-muted-foreground">{state.message}</div>
+        {onRetry ? (
+          <Button type="button" variant="secondary" size="sm" className="w-full" onClick={onRetry}>
+            Try again
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  const meters = metersForState(state)!;
+  const blocked = meters.compute.blocked || meters.llm.blocked;
 
   return (
-    <div className="border-t border-border-light py-1">
-      <ConsumptionMeterRow
+    <div className="py-1">
+      <div className="px-2.5 pb-1 pt-1 text-ui-sm font-medium text-sidebar-muted-foreground">
+        Usage
+      </div>
+      <ConsumptionDetailRow
         label="Compute"
-        state={computeState}
-        remainingLabel={formatRemainingHours(usageSummary.computeRemainingSeconds)}
+        state={meters.compute}
+        remainingLabel={formatRemainingHours(state.usageSummary.computeRemainingSeconds)}
       />
-      <ConsumptionMeterRow
-        label="LLM credits"
-        state={llmState}
-        remainingLabel={formatRemainingUsd(usageSummary.llmRemainingUsd)}
+      <ConsumptionDetailRow
+        label="LLM"
+        state={meters.llm}
+        remainingLabel={formatRemainingUsd(state.usageSummary.llmRemainingUsd)}
       />
-      {blocked ? (
-        <div className="px-2.5 pt-1">
-          {usageSummary.canSelfServeTopUp ? (
-            <Button type="button" variant="secondary" size="sm" className="w-full" onClick={onTopUp}>
+      {blocked && !onTopUp ? (
+        <div className="px-2.5 py-1.5 text-ui-sm text-destructive">
+          Ask your admin to raise your limit.
+        </div>
+      ) : null}
+      {onTopUp || onBilling ? (
+        <div className="mt-1 flex gap-2 border-t border-border-light px-2 py-2">
+          {onTopUp ? (
+            <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={onTopUp}>
               Top up
             </Button>
-          ) : (
-            <div className="text-ui-sm text-destructive">Ask your admin to raise your limit.</div>
-          )}
+          ) : null}
+          {onBilling ? (
+            <Button type="button" variant="secondary" size="sm" className="flex-1" onClick={onBilling}>
+              Billing
+            </Button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarHelpFooter.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarHelpFooter.tsx
@@ -1,0 +1,74 @@
+import { CircleHelp } from "lucide-react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { Button } from "@proliferate/ui/primitives/Button";
+import {
+  POPOVER_SURFACE_CLASS,
+  PopoverButton,
+} from "@proliferate/ui/primitives/PopoverButton";
+import { SidebarAppVersionRow } from "#product/components/app/sidebar/SidebarAppVersionRow";
+import { SidebarHelpSection } from "#product/components/app/sidebar/SidebarHelpSection";
+import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
+import { useWebAppTarget } from "#product/hooks/capabilities/derived/use-web-app-target";
+import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
+import { useSupportMenuAction } from "#product/hooks/support/derived/use-support-menu-action";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+/** Help/support owns its own compact footer trigger and popover. */
+export function SidebarHelpFooter() {
+  const { openExternal } = useProductHost().links;
+  const capabilities = useAppCapabilities();
+  const webApp = useWebAppTarget();
+  const supportAction = useSupportMenuAction();
+  const {
+    openBug: openSupport,
+    openFeature: openPrompt,
+    disabledReason: supportDisabledReason,
+  } = useOpenSupportReportWindow({ source: "sidebar" });
+  const showToast = useToastStore((state) => state.show);
+
+  const openExternalUrl = (url: string) => {
+    void openExternal(url).catch(() => {
+      showToast("Failed to open the link.");
+    });
+  };
+
+  return (
+    <PopoverButton
+      align="end"
+      side="top"
+      offset={8}
+      trigger={(
+        <Button
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          aria-label="Open help menu"
+          title="Help and support"
+          className="size-10 rounded-lg text-sidebar-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground"
+        >
+          <CircleHelp className="size-4" />
+        </Button>
+      )}
+      className={`w-64 ${POPOVER_SURFACE_CLASS}`}
+    >
+      {(close) => (
+        <div>
+          <SidebarHelpSection
+            webApp={webApp}
+            supportAction={supportAction}
+            supportDisabledReason={supportDisabledReason}
+            openSupport={openSupport}
+            openPrompt={openPrompt}
+            openExternalUrl={openExternalUrl}
+            onClose={close}
+          />
+          <SidebarAppVersionRow
+            connectedServerName={
+              capabilities.isSelfManaged ? capabilities.serverDisplayName : null
+            }
+          />
+        </div>
+      )}
+    </PopoverButton>
+  );
+}

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.test.tsx
@@ -20,7 +20,6 @@ function renderSection(overrides: {
   const openSupport = vi.fn();
   const openPrompt = vi.fn();
   const openExternalUrl = vi.fn();
-  const onShowKeyboardShortcuts = vi.fn();
   const onClose = vi.fn();
 
   render(
@@ -31,12 +30,11 @@ function renderSection(overrides: {
       openSupport={openSupport}
       openPrompt={openPrompt}
       openExternalUrl={openExternalUrl}
-      onShowKeyboardShortcuts={onShowKeyboardShortcuts}
       onClose={onClose}
     />,
   );
 
-  return { openSupport, openPrompt, openExternalUrl, onShowKeyboardShortcuts, onClose };
+  return { openSupport, openPrompt, openExternalUrl, onClose };
 }
 
 describe("SidebarHelpSection", () => {
@@ -44,11 +42,11 @@ describe("SidebarHelpSection", () => {
     cleanup();
   });
 
-  it("Docs/Changelog/Discord are always rendered regardless of support kind", () => {
+  it("Documentation/Changelog/Discord are always rendered regardless of support kind", () => {
     renderSection({ supportAction: { kind: "none" } });
 
     // getByRole throws if absent, which is itself the presence assertion.
-    expect(screen.getByRole("button", { name: "Docs" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Documentation" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Changelog" })).not.toBeNull();
     expect(screen.getByRole("button", { name: "Discord" })).not.toBeNull();
   });

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarHelpSection.tsx
@@ -2,7 +2,6 @@ import {
   BookMarked,
   BookOpen,
   Globe,
-  Keyboard,
   Lightbulb,
   MessageSquare,
 } from "lucide-react";
@@ -24,13 +23,12 @@ export interface SidebarHelpSectionProps {
   openSupport: () => void;
   openPrompt: () => void;
   openExternalUrl: (url: string) => void;
-  onShowKeyboardShortcuts: () => void;
   onClose: () => void;
 }
 
 /**
- * Docs/Changelog/Discord/keyboard-shortcuts (always universal — no gating) plus
- * the capability-gated "Go to web" and support actions:
+ * Documentation/Changelog/Discord (always universal — no gating) plus the
+ * capability-gated "Go to web" and support actions:
  *
  * - `supportAction.kind === "vendor"` (hosted): unchanged "Send feedback" /
  *   "Submit a prompt" actions into the vendor support-report window.
@@ -48,63 +46,10 @@ export function SidebarHelpSection({
   openSupport,
   openPrompt,
   openExternalUrl,
-  onShowKeyboardShortcuts,
   onClose,
 }: SidebarHelpSectionProps) {
   return (
-    <div className="border-t border-border-light py-1">
-      <PopoverMenuItem
-        variant="sidebar"
-        label="Keyboard shortcuts"
-        icon={<Keyboard className="size-4" />}
-        trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.showKeyboardShortcuts)}</span>}
-        onClick={() => {
-          onClose();
-          onShowKeyboardShortcuts();
-        }}
-      />
-      <PopoverMenuItem
-        variant="sidebar"
-        label="Docs"
-        icon={<BookOpen className="size-4" />}
-        trailing={<ArrowUpRight className="size-3" />}
-        onClick={() => {
-          openExternalUrl(PROLIFERATE_DOCS_URL);
-          onClose();
-        }}
-      />
-      <PopoverMenuItem
-        variant="sidebar"
-        label="Changelog"
-        icon={<BookMarked className="size-4" />}
-        trailing={<ArrowUpRight className="size-3" />}
-        onClick={() => {
-          openExternalUrl(PROLIFERATE_CHANGELOG_URL);
-          onClose();
-        }}
-      />
-      <PopoverMenuItem
-        variant="sidebar"
-        label="Discord"
-        icon={<Discord className="size-4" />}
-        trailing={<ArrowUpRight className="size-3" />}
-        onClick={() => {
-          openExternalUrl(PROLIFERATE_DISCORD_URL);
-          onClose();
-        }}
-      />
-      {webApp.available && webApp.baseUrl ? (
-        <PopoverMenuItem
-          variant="sidebar"
-          label="Go to web"
-          icon={<Globe className="size-4" />}
-          trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openWebApp)}</span>}
-          onClick={() => {
-            openExternalUrl(webApp.baseUrl!);
-            onClose();
-          }}
-        />
-      ) : null}
+    <div className="py-1">
       {supportAction.kind === "vendor" ? (
         <>
           <PopoverMenuItem
@@ -138,6 +83,48 @@ export function SidebarHelpSection({
           icon={<Mail className="size-4" />}
           onClick={() => {
             openExternalUrl(supportAction.url);
+            onClose();
+          }}
+        />
+      ) : null}
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Documentation"
+        icon={<BookOpen className="size-4" />}
+        trailing={<ArrowUpRight className="size-3" />}
+        onClick={() => {
+          openExternalUrl(PROLIFERATE_DOCS_URL);
+          onClose();
+        }}
+      />
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Discord"
+        icon={<Discord className="size-4" />}
+        trailing={<ArrowUpRight className="size-3" />}
+        onClick={() => {
+          openExternalUrl(PROLIFERATE_DISCORD_URL);
+          onClose();
+        }}
+      />
+      <PopoverMenuItem
+        variant="sidebar"
+        label="Changelog"
+        icon={<BookMarked className="size-4" />}
+        trailing={<ArrowUpRight className="size-3" />}
+        onClick={() => {
+          openExternalUrl(PROLIFERATE_CHANGELOG_URL);
+          onClose();
+        }}
+      />
+      {webApp.available && webApp.baseUrl ? (
+        <PopoverMenuItem
+          variant="sidebar"
+          label="Go to web"
+          icon={<Globe className="size-4" />}
+          trailing={<span>{getShortcutDisplayLabel(SHORTCUTS.openWebApp)}</span>}
+          onClick={() => {
+            openExternalUrl(webApp.baseUrl!);
             onClose();
           }}
         />

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarUsageFooter } from "#product/components/app/sidebar/SidebarUsageFooter";
+
+const state = vi.hoisted(() => ({
+  authStatus: "authenticated" as "loading" | "anonymous" | "authenticated",
+  usageMeteringEnabled: true,
+  billingEnabled: true,
+  query: {
+    data: undefined as ReturnType<typeof usage> | undefined,
+    isLoading: true,
+    refetch: vi.fn(),
+  },
+  navigate: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...await importOriginal<typeof import("react-router-dom")>(),
+  useNavigate: () => state.navigate,
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useUsageSummary: () => state.query,
+}));
+
+vi.mock("#product/hooks/auth/facade/use-product-auth", () => ({
+  useProductAuthStatus: () => state.authStatus,
+}));
+
+vi.mock("#product/hooks/capabilities/derived/use-app-capabilities", () => ({
+  useAppCapabilities: () => ({
+    usageMeteringEnabled: state.usageMeteringEnabled,
+    billingEnabled: state.billingEnabled,
+  }),
+}));
+
+vi.mock("@proliferate/ui/primitives/PopoverButton", () => ({
+  POPOVER_SURFACE_CLASS: "surface",
+  PopoverButton: ({
+    trigger,
+    children,
+  }: {
+    trigger: ReactElement<{ meter?: "compute" | "llm" }>;
+    children: (close: () => void) => ReactNode;
+  }) => (
+    <div>
+      {trigger}
+      {trigger.props.meter === "compute" ? (
+        <div>{children(vi.fn())}</div>
+      ) : null}
+    </div>
+  ),
+}));
+
+describe("SidebarUsageFooter", () => {
+  beforeEach(() => {
+    state.authStatus = "authenticated";
+    state.usageMeteringEnabled = true;
+    state.billingEnabled = true;
+    state.query = { data: undefined, isLoading: true, refetch: vi.fn() };
+    state.navigate.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it("hides the concern when signed out or usage metering is unavailable", () => {
+    state.authStatus = "anonymous";
+    const { container, rerender } = render(<SidebarUsageFooter />);
+    expect(container.childElementCount).toBe(0);
+
+    state.authStatus = "authenticated";
+    state.usageMeteringEnabled = false;
+    rerender(<SidebarUsageFooter />);
+    expect(container.childElementCount).toBe(0);
+  });
+
+  it("renders truthful loading and unavailable states", () => {
+    const { rerender } = render(<SidebarUsageFooter />);
+    expect(screen.getByRole("button", { name: /Compute usage, loading/ })).not.toBeNull();
+    expect(screen.getByText(/Loading usage/)).not.toBeNull();
+
+    state.query = { data: undefined, isLoading: false, refetch: vi.fn() };
+    rerender(<SidebarUsageFooter />);
+    expect(screen.getByRole("button", { name: /LLM usage, unavailable/ })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(state.query.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes top-up and billing only when the server supports them", () => {
+    state.query = { data: usage(), isLoading: false, refetch: vi.fn() };
+    const { rerender } = render(<SidebarUsageFooter />);
+    expect(screen.getByRole("button", { name: "Top up" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Billing" })).not.toBeNull();
+
+    state.billingEnabled = false;
+    rerender(<SidebarUsageFooter />);
+    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
+  });
+});
+
+function usage() {
+  return {
+    computeUsedSecondsMtd: 1,
+    computeRemainingSeconds: 9,
+    llmUsedUsdMtd: 1,
+    llmRemainingUsd: 9,
+    computeLimit: null,
+    llmLimit: null,
+    canSelfServeTopUp: true,
+  };
+}

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageSummary } from "@proliferate/cloud-sdk";
 import { SidebarUsageFooter } from "#product/components/app/sidebar/SidebarUsageFooter";
 
 const state = vi.hoisted(() => ({
@@ -100,9 +101,28 @@ describe("SidebarUsageFooter", () => {
     expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
   });
+
+  it("does not direct billing-disabled users to an admin when usage is exhausted", () => {
+    state.billingEnabled = false;
+    state.query = {
+      data: usage({
+        computeUsedSecondsMtd: 0,
+        computeRemainingSeconds: 0,
+        llmUsedUsdMtd: 0,
+        llmRemainingUsd: 0,
+      }),
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    render(<SidebarUsageFooter />);
+
+    expect(screen.queryByText(/Ask your admin/)).toBeNull();
+    expect(screen.getByText("Billing actions aren't available on this deployment.")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute usage, exhausted/ })).not.toBeNull();
+  });
 });
 
-function usage() {
+function usage(overrides: Partial<UsageSummary> = {}): UsageSummary {
   return {
     computeUsedSecondsMtd: 1,
     computeRemainingSeconds: 9,
@@ -111,5 +131,6 @@ function usage() {
     computeLimit: null,
     llmLimit: null,
     canSelfServeTopUp: true,
+    ...overrides,
   };
 }

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
@@ -102,7 +102,7 @@ describe("SidebarUsageFooter", () => {
     expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
   });
 
-  it("does not direct billing-disabled users to an admin when usage is exhausted", () => {
+  it("does not direct billing-disabled users to an admin when usage has no allocation", () => {
     state.billingEnabled = false;
     state.query = {
       data: usage({
@@ -118,7 +118,7 @@ describe("SidebarUsageFooter", () => {
 
     expect(screen.queryByText(/Ask your admin/)).toBeNull();
     expect(screen.getByText("Billing actions aren't available on this deployment.")).not.toBeNull();
-    expect(screen.getByRole("button", { name: /Compute usage, exhausted/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute usage, No allocation/ })).not.toBeNull();
   });
 });
 

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
@@ -5,6 +5,9 @@ import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UsageSummary } from "@proliferate/cloud-sdk";
 import { SidebarUsageFooter } from "#product/components/app/sidebar/SidebarUsageFooter";
+import { useOrganizationStore } from "#product/stores/organizations/organization-store";
+
+const useUsageSummary = vi.hoisted(() => vi.fn());
 
 const state = vi.hoisted(() => ({
   authStatus: "authenticated" as "loading" | "anonymous" | "authenticated",
@@ -24,7 +27,7 @@ vi.mock("react-router-dom", async (importOriginal) => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useUsageSummary: () => state.query,
+  useUsageSummary,
 }));
 
 vi.mock("#product/hooks/auth/facade/use-product-auth", () => ({
@@ -63,6 +66,12 @@ describe("SidebarUsageFooter", () => {
     state.billingEnabled = true;
     state.query = { data: undefined, isLoading: true, refetch: vi.fn() };
     state.navigate.mockClear();
+    useUsageSummary.mockReset();
+    useUsageSummary.mockImplementation(() => state.query);
+    useOrganizationStore.setState({
+      activeOrganizationId: null,
+      activeOrganizationValidated: false,
+    });
   });
 
   afterEach(cleanup);
@@ -90,16 +99,85 @@ describe("SidebarUsageFooter", () => {
     expect(state.query.refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("exposes top-up and billing only when the server supports them", () => {
+  it("reads personal usage explicitly and explains why its unsupported route has no action", () => {
     state.query = { data: usage(), isLoading: false, refetch: vi.fn() };
-    const { rerender } = render(<SidebarUsageFooter />);
-    expect(screen.getByRole("button", { name: "Top up" })).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Billing" })).not.toBeNull();
+    render(<SidebarUsageFooter />);
 
-    state.billingEnabled = false;
-    rerender(<SidebarUsageFooter />);
+    expect(useUsageSummary).toHaveBeenLastCalledWith(
+      { ownerScope: "personal", organizationId: null },
+      true,
+    );
     expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
+    expect(screen.getByText(
+      "Billing for personal usage isn't available from this sidebar.",
+    )).not.toBeNull();
+  });
+
+  it("preserves the selected organization owner in the single Billing destination", () => {
+    useOrganizationStore.setState({
+      activeOrganizationId: "org-1",
+      activeOrganizationValidated: true,
+    });
+    state.query = { data: usage(), isLoading: false, refetch: vi.fn() };
+    render(<SidebarUsageFooter />);
+
+    expect(useUsageSummary).toHaveBeenLastCalledWith(
+      { ownerScope: "organization", organizationId: "org-1" },
+      true,
+    );
+    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Billing" }));
+    expect(state.navigate).toHaveBeenCalledWith(
+      "/settings?section=billing&billingOwnerScope=organization&billingOrganizationId=org-1",
+    );
+  });
+
+  it("keeps organization-member billing admin-managed and owner-correct", () => {
+    useOrganizationStore.setState({
+      activeOrganizationId: "org-member",
+      activeOrganizationValidated: true,
+    });
+    state.query = {
+      data: usage({ canSelfServeTopUp: false }),
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    render(<SidebarUsageFooter />);
+
+    expect(screen.getByText("Billing is managed by your organization admins.")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Billing" }));
+    expect(state.navigate).toHaveBeenCalledWith(
+      "/settings?section=billing&billingOwnerScope=organization&billingOrganizationId=org-member",
+    );
+  });
+
+  it("does not invent an organization admin for a non-self-service personal owner", () => {
+    state.query = {
+      data: usage({ canSelfServeTopUp: false }),
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+    render(<SidebarUsageFooter />);
+
+    expect(screen.queryByText(/organization admins/)).toBeNull();
+    expect(screen.getByText(
+      "Billing for personal usage isn't available from this sidebar.",
+    )).not.toBeNull();
+  });
+
+  it("hides billing actions when the deployment capability is disabled", () => {
+    useOrganizationStore.setState({
+      activeOrganizationId: "org-1",
+      activeOrganizationValidated: true,
+    });
+    state.query = { data: usage(), isLoading: false, refetch: vi.fn() };
+    state.billingEnabled = false;
+    render(<SidebarUsageFooter />);
+
+    expect(screen.queryByRole("button", { name: "Top up" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
+    expect(screen.getByText("Billing actions aren't available on this deployment.")).not.toBeNull();
   });
 
   it("does not direct billing-disabled users to an admin when usage has no allocation", () => {

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
@@ -1,0 +1,83 @@
+import { useNavigate } from "react-router-dom";
+import { useUsageSummary } from "@proliferate/cloud-sdk-react";
+import {
+  POPOVER_SURFACE_CLASS,
+  PopoverButton,
+} from "@proliferate/ui/primitives/PopoverButton";
+import {
+  ConsumptionCard,
+  SidebarUsageMeterTrigger,
+  type SidebarConsumptionMeter,
+  type SidebarConsumptionState,
+} from "#product/components/app/sidebar/SidebarConsumptionCard";
+import { useProductAuthStatus } from "#product/hooks/auth/facade/use-product-auth";
+import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
+
+/** Capability-gated usage concern with independently focusable Compute/LLM rings. */
+export function SidebarUsageFooter() {
+  const navigate = useNavigate();
+  const authStatus = useProductAuthStatus();
+  const capabilities = useAppCapabilities();
+  const enabled = authStatus === "authenticated" && capabilities.usageMeteringEnabled;
+  const usageQuery = useUsageSummary(undefined, enabled);
+
+  if (!enabled) {
+    return null;
+  }
+
+  const state: SidebarConsumptionState = usageQuery.data
+    ? { kind: "ready", usageSummary: usageQuery.data }
+    : usageQuery.isLoading
+      ? { kind: "loading" }
+      : {
+        kind: "unavailable",
+        message: "We couldn't load current usage.",
+      };
+  const canTopUp = state.kind === "ready"
+    && state.usageSummary.canSelfServeTopUp
+    && capabilities.billingEnabled;
+
+  const meterPopover = (meter: SidebarConsumptionMeter) => (
+    <PopoverButton
+      key={meter}
+      align="end"
+      side="top"
+      offset={8}
+      trigger={<SidebarUsageMeterTrigger meter={meter} state={state} />}
+      className={`w-64 ${POPOVER_SURFACE_CLASS}`}
+    >
+      {(close) => (
+        <ConsumptionCard
+          state={state}
+          onRetry={state.kind === "unavailable"
+            ? () => { void usageQuery.refetch(); }
+            : undefined}
+          onTopUp={canTopUp
+            ? () => {
+              navigate("/settings?section=billing");
+              close();
+            }
+            : undefined}
+          onBilling={capabilities.billingEnabled
+            ? () => {
+              navigate("/settings?section=billing");
+              close();
+            }
+            : undefined}
+        />
+      )}
+    </PopoverButton>
+  );
+
+  return (
+    <div
+      role="group"
+      aria-label="Usage meters"
+      title="Usage"
+      className="flex h-10 items-center gap-0.5 rounded-lg px-1 text-sidebar-muted-foreground hover:bg-sidebar-accent"
+    >
+      {meterPopover("compute")}
+      {meterPopover("llm")}
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
@@ -13,14 +13,17 @@ import {
 } from "#product/components/app/sidebar/SidebarConsumptionCard";
 import { useProductAuthStatus } from "#product/hooks/auth/facade/use-product-auth";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
+import { useSelectedCloudOwner } from "#product/hooks/organizations/derived/use-selected-cloud-owner";
+import { buildBillingSettingsHref } from "#product/lib/domain/settings/navigation";
 
 /** Capability-gated usage concern with independently focusable Compute/LLM rings. */
 export function SidebarUsageFooter() {
   const navigate = useNavigate();
   const authStatus = useProductAuthStatus();
   const capabilities = useAppCapabilities();
+  const usageOwner = useSelectedCloudOwner();
   const enabled = authStatus === "authenticated" && capabilities.usageMeteringEnabled;
-  const usageQuery = useUsageSummary(undefined, enabled);
+  const usageQuery = useUsageSummary(usageOwner, enabled);
 
   if (!enabled) {
     return null;
@@ -34,8 +37,9 @@ export function SidebarUsageFooter() {
         kind: "unavailable",
         message: "We couldn't load current usage.",
       };
-  const openBilling = (close: () => void) => {
-    navigate("/settings?section=billing");
+  const billingHref = buildBillingSettingsHref(usageOwner);
+  const openBilling = (href: string, close: () => void) => {
+    navigate(href);
     close();
   };
 
@@ -57,7 +61,8 @@ export function SidebarUsageFooter() {
           actions={resolveConsumptionActions(
             state,
             capabilities.billingEnabled,
-            () => openBilling(close),
+            billingHref,
+            billingHref ? () => openBilling(billingHref, close) : undefined,
           )}
         />
       )}
@@ -80,7 +85,8 @@ export function SidebarUsageFooter() {
 function resolveConsumptionActions(
   state: SidebarConsumptionState,
   billingEnabled: boolean,
-  openBilling: () => void,
+  billingHref: string | null,
+  openBilling: (() => void) | undefined,
 ): SidebarConsumptionActions | undefined {
   if (state.kind !== "ready") {
     return undefined;
@@ -91,8 +97,24 @@ function resolveConsumptionActions(
       message: "Billing actions aren't available on this deployment.",
     };
   }
-  if (state.usageSummary.canSelfServeTopUp) {
-    return { kind: "self-serve", onTopUp: openBilling, onBilling: openBilling };
+  if (!state.usageSummary.canSelfServeTopUp) {
+    if (billingHref && openBilling) {
+      return {
+        kind: "admin-managed",
+        message: "Billing is managed by your organization admins.",
+        onBilling: openBilling,
+      };
+    }
+    return {
+      kind: "unavailable",
+      message: "Billing for personal usage isn't available from this sidebar.",
+    };
   }
-  return { kind: "admin-managed", onBilling: openBilling };
+  if (billingHref && openBilling) {
+    return { kind: "billing", onBilling: openBilling };
+  }
+  return {
+    kind: "unavailable",
+    message: "Billing for personal usage isn't available from this sidebar.",
+  };
 }

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
@@ -9,6 +9,7 @@ import {
   SidebarUsageMeterTrigger,
   type SidebarConsumptionMeter,
   type SidebarConsumptionState,
+  type SidebarConsumptionActions,
 } from "#product/components/app/sidebar/SidebarConsumptionCard";
 import { useProductAuthStatus } from "#product/hooks/auth/facade/use-product-auth";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
@@ -33,9 +34,10 @@ export function SidebarUsageFooter() {
         kind: "unavailable",
         message: "We couldn't load current usage.",
       };
-  const canTopUp = state.kind === "ready"
-    && state.usageSummary.canSelfServeTopUp
-    && capabilities.billingEnabled;
+  const openBilling = (close: () => void) => {
+    navigate("/settings?section=billing");
+    close();
+  };
 
   const meterPopover = (meter: SidebarConsumptionMeter) => (
     <PopoverButton
@@ -52,18 +54,11 @@ export function SidebarUsageFooter() {
           onRetry={state.kind === "unavailable"
             ? () => { void usageQuery.refetch(); }
             : undefined}
-          onTopUp={canTopUp
-            ? () => {
-              navigate("/settings?section=billing");
-              close();
-            }
-            : undefined}
-          onBilling={capabilities.billingEnabled
-            ? () => {
-              navigate("/settings?section=billing");
-              close();
-            }
-            : undefined}
+          actions={resolveConsumptionActions(
+            state,
+            capabilities.billingEnabled,
+            () => openBilling(close),
+          )}
         />
       )}
     </PopoverButton>
@@ -80,4 +75,24 @@ export function SidebarUsageFooter() {
       {meterPopover("llm")}
     </div>
   );
+}
+
+function resolveConsumptionActions(
+  state: SidebarConsumptionState,
+  billingEnabled: boolean,
+  openBilling: () => void,
+): SidebarConsumptionActions | undefined {
+  if (state.kind !== "ready") {
+    return undefined;
+  }
+  if (!billingEnabled) {
+    return {
+      kind: "unavailable",
+      message: "Billing actions aren't available on this deployment.",
+    };
+  }
+  if (state.usageSummary.canSelfServeTopUp) {
+    return { kind: "self-serve", onTopUp: openBilling, onBilling: openBilling };
+  }
+  return { kind: "admin-managed", onBilling: openBilling };
 }

--- a/apps/packages/product-client/src/components/settings/panes/BillingPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/BillingPane.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BillingPane } from "#product/components/settings/panes/BillingPane";
+
+const state = vi.hoisted(() => ({
+  activeOrganization: { id: "org-active", name: "Active org" } as {
+    id: string;
+    name: string;
+  } | null,
+  organizations: [
+    { id: "org-active", name: "Active org" },
+    { id: "org-meter", name: "Meter org" },
+  ],
+  organizationsQuery: { isLoading: false },
+  isAdmin: vi.fn(() => ({ isAdmin: true, isLoading: false })),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@proliferate/product-surfaces/settings/BillingSettingsSurface", () => ({
+  BillingSettingsSurface: ({
+    organization,
+    checkoutReturnState,
+  }: {
+    organization: { id: string; name: string } | null;
+    checkoutReturnState: string | null;
+  }) => (
+    <div data-testid="billing-surface">
+      {organization?.id ?? "personal"}:{checkoutReturnState ?? "none"}
+    </div>
+  ),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ links: { openExternal: vi.fn() } }),
+}));
+
+vi.mock("#product/hooks/organizations/facade/use-active-organization", () => ({
+  useActiveOrganization: () => ({
+    activeOrganization: state.activeOrganization,
+    organizations: state.organizations,
+    organizationsQuery: state.organizationsQuery,
+  }),
+}));
+
+vi.mock("#product/hooks/access/cloud/organizations/use-is-admin", () => ({
+  useIsAdmin: state.isAdmin,
+}));
+
+vi.mock("#product/hooks/capabilities/derived/use-app-capabilities", () => ({
+  useAppCapabilities: () => ({ billingEnabled: true, pricing: {} }),
+}));
+
+vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: true }),
+}));
+
+describe("BillingPane owner routing", () => {
+  beforeEach(() => {
+    state.activeOrganization = { id: "org-active", name: "Active org" };
+    state.organizations = [
+      { id: "org-active", name: "Active org" },
+      { id: "org-meter", name: "Meter org" },
+    ];
+    state.organizationsQuery = { isLoading: false };
+    state.isAdmin.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it("renders the exact routed organization rather than the unrelated active owner", () => {
+    render(
+      <BillingPane focus={{
+        billingOwnerScope: "organization",
+        billingOrganizationId: "org-meter",
+        checkout: "success",
+      }} />,
+    );
+
+    expect(screen.getByTestId("billing-surface").textContent).toBe("org-meter:success");
+    expect(state.isAdmin).toHaveBeenCalledWith("org-meter");
+  });
+
+  it("fails closed instead of falling back when the routed owner is unavailable", () => {
+    render(
+      <BillingPane focus={{
+        billingOwnerScope: "organization",
+        billingOrganizationId: "org-missing",
+      }} />,
+    );
+
+    expect(screen.queryByTestId("billing-surface")).toBeNull();
+    expect(screen.getByText("Billing owner unavailable")).not.toBeNull();
+  });
+
+  it("preserves the existing active-organization behavior for ordinary settings navigation", () => {
+    render(<BillingPane />);
+
+    expect(screen.getByTestId("billing-surface").textContent).toBe("org-active:none");
+    expect(state.isAdmin).toHaveBeenCalledWith("org-active");
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/BillingPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/BillingPane.tsx
@@ -1,44 +1,62 @@
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   BillingSettingsSurface,
   type BillingCheckoutReturnState,
 } from "@proliferate/product-surfaces/settings/BillingSettingsSurface";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmptyState";
+import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
 
 import { PROLIFERATE_PRICING_URL } from "#product/config/capabilities";
 import { useIsAdmin } from "#product/hooks/access/cloud/organizations/use-is-admin";
 import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
-import { buildSettingsHref } from "#product/lib/domain/settings/navigation";
+import {
+  buildSettingsHref,
+  type SettingsFocus,
+} from "#product/lib/domain/settings/navigation";
 
-export function BillingPane() {
+export function BillingPane({ focus = {} }: { focus?: SettingsFocus }) {
   const navigate = useNavigate();
   const {
     activeOrganization,
-    activeOrganizationId,
+    organizations,
     organizationsQuery,
   } = useActiveOrganization();
-  const admin = useIsAdmin(activeOrganizationId);
+  const routedOrganizationId = focus.billingOwnerScope === "organization"
+    ? focus.billingOrganizationId ?? null
+    : null;
+  const organization = routedOrganizationId
+    ? organizations.find((candidate) => candidate.id === routedOrganizationId) ?? null
+    : activeOrganization;
+  const admin = useIsAdmin(routedOrganizationId ?? organization?.id ?? null);
   const { billingEnabled, pricing } = useAppCapabilities();
   const { cloudActive } = useCloudAvailabilityState();
   const { openExternal } = useProductHost().links;
-  const [searchParams] = useSearchParams();
+
+  if (routedOrganizationId && organizationsQuery.isLoading) {
+    return <BillingOwnerState loading />;
+  }
+
+  if (routedOrganizationId && !organization) {
+    return <BillingOwnerState loading={false} />;
+  }
 
   return (
     <BillingSettingsSurface
       enabled={billingEnabled && cloudActive}
       billingReturnSurface="desktop"
-      organization={activeOrganization
+      organization={organization
         ? {
-            id: activeOrganization.id,
-            name: activeOrganization.name,
+            id: organization.id,
+            name: organization.name,
             canManageBilling: admin.isAdmin,
             loading: admin.isLoading,
           }
         : null}
-      organizationLoading={organizationsQuery.isLoading || (activeOrganization ? admin.isLoading : false)}
-      checkoutReturnState={checkoutReturnStateFromParams(searchParams)}
+      organizationLoading={organizationsQuery.isLoading || (organization ? admin.isLoading : false)}
+      checkoutReturnState={checkoutReturnStateFromFocus(focus)}
       onOpenUrl={openExternal}
       onOpenPricingPage={() => openExternal(pricing.url ?? PROLIFERATE_PRICING_URL)}
       onOpenOrganizationSettings={() => {
@@ -48,9 +66,23 @@ export function BillingPane() {
   );
 }
 
-function checkoutReturnStateFromParams(
-  searchParams: URLSearchParams,
+function BillingOwnerState({ loading }: { loading: boolean }) {
+  return (
+    <section className="space-y-6">
+      <SettingsPageHeader title="Billing" />
+      <SettingsEmptyState
+        title={loading ? "Loading billing owner…" : "Billing owner unavailable"}
+        description={loading
+          ? "Confirming the organization for this billing destination."
+          : "This organization is no longer available to your account. Return to the sidebar and select an available owner."}
+      />
+    </section>
+  );
+}
+
+function checkoutReturnStateFromFocus(
+  focus: SettingsFocus,
 ): BillingCheckoutReturnState {
-  const checkout = searchParams.get("checkout");
+  const checkout = focus.checkout;
   return checkout === "success" || checkout === "cancel" ? checkout : null;
 }

--- a/apps/packages/product-client/src/components/settings/screen/render-settings-section.tsx
+++ b/apps/packages/product-client/src/components/settings/screen/render-settings-section.tsx
@@ -88,7 +88,7 @@ export function renderSettingsSection(
     return renderCloudGatedPane(authGate, () => <UserIntegrationsPane focus={focus} />);
   }
   if (activeSection === "billing") {
-    return <BillingPane />;
+    return <BillingPane focus={focus} />;
   }
   if (activeSection === "organization") {
     return <OrganizationPane />;

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook } from "@testing-library/react";
+import { cleanup, render, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppCommandActions } from "#product/hooks/app/workflows/app-command-action-types";
 import { useAppShortcuts } from "#product/hooks/app/lifecycle/use-app-shortcuts";
+import { useShortcutDispatcher } from "#product/hooks/shortcuts/lifecycle/use-shortcut-dispatcher";
 import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import {
   clearShortcutHandlerRegistryForTests,
@@ -67,6 +69,7 @@ describe("useAppShortcuts", () => {
     cleanup();
     clearShortcutHandlerRegistryForTests();
     document.body.innerHTML = "";
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
@@ -162,28 +165,36 @@ describe("useAppShortcuts", () => {
     expect(actions.openWebApp.execute).toHaveBeenCalledWith("shortcut");
   });
 
-  it("lets active Cowork temporarily own Cmd-N, then restores the normal fallback", () => {
+  it("prioritizes a child Cowork owner across unmount and remount regardless of effect order", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
     const actions = commandActions();
     const createCoworkThread = vi.fn();
-    const { rerender } = renderHook(
-      ({ cowork }) => {
-        useAppShortcuts(actions);
-        useShortcutHandler("workspace.new-default", createCoworkThread, {
-          enabled: cowork,
-          allowOverride: true,
-        });
-      },
-      { initialProps: { cowork: true } },
+    const { rerender } = render(
+      <GlobalShortcutOwner actions={actions}>
+        <ContextualCoworkShortcutOwner onCreateThread={createCoworkThread} />
+      </GlobalShortcutOwner>,
     );
 
-    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(dispatchNewChatKeyboardShortcut().defaultPrevented).toBe(true);
     expect(createCoworkThread).toHaveBeenCalledTimes(1);
     expect(actions.newLocalWorkspace.execute).not.toHaveBeenCalled();
     expect(actions.newWorktreeWorkspace.execute).not.toHaveBeenCalled();
 
-    rerender({ cowork: false });
-    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    rerender(<GlobalShortcutOwner actions={actions} />);
+    expect(dispatchNewChatKeyboardShortcut().defaultPrevented).toBe(true);
     expect(createCoworkThread).toHaveBeenCalledTimes(1);
+    expect(actions.newWorktreeWorkspace.execute).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <GlobalShortcutOwner actions={actions}>
+        <ContextualCoworkShortcutOwner onCreateThread={createCoworkThread} />
+      </GlobalShortcutOwner>,
+    );
+    expect(dispatchNewChatKeyboardShortcut().defaultPrevented).toBe(true);
+    expect(createCoworkThread).toHaveBeenCalledTimes(2);
     expect(actions.newWorktreeWorkspace.execute).toHaveBeenCalledTimes(1);
   });
 
@@ -218,6 +229,41 @@ describe("useAppShortcuts", () => {
     });
   });
 });
+
+function GlobalShortcutOwner({
+  actions,
+  children,
+}: {
+  actions: AppCommandActions;
+  children?: ReactNode;
+}) {
+  useAppShortcuts(actions);
+  useShortcutDispatcher();
+  return children;
+}
+
+function ContextualCoworkShortcutOwner({
+  onCreateThread,
+}: {
+  onCreateThread: () => void;
+}) {
+  useShortcutHandler("workspace.new-default", onCreateThread, {
+    priority: "contextual",
+  });
+  return null;
+}
+
+function dispatchNewChatKeyboardShortcut(): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "n",
+    code: "KeyN",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
 
 function commandActions(): AppCommandActions {
   const action = () => ({

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppCommandActions } from "#product/hooks/app/workflows/app-command-action-types";
 import { useAppShortcuts } from "#product/hooks/app/lifecycle/use-app-shortcuts";
+import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import {
   clearShortcutHandlerRegistryForTests,
   runShortcutHandler,
@@ -11,10 +12,6 @@ import {
 import { USER_PREFERENCE_DEFAULTS } from "#product/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
-import {
-  clearCoworkNewThreadShortcutForTests,
-  registerCoworkNewThreadShortcut,
-} from "#product/lib/domain/cowork/new-thread-shortcut";
 
 const navigationMocks = vi.hoisted(() => ({
   selectWorkspaceFromSurface: vi.fn(),
@@ -59,7 +56,6 @@ describe("useAppShortcuts", () => {
     harnessState.selectedLogicalWorkspaceId = null;
     harnessState.sidebarShortcutTargets = [];
     clearShortcutHandlerRegistryForTests();
-    clearCoworkNewThreadShortcutForTests();
     useUserPreferencesStore.setState({
       ...USER_PREFERENCE_DEFAULTS,
       _hydrated: true,
@@ -70,7 +66,6 @@ describe("useAppShortcuts", () => {
   afterEach(() => {
     cleanup();
     clearShortcutHandlerRegistryForTests();
-    clearCoworkNewThreadShortcutForTests();
     document.body.innerHTML = "";
     vi.clearAllMocks();
   });
@@ -167,16 +162,29 @@ describe("useAppShortcuts", () => {
     expect(actions.openWebApp.execute).toHaveBeenCalledWith("shortcut");
   });
 
-  it("lets the active Cowork context consume Cmd-N exactly once", () => {
+  it("lets active Cowork temporarily own Cmd-N, then restores the normal fallback", () => {
     const actions = commandActions();
     const createCoworkThread = vi.fn();
-    registerCoworkNewThreadShortcut(createCoworkThread);
-    renderHook(() => useAppShortcuts(actions));
+    const { rerender } = renderHook(
+      ({ cowork }) => {
+        useAppShortcuts(actions);
+        useShortcutHandler("workspace.new-default", createCoworkThread, {
+          enabled: cowork,
+          allowOverride: true,
+        });
+      },
+      { initialProps: { cowork: true } },
+    );
 
     expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
     expect(createCoworkThread).toHaveBeenCalledTimes(1);
     expect(actions.newLocalWorkspace.execute).not.toHaveBeenCalled();
     expect(actions.newWorktreeWorkspace.execute).not.toHaveBeenCalled();
+
+    rerender({ cowork: false });
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(createCoworkThread).toHaveBeenCalledTimes(1);
+    expect(actions.newWorktreeWorkspace.execute).toHaveBeenCalledTimes(1);
   });
 
   it("preserves the normal Cmd-N action outside Cowork", () => {

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -11,6 +11,10 @@ import {
 import { USER_PREFERENCE_DEFAULTS } from "#product/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
+import {
+  clearCoworkNewThreadShortcutForTests,
+  registerCoworkNewThreadShortcut,
+} from "#product/lib/domain/cowork/new-thread-shortcut";
 
 const navigationMocks = vi.hoisted(() => ({
   selectWorkspaceFromSurface: vi.fn(),
@@ -55,6 +59,7 @@ describe("useAppShortcuts", () => {
     harnessState.selectedLogicalWorkspaceId = null;
     harnessState.sidebarShortcutTargets = [];
     clearShortcutHandlerRegistryForTests();
+    clearCoworkNewThreadShortcutForTests();
     useUserPreferencesStore.setState({
       ...USER_PREFERENCE_DEFAULTS,
       _hydrated: true,
@@ -65,6 +70,7 @@ describe("useAppShortcuts", () => {
   afterEach(() => {
     cleanup();
     clearShortcutHandlerRegistryForTests();
+    clearCoworkNewThreadShortcutForTests();
     document.body.innerHTML = "";
     vi.clearAllMocks();
   });
@@ -159,6 +165,27 @@ describe("useAppShortcuts", () => {
 
     expect(runShortcutHandler("app.open-web", { source: "keyboard" })).toBe(true);
     expect(actions.openWebApp.execute).toHaveBeenCalledWith("shortcut");
+  });
+
+  it("lets the active Cowork context consume Cmd-N exactly once", () => {
+    const actions = commandActions();
+    const createCoworkThread = vi.fn();
+    registerCoworkNewThreadShortcut(createCoworkThread);
+    renderHook(() => useAppShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(createCoworkThread).toHaveBeenCalledTimes(1);
+    expect(actions.newLocalWorkspace.execute).not.toHaveBeenCalled();
+    expect(actions.newWorktreeWorkspace.execute).not.toHaveBeenCalled();
+  });
+
+  it("preserves the normal Cmd-N action outside Cowork", () => {
+    const actions = commandActions();
+    renderHook(() => useAppShortcuts(actions));
+
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(actions.newWorktreeWorkspace.execute).toHaveBeenCalledTimes(1);
+    expect(actions.newLocalWorkspace.execute).not.toHaveBeenCalled();
   });
 
   describe("app.open-support gating", () => {

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -17,6 +17,7 @@ import {
   runSelectAllCommand,
   runUndoCommand,
 } from "#product/lib/infra/dom/dom-select-all";
+import { runCoworkNewThreadShortcut } from "#product/lib/domain/cowork/new-thread-shortcut";
 
 // Owns global app shortcut registration. App command behavior stays in the
 // workflow actions passed by the caller.
@@ -125,6 +126,9 @@ export function useAppShortcuts(actions: AppCommandActions): void {
   });
 
   useShortcutHandler("workspace.new-default", () => {
+    if (runCoworkNewThreadShortcut()) {
+      return;
+    }
     const mode = useUserPreferencesStore.getState().defaultNewWorkspaceMode;
     if (mode === "local") {
       actions.newLocalWorkspace.execute("shortcut");

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -17,7 +17,6 @@ import {
   runSelectAllCommand,
   runUndoCommand,
 } from "#product/lib/infra/dom/dom-select-all";
-import { runCoworkNewThreadShortcut } from "#product/lib/domain/cowork/new-thread-shortcut";
 
 // Owns global app shortcut registration. App command behavior stays in the
 // workflow actions passed by the caller.
@@ -126,9 +125,6 @@ export function useAppShortcuts(actions: AppCommandActions): void {
   });
 
   useShortcutHandler("workspace.new-default", () => {
-    if (runCoworkNewThreadShortcut()) {
-      return;
-    }
     const mode = useUserPreferencesStore.getState().defaultNewWorkspaceMode;
     if (mode === "local") {
       actions.newLocalWorkspace.execute("shortcut");

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderableOutboxEntriesForTranscript } from "@proliferate/product-domain/sessions/intents/session-intent-selectors";
 import {
   buildPendingWorkspaceUiKey,
@@ -43,7 +43,9 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...await importOriginal<typeof import("react-router-dom")>(),
+  useLocation: () => ({ pathname: "/" }),
   useNavigate: () => mocks.navigate,
 }));
 
@@ -77,6 +79,10 @@ vi.mock("#product/hooks/workspaces/workflows/selection/use-workspace-selection",
   useWorkspaceSelection: () => ({
     selectWorkspace: mocks.selectWorkspace,
   }),
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({ data: { workspaces: [] } }),
 }));
 
 vi.mock("#product/hooks/sessions/workflows/use-session-creation-actions", () => ({
@@ -120,6 +126,8 @@ describe("useHomeNextLaunch", () => {
     useChatLaunchIntentStore.setState({ activeIntent: null });
     useDeferredHomeLaunchStore.setState({ launches: {} });
   });
+
+  afterEach(cleanup);
 
   it("projects one destination prompt for a Home worktree launch", async () => {
     const sessionId = "client-session:codex:home-worktree";

--- a/apps/packages/product-client/src/hooks/organizations/derived/use-selected-cloud-owner.ts
+++ b/apps/packages/product-client/src/hooks/organizations/derived/use-selected-cloud-owner.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import type { CloudOwnerSelection } from "#product/lib/domain/cloud/billing";
+import { useOrganizationStore } from "#product/stores/organizations/organization-store";
+
+/** The validated owner selected for owner-scoped Cloud reads. */
+export function useSelectedCloudOwner(): CloudOwnerSelection {
+  const activeOrganizationId = useOrganizationStore((state) => state.activeOrganizationId);
+  const activeOrganizationValidated = useOrganizationStore(
+    (state) => state.activeOrganizationValidated,
+  );
+
+  return useMemo(() => (
+    activeOrganizationId && activeOrganizationValidated
+      ? { ownerScope: "organization", organizationId: activeOrganizationId }
+      : { ownerScope: "personal", organizationId: null }
+  ), [activeOrganizationId, activeOrganizationValidated]);
+}

--- a/apps/packages/product-client/src/hooks/settings/workflows/use-settings-navigation.ts
+++ b/apps/packages/product-client/src/hooks/settings/workflows/use-settings-navigation.ts
@@ -34,6 +34,8 @@ export function useSettingsNavigation({
   const rawFlowId = searchParams.get("flowId");
   const rawStatus = searchParams.get("status");
   const rawFailureCode = searchParams.get("failureCode");
+  const rawBillingOwnerScope = searchParams.get("billingOwnerScope");
+  const rawBillingOrganizationId = searchParams.get("billingOrganizationId");
 
   const selection = useMemo(() => resolveSettingsSelection({
     rawSection,
@@ -48,8 +50,12 @@ export function useSettingsNavigation({
     rawFlowId,
     rawStatus,
     rawFailureCode,
+    rawBillingOwnerScope,
+    rawBillingOrganizationId,
     repositories,
   }), [
+    rawBillingOrganizationId,
+    rawBillingOwnerScope,
     rawCloudRepoName,
     rawCloudRepoOwner,
     rawContext,

--- a/apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher.test.tsx
+++ b/apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-native-menu-command-dispatcher.test.tsx
@@ -58,6 +58,23 @@ describe("useNativeMenuCommandDispatcher", () => {
     window.removeEventListener(SHORTCUT_REVEAL_RESET_EVENT, onRevealReset);
   });
 
+  it("dispatches native New Chat to the contextual owner even when global registers later", () => {
+    const subscription = makeSubscription();
+    const contextualHandler = vi.fn();
+    const globalHandler = vi.fn();
+    registerShortcutHandler("workspace.new-default", contextualHandler, {
+      priority: "contextual",
+    });
+    registerShortcutHandler("workspace.new-default", globalHandler);
+
+    renderHook(() => useNativeMenuCommandDispatcher(subscription.subscribe));
+    subscription.emit("workspace.new-default");
+
+    expect(contextualHandler).toHaveBeenCalledWith({ source: "menu" });
+    expect(contextualHandler).toHaveBeenCalledTimes(1);
+    expect(globalHandler).not.toHaveBeenCalled();
+  });
+
   it("ignores invalid commands and does not reset reveal state when unconsumed", () => {
     const subscription = makeSubscription();
     const handler = vi.fn(() => false);

--- a/apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-handler.ts
+++ b/apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-handler.ts
@@ -3,15 +3,16 @@ import type { ShortcutId } from "#product/config/shortcuts/registry";
 import {
   registerShortcutHandler,
   type ShortcutHandler,
+  type ShortcutHandlerPriority,
 } from "#product/lib/domain/shortcuts/registry";
 
 interface UseShortcutHandlerOptions {
   enabled?: boolean;
-  allowOverride?: boolean;
+  priority?: ShortcutHandlerPriority;
 }
 
-// Owns registering a mounted shortcut handler while keeping the latest callback.
-// Does not own global shortcut event dispatch.
+// Owns registering a mounted shortcut handler and its priority while keeping
+// the latest callback. Does not own global shortcut event dispatch.
 export function useShortcutHandler(
   id: ShortcutId,
   handler: ShortcutHandler,
@@ -32,7 +33,7 @@ export function useShortcutHandler(
     return registerShortcutHandler(
       id,
       (trigger) => handlerRef.current(trigger),
-      { allowOverride: options?.allowOverride },
+      { priority: options?.priority },
     );
-  }, [enabled, id, options?.allowOverride]);
+  }, [enabled, id, options?.priority]);
 }

--- a/apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-handler.ts
+++ b/apps/packages/product-client/src/hooks/shortcuts/lifecycle/use-shortcut-handler.ts
@@ -7,6 +7,7 @@ import {
 
 interface UseShortcutHandlerOptions {
   enabled?: boolean;
+  allowOverride?: boolean;
 }
 
 // Owns registering a mounted shortcut handler while keeping the latest callback.
@@ -28,6 +29,10 @@ export function useShortcutHandler(
       return undefined;
     }
 
-    return registerShortcutHandler(id, (trigger) => handlerRef.current(trigger));
-  }, [enabled, id]);
+    return registerShortcutHandler(
+      id,
+      (trigger) => handlerRef.current(trigger),
+      { allowOverride: options?.allowOverride },
+    );
+  }, [enabled, id, options?.allowOverride]);
 }

--- a/apps/packages/product-client/src/lib/domain/cowork/new-thread-shortcut.test.ts
+++ b/apps/packages/product-client/src/lib/domain/cowork/new-thread-shortcut.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { ownsCoworkNewThreadShortcut } from "#product/lib/domain/cowork/new-thread-shortcut";
+
+describe("ownsCoworkNewThreadShortcut", () => {
+  it("owns Cmd-N only on the active Cowork shell", () => {
+    expect(ownsCoworkNewThreadShortcut("/", "cowork")).toBe(true);
+    expect(ownsCoworkNewThreadShortcut("/", "standard")).toBe(false);
+    expect(ownsCoworkNewThreadShortcut("/settings", "cowork")).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/cowork/new-thread-shortcut.ts
+++ b/apps/packages/product-client/src/lib/domain/cowork/new-thread-shortcut.ts
@@ -1,46 +1,8 @@
-type CoworkNewThreadShortcutHandler = () => void;
-
 type CoworkShortcutSurface = "standard" | "cowork";
-
-let registeredHandler: {
-  token: symbol;
-  handler: CoworkNewThreadShortcutHandler;
-} | null = null;
 
 export function ownsCoworkNewThreadShortcut(
   pathname: string,
   surface: CoworkShortcutSurface,
 ): boolean {
   return pathname === "/" && surface === "cowork";
-}
-
-/**
- * The authenticated Cowork provider owns the context-sensitive Cmd-N action,
- * while the app shortcut lifecycle owns the one global keyboard registration.
- * This small bridge keeps those owners separate without registering two
- * handlers for the same shortcut id.
- */
-export function registerCoworkNewThreadShortcut(
-  handler: CoworkNewThreadShortcutHandler,
-): () => void {
-  const token = Symbol("cowork-new-thread");
-  registeredHandler = { token, handler };
-
-  return () => {
-    if (registeredHandler?.token === token) {
-      registeredHandler = null;
-    }
-  };
-}
-
-export function runCoworkNewThreadShortcut(): boolean {
-  if (!registeredHandler) {
-    return false;
-  }
-  registeredHandler.handler();
-  return true;
-}
-
-export function clearCoworkNewThreadShortcutForTests(): void {
-  registeredHandler = null;
 }

--- a/apps/packages/product-client/src/lib/domain/cowork/new-thread-shortcut.ts
+++ b/apps/packages/product-client/src/lib/domain/cowork/new-thread-shortcut.ts
@@ -1,0 +1,46 @@
+type CoworkNewThreadShortcutHandler = () => void;
+
+type CoworkShortcutSurface = "standard" | "cowork";
+
+let registeredHandler: {
+  token: symbol;
+  handler: CoworkNewThreadShortcutHandler;
+} | null = null;
+
+export function ownsCoworkNewThreadShortcut(
+  pathname: string,
+  surface: CoworkShortcutSurface,
+): boolean {
+  return pathname === "/" && surface === "cowork";
+}
+
+/**
+ * The authenticated Cowork provider owns the context-sensitive Cmd-N action,
+ * while the app shortcut lifecycle owns the one global keyboard registration.
+ * This small bridge keeps those owners separate without registering two
+ * handlers for the same shortcut id.
+ */
+export function registerCoworkNewThreadShortcut(
+  handler: CoworkNewThreadShortcutHandler,
+): () => void {
+  const token = Symbol("cowork-new-thread");
+  registeredHandler = { token, handler };
+
+  return () => {
+    if (registeredHandler?.token === token) {
+      registeredHandler = null;
+    }
+  };
+}
+
+export function runCoworkNewThreadShortcut(): boolean {
+  if (!registeredHandler) {
+    return false;
+  }
+  registeredHandler.handler();
+  return true;
+}
+
+export function clearCoworkNewThreadShortcutForTests(): void {
+  registeredHandler = null;
+}

--- a/apps/packages/product-client/src/lib/domain/settings/navigation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/navigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildBillingSettingsHref,
   buildCloudRepoSettingsHref,
   buildSettingsHref,
   resolveSettingsSelection,
@@ -171,6 +172,47 @@ describe("settings navigation", () => {
       focus: { checkout: "success" },
       joinOrganizationId: null,
     });
+  });
+
+  it("builds and preserves an exact organization owner for Billing", () => {
+    expect(buildBillingSettingsHref({
+      ownerScope: "organization",
+      organizationId: "org-1",
+    })).toBe(
+      "/settings?section=billing&billingOwnerScope=organization&billingOrganizationId=org-1",
+    );
+    expect(resolveSettingsSelection({
+      rawSection: "billing",
+      rawBillingOwnerScope: "organization",
+      rawBillingOrganizationId: "org-1",
+      repositories: [],
+    }).focus).toEqual({
+      billingOwnerScope: "organization",
+      billingOrganizationId: "org-1",
+    });
+  });
+
+  it("fails closed for unsupported or malformed Billing owners", () => {
+    expect(buildBillingSettingsHref({
+      ownerScope: "personal",
+      organizationId: null,
+    })).toBeNull();
+    expect(buildBillingSettingsHref({
+      ownerScope: "organization",
+      organizationId: " ",
+    })).toBeNull();
+    expect(resolveSettingsSelection({
+      rawSection: "billing",
+      rawBillingOwnerScope: "personal",
+      rawBillingOrganizationId: "org-1",
+      repositories: [],
+    }).focus).toEqual({});
+    expect(resolveSettingsSelection({
+      rawSection: "general",
+      rawBillingOwnerScope: "organization",
+      rawBillingOrganizationId: "org-1",
+      repositories: [],
+    }).focus).toEqual({});
   });
 
   it("preserves OAuth return focus only on the integrations section", () => {

--- a/apps/packages/product-client/src/lib/domain/settings/navigation.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/navigation.ts
@@ -10,6 +10,7 @@ import {
   type SettingsRepositoryEntry,
 } from "#product/lib/domain/settings/repositories";
 import { isRepoSettingsContext } from "#product/lib/domain/settings/repo-scope-selection";
+import type { CloudOwnerSelection } from "#product/lib/domain/cloud/billing";
 
 const FOCUS_PARAM_NAMES = [
   "focus",
@@ -22,6 +23,8 @@ const FOCUS_PARAM_NAMES = [
   "flowId",
   "status",
   "failureCode",
+  "billingOwnerScope",
+  "billingOrganizationId",
 ] as const;
 
 type SettingsFocusParam = (typeof FOCUS_PARAM_NAMES)[number];
@@ -119,6 +122,25 @@ export function buildCloudRepoSettingsHref(
 }
 
 /**
+ * Billing settings currently support an owner-preserving destination only for
+ * an explicitly identified organization. Personal billing has no dedicated
+ * Desktop route, so callers must fail closed instead of linking there.
+ */
+export function buildBillingSettingsHref(owner: CloudOwnerSelection): string | null {
+  const organizationId = owner.organizationId?.trim() ?? "";
+  if (owner.ownerScope !== "organization" || !organizationId) {
+    return null;
+  }
+  return buildSettingsHref({
+    section: "billing",
+    focus: {
+      billingOwnerScope: "organization",
+      billingOrganizationId: organizationId,
+    },
+  });
+}
+
+/**
  * Repository settings link for a workspace: cloud repos deep-link into the
  * cloud environment entry; local workspaces fall back to the repo root path
  * (or the workspace path) and resolve to null when neither is known.
@@ -159,6 +181,8 @@ export interface SettingsSelectionInput {
   rawFlowId?: string | null;
   rawStatus?: string | null;
   rawFailureCode?: string | null;
+  rawBillingOwnerScope?: string | null;
+  rawBillingOrganizationId?: string | null;
   repositories: SettingsRepositoryEntry[];
 }
 
@@ -182,6 +206,8 @@ export function resolveSettingsSelection({
   rawFlowId = null,
   rawStatus = null,
   rawFailureCode = null,
+  rawBillingOwnerScope = null,
+  rawBillingOrganizationId = null,
   repositories,
 }: SettingsSelectionInput): SettingsSelection {
   const repositoryRoots = new Set(repositories.map((repository) => repository.sourceRoot));
@@ -211,6 +237,8 @@ export function resolveSettingsSelection({
     flowId: rawFlowId,
     status: rawStatus,
     failureCode: rawFailureCode,
+    billingOwnerScope: rawBillingOwnerScope,
+    billingOrganizationId: rawBillingOrganizationId,
   });
   let repoSourceRoot: string | null = isRepoScopeSection(section) ? rawRepo : null;
 
@@ -295,7 +323,14 @@ function sanitizeFocusForSection(
     });
   }
   if (section === "billing") {
-    return pickFocus({ checkout: focus.checkout });
+    const organizationFocus = focus.billingOwnerScope === "organization"
+      && focus.billingOrganizationId
+      ? {
+        billingOwnerScope: focus.billingOwnerScope,
+        billingOrganizationId: focus.billingOrganizationId,
+      }
+      : {};
+    return pickFocus({ checkout: focus.checkout, ...organizationFocus });
   }
   if (section === "account") {
     return pickFocus({ joinOrganizationId: focus.joinOrganizationId });

--- a/apps/packages/product-client/src/lib/domain/shortcuts/registry.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/registry.test.ts
@@ -30,7 +30,7 @@ describe("shortcut registry", () => {
     const cleanupB = registerShortcutHandler("app.open-settings", secondHandler);
 
     expect(consoleWarn).toHaveBeenCalledWith(
-      "Duplicate shortcut handler registration for app.open-settings; using latest handler",
+      "Duplicate shortcut handler registration for app.open-settings at global priority; using latest same-priority handler",
     );
 
     expect(runShortcutHandler("app.open-settings", { source: "keyboard" })).toBe(true);
@@ -43,6 +43,64 @@ describe("shortcut registry", () => {
     expect(firstHandler).toHaveBeenCalledWith({ source: "menu" });
 
     cleanupA();
+    consoleWarn.mockRestore();
+  });
+
+  it("keeps contextual ownership above a later global registration", () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const contextualHandler = vi.fn();
+    const globalHandler = vi.fn();
+
+    const cleanupContextual = registerShortcutHandler(
+      "workspace.new-default",
+      contextualHandler,
+      { priority: "contextual" },
+    );
+    const cleanupGlobal = registerShortcutHandler("workspace.new-default", globalHandler);
+
+    expect(consoleWarn).not.toHaveBeenCalled();
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(contextualHandler).toHaveBeenCalledWith({ source: "keyboard" });
+    expect(globalHandler).not.toHaveBeenCalled();
+
+    cleanupContextual();
+    expect(runShortcutHandler("workspace.new-default", { source: "menu" })).toBe(true);
+    expect(globalHandler).toHaveBeenCalledWith({ source: "menu" });
+
+    cleanupGlobal();
+    consoleWarn.mockRestore();
+  });
+
+  it("uses registration order only to break ties between contextual owners", () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const globalHandler = vi.fn();
+    const contextualA = vi.fn();
+    const contextualB = vi.fn();
+    const cleanupGlobal = registerShortcutHandler("workspace.new-default", globalHandler);
+    const cleanupA = registerShortcutHandler("workspace.new-default", contextualA, {
+      priority: "contextual",
+    });
+    const cleanupB = registerShortcutHandler("workspace.new-default", contextualB, {
+      priority: "contextual",
+    });
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "Duplicate shortcut handler registration for workspace.new-default at contextual priority; using latest same-priority handler",
+    );
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(contextualB).toHaveBeenCalledTimes(1);
+    expect(contextualA).not.toHaveBeenCalled();
+    expect(globalHandler).not.toHaveBeenCalled();
+
+    cleanupB();
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(contextualA).toHaveBeenCalledTimes(1);
+
+    cleanupA();
+    expect(runShortcutHandler("workspace.new-default", { source: "keyboard" })).toBe(true);
+    expect(globalHandler).toHaveBeenCalledTimes(1);
+
+    cleanupGlobal();
     consoleWarn.mockRestore();
   });
 

--- a/apps/packages/product-client/src/lib/domain/shortcuts/registry.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/registry.ts
@@ -16,6 +16,10 @@ interface RegisteredShortcutHandler {
   handler: ShortcutHandler;
 }
 
+interface RegisterShortcutHandlerOptions {
+  allowOverride?: boolean;
+}
+
 const shortcutHandlers = new Map<ShortcutId, RegisteredShortcutHandler[]>();
 const VALID_SHORTCUT_IDS = new Set<ShortcutId>(
   Object.values(SHORTCUTS).map((shortcut) => shortcut.id),
@@ -24,6 +28,7 @@ const VALID_SHORTCUT_IDS = new Set<ShortcutId>(
 export function registerShortcutHandler(
   id: ShortcutId,
   handler: ShortcutHandler,
+  options?: RegisterShortcutHandlerOptions,
 ): () => void {
   if (!VALID_SHORTCUT_IDS.has(id)) {
     const message = `Unknown shortcut handler registration for ${id}`;
@@ -37,7 +42,7 @@ export function registerShortcutHandler(
 
   const token = Symbol(id);
   const handlers = shortcutHandlers.get(id) ?? [];
-  if (handlers.length > 0) {
+  if (handlers.length > 0 && !options?.allowOverride) {
     console.warn(`Duplicate shortcut handler registration for ${id}; using latest handler`);
   }
 

--- a/apps/packages/product-client/src/lib/domain/shortcuts/registry.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/registry.ts
@@ -11,16 +11,25 @@ export interface ShortcutTrigger {
 // handler intentionally performed no action because the app was already busy.
 export type ShortcutHandler = (trigger: ShortcutTrigger) => boolean | void;
 
+export type ShortcutHandlerPriority = "global" | "contextual";
+
 interface RegisteredShortcutHandler {
   token: symbol;
   handler: ShortcutHandler;
+  priority: ShortcutHandlerPriority;
 }
 
 interface RegisterShortcutHandlerOptions {
-  allowOverride?: boolean;
+  priority?: ShortcutHandlerPriority;
 }
 
 const shortcutHandlers = new Map<ShortcutId, RegisteredShortcutHandler[]>();
+// Contextual surfaces own a shortcut while mounted. Global handlers remain
+// deterministic fallbacks regardless of React passive-effect registration order.
+const SHORTCUT_HANDLER_PRIORITY_RANK: Record<ShortcutHandlerPriority, number> = {
+  global: 0,
+  contextual: 1,
+};
 const VALID_SHORTCUT_IDS = new Set<ShortcutId>(
   Object.values(SHORTCUTS).map((shortcut) => shortcut.id),
 );
@@ -41,12 +50,15 @@ export function registerShortcutHandler(
   }
 
   const token = Symbol(id);
+  const priority = options?.priority ?? "global";
   const handlers = shortcutHandlers.get(id) ?? [];
-  if (handlers.length > 0 && !options?.allowOverride) {
-    console.warn(`Duplicate shortcut handler registration for ${id}; using latest handler`);
+  if (handlers.some((entry) => entry.priority === priority)) {
+    console.warn(
+      `Duplicate shortcut handler registration for ${id} at ${priority} priority; using latest same-priority handler`,
+    );
   }
 
-  shortcutHandlers.set(id, [...handlers, { token, handler }]);
+  shortcutHandlers.set(id, [...handlers, { token, handler, priority }]);
 
   return () => {
     const current = shortcutHandlers.get(id);
@@ -66,7 +78,16 @@ export function registerShortcutHandler(
 
 export function getShortcutHandler(id: ShortcutId): ShortcutHandler | null {
   const handlers = shortcutHandlers.get(id);
-  return handlers?.[handlers.length - 1]?.handler ?? null;
+  if (!handlers || handlers.length === 0) {
+    return null;
+  }
+
+  const owner = handlers.reduce((currentOwner, candidate) =>
+    SHORTCUT_HANDLER_PRIORITY_RANK[candidate.priority]
+      >= SHORTCUT_HANDLER_PRIORITY_RANK[currentOwner.priority]
+      ? candidate
+      : currentOwner);
+  return owner.handler;
 }
 
 export function runShortcutHandler(id: ShortcutId, trigger: ShortcutTrigger): boolean {

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.test.ts
@@ -12,6 +12,37 @@ import {
 } from "#product/lib/domain/workspaces/sidebar/sidebar-test-fixtures";
 
 describe("pending sidebar projection", () => {
+  it("leaves cowork pending rows to the dedicated Threads section", () => {
+    const pendingWorkspaceEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-cowork",
+      selectedWorkspaceId: null,
+      source: "cowork-created",
+      displayName: "Untitled chat",
+      request: {
+        kind: "cowork",
+        input: {
+          agentKind: "codex",
+          modelId: "gpt-5",
+          sourceWorkspaceId: null,
+        },
+      },
+    });
+
+    expect(buildPendingSidebarProjection({
+      entry: pendingWorkspaceEntry,
+      repoRootsById: new Map(),
+      selectedLogicalWorkspaceId: buildPendingWorkspaceUiKey(pendingWorkspaceEntry),
+      selectedWorkspaceId: null,
+      activeSessionTitle: null,
+    })).toBeNull();
+
+    expect(buildGroups({
+      logicalWorkspaces: [],
+      pendingWorkspaceEntry,
+      selectedLogicalWorkspaceId: buildPendingWorkspaceUiKey(pendingWorkspaceEntry),
+    })).toEqual([]);
+  });
+
   it("projects a pending worktree into its repo group before materialization", () => {
     const pendingWorkspaceEntry = buildSubmittingPendingWorkspaceEntry({
       attemptId: "attempt-1",

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/pending-sidebar-projection.ts
@@ -30,6 +30,12 @@ export function buildPendingSidebarProjection(args: {
   activeSessionTitle: string | null;
 }): PendingSidebarProjection | null {
   const { entry, repoRootsById } = args;
+  // Cowork owns its pending and materialized rows in CoworkThreadsSection.
+  // Projecting the same pending entry into the generic repository groups made
+  // a second row flash there while a newly opened thread finished activating.
+  if (entry.source === "cowork-created") {
+    return null;
+  }
   const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(entry);
   const materializedSelectedLogicalId =
     entry.workspaceId

--- a/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
+++ b/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
@@ -1,14 +1,12 @@
 import type { Workspace } from "@anyharness/sdk";
-import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useCoworkThreadWorkflow } from "#product/hooks/cowork/workflows/use-cowork-thread-workflow";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
+import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import { resolveWorkspaceShellSurface } from "#product/lib/domain/workspaces/shell/shell-surface";
-import {
-  ownsCoworkNewThreadShortcut,
-  registerCoworkNewThreadShortcut,
-} from "#product/lib/domain/cowork/new-thread-shortcut";
+import { ownsCoworkNewThreadShortcut } from "#product/lib/domain/cowork/new-thread-shortcut";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 
 type CreateCoworkThreadFromSelection = ReturnType<
@@ -56,14 +54,13 @@ function DesktopCoworkThreadLaunchProvider({ children }: { children: ReactNode }
     resolveWorkspaceShellSurface(selectedWorkspace, pendingWorkspaceEntry),
   );
 
-  useEffect(() => {
-    if (!ownsNewThreadShortcut) {
-      return undefined;
-    }
-    return registerCoworkNewThreadShortcut(() => {
+  useShortcutHandler(
+    "workspace.new-default",
+    () => {
       void createThread();
-    });
-  }, [createThread, ownsNewThreadShortcut]);
+    },
+    { enabled: ownsNewThreadShortcut, allowOverride: true },
+  );
 
   const value = useMemo(
     () => ({ desktopTargetsAvailable: true, createThreadFromSelection }),

--- a/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
+++ b/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
@@ -59,7 +59,7 @@ function DesktopCoworkThreadLaunchProvider({ children }: { children: ReactNode }
     () => {
       void createThread();
     },
-    { enabled: ownsNewThreadShortcut, allowOverride: true },
+    { enabled: ownsNewThreadShortcut, priority: "contextual" },
   );
 
   const value = useMemo(

--- a/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
+++ b/apps/packages/product-client/src/providers/CoworkThreadLaunchProvider.tsx
@@ -1,6 +1,15 @@
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { Workspace } from "@anyharness/sdk";
+import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useCoworkThreadWorkflow } from "#product/hooks/cowork/workflows/use-cowork-thread-workflow";
+import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
+import { resolveWorkspaceShellSurface } from "#product/lib/domain/workspaces/shell/shell-surface";
+import {
+  ownsCoworkNewThreadShortcut,
+  registerCoworkNewThreadShortcut,
+} from "#product/lib/domain/cowork/new-thread-shortcut";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 
 type CreateCoworkThreadFromSelection = ReturnType<
   typeof useCoworkThreadWorkflow
@@ -32,7 +41,30 @@ export function CoworkThreadLaunchProvider({ children }: { children: ReactNode }
 }
 
 function DesktopCoworkThreadLaunchProvider({ children }: { children: ReactNode }) {
-  const { createThreadFromSelection } = useCoworkThreadWorkflow();
+  const location = useLocation();
+  const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
+  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const { data: workspaceCollections } = useWorkspaces();
+  const workspaces = workspaceCollections?.workspaces ?? EMPTY_WORKSPACES;
+  const selectedWorkspace = useMemo(
+    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? null,
+    [selectedWorkspaceId, workspaces],
+  );
+  const { createThread, createThreadFromSelection } = useCoworkThreadWorkflow();
+  const ownsNewThreadShortcut = ownsCoworkNewThreadShortcut(
+    location.pathname,
+    resolveWorkspaceShellSurface(selectedWorkspace, pendingWorkspaceEntry),
+  );
+
+  useEffect(() => {
+    if (!ownsNewThreadShortcut) {
+      return undefined;
+    }
+    return registerCoworkNewThreadShortcut(() => {
+      void createThread();
+    });
+  }, [createThread, ownsNewThreadShortcut]);
+
   const value = useMemo(
     () => ({ desktopTargetsAvailable: true, createThreadFromSelection }),
     [createThreadFromSelection],
@@ -43,6 +75,8 @@ function DesktopCoworkThreadLaunchProvider({ children }: { children: ReactNode }
     </CoworkThreadLaunchContext.Provider>
   );
 }
+
+const EMPTY_WORKSPACES: Workspace[] = [];
 
 export function useCoworkThreadLaunchContext(): CoworkThreadLaunchContextValue {
   const value = useContext(CoworkThreadLaunchContext);

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.test.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProductSidebarWorkspaceRow } from "./ProductSidebarRepositories";
+
+afterEach(cleanup);
+
+describe("ProductSidebarWorkspaceRow trailing slot", () => {
+  it("renders the quieter unread dot in the shared right slot instead of the date", () => {
+    render(
+      <ProductSidebarWorkspaceRow
+        label="Unread workspace"
+        unreadDot
+        trailingLabel="2m"
+      />,
+    );
+
+    const unreadDot = screen.getByRole("img", { name: "Unseen activity" });
+    expect(unreadDot.className).toContain("size-1.5");
+    expect(unreadDot.className).toContain("bg-info/70");
+    expect(screen.queryByText("2m")).toBeNull();
+    expect(unreadDot.closest(".grid")?.className).toContain("min-w-[26px]");
+  });
+
+  it("gives live status precedence over unread and date in that same slot", () => {
+    render(
+      <ProductSidebarWorkspaceRow
+        label="Running workspace"
+        trailingStatus={<span data-testid="running-status">Running</span>}
+        unreadDot
+        trailingLabel="now"
+      />,
+    );
+
+    expect(screen.getByTestId("running-status")).not.toBeNull();
+    expect(screen.queryByRole("img", { name: "Unseen activity" })).toBeNull();
+    expect(screen.queryByText("now")).toBeNull();
+  });
+
+  it("uses the same right-slot geometry for an idle date", () => {
+    render(
+      <ProductSidebarWorkspaceRow label="Idle workspace" trailingLabel="4h" />,
+    );
+
+    const date = screen.getByText("4h");
+    expect(date.closest(".grid")?.className).toContain("min-w-[26px]");
+  });
+});

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarRepositories.tsx
@@ -209,7 +209,7 @@ export function ProductSidebarWorkspaceRow({
                 <span
                   role="img"
                   aria-label="Unseen activity"
-                  className="block size-2 rounded-full bg-info"
+                  className="block size-1.5 rounded-full bg-info/70"
                 />
               </Tooltip>
             ) : trailingLabel ? (

--- a/specs/codebase/platforms/product/billing.md
+++ b/specs/codebase/platforms/product/billing.md
@@ -156,9 +156,15 @@ UTC window. Its principal owners are
 and
 [`OrganizationLimitsEditor.tsx`](../../../../apps/packages/product-client/src/components/settings/panes/OrganizationLimitsEditor.tsx).
 
-When usage metering is enabled and a usage summary exists, the compact
-[`SidebarConsumptionCard`](../../../../apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx)
-renders above the account footer. It is not part of an account popover.
+When the user is authenticated and usage metering is enabled, the app sidebar
+footer exposes independent **Compute** and **LLM** meter triggers outside the
+account popover. Each trigger opens the compact
+[`SidebarConsumptionCard`](../../../../apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx).
+The concern preserves explicit loading and unavailable states while the summary
+is absent, then renders each ready meter from its own returned units and limit
+state. Billing actions are gated independently by the billing capability; a
+billing-disabled deployment does not imply that an administrator can raise a
+limit.
 
 ## Known Gaps
 

--- a/specs/codebase/platforms/product/billing.md
+++ b/specs/codebase/platforms/product/billing.md
@@ -164,7 +164,12 @@ The concern preserves explicit loading and unavailable states while the summary
 is absent, then renders each ready meter from its own returned units and limit
 state. Billing actions are gated independently by the billing capability; a
 billing-disabled deployment does not imply that an administrator can raise a
-limit.
+limit. A ready, self-service organization owner exposes one **Billing** action
+whose settings URL preserves that exact organization. Organization members use
+the same owner-preserving destination with admin-managed copy. Personal owners
+expose no billing action because Desktop has no owner-correct personal billing
+destination; the card explains why instead of falling back to an unrelated
+active organization.
 
 ## Known Gaps
 

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -286,9 +286,12 @@ member, timeseries, and limit hooks. Billing is also connected: Desktop and
 Web both reuse `BillingSettingsSurface`, while their navigation remains
 surface-specific.
 
-When usage metering is enabled and a usage summary exists,
-`SidebarConsumptionCard` renders directly above the app sidebar's account
-footer. It is always outside the account popover.
+When the user is authenticated and usage metering is enabled, independent
+Compute and LLM meter triggers render in the app sidebar footer outside the
+account popover. Each trigger opens `SidebarConsumptionCard`, which preserves
+truthful loading, unavailable, and ready states for the usage summary. Billing
+actions are a separate capability-gated concern rather than a prerequisite for
+showing usage.
 
 Personal Integrations and Workflows are top-level app pages rather than
 Settings sections. Rows outside the target list are marked with a small

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -291,7 +291,10 @@ Compute and LLM meter triggers render in the app sidebar footer outside the
 account popover. Each trigger opens `SidebarConsumptionCard`, which preserves
 truthful loading, unavailable, and ready states for the usage summary. Billing
 actions are a separate capability-gated concern rather than a prerequisite for
-showing usage.
+showing usage. A supported self-service organization owner gets one Billing
+action with that owner preserved in the settings route. When Desktop cannot
+guarantee a destination for the same personal or organization owner represented
+by the meters, the card renders no action and explains the unavailability.
 
 Personal Integrations and Workflows are top-level app pages rather than
 Settings sections. Rows outside the target list are marked with a small


### PR DESCRIPTION
## What this changes

The sidebar now has clear account, help, and usage controls, with correct Cowork shortcuts and one truthful Billing path instead of duplicate, misleading, or misrouted actions.

**Owned surface:** Product sidebar navigation and footer, including Cowork row/shortcut behavior and the account, help, and usage popovers launched from that surface.

**Explicit non-goals:** No composer, workspace/repository management, workflow content, account/settings visual redesign, or billing-policy redesign; only routing and copy needed to keep this sidebar surface truthful are in scope.

## Before / after

**Before:** Opening a thread could duplicate a sidebar icon; account, support, and usage were crowded into one control; Cmd-N could start the wrong kind of chat; and exhausted usage could be mislabeled or linked to the wrong billing owner.

**After:** The footer has three calm, separate controls; unread and status indicators stay aligned; Cmd-N creates a Cowork thread only in Cowork; usage states tell the truth; and each supported organization gets one Billing action for the same owner shown by the meters.

## When this matters

An organization member who reaches an LLM or compute limit can inspect the exhausted state, understand that an admin manages the limit, and open the exact organization Billing view without being sent to an unrelated active organization. This is a normal reachable organization flow, so the recommendation is to keep the owner-preserving behavior.

## Design reference

1. **Primary reference:** Codex.
2. **Exact screen, state, and viewport:** the saved Codex main sidebar with project/thread rows and the idle footer visible; its captured sidebar measured `376.663px` wide. The comparison below replays that saved DOM/CSS at `1280 × 720` beside the hosted Proliferate head at the same viewport. The Codex account dropdown open after activating the identity trigger was also inspected; that capture reported `1585 × 947.7px` available area at `0.9` zoom. Sources: `reference/codex/sidebar/sidebar.html` and `reference/codex/popover/popover.html`, captured July 14, 2026.
3. **Elements and interactions intentionally matched:** the footer hierarchy below a short inset divider; one broad identity trigger and a separate help trigger; compact row rhythm and hit areas; independently anchored account/help surfaces; identity-trigger activation opening the account surface; and a small, quiet unread dot occupying the same trailing slot as dates and status.
4. **Intentional Proliferate divergences:** Proliferate keeps its theme, copy, organization switching and invitations, plan, shortcuts, self-managed support, server identity, version, and capability gates. It adds separate Compute and LLM meters with truthful loading, unavailable, zero-allocation, and exhausted states plus owner-correct Billing because Codex does not define those product contracts. Existing Proliferate popover motion is retained rather than copying an unmeasured Codex transition.
5. **Secondary comparison only:** Conductor informed support/learning-link inventory; it did not own hierarchy, spacing, sizing, controls, motion, or state treatment.
6. **Mock and ambiguity status:** no mock was required because the saved Codex states directly specified the borrowed properties. This already-built slice has no unresolved visual ambiguity, and no retroactive mock was manufactured.

## Demo

<img width="2560" height="720" alt="codex-vs-proliferate-exact-head-3010d315" src="https://github.com/user-attachments/assets/e8edf582-729c-49ae-ad0d-649b961cd57f" />

**Comparison:** Codex saved-state replay (left) versus Proliferate hosted Web at exact head `3010d315d1f16907a1ebe98b1fe36f25e44a15dd` (right), both rendered at `1280 × 720`. The Codex side is explicitly a deterministic DOM/CSS replay, not a live screenshot; the Proliferate side is the live hosted signed-out state and proves the shared sidebar/footer hierarchy. Authenticated meter and Billing states are covered by the exact-head owner-state proof in Engineering evidence.

[Open the verified hosted Web preview](https://proliferate-web-git-codex-ui-sidebar-navigation-getonyx.vercel.app) — HTTP 200 verified at the same head; Vercel hosted Web build. Authenticated usage states require sign-in. The local Desktop preview has stopped.

## Current disposition

**Merged** — UI 05 is complete; no further action is required.

## Founder decision needed

None. Decision-05-01 is resolved: show one owner-correct Billing action when supported, and otherwise show no action with a truthful explanation.

---

## Engineering evidence

### Scope and outcome

- split the sidebar footer into independent account, help, and usage concerns while preserving organization, plan, support, version, and capability gating
- remove the transient duplicate Cowork row by keeping Cowork-created pending entries out of generic repository projection
- make unread activity quieter in the shared trailing slot and route Cmd-N to Cowork only when the active shell is Cowork
- expose one truthful, owner-preserving Billing action for supported organization owners; unsupported personal ownership remains informative and non-actionable

### Stable review findings and repairs

- **B01:** isolate `use-home-next-launch` from Cowork provider router/workspace dependencies so the exact Shared frontend packages boundary passes
- **B02:** model explicit usage states: 0/0 is `No allocation`, positive used/0 remaining is `100% used · Exhausted`, and explicit blocking stays distinct; visual text and ARIA agree for Compute and LLM
- **B02:** preserve deployment-billing-disabled and admin-managed action copy so self-managed users are not incorrectly told to ask an admin
- **B03:** give the existing shortcut registry explicit global/contextual ownership priority so mounted Cowork wins independently of React effect order, with registration order only a same-priority tiebreaker and cleanup restoring the prior owner or global fallback
- **B03:** keep the Cowork route-ownership predicate pure and mounted callback lifetime in the shortcut/Cowork lifecycle
- **B04:** update canonical billing and Settings IA docs for capability/auth-gated Compute and LLM footer triggers and truthful loading/unavailable/ready states
- **Decision-05-01:** remove duplicate Top up/Billing labels; bind usage reads and Billing routes to the same validated owner; resolve the exact routed organization in Billing settings and fail closed instead of falling back to an unrelated active organization

### Owner-routing contract

- organization owner/admin: one Billing action carrying the exact organization ID
- organization member: the same owner-correct Billing destination with admin-managed copy; no Top up duplicate
- personal owner: no action because Desktop has no owner-correct personal Billing destination; the footer explains the limitation
- routed organization missing from the account: Billing settings render an unavailable state and never substitute the active organization
- billing capability disabled: no dead action and deployment-appropriate copy

### Revisions and metadata

- frozen base: `c91d6f9275cd6e21723f9b83388df2ac8a697389`
- review-ready head: `3010d315d1f16907a1ebe98b1fe36f25e44a15dd`
- branch: `codex/ui-sidebar-navigation`
- title: `feat(product): refine sidebar navigation and footer`
- labels: `release:minor-feature`, `area:product`, `area:docs`
- squash-merged as `0921641c88ff033be9fc302be213456cfcd8e620`
- all exact-head GitHub, CodeQL, intent, Vercel, and smoke checks passed

### Verification matrix

- focused meter/owner-route/settings tests: 4 files, 66 tests
- full ProductClient CI-equivalent Vitest job: 597 files, 3,599 tests
- full Product UI Vitest job: 37 files, 215 tests
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-ui typecheck`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only` (0 violations)
- `python3 scripts/check_docs.py` (220 Markdown files)
- login first-load budget at exact head: JS 482,354 / 485,000 bytes; CSS 65,788 / 66,000 bytes; zero eager fonts/images/audio
- `git diff --check`
- local PR metadata validation passed

### Local visual evidence inventory

The ignored local proof bundle is at `reference/proliferate/sidebar-navigation-footer/`.

- exact-head Codex-versus-Proliferate 1280×720 comparison embedded in Demo: `codex-vs-proliferate-exact-head-3010d315.png`
- exact-head owner-routing contact sheet: `owner-correct-billing-contact-sheet-final.jpg`
- exact-head capture metadata: `owner-correct-billing-final-metadata.json`
- matched reference bundle: `sidebar-before-after.png`, `account-before-after.png`, `after-account-ready.png`, `after-help-ready.png`, `after-usage-ready.png`
- usage truthfulness: `after-usage-exhausted-open-r1.png`, `after-usage-positive-exhausted-open-r2.png`, `sidebar-positive-exhausted-before-after-r2.png`
- multi-state interaction proof: `footer-multi-state.mp4`, `cowork-creation.mp4`, `usage-exhausted-r1.mp4`

### Capture environment

The embedded 1280×720 comparison uses a deterministic replay of the saved Codex DOM/CSS on the left and the Vercel hosted Web build for exact head `3010d315d1f16907a1ebe98b1fe36f25e44a15dd` on the right; HMR is not applicable to that hosted capture. Real ProductClient behavior was validated on the Desktop Vite renderer with isolated profile `ui-05-sidebar`; exact-head owner states were captured through a focused ProductClient harness on that renderer. App version 0.3.43, HMR enabled on 127.0.0.1:1673, renderer 127.0.0.1:1672, not packaged Desktop. The local preview is stopped. Docker was not started. An earlier full-dev attempt started a local Tauri compile and was stopped before final proof; no Rust changes or native artifacts are included.

