### PR TITLE
perf(product): defer utility hosts from Web login

### DIFF
--- a/apps/packages/product-client/src/App.tsx
+++ b/apps/packages/product-client/src/App.tsx
@@ -1,16 +1,16 @@
 import { Suspense, lazy } from "react"
-import { Navigate, Route } from "react-router-dom"
+import { Navigate, Route, useLocation } from "react-router-dom"
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider"
+import type { AuthState } from "@proliferate/product-client/host/product-host"
 import { BootstrappedRoute, PublicOnlyRoute } from "#product/components/auth/AuthGate"
 import { UserPreferencesGate } from "#product/components/app/UserPreferencesGate"
-import { KeyboardShortcutsDialog } from "#product/components/workspace/shell/sidebar/KeyboardShortcutsDialog"
 import { UpdateRestartDialog } from "#product/components/feedback/UpdateRestartDialog"
 import { UpdateToastPresenter } from "#product/components/feedback/UpdateToastPresenter"
-import { HarnessUpdateToastPresenter } from "#product/components/feedback/HarnessUpdateToastPresenter"
+import { KeyboardShortcutsDialog } from "#product/components/workspace/shell/sidebar/KeyboardShortcutsDialog"
 import { Toaster } from "@proliferate/ui/kit/Sonner"
 import { MacWindowControlsSafeArea } from "#product/components/app/chrome/MacWindowControlsSafeArea"
 import { useLocalWorktreeSettingsTarget } from "#product/hooks/workspaces/facade/use-local-worktree-settings-target"
 import { useWorktreeCleanupPolicySync } from "#product/hooks/workspaces/lifecycle/use-worktree-cleanup-policy-sync"
-import { SupportModalHost } from "#product/components/support/SupportModalHost"
 import { LoginPage } from "#product/pages/LoginPage"
 import { SettingsCloudRedirect } from "#product/pages/SettingsCloudRedirect"
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store"
@@ -22,6 +22,13 @@ import type { ProductRoutesComponent } from "#product/ProductClient"
 // eagerly pulls the authenticated-only chunks (editor/terminal/etc.).
 const AuthenticatedProductClient = lazy(
   () => import("#product/app/AuthenticatedProductClient"),
+)
+
+// Product utility hosts are useful only once a Web user can enter the product.
+// Keep them available during Desktop's native/local startup, but do not make an
+// anonymous Web /login fetch their workspace, agent-catalog, and support trees.
+const ProductUtilityHosts = lazy(
+  () => import("#product/app/ProductUtilityHosts"),
 )
 
 // Dev-only playground. Lazy-loaded with a DEV guard so neither this file
@@ -213,15 +220,46 @@ export function App({ RoutesComponent }: AppProps) {
           )}
           <Route path="*" element={<Navigate to="/" replace />} />
         </RoutesComponent>
-        <SupportModalHost />
         {/* Kit Sonner toaster: all toasts (update lifecycle + legacy
             toast-store call sites, which now delegate to Sonner). */}
         <Toaster />
         <UpdateToastPresenter />
-        <HarnessUpdateToastPresenter />
         <KeyboardShortcutsDialog />
+        <ProductUtilityHostsGate />
       </ShortcutRevealProvider>
   )
+}
+
+function ProductUtilityHostsGate() {
+  const { auth, desktop } = useProductHost()
+  const location = useLocation()
+  const shouldLoad = shouldLoadProductUtilityHosts({
+    hasDesktop: desktop !== null,
+    authStatus: auth.state.status,
+    pathname: location.pathname,
+  })
+
+  if (!shouldLoad) {
+    return null
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <ProductUtilityHosts />
+    </Suspense>
+  )
+}
+
+export function shouldLoadProductUtilityHosts({
+  hasDesktop,
+  authStatus,
+  pathname,
+}: {
+  hasDesktop: boolean
+  authStatus: AuthState["status"]
+  pathname: string
+}): boolean {
+  return hasDesktop || authStatus === "authenticated" || pathname !== "/login"
 }
 
 function WorktreeCleanupPolicySyncGate() {

--- a/apps/packages/product-client/src/App.utility-hosts.test.ts
+++ b/apps/packages/product-client/src/App.utility-hosts.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { shouldLoadProductUtilityHosts } from "#product/App"
+
+describe("product utility host loading", () => {
+  it("defers the utility tree for anonymous and loading Web login", () => {
+    expect(
+      shouldLoadProductUtilityHosts({
+        hasDesktop: false,
+        authStatus: "anonymous",
+        pathname: "/login",
+      }),
+    ).toBe(false)
+    expect(
+      shouldLoadProductUtilityHosts({
+        hasDesktop: false,
+        authStatus: "loading",
+        pathname: "/login",
+      }),
+    ).toBe(false)
+  })
+
+  it("preserves Desktop, authenticated Web, and auth-optional product routes", () => {
+    expect(
+      shouldLoadProductUtilityHosts({
+        hasDesktop: true,
+        authStatus: "anonymous",
+        pathname: "/login",
+      }),
+    ).toBe(true)
+    expect(
+      shouldLoadProductUtilityHosts({
+        hasDesktop: false,
+        authStatus: "authenticated",
+        pathname: "/login",
+      }),
+    ).toBe(true)
+    expect(
+      shouldLoadProductUtilityHosts({
+        hasDesktop: false,
+        authStatus: "anonymous",
+        pathname: "/",
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/packages/product-client/src/app/ProductUtilityHosts.tsx
+++ b/apps/packages/product-client/src/app/ProductUtilityHosts.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from "react"
+
+import { HarnessUpdateToastPresenter } from "#product/components/feedback/HarnessUpdateToastPresenter"
+import { SupportModalHost } from "#product/components/support/SupportModalHost"
+
+/**
+ * Product utility hosts that have no anonymous Web behavior.
+ *
+ * App lazy-loads this module for authenticated/auth-optional Web and for every
+ * Desktop posture, preserving Desktop's pre-auth local-runtime behavior while
+ * keeping the public Web login shell independent of agent and support trees.
+ */
+export default function ProductUtilityHosts(): ReactElement {
+  return (
+    <>
+      <SupportModalHost />
+      <HarnessUpdateToastPresenter />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- lazy-load the support modal and harness-update toast hosts outside the anonymous/loading Web `/login` shell
- preserve those hosts during every Desktop posture, authenticated Web login, and auth-optional Web product routes
- add a focused posture matrix for the load boundary

## Why

Current main crossed the founder-approved anonymous Web login JS ceiling (486,880 B versus 485,000 B). The public `App` statically imported product-only utility hosts; the harness-update host transitively pulled the generated agent catalog and authenticated workspace hooks into the first-load chunk even though neither host has anonymous Web login behavior.

This changes the ownership boundary rather than raising the cap, changing the collector, or suppressing CI.

## Custody

- exact base: `ec2aafc2cf1d0d254adfce1bb0084a90e06e4b38`
- exact head: `f2218e4cac18e81522b522c5ebe97b42afc7227c`

## Proof

Exact-head runtime collector after a clean shared/Web build:

- JS: **467,353 / 485,000 B** (17,647 B headroom)
- CSS: **65,789 / 66,000 B** (211 B headroom)
- fonts/images/audio: **0 / 0 / 0**
- login-ready marker reached, network settled, no unexpected cross-origin requests

Offline checks:

- focused product-client tests: **10/10**
- product-client typecheck: green
- max-lines, frontend boundaries, strict frontend structure, docs integrity: green
- `git diff --check`: green

No Rust, Docker, provider, production, cap, collector, or PR #1446 changes.