### PR TITLE
fix(server): signal CloudFormation bootstrap failures

### DIFF
--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -10,6 +10,10 @@ name: Self-Host Smoke
 # day, so this is the check that keeps it from regressing silently. Designed
 # to be a blocking required check on PRs to main.
 #
+# Before the heavy image/Compose smoke, this same required Ubuntu job runs the
+# no-network deploy/template suite, including the rendered GNU timeout proof
+# that a TERM-resistant CloudFormation bootstrap is hard-bounded and signaled.
+#
 # No on.*.paths filter: a path-skipped run of a required check never reports a
 # conclusion, so unrelated PRs would sit on a Pending check forever and be
 # unmergeable. Instead a cheap changes job always runs, diffs against the merge
@@ -119,6 +123,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Test self-host deploy and CloudFormation controls
+        run: server/deploy/tests/run.sh
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -503,6 +503,51 @@ grep -q "fetch_bundle:" "$AWS_TEMPLATE" && ok "template fetches the deploy bundl
 grep -q "sha256sum -c --ignore-missing" "$AWS_TEMPLATE" && ok "template verifies the bundle checksum" || no "template missing checksum verification"
 grep -q "docker-compose.production.yml:" "$AWS_TEMPLATE" && no "template still embeds docker-compose (drift)" || ok "template no longer embeds docker-compose"
 grep -q "DeployBundleUrl" "$AWS_TEMPLATE" && ok "template exposes DeployBundleUrl override" || no "template missing DeployBundleUrl override"
+
+# Execute the template's exact UserData body with fake cfn tools. The failure
+# path must preserve cfn-init's exit code and invoke cfn-signal with a bounded,
+# secret-free reason; `bash -e` would exit before the signal and fail this test.
+user_data="$SCRATCH/cfn-user-data.sh"
+awk '
+  /Fn::Base64: !Sub \|/ { in_user_data = 1; next }
+  in_user_data && /^  ProliferateDnsRecord:/ { exit }
+  in_user_data { sub(/^          /, ""); print }
+' "$AWS_TEMPLATE" \
+  | sed \
+      -e 's|/opt/aws/bin/cfn-init|"$FAKE_CFN_BIN/cfn-init"|g' \
+      -e 's|/opt/aws/bin/cfn-signal|"$FAKE_CFN_BIN/cfn-signal"|g' \
+      -e 's|dnf install|"$FAKE_CFN_BIN/dnf" install|g' \
+      -e 's|${AWS::StackName}|test-stack|g' \
+      -e 's|${AWS::Region}|us-east-1|g' \
+  >"$user_data"
+
+FAKE_CFN_BIN="$SCRATCH/fake-cfn-bin"
+mkdir -p "$FAKE_CFN_BIN"
+cat >"$FAKE_CFN_BIN/dnf" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$FAKE_CFN_BIN/cfn-init" <<'EOF'
+#!/usr/bin/env bash
+exit "${FAKE_CFN_INIT_EXIT:-0}"
+EOF
+cat >"$FAKE_CFN_BIN/cfn-signal" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$CFN_SIGNAL_ARGS_FILE"
+EOF
+chmod +x "$FAKE_CFN_BIN/dnf" "$FAKE_CFN_BIN/cfn-init" "$FAKE_CFN_BIN/cfn-signal"
+
+signal_args="$SCRATCH/cfn-signal.args"
+FAKE_CFN_BIN="$FAKE_CFN_BIN" FAKE_CFN_INIT_EXIT=23 CFN_SIGNAL_ARGS_FILE="$signal_args" \
+  bash "$user_data" >/dev/null 2>&1
+user_data_status=$?
+[[ "$user_data_status" -eq 23 ]] && ok "template UserData preserves failed cfn-init exit code" || no "template UserData returned $user_data_status instead of cfn-init exit 23"
+grep -qx -- '-e' "$signal_args" \
+  && grep -qx -- '23' "$signal_args" \
+  && grep -qx -- 'cfn-init bootstrap failed with exit code 23; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$signal_args" \
+  && ok "template UserData failure invokes cfn-signal with bounded diagnostics" \
+  || no "template UserData failure did not invoke cfn-signal with the expected bounded reason"
+
 if [[ "${PROLIFERATE_TEST_AWS:-0}" == "1" ]] && command -v aws >/dev/null 2>&1; then
   if aws cloudformation validate-template --template-body "file://$AWS_TEMPLATE" >/dev/null 2>&1; then
     ok "aws cloudformation validate-template passed"

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -517,6 +517,7 @@ awk '
       -e 's|/opt/aws/bin/cfn-init|"$FAKE_CFN_BIN/cfn-init"|g' \
       -e 's|/opt/aws/bin/cfn-signal|"$FAKE_CFN_BIN/cfn-signal"|g' \
       -e 's|dnf install|"$FAKE_CFN_BIN/dnf" install|g' \
