### PR TITLE
test(release): retain bounded CFN bootstrap diagnostics

### DIFF
--- a/specs/developing/testing/tier-3-scenario-contract.md
+++ b/specs/developing/testing/tier-3-scenario-contract.md
@@ -759,6 +759,16 @@ image, deploy-bundle, and platform runtime input digests, stack outputs,
 DNS/TLS, and `/meta` version. Do not repeat the owner, invite, and Desktop
 authentication journey already proved above.
 
+The qualification controller may retain a failed, disposable run-scoped stack
+only long enough to capture one bounded SSM bootstrap diagnostic. It registers
+stack cleanup before creation, reduces `cfn-init` output to allowlisted
+stage/exit/category observations, persists that secret-free companion beside
+the parent run evidence, and then runs the ordinary registered cleanup. Raw log
+lines, command text, URLs, environment values, and provider payloads are not
+evidence. An unavailable SSM path remains red and does not excuse stack
+cleanup. This diagnostic posture is qualification-only and does not change the
+production template or operator launch path.
+
 Self-hosted Web, when supported, is the instance's same-origin Web application.
 It reuses product assertions but has no server picker, config rewrite, relaunch,
 or cross-server switch. Hosted Proliferate Web is never pointed arbitrarily at

--- a/specs/developing/testing/tier-3-scenario-contract.md
+++ b/specs/developing/testing/tier-3-scenario-contract.md
@@ -767,7 +767,12 @@ the parent run evidence, and then runs the ordinary registered cleanup. Raw log
 lines, command text, URLs, environment values, and provider payloads are not
 evidence. An unavailable SSM path remains red and does not excuse stack
 cleanup. This diagnostic posture is qualification-only and does not change the
-production template or operator launch path.
+production template or operator launch path. Supported `SIGINT`/`SIGTERM`
+cancellation enters the shared memoized world finalizer: it submits one bounded
+stack deletion and observes its immediate status without entering the ordinary
+long waiter. A deletion not yet proved complete remains unreconciled in the
+durable ledger, produces red cancellation custody, and is left for idempotent
+follow-up verification.
 
 Self-hosted Web, when supported, is the instance's same-origin Web application.
 It reuses product assertions but has no server picker, config rewrite, relaunch,

--- a/tests/release/src/cli/cancellation-finalizer.test.ts
+++ b/tests/release/src/cli/cancellation-finalizer.test.ts
@@ -83,6 +83,36 @@ test("normal close and cancellation share one finalizer invocation", async () =>
   }
 });
 
