### PR TITLE
test(release): recover failed CFN instance identity from events

### DIFF
--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -645,6 +645,20 @@ test("create failure: registered retention captures bounded SSM evidence before 
     }
     if (args[0] === "cloudformation" && args[1] === "describe-stack-events" && args.includes("--query")) {
       order.push("describe-instance-events");
+      assert.deepEqual(args, [
+        "cloudformation",
+        "describe-stack-events",
+        "--stack-name",
+        "stk",
+        "--region",
+        "us-east-1",
+        "--max-items",
+        "32",
+        "--query",
+        "StackEvents[?LogicalResourceId=='ProliferateInstance'].[PhysicalResourceId,ResourceStatusReason]",
+        "--output",
+        "json",
+      ]);
       return JSON.stringify([[null, "Received FAILURE signal with UniqueId i-0abc"]]);
     }
     if (args[0] === "cloudformation" && args[1] === "describe-stack-events") {
@@ -862,6 +876,13 @@ test("parseCfnInstanceIdEventProjection: accepts one signaling instance and reje
     ),
     null,
   );
+  for (const malformed of [
+    [["i-0abc", null], { corrupt: true }],
+    [["i-0abc", null, null]],
+    [["i-0abc", 7]],
+  ]) {
+    assert.equal(parseCfnInstanceIdEventProjection(JSON.stringify(malformed)), null);
+  }
   assert.equal(parseCfnInstanceIdEventProjection("not-json"), null);
 });
 

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -24,6 +24,7 @@ import {
   imageDigestBound,
   outputsWellFormed,
   parseCfnBootstrapDiagnosticOutput,
+  parseCfnInstanceIdEventProjection,
   parseGhcrRepo,
   parseGhcrVersions,
   parseStackOutputs,
@@ -642,18 +643,22 @@ test("create failure: registered retention captures bounded SSM evidence before 
       order.push("wait-create");
       throw new Error("waiter observed CREATE_FAILED");
     }
+    if (args[0] === "cloudformation" && args[1] === "describe-stack-events" && args.includes("--query")) {
+      order.push("describe-instance-events");
+      return JSON.stringify([[null, "Received FAILURE signal with UniqueId i-0abc"]]);
+    }
     if (args[0] === "cloudformation" && args[1] === "describe-stack-events") {
       return JSON.stringify({
         StackEvents: [{
           LogicalResourceId: "ProliferateInstance",
           ResourceStatus: "CREATE_FAILED",
-          ResourceStatusReason: "Received FAILURE signal",
+          ResourceStatusReason: "Received FAILURE signal with UniqueId i-0abc",
         }],
       });
     }
     if (args[0] === "cloudformation" && args[1] === "describe-stack-resource") {
       order.push("describe-instance");
-      return "i-0abc\n";
+      return "None\n";
     }
     if (args[0] === "ssm" && args[1] === "describe-instance-information") {
       order.push("ssm-online");
@@ -733,6 +738,10 @@ test("create failure: registered retention captures bounded SSM evidence before 
       assert.ok(!persisted.includes(secret), `diagnostic artifact leaked ${secret}`);
     }
     assert.ok(order.indexOf("register") < order.indexOf("create"), `registered before create: ${order}`);
+    assert.ok(
+      order.indexOf("describe-instance") < order.indexOf("describe-instance-events"),
+      `event fallback follows direct lookup: ${order}`,
+    );
     assert.ok(order.indexOf("ssm-read") < order.indexOf("artifact"), `SSM capture before artifact: ${order}`);
     assert.ok(order.indexOf("artifact") < order.indexOf("delete"), `artifact before delete: ${order}`);
     assert.ok(order.indexOf("delete") < order.indexOf("wait-delete"), `delete is awaited: ${order}`);
@@ -832,6 +841,28 @@ test("describeStackEventsTail: returns the bounded formatter output", async () =
     JSON.stringify({ StackEvents: [{ LogicalResourceId: "X", ResourceStatus: "DELETE_FAILED", ResourceStatusReason: "boom" }] }),
   );
   assert.equal(await describeStackEventsTail(exec, "stk", "us-east-1"), "X DELETE_FAILED: boom");
+});
+
+test("parseCfnInstanceIdEventProjection: accepts one signaling instance and rejects ambiguity", () => {
+  assert.equal(
+    parseCfnInstanceIdEventProjection(
+      JSON.stringify([
+        ["i-0abc", "Received FAILURE signal with UniqueId i-0abc"],
+        [null, "Received FAILURE signal with UniqueId i-0abc"],
+      ]),
+    ),
+    "i-0abc",
+  );
+  assert.equal(
+    parseCfnInstanceIdEventProjection(
+      JSON.stringify([
+        [null, "Received FAILURE signal with UniqueId i-0abc"],
+        [null, "Received FAILURE signal with UniqueId i-0def"],
+      ]),
+    ),
+    null,
+  );
+  assert.equal(parseCfnInstanceIdEventProjection("not-json"), null);
 });
 
 // ── SSM digest readback ───────────────────────────────────────────────────────

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -1105,7 +1105,13 @@ export function parseCfnInstanceIdEventProjection(raw: string): string | null {
 
   const candidates = new Set<string>();
   for (const row of parsed) {
-    if (!Array.isArray(row)) continue;
+    if (
+      !Array.isArray(row)
+      || row.length !== 2
+      || row.some((field) => field !== null && typeof field !== "string")
+    ) {
+      return null;
+    }
     const physicalId = typeof row[0] === "string" ? row[0].trim() : "";
     if (/^i-[0-9a-f]+$/i.test(physicalId)) {
       candidates.add(physicalId.toLowerCase());

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -1085,6 +1085,96 @@ function cfnStackAbsentError(error: unknown): boolean {
   return /(?:does not exist|not exist|not found)/i.test(message);
 }
 
+/**
+ * Parses the bounded `describe-stack-events` projection used when a failed
+ * EC2 resource has no `describe-stack-resource` physical id. CloudFormation's
+ * CreationPolicy failure event carries the signaling instance as either the
+ * physical id or the exact `UniqueId i-...` token. Ambiguous projections fail
+ * closed instead of selecting an instance from an earlier attempt.
+ */
+export function parseCfnInstanceIdEventProjection(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) {
+    return null;
+  }
+
+  const candidates = new Set<string>();
+  for (const row of parsed) {
+    if (!Array.isArray(row)) continue;
+    const physicalId = typeof row[0] === "string" ? row[0].trim() : "";
+    if (/^i-[0-9a-f]+$/i.test(physicalId)) {
+      candidates.add(physicalId.toLowerCase());
+    }
+    const reason = typeof row[1] === "string" ? row[1] : "";
+    for (const match of reason.matchAll(/\bUniqueId\s+(i-[0-9a-f]+)\b/gi)) {
+      candidates.add(match[1].toLowerCase());
+    }
+  }
+  return candidates.size === 1 ? [...candidates][0] : null;
+}
+
+async function resolveCfnBootstrapInstanceId(
+  exec: CfnAwsExec,
+  stackName: string,
+  region: string,
+): Promise<string | null> {
+  try {
+    const direct = (
+      await exec.run(
+        [
+          "cloudformation",
+          "describe-stack-resource",
+          "--stack-name",
+          stackName,
+          "--logical-resource-id",
+          "ProliferateInstance",
+          "--region",
+          region,
+          "--query",
+          "StackResourceDetail.PhysicalResourceId",
+          "--output",
+          "text",
+        ],
+        { timeoutMs: 15_000 },
+      )
+    ).trim();
+    if (/^i-[0-9a-f]+$/i.test(direct)) {
+      return direct.toLowerCase();
+    }
+  } catch {
+    // A CreationPolicy failure may omit StackResourceDetail even though its
+    // matching failure event retains the signaling EC2 UniqueId.
+  }
+
+  try {
+    const projectedEvents = await exec.run(
+      [
+        "cloudformation",
+        "describe-stack-events",
+        "--stack-name",
+        stackName,
+        "--region",
+        region,
+        "--max-items",
+        "32",
+        "--query",
+        "StackEvents[?LogicalResourceId=='ProliferateInstance'].[PhysicalResourceId,ResourceStatusReason]",
+        "--output",
+        "json",
+      ],
+      { timeoutMs: 15_000 },
+    );
+    return parseCfnInstanceIdEventProjection(projectedEvents);
+  } catch {
+    return null;
+  }
+}
+
 // ── Failed-bootstrap SSM diagnostics (qualification only) ──────────────────
 
 /**
@@ -1109,31 +1199,8 @@ export async function captureCfnBootstrapDiagnostic(input: {
   const sleepFn = input.sleep ?? sleep;
   const stackNameHash = createHash("sha256").update(stackName).digest("hex");
 
-  let instanceId: string;
-  try {
-    instanceId = (
-      await exec.run(
-        [
-          "cloudformation",
-          "describe-stack-resource",
-          "--stack-name",
-          stackName,
-          "--logical-resource-id",
-          "ProliferateInstance",
-          "--region",
-          region,
-          "--query",
-          "StackResourceDetail.PhysicalResourceId",
-          "--output",
-          "text",
-        ],
-        { timeoutMs: 15_000 },
-      )
-    ).trim();
-  } catch {
-    instanceId = "";
-  }
-  if (!/^i-[0-9a-f]+$/i.test(instanceId)) {
+  const instanceId = await resolveCfnBootstrapInstanceId(exec, stackName, region);
+  if (instanceId === null) {
     return emptyCfnBootstrapDiagnostic(stackNameHash, null, "instance_unavailable", "instance_not_found");
   }
   const instanceIdHash = createHash("sha256").update(instanceId).digest("hex");


### PR DESCRIPTION
## Scope

Focused self-host qualification repair for issue #1437. Exact live run 29691269664 proved the failed `ProliferateInstance` event retained `UniqueId i-…` while `describe-stack-resource` returned no physical id, leaving the bounded SSM diagnostic at `instance_unavailable`.

Base: `81cbdc8eb719e97e0d23544cd379a4d7ead48a77`
Head: `854166eb35942bf8a25baec47bf9d770e1a790e2`

## Behavior

- Preserve direct `describe-stack-resource` resolution as the first path.
- Fall back to a bounded, exact `ProliferateInstance` event projection containing only physical id and status reason.
- Accept exactly one strict EC2 instance id; reject the entire projection on malformed row shape/type drift or ambiguous identities.
- Preserve the existing bounded/redacted SSM capture, failed-stack cleanup, and cancellation-finalizer contracts.

## Proof

- Exact-head focused CFN tests: 37/37
- Exact-head release suite: 1470/1470
- Exact-head TypeScript typecheck: green
- `check_max_lines.py`: green
- `git diff --check`: green
- Independent read-only audit of run 29691269664: exact receipt/artifact integrity and zero active survivors across CFN, EC2, networking, Route53, S3, IAM, and GHCR
- Independent exact-head review: `CONTROL_CLEAN / CODE_MERGE_READY`; ordinary CI must still settle green

No deployment, provider mutation, credentials change, or live qualification run was performed. A new strict CFN dispatch remains closed until exact-head CI is green and this PR is merged.