+      -e 's|timeout --signal=TERM 18m|"$FAKE_CFN_BIN/timeout"|g' \
       -e 's|${AWS::StackName}|test-stack|g' \
       -e 's|${AWS::Region}|us-east-1|g' \
   >"$user_data"
@@ -531,11 +532,18 @@ cat >"$FAKE_CFN_BIN/cfn-init" <<'EOF'
 #!/usr/bin/env bash
 exit "${FAKE_CFN_INIT_EXIT:-0}"
 EOF
+cat >"$FAKE_CFN_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_TIMEOUT_EXIT:-}" ]]; then
+  exit "$FAKE_TIMEOUT_EXIT"
+fi
+exec "$@"
+EOF
 cat >"$FAKE_CFN_BIN/cfn-signal" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$@" >"$CFN_SIGNAL_ARGS_FILE"
 EOF
-chmod +x "$FAKE_CFN_BIN/dnf" "$FAKE_CFN_BIN/cfn-init" "$FAKE_CFN_BIN/cfn-signal"
+chmod +x "$FAKE_CFN_BIN/dnf" "$FAKE_CFN_BIN/cfn-init" "$FAKE_CFN_BIN/timeout" "$FAKE_CFN_BIN/cfn-signal"
 
 signal_args="$SCRATCH/cfn-signal.args"
 FAKE_CFN_BIN="$FAKE_CFN_BIN" FAKE_CFN_INIT_EXIT=23 CFN_SIGNAL_ARGS_FILE="$signal_args" \
@@ -547,6 +555,15 @@ grep -qx -- '-e' "$signal_args" \
   && grep -qx -- 'cfn-init bootstrap failed with exit code 23; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$signal_args" \
   && ok "template UserData failure invokes cfn-signal with bounded diagnostics" \
   || no "template UserData failure did not invoke cfn-signal with the expected bounded reason"
+
+timeout_signal_args="$SCRATCH/cfn-timeout-signal.args"
+FAKE_CFN_BIN="$FAKE_CFN_BIN" FAKE_TIMEOUT_EXIT=124 CFN_SIGNAL_ARGS_FILE="$timeout_signal_args" \
+  bash "$user_data" >/dev/null 2>&1
+user_data_status=$?
+[[ "$user_data_status" -eq 124 ]] && ok "template UserData bounds an overlong cfn-init before the CreationPolicy timeout" || no "template UserData returned $user_data_status instead of timeout exit 124"
+grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$timeout_signal_args" \
+  && ok "template UserData timeout invokes cfn-signal with bounded diagnostics" \
+  || no "template UserData timeout did not invoke cfn-signal with the expected bounded reason"
 
 if [[ "${PROLIFERATE_TEST_AWS:-0}" == "1" ]] && command -v aws >/dev/null 2>&1; then
   if aws cloudformation validate-template --template-body "file://$AWS_TEMPLATE" >/dev/null 2>&1; then

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -517,7 +517,7 @@ awk '
       -e 's|/opt/aws/bin/cfn-init|"$FAKE_CFN_BIN/cfn-init"|g' \
       -e 's|/opt/aws/bin/cfn-signal|"$FAKE_CFN_BIN/cfn-signal"|g' \
       -e 's|dnf install|"$FAKE_CFN_BIN/dnf" install|g' \