+test("a bounded signal posture and ordinary close still share one invocation", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "qualification-cancel-signal-mode-"));
+  try {
+    const calls: string[] = [];
+    const handle = registerCancellationFinalizer({
+      world: "self-host",
+      run: run("qs-signal-mode"),
+      runDir: path.join(dir, "self-host", "1"),
+      finalize: async () => {
+        calls.push("ordinary");
+        return { failed: 0 };
+      },
+      finalizeForSignal: async (signal) => {
+        calls.push(`signal:${signal}`);
+        return { failed: 1 };
+      },
+    });
+
+    await finalizeRegisteredForSignal("SIGTERM");
+    await handle.run();
+    assert.deepEqual(calls, ["signal:SIGTERM"]);
+
+    const raw = await readFile(path.join(dir, "self-host", "1-cancellation-finalization.json"), "utf8");
+    const receipt = JSON.parse(raw);
+    assert.equal(receipt.status, "failed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("a cancellation cleanup failure remains identity-bound and red", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "qualification-cancel-failed-"));
   try {

--- a/tests/release/src/cli/cancellation-finalizer.ts
+++ b/tests/release/src/cli/cancellation-finalizer.ts
@@ -3,14 +3,14 @@ import path from "node:path";
 
 import type { RunIdentityV1 } from "../runner/identity.js";
 
-type SupportedSignal = "SIGINT" | "SIGTERM";
+export type SupportedSignal = "SIGINT" | "SIGTERM";
 
 interface RegisteredFinalizer {
   id: string;
   world: "local" | "managed-cloud" | "self-host";
   run: RunIdentityV1;
   receiptPath: string;
-  runOnce: () => Promise<unknown>;
+  runOnce: (signal?: SupportedSignal) => Promise<unknown>;
 }
 
 export interface CancellationFinalizerHandle<T> {
@@ -33,14 +33,22 @@ export function registerCancellationFinalizer<T>(options: {
   run: RunIdentityV1;
   runDir: string;
   finalize: () => Promise<T>;
+  /**
+   * Optional cleanup posture whose entire provider interaction fits inside the
+   * process signal deadline. It shares the same single-flight promise as the
+   * ordinary finalizer; whichever path starts first owns the one invocation.
+   */
+  finalizeForSignal?: (signal: SupportedSignal) => Promise<T>;
 }): CancellationFinalizerHandle<T> {
   const id = `${options.world}:${options.run.run_id}:${options.run.shard_id}:${options.run.attempt}`;
   if (registered.has(id)) {
     throw new Error(`Cancellation finalizer is already registered for ${id}.`);
   }
   let inFlight: Promise<T> | undefined;
-  const runOnce = (): Promise<T> => {
-    inFlight ??= options.finalize();
+  const runOnce = (signal?: SupportedSignal): Promise<T> => {
+    inFlight ??= signal && options.finalizeForSignal
+      ? options.finalizeForSignal(signal)
+      : options.finalize();
     return inFlight;
   };
   const receiptPath = path.join(
@@ -66,7 +74,7 @@ export async function finalizeRegisteredForSignal(signal: SupportedSignal): Prom
     let status: "reconciled" | "failed" = "reconciled";
     let reason: string | null = null;
     try {
-      const result = await entry.runOnce();
+      const result = await entry.runOnce(signal);
       if (cleanupResultFailed(result)) {
         status = "failed";
         reason = "The registered cleanup finalizer reported failures; inspect the identity-bound cleanup ledger.";

--- a/tests/release/src/scenarios/selfhost-cfn-1.test.ts
+++ b/tests/release/src/scenarios/selfhost-cfn-1.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
 
 import {
   SELFHOST_CFN_1_ID,
@@ -7,6 +10,7 @@ import {
   attachCfnCleanup,
   cleanupIsClean,
   constructSelfHostCfnWorld,
+  registerSelfHostCfnCancellationFinalizer,
   resolveCfnWorldInputs,
   runCfnWrapperCell,
   runSelfHostCfnCells,
@@ -25,6 +29,22 @@ import {
   type TestRunReportV4,
 } from "../evidence/schema.js";
 import type { SelfHostCfnWorldCleanupEvidence } from "../worlds/selfhost/cfn.js";
+import {
+  SelfHostCfnCleanupStack,
+  buildCfnStackTags,
+  createCfnStackAndWait,
+  type CfnAwsExec,
+} from "../worlds/selfhost/cfn.js";
+import {
+  clearCancellationFinalizersForTest,
+  finalizeRegisteredForSignal,
+} from "../cli/cancellation-finalizer.js";
+import {
+  CLEANUP_LEDGER_FILENAME,
+  openCleanupLedger,
+} from "../worlds/local-workspace/cleanup-ledger.js";
+
+afterEach(() => clearCancellationFinalizersForTest());
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
 
@@ -313,6 +333,126 @@ test("constructSelfHostCfnWorld rejects a CFN map without the exact arm64 runtim
     }),
     /missing the required selfhost-runtime\/linux\/arm64 artifact/,
   );
+});
+
+test("SIGTERM during retained-stack diagnostics initiates one bounded delete and preserves red custody", async () => {
+  const parentDir = await mkdtemp(path.join(os.tmpdir(), "selfhost-cfn-signal-"));
+  const cfnDir = path.join(parentDir, "cfn");
+  await mkdir(cfnDir, { recursive: true });
+  const run = fakeCtx().runIdentity!;
+  const ledger = await openCleanupLedger({
+    runDir: cfnDir,
+    runId: run.run_id,
+    shardId: run.shard_id,
+  });
+  const stack = new SelfHostCfnCleanupStack({ ledger });
+  const finalizer = registerSelfHostCfnCancellationFinalizer(stack, run, cfnDir);
+  let runDirectoryReleased = false;
+  await stack.registerAcquire("run_directory", cfnDir, async () => {
+    runDirectoryReleased = true;
+  });
+
+  const calls: Array<{ args: string[]; timeoutMs: number | undefined }> = [];
+  const exec: CfnAwsExec = {
+    async run(args, options) {
+      const copy = [...args];
+      calls.push({ args: copy, timeoutMs: options?.timeoutMs });
+      if (copy[0] === "cloudformation" && copy[1] === "wait" && copy[2] === "stack-create-complete") {
+        throw new Error("waiter observed CREATE_FAILED");
+      }
+      if (copy[0] === "cloudformation" && copy[1] === "describe-stack-events") {
+        return JSON.stringify({
+          StackEvents: [{
+            LogicalResourceId: "ProliferateInstance",
+            ResourceStatus: "CREATE_FAILED",
+            ResourceStatusReason: "Received FAILURE signal",
+          }],
+        });
+      }
+      if (copy[0] === "cloudformation" && copy[1] === "describe-stacks") {
+        return "DELETE_IN_PROGRESS\n";
+      }
+      return "";
+    },
+  };
+
+  let markCaptureStarted!: () => void;
+  const captureStarted = new Promise<void>((resolve) => { markCaptureStarted = resolve; });
+  let releaseCapture!: () => void;
+  const captureHeld = new Promise<void>((resolve) => { releaseCapture = resolve; });
+
+  try {
+    const create = createCfnStackAndWait({
+      exec,
+      stackName: "proliferate-sh-cfn-signal",
+      templatePath: "/t.yaml",
+      parameters: [],
+      tags: buildCfnStackTags({
+        stackName: "proliferate-sh-cfn-signal",
+        runId: run.run_id,
+        shardId: run.shard_id,
+      }),
+      region: "us-east-1",
+      writeParameterFile: async () => ({ path: "/tmp/p.json", remove: async () => undefined }),
+      registerCleanup: (kind, providerId, release, cancellationRelease) =>
+        stack.registerAcquire(kind, providerId, release, cancellationRelease),
+      onCreateFailure: async () => {
+        markCaptureStarted();
+        await captureHeld;
+        throw new Error("diagnostic capture interrupted by supported signal");
+      },
+    });
+
+    await captureStarted;
+    await finalizeRegisteredForSignal("SIGTERM");
+    const signalSummary = await finalizer.run();
+
+    const deletes = calls.filter((call) =>
+      call.args[0] === "cloudformation" && call.args[1] === "delete-stack"
+    );
+    const deleteWaits = calls.filter((call) =>
+      call.args[0] === "cloudformation" && call.args[1] === "wait" && call.args[2] === "stack-delete-complete"
+    );
+    const deleteObservations = calls.filter((call) =>
+      call.args[0] === "cloudformation" && call.args[1] === "describe-stacks"
+    );
+    assert.equal(deletes.length, 1, "supported signal submits the exact stack delete once");
+    assert.equal(deleteWaits.length, 0, "signal cleanup must not enter the ordinary 30-minute waiter");
+    assert.equal(deleteObservations.length, 1, "signal cleanup makes one immediate status observation");
+    assert.equal(deletes[0]?.timeoutMs, 5_000);
+    assert.equal(deleteObservations[0]?.timeoutMs, 5_000);
+    assert.equal(runDirectoryReleased, false, "the ledger directory remains for follow-up cleanup");
+    assert.equal(signalSummary.failed, 2);
+    assert.equal(signalSummary.stackDeleted, false);
+
+    const persistedLedger = JSON.parse(
+      await readFile(path.join(cfnDir, CLEANUP_LEDGER_FILENAME), "utf8"),
+    ) as { entries: Array<{ kind: string; phase: string; providerId: string | null }> };
+    const stackEntry = persistedLedger.entries.find((entry) => entry.kind === "cloudformation_stack");
+    assert.deepEqual(
+      { phase: stackEntry?.phase, providerId: stackEntry?.providerId },
+      { phase: "acquired", providerId: "proliferate-sh-cfn-signal" },
+      "DELETE_IN_PROGRESS remains durable, unreconciled follow-up custody",
+    );
+
+    const receiptRaw = await readFile(path.join(parentDir, "cfn-cancellation-finalization.json"), "utf8");
+    const receipt = JSON.parse(receiptRaw);
+    assert.equal(receipt.signal, "SIGTERM");
+    assert.equal(receipt.status, "failed");
+    assert.doesNotMatch(receiptRaw, /proliferate-sh-cfn-signal|Received FAILURE signal/);
+
+    const createRejected = assert.rejects(create, /Bootstrap diagnostic: capture_failed/);
+    releaseCapture();
+    await createRejected;
+    assert.equal(
+      calls.filter((call) => call.args[0] === "cloudformation" && call.args[1] === "delete-stack").length,
+      1,
+      "construction failure and signal share the memoized finalizer",
+    );
+  } finally {
+    releaseCapture?.();
+    await rm(parentDir, { recursive: true, force: true });
+  }
 });
 
 // ── Build / close failure semantics ───────────────────────────────────────────

--- a/tests/release/src/scenarios/selfhost-cfn-1.ts
+++ b/tests/release/src/scenarios/selfhost-cfn-1.ts
@@ -27,6 +27,8 @@ import {
   buildCfnParameters,
   buildCfnStackTags,
   bundleDigestBound,
+  captureCfnBootstrapDiagnostic,
+  cfnBootstrapDiagnosticArtifactPath,
   cfnSiteAddress,
   cfnStackName,
   createCfnStackAndWait,
@@ -45,6 +47,8 @@ import {
   tmpParameterFileIo,
   uploadBundleAndPresign,
   validateTemplate,
+  writeCfnBootstrapDiagnosticArtifact,
+  type CfnBootstrapDiagnosticArtifactV1,
   type CfnStackOutputs,
   type SelfHostCfnWorldCleanupEvidence,
 } from "../worlds/selfhost/cfn.js";
@@ -543,6 +547,33 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
       region: inputs.region,
       registerCleanup: (kind, providerId, release) => stack.registerAcquire(kind, providerId, release),
       writeParameterFile: tmpParameterFileIo(),
+      onCreateFailure: async ({ stackName: failedStackName, region }) => {
+        const diagnostic = await captureCfnBootstrapDiagnostic({
+          exec: aws,
+          stackName: failedStackName,
+          region,
+        });
+        const artifact: CfnBootstrapDiagnosticArtifactV1 = {
+          schema_version: 1,
+          kind: "proliferate.selfhost-cfn-bootstrap-diagnostic",
+          run: {
+            run_id: inputs.run.run_id,
+            shard_id: inputs.run.shard_id,
+            attempt: inputs.run.attempt,
+            source_sha: inputs.run.source_sha,
+          },
+          diagnostic,
+        };
+        // This path is deliberately a sibling of `<runDir>/cfn`, not inside
+        // it: the nested run-directory releaser may delete `cfn/` after the
+        // callback returns, while the workflow's existing `**/logs/` glob must
+        // retain this bounded artifact on the red run.
+        await writeCfnBootstrapDiagnosticArtifact(
+          cfnBootstrapDiagnosticArtifactPath(inputs.runDir),
+          artifact,
+        );
+        return diagnostic;
+      },
       log,
     });
 

--- a/tests/release/src/scenarios/selfhost-cfn-1.ts
+++ b/tests/release/src/scenarios/selfhost-cfn-1.ts
@@ -16,6 +16,7 @@ import type { CandidateBuildMapV1 } from "../artifacts/build-map.js";
 import type { SelfHostCfnCleanupEvidenceBlock, SelfHostCfnWrapperEvidenceV1 } from "../evidence/schema.js";
 import type { PlannedCellV1, ResultReason, ScenarioDeclarableStatus } from "../runner/result.js";
 import type { RunIdentityV1 } from "../runner/identity.js";
+import { registerCancellationFinalizer } from "../cli/cancellation-finalizer.js";
 import { resolveSelfHostCandidateSet } from "../artifacts/selfhost-candidate-set.js";
 import { materializeLocalArtifact } from "../artifacts/materialize-local.js";
 import { openCleanupLedger } from "../worlds/local-workspace/cleanup-ledger.js";
@@ -470,6 +471,7 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
     log,
     observeRoute53RecordAbsent: () => route53RecordAbsent(aws, inputs.hostedZoneId, siteAddress, inputs.region),
   });
+  const cancellationFinalizer = registerSelfHostCfnCancellationFinalizer(stack, inputs.run, cfnDir);
 
   try {
     // Local materialized paths tear down LAST (register first). run_directory
@@ -500,7 +502,8 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
       bundlePath,
       runtimePath,
       sumsPath,
-      registerCleanup: (kind, providerId, release) => stack.registerAcquire(kind, providerId, release),
+      registerCleanup: (kind, providerId, release, cancellationRelease) =>
+        stack.registerAcquire(kind, providerId, release, cancellationRelease),
       log,
     });
 
@@ -512,7 +515,8 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
       archivePath: serverImagePath,
       targetRepo: inputs.imageRepo,
       tag,
-      registerCleanup: (kind, providerId, release) => stack.registerAcquire(kind, providerId, release),
+      registerCleanup: (kind, providerId, release, cancellationRelease) =>
+        stack.registerAcquire(kind, providerId, release, cancellationRelease),
       log,
     });
 
@@ -545,7 +549,8 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
         shardId: inputs.run.shard_id,
       }),
       region: inputs.region,
