### PR TITLE
fix(product): scale right panel tab chrome

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -1894,18 +1894,10 @@ body {
   --tab-stable-end-margin: 0px;
   --tab-gap: 3px;
   --tab-bar-mask-size: 28px;
-  --right-panel-tab-leading-inset: 0px;
-  --right-panel-tab-radius: 8px;
-  --right-panel-tab-overlay-radius: 8px;
   --right-panel-tab-surface: transparent;
   /* Matches the surface painted behind the header (workspace shell bg-sidebar)
      so the sticky new-tab trigger masks tabs scrolling underneath it. */
   --right-panel-tab-sticky-surface: color-mix(in srgb, var(--color-sidebar-background) 88%, transparent);
-  --right-panel-tab-hover-bg: color-mix(
-    in srgb,
-    var(--color-sidebar-foreground) 4%,
-    transparent
-  );
   --right-panel-tab-active-bg: color-mix(
     in srgb,
     var(--color-sidebar-foreground) 5%,
@@ -1914,35 +1906,25 @@ body {
   --right-panel-tab-text-primary: var(--color-sidebar-foreground);
   --right-panel-tab-text-secondary: color-mix(in srgb, var(--color-sidebar-foreground) 65%, transparent);
   --right-panel-tab-text-tertiary: var(--color-sidebar-muted-foreground);
-  --right-panel-tab-focus: var(--color-sidebar-ring);
-  --right-panel-tab-font-size: var(--workspace-shell-tab-font-size);
-  --right-panel-tab-line-height: var(--workspace-shell-tab-line-height);
-  --right-panel-tab-font-weight: var(--workspace-shell-tab-font-weight);
-  --right-panel-tab-icon-size: var(--workspace-shell-tab-icon-size);
-  --right-panel-tab-content-gap: var(--workspace-shell-tab-content-gap);
-  --right-panel-tab-dot-size: 5px;
-  --right-panel-tab-dot-gap: 2px;
-  --right-panel-tab-close-size: 1rem;
-  --right-panel-tab-close-offset: calc(
-    8px - ((var(--right-panel-tab-close-size) - var(--right-panel-tab-icon-size)) / 2)
-  );
+  --right-panel-tab-icon-size: 1.27em;
+  --right-panel-tab-dot-size: 0.45em;
+  --right-panel-tab-close-size: calc(var(--text-ui-sm) * 1.45);
   display: flex;
   flex-direction: column;
   width: 100%;
   height: var(--tab-system-height);
-  box-sizing: border-box;
   flex-shrink: 0;
   min-width: 0;
   background-color: var(--right-panel-tab-surface);
   color: var(--right-panel-tab-text-secondary);
-  font-size: var(--right-panel-tab-font-size);
-  line-height: var(--right-panel-tab-line-height);
+  font-size: var(--text-ui-sm);
+  line-height: var(--text-ui-sm--line-height);
+  font-weight: 500;
 }
 
 :root[data-mode="light"] .right-panel-tab-system {
   --right-panel-tab-surface: var(--color-surface);
   --right-panel-tab-sticky-surface: color-mix(in srgb, var(--color-surface) 88%, transparent);
-  --right-panel-tab-hover-bg: color-mix(in oklab, var(--color-foreground) 5%, transparent);
   --right-panel-tab-active-bg: color-mix(in oklab, var(--color-foreground) 5%, transparent);
   --right-panel-tab-text-secondary: color-mix(in oklab, var(--color-foreground) 65%, transparent);
 }
@@ -1951,14 +1933,12 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0;
   height: 100%;
   width: 100%;
   min-width: 0;
   padding: 0 8px;
   background-color: var(--right-panel-tab-surface);
   flex-shrink: 0;
-  box-sizing: border-box;
   /* Tab drag-reorder is pointer-event driven; without this WebKit starts a
      text selection mid-drag and paints the whole bar (and anything the sweep
      crosses) blue. */
@@ -1972,8 +1952,6 @@ body {
   height: 100%;
   min-width: 0;
   width: 100%;
-  box-sizing: border-box;
-  padding-left: var(--right-panel-tab-leading-inset);
 }
 
 .right-panel-tab-system .ui-tab-system-section {
@@ -1985,7 +1963,6 @@ body {
   height: 100%;
   padding: var(--tab-container-padding) 0;
   color: var(--right-panel-tab-text-tertiary);
-  box-sizing: border-box;
 }
 
 .right-panel-tab-system .ui-tab-system-tabs__scrollable {
@@ -1993,7 +1970,6 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0;
   flex: 1;
   min-width: 0;
   height: 100%;
@@ -2126,13 +2102,9 @@ body {
   border: none;
   margin: 0;
   font: inherit;
-  font-size: var(--right-panel-tab-font-size);
-  line-height: var(--right-panel-tab-line-height);
-  font-weight: var(--right-panel-tab-font-weight);
   letter-spacing: 0;
   color: inherit;
   cursor: pointer;
-  box-sizing: border-box;
   touch-action: manipulation;
   outline: none;
   position: relative;
@@ -2144,7 +2116,7 @@ body {
   padding: 4px 8px;
   color: var(--right-panel-tab-text-secondary);
   flex-shrink: 0;
-  border-radius: var(--right-panel-tab-radius);
+  border-radius: 8px;
   overflow: hidden;
   transition-property: color;
   transition-duration: 100ms;
@@ -2156,7 +2128,7 @@ body {
   position: absolute;
   inset: 0;
   z-index: 0;
-  border-radius: var(--right-panel-tab-overlay-radius);
+  border-radius: 8px;
   background-color: transparent;
   pointer-events: none;
   transition: background-color 100ms ease;
@@ -2212,7 +2184,7 @@ body {
 }
 
 .right-panel-tab-system .ui-tab-system-tab:focus-visible {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--right-panel-tab-focus) 34%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-sidebar-ring) 34%, transparent);
 }
 
 .right-panel-tab-system .ui-tab-system-tab:disabled {
@@ -2225,16 +2197,13 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--right-panel-tab-content-gap);
+  gap: var(--workspace-shell-tab-content-gap);
   flex: 1;
   height: 100%;
   min-width: 0;
   overflow: hidden;
   position: relative;
   z-index: 1;
-  font-size: var(--right-panel-tab-font-size);
-  line-height: var(--right-panel-tab-line-height);
-  font-weight: var(--right-panel-tab-font-weight);
 }
 
 .right-panel-tab-system .ui-tab-system-tab__content[data-shortcut-reveal="true"] {
@@ -2278,9 +2247,6 @@ body {
   height: 100%;
   min-width: 0;
   text-align: left;
-  font-size: var(--right-panel-tab-font-size);
-  line-height: var(--right-panel-tab-line-height);
-  font-weight: var(--right-panel-tab-font-weight);
 }
 
 .right-panel-tab-system .ui-tab-system-tab__label-primary {
@@ -2290,9 +2256,6 @@ body {
   white-space: nowrap;
   flex: 1;
   min-width: 0;
-  font-weight: inherit;
-  font-size: var(--right-panel-tab-font-size);
-  line-height: var(--right-panel-tab-line-height);
 }
 
 .right-panel-tab-system .ui-tab-system-tab__dirty-indicator {
@@ -2300,7 +2263,7 @@ body {
   flex-shrink: 0;
   width: var(--right-panel-tab-dot-size);
   height: var(--right-panel-tab-dot-size);
-  margin-left: var(--right-panel-tab-dot-gap);
+  margin-left: 0.18em;
   border-radius: 9999px;
   background-color: var(--right-panel-tab-text-tertiary);
 }
@@ -2331,7 +2294,7 @@ body {
 
 .right-panel-tab-system .right-panel-terminal-tab-shell .ui-tab-system-tab__close-container {
   position: absolute;
-  left: var(--right-panel-tab-close-offset);
+  left: 0.64em;
   top: 0;
   bottom: 0;
   width: var(--right-panel-tab-close-size);
@@ -2361,7 +2324,6 @@ body {
 
 .right-panel-tab-system .ui-tab-system-tab__close,
 .right-panel-tab-system .right-panel-terminal-edit-action {
-  box-sizing: border-box;
   width: var(--right-panel-tab-close-size);
   height: var(--right-panel-tab-close-size);
   min-width: var(--right-panel-tab-close-size);

--- a/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
@@ -145,3 +145,30 @@ describe("design-package @theme --text-* tokens", () => {
     }
   });
 });
+
+describe("right-panel tab typography", () => {
+  const productCss = stripCssComments(
+    readFileSync(resolve(designCssDir, "product.css"), "utf8"),
+  );
+  const rightPanelRule = productCss.match(
+    /\.right-panel-tab-system\s*\{([\s\S]*?)\}/,
+  )?.[1];
+
+  it("consumes live compact UI tokens instead of removed workspace-tab aliases", () => {
+    expect(rightPanelRule).toContain("font-size: var(--text-ui-sm);");
+    expect(rightPanelRule).toContain(
+      "line-height: var(--text-ui-sm--line-height);",
+    );
+    expect(rightPanelRule).toContain("font-weight: 500;");
+    expect(rightPanelRule).not.toContain("--workspace-shell-tab-font-size");
+    expect(rightPanelRule).not.toContain("--workspace-shell-tab-line-height");
+    expect(rightPanelRule).not.toContain("--workspace-shell-tab-font-weight");
+    expect(rightPanelRule).toContain("--right-panel-tab-icon-size: 1.27em;");
+    expect(rightPanelRule).toContain(
+      "--right-panel-tab-close-size: calc(var(--text-ui-sm) * 1.45);",
+    );
+    expect(productCss).not.toContain("--right-panel-tab-font-size");
+    expect(productCss).not.toContain("--right-panel-tab-line-height");
+    expect(productCss).not.toContain("--right-panel-tab-font-weight");
+  });
+});

--- a/apps/packages/ui/src/utils/tw-merge.ts
+++ b/apps/packages/ui/src/utils/tw-merge.ts
@@ -12,6 +12,7 @@ export const TEXT_SIZE_TOKEN_IDS = [
   "ui",
   "ui-sm",
   "composer",
+  "workspace-title",
   "title",
   "hero",
   "chat",


### PR DESCRIPTION
## What this changes

This fixes the workspace right-panel tab chrome so Scratch, Changes, Terminal, and file titles return to a compact scale and grow proportionally with their icons.

**Owned surface:** the Desktop/Web workspace right-panel tab strip.

**Explicit non-goals:** readable-code preset remapping; repository-wide text-token migration; repository-wide icon migration; workspace/session/header redesign; native/Rust work.

## Before / after

Before, the pane titles inherited 16px / 24px body typography because their removed custom properties invalidated the declarations, making Scratch and Changes visually oversized. After, the Default preset renders 11px / 15px / 500 labels with 13.97px icons, and the Large preset renders 12px / 16px labels with 15.23px icons.

## When this matters

This is visible whenever the right pane is open for Scratch, Changes, terminals, or files; the pane chrome now stays subordinate to the workspace/session context and scales with the user's UI-size preference.

## Design reference

1. **Primary reference:** Codex.
2. **Exact state inspected:** compact Codex-style pane chrome, compared against the founder-supplied Proliferate regression screenshot and the real Proliferate Desktop renderer with Scratch, Changes, and Terminal tabs open.
3. **Intentionally matched:** compact pane-tab hierarchy, 500 weight, compact line height, and icon/control sizing proportional to the tab label.
4. **Intentional Proliferate differences:** Proliferate keeps its Scratch/Changes/Terminal controls, 28px tab pill, and product colors.
5. **Mock approval:** not required. The supplied regression screenshot and direct founder correction fully specified the repair; no retroactive mock was manufactured.

## Demo

[Open the hosted exact-head preview](https://proliferate-web-git-codex-ui-right-pane-title-scale-getonyx.vercel.app/) — head `f2a96731ed6ed7534be222075abe5a5a268abe97`, verified HTTP 200. Real Desktop renderer proof used isolated profile `ui-01-typography`, app 0.3.44, HMR on at `http://127.0.0.1:1684/`; the hosted link is the durable primary demo.

## Current disposition

Merged — squash commit `ec2aafc2cf1d0d254adfce1bb0084a90e06e4b38`; next action: shape and founder-approve the separate proportional-scaling follow-up.

## Founder decision needed

None.

---

## Engineering evidence

### Root cause and repair

- The right-panel CSS still referenced `--workspace-shell-tab-font-size`, `--workspace-shell-tab-line-height`, and `--workspace-shell-tab-font-weight` after those variables were removed, so the browser discarded those declarations and inherited 16px / 24px / 430.
- The tab strip now consumes `--text-ui-sm*` directly and inherits one typography declaration through its descendants.
- Pane glyphs, dirty indicators, and close controls use proportional units while preserving the former Default optical sizes.
- The missing `workspace-title` entry is restored in the shared `twMerge` font-size registry; exact `main` CI currently fails the pre-existing contract test without it.

### Exact measurements

| State | Label | Icon | Close control |
| --- | --- | --- | --- |
| Before | 16px / 24px / 430 | fixed 14px | fixed 16px |
| Default | 11px / 15px / 500 | 13.9688px | 15.9453px |
| Large | 12px / 16px / 500 | 15.2344px | proportional |

Local proof bundle: `reference/proliferate/right-panel-tab-title-scale/` (left side of `before-after-contact-sheet.png` is the supplied regression; right side is this exact implementation state).

### Validation

- `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/preferences/appearance-css-drift.test.ts` — 5 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- `python3 scripts/report_frontend_structure.py --strict --summary-only` — 0 violations across 2,288 files.
- `git diff --check` — passed.
- Real Desktop renderer at Default: 11px / 15px / 500 label, 13.9688px icon, 15.9453px close control.
- Real Desktop renderer at Large: 12px / 16px label, 15.2344px icon; profile restored to Default after proof.

### Login budget baseline

The CSS regression is repaired with useful headroom; the only remaining gate failure is inherited JS debt on `main`.

| Build | JS gzip | CSS gzip |
| --- | ---: | ---: |
| Exact merged base `0e50751b` (local clean worktree) | 485,805 / 485,000 | 65,931 / 66,000 |
| This head | 485,814 / 485,000 | 65,785 / 66,000 |
| Delta | +9 | −146 |

Current `main` CI is independently red at 486,871 JS and 66,069 CSS in [run 29698767143](https://github.com/proliferate-ai/proliferate/actions/runs/29698767143). This patch removes enough CSS to put that observed CSS baseline back under the cap by projection, but does not absorb the unrelated ~1.8KB mainline JS reduction into this pane fix.

### Product-wide scaling audit (not part of this PR)

- Default visible message/composer text is 13px; Default readable code is 10px. Extra Large code is 12px and Extra Extra Large code is 13px. Same-name presets are therefore not visually equal.
- Static production scan (tests, stories, and playgrounds excluded) found 32 fixed text-size declarations across 20 files; two are runtime-overwritten code/diff defaults.
- The conservative icon scan found 107 reachable icon/glyph call sites with fixed numeric dimensions. Those respond to window zoom but generally not to the UI-font preference.
- Recommendation: follow with one separately specified scaling migration for semantic text literals, proportional icon tiers, and the intended UI↔readable-code preset mapping.

### Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and evidence.
- [x] No Rust or Docker build was run.
- [ ] Inherited `main` JS budget is below the founder cap.

### Support and attribution

No support relationship or private source data is associated with this PR.