### PR TITLE
test(release): resolve canonical Haiku composer alias

### DIFF
--- a/tests/release/src/scenarios/local-world-smoke-1.ts
+++ b/tests/release/src/scenarios/local-world-smoke-1.ts
@@ -25,6 +25,10 @@ import {
   type LocalWorldPorts,
   type ReadyLocalWorld,
 } from "../worlds/local-workspace/world.js";
+import {
+  resolveVisibleComposerModelOptionId,
+  waitForComposerModelSelection,
+} from "./local/composer-model-option.js";
 import { resolveLocalWorkspaceSessionId } from "./local/local-session.js";
 
 /**
@@ -172,7 +176,7 @@ export interface LocalWorldSmokeDriver {
   liveProbeModels(world: ReadyLocalWorld, harnessKind: string): Promise<string[]>;
   /** The qualification allowlist, cheapest-first (from controller preflight). */
   allowlistModels(world: ReadyLocalWorld): Promise<string[]>;
-  /** Selects `modelId` in the home composer's model picker and asserts the picker reflects it. */
+  /** Selects canonical `modelId` through its unique exact/known-alias option and asserts it sticks. */
   selectModelInUi(page: ProductPage, modelId: string): Promise<void>;
   /**
    * Sends the bounded prompt from the home composer. This materializes the
@@ -345,7 +349,6 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
     // ready (Desktop refetches agents on an interval). Retry opening the picker
     // until the model option appears.
     const deadline = Date.now() + MODEL_PICKER_TIMEOUT_MS;
-    const optionSelector = `[data-model-option="${cssAttr(modelId)}"]`;
     let lastAvailable: Array<string | null> = [];
     while (Date.now() < deadline) {
       const trigger = p.locator("[data-composer-model-trigger]:not([disabled])").first();
@@ -356,20 +359,26 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
         await sleep(1_500);
         continue;
       }
-      const option = p.locator(optionSelector).first();
-      if (await option.count().catch(() => 0)) {
-        await option.click();
-        // Assert the composer now reflects the selection (spec step 7).
-        await p
-          .locator(`[data-composer-model-trigger][data-composer-selected-model="${cssAttr(modelId)}"]`)
-          .first()
-          .waitFor({ state: "attached", timeout: 10_000 });
-        return;
-      }
       lastAvailable = await p
         .locator("[data-model-option]")
         .evaluateAll((els) => els.map((el) => el.getAttribute("data-model-option")))
         .catch(() => []);
+      const visibleModelId = resolveVisibleComposerModelOptionId(
+        modelId,
+        lastAvailable.filter((candidate): candidate is string => candidate !== null),
+      );
+      if (visibleModelId) {
+        const option = p.locator(`[data-model-option="${cssAttr(visibleModelId)}"]`).first();
+        await option.click();
+        // The runtime/LiteLLM id remains canonical evidence, while Claude's
+        // live selector may reflect the equivalent agent alias (`haiku`).
+        await waitForComposerModelSelection(
+          () => trigger.getAttribute("data-composer-selected-model"),
+          modelId,
+          10_000,
+        );
+        return;
+      }
       // Close the popover and retry after a beat.
       await p.keyboard.press("Escape").catch(() => undefined);
       await sleep(2_000);
@@ -443,17 +452,16 @@ export const defaultLocalWorldSmokeDriver: LocalWorldSmokeDriver = {
       throw new Error("reopenAndVerify: the transcript did not re-render an assistant reply after reopen.");
     }
     // The selected model (and thus harness) must remain visible in the composer.
-    await p
-      .locator(
-        `[data-composer-model-trigger][data-composer-selected-model="${cssAttr(expectations.modelId)}"]`,
-      )
-      .first()
-      .waitFor({ state: "attached", timeout: 15_000 })
-      .catch(() => {
-        throw new Error(
-          `reopenAndVerify: composer no longer reflects model "${expectations.modelId}" after reopen.`,
-        );
-      });
+    const modelTrigger = p.locator("[data-composer-model-trigger]").first();
+    await waitForComposerModelSelection(
+      () => modelTrigger.getAttribute("data-composer-selected-model"),
+      expectations.modelId,
+      15_000,
+    ).catch(() => {
+      throw new Error(
+        `reopenAndVerify: composer no longer reflects model "${expectations.modelId}" after reopen.`,
+      );
+    });
   },
   snapshotSpend: (world, actor) => world.gateway.snapshotSpend(actor.gatewayKey),
   correlateTurn: (world, params) =>

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -17,6 +17,7 @@ import {
 } from "../local-world-smoke-1.js";
 import { bootLocalFunctionalWorld, isWorldBackedRun, resolveLocalFunctionalWorldInputs } from "./world-boot.js";
 import { captureLocalDriverFailure } from "./debug-capture.js";
+import { waitForComposerModelSelection } from "./composer-model-option.js";
 import {
   resolveLocalWorkspaceSessionAfter,
   resolveLocalWorkspaceSessionId,
@@ -490,13 +491,14 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     if (!reply.trim()) {
       throw new Error("reopenAndVerify: the transcript did not re-render an assistant reply after reopen.");
     }
-    await p
-      .locator(`[data-composer-model-trigger][data-composer-selected-model="${cssAttr(expect.modelId)}"]`)
-      .first()
-      .waitFor({ state: "attached", timeout: 15_000 })
-      .catch(() => {
-        throw new Error(`reopenAndVerify: composer no longer reflects model "${expect.modelId}" after reopen.`);
-      });
+    const modelTrigger = p.locator("[data-composer-model-trigger]").first();
+    await waitForComposerModelSelection(
+      () => modelTrigger.getAttribute("data-composer-selected-model"),
+      expect.modelId,
+      15_000,
+    ).catch(() => {
+      throw new Error(`reopenAndVerify: composer no longer reflects model "${expect.modelId}" after reopen.`);
+    });
   },
   async correlateGatewaySpend(world, params) {
     const correlated = await world.gateway.correlateTurn({

--- a/tests/release/src/scenarios/local/composer-model-option.test.ts
+++ b/tests/release/src/scenarios/local/composer-model-option.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  composerModelSelectionMatches,
+  resolveVisibleComposerModelOptionId,
+  waitForComposerModelSelection,
+} from "./composer-model-option.js";
+
+test("exact composer model ids win without aliasing", () => {
+  assert.equal(
+    resolveVisibleComposerModelOptionId("gpt-5.4", ["haiku", "gpt-5.4"]),
+    "gpt-5.4",
+  );
+});
+
+test("canonical Haiku 4.5 gateway ids resolve to the unique live Claude alias", () => {
+  const visible = ["opus[1m]", "sonnet", "haiku", "claude-fable-5"];
+  assert.equal(resolveVisibleComposerModelOptionId("claude-haiku-4-5", visible), "haiku");
+  assert.equal(
+    resolveVisibleComposerModelOptionId("anthropic/claude-haiku-4-5-20251001", visible),
+    "haiku",
+  );
+  assert.equal(composerModelSelectionMatches("claude-haiku-4-5", "haiku"), true);
+});
+
+test("alias resolution fails closed for duplicates and version-ambiguous families", () => {
+  assert.equal(resolveVisibleComposerModelOptionId("gpt-5.4", ["gpt-5.4", "gpt-5.4"]), null);
+  assert.equal(resolveVisibleComposerModelOptionId("claude-haiku-4-5", ["haiku", "haiku"]), null);
+  assert.equal(resolveVisibleComposerModelOptionId("claude-sonnet-4-5", ["sonnet"]), null);
+  assert.equal(resolveVisibleComposerModelOptionId("claude-opus-4-5", ["opus[1m]"]), null);
+  assert.equal(resolveVisibleComposerModelOptionId("claude-fable-5", ["haiku"]), null);
+});
+
+test("selection wait accepts the live Haiku alias after route reconciliation", async () => {
+  const selected = [null, "sonnet", "haiku"];
+  assert.equal(
+    await waitForComposerModelSelection(
+      async () => {
+        const next = selected.shift();
+        return next === undefined ? "haiku" : next;
+      },
+      "claude-haiku-4-5",
+      100,
+      1,
+    ),
+    "haiku",
+  );
+});
+
+test("selection wait fails closed on a non-equivalent visible alias", async () => {
+  await assert.rejects(
+    waitForComposerModelSelection(async () => "sonnet", "claude-haiku-4-5", 0, 0),
+    /last selected option: "sonnet"/,
+  );
+});

--- a/tests/release/src/scenarios/local/composer-model-option.ts
+++ b/tests/release/src/scenarios/local/composer-model-option.ts
@@ -1,0 +1,60 @@
+const CLAUDE_HAIKU_45_MODEL = /^(?:anthropic\/)?claude-haiku-4-5(?:-\d{8})?$/;
+
+/**
+ * Resolves a canonical qualification model id to the exact option id exposed
+ * by the live composer. Exact ids always win. The only alias relationship
+ * encoded here is Claude Haiku 4.5, whose agent-facing selector id is `haiku`;
+ * other Claude family aliases are version-ambiguous and therefore fail closed.
+ */
+export function resolveVisibleComposerModelOptionId(
+  requestedModelId: string,
+  visibleModelIds: readonly string[],
+): string | null {
+  const exactMatches = visibleModelIds.filter((modelId) => modelId === requestedModelId).length;
+  if (exactMatches > 0) {
+    return exactMatches === 1 ? requestedModelId : null;
+  }
+
+  const alias = CLAUDE_HAIKU_45_MODEL.test(requestedModelId) ? "haiku" : null;
+  if (!alias) {
+    return null;
+  }
+  return visibleModelIds.filter((modelId) => modelId === alias).length === 1 ? alias : null;
+}
+
+export function composerModelSelectionMatches(
+  requestedModelId: string,
+  selectedModelId: string | null,
+): boolean {
+  return selectedModelId !== null
+    && resolveVisibleComposerModelOptionId(requestedModelId, [selectedModelId]) === selectedModelId;
+}
+
+export async function waitForComposerModelSelection(
+  readSelectedModelId: () => Promise<string | null>,
+  requestedModelId: string,
+  timeoutMs: number,
+  pollMs = 100,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastSelectedModelId: string | null = null;
+  do {
+    lastSelectedModelId = await readSelectedModelId();
+    if (
+      lastSelectedModelId !== null
+      && composerModelSelectionMatches(requestedModelId, lastSelectedModelId)
+    ) {
+      return lastSelectedModelId;
+    }
+    await sleep(pollMs);
+  } while (Date.now() < deadline);
+
+  throw new Error(
+    `composer did not reflect model "${requestedModelId}" within ${timeoutMs}ms `
+      + `(last selected option: "${lastSelectedModelId ?? ""}")`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Repair the local Tier 3 browser driver so the canonical qualification gateway id `claude-haiku-4-5` can select and re-verify the unique live Claude composer option `haiku`.

The canonical gateway id remains unchanged in qualification evidence and LiteLLM spend correlation. Exact visible ids still win, duplicate aliases fail closed, and no fuzzy mapping is allowed for version-ambiguous Sonnet, Opus, Fable, or non-Claude ids.

Fixes #1438.

## Root cause

Exact-main [Release E2E run 29676389767](https://github.com/proliferate-ai/proliferate/actions/runs/29676389767) selected canonical runtime model `claude-haiku-4-5`, but the live Claude agent composer exposed `["opus[1m]", "sonnet", "haiku", "claude-fable-5"]`. The driver required an exact DOM option id and failed LOCAL-6 before the gateway send. The same exact-only assumption also existed in reload verification.

## Exact custody

- Base: `b68fe0ab3007f285fc8de3c9385b4106f9f68f25`
- Head: `cb4189337cd22c1e328947101736da7a33a0313a`

## Proof

- `pnpm exec tsx --test src/scenarios/local/composer-model-option.test.ts src/scenarios/local-world-smoke-1.test.ts src/scenarios/local/chat-authroute.test.ts` — 49/49 green
- `pnpm run typecheck` in `tests/release` — green
- `python3 scripts/check_max_lines.py` — green
- `git diff --check` — green

## Non-goals

- No product or catalog behavior change.
- No provider budget change.
- No OpenCode/#1411 change.
- No live E2E dispatch or qualification acceptance claim.