-      -e 's|timeout --signal=TERM 18m|"$FAKE_CFN_BIN/timeout"|g' \
+      -e 's|timeout --signal=TERM --kill-after=30s 18m|"$FAKE_CFN_BIN/timeout"|g' \
       -e 's|${AWS::StackName}|test-stack|g' \
       -e 's|${AWS::Region}|us-east-1|g' \
   >"$user_data"
@@ -541,7 +541,10 @@ exec "$@"
 EOF
 cat >"$FAKE_CFN_BIN/cfn-signal" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "$@" >"$CFN_SIGNAL_ARGS_FILE"
+{
+  printf 'CALL\n'
+  printf '%s\n' "$@"
+} >>"$CFN_SIGNAL_ARGS_FILE"
 EOF
 chmod +x "$FAKE_CFN_BIN/dnf" "$FAKE_CFN_BIN/cfn-init" "$FAKE_CFN_BIN/timeout" "$FAKE_CFN_BIN/cfn-signal"
 
@@ -564,6 +567,72 @@ user_data_status=$?
 grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$timeout_signal_args" \
   && ok "template UserData timeout invokes cfn-signal with bounded diagnostics" \
   || no "template UserData timeout did not invoke cfn-signal with the expected bounded reason"
+
+kill_timeout_signal_args="$SCRATCH/cfn-kill-timeout-signal.args"
+FAKE_CFN_BIN="$FAKE_CFN_BIN" FAKE_TIMEOUT_EXIT=137 CFN_SIGNAL_ARGS_FILE="$kill_timeout_signal_args" \
+  bash "$user_data" >/dev/null 2>&1
+user_data_status=$?
+[[ "$user_data_status" -eq 124 ]] && ok "template UserData normalizes kill-after exit 137 to timeout exit 124" || no "template UserData returned $user_data_status instead of normalized timeout exit 124"
+grep -qx -- '124' "$kill_timeout_signal_args" \
+  && grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$kill_timeout_signal_args" \
+  && ok "template UserData kill-after invokes cfn-signal with timeout diagnostics" \
+  || no "template UserData kill-after did not invoke cfn-signal with normalized timeout diagnostics"
+
+# On Linux, execute a short-duration rendering of the production GNU timeout
+# semantics against a child that ignores TERM. An independent five-second KILL
+# guard prevents the regression itself from hanging if the hard deadline ever
+# regresses. Reaching exactly one cfn-signal proves the real TERM -> KILL path,
+# not merely the synthetic status plumbing above.
+if [[ "$(uname -s)" == "Linux" ]]; then
+  if timeout --version 2>/dev/null | grep -q 'GNU coreutils'; then
+    term_resistant_init="$FAKE_CFN_BIN/cfn-init-term-resistant"
+    cat >"$term_resistant_init" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$$" >"$CFN_INIT_PID_FILE"
+trap '' TERM
+while :; do :; done
+EOF
+    chmod +x "$term_resistant_init"
+
+    hard_deadline_user_data="$SCRATCH/cfn-hard-deadline-user-data.sh"
+    awk '
+      /Fn::Base64: !Sub \|/ { in_user_data = 1; next }
+      in_user_data && /^  ProliferateDnsRecord:/ { exit }
+      in_user_data { sub(/^          /, ""); print }
+    ' "$AWS_TEMPLATE" \
+      | sed \
+          -e 's|/opt/aws/bin/cfn-init|"$FAKE_CFN_BIN/cfn-init-term-resistant"|g' \
+          -e 's|/opt/aws/bin/cfn-signal|"$FAKE_CFN_BIN/cfn-signal"|g' \
+          -e 's|dnf install|"$FAKE_CFN_BIN/dnf" install|g' \
+          -e 's|timeout --signal=TERM --kill-after=30s 18m|timeout --signal=TERM --kill-after=0.2s 0.2s|g' \
+          -e 's|${AWS::StackName}|test-stack|g' \
+          -e 's|${AWS::Region}|us-east-1|g' \
+      >"$hard_deadline_user_data"
+
+    hard_deadline_signal_args="$SCRATCH/cfn-hard-deadline-signal.args"
+    term_resistant_pid_file="$SCRATCH/cfn-term-resistant.pid"
+    timeout --signal=KILL 5s env \
+      FAKE_CFN_BIN="$FAKE_CFN_BIN" \
+      CFN_INIT_PID_FILE="$term_resistant_pid_file" \
+      CFN_SIGNAL_ARGS_FILE="$hard_deadline_signal_args" \
+      bash "$hard_deadline_user_data" >/dev/null 2>&1
+    hard_deadline_status=$?
+    if [[ -f "$term_resistant_pid_file" ]]; then
+      kill -KILL "$(cat "$term_resistant_pid_file")" 2>/dev/null || true
+    fi
+    signal_call_count="$(grep -c '^CALL$' "$hard_deadline_signal_args" 2>/dev/null || true)"
+    [[ "$hard_deadline_status" -eq 124 ]] \
+      && [[ "$signal_call_count" -eq 1 ]] \
+      && grep -qx -- '124' "$hard_deadline_signal_args" \
+      && grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$hard_deadline_signal_args" \
+      && ok "template UserData hard-kills a TERM-resistant cfn-init and signals one bounded timeout" \
+      || no "template UserData did not hard-bound and signal the TERM-resistant cfn-init (status=$hard_deadline_status calls=$signal_call_count)"
+  else
+    no "Linux template regression requires GNU coreutils timeout"
+  fi
+else
+  printf '  skip  GNU timeout TERM-resistant UserData regression (runs on Linux CI)\n'
+fi
 
 if [[ "${PROLIFERATE_TEST_AWS:-0}" == "1" ]] && command -v aws >/dev/null 2>&1; then
   if aws cloudformation validate-template --template-body "file://$AWS_TEMPLATE" >/dev/null 2>&1; then

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -327,7 +327,10 @@ if PATH="$FAKE_BIN:$PATH" PROLIFERATE_INSTALL_ROOT="$BADBUNDLE" \
 else
   ok "--bundle install dies when the SUMS omits the bundle line"
 fi
