### PR TITLE
fix(litellm): pin upstream image to v1.93.0

### DIFF
--- a/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
+++ b/scripts/agent-gateway-smoke/HARNESS-MATRIX.md
@@ -1,10 +1,11 @@
-# Harness ↔ LiteLLM Compatibility Matrix (live-verified, LiteLLM main-stable)
+# Harness ↔ LiteLLM Compatibility Matrix (live-verified 2026-07-03)
 
 ## Re-verification — 2026-07-03 (P4, agent-auth cleanup, REAL upstreams)
 
 Re-ran `scripts/agent-gateway-smoke/run.sh` (proxy-health, mint-key,
 models-list, chat-completion, spend-log, then all four per-harness runners)
-against a fresh local `litellm` + `litellm-db` (main-stable image, remapped
+against a fresh local `litellm` + `litellm-db` (the then-current `main-stable`
+image, remapped
 to host port 14001 — 14000 was held by an unrelated stale `litellm-probe`
 container) with **real** Anthropic/OpenAI/xAI provider keys (not mocks, not
 the invalid dev key the prior pass hit). Added one manual tool-call check
@@ -86,7 +87,10 @@ Recipe:
     wire_api = "responses"
   env: PROLIFERATE_GATEWAY_KEY=<vk>; sanitize OPENAI_API_KEY/ANTHROPIC_API_KEY.
   codex exec -m claude-haiku-4-5-20251001 --skip-git-repo-check "..."
-- LiteLLM main-stable SERVES /v1/responses and translates it to anthropic upstream: plain completion AND a shell tool call both succeeded (verified "codex_tool_ok" run → DONE; endpoints: POST /v1/responses 200s).
+- The then-current LiteLLM `main-stable` image served `/v1/responses` and
+  translated it to the Anthropic upstream: plain completion and a shell tool
+  call both succeeded (verified `codex_tool_ok` run → `DONE`; endpoints:
+  `POST /v1/responses` returned 200s).
 - The spec's feared "Unsupported tool type: namespace"/client_metadata errors did NOT reproduce on current LiteLLM — the /v1/responses bridge appears to have matured. Codex-on-gateway is NOT OpenAI-only.
 - codex exec without --skip-git-repo-check hangs outside a git repo — adapters must pass it or run in a repo.
 - gpt-5-mini upstream test blocked by an invalid OPENAI_API_KEY in the dev .env (upstream 401) — openai-family path unverified here, but it's the native wire format (low risk).

--- a/scripts/ci-cd/litellm-image-pin.test.mjs
+++ b/scripts/ci-cd/litellm-image-pin.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const UPSTREAM_REPOSITORY = "ghcr.io/berriai/litellm";
+const IMMUTABLE_UPSTREAM_IMAGE =
+  /^ghcr\.io\/berriai\/litellm:v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$/;
+const EXPECTED_IMAGE =
+  `${UPSTREAM_REPOSITORY}:v1.93.0@sha256:` +
+  "a1745e629abfb17d434426ff48b115f54f4f4c4a0f5af241de569e93c63c411e";
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function assertReviewedImmutableImage(image) {
+  assert.match(
+    image,
+    IMMUTABLE_UPSTREAM_IMAGE,
+    "LiteLLM must use an official version tag plus an immutable OCI digest",
+  );
+  assert.equal(image, EXPECTED_IMAGE, "LiteLLM upstream release/digest changed without review");
+}
+
+function upstreamImages(contents) {
+  return [...contents.matchAll(/(?:^|\s)(ghcr\.io\/berriai\/litellm:\S+)/gm)].map(
+    (match) => match[1],
+  );
+}
+
+test("rejects floating and tag-only LiteLLM image references", () => {
+  assert.throws(
+    () => assertReviewedImmutableImage(`${UPSTREAM_REPOSITORY}:main-stable`),
+    /immutable OCI digest/,
+  );
+  assert.throws(
+    () => assertReviewedImmutableImage(`${UPSTREAM_REPOSITORY}:v1.93.0`),
+    /immutable OCI digest/,
+  );
+});
+
+test("wrapper build and local Compose bind the reviewed LiteLLM release and digest", () => {
+  const buildSurface = readFileSync(path.join(REPO_ROOT, "server/litellm/Dockerfile"), "utf8");
+  const localSurface = readFileSync(path.join(REPO_ROOT, "server/docker-compose.yml"), "utf8");
+
+  const buildImages = upstreamImages(buildSurface);
+  const localImages = upstreamImages(localSurface);
+  assert.deepEqual(buildImages, [EXPECTED_IMAGE]);
+  assert.deepEqual(localImages, [EXPECTED_IMAGE]);
+  assertReviewedImmutableImage(buildImages[0]);
+  assertReviewedImmutableImage(localImages[0]);
+});

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       retries: 5
 
   litellm:
-    image: ghcr.io/berriai/litellm:main-stable
+    image: ghcr.io/berriai/litellm:v1.93.0@sha256:a1745e629abfb17d434426ff48b115f54f4f4c4a0f5af241de569e93c63c411e
     ports:
       - "14000:4000"
     environment:

--- a/server/litellm/Dockerfile
+++ b/server/litellm/Dockerfile
@@ -1,11 +1,13 @@
 # LiteLLM proxy image for the Proliferate agent gateway.
 #
 # Layers the checked-in gateway config onto the upstream LiteLLM image so the
-# deployed ECS task runs the exact model list reviewed in this repo.
+# deployed ECS task runs the exact model list reviewed in this repo. Keep the
+# official release tag and OCI index digest together: the digest makes builds
+# reproducible while the tag keeps the reviewed upstream version visible.
 #
 # Build context: repo root (matches server/Dockerfile convention):
 #   docker build -f server/litellm/Dockerfile .
-FROM ghcr.io/berriai/litellm:main-stable
+FROM ghcr.io/berriai/litellm:v1.93.0@sha256:a1745e629abfb17d434426ff48b115f54f4f4c4a0f5af241de569e93c63c411e
 
 COPY server/litellm/config.yaml /app/proliferate-litellm-config.yaml
 

--- a/server/proliferate/integrations/litellm/client.py
+++ b/server/proliferate/integrations/litellm/client.py
@@ -4,7 +4,8 @@ Coarse operations only, per the agent-auth-litellm spec (section 2.2). This is
 the single module that knows LiteLLM endpoint paths; product services call the
 public functions re-exported from ``proliferate.integrations.litellm``.
 
-Verified against ghcr.io/berriai/litellm:main-stable:
+Verified against the upstream LiteLLM v1.93.0 image pinned in
+``server/litellm/Dockerfile``:
 
 - ``/team/new`` does NOT enforce unique ``team_alias``. The pinned image also
   ignores the ``team_alias`` query param on ``/team/list`` and returns *all*

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -24,6 +24,17 @@ The self-host CloudFormation template is one of the assets attached to a
 version does not identify an exact artifact build unless the corresponding
 artifact tag and source SHA are also known.
 
+The Proliferate LiteLLM wrapper has a separate upstream input coordinate. Both
+`server/litellm/Dockerfile` and local development Compose bind
+`ghcr.io/berriai/litellm:v1.93.0@sha256:a1745e629abfb17d434426ff48b115f54f4f4c4a0f5af241de569e93c63c411e`.
+The digest identifies the official multi-architecture OCI index and the tag
+makes its reviewed release legible; neither may be replaced by a floating or
+tag-only reference. This pin preserves Proliferate's checked-in model config,
+LiteLLM management API contract, and existing `$5` team/key enrollment cap.
+The selected upstream source contains the bounded per-request budget
+reservation behavior, so a request without `max_tokens` does not reserve all
+remaining budget headroom while it is in flight.
+
 ## Topology
 
 ### Hosted spine
@@ -199,6 +210,10 @@ Server releases publish server and LiteLLM GHCR images with version and rolling
 also holds the two Linux runtime bundles, CloudFormation template, installer,
 AWS launch helper, deploy bundle, and checksum manifest enumerated in the
 [Release procedure](../../../../developing/deploying/releases.md).
+
+Those published LiteLLM images are Proliferate-owned wrappers. Their rolling or
+versioned outer tags do not loosen the wrapper's upstream input: every build
+still starts from the exact release-and-index-digest coordinate above.
 
 ## Workflow Inventory
 

--- a/specs/developing/deploying/releases.md
+++ b/specs/developing/deploying/releases.md
@@ -97,6 +97,16 @@ GHCR tags are not produced. Manual dispatch is validation-only; GHCR and
 release-asset publication require either a `server-v*` tag push or a publishing
 reusable-workflow call.
 
+The LiteLLM wrapper and the direct local-development service both consume the
+exact upstream coordinate recorded in the Delivery system contract. Treat an
+upstream change as one reviewed tag-and-digest update: verify an official
+non-prerelease tag, confirm its GHCR OCI-index digest and Linux amd64/arm64
+manifests, confirm the image's source-revision label matches the release commit,
+and check the configured models and management API against that source. Never
+substitute `main-stable`, another floating tag, or a version tag without its
+digest. Run `node --test scripts/ci-cd/litellm-image-pin.test.mjs` after an
+update; the test binds both build surfaces to the reviewed coordinate.
+
 The `server-v<version>` GitHub Release contains exactly these seven self-host
 assets:
 


### PR DESCRIPTION
## Summary

- Pin the official LiteLLM `v1.93.0` multi-architecture OCI index by immutable digest in the wrapper build and direct local Compose surface.
- Preserve checked-in model configuration, management APIs, and the existing `$5` team/key cap while selecting upstream bytes containing the bounded-reservation fix.
- Add merge-tier contracts rejecting floating/tag-only references and binding both executable surfaces to the reviewed tag/digest; document provenance and update ownership.

Addresses #1410. This merge does **not** claim staging deployment or LOCAL-6 acceptance; the issue stays open until deploy plus exact strict proof/cleanup.

## Exact custody and provenance

- Base: `c78b7559e73d87d59d1f127597f5df30c26b7207`
- Head: `21e83c5821eab20883bc3d404ff51f97d8447f68`
- Official release: https://github.com/BerriAI/litellm/releases/tag/v1.93.0
- Release commit: `052b5a2169d8d3082e1d66e69f200a72b0c1e274`
- Official multi-arch OCI index: `sha256:a1745e629abfb17d434426ff48b115f54f4f4c4a0f5af241de569e93c63c411e` (`linux/amd64` + `linux/arm64`)
- Reservation fix ancestry: https://github.com/BerriAI/litellm/commit/adc41ade8c0eb15ec6165906b2c3c9803b26d386
- At verification, `main-stable` resolved to this same index digest; the PR freezes existing bytes rather than changing the deployed byte selection by intent.

## Verification

- CI/CD suite: 165/165
- Pin contracts: 2/2
- Ruff check/format, max-lines, docs integrity, and diff check: green
- Exact-head CI, Intent, CodeQL, Self-Host Smoke, metadata, and Vercel: settled green
- Exact-head independent review `PR1440-R1`: `CONTROL_CLEAN / CODE_MERGE_READY`, zero findings (comment 5015182617)
- Current-main merge tree: clean; intervening UI-only change is disjoint

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, evidence, and exact-head review.

No Docker daemon, provider call, staging deploy, AWS/ECS action, budget change, or live E2E was performed by this PR.