### PR TITLE
feat(product): combine sidebar usage rings

### DIFF
--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UsageSummary } from "@proliferate/cloud-sdk";
 import {
   ConsumptionCard,
-  SidebarUsageMeterTrigger,
+  SidebarUsageTrigger,
   type SidebarConsumptionMeter,
   type SidebarConsumptionState,
 } from "#product/components/app/sidebar/SidebarConsumptionCard";
@@ -13,29 +14,30 @@ import {
 afterEach(cleanup);
 
 describe("sidebar consumption", () => {
-  it("renders independently labeled keyboard-focusable Compute and LLM rings", () => {
-    const onComputeOpen = vi.fn();
-    const onLlmOpen = vi.fn();
+  it("renders one keyboard-focusable trigger that labels both concentric rings", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
     const state = { kind: "ready", usageSummary: usage() } as const;
-    render(
-      <>
-        <SidebarUsageMeterTrigger meter="compute" state={state} onClick={onComputeOpen} />
-        <SidebarUsageMeterTrigger meter="llm" state={state} onClick={onLlmOpen} />
-      </>,
-    );
+    render(<SidebarUsageTrigger state={state} onClick={onOpen} />);
 
-    const compute = screen.getByRole("button", { name: /Compute usage, 50% used/ });
-    const llm = screen.getByRole("button", { name: /LLM usage, 90% used/ });
-    expect(compute.getAttribute("type")).toBe("button");
-    expect(llm.getAttribute("type")).toBe("button");
-    compute.focus();
-    expect(document.activeElement).toBe(compute);
-    llm.focus();
-    expect(document.activeElement).toBe(llm);
-    fireEvent.keyDown(compute, { key: "Enter" });
-    fireEvent.keyDown(llm, { key: " " });
-    expect(onComputeOpen).toHaveBeenCalledTimes(1);
-    expect(onLlmOpen).toHaveBeenCalledTimes(1);
+    const trigger = screen.getByRole("button", {
+      name: /Usage\. Compute, 50% used\. LLM, 90% used/,
+    });
+    expect(trigger.getAttribute("type")).toBe("button");
+    expect(trigger.querySelectorAll("circle[data-meter]")).toHaveLength(4);
+    const computeRadius = Number(trigger
+      .querySelector('circle[data-meter="compute"][data-part="track"]')
+      ?.getAttribute("r"));
+    const llmRadius = Number(trigger
+      .querySelector('circle[data-meter="llm"][data-part="track"]')
+      ?.getAttribute("r"));
+    expect(computeRadius).toBeGreaterThan(llmRadius);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+    await user.keyboard("{Enter}");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    await user.keyboard(" ");
+    expect(onOpen).toHaveBeenCalledTimes(2);
   });
 
   it("keeps loading and unavailable states explicit", () => {
@@ -177,18 +179,23 @@ describe("sidebar consumption", () => {
       const state = stateForMeterScenario(meter, scenario);
       render(
         <>
-          <SidebarUsageMeterTrigger meter={meter} state={state} />
+          <SidebarUsageTrigger state={state} />
           <ConsumptionCard state={state} />
         </>,
       );
 
-      const trigger = screen.getByRole("button", { name: new RegExp(`${label} usage`) });
-      expect(trigger.getAttribute("aria-label")).toContain(ariaStatus);
-      const dashOffset = trigger.querySelectorAll("circle")[1]?.getAttribute("stroke-dashoffset");
+      const trigger = screen.getByRole("button", { name: /Open usage details/ });
+      expect(trigger.getAttribute("aria-label")).toContain(`${label}, ${ariaStatus}`);
+      const dashOffset = trigger
+        .querySelector(`circle[data-meter="${meter}"][data-part="progress"]`)
+        ?.getAttribute("stroke-dashoffset");
       expect(dashOffset === "0").toBe(fullRing);
 
       if (state.kind === "ready") {
         expect(screen.getByText(label).parentElement?.textContent).toContain(detail);
+        expect(screen.getByText(label).parentElement?.textContent).toContain(
+          meter === "compute" ? "Outer ring" : "Inner ring",
+        );
         if (scenario === "zero-allocation") {
           expect(screen.queryByText("0% used")).toBeNull();
         }
@@ -205,12 +212,12 @@ describe("sidebar consumption", () => {
     } as const;
     render(
       <>
-        <SidebarUsageMeterTrigger meter="compute" state={state} />
+        <SidebarUsageTrigger state={state} />
         <ConsumptionCard state={state} />
       </>,
     );
 
-    expect(screen.getByRole("button", { name: /Compute usage, unlimited/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute, unlimited/ })).not.toBeNull();
     expect(screen.getByText("Compute").parentElement?.textContent).toContain("No limit");
   });
 });

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx
@@ -31,8 +31,13 @@ export type SidebarConsumptionActions =
   | { kind: "unavailable"; message: string };
 
 const CONSUMPTION_NEAR_LIMIT_PERCENT = 80;
-const RING_RADIUS = 8;
-const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+const CONSUMPTION_RING_GEOMETRY: Record<
+  SidebarConsumptionMeter,
+  { radius: number; circumference: number }
+> = {
+  compute: { radius: 10, circumference: 2 * Math.PI * 10 },
+  llm: { radius: 6.25, circumference: 2 * Math.PI * 6.25 },
+};
 
 const CONSUMPTION_METER_TEXT_CLASS: Record<ConsumptionMeterTone, string> = {
   default: "text-sidebar-muted-foreground",
@@ -145,38 +150,83 @@ function metersForState(state: SidebarConsumptionState) {
   };
 }
 
-interface SidebarUsageMeterTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  meter: SidebarConsumptionMeter;
+interface SidebarUsageTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   state: SidebarConsumptionState;
 }
 
-/** One independently labeled, focusable ring trigger for the usage concern. */
-export const SidebarUsageMeterTrigger = forwardRef<
-  HTMLButtonElement,
-  SidebarUsageMeterTriggerProps
->(function SidebarUsageMeterTrigger({
+function meterStatusLabel(
+  state: SidebarConsumptionState,
+  meter: SidebarConsumptionMeter,
+): string {
+  if (state.kind === "loading") {
+    return "loading";
+  }
+  if (state.kind === "unavailable") {
+    return "unavailable";
+  }
+  return consumptionMeterAriaStatus(metersForState(state)![meter]);
+}
+
+function ConcentricMeterRing({
   meter,
+  meterState,
+  fallbackTone,
+}: {
+  meter: SidebarConsumptionMeter;
+  meterState: ConsumptionMeterState | null;
+  fallbackTone: ConsumptionMeterTone;
+}) {
+  const geometry = CONSUMPTION_RING_GEOMETRY[meter];
+  const percent = meterState?.percent ?? null;
+  const dashOffset = percent === null
+    ? geometry.circumference
+    : geometry.circumference * (1 - Math.max(0, Math.min(100, percent)) / 100);
+  const tone = meterState?.tone ?? fallbackTone;
+
+  return (
+    <>
+      <circle
+        data-meter={meter}
+        data-part="track"
+        cx="14"
+        cy="14"
+        r={geometry.radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        className="opacity-20"
+      />
+      <circle
+        data-meter={meter}
+        data-part="progress"
+        cx="14"
+        cy="14"
+        r={geometry.radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeDasharray={geometry.circumference}
+        strokeDashoffset={dashOffset}
+        className={CONSUMPTION_METER_TEXT_CLASS[tone]}
+      />
+    </>
+  );
+}
+
+/** One focusable usage trigger with outer Compute and inner LLM rings. */
+export const SidebarUsageTrigger = forwardRef<
+  HTMLButtonElement,
+  SidebarUsageTriggerProps
+>(function SidebarUsageTrigger({
   state,
   className = "",
-  onKeyDown,
   ...buttonProps
 }, ref) {
   const meters = metersForState(state);
   const fallbackTone: ConsumptionMeterTone = state.kind === "unavailable"
     ? "destructive"
     : "default";
-  const label = meter === "compute" ? "Compute" : "LLM";
-  const shortLabel = meter === "compute" ? "C" : "L";
-  const percent = meters?.[meter].percent ?? null;
-  const tone = meters?.[meter].tone ?? fallbackTone;
-  const statusLabel = state.kind === "loading"
-    ? "loading"
-    : state.kind === "unavailable"
-      ? "unavailable"
-      : consumptionMeterAriaStatus(meters![meter]);
-  const dashOffset = percent === null
-    ? RING_CIRCUMFERENCE
-    : RING_CIRCUMFERENCE * (1 - Math.max(0, Math.min(100, percent)) / 100);
 
   return (
     <Button
@@ -185,52 +235,39 @@ export const SidebarUsageMeterTrigger = forwardRef<
       type="button"
       variant="unstyled"
       size="unstyled"
-      aria-label={`${label} usage, ${statusLabel}. Open usage details`}
-      onKeyDown={(event) => {
-        onKeyDown?.(event);
-        if (!event.defaultPrevented && (event.key === "Enter" || event.key === " ")) {
-          event.preventDefault();
-          event.currentTarget.click();
-        }
-      }}
-      className={`relative flex size-7 shrink-0 items-center justify-center rounded-full text-sidebar-muted-foreground outline-none hover:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring data-[state=open]:text-sidebar-foreground ${className}`}
+      aria-label={`Usage. Compute, ${meterStatusLabel(state, "compute")}. LLM, ${meterStatusLabel(state, "llm")}. Open usage details`}
+      title="Usage"
+      className={`relative flex size-10 shrink-0 items-center justify-center rounded-lg text-sidebar-muted-foreground outline-none hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground ${className}`}
     >
-      <svg viewBox="0 0 20 20" className="size-5 -rotate-90" aria-hidden="true">
-        <circle
-          cx="10"
-          cy="10"
-          r={RING_RADIUS}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          className="opacity-20"
+      <svg viewBox="0 0 28 28" className="size-6 -rotate-90" aria-hidden="true">
+        <ConcentricMeterRing
+          meter="compute"
+          meterState={meters?.compute ?? null}
+          fallbackTone={fallbackTone}
         />
-        <circle
-          cx="10"
-          cy="10"
-          r={RING_RADIUS}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeDasharray={RING_CIRCUMFERENCE}
-          strokeDashoffset={dashOffset}
-          className={CONSUMPTION_METER_TEXT_CLASS[tone]}
+        <ConcentricMeterRing
+          meter="llm"
+          meterState={meters?.llm ?? null}
+          fallbackTone={fallbackTone}
         />
       </svg>
-      <span className="pointer-events-none absolute text-[7px] font-semibold leading-none text-sidebar-foreground" aria-hidden="true">
-        {state.kind === "unavailable" ? "!" : shortLabel}
-      </span>
+      {state.kind === "unavailable" ? (
+        <span className="pointer-events-none absolute text-[8px] font-semibold leading-none text-destructive" aria-hidden="true">
+          !
+        </span>
+      ) : null}
     </Button>
   );
 });
 
 function ConsumptionDetailRow({
   label,
+  ringLabel,
   state,
   remainingLabel,
 }: {
   label: string;
+  ringLabel: string;
   state: ConsumptionMeterState;
   remainingLabel: string;
 }) {
@@ -240,7 +277,7 @@ function ConsumptionDetailRow({
       <div>
         <div className="text-ui text-sidebar-foreground">{label}</div>
         <div className={`text-ui-sm ${CONSUMPTION_METER_TEXT_CLASS[state.tone]}`}>
-          {usedLabel}
+          {usedLabel} · {ringLabel}
         </div>
       </div>
       <div className={`text-right text-ui-sm ${CONSUMPTION_METER_TEXT_CLASS[state.tone]}`}>
@@ -297,11 +334,13 @@ export function ConsumptionCard({
       </div>
       <ConsumptionDetailRow
         label="Compute"
+        ringLabel="Outer ring"
         state={meters.compute}
         remainingLabel={formatRemainingHours(state.usageSummary.computeRemainingSeconds)}
       />
       <ConsumptionDetailRow
         label="LLM"
+        ringLabel="Inner ring"
         state={meters.llm}
         remainingLabel={formatRemainingUsd(state.usageSummary.llmRemainingUsd)}
       />

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.test.tsx
@@ -47,14 +47,12 @@ vi.mock("@proliferate/ui/primitives/PopoverButton", () => ({
     trigger,
     children,
   }: {
-    trigger: ReactElement<{ meter?: "compute" | "llm" }>;
+    trigger: ReactElement;
     children: (close: () => void) => ReactNode;
   }) => (
     <div>
       {trigger}
-      {trigger.props.meter === "compute" ? (
-        <div>{children(vi.fn())}</div>
-      ) : null}
+      <div>{children(vi.fn())}</div>
     </div>
   ),
 }));
@@ -89,12 +87,12 @@ describe("SidebarUsageFooter", () => {
 
   it("renders truthful loading and unavailable states", () => {
     const { rerender } = render(<SidebarUsageFooter />);
-    expect(screen.getByRole("button", { name: /Compute usage, loading/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute, loading\. LLM, loading/ })).not.toBeNull();
     expect(screen.getByText(/Loading usage/)).not.toBeNull();
 
     state.query = { data: undefined, isLoading: false, refetch: vi.fn() };
     rerender(<SidebarUsageFooter />);
-    expect(screen.getByRole("button", { name: /LLM usage, unavailable/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute, unavailable\. LLM, unavailable/ })).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
     expect(state.query.refetch).toHaveBeenCalledTimes(1);
   });
@@ -196,7 +194,7 @@ describe("SidebarUsageFooter", () => {
 
     expect(screen.queryByText(/Ask your admin/)).toBeNull();
     expect(screen.getByText("Billing actions aren't available on this deployment.")).not.toBeNull();
-    expect(screen.getByRole("button", { name: /Compute usage, No allocation/ })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Compute, No allocation/ })).not.toBeNull();
   });
 });
 

--- a/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
+++ b/apps/packages/product-client/src/components/app/sidebar/SidebarUsageFooter.tsx
@@ -6,8 +6,7 @@ import {
 } from "@proliferate/ui/primitives/PopoverButton";
 import {
   ConsumptionCard,
-  SidebarUsageMeterTrigger,
-  type SidebarConsumptionMeter,
+  SidebarUsageTrigger,
   type SidebarConsumptionState,
   type SidebarConsumptionActions,
 } from "#product/components/app/sidebar/SidebarConsumptionCard";
@@ -16,7 +15,7 @@ import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-
 import { useSelectedCloudOwner } from "#product/hooks/organizations/derived/use-selected-cloud-owner";
 import { buildBillingSettingsHref } from "#product/lib/domain/settings/navigation";
 
-/** Capability-gated usage concern with independently focusable Compute/LLM rings. */
+/** Capability-gated usage concern with concentric Compute/LLM rings. */
 export function SidebarUsageFooter() {
   const navigate = useNavigate();
   const authStatus = useProductAuthStatus();
@@ -43,13 +42,12 @@ export function SidebarUsageFooter() {
     close();
   };
 
-  const meterPopover = (meter: SidebarConsumptionMeter) => (
+  return (
     <PopoverButton
-      key={meter}
       align="end"
       side="top"
       offset={8}
-      trigger={<SidebarUsageMeterTrigger meter={meter} state={state} />}
+      trigger={<SidebarUsageTrigger state={state} />}
       className={`w-64 ${POPOVER_SURFACE_CLASS}`}
     >
       {(close) => (
@@ -67,18 +65,6 @@ export function SidebarUsageFooter() {
         />
       )}
     </PopoverButton>
-  );
-
-  return (
-    <div
-      role="group"
-      aria-label="Usage meters"
-      title="Usage"
-      className="flex h-10 items-center gap-0.5 rounded-lg px-1 text-sidebar-muted-foreground hover:bg-sidebar-accent"
-    >
-      {meterPopover("compute")}
-      {meterPopover("llm")}
-    </div>
   );
 }
 

--- a/specs/codebase/platforms/product/billing.md
+++ b/specs/codebase/platforms/product/billing.md
@@ -157,8 +157,9 @@ and
 [`OrganizationLimitsEditor.tsx`](../../../../apps/packages/product-client/src/components/settings/panes/OrganizationLimitsEditor.tsx).
 
 When the user is authenticated and usage metering is enabled, the app sidebar
-footer exposes independent **Compute** and **LLM** meter triggers outside the
-account popover. Each trigger opens the compact
+footer exposes one usage trigger outside the account popover. Its concentric
+rings show **Compute** on the outside and **LLM** on the inside, and the trigger's
+accessible name reports both states. The trigger opens the compact
 [`SidebarConsumptionCard`](../../../../apps/packages/product-client/src/components/app/sidebar/SidebarConsumptionCard.tsx).
 The concern preserves explicit loading and unavailable states while the summary
 is absent, then renders each ready meter from its own returned units and limit

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -286,15 +286,16 @@ member, timeseries, and limit hooks. Billing is also connected: Desktop and
 Web both reuse `BillingSettingsSurface`, while their navigation remains
 surface-specific.
 
-When the user is authenticated and usage metering is enabled, independent
-Compute and LLM meter triggers render in the app sidebar footer outside the
-account popover. Each trigger opens `SidebarConsumptionCard`, which preserves
-truthful loading, unavailable, and ready states for the usage summary. Billing
-actions are a separate capability-gated concern rather than a prerequisite for
-showing usage. A supported self-service organization owner gets one Billing
-action with that owner preserved in the settings route. When Desktop cannot
-guarantee a destination for the same personal or organization owner represented
-by the meters, the card renders no action and explains the unavailability.
+When the user is authenticated and usage metering is enabled, one usage trigger
+renders in the app sidebar footer outside the account popover. Its outer Compute
+ring and inner LLM ring share one focus target and open
+`SidebarConsumptionCard`, which preserves truthful loading, unavailable, and
+ready states for the usage summary. Billing actions are a separate
+capability-gated concern rather than a prerequisite for showing usage. A
+supported self-service organization owner gets one Billing action with that
+owner preserved in the settings route. When Desktop cannot guarantee a
+destination for the same personal or organization owner represented by the
+meters, the card renders no action and explains the unavailability.
 
 Personal Integrations and Workflows are top-level app pages rather than
 Settings sections. Rows outside the target list are marked with a small


### PR DESCRIPTION
## What this changes

The Compute and LLLM usage indicators are now one nested meter, keeping both balances available through one control.

## Before / after

Before, Compute and LLM used two controls that opened the same detail. After, Compute is the outer ring, LLM is the inner ring, and one control opens that same detail.

## When this matters

Whenever usage is shown, both balances fit into one compact footer control.

## Reference

1. **Primary reference:** Codex.
2. **State:** sidebar at 1600×900 with usage detail open.
3. **Carried over:** one compact control and one popover interaction.
4. **Difference:** two nested progress rings reflect Proliferate's two usage resources.

## Demo

[Deployed build at 3b13f853f](https://proliferate-web-git-codex-ui-concentric-usage-getonyx.vercel.app) — Vercel preview; the usage control appears for authenticated accounts with usage enabled.

## Disposition

**Ready** — merging with Pablo's explicit approval despite two inherited failing checks.

## Founder decision

None.

---

## Evidence

- Head: `3b13f853f943a96529251f2f6d7e7905d8628854`.
- Both resources preserve loading, unavailable, zero, available, exhausted, and blocked states.
- Keyboard activation and owner-aware billing behavior remain covered.
- Help is unchanged: **Send feedback** and **Submit a prompt** remain in the question-mark menu where supported.
- Focused tests: 36/36. Product UI: 223/223.
- Full client tests: 3,754/3,755; the lone failure is the base branch's unrelated appearance-CSS test.
- Size check: base 485,805 B JS / 65,931 B CSS; branch 485,804 B JS / 65,936 B CSS.
- All other CI jobs passed.