-grep -qi "did not cover proliferate-deploy.tar.gz" "$SCRATCH/badbundle.log" \
+# GNU coreutils exits non-zero itself when --ignore-missing verifies no files,
+# while Darwin's sha256sum returns zero and reaches our explicit coverage guard.
+# Both safe paths must name the bundle/checksum failure and refuse extraction.
+grep -Eqi "did not cover proliferate-deploy.tar.gz|checksum verification FAILED for proliferate-deploy.tar.gz" "$SCRATCH/badbundle.log" \
   && ok "missing-bundle-line failure is reported" || no "missing-bundle-line failure not reported"
 [[ ! -f "$BADBUNDLE/server/deploy/bootstrap.sh" ]] \
   && ok "no files extracted when the bundle line is absent" || no "files were extracted despite an unverified bundle"

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -562,9 +562,12 @@ Resources:
             FAILURE_REASON="aws-cfn-bootstrap installation failed with exit code $EXIT_CODE."
           }
           if [ "$EXIT_CODE" -eq 0 ]; then
-            timeout --signal=TERM 18m /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region} --configsets bootstrap || {
+            timeout --signal=TERM --kill-after=30s 18m /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region} --configsets bootstrap || {
               EXIT_CODE=$?
-              if [ "$EXIT_CODE" -eq 124 ]; then
+              # GNU timeout returns 137 when its kill-after KILL is required.
+              # Normalize that hard-deadline path to the owned timeout status.
+              if [ "$EXIT_CODE" -eq 124 ] || [ "$EXIT_CODE" -eq 137 ]; then
+                EXIT_CODE=124
                 FAILURE_REASON="cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
               else
                 FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -552,9 +552,9 @@ Resources:
           #!/bin/bash -x
           set -o pipefail
 
-          # Do not enable `errexit` here. A failed cfn-init must still reach
-          # cfn-signal so CloudFormation reports the bounded stage/exit reason
-          # immediately instead of waiting for the CreationPolicy timeout.
+          # Do not enable `errexit` here. A failed or overlong cfn-init must
+          # still reach cfn-signal so CloudFormation reports the bounded
+          # stage/exit reason before the 20-minute CreationPolicy timeout.
           EXIT_CODE=0
           FAILURE_REASON="CloudFormation bootstrap completed."
           dnf install -y aws-cfn-bootstrap || {
@@ -562,9 +562,13 @@ Resources:
             FAILURE_REASON="aws-cfn-bootstrap installation failed with exit code $EXIT_CODE."
           }
           if [ "$EXIT_CODE" -eq 0 ]; then
-            /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region} --configsets bootstrap || {
+            timeout --signal=TERM 18m /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region} --configsets bootstrap || {
               EXIT_CODE=$?
-              FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+              if [ "$EXIT_CODE" -eq 124 ]; then
+                FAILURE_REASON="cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+              else
+                FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+              fi
             }
           fi
           if [ -x /opt/aws/bin/cfn-signal ]; then

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -549,12 +549,30 @@ Resources:
           Value: !Sub ${AWS::StackName}-instance
       UserData:
         Fn::Base64: !Sub |
-          #!/bin/bash -xe
-          dnf install -y aws-cfn-bootstrap
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region} --configsets bootstrap
-          EXIT_CODE=$?
-          /opt/aws/bin/cfn-signal -e $EXIT_CODE --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region}
-          exit $EXIT_CODE
+          #!/bin/bash -x
+          set -o pipefail
+
+          # Do not enable `errexit` here. A failed cfn-init must still reach
+          # cfn-signal so CloudFormation reports the bounded stage/exit reason
+          # immediately instead of waiting for the CreationPolicy timeout.
+          EXIT_CODE=0
+          FAILURE_REASON="CloudFormation bootstrap completed."
+          dnf install -y aws-cfn-bootstrap || {
+            EXIT_CODE=$?
+            FAILURE_REASON="aws-cfn-bootstrap installation failed with exit code $EXIT_CODE."
+          }
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region} --configsets bootstrap || {
+              EXIT_CODE=$?
+              FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+            }
+          fi
+          if [ -x /opt/aws/bin/cfn-signal ]; then
+            /opt/aws/bin/cfn-signal -e "$EXIT_CODE" --reason "$FAILURE_REASON" --stack ${AWS::StackName} --resource ProliferateInstance --region ${AWS::Region}
+          else
+            echo "cfn-signal is unavailable; bootstrap exit code $EXIT_CODE." >&2
+          fi
+          exit "$EXIT_CODE"
 
   ProliferateDnsRecord:
     Type: AWS::Route53::RecordSet

--- a/specs/developing/deploying/self-hosted-aws.md
+++ b/specs/developing/deploying/self-hosted-aws.md
@@ -54,6 +54,12 @@ public `/health` URL, and writes it to `.env.runtime`; the stack reports
 success only after both the local API and that advertised public HTTPS endpoint
 respond.
 
+The instance always reports the bootstrap exit status through `cfn-signal`.
+When `cfn-init` fails, the stack event carries only a bounded stage and exit-code
+reason; inspect `/var/log/cfn-init.log` and `/var/log/cfn-init-cmd.log` through
+SSM for host-local detail rather than copying those potentially secret-bearing
+logs into CloudFormation events.
+
 ## Required Inputs
 
 The base stack needs:

--- a/specs/developing/deploying/self-hosted-aws.md
+++ b/specs/developing/deploying/self-hosted-aws.md
@@ -54,10 +54,11 @@ public `/health` URL, and writes it to `.env.runtime`; the stack reports
 success only after both the local API and that advertised public HTTPS endpoint
 respond.
 
-The instance gives `cfn-init` an 18-minute inner deadline and always reports its
-bootstrap exit status through `cfn-signal`, leaving headroom inside the stack's
-20-minute creation policy. A failed or overlong bootstrap therefore puts only a
-bounded stage and exit-code reason in the stack event. Inspect
+The instance gives `cfn-init` an 18-minute inner deadline, followed by a
+30-second forced-kill fallback if it does not stop on `TERM`, and always reports
+its bootstrap exit status through `cfn-signal`. This leaves headroom inside the
+stack's 20-minute creation policy. A failed or overlong bootstrap therefore
+puts only a bounded stage and exit-code reason in the stack event. Inspect
 `/var/log/cfn-init.log` and `/var/log/cfn-init-cmd.log` through SSM for host-local
 detail rather than copying those potentially secret-bearing logs into
 CloudFormation events.

--- a/specs/developing/deploying/self-hosted-aws.md
+++ b/specs/developing/deploying/self-hosted-aws.md
@@ -54,11 +54,13 @@ public `/health` URL, and writes it to `.env.runtime`; the stack reports
 success only after both the local API and that advertised public HTTPS endpoint
 respond.
 
-The instance always reports the bootstrap exit status through `cfn-signal`.
-When `cfn-init` fails, the stack event carries only a bounded stage and exit-code
-reason; inspect `/var/log/cfn-init.log` and `/var/log/cfn-init-cmd.log` through
-SSM for host-local detail rather than copying those potentially secret-bearing
-logs into CloudFormation events.
+The instance gives `cfn-init` an 18-minute inner deadline and always reports its
+bootstrap exit status through `cfn-signal`, leaving headroom inside the stack's
+20-minute creation policy. A failed or overlong bootstrap therefore puts only a
+bounded stage and exit-code reason in the stack event. Inspect
+`/var/log/cfn-init.log` and `/var/log/cfn-init-cmd.log` through SSM for host-local
+detail rather than copying those potentially secret-bearing logs into
+CloudFormation events.
 
 ## Required Inputs
 


### PR DESCRIPTION
## Summary

- give `cfn-init` an 18-minute inner deadline inside the 20-minute CloudFormation creation policy
- harden that deadline with a 30-second TERM→KILL fallback, and normalize GNU timeout's kill-after status 137 to the owned outward timeout status 124
- let the instance reach `cfn-signal` when `cfn-init` fails or exceeds the hard deadline, carrying only a bounded stage/exit-code reason while potentially secret-bearing host logs remain available only through SSM
- execute the template's exact inline user-data against fake CFN tools for ordinary failure and status normalization
- on Linux with GNU coreutils, execute a short rendering against a TERM-resistant child under an independent five-second KILL guard and require exactly one bounded failure signal
- gate the no-network deploy/template suite in the existing required Ubuntu `Production compose smoke` job before image or Compose work
- document the failure-reporting boundary

Follow-up to #1437 after exact-main strict run [29678997256](https://github.com/proliferate-ai/proliferate/actions/runs/29678997256) exposed an opaque `CreationPolicy` timeout. The terminated console proves `cfn-init` started but cannot distinguish a nonzero exit from an overlong bootstrap; this repair makes both terminal outcomes observable. This PR does not dispatch another qualification run.

## Proof

- required exact-head Ubuntu [Self-Host Smoke run 29684903444](https://github.com/proliferate-ai/proliferate/actions/runs/29684903444), `Production compose smoke` job `88187407991` — passed at `6750a309d72e4668238615ec2fd6b13a08b11e4f`
  - `server/deploy/tests/run.sh` — 130 passed, 0 failed on GNU/Linux
  - real rendered UserData test hard-killed the TERM-resistant `cfn-init` and emitted exactly one bounded timeout signal
  - production Compose smoke also passed
- local `server/deploy/tests/run.sh` — 129 passed, 0 failed on Darwin; the real GNU timeout regression is explicitly Linux-only
- `actionlint .github/workflows/self-host-smoke.yml` — passed
- `python3 scripts/check_docs.py` — passed (220 Markdown files)
- `bash -n server/deploy/tests/run.sh` — passed
- `git diff --check` — passed

Review repair `PR1441-R1-TIMEOUT-001` is commit `2ea7dc26e`.
Review repair `PR1441-R2-LINUX-CI-001` is commits `39300d3e8` and `6750a309d`, with exact repaired head `6750a309d72e4668238615ec2fd6b13a08b11e4f`.