-      registerCleanup: (kind, providerId, release) => stack.registerAcquire(kind, providerId, release),
+      registerCleanup: (kind, providerId, release, cancellationRelease) =>
+        stack.registerAcquire(kind, providerId, release, cancellationRelease),
       writeParameterFile: tmpParameterFileIo(),
       onCreateFailure: async ({ stackName: failedStackName, region }) => {
         const diagnostic = await captureCfnBootstrapDiagnostic({
@@ -602,12 +607,31 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
         ssmInspectRunningImageDigest({ exec: aws, instanceId: outputs.instanceId, region: inputs.region, log }),
       waitHealthy: () => waitForHealth(`https://${siteAddress}`, {}),
       fetchMeta: () => fetchCfnMeta(`https://${siteAddress}`),
-      close: () => stack.runAll(),
+      close: () => cancellationFinalizer.run(),
     };
   } catch (error) {
-    await stack.runAll().catch(() => undefined);
+    await cancellationFinalizer.run().catch(() => undefined);
     throw error;
   }
+}
+
+/**
+ * Registers the CFN world's one memoized cleanup owner immediately after the
+ * ledger/stack exist. Normal close and setup failure retain full reconciliation;
+ * supported signals use the stack's bounded delete-initiation custody posture.
+ */
+export function registerSelfHostCfnCancellationFinalizer(
+  stack: SelfHostCfnCleanupStack,
+  run: RunIdentityV1,
+  runDir: string,
+) {
+  return registerCancellationFinalizer({
+    world: "self-host",
+    run,
+    runDir,
+    finalize: () => stack.runAll(),
+    finalizeForSignal: () => stack.runForCancellation(),
+  });
 }
 
 /** Reads the public `/meta` serverVersion + base capability booleans. */

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import {
@@ -8,6 +11,8 @@ import {
   buildCfnParameters,
   buildCfnStackTags,
   bundleDigestBound,
+  captureCfnBootstrapDiagnostic,
+  cfnBootstrapDiagnosticArtifactPath,
   runtimeDigestBound,
   cfnSiteAddress,
   cfnStackName,
@@ -18,6 +23,7 @@ import {
   ghcrVersionIdForTag,
   imageDigestBound,
   outputsWellFormed,
+  parseCfnBootstrapDiagnosticOutput,
   parseGhcrRepo,
   parseGhcrVersions,
   parseStackOutputs,
@@ -30,6 +36,8 @@ import {
   templateFileSha256,
   uploadBundleAndPresign,
   validateTemplate,
+  writeCfnBootstrapDiagnosticArtifact,
+  type CfnBootstrapDiagnosticArtifactV1,
   type CfnAwsExec,
   type DockerExec,
   type GhExec,
@@ -236,6 +244,29 @@ test("boundedStackEventsTail: only FAILED events, bounded count, secret-free for
   assert.ok(parts.length <= MAX_STACK_EVENT_TAIL);
   assert.equal(boundedStackEventsTail("not json"), "(stack events unavailable)");
   assert.equal(boundedStackEventsTail(JSON.stringify({ StackEvents: [] })), "(no FAILED stack events)");
+});
+
+test("parseCfnBootstrapDiagnosticOutput: emits only allowlisted tokens and drops raw secrets", () => {
+  const raw = [
+    "__PROLIFERATE_CFN_LOG__:cfn-init-cmd.log",
+    "2026-07-19 Running Command 02-bootstrap",
+    "2026-07-19 Exited with error code 17: https://bucket/x?X-Amz-Signature=deadbeef",
+    "Bearer eyJsecret.payload.signature vk-super-secret-value",
+    "download error from https://example.invalid/private?token=secret",
+  ].join("\n");
+  const observations = parseCfnBootstrapDiagnosticOutput(raw);
+
+  assert.deepEqual(observations[0], {
+    source: "cfn-init-cmd.log",
+    stage: "02-bootstrap",
+    outcome: "failed",
+    exit_code: 17,
+    category: "download",
+  });
+  const serialized = JSON.stringify(observations);
+  for (const secret of ["X-Amz-Signature", "deadbeef", "Bearer", "eyJsecret", "vk-super", "https://"]) {
+    assert.ok(!serialized.includes(secret), `structured evidence leaked ${secret}`);
+  }
 });
 
 test("parseGhcrVersions + ghcrVersionIdForTag: finds the version whose tags include the run tag", () => {
@@ -492,6 +523,9 @@ test("createCfnStackAndWait: registers stack BEFORE create, passes params, retur
   // PR7-CONTROL-003: params go through a file, NOT argv — and the presigned
   // bearer signature never appears in the create-stack argv.
   assert.ok(createArgs.includes("file:///tmp/params.json"), "parameters must be passed as file://");
+  const onFailureAt = createArgs.indexOf("--on-failure");
+  assert.ok(onFailureAt >= 0, "qualification create must retain a failed stack for bounded diagnostics");
+  assert.equal(createArgs[onFailureAt + 1], "DO_NOTHING");
   const tagsAt = createArgs.indexOf("--tags");
   assert.ok(tagsAt >= 0, "create-stack must carry positive run-ownership tags");
   assert.deepEqual(createArgs.slice(tagsAt + 1, tagsAt + 5), [
@@ -592,6 +626,205 @@ test("createCfnStackAndWait: a create-complete wait failure tails describe-stack
     }),
     /ProliferateInstance CREATE_FAILED/,
   );
+});
+
+test("create failure: registered retention captures bounded SSM evidence before artifact then delete", async () => {
+  const runDir = await mkdtemp(path.join(tmpdir(), "selfhost-cfn-diagnostic-"));
+  const artifactPath = cfnBootstrapDiagnosticArtifactPath(runDir);
+  const order: string[] = [];
+  let releaseStack: (() => Promise<void>) | undefined;
+  const exec = new FakeExec((args) => {
+    if (args[0] === "cloudformation" && args[1] === "create-stack") {
+      order.push("create");
+      return "";
+    }
+    if (args[0] === "cloudformation" && args[1] === "wait" && args[2] === "stack-create-complete") {
+      order.push("wait-create");
+      throw new Error("waiter observed CREATE_FAILED");
+    }
+    if (args[0] === "cloudformation" && args[1] === "describe-stack-events") {
+      return JSON.stringify({
+        StackEvents: [{
+          LogicalResourceId: "ProliferateInstance",
+          ResourceStatus: "CREATE_FAILED",
+          ResourceStatusReason: "Received FAILURE signal",
+        }],
+      });
+    }
+    if (args[0] === "cloudformation" && args[1] === "describe-stack-resource") {
+      order.push("describe-instance");
+      return "i-0abc\n";
+    }
+    if (args[0] === "ssm" && args[1] === "describe-instance-information") {
+      order.push("ssm-online");
+      return "Online\n";
+    }
+    if (args[0] === "ssm" && args[1] === "send-command") {
+      order.push("ssm-send");
+      return "command-1\n";
+    }
+    if (args[0] === "ssm" && args[1] === "get-command-invocation") {
+      order.push("ssm-read");
+      return JSON.stringify({
+        Status: "Success",
+        StandardOutputContent: [
+          "__PROLIFERATE_CFN_LOG__:cfn-init-cmd.log",
+          "Running Command 02-bootstrap",
+          "Exited with error code 17: https://s3/x?X-Amz-Signature=secret",
+        ].join("\n"),
+      });
+    }
+    if (args[0] === "cloudformation" && args[1] === "delete-stack") {
+      order.push("delete");
+      return "";
+    }
+    if (args[0] === "cloudformation" && args[1] === "wait" && args[2] === "stack-delete-complete") {
+      order.push("wait-delete");
+      return "";
+    }
+    return "";
+  });
+
+  try {
+    await assert.rejects(
+      createCfnStackAndWait({
+        exec,
+        stackName: "stk",
+        templatePath: "/t.yaml",
+        parameters: [],
+        tags: TEST_CFN_TAGS,
+        region: "us-east-1",
+        writeParameterFile: async () => ({ path: "/tmp/p.json", remove: async () => undefined }),
+        registerCleanup: async (_kind, _providerId, release) => {
+          order.push("register");
+          releaseStack = release;
+        },
+        onCreateFailure: async ({ stackName, region }) => {
+          const diagnostic = await captureCfnBootstrapDiagnostic({
+            exec,
+            stackName,
+            region,
+            pollTimeoutMs: 100,
+            pollIntervalMs: 0,
+            now: () => 0,
+            sleep: async () => undefined,
+          });
+          const artifact: CfnBootstrapDiagnosticArtifactV1 = {
+            schema_version: 1,
+            kind: "proliferate.selfhost-cfn-bootstrap-diagnostic",
+            run: { run_id: "run-1", shard_id: "shard-0", attempt: 1, source_sha: "a".repeat(40) },
+            diagnostic,
+          };
+          await writeCfnBootstrapDiagnosticArtifact(artifactPath, artifact);
+          order.push("artifact");
+          return diagnostic;
+        },
+      }),
+      /Bootstrap diagnostic: captured\(02-bootstrap:failed:exit=17:download\)/,
+    );
+
+    assert.ok(releaseStack, "stack cleanup must be registered before create");
+    await releaseStack();
+    const persisted = await readFile(artifactPath, "utf8");
+    const parsed = JSON.parse(persisted) as CfnBootstrapDiagnosticArtifactV1;
+    assert.equal(parsed.diagnostic.capture_status, "captured");
+    assert.equal(parsed.diagnostic.observations[0]?.stage, "02-bootstrap");
+    for (const secret of ["X-Amz-Signature", "secret", "https://", "i-0abc", "stk"]) {
+      assert.ok(!persisted.includes(secret), `diagnostic artifact leaked ${secret}`);
+    }
+    assert.ok(order.indexOf("register") < order.indexOf("create"), `registered before create: ${order}`);
+    assert.ok(order.indexOf("ssm-read") < order.indexOf("artifact"), `SSM capture before artifact: ${order}`);
+    assert.ok(order.indexOf("artifact") < order.indexOf("delete"), `artifact before delete: ${order}`);
+    assert.ok(order.indexOf("delete") < order.indexOf("wait-delete"), `delete is awaited: ${order}`);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("create failure: SSM unavailable remains red, persists fixed evidence, and leaves no stack orphan", async () => {
+  const runDir = await mkdtemp(path.join(tmpdir(), "selfhost-cfn-no-ssm-"));
+  const artifactPath = cfnBootstrapDiagnosticArtifactPath(runDir);
+  const order: string[] = [];
+  let releaseStack: (() => Promise<void>) | undefined;
+  let clock = 0;
+  const exec = new FakeExec((args) => {
+    if (args[0] === "cloudformation" && args[1] === "create-stack") {
+      order.push("create");
+      return "";
+    }
+    if (args[0] === "cloudformation" && args[1] === "wait" && args[2] === "stack-create-complete") {
+      throw new Error("waiter observed CREATE_FAILED");
+    }
+    if (args[0] === "cloudformation" && args[1] === "describe-stack-events") {
+      return JSON.stringify({ StackEvents: [] });
+    }
+    if (args[0] === "cloudformation" && args[1] === "describe-stack-resource") {
+      return "i-0abc\n";
+    }
+    if (args[0] === "ssm" && args[1] === "describe-instance-information") {
+      order.push("ssm-offline");
+      return "Offline\n";
+    }
+    if (args[0] === "cloudformation" && args[1] === "delete-stack") {
+      order.push("delete");
+      return "";
+    }
+    if (args[0] === "cloudformation" && args[1] === "wait" && args[2] === "stack-delete-complete") {
+      order.push("wait-delete");
+      return "";
+    }
+    return "";
+  });
+
+  try {
+    await assert.rejects(
+      createCfnStackAndWait({
+        exec,
+        stackName: "stk",
+        templatePath: "/t.yaml",
+        parameters: [],
+        tags: TEST_CFN_TAGS,
+        region: "us-east-1",
+        writeParameterFile: async () => ({ path: "/tmp/p.json", remove: async () => undefined }),
+        registerCleanup: async (_kind, _providerId, release) => {
+          order.push("register");
+          releaseStack = release;
+        },
+        onCreateFailure: async ({ stackName, region }) => {
+          const diagnostic = await captureCfnBootstrapDiagnostic({
+            exec,
+            stackName,
+            region,
+            pollTimeoutMs: 2,
+            pollIntervalMs: 1,
+            now: () => clock,
+            sleep: async (ms) => { clock += ms; },
+          });
+          await writeCfnBootstrapDiagnosticArtifact(artifactPath, {
+            schema_version: 1,
+            kind: "proliferate.selfhost-cfn-bootstrap-diagnostic",
+            run: { run_id: "run-1", shard_id: "shard-0", attempt: 1, source_sha: "a".repeat(40) },
+            diagnostic,
+          });
+          order.push("artifact");
+          return diagnostic;
+        },
+      }),
+      /Bootstrap diagnostic: ssm_unavailable\(ssm_not_online\)/,
+    );
+
+    assert.ok(releaseStack, "stack cleanup must still be registered");
+    await releaseStack();
+    const persisted = JSON.parse(await readFile(artifactPath, "utf8")) as CfnBootstrapDiagnosticArtifactV1;
+    assert.equal(persisted.diagnostic.capture_status, "ssm_unavailable");
+    assert.equal(persisted.diagnostic.detail, "ssm_not_online");
+    assert.equal(exec.calls.some((call) => call[0] === "ssm" && call[1] === "send-command"), false);
+    assert.ok(order.indexOf("register") < order.indexOf("create"), `registered before create: ${order}`);
+    assert.ok(order.indexOf("artifact") < order.indexOf("delete"), `artifact before cleanup: ${order}`);
+    assert.ok(order.includes("wait-delete"), `stack delete must be awaited: ${order}`);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
+  }
 });
 
 test("describeStackEventsTail: returns the bounded formatter output", async () => {

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -67,6 +67,7 @@ export type RegisterCfnCleanup = (
   kind: Extract<CleanupResourceKind, "cloudformation_stack" | "s3_object" | "ghcr_package_version">,
   providerId: string,
   release: () => Promise<void>,
+  cancellationRelease?: () => Promise<CfnCancellationReleaseOutcome>,
 ) => Promise<void>;
 
 /** The owned Route53 zone the run subdomain lives under (matches `dns.ts`). */
@@ -77,6 +78,8 @@ export const SELFHOST_QUALIFICATION_PURPOSE = "self-hosting-qualification";
 export const PRESIGN_EXPIRY_SECONDS = 3600;
 /** Bounded stack create/delete wait (a t4g bootstrap has a PT20M CreationPolicy). */
 export const STACK_WAIT_TIMEOUT_MS = 30 * 60_000;
+/** Each cancellation delete/observe call must leave headroom in the 25s process bridge. */
+export const CFN_CANCELLATION_CALL_TIMEOUT_MS = 5_000;
 /** Bounded describe-stack-events tail on a create failure. */
 export const MAX_STACK_EVENT_TAIL = 8;
 const MAX_EVENT_REASON_CHARS = 240;
@@ -166,6 +169,9 @@ export interface CfnBootstrapDiagnosticArtifactV1 {
   };
   diagnostic: CfnBootstrapDiagnostic;
 }
+
+/** A signal cleanup reconciles only observed absence; initiation stays in durable custody. */
+export type CfnCancellationReleaseOutcome = "reconciled" | "delete_initiated";
 
 // ── Pure, offline-testable helpers ──────────────────────────────────────────
 
@@ -894,8 +900,11 @@ export async function createCfnStackAndWait(input: {
   const log = input.log ?? (() => undefined);
   const waitTimeoutMs = input.waitTimeoutMs ?? STACK_WAIT_TIMEOUT_MS;
 
-  await input.registerCleanup("cloudformation_stack", stackName, () =>
-    deleteCfnStackAndWait(exec, stackName, region, { waitTimeoutMs }),
+  await input.registerCleanup(
+    "cloudformation_stack",
+    stackName,
+    () => deleteCfnStackAndWait(exec, stackName, region, { waitTimeoutMs }),
+    () => initiateCfnStackDeletionForCancellation(exec, stackName, region),
   );
 
   log(`create-stack ${stackName}`);
@@ -1019,6 +1028,61 @@ export async function deleteCfnStackAndWait(
   await exec.run(["cloudformation", "wait", "stack-delete-complete", "--stack-name", stackName, "--region", region], {
     timeoutMs: waitTimeoutMs,
   });
+}
+
+/**
+ * Signal-safe stack cleanup: submit one exact `delete-stack`, then make one
+ * bounded status observation. It never enters the ordinary 30-minute waiter.
+ * A successfully submitted but still-running deletion remains unreconciled in
+ * the durable ledger so the cancellation receipt is red and follow-up cleanup
+ * can verify absence idempotently.
+ */
+export async function initiateCfnStackDeletionForCancellation(
+  exec: CfnAwsExec,
+  stackName: string,
+  region: string,
+  options: { callTimeoutMs?: number } = {},
+): Promise<CfnCancellationReleaseOutcome> {
+  const callTimeoutMs = options.callTimeoutMs ?? CFN_CANCELLATION_CALL_TIMEOUT_MS;
+  try {
+    await exec.run(
+      ["cloudformation", "delete-stack", "--stack-name", stackName, "--region", region],
+      { timeoutMs: callTimeoutMs },
+    );
+  } catch (error) {
+    if (cfnStackAbsentError(error)) {
+      return "reconciled";
+    }
+    throw new Error("CFN cancellation cleanup could not confirm that delete-stack was accepted.");
+  }
+
+  try {
+    const status = (
+      await exec.run(
+        [
+          "cloudformation",
+          "describe-stacks",
+          "--stack-name",
+          stackName,
+          "--region",
+          region,
+          "--query",
+          "Stacks[0].StackStatus",
+          "--output",
+          "text",
+        ],
+        { timeoutMs: callTimeoutMs },
+      )
+    ).trim();
+    return status === "DELETE_COMPLETE" ? "reconciled" : "delete_initiated";
+  } catch (error) {
+    return cfnStackAbsentError(error) ? "reconciled" : "delete_initiated";
+  }
+}
+
+function cfnStackAbsentError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /(?:does not exist|not exist|not found)/i.test(message);
 }
 
 // ── Failed-bootstrap SSM diagnostics (qualification only) ──────────────────
@@ -1359,6 +1423,7 @@ interface CfnCleanupRegistration {
   entryId: string;
   kind: SelfHostCfnCleanupResourceKind;
   release: () => Promise<void>;
+  cancellationRelease?: () => Promise<CfnCancellationReleaseOutcome>;
 }
 
 /**
@@ -1394,10 +1459,14 @@ export class SelfHostCfnCleanupStack {
   }
 
   /** Writes an `intent` record and returns the entry id to acquire. */
-  async register(kind: SelfHostCfnCleanupResourceKind, release: () => Promise<void>): Promise<string> {
+  async register(
+    kind: SelfHostCfnCleanupResourceKind,
+    release: () => Promise<void>,
+    cancellationRelease?: () => Promise<CfnCancellationReleaseOutcome>,
+  ): Promise<string> {
     const entryId = randomUUID();
     await this.ledger.registerIntent(kind, entryId);
-    this.registrations.push({ entryId, kind, release });
+    this.registrations.push({ entryId, kind, release, cancellationRelease });
     return entryId;
   }
 
@@ -1411,8 +1480,9 @@ export class SelfHostCfnCleanupStack {
     kind: SelfHostCfnCleanupResourceKind,
     providerId: string,
     release: () => Promise<void>,
+    cancellationRelease?: () => Promise<CfnCancellationReleaseOutcome>,
   ): Promise<void> {
-    const entryId = await this.register(kind, release);
+    const entryId = await this.register(kind, release, cancellationRelease);
     await this.acquired(entryId, providerId);
   }
 
@@ -1479,6 +1549,56 @@ export class SelfHostCfnCleanupStack {
       ghcrVersionDeleted: this.categoryClean("ghcrVersionDeleted", succeeded),
       route53RecordDeleted,
       localPathsRemoved: this.categoryClean("localPathsRemoved", succeeded),
+    };
+  }
+
+  /**
+   * Bounded SIGINT/SIGTERM posture. Only the stack has a signal-specific
+   * releaser: submit its exact delete request and observe once, leaving every
+   * unverified/deferred entry acquired. The run directory and ledger therefore
+   * survive for upload and replay, and the returned summary stays red until an
+   * observed-absent follow-up performs ordinary reconciliation.
+   */
+  async runForCancellation(): Promise<SelfHostCfnWorldCleanupEvidence> {
+    const succeeded = new Set<string>();
+    let failed = this.registrations.length;
+    for (const registration of [...this.registrations].reverse()) {
+      if (registration.kind !== "cloudformation_stack") {
+        continue;
+      }
+      if (!registration.cancellationRelease) {
+        this.log("CFN cancellation cleanup has no bounded stack releaser; preserving durable custody");
+        continue;
+      }
+      try {
+        const outcome = await registration.cancellationRelease();
+        if (outcome !== "reconciled") {
+          this.log("CFN cancellation delete was initiated but absence is not yet proven; preserving durable custody");
+          continue;
+        }
+        try {
+          await this.ledger.markReconciled(registration.entryId);
+          succeeded.add(registration.entryId);
+          failed -= 1;
+        } catch {
+          this.log("CFN cancellation observed stack absence but could not persist reconciliation; preserving custody");
+        }
+      } catch {
+        this.log("CFN cancellation delete initiation failed; preserving durable custody");
+      }
+    }
+    return {
+      ledgerIdHash: hashLedgerId(this.ledger.ledgerId),
+      registered: this.registrations.length,
+      reconciled: succeeded.size,
+      failed,
+      stackDeleted: this.categoryClean("stackDeleted", succeeded),
+      s3ObjectsDeleted: false,
+      ghcrVersionDeleted: false,
+      // Signal cleanup intentionally avoids an extra Route53 provider call.
+      // Even observed stack absence remains fail-closed for DNS until replay.
+      route53RecordDeleted: false,
+      localPathsRemoved: false,
     };
   }
 

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -10,7 +10,6 @@ import {
   type CleanupLedger,
   type CleanupResourceKind,
 } from "../local-workspace/cleanup-ledger.js";
-import { randomUUID } from "node:crypto";
 
 /**
  * The self-host CloudFormation-WRAPPER controller (frozen tier-3 contract
@@ -84,6 +83,89 @@ const MAX_EVENT_REASON_CHARS = 240;
 /** Bounded SSM command poll (docker-inspect the running api image RepoDigest). */
 export const SSM_POLL_TIMEOUT_MS = 120_000;
 const SSM_POLL_INTERVAL_MS = 3_000;
+/** Failure-diagnostic SSM acquisition stays well below the outer stack/cleanup budget. */
+export const CFN_DIAGNOSTIC_TIMEOUT_MS = 90_000;
+export const CFN_BOOTSTRAP_DIAGNOSTIC_FILENAME = "cfn-bootstrap-diagnostic.json";
+const CFN_DIAGNOSTIC_MAX_OBSERVATIONS = 24;
+const CFN_DIAGNOSTIC_COMMAND_TIMEOUT_SECONDS = 30;
+const CFN_DIAGNOSTIC_COMMAND = [
+  "for f in /var/log/cfn-init.log /var/log/cfn-init-cmd.log; do",
+  "  [ -r \"$f\" ] || continue",
+  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+  "  sudo grep -aiE 'Command [0-9]{2}-[A-Za-z0-9_-]+|exit(ed)?( with)? (error )?(code|status)|return code|timed out|timeout|failed|error|unhealthy|checksum|sha256|no space|permission denied|access denied|curl|download|docker compose|health' \"$f\" 2>/dev/null | tail -n 60 | cut -c1-500",
+  "done",
+].join("\n");
+
+export type CfnBootstrapDiagnosticCaptureStatus =
+  | "captured"
+  | "instance_unavailable"
+  | "ssm_unavailable"
+  | "command_failed"
+  | "no_allowlisted_observations";
+
+export type CfnBootstrapDiagnosticSource = "cfn-init.log" | "cfn-init-cmd.log";
+
+export type CfnBootstrapStage =
+  | "01-install-base"
+  | "02-install-compose-plugin"
+  | "03-enable-docker"
+  | "04-create-directories"
+  | "01-fetch-verify-extract"
+  | "01-daemon-reload"
+  | "02-bootstrap"
+  | "03-enable-cfn-hup"
+  | "unknown";
+
+export type CfnBootstrapFailureCategory =
+  | "timeout"
+  | "no_space"
+  | "permission_denied"
+  | "checksum"
+  | "download"
+  | "compose"
+  | "health"
+  | "command_failed"
+  | "other";
+
+export interface CfnBootstrapDiagnosticObservation {
+  source: CfnBootstrapDiagnosticSource;
+  stage: CfnBootstrapStage;
+  outcome: "failed" | "completed" | "observed";
+  exit_code: number | null;
+  category: CfnBootstrapFailureCategory;
+}
+
+/**
+ * Evidence-safe failure diagnostic. It deliberately carries no raw log line,
+ * provider payload, hostname, URL, command text, or secret-shaped value.
+ */
+export interface CfnBootstrapDiagnostic {
+  stack_name_hash: string;
+  instance_id_hash: string | null;
+  capture_status: CfnBootstrapDiagnosticCaptureStatus;
+  detail:
+    | "captured"
+    | "instance_not_found"
+    | "ssm_not_online"
+    | "send_command_failed"
+    | "command_poll_timeout"
+    | "command_terminal"
+    | "no_allowlisted_observations";
+  ssm_status: "Online" | "Success" | "Failed" | "TimedOut" | "Unavailable";
+  observations: CfnBootstrapDiagnosticObservation[];
+}
+
+export interface CfnBootstrapDiagnosticArtifactV1 {
+  schema_version: 1;
+  kind: "proliferate.selfhost-cfn-bootstrap-diagnostic";
+  run: {
+    run_id: string;
+    shard_id: string;
+    attempt: number;
+    source_sha: string;
+  };
+  diagnostic: CfnBootstrapDiagnostic;
+}
 
 // ── Pure, offline-testable helpers ──────────────────────────────────────────
 
@@ -406,6 +488,138 @@ export function boundedStackEventsTail(describeStackEventsJson: string, max: num
   return failures.length > 0 ? failures.join(" | ") : "(no FAILED stack events)";
 }
 
+const ALLOWED_CFN_BOOTSTRAP_STAGES = new Set<CfnBootstrapStage>([
+  "01-install-base",
+  "02-install-compose-plugin",
+  "03-enable-docker",
+  "04-create-directories",
+  "01-fetch-verify-extract",
+  "01-daemon-reload",
+  "02-bootstrap",
+  "03-enable-cfn-hup",
+]);
+
+/**
+ * Reduces bounded raw SSM output to a fixed-token diagnostic. Raw lines are
+ * never returned or persisted: only allowlisted template stage names, numeric
+ * exit codes, and coarse failure categories survive.
+ */
+export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiagnosticObservation[] {
+  let source: CfnBootstrapDiagnosticSource = "cfn-init.log";
+  const observations: CfnBootstrapDiagnosticObservation[] = [];
+  const seen = new Set<string>();
+  const activeStage: Record<CfnBootstrapDiagnosticSource, CfnBootstrapStage> = {
+    "cfn-init.log": "unknown",
+    "cfn-init-cmd.log": "unknown",
+  };
+
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const marker = rawLine.match(/^__PROLIFERATE_CFN_LOG__:(cfn-init(?:-cmd)?\.log)$/);
+    if (marker) {
+      source = marker[1] as CfnBootstrapDiagnosticSource;
+      continue;
+    }
+    const line = rawLine.slice(0, 500);
+    if (!line.trim()) {
+      continue;
+    }
+
+    const stageMatch = line.match(/\bCommand\s+([0-9]{2}-[A-Za-z0-9_-]{1,64})\b/i);
+    const candidateStage = stageMatch?.[1]?.toLowerCase() as CfnBootstrapStage | undefined;
+    if (candidateStage && ALLOWED_CFN_BOOTSTRAP_STAGES.has(candidateStage)) {
+      activeStage[source] = candidateStage;
+    }
+    // cfn-init commonly logs the command name and its error/exit on adjacent
+    // lines. Carry only the last allowlisted stage token within the same file;
+    // no arbitrary prior text survives.
+    const stage = activeStage[source];
+    const exitMatch = line.match(
+      /\b(?:exit(?:ed)?(?:\s+with)?(?:\s+(?:error\s+)?(?:code|status))?|return\s+code)\s*[:=]?\s*(\d{1,3})\b/i,
+    );
+    const exitCode = exitMatch ? Number.parseInt(exitMatch[1], 10) : null;
+    const lower = line.toLowerCase();
+    const outcome: CfnBootstrapDiagnosticObservation["outcome"] =
+      /failed|error|denied|unhealthy|no space|timed out|timeout/.test(lower)
+        ? "failed"
+        : /completed|succeeded|success/.test(lower)
+          ? "completed"
+          : "observed";
+    const category = cfnBootstrapFailureCategory(lower);
+
+    // A stage-heading line updates `activeStage` but is not itself a failure
+    // observation. Lines without an exit/outcome/category carry no result.
+    if (exitCode === null && category === "other" && outcome === "observed") {
+      continue;
+    }
+    const observation: CfnBootstrapDiagnosticObservation = {
+      source,
+      stage,
+      outcome,
+      exit_code: exitCode,
+      category,
+    };
+    const key = JSON.stringify(observation);
+    if (!seen.has(key)) {
+      seen.add(key);
+      observations.push(observation);
+    }
+    if (observations.length >= CFN_DIAGNOSTIC_MAX_OBSERVATIONS) {
+      break;
+    }
+  }
+  return observations;
+}
+
+function cfnBootstrapFailureCategory(lower: string): CfnBootstrapFailureCategory {
+  if (/timed out|timeout/.test(lower)) return "timeout";
+  if (/no space/.test(lower)) return "no_space";
+  if (/permission denied|access denied/.test(lower)) return "permission_denied";
+  if (/checksum|sha256/.test(lower)) return "checksum";
+  if (/curl|download|fetch|http/.test(lower)) return "download";
+  if (/docker compose|\bcompose\b/.test(lower)) return "compose";
+  if (/unhealthy|\bhealth\b/.test(lower)) return "health";
+  if (/failed|error|exit|return code/.test(lower)) return "command_failed";
+  return "other";
+}
+
+/** The artifact lives outside `<runDir>/cfn`, which cleanup removes on success. */
+export function cfnBootstrapDiagnosticArtifactPath(runDir: string): string {
+  return path.join(runDir, "logs", CFN_BOOTSTRAP_DIAGNOSTIC_FILENAME);
+}
+
+/** Atomically writes the already-reduced diagnostic before stack cleanup. */
+export async function writeCfnBootstrapDiagnosticArtifact(
+  artifactPath: string,
+  artifact: CfnBootstrapDiagnosticArtifactV1,
+): Promise<void> {
+  const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
+  // Defense in depth: the structured type cannot carry raw output, and this
+  // guard prevents a future widening from persisting common secret shapes.
+  if (/X-Amz-|Bearer\s+|\b(?:sk|vk)-[A-Za-z0-9._-]{6,}|\beyJ[A-Za-z0-9._-]{10,}/i.test(serialized)) {
+    throw new Error("CFN: refusing to persist a secret-shaped bootstrap diagnostic.");
+  }
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  const tmpPath = `${artifactPath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    await writeFile(tmpPath, serialized, { mode: 0o600 });
+    await rename(tmpPath, artifactPath);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+/** Safe one-line summary for the ordinary failed-cell reason. */
+export function summarizeCfnBootstrapDiagnostic(diagnostic: CfnBootstrapDiagnostic): string {
+  const observations = diagnostic.observations
+    .slice(0, 4)
+    .map((item) => `${item.stage}:${item.outcome}:exit=${item.exit_code ?? "unknown"}:${item.category}`)
+    .join(",");
+  return observations
+    ? `${diagnostic.capture_status}(${observations})`
+    : `${diagnostic.capture_status}(${diagnostic.detail})`;
+}
+
 // ── S3 upload / presign ─────────────────────────────────────────────────────
 
 /**
@@ -648,9 +862,11 @@ export async function validateTemplate(
 /**
  * Registers the stack cleanup BEFORE `create-stack`, submits the create with the
  * candidate parameters, waits (bounded) for `stack-create-complete`, and returns
- * the parsed Outputs. On a create failure it appends a bounded, secret-free
- * `describe-stack-events` tail to the thrown error. The Route53 record is
- * stack-owned (`CreateRoute53Record=true`), so its deletion rides `delete-stack`.
+ * the parsed Outputs. Qualification alone asks CloudFormation to retain a failed
+ * create (`DO_NOTHING`) just long enough for the optional bounded diagnostic
+ * callback, then the already-registered cleanup owns deletion. On a create
+ * failure it appends bounded, secret-free event + diagnostic summaries to the
+ * thrown error. The production template/launch path is unchanged.
  */
 export async function createCfnStackAndWait(input: {
   exec: CfnAwsExec;
@@ -666,6 +882,11 @@ export async function createCfnStackAndWait(input: {
    * disk; the production impl (`tmpParameterFileIo`) uses mkdtemp + 0600.
    */
   writeParameterFile: (json: string) => Promise<{ path: string; remove: () => Promise<void> }>;
+  onCreateFailure?: (context: {
+    stackName: string;
+    region: string;
+    eventTail: string;
+  }) => Promise<CfnBootstrapDiagnostic>;
   waitTimeoutMs?: number;
   log?: (message: string) => void;
 }): Promise<CfnStackOutputs> {
@@ -695,6 +916,11 @@ export async function createCfnStackAndWait(input: {
       `file://${paramFile.path}`,
       "--capabilities",
       "CAPABILITY_IAM",
+      // Qualification-only retention: the durable cleanup was registered
+      // before create, so a failed stack remains only for bounded diagnostics
+      // and is still deleted by the ordinary reverse-order finalizer.
+      "--on-failure",
+      "DO_NOTHING",
       "--tags",
       ...input.tags.map((tag) => `Key=${tag.key},Value=${tag.value}`),
       "--region",
@@ -734,9 +960,21 @@ export async function createCfnStackAndWait(input: {
     });
   } catch (error) {
     const tail = await describeStackEventsTail(exec, stackName, region).catch(() => "(stack events unavailable)");
+    let diagnosticSummary = "not_requested";
+    if (input.onCreateFailure) {
+      try {
+        const diagnostic = await input.onCreateFailure({ stackName, region, eventTail: tail });
+        diagnosticSummary = summarizeCfnBootstrapDiagnostic(diagnostic);
+      } catch {
+        // Keep the original create failure authoritative and fail closed. The
+        // fixed marker cannot leak a callback/provider/filesystem error.
+        diagnosticSummary = "capture_failed";
+      }
+    }
     throw new Error(
       scrubCfnParameterUrls(
-        `CFN: stack ${stackName} did not reach CREATE_COMPLETE (${errText(error)}). Recent failures: ${tail}`,
+        `CFN: stack ${stackName} did not reach CREATE_COMPLETE (${errText(error)}). ` +
+          `Recent failures: ${tail}. Bootstrap diagnostic: ${diagnosticSummary}`,
       ),
     );
   }
@@ -781,6 +1019,215 @@ export async function deleteCfnStackAndWait(
   await exec.run(["cloudformation", "wait", "stack-delete-complete", "--stack-name", stackName, "--region", region], {
     timeoutMs: waitTimeoutMs,
   });
+}
+
+// ── Failed-bootstrap SSM diagnostics (qualification only) ──────────────────
+
+/**
+ * Captures a bounded, allowlisted diagnostic from a retained CREATE_FAILED
+ * stack. Every provider call and the total poll are bounded. Provider errors
+ * become a fixed non-green diagnostic status; arbitrary error/output text is
+ * never serialized.
+ */
+export async function captureCfnBootstrapDiagnostic(input: {
+  exec: CfnAwsExec;
+  stackName: string;
+  region: string;
+  pollTimeoutMs?: number;
+  pollIntervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<CfnBootstrapDiagnostic> {
+  const { exec, stackName, region } = input;
+  const pollTimeoutMs = input.pollTimeoutMs ?? CFN_DIAGNOSTIC_TIMEOUT_MS;
+  const pollIntervalMs = input.pollIntervalMs ?? SSM_POLL_INTERVAL_MS;
+  const now = input.now ?? Date.now;
+  const sleepFn = input.sleep ?? sleep;
+  const stackNameHash = createHash("sha256").update(stackName).digest("hex");
+
+  let instanceId: string;
+  try {
+    instanceId = (
+      await exec.run(
+        [
+          "cloudformation",
+          "describe-stack-resource",
+          "--stack-name",
+          stackName,
+          "--logical-resource-id",
+          "ProliferateInstance",
+          "--region",
+          region,
+          "--query",
+          "StackResourceDetail.PhysicalResourceId",
+          "--output",
+          "text",
+        ],
+        { timeoutMs: 15_000 },
+      )
+    ).trim();
+  } catch {
+    instanceId = "";
+  }
+  if (!/^i-[0-9a-f]+$/i.test(instanceId)) {
+    return emptyCfnBootstrapDiagnostic(stackNameHash, null, "instance_unavailable", "instance_not_found");
+  }
+  const instanceIdHash = createHash("sha256").update(instanceId).digest("hex");
+
+  const deadline = now() + pollTimeoutMs;
+  let online = false;
+  do {
+    try {
+      const ping = (
+        await exec.run(
+          [
+            "ssm",
+            "describe-instance-information",
+            "--filters",
+            `Key=InstanceIds,Values=${instanceId}`,
+            "--region",
+            region,
+            "--query",
+            "InstanceInformationList[0].PingStatus",
+            "--output",
+            "text",
+          ],
+          { timeoutMs: 15_000 },
+        )
+      ).trim();
+      if (ping === "Online") {
+        online = true;
+        break;
+      }
+    } catch {
+      // Keep polling until the shared deadline. The final artifact records only
+      // the fixed ssm_not_online code, never raw provider errors.
+    }
+    if (now() >= deadline) break;
+    await sleepFn(pollIntervalMs);
+  } while (now() < deadline);
+  if (!online) {
+    return emptyCfnBootstrapDiagnostic(stackNameHash, instanceIdHash, "ssm_unavailable", "ssm_not_online");
+  }
+
+  let commandId: string;
+  try {
+    commandId = (
+      await exec.run(
+        [
+          "ssm",
+          "send-command",
+          "--instance-ids",
+          instanceId,
+          "--document-name",
+          "AWS-RunShellScript",
+          "--timeout-seconds",
+          String(CFN_DIAGNOSTIC_COMMAND_TIMEOUT_SECONDS),
+          "--parameters",
+          JSON.stringify({ commands: [CFN_DIAGNOSTIC_COMMAND] }),
+          "--region",
+          region,
+          "--query",
+          "Command.CommandId",
+          "--output",
+          "text",
+        ],
+        { timeoutMs: 15_000 },
+      )
+    ).trim();
+  } catch {
+    commandId = "";
+  }
+  if (!commandId || commandId === "None") {
+    return emptyCfnBootstrapDiagnostic(stackNameHash, instanceIdHash, "ssm_unavailable", "send_command_failed");
+  }
+
+  let lastStatus = "Pending";
+  while (now() < deadline) {
+    await sleepFn(pollIntervalMs);
+    let raw = "";
+    try {
+      raw = await exec.run(
+        [
+          "ssm",
+          "get-command-invocation",
+          "--command-id",
+          commandId,
+          "--instance-id",
+          instanceId,
+          "--region",
+          region,
+          "--output",
+          "json",
+        ],
+        { timeoutMs: 15_000 },
+      );
+    } catch {
+      continue;
+    }
+    let parsed: { Status?: unknown; StandardOutputContent?: unknown };
+    try {
+      parsed = JSON.parse(raw) as { Status?: unknown; StandardOutputContent?: unknown };
+    } catch {
+      continue;
+    }
+    lastStatus = typeof parsed.Status === "string" ? parsed.Status : lastStatus;
+    if (lastStatus === "Success") {
+      const observations = parseCfnBootstrapDiagnosticOutput(
+        typeof parsed.StandardOutputContent === "string" ? parsed.StandardOutputContent : "",
+      );
+      if (observations.length === 0) {
+        return emptyCfnBootstrapDiagnostic(
+          stackNameHash,
+          instanceIdHash,
+          "no_allowlisted_observations",
+          "no_allowlisted_observations",
+          "Success",
+        );
+      }
+      return {
+        stack_name_hash: stackNameHash,
+        instance_id_hash: instanceIdHash,
+        capture_status: "captured",
+        detail: "captured",
+        ssm_status: "Success",
+        observations,
+      };
+    }
+    if (["Failed", "Cancelled", "TimedOut", "Undeliverable", "Terminated"].includes(lastStatus)) {
+      return emptyCfnBootstrapDiagnostic(
+        stackNameHash,
+        instanceIdHash,
+        "command_failed",
+        "command_terminal",
+        lastStatus === "TimedOut" ? "TimedOut" : "Failed",
+      );
+    }
+  }
+  return emptyCfnBootstrapDiagnostic(
+    stackNameHash,
+    instanceIdHash,
+    "ssm_unavailable",
+    "command_poll_timeout",
+    "Unavailable",
+  );
+}
+
+function emptyCfnBootstrapDiagnostic(
+  stackNameHash: string,
+  instanceIdHash: string | null,
+  captureStatus: CfnBootstrapDiagnosticCaptureStatus,
+  detail: CfnBootstrapDiagnostic["detail"],
+  ssmStatus: CfnBootstrapDiagnostic["ssm_status"] = "Unavailable",
+): CfnBootstrapDiagnostic {
+  return {
+    stack_name_hash: stackNameHash,
+    instance_id_hash: instanceIdHash,
+    capture_status: captureStatus,
+    detail,
+    ssm_status: ssmStatus,
+    observations: [],
+  };
 }
 
 // ── SSM image-digest readback (the image-digest binding proof) ───────────────

--- a/tests/release/src/worlds/selfhost/cleanup-ledger-artifact-upload.test.ts
+++ b/tests/release/src/worlds/selfhost/cleanup-ledger-artifact-upload.test.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { CLEANUP_LEDGER_FILENAME } from "../local-workspace/cleanup-ledger.js";
+import { CFN_BOOTSTRAP_DIAGNOSTIC_FILENAME } from "./cfn.js";
 
 /**
  * SHR-006: the self-host cleanup ledger must be Actions-durable — it must
@@ -61,6 +62,24 @@ function matchesGlob(glob: string, candidate: string): boolean {
     .split(" DS ")
     .join(".*");
   return new RegExp(`^${escaped}$`).test(candidate);
+}
+
+/** `upload-artifact` includes a directory entry's descendants recursively. */
+function uploadGlobIncludes(glob: string, candidate: string): boolean {
+  if (matchesGlob(glob, candidate)) {
+    return true;
+  }
+  if (!glob.endsWith("/")) {
+    return false;
+  }
+  let parent = path.posix.dirname(candidate);
+  while (parent !== "." && parent !== "/") {
+    if (matchesGlob(glob, `${parent}/`)) {
+      return true;
+    }
+    parent = path.posix.dirname(parent);
+  }
+  return false;
 }
 
 /** Isolates the `release-e2e-selfhost-install` job's upload-step `path:` block from the real workflow file. */
@@ -136,6 +155,15 @@ test("the selfhost job's upload-artifact step path globs cover the cleanup ledge
       `no upload glob (${JSON.stringify(globs)}) matches the nested ledger "${nested}".`,
     );
   }
+
+  // Failed CFN bootstrap diagnostics are written before nested-world cleanup
+  // beside the parent run evidence, so they must also survive the red job.
+  const cfnDiagnosticPath =
+    `tests/release/.output/selfhost-world/qs-ci-12345-1/1/logs/${CFN_BOOTSTRAP_DIAGNOSTIC_FILENAME}`;
+  assert.ok(
+    globs.some((glob) => uploadGlobIncludes(glob, cfnDiagnosticPath)),
+    `no upload glob (${JSON.stringify(globs)}) matches the CFN diagnostic "${cfnDiagnosticPath}".`,
+  );
 });
 
 test("matchesGlob: single-level `*` never crosses a `/` boundary", () => {

--- a/tests/release/src/worlds/selfhost/cleanup-ledger-artifact-upload.test.ts
+++ b/tests/release/src/worlds/selfhost/cleanup-ledger-artifact-upload.test.ts
@@ -164,6 +164,14 @@ test("the selfhost job's upload-artifact step path globs cover the cleanup ledge
     globs.some((glob) => uploadGlobIncludes(glob, cfnDiagnosticPath)),
     `no upload glob (${JSON.stringify(globs)}) matches the CFN diagnostic "${cfnDiagnosticPath}".`,
   );
+
+  const cfnCancellationReceiptPath =
+    "tests/release/.output/selfhost-world/qs-ci-12345-1/1/cfn-cancellation-finalization.json";
+  assert.ok(
+    globs.some((glob) => matchesGlob(glob, cfnCancellationReceiptPath)),
+    `no upload glob (${JSON.stringify(globs)}) matches the CFN cancellation receipt ` +
+      `"${cfnCancellationReceiptPath}".`,
+  );
 });
 
 test("matchesGlob: single-level `*` never crosses a `/` boundary", () => {


### PR DESCRIPTION
## Summary

- retain a failed, disposable self-host CloudFormation qualification stack with `--on-failure DO_NOTHING` only after its cleanup has been durably registered
- before the ordinary finalizer deletes the stack, discover the failed instance and run one bounded SSM diagnostic that reduces `cfn-init` / `cfn-init-cmd` output to allowlisted stage, exit-code, outcome, and category tokens
- atomically persist the structured, secret-free companion under the parent run's existing uploaded `logs/` path so nested `cfn/` cleanup cannot erase it
- register the CFN world with the shared memoized cancellation finalizer; supported signals submit one 5-second-bounded `delete-stack`, make one 5-second-bounded status observation, never enter the 30-minute ordinary waiter, and retain red ledger/receipt custody until absence is proved
- keep SSM-unavailable, diagnostic-capture, and incomplete cancellation cleanup paths red
- leave the production CloudFormation template and operator launch path unchanged

## Why

The exact-main SELFHOST-CFN-1 run proved that failure signaling worked, but CloudFormation retained only the generic instance signal UniqueId. Automatic rollback removed the failed instance before host-local `cfn-init` diagnostics could be inspected. This qualification-only posture preserves the failed resource briefly enough to collect bounded evidence without weakening strict failure or zero-survivor cleanup.

Part of #1437.

## Scope and custody

- frozen base: `aaa6b9401ce4ae40b4be488461a7754f5bb9f48c`
- reviewed implementation head: `3617437fe04ffd31bddf10e8a58977e179d5e819`
- accepted blocker repaired: `PR1442-R1-CANCEL-FINALIZER-001`
- production template behavior: unchanged
- live AWS/provider calls, deployment, E2E retry, readiness, and merge: not performed
- assumptions/deviations/blockers: none pending exact-head re-review

## Proof

- `pnpm --dir tests/release exec tsx --test src/cli/cancellation-finalizer.test.ts src/worlds/selfhost/cfn.test.ts src/scenarios/selfhost-cfn-1.test.ts src/worlds/selfhost/cleanup-ledger-artifact-upload.test.ts` — 61 passed
- `pnpm --dir tests/release typecheck` — passed
- `python3 scripts/check_docs.py` — passed
- `git diff --check` — passed

## Exact-head independent review requested

Please review exact head `3617437fe04ffd31bddf10e8a58977e179d5e819`. In addition to the diagnostic data boundary, verify the shared-finalizer integration, single-flight normal/signal ownership, two-call 10-second maximum provider posture, no ordinary delete waiter on signals, exact one-delete behavior during held diagnostic capture, unreconciled ledger persistence for `DELETE_IN_PROGRESS`, red identity-bound receipt, and upload coverage for both ledger and receipt.