### PR TITLE
test(release): classify local turn failures safely

### DIFF
--- a/tests/release/src/scenarios/local/chat-authroute.test.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.test.ts
@@ -10,9 +10,11 @@ import {
   NoEligibleGatewayModelError,
   assertOpencodeProviderSource,
   buildLocalRouteTurnEvidence,
+  classifyTurnErrorForEvidence,
   collectLocal2GatewayCells,
   collectLocal3UserKeyCells,
   collectLocal6RouteChangeCell,
+  turnErrorEvidenceMessage,
   type LocalRouteDriver,
   type RouteModelSelection,
 } from "./chat-authroute.js";
@@ -273,6 +275,21 @@ function fakeDriver(options: FakeDriverOptions = {}): { driver: LocalRouteDriver
 }
 
 // ── LOCAL-2 (gateway per harness) ─────────────────────────────────────────────
+
+test("turn errors retain only a fixed route and safe class in evidence", () => {
+  const raw = "LiteLLM 429: Budget has been exceeded; current=5 max=5 key=sk-secret";
+  assert.equal(classifyTurnErrorForEvidence(raw), "budget_exceeded");
+  const message = turnErrorEvidenceMessage("gateway", raw);
+  assert.equal(message, "sendBoundedTurn route=gateway error_class=budget_exceeded");
+  assert.doesNotMatch(message, /(?:sk-secret|current|\b5\b)/);
+});
+
+test("turn error classification is conservative and bounded", () => {
+  assert.equal(classifyTurnErrorForEvidence("HTTP 429 from upstream"), "rate_limited");
+  assert.equal(classifyTurnErrorForEvidence("provider returned 401 unauthorized"), "authentication_failed");
+  assert.equal(classifyTurnErrorForEvidence("upstream service unavailable (503)"), "provider_unavailable");
+  assert.equal(classifyTurnErrorForEvidence("opaque provider detail secret=abc"), "unclassified");
+});
 
 test("LOCAL-2: a non-cursor harness produces a green local_route_turn (route=gateway) with folded cleanup", async () => {
   const { driver } = fakeDriver();

--- a/tests/release/src/scenarios/local/chat-authroute.test.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import {
@@ -8,8 +11,10 @@ import {
   HARNESSES_WITHOUT_GATEWAY_AUTH_SLOT,
   LOCAL6_REPRESENTATIVE_HARNESS,
   NoEligibleGatewayModelError,
+  SafeTurnFailure,
   assertOpencodeProviderSource,
   buildLocalRouteTurnEvidence,
+  captureLocalRouteFailure,
   classifyTurnErrorForEvidence,
   collectLocal2GatewayCells,
   collectLocal3UserKeyCells,
@@ -289,6 +294,37 @@ test("turn error classification is conservative and bounded", () => {
   assert.equal(classifyTurnErrorForEvidence("provider returned 401 unauthorized"), "authentication_failed");
   assert.equal(classifyTurnErrorForEvidence("upstream service unavailable (503)"), "provider_unavailable");
   assert.equal(classifyTurnErrorForEvidence("opaque provider detail secret=abc"), "unclassified");
+});
+
+test("safe turn failures never persist raw browser diagnostics", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "local-turn-safe-"));
+  const debugDir = path.join(root, "debug");
+  const previous = process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+  const raw = "LiteLLM 429: Budget has been exceeded; current=5 max=5 key=sk-secret";
+  try {
+    await mkdir(debugDir);
+    await writeFile(path.join(debugDir, "unrelated.txt"), "keep");
+    process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR = debugDir;
+    const page = {
+      page: {
+        content: async () => `<main>${raw}</main>`,
+        screenshot: async ({ path: outputPath }: { path: string }) => writeFile(outputPath, raw),
+      },
+      debug: { console: [raw], network: [raw] },
+    } as unknown as ProductPage;
+
+    await captureLocalRouteFailure(page, "route-change", new SafeTurnFailure("gateway", raw));
+
+    assert.deepEqual(await readdir(debugDir), ["unrelated.txt"]);
+    assert.equal(await readFile(path.join(debugDir, "unrelated.txt"), "utf8"), "keep");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR;
+    } else {
+      process.env.LOCAL_WORLD_SMOKE_DEBUG_DIR = previous;
+    }
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("LOCAL-2: a non-cursor harness produces a green local_route_turn (route=gateway) with folded cleanup", async () => {

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -85,6 +85,26 @@ export function turnErrorEvidenceMessage(route: LocalRoute, raw: string): string
   return `sendBoundedTurn route=${route} error_class=${classifyTurnErrorForEvidence(raw)}`;
 }
 
+/** Carries only the fixed-vocabulary turn failure; the raw provider payload is discarded. */
+export class SafeTurnFailure extends Error {
+  constructor(route: LocalRoute, raw: string) {
+    super(turnErrorEvidenceMessage(route, raw));
+    this.name = "SafeTurnFailure";
+  }
+}
+
+/** Provider turn failures must not persist the rendered/raw browser diagnostics. */
+export async function captureLocalRouteFailure(
+  page: ProductPage | undefined,
+  label: string,
+  error: unknown,
+): Promise<void> {
+  if (error instanceof SafeTurnFailure) {
+    return;
+  }
+  await captureLocalDriverFailure(page, label);
+}
+
 /**
  * BYOK env mapping (BRIEF §"BYOK input mapping"). Each user-key harness reads a
  * dedicated bounded provider key from the controller's secret environment and
@@ -445,7 +465,7 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     );
     const completion = await waitForTurnCompletion(world, sessionId, TURN_TIMEOUT_MS);
     if (completion.error) {
-      throw new Error(turnErrorEvidenceMessage(expectedRoute, completion.error));
+      throw new SafeTurnFailure(expectedRoute, completion.error);
     }
     if (!completion.ended) {
       throw new Error(`sendBoundedTurn: assistant turn did not end within ${TURN_TIMEOUT_MS}ms.`);
@@ -764,7 +784,7 @@ async function runLocal2GatewayCell(
         },
       };
     } catch (uiError) {
-      await captureLocalDriverFailure(page, `${cell.cell_id}-ui-failure`);
+      await captureLocalRouteFailure(page, `${cell.cell_id}-ui-failure`, uiError);
       throw uiError;
     } finally {
       await page.close().catch(() => undefined);
@@ -845,7 +865,7 @@ async function runLocal3UserKeyCell(
         },
       };
     } catch (uiError) {
-      await captureLocalDriverFailure(page, `${cell.cell_id}-ui-failure`);
+      await captureLocalRouteFailure(page, `${cell.cell_id}-ui-failure`, uiError);
       throw uiError;
     } finally {
       await page.close().catch(() => undefined);
@@ -961,7 +981,7 @@ async function runLocal6RouteChangeCell(
         },
       };
     } catch (uiError) {
-      await captureLocalDriverFailure(page, `${cell.cell_id}-ui-failure`);
+      await captureLocalRouteFailure(page, `${cell.cell_id}-ui-failure`, uiError);
       throw uiError;
     } finally {
       await page.close().catch(() => undefined);

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -63,6 +63,28 @@ import {
 /** The route a functional cell drives. */
 export type { LocalRoute } from "../../evidence/schema.js";
 
+export type SafeTurnErrorClass =
+  | "budget_exceeded"
+  | "rate_limited"
+  | "authentication_failed"
+  | "provider_unavailable"
+  | "unclassified";
+
+/** Maps an untrusted runtime/provider error to a fixed evidence-safe class. */
+export function classifyTurnErrorForEvidence(raw: string): SafeTurnErrorClass {
+  const message = raw.toLowerCase();
+  if (/\bbudget\b[\s\S]{0,120}\b(?:exceed(?:ed|s|ing)?|exhausted|reached)\b/.test(message)) return "budget_exceeded";
+  if (/\b429\b|\brate[ _-]?limit(?:ed|ing)?\b/.test(message)) return "rate_limited";
+  if (/\b(?:401|403)\b|\bunauthori[sz]ed\b|\bauthentication failed\b|\binvalid api[ _-]?key\b/.test(message)) return "authentication_failed";
+  if (/\b(?:502|503|504)\b|\b(?:service|provider|upstream) unavailable\b/.test(message)) return "provider_unavailable";
+  return "unclassified";
+}
+
+/** Builds a diagnostic reason whose vocabulary cannot carry provider payloads. */
+export function turnErrorEvidenceMessage(route: LocalRoute, raw: string): string {
+  return `sendBoundedTurn route=${route} error_class=${classifyTurnErrorForEvidence(raw)}`;
+}
+
 /**
  * BYOK env mapping (BRIEF §"BYOK input mapping"). Each user-key harness reads a
  * dedicated bounded provider key from the controller's secret environment and
@@ -369,7 +391,7 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     return { route, modelId, providerId: directProviderId(modelId) };
   },
   selectModelInUi: (page, modelId) => defaultLocalWorldSmokeDriver.selectModelInUi(page, modelId),
-  async sendBoundedTurn(world, page, _expectedRoute, repoPath, existingSessionIds) {
+  async sendBoundedTurn(world, page, expectedRoute, repoPath, existingSessionIds) {
     const p = page.page;
     // Snapshot before Send. LOCAL-6 uses the same concrete workspace for both
     // routes; resolving the "latest" session after the click can otherwise
@@ -423,7 +445,7 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     );
     const completion = await waitForTurnCompletion(world, sessionId, TURN_TIMEOUT_MS);
     if (completion.error) {
-      throw new Error(`sendBoundedTurn: assistant turn errored: ${completion.error}`);
+      throw new Error(turnErrorEvidenceMessage(expectedRoute, completion.error));
     }
     if (!completion.ended) {
       throw new Error(`sendBoundedTurn: assistant turn did not end within ${TURN_TIMEOUT_MS}ms.`);


### PR DESCRIPTION
## Scope

Narrow diagnostic repair for #1410. When a local qualification turn emits an untrusted runtime/provider error, retain only the expected route and a fixed error class in the report. Raw provider bodies, budget values, and key material are discarded from the Error object and suppressed from HTML, screenshot, console, network, and WebSocket-backed failure artifacts. Ordinary UI failures retain the existing debug capture.

This does **not** widen budgets or claim #1410 fixed. It makes the next exact-head diagnostic distinguish `budget_exceeded` from generic rate limiting/authentication/provider availability while preserving evidence safety. #1411 remains separate.

## Exact custody

- Base: `fbb8dc35294b414ec0ec2a5b1657c88dbae304c6`
- Head: `d557c69d875e429d52ecaf42f65cfb5b9eb9d382`
- Reproduction: [run 29674146779](https://github.com/proliferate-ai/proliferate/actions/runs/29674146779), where `route=change` failed again but the provider class was unavailable

## Proof

- `chat-authroute.test.ts`: 28/28 green, including persisted-artifact suppression and ordinary-error capture preservation
- `tsc --noEmit -p tests/release/tsconfig.json`: green
- `make check-max-lines`: green
- `git diff --check`: green
- Exact-head CI, Intent Tests, CodeQL, Self-Host Smoke, and PR Metadata: settled green
- Exact-head CONTROL: code clean; `BLOCKER-1436-01` resolved in comment 5014676259

No live provider call was made by this change. Local Tier-3 remains unaccepted until a later exact-head strict run proves the real route-change turn and cleanup.