### PR TITLE
fix(release): preserve CFN bootstrap timeout truth

### DIFF
--- a/server/deploy/README.md
+++ b/server/deploy/README.md
@@ -38,7 +38,7 @@ flags (`--version`, `--eval`, `--no-start`, `--dry-run`, `--yes`).
 | `docker-compose.production.yml` | The stack: `caddy`, `db`, `migrate`, `api`, and the profiled `litellm`/`litellm-db` (agent-gateway) and `redis` (cloud-workspaces). |
 | `Caddyfile` | Public HTTPS via Caddy (Let's Encrypt), plus the `/llm` route to the agent gateway when enabled. |
 | `.env.production.example` | Copy to `.env.static` and fill in; the installer does this for you. |
-| `bootstrap.sh` | First-run: generate secrets, migrate, boot, wait for health, print the claim token. |
+| `bootstrap.sh` | First-run: generate secrets, migrate, boot, wait for health, print the claim token, and emit fixed secret-free substep progress markers for bounded AWS diagnostics. |
 | `update.sh` | Pull + migrate + restart, including any enabled optional profile. |
 | `preflight.sh` | Validate config before replacing a running stack. |
 | `doctor.sh` | Redacting diagnostics for the running instance. |

--- a/server/deploy/bootstrap.sh
+++ b/server/deploy/bootstrap.sh
@@ -10,6 +10,23 @@ LEGACY_ENV_FILE="$SCRIPT_DIR/.env"
 RUNTIME_ENV_FILE="$SCRIPT_DIR/.env.runtime"
 EXAMPLE_ENV_FILE="$SCRIPT_DIR/.env.production.example"
 
+# Fixed, secret-free progress markers consumed by the bounded CloudFormation
+# failure diagnostic. Keep both token allowlists in sync; never place command
+# output, paths, hostnames, or environment values in this protocol.
+bootstrap_substep_marker() {
+  local substep="$1"
+  local status="$2"
+  case "$substep" in
+    ensure-secrets|preflight|registry-login|runtime-install|db-up|migrate|api-caddy-up|optional-profiles|health-wait) ;;
+    *) return 2 ;;
+  esac
+  case "$status" in
+    started|completed) ;;
+    *) return 2 ;;
+  esac
+  printf '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:%s:%s\n' "$substep" "$status"
+}
+
 if [[ -f "$STATIC_ENV_FILE" ]]; then
   ENV_FILE="$STATIC_ENV_FILE"
 else
@@ -36,15 +53,23 @@ fi
 export PROLIFERATE_STATIC_ENV_FILE="$ENV_FILE"
 export PROLIFERATE_ENV_FILE="$RUNTIME_ENV_FILE"
 
+bootstrap_substep_marker ensure-secrets started
 "$SCRIPT_DIR/ensure-secrets.sh"
+bootstrap_substep_marker ensure-secrets completed
 
 # Validate the resolved config before touching containers, so a dangerous
 # partial config (e.g. E2B_API_KEY without E2B_TEMPLATE_NAME, which crash-loops
 # the api) fails here instead of after we have replaced a running stack.
+bootstrap_substep_marker preflight started
 "$SCRIPT_DIR/preflight.sh" "$RUNTIME_ENV_FILE"
+bootstrap_substep_marker preflight completed
 
+bootstrap_substep_marker registry-login started
 "$SCRIPT_DIR/registry-login.sh"
+bootstrap_substep_marker registry-login completed
+bootstrap_substep_marker runtime-install started
 "$SCRIPT_DIR/install-runtime.sh"
+bootstrap_substep_marker runtime-install completed
 
 COMPOSE_ARGS=(--env-file "$RUNTIME_ENV_FILE" -f "$SCRIPT_DIR/docker-compose.production.yml")
 
@@ -68,9 +93,15 @@ while IFS= read -r _profile_service; do
   [[ -n "$_profile_service" ]] && PROFILE_SERVICES+=("$_profile_service")
 done < <(proliferate_profile_services "$RUNTIME_ENV_FILE")
 
+bootstrap_substep_marker db-up started
 docker compose "${COMPOSE_ARGS[@]}" up -d db
+bootstrap_substep_marker db-up completed
+bootstrap_substep_marker migrate started
 docker compose "${COMPOSE_ARGS[@]}" run --rm migrate
+bootstrap_substep_marker migrate completed
+bootstrap_substep_marker api-caddy-up started
 docker compose "${COMPOSE_ARGS[@]}" up -d api caddy
+bootstrap_substep_marker api-caddy-up completed
 
 # Bring up any enabled optional-profile services (agent-gateway litellm +
 # litellm-db, cloud-workspaces redis) and WAIT for their healthchecks before
@@ -82,10 +113,14 @@ docker compose "${COMPOSE_ARGS[@]}" up -d api caddy
 # a bare `up -d --wait` across the whole compose file): otherwise it would
 # also try to reconcile the one-shot `migrate` job, which always exits after
 # running and would make --wait report a false failure.
+bootstrap_substep_marker optional-profiles started
 if ((${#PROFILE_SERVICES[@]})); then
   docker compose "${COMPOSE_ARGS[@]}" "${PROFILE_ARGS[@]}" up -d --wait --wait-timeout "${PROLIFERATE_PROFILE_WAIT_TIMEOUT_SECONDS:-300}" "${PROFILE_SERVICES[@]}"
 fi
+bootstrap_substep_marker optional-profiles completed
 
 # Waits for /health, then prints the first-run setup token and claim URL when
 # the instance is still unclaimed.
+bootstrap_substep_marker health-wait started
 "$SCRIPT_DIR/wait-for-health.sh"
+bootstrap_substep_marker health-wait completed

--- a/server/deploy/tests/bootstrap-markers.sh
+++ b/server/deploy/tests/bootstrap-markers.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Offline contract test for bootstrap.sh's fixed diagnostic marker protocol.
+# It executes the real script with fake helpers/docker: no Docker daemon,
+# network, credentials, or provider resources are used.
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/proliferate-bootstrap-markers.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+FIXTURE="$SCRATCH/deploy"
+FAKE_BIN="$SCRATCH/bin"
+mkdir -p "$FIXTURE" "$FAKE_BIN"
+cp "$DEPLOY_DIR/bootstrap.sh" "$DEPLOY_DIR/common.sh" "$FIXTURE/"
+printf 'AGENT_GATEWAY_ENABLED=false\nE2B_API_KEY=\nE2B_TEMPLATE_NAME=\n' >"$FIXTURE/.env.static"
+cp "$FIXTURE/.env.static" "$FIXTURE/.env.runtime"
+
+cat >"$FIXTURE/helper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$(basename "$0" .sh)" >>"$BOOTSTRAP_OPS"
+EOF
+chmod +x "$FIXTURE/helper"
+for helper in ensure-secrets preflight registry-login install-runtime wait-for-health; do
+  ln -s helper "$FIXTURE/$helper.sh"
+done
+
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == "compose version" ]]; then
+  exit 0
+fi
+printf 'docker:%s\n' "$*" >>"$BOOTSTRAP_OPS"
+if [[ -n "${FAIL_DOCKER_MATCH:-}" && "$*" == *"$FAIL_DOCKER_MATCH"* ]]; then
+  exit 41
+fi
+EOF
+chmod +x "$FAKE_BIN/docker"
+
+expected_success="$SCRATCH/expected-success"
+cat >"$expected_success" <<'EOF'
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:registry-login:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:registry-login:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:runtime-install:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:runtime-install:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:db-up:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:db-up:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:migrate:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:migrate:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:api-caddy-up:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:api-caddy-up:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:optional-profiles:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:optional-profiles:completed
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:health-wait:started
+__PROLIFERATE_BOOTSTRAP_SUBSTEP__:health-wait:completed
+EOF
+
+success_output="$SCRATCH/success.out"
+success_ops="$SCRATCH/success.ops"
+PATH="$FAKE_BIN:$PATH" BOOTSTRAP_OPS="$success_ops" bash "$FIXTURE/bootstrap.sh" >"$success_output"
+grep '^__PROLIFERATE_BOOTSTRAP_SUBSTEP__:' "$success_output" >"$SCRATCH/success.markers"
+diff -u "$expected_success" "$SCRATCH/success.markers"
+
+failed_output="$SCRATCH/failed.out"
+failed_ops="$SCRATCH/failed.ops"
+set +e
+PATH="$FAKE_BIN:$PATH" BOOTSTRAP_OPS="$failed_ops" FAIL_DOCKER_MATCH='run --rm migrate' \
+  bash "$FIXTURE/bootstrap.sh" >"$failed_output" 2>&1
+failed_status=$?
+set -e
+[[ "$failed_status" -eq 41 ]]
+grep -qx '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:migrate:started' "$failed_output"
+if grep -qE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:migrate:completed|__PROLIFERATE_BOOTSTRAP_SUBSTEP__:api-caddy-up:' "$failed_output"; then
+  printf 'bootstrap emitted completion/later markers after migrate failed\n' >&2
+  exit 1
+fi

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -145,6 +145,12 @@ env_both="$SCRATCH/both.env"
 printf 'AGENT_GATEWAY_ENABLED=true\nE2B_API_KEY=k\nE2B_TEMPLATE_NAME=t/x:production\n' >"$env_both"
 [[ "$(proliferate_enabled_profiles "$env_both")" == "agent-gateway cloud-workspaces" ]] && ok "gateway + cloud both on -> both profiles" || no "expected both profiles: got '$(proliferate_enabled_profiles "$env_both")'"
 
+if bash "$TESTS_DIR/bootstrap-markers.sh"; then
+  ok "bootstrap markers are ordered and stop without completion on failure"
+else
+  no "bootstrap marker ordering/failure contract regressed"
+fi
+
 mv="$(printf '0.3.2\n0.3.18\n0.10.0\n2.0.0\n0.3.9\n' | proliferate_max_version)"
 [[ "$mv" == "2.0.0" ]] && ok "max_version picks 2.0.0" || no "max_version wrong: $mv"
 mv2="$(printf '0.3.2\n0.3.18\n0.3.9\n' | proliferate_max_version)"

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -569,8 +569,10 @@ Resources:
               if [ "$EXIT_CODE" -eq 124 ] || [ "$EXIT_CODE" -eq 137 ]; then
                 EXIT_CODE=124
                 FAILURE_REASON="cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+                printf '__PROLIFERATE_CFN_OUTER__:timeout\n'
               else
                 FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+                printf '__PROLIFERATE_CFN_OUTER__:command_failure\n'
               fi
             }
           fi

--- a/specs/developing/deploying/self-hosted-aws.md
+++ b/specs/developing/deploying/self-hosted-aws.md
@@ -63,6 +63,15 @@ puts only a bounded stage and exit-code reason in the stack event. Inspect
 detail rather than copying those potentially secret-bearing logs into
 CloudFormation events.
 
+`bootstrap.sh` emits fixed, secret-free start/completion markers for its
+material substeps (secret resolution, preflight, registry login, runtime
+installation, database start/migration, API+Caddy start, optional profiles,
+and health wait). Qualification diagnostics accept only those allowlisted
+tokens. A timeout can therefore identify the last started substep without
+persisting command output, environment values, URLs, or provider payloads;
+absence of a completion marker is reported as unfinished rather than guessed
+as a command failure.
+
 ## Required Inputs
 
 The base stack needs:

--- a/tests/release/src/scenarios/selfhost-cfn-1.ts
+++ b/tests/release/src/scenarios/selfhost-cfn-1.ts
@@ -49,7 +49,7 @@ import {
   uploadBundleAndPresign,
   validateTemplate,
   writeCfnBootstrapDiagnosticArtifact,
-  type CfnBootstrapDiagnosticArtifactV1,
+  type CfnBootstrapDiagnosticArtifactV2,
   type CfnStackOutputs,
   type SelfHostCfnWorldCleanupEvidence,
 } from "../worlds/selfhost/cfn.js";
@@ -558,8 +558,8 @@ export async function constructSelfHostCfnWorld(inputs: CfnWorldInputs): Promise
           stackName: failedStackName,
           region,
         });
-        const artifact: CfnBootstrapDiagnosticArtifactV1 = {
-          schema_version: 1,
+        const artifact: CfnBootstrapDiagnosticArtifactV2 = {
+          schema_version: 2,
           kind: "proliferate.selfhost-cfn-bootstrap-diagnostic",
           run: {
             run_id: inputs.run.run_id,

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { promisify } from "node:util";
 
 import {
   CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET,
   MAX_STACK_EVENT_TAIL,
   SelfHostCfnCleanupStack,
   boundedStackEventsTail,
+  buildCfnDiagnosticCommand,
   buildCfnParameters,
   buildCfnStackTags,
   bundleDigestBound,
@@ -46,6 +49,8 @@ import {
   type GhExec,
 } from "./cfn.js";
 import type { CleanupLedger, CleanupLedgerEntry, CleanupResourceKind } from "../local-workspace/cleanup-ledger.js";
+
+const execFileAsync = promisify(execFile);
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
 
@@ -392,6 +397,77 @@ test("parseCfnBootstrapDiagnosticOutput: identifies the last started bootstrap s
     ],
   );
   assert.equal(JSON.stringify(parsed).includes("secret-token"), false);
+});
+
+test("CFN-DIAG-CONTROL-002: multibyte context cannot truncate fixed outer/substep markers", async () => {
+  const logDirectory = await mkdtemp(path.join(tmpdir(), "cfn-diagnostic-multibyte-"));
+  const multibyteLine = `${"😀".repeat(240)} error Command 02-bootstrap`;
+  const variableLines = Array.from({ length: 36 }, () => multibyteLine).join("\n");
+  const outerMarker = "__PROLIFERATE_CFN_OUTER__:timeout";
+  const substepMarker = "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started";
+
+  try {
+    await writeFile(
+      path.join(logDirectory, "cloud-init-output.log"),
+      `${variableLines}\n${outerMarker}\n`,
+    );
+    await writeFile(
+      path.join(logDirectory, "cfn-init-cmd.log"),
+      `${variableLines}\n__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:completed\n${substepMarker}\n`,
+    );
+    await writeFile(
+      path.join(logDirectory, "cfn-init.log"),
+      `Running Command 02-bootstrap\n${variableLines}\n`,
+    );
+
+    // The old variable-first, character-counted projection is >20 KB before
+    // either marker class is appended, so its aggregate byte cap loses both.
+    const legacyCharacterProjection = Array.from({ length: 36 }, () =>
+      [...multibyteLine].slice(0, 240).join(""),
+    ).join("\n");
+    const legacyCapped = Buffer.from(
+      `${legacyCharacterProjection}\n${substepMarker}\n${outerMarker}\n`,
+      "utf8",
+    ).subarray(0, CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET).toString("utf8");
+    assert.ok(Buffer.byteLength(legacyCharacterProjection, "utf8") > CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET);
+    assert.equal(legacyCapped.includes(substepMarker), false, "old ordering loses the substep marker");
+    assert.equal(legacyCapped.includes(outerMarker), false, "old ordering loses the outer marker");
+
+    const command = buildCfnDiagnosticCommand({ logDirectory, elevated: false });
+    const { stdout } = await execFileAsync("bash", ["-c", command], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+    assert.ok(Buffer.byteLength(stdout, "utf8") <= CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET);
+    assert.ok(Buffer.byteLength(stdout, "utf8") < 24_000);
+    assert.match(stdout, /^[\x00-\x7f]*$/, "diagnostic stdout is a byte-bounded ASCII token projection");
+    assert.ok(stdout.includes(outerMarker), "outer terminal marker survives adversarial context");
+    assert.ok(stdout.includes(substepMarker), "bootstrap substep marker survives adversarial context");
+
+    const parsed = parseCfnBootstrapDiagnosticOutput(stdout);
+    assert.equal(parsed.terminal_cause, "outer_timeout");
+    assert.equal(
+      parsed.observations.some(
+        (item) => item.substep === "preflight" && item.outcome === "started",
+      ),
+      true,
+    );
+    assert.match(
+      summarizeCfnBootstrapDiagnostic({
+        stack_name_hash: "a".repeat(64),
+        instance_id_hash: "b".repeat(64),
+        capture_status: "captured",
+        detail: "captured",
+        ssm_status: "Success",
+        terminal_cause: parsed.terminal_cause,
+        observations: parsed.observations,
+      }),
+      /02-bootstrap\/preflight:started:exit=unknown:other/,
+      "priority-safe acquisition still places the deepest substep in the evidence tail",
+    );
+  } finally {
+    await rm(logDirectory, { recursive: true, force: true });
+  }
 });
 
 test("parseGhcrVersions + ghcrVersionIdForTag: finds the version whose tags include the run tag", () => {

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET,
   MAX_STACK_EVENT_TAIL,
   SelfHostCfnCleanupStack,
   boundedStackEventsTail,
@@ -34,11 +35,12 @@ import {
   s3KeyPrefix,
   scrubCfnParameterUrls,
   ssmInspectRunningImageDigest,
+  summarizeCfnBootstrapDiagnostic,
   templateFileSha256,
   uploadBundleAndPresign,
   validateTemplate,
   writeCfnBootstrapDiagnosticArtifact,
-  type CfnBootstrapDiagnosticArtifactV1,
+  type CfnBootstrapDiagnosticArtifactV2,
   type CfnAwsExec,
   type DockerExec,
   type GhExec,
@@ -249,17 +251,20 @@ test("boundedStackEventsTail: only FAILED events, bounded count, secret-free for
 
 test("parseCfnBootstrapDiagnosticOutput: emits only allowlisted tokens and drops raw secrets", () => {
   const raw = [
-    "__PROLIFERATE_CFN_LOG__:cfn-init-cmd.log",
+    "__PROLIFERATE_CFN_LOG__:cfn-init.log",
     "2026-07-19 Running Command 02-bootstrap",
     "2026-07-19 Exited with error code 17: https://bucket/x?X-Amz-Signature=deadbeef",
     "Bearer eyJsecret.payload.signature vk-super-secret-value",
     "download error from https://example.invalid/private?token=secret",
   ].join("\n");
-  const observations = parseCfnBootstrapDiagnosticOutput(raw);
+  const parsed = parseCfnBootstrapDiagnosticOutput(raw);
+  const { observations } = parsed;
 
+  assert.equal(parsed.terminal_cause, "command_failure");
   assert.deepEqual(observations[0], {
-    source: "cfn-init-cmd.log",
+    source: "cfn-init.log",
     stage: "02-bootstrap",
+    substep: null,
     outcome: "failed",
     exit_code: 17,
     category: "download",
@@ -268,6 +273,125 @@ test("parseCfnBootstrapDiagnosticOutput: emits only allowlisted tokens and drops
   for (const secret of ["X-Amz-Signature", "deadbeef", "Bearer", "eyJsecret", "vk-super", "https://"]) {
     assert.ok(!serialized.includes(secret), `structured evidence leaked ${secret}`);
   }
+});
+
+test("run 29704360192: terminal cfn-init success overrides tolerated compose stderr and keeps the unfinished tail", () => {
+  const raw = [
+    "__PROLIFERATE_CFN_LOG__:cfn-init.log",
+    "2026-07-19 22:54:10 Running Command 01-install-base",
+    "2026-07-19 22:54:21 Command 01-install-base succeeded",
+    "2026-07-19 22:54:21 Running Command 02-install-compose-plugin",
+    "2026-07-19 22:54:22 Command 02-install-compose-plugin output: Error: Unable to find a match: docker-compose-plugin",
+    "2026-07-19 22:54:23 Command 02-install-compose-plugin succeeded",
+    "2026-07-19 22:54:23 Command 02-install-compose-plugin output: tolerated package lookup failed before fallback",
+    "2026-07-19 22:54:23 Running Command 03-enable-docker",
+    "2026-07-19 22:54:24 Command 03-enable-docker succeeded",
+    "2026-07-19 22:54:24 Running Command 04-create-directories",
+    "2026-07-19 22:54:25 Command 04-create-directories succeeded",
+    "2026-07-19 22:54:25 Running Command 01-fetch-verify-extract",
+    "2026-07-19 22:57:40 Command 01-fetch-verify-extract succeeded",
+    "2026-07-19 22:57:41 Running Command 01-daemon-reload",
+    "2026-07-19 22:57:41 Command 01-daemon-reload succeeded",
+    "2026-07-19 22:57:42 Running Command 02-bootstrap",
+    "__PROLIFERATE_CFN_LOG__:cfn-init-cmd.log",
+    "2026-07-19 22:54:22 Command 02-install-compose-plugin",
+    "Error: Unable to find a match: docker-compose-plugin",
+    "Docker Compose version v2.39.4",
+    "__PROLIFERATE_CFN_LOG__:cloud-init-output.log",
+    "cfn-init bootstrap exceeded the 18-minute limit; inspect host logs through SSM.",
+  ].join("\n");
+
+  const parsed = parseCfnBootstrapDiagnosticOutput(raw);
+  const compose = parsed.observations.find((item) => item.stage === "02-install-compose-plugin");
+  const bootstrap = parsed.observations.find((item) => item.stage === "02-bootstrap" && item.substep === null);
+
+  assert.equal(parsed.terminal_cause, "outer_timeout");
+  assert.deepEqual(compose, {
+    source: "cfn-init.log",
+    stage: "02-install-compose-plugin",
+    substep: null,
+    outcome: "completed",
+    exit_code: 0,
+    category: "other",
+  });
+  assert.deepEqual(bootstrap, {
+    source: "cfn-init.log",
+    stage: "02-bootstrap",
+    substep: null,
+    outcome: "started",
+    exit_code: null,
+    category: "timeout",
+  });
+  assert.equal(
+    parsed.observations.some((item) => item.stage === "02-install-compose-plugin" && item.outcome === "failed"),
+    false,
+  );
+
+  const summary = summarizeCfnBootstrapDiagnostic({
+    stack_name_hash: "a".repeat(64),
+    instance_id_hash: "b".repeat(64),
+    capture_status: "captured",
+    detail: "captured",
+    ssm_status: "Success",
+    terminal_cause: parsed.terminal_cause,
+    observations: parsed.observations,
+  });
+  assert.match(summary, /terminal=outer_timeout/);
+  assert.match(summary, /02-bootstrap:started:exit=unknown:timeout/);
+  assert.doesNotMatch(summary, /02-install-compose-plugin:failed/);
+});
+
+test("parseCfnBootstrapDiagnosticOutput: terminal success clears a tolerated adjacent nonzero exit", () => {
+  const parsed = parseCfnBootstrapDiagnosticOutput([
+    "__PROLIFERATE_CFN_LOG__:cfn-init.log",
+    "Running Command 02-install-compose-plugin",
+    "Exited with error code 1: Error: Unable to find a match: docker-compose-plugin",
+    "Command 02-install-compose-plugin succeeded",
+  ].join("\n"));
+
+  assert.equal(parsed.terminal_cause, "unknown");
+  assert.equal(parsed.observations[0]?.outcome, "completed");
+  assert.equal(parsed.observations[0]?.category, "other");
+});
+
+test("parseCfnBootstrapDiagnosticOutput: identifies the last started bootstrap substep without inventing completion", () => {
+  const parsed = parseCfnBootstrapDiagnosticOutput([
+    "__PROLIFERATE_CFN_LOG__:cfn-init.log",
+    "2026-07-19 Running Command 02-bootstrap",
+    "__PROLIFERATE_CFN_LOG__:cfn-init-cmd.log",
+    "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:started",
+    "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:completed",
+    "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started",
+    "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:secret-token:started",
+    "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:started",
+    "preflight output mentions an unrelated error that is not a terminal marker",
+    "__PROLIFERATE_CFN_LOG__:cloud-init-output.log",
+    "__PROLIFERATE_CFN_OUTER__:timeout",
+  ].join("\n"));
+
+  assert.equal(parsed.terminal_cause, "outer_timeout");
+  assert.deepEqual(
+    parsed.observations.filter((item) => item.substep !== null),
+    [
+      {
+        source: "bootstrap.sh",
+        stage: "02-bootstrap",
+        substep: "ensure-secrets",
+        outcome: "completed",
+        exit_code: 0,
+        category: "other",
+      },
+      {
+        source: "bootstrap.sh",
+        stage: "02-bootstrap",
+        substep: "preflight",
+        outcome: "started",
+        exit_code: null,
+        category: "other",
+      },
+    ],
+  );
+  assert.equal(JSON.stringify(parsed).includes("secret-token"), false);
 });
 
 test("parseGhcrVersions + ghcrVersionIdForTag: finds the version whose tags include the run tag", () => {
@@ -693,7 +817,7 @@ test("create failure: registered retention captures bounded SSM evidence before 
       return JSON.stringify({
         Status: "Success",
         StandardOutputContent: [
-          "__PROLIFERATE_CFN_LOG__:cfn-init-cmd.log",
+          "__PROLIFERATE_CFN_LOG__:cfn-init.log",
           "Running Command 02-bootstrap",
           "Exited with error code 17: https://s3/x?X-Amz-Signature=secret",
         ].join("\n"),
@@ -734,8 +858,8 @@ test("create failure: registered retention captures bounded SSM evidence before 
             now: () => 0,
             sleep: async () => undefined,
           });
-          const artifact: CfnBootstrapDiagnosticArtifactV1 = {
-            schema_version: 1,
+          const artifact: CfnBootstrapDiagnosticArtifactV2 = {
+            schema_version: 2,
             kind: "proliferate.selfhost-cfn-bootstrap-diagnostic",
             run: { run_id: "run-1", shard_id: "shard-0", attempt: 1, source_sha: "a".repeat(40) },
             diagnostic,
@@ -745,17 +869,37 @@ test("create failure: registered retention captures bounded SSM evidence before 
           return diagnostic;
         },
       }),
-      /Bootstrap diagnostic: captured\(02-bootstrap:failed:exit=17:download\)/,
+      /Bootstrap diagnostic: captured\(terminal=command_failure;02-bootstrap:failed:exit=17:download\)/,
     );
 
     assert.ok(releaseStack, "stack cleanup must be registered before create");
     await releaseStack();
     const persisted = await readFile(artifactPath, "utf8");
-    const parsed = JSON.parse(persisted) as CfnBootstrapDiagnosticArtifactV1;
+    const parsed = JSON.parse(persisted) as CfnBootstrapDiagnosticArtifactV2;
+    assert.equal(parsed.schema_version, 2);
     assert.equal(parsed.diagnostic.capture_status, "captured");
+    assert.equal(parsed.diagnostic.terminal_cause, "command_failure");
     assert.equal(parsed.diagnostic.observations[0]?.stage, "02-bootstrap");
     assert.equal(sendAttempts, 2, "a transient not-ready target retries through send-command");
     assert.equal(pollAttempts, 2, "eventually consistent command registration is retried");
+    const diagnosticSend = exec.calls.find(
+      (call) => call[0] === "ssm" && call[1] === "send-command" && call.includes("--parameters"),
+    );
+    assert.ok(diagnosticSend, "diagnostic send-command was captured");
+    const parameterIndex = diagnosticSend.indexOf("--parameters");
+    const parameters = JSON.parse(diagnosticSend[parameterIndex + 1] ?? "{}") as { commands?: unknown[] };
+    assert.equal(parameters.commands?.length, 1);
+    const diagnosticCommand = String(parameters.commands?.[0] ?? "");
+    assert.match(diagnosticCommand, new RegExp(`head -c ${CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET}$`));
+    assert.ok(CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET < 24_000, "hard cap stays below SSM's stdout limit");
+    assert.ok(
+      diagnosticCommand.indexOf("__PROLIFERATE_BOOTSTRAP_SUBSTEP__") < diagnosticCommand.indexOf("no space"),
+      "fixed substep markers are emitted before verbose keyword context",
+    );
+    assert.ok(
+      diagnosticCommand.indexOf("__PROLIFERATE_CFN_OUTER__") < diagnosticCommand.indexOf("no space"),
+      "fixed outer terminal markers are emitted before verbose keyword context",
+    );
     assert.equal(
       exec.calls.some((call) => call[0] === "ssm" && call[1] === "describe-instance-information"),
       false,
@@ -836,7 +980,7 @@ test("create failure: SSM unavailable remains red, persists fixed evidence, and 
             sleep: async (ms) => { clock += ms; },
           });
           await writeCfnBootstrapDiagnosticArtifact(artifactPath, {
-            schema_version: 1,
+            schema_version: 2,
             kind: "proliferate.selfhost-cfn-bootstrap-diagnostic",
             run: { run_id: "run-1", shard_id: "shard-0", attempt: 1, source_sha: "a".repeat(40) },
             diagnostic,
@@ -850,7 +994,7 @@ test("create failure: SSM unavailable remains red, persists fixed evidence, and 
 
     assert.ok(releaseStack, "stack cleanup must still be registered");
     await releaseStack();
-    const persisted = JSON.parse(await readFile(artifactPath, "utf8")) as CfnBootstrapDiagnosticArtifactV1;
+    const persisted = JSON.parse(await readFile(artifactPath, "utf8")) as CfnBootstrapDiagnosticArtifactV2;
     assert.equal(persisted.diagnostic.capture_status, "ssm_unavailable");
     assert.equal(persisted.diagnostic.detail, "ssm_not_online");
     assert.ok(order.filter((item) => item === "ssm-not-ready").length > 1, "not-ready dispatch is retried");

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -470,6 +470,64 @@ test("CFN-DIAG-CONTROL-002: multibyte context cannot truncate fixed outer/subste
   }
 });
 
+test("CFN-DIAG-CONTROL-003: named failure preserves exit code and bounded context refines category", async () => {
+  const logDirectory = await mkdtemp(path.join(tmpdir(), "cfn-diagnostic-terminal-failure-"));
+  const rawSecretLine =
+    "Exited with error code 17: curl download https://private.invalid/?X-Amz-Signature=deadbeef Bearer eyJsecret permission denied";
+
+  try {
+    await writeFile(path.join(logDirectory, "cloud-init-output.log"), "");
+    await writeFile(path.join(logDirectory, "cfn-init-cmd.log"), "");
+    await writeFile(
+      path.join(logDirectory, "cfn-init.log"),
+      [
+        "Running Command 01-daemon-reload",
+        "Command 01-daemon-reload succeeded",
+        "Command 01-daemon-reload output: curl download",
+        "Running Command 02-bootstrap",
+        rawSecretLine,
+        "Command 02-bootstrap failed",
+        "Running Command 03-enable-cfn-hup",
+        "Command 03-enable-cfn-hup output: curl download",
+      ].join("\n"),
+    );
+
+    const command = buildCfnDiagnosticCommand({ logDirectory, elevated: false });
+    const { stdout } = await execFileAsync("bash", ["-c", command], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+    const parsed = parseCfnBootstrapDiagnosticOutput(stdout);
+    const bootstrap = parsed.observations.find(
+      (item) => item.stage === "02-bootstrap" && item.substep === null,
+    );
+    assert.deepEqual(bootstrap, {
+      source: "cfn-init.log",
+      stage: "02-bootstrap",
+      substep: null,
+      outcome: "failed",
+      exit_code: 17,
+      category: "download",
+    });
+    assert.equal(
+      parsed.observations.find((item) => item.stage === "01-daemon-reload")?.outcome,
+      "completed",
+      "context cannot change a completed outcome",
+    );
+    assert.equal(
+      parsed.observations.find((item) => item.stage === "03-enable-cfn-hup")?.outcome,
+      "started",
+      "context cannot change a started outcome",
+    );
+    for (const raw of ["https://", "X-Amz-Signature", "deadbeef", "Bearer", "eyJsecret", rawSecretLine]) {
+      assert.equal(stdout.includes(raw), false, `bounded command leaked ${raw}`);
+      assert.equal(JSON.stringify(parsed).includes(raw), false, `parsed diagnostic leaked ${raw}`);
+    }
+  } finally {
+    await rm(logDirectory, { recursive: true, force: true });
+  }
+});
+
 test("parseGhcrVersions + ghcrVersionIdForTag: finds the version whose tags include the run tag", () => {
   const page1 = JSON.stringify([
     { id: 11, metadata: { container: { tags: ["stable"] } } },

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -93,34 +93,57 @@ const CFN_DIAGNOSTIC_MAX_OBSERVATIONS = 24;
 const CFN_DIAGNOSTIC_COMMAND_TIMEOUT_SECONDS = 30;
 /** SSM returns at most 24,000 stdout characters; stay below that hard provider cap. */
 export const CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET = 20_000;
-const CFN_DIAGNOSTIC_COMMAND = [
-  "{",
-  // Authoritative/fixed tokens come first. Even if verbose context exhausts
-  // the global cap below, terminal stage, substep, and outer-timeout truth is
-  // retained by SSM's bounded StandardOutputContent response.
-  "f=/var/log/cfn-init.log",
-  "if sudo test -r \"$f\"; then",
-  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
-  "  sudo grep -aiE 'Running Command [0-9]{2}-[A-Za-z0-9_-]+|Command [0-9]{2}-[A-Za-z0-9_-]+ (succeeded|successfully completed|completed successfully|failed)([^A-Za-z]|$)|exit(ed)?( with)? (error )?(code|status)|return code' \"$f\" 2>/dev/null | tail -n 36 | cut -c1-240",
-  "fi",
-  "f=/var/log/cfn-init-cmd.log",
-  "if sudo test -r \"$f\"; then",
-  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
-  "  sudo grep -aiE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:(ensure-secrets|preflight|registry-login|runtime-install|db-up|migrate|api-caddy-up|optional-profiles|health-wait):(started|completed)' \"$f\" 2>/dev/null | tail -n 24 | cut -c1-160",
-  "fi",
-  "f=/var/log/cloud-init-output.log",
-  "if sudo test -r \"$f\"; then",
-  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
-  "  sudo grep -aiE '__PROLIFERATE_CFN_OUTER__:(timeout|command_failure)|cfn-init bootstrap exceeded the 18-minute limit' \"$f\" 2>/dev/null | tail -n 4 | cut -c1-240",
-  "fi",
-  // Coarse allowlisted context is useful only after fixed truth is secured.
-  "for f in /var/log/cfn-init.log /var/log/cfn-init-cmd.log; do",
-  "  sudo test -r \"$f\" || continue",
-  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
-  "  sudo grep -aiE 'Command [0-9]{2}-[A-Za-z0-9_-]+|timed out|timeout|failed|error|unhealthy|checksum|sha256|no space|permission denied|access denied|curl|download|docker compose|health' \"$f\" 2>/dev/null | tail -n 16 | cut -c1-240",
-  "done",
-  `} | head -c ${CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET}`,
-].join("\n");
+
+function shellQuoteDiagnosticPath(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/** Builds the fixed-token SSM command; configurable paths keep its byte bounds executable offline. */
+export function buildCfnDiagnosticCommand(options?: {
+  logDirectory?: string;
+  elevated?: boolean;
+}): string {
+  const logDirectory = options?.logDirectory ?? "/var/log";
+  const elevated = options?.elevated ?? true;
+  const sudo = elevated ? "sudo " : "";
+  const logPath = (name: string): string => shellQuoteDiagnosticPath(path.posix.join(logDirectory, name));
+
+  return [
+    "{",
+    // Emit the two authoritative fixed-marker classes first. grep -o projects
+    // only bounded ASCII tokens, so multibyte log context can consume neither
+    // their per-section allowance nor the aggregate byte budget.
+    `f=${logPath("cloud-init-output.log")}`,
+    `if ${sudo}test -r \"$f\"; then`,
+    "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+    `  ${sudo}grep -aioE '__PROLIFERATE_CFN_OUTER__:(timeout|command_failure)' \"$f\" 2>/dev/null | tail -n 4`,
+    `  if ${sudo}grep -aiq 'cfn-init bootstrap exceeded the 18-minute limit' \"$f\" 2>/dev/null; then`,
+    "    printf '__PROLIFERATE_CFN_OUTER__:timeout\\n'",
+    "  fi",
+    "fi",
+    `f=${logPath("cfn-init-cmd.log")}`,
+    `if ${sudo}test -r \"$f\"; then`,
+    "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+    `  ${sudo}grep -aioE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:(ensure-secrets|preflight|registry-login|runtime-install|db-up|migrate|api-caddy-up|optional-profiles|health-wait):(started|completed)' \"$f\" 2>/dev/null | tail -n 24`,
+    "fi",
+    // cfn-init stage truth is also normalized to bounded ASCII rather than
+    // retaining variable prefixes/suffixes or relying on character-counted cut.
+    `f=${logPath("cfn-init.log")}`,
+    `if ${sudo}test -r \"$f\"; then`,
+    "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+    `  ${sudo}grep -aioE 'Running Command [0-9]{2}-[A-Za-z0-9_-]+|Command [0-9]{2}-[A-Za-z0-9_-]+ (succeeded|successfully completed|completed successfully|failed)|exit(ed)?( with)? (error )?(code|status)[ :=]*[0-9]{1,3}|return code[ :=]*[0-9]{1,3}' \"$f\" 2>/dev/null | tail -n 36`,
+    "fi",
+    // Coarse context comes last and is likewise an ASCII token projection.
+    `for f in ${logPath("cfn-init.log")} ${logPath("cfn-init-cmd.log")}; do`,
+    `  ${sudo}test -r \"$f\" || continue`,
+    "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+    `  ${sudo}grep -aioE 'Command [0-9]{2}-[A-Za-z0-9_-]+|timed out|timeout|failed|error|unhealthy|checksum|sha256|no space|permission denied|access denied|curl|download|docker compose|health' \"$f\" 2>/dev/null | tail -n 16`,
+    "done",
+    `} | head -c ${CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET}`,
+  ].join("\n");
+}
+
+const CFN_DIAGNOSTIC_COMMAND = buildCfnDiagnosticCommand();
 
 export type CfnBootstrapDiagnosticCaptureStatus =
   | "captured"
@@ -742,8 +765,14 @@ export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiag
     }
   }
 
-  const observations = [...stages.values(), ...substeps.values()]
-    .sort((left, right) => left.order - right.order)
+  // The SSM command is priority-ordered for truncation safety rather than
+  // globally chronological. Preserve chronology within each class, then keep
+  // bootstrap substeps after template stages so the evidence tail still names
+  // the deepest proven progress point.
+  const observations = [
+    ...[...stages.values()].sort((left, right) => left.order - right.order),
+    ...[...substeps.values()].sort((left, right) => left.order - right.order),
+  ]
     .slice(-CFN_DIAGNOSTIC_MAX_OBSERVATIONS)
     .map(({ order: _order, terminal: _terminal, ...observation }) => observation);
   return { terminal_cause: terminalCause, observations };

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -725,16 +725,37 @@ export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiag
       const priorCategory = current.category;
       const category =
         lineCategory === "command_failed" && priorCategory !== "other" ? priorCategory : lineCategory;
+      const preservedExitCode =
+        namedTerminalFailure &&
+        exitCode === null &&
+        current.outcome === "failed" &&
+        current.exit_code !== null &&
+        current.exit_code !== 0
+          ? current.exit_code
+          : exitCode;
       stages.set(stage, {
         source,
         stage,
         substep: null,
         outcome: "failed",
-        exit_code: exitCode,
+        exit_code: preservedExitCode,
         category,
         order,
         terminal: true,
       });
+      continue;
+    }
+
+    // A later bounded context token may refine only a generic, already-failed
+    // stage. Never change an outcome/exit code and never replace one specific
+    // allowlisted category with another token observed later in the log.
+    if (
+      current.outcome === "failed" &&
+      current.category === "command_failed" &&
+      lineCategory !== "command_failed" &&
+      lineCategory !== "other"
+    ) {
+      stages.set(stage, { ...current, category: lineCategory });
       continue;
     }
 

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -91,12 +91,35 @@ export const CFN_DIAGNOSTIC_TIMEOUT_MS = 90_000;
 export const CFN_BOOTSTRAP_DIAGNOSTIC_FILENAME = "cfn-bootstrap-diagnostic.json";
 const CFN_DIAGNOSTIC_MAX_OBSERVATIONS = 24;
 const CFN_DIAGNOSTIC_COMMAND_TIMEOUT_SECONDS = 30;
+/** SSM returns at most 24,000 stdout characters; stay below that hard provider cap. */
+export const CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET = 20_000;
 const CFN_DIAGNOSTIC_COMMAND = [
-  "for f in /var/log/cfn-init.log /var/log/cfn-init-cmd.log; do",
-  "  [ -r \"$f\" ] || continue",
+  "{",
+  // Authoritative/fixed tokens come first. Even if verbose context exhausts
+  // the global cap below, terminal stage, substep, and outer-timeout truth is
+  // retained by SSM's bounded StandardOutputContent response.
+  "f=/var/log/cfn-init.log",
+  "if sudo test -r \"$f\"; then",
   "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
-  "  sudo grep -aiE 'Command [0-9]{2}-[A-Za-z0-9_-]+|exit(ed)?( with)? (error )?(code|status)|return code|timed out|timeout|failed|error|unhealthy|checksum|sha256|no space|permission denied|access denied|curl|download|docker compose|health' \"$f\" 2>/dev/null | tail -n 60 | cut -c1-500",
+  "  sudo grep -aiE 'Running Command [0-9]{2}-[A-Za-z0-9_-]+|Command [0-9]{2}-[A-Za-z0-9_-]+ (succeeded|successfully completed|completed successfully|failed)([^A-Za-z]|$)|exit(ed)?( with)? (error )?(code|status)|return code' \"$f\" 2>/dev/null | tail -n 36 | cut -c1-240",
+  "fi",
+  "f=/var/log/cfn-init-cmd.log",
+  "if sudo test -r \"$f\"; then",
+  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+  "  sudo grep -aiE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:(ensure-secrets|preflight|registry-login|runtime-install|db-up|migrate|api-caddy-up|optional-profiles|health-wait):(started|completed)' \"$f\" 2>/dev/null | tail -n 24 | cut -c1-160",
+  "fi",
+  "f=/var/log/cloud-init-output.log",
+  "if sudo test -r \"$f\"; then",
+  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+  "  sudo grep -aiE '__PROLIFERATE_CFN_OUTER__:(timeout|command_failure)|cfn-init bootstrap exceeded the 18-minute limit' \"$f\" 2>/dev/null | tail -n 4 | cut -c1-240",
+  "fi",
+  // Coarse allowlisted context is useful only after fixed truth is secured.
+  "for f in /var/log/cfn-init.log /var/log/cfn-init-cmd.log; do",
+  "  sudo test -r \"$f\" || continue",
+  "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
+  "  sudo grep -aiE 'Command [0-9]{2}-[A-Za-z0-9_-]+|timed out|timeout|failed|error|unhealthy|checksum|sha256|no space|permission denied|access denied|curl|download|docker compose|health' \"$f\" 2>/dev/null | tail -n 16 | cut -c1-240",
   "done",
+  `} | head -c ${CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET}`,
 ].join("\n");
 
 export type CfnBootstrapDiagnosticCaptureStatus =
@@ -106,7 +129,11 @@ export type CfnBootstrapDiagnosticCaptureStatus =
   | "command_failed"
   | "no_allowlisted_observations";
 
-export type CfnBootstrapDiagnosticSource = "cfn-init.log" | "cfn-init-cmd.log";
+export type CfnBootstrapDiagnosticSource =
+  | "cfn-init.log"
+  | "cfn-init-cmd.log"
+  | "cloud-init-output.log"
+  | "bootstrap.sh";
 
 export type CfnBootstrapStage =
   | "01-install-base"
@@ -130,12 +157,31 @@ export type CfnBootstrapFailureCategory =
   | "command_failed"
   | "other";
 
+export type CfnBootstrapSubstep =
+  | "ensure-secrets"
+  | "preflight"
+  | "registry-login"
+  | "runtime-install"
+  | "db-up"
+  | "migrate"
+  | "api-caddy-up"
+  | "optional-profiles"
+  | "health-wait";
+
+export type CfnBootstrapTerminalCause = "outer_timeout" | "command_failure" | "unknown";
+
 export interface CfnBootstrapDiagnosticObservation {
   source: CfnBootstrapDiagnosticSource;
   stage: CfnBootstrapStage;
-  outcome: "failed" | "completed" | "observed";
+  substep: CfnBootstrapSubstep | null;
+  outcome: "failed" | "completed" | "started";
   exit_code: number | null;
   category: CfnBootstrapFailureCategory;
+}
+
+export interface CfnBootstrapDiagnosticParseResult {
+  terminal_cause: CfnBootstrapTerminalCause;
+  observations: CfnBootstrapDiagnosticObservation[];
 }
 
 /**
@@ -159,11 +205,12 @@ export interface CfnBootstrapDiagnostic {
     | "command_terminal"
     | "no_allowlisted_observations";
   ssm_status: "Online" | "Success" | "Failed" | "TimedOut" | "Unavailable";
+  terminal_cause: CfnBootstrapTerminalCause;
   observations: CfnBootstrapDiagnosticObservation[];
 }
 
-export interface CfnBootstrapDiagnosticArtifactV1 {
-  schema_version: 1;
+export interface CfnBootstrapDiagnosticArtifactV2 {
+  schema_version: 2;
   kind: "proliferate.selfhost-cfn-bootstrap-diagnostic";
   run: {
     run_id: string;
@@ -509,24 +556,51 @@ const ALLOWED_CFN_BOOTSTRAP_STAGES = new Set<CfnBootstrapStage>([
   "03-enable-cfn-hup",
 ]);
 
+const ALLOWED_CFN_BOOTSTRAP_SUBSTEPS = new Set<CfnBootstrapSubstep>([
+  "ensure-secrets",
+  "preflight",
+  "registry-login",
+  "runtime-install",
+  "db-up",
+  "migrate",
+  "api-caddy-up",
+  "optional-profiles",
+  "health-wait",
+]);
+
 /**
- * Reduces bounded raw SSM output to a fixed-token diagnostic. Raw lines are
- * never returned or persisted: only allowlisted template stage names, numeric
- * exit codes, and coarse failure categories survive.
+ * Reduces bounded raw SSM output to a resolved fixed-token diagnostic. An
+ * explicit cfn-init command terminal status is authoritative for its template
+ * stage: tolerated stderr/stdout keywords cannot turn a succeeded command red.
+ * Started stages/substeps without a completion marker remain `started`, and
+ * the bounded outer-timeout marker is recorded separately. Raw lines are never
+ * returned or persisted.
  */
-export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiagnosticObservation[] {
-  let source: CfnBootstrapDiagnosticSource = "cfn-init.log";
-  const observations: CfnBootstrapDiagnosticObservation[] = [];
-  const seen = new Set<string>();
-  const activeStage: Record<CfnBootstrapDiagnosticSource, CfnBootstrapStage> = {
+export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiagnosticParseResult {
+  type ResolvedState = CfnBootstrapDiagnosticObservation & { order: number; terminal: boolean };
+
+  let source: Exclude<CfnBootstrapDiagnosticSource, "bootstrap.sh"> = "cfn-init.log";
+  let order = 0;
+  let terminalCause: CfnBootstrapTerminalCause = "unknown";
+  let commandFailureMarker = false;
+  const stages = new Map<CfnBootstrapStage, ResolvedState>();
+  const substeps = new Map<CfnBootstrapSubstep, ResolvedState>();
+  const activeStage: Record<Exclude<CfnBootstrapDiagnosticSource, "bootstrap.sh">, CfnBootstrapStage> = {
     "cfn-init.log": "unknown",
     "cfn-init-cmd.log": "unknown",
+    "cloud-init-output.log": "unknown",
   };
 
   for (const rawLine of raw.split(/\r?\n/)) {
-    const marker = rawLine.match(/^__PROLIFERATE_CFN_LOG__:(cfn-init(?:-cmd)?\.log)$/);
+    order += 1;
+    const marker = rawLine.match(
+      /^__PROLIFERATE_CFN_LOG__:(cfn-init\.log|cfn-init-cmd\.log|cloud-init-output\.log)$/,
+    );
     if (marker) {
-      source = marker[1] as CfnBootstrapDiagnosticSource;
+      source = marker[1] as Exclude<CfnBootstrapDiagnosticSource, "bootstrap.sh">;
+      // The bounded command emits a priority pass and then a context pass.
+      // Never carry active-stage context across repeated source sections.
+      activeStage[source] = "unknown";
       continue;
     }
     const line = rawLine.slice(0, 500);
@@ -534,50 +608,145 @@ export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiag
       continue;
     }
 
+    if (
+      /__PROLIFERATE_CFN_OUTER__:timeout\b/i.test(line) ||
+      /cfn-init bootstrap exceeded the 18-minute limit/i.test(line)
+    ) {
+      terminalCause = "outer_timeout";
+    } else if (/__PROLIFERATE_CFN_OUTER__:command_failure\b/i.test(line)) {
+      commandFailureMarker = true;
+    }
+
+    const substepMatch = line.match(
+      /__PROLIFERATE_BOOTSTRAP_SUBSTEP__:([a-z0-9-]{1,48}):(started|completed)\b/i,
+    );
+    const candidateSubstep = substepMatch?.[1]?.toLowerCase() as CfnBootstrapSubstep | undefined;
+    if (candidateSubstep && ALLOWED_CFN_BOOTSTRAP_SUBSTEPS.has(candidateSubstep)) {
+      const outcome = substepMatch?.[2]?.toLowerCase() as "started" | "completed";
+      const prior = substeps.get(candidateSubstep);
+      // The same command output can appear in both cfn-init logs. A later copy
+      // of STARTED must not regress an already observed completion.
+      if (!prior?.terminal || outcome === "completed") {
+        substeps.set(candidateSubstep, {
+          source: "bootstrap.sh",
+          stage: "02-bootstrap",
+          substep: candidateSubstep,
+          outcome,
+          exit_code: outcome === "completed" ? 0 : null,
+          category: "other",
+          order,
+          terminal: outcome === "completed",
+        });
+      }
+    }
+
     const stageMatch = line.match(/\bCommand\s+([0-9]{2}-[A-Za-z0-9_-]{1,64})\b/i);
     const candidateStage = stageMatch?.[1]?.toLowerCase() as CfnBootstrapStage | undefined;
     if (candidateStage && ALLOWED_CFN_BOOTSTRAP_STAGES.has(candidateStage)) {
       activeStage[source] = candidateStage;
+      if (!stages.has(candidateStage)) {
+        stages.set(candidateStage, {
+          source,
+          stage: candidateStage,
+          substep: null,
+          outcome: "started",
+          exit_code: null,
+          category: "other",
+          order,
+          terminal: false,
+        });
+      }
     }
-    // cfn-init commonly logs the command name and its error/exit on adjacent
-    // lines. Carry only the last allowlisted stage token within the same file;
-    // no arbitrary prior text survives.
     const stage = activeStage[source];
+    if (stage === "unknown") {
+      continue;
+    }
+    const current = stages.get(stage);
+    if (!current) {
+      continue;
+    }
     const exitMatch = line.match(
       /\b(?:exit(?:ed)?(?:\s+with)?(?:\s+(?:error\s+)?(?:code|status))?|return\s+code)\s*[:=]?\s*(\d{1,3})\b/i,
     );
     const exitCode = exitMatch ? Number.parseInt(exitMatch[1], 10) : null;
     const lower = line.toLowerCase();
-    const outcome: CfnBootstrapDiagnosticObservation["outcome"] =
-      /failed|error|denied|unhealthy|no space|timed out|timeout/.test(lower)
-        ? "failed"
-        : /completed|succeeded|success/.test(lower)
-          ? "completed"
-          : "observed";
-    const category = cfnBootstrapFailureCategory(lower);
+    const lineCategory = cfnBootstrapFailureCategory(lower);
+    const authoritativeCfnStatus = source === "cfn-init.log";
+    const namedTerminalSuccess =
+      authoritativeCfnStatus &&
+      /\bCommand\s+[0-9]{2}-[A-Za-z0-9_-]{1,64}\s+(?:succeeded|successfully completed|completed successfully)\b/i
+        .test(line);
+    const namedTerminalFailure =
+      authoritativeCfnStatus &&
+      /\bCommand\s+[0-9]{2}-[A-Za-z0-9_-]{1,64}\s+failed\b/i.test(line);
+    // Bare adjacent exit-status lines are accepted only from cfn-init's own
+    // log and only until a named terminal status resolves the command. Output
+    // copied into cfn-init-cmd.log can describe a tolerated inner failure.
+    const exitTerminal = authoritativeCfnStatus && exitCode !== null && !current.terminal;
 
-    // A stage-heading line updates `activeStage` but is not itself a failure
-    // observation. Lines without an exit/outcome/category carry no result.
-    if (exitCode === null && category === "other" && outcome === "observed") {
+    if (namedTerminalSuccess || (exitTerminal && exitCode === 0)) {
+      stages.set(stage, {
+        source,
+        stage,
+        substep: null,
+        outcome: "completed",
+        exit_code: exitCode ?? 0,
+        category: "other",
+        order,
+        terminal: true,
+      });
       continue;
     }
-    const observation: CfnBootstrapDiagnosticObservation = {
-      source,
-      stage,
-      outcome,
-      exit_code: exitCode,
-      category,
-    };
-    const key = JSON.stringify(observation);
-    if (!seen.has(key)) {
-      seen.add(key);
-      observations.push(observation);
+
+    if (namedTerminalFailure || (exitTerminal && exitCode !== 0)) {
+      const priorCategory = current.category;
+      const category =
+        lineCategory === "command_failed" && priorCategory !== "other" ? priorCategory : lineCategory;
+      stages.set(stage, {
+        source,
+        stage,
+        substep: null,
+        outcome: "failed",
+        exit_code: exitCode,
+        category,
+        order,
+        terminal: true,
+      });
+      continue;
     }
-    if (observations.length >= CFN_DIAGNOSTIC_MAX_OBSERVATIONS) {
-      break;
+
+    // Keep a coarse category only as context for a genuinely unfinished or
+    // later explicitly failed command. It must never override a terminal
+    // success, even when tolerated tool stderr says "Error" or "failed".
+    if (!current.terminal && lineCategory !== "other") {
+      stages.set(stage, { ...current, category: lineCategory, order });
     }
   }
-  return observations;
+
+  if (
+    terminalCause !== "outer_timeout" &&
+    (commandFailureMarker || [...stages.values()].some((item) => item.outcome === "failed"))
+  ) {
+    terminalCause = "command_failure";
+  }
+
+  if (terminalCause === "outer_timeout") {
+    const lastUnfinishedStage = [...stages.values()]
+      .filter((item) => item.outcome === "started")
+      .sort((left, right) => right.order - left.order)[0];
+    if (lastUnfinishedStage) {
+      stages.set(lastUnfinishedStage.stage, {
+        ...lastUnfinishedStage,
+        category: "timeout",
+      });
+    }
+  }
+
+  const observations = [...stages.values(), ...substeps.values()]
+    .sort((left, right) => left.order - right.order)
+    .slice(-CFN_DIAGNOSTIC_MAX_OBSERVATIONS)
+    .map(({ order: _order, terminal: _terminal, ...observation }) => observation);
+  return { terminal_cause: terminalCause, observations };
 }
 
 function cfnBootstrapFailureCategory(lower: string): CfnBootstrapFailureCategory {
@@ -600,7 +769,7 @@ export function cfnBootstrapDiagnosticArtifactPath(runDir: string): string {
 /** Atomically writes the already-reduced diagnostic before stack cleanup. */
 export async function writeCfnBootstrapDiagnosticArtifact(
   artifactPath: string,
-  artifact: CfnBootstrapDiagnosticArtifactV1,
+  artifact: CfnBootstrapDiagnosticArtifactV2,
 ): Promise<void> {
   const serialized = `${JSON.stringify(artifact, null, 2)}\n`;
   // Defense in depth: the structured type cannot carry raw output, and this
@@ -622,11 +791,14 @@ export async function writeCfnBootstrapDiagnosticArtifact(
 /** Safe one-line summary for the ordinary failed-cell reason. */
 export function summarizeCfnBootstrapDiagnostic(diagnostic: CfnBootstrapDiagnostic): string {
   const observations = diagnostic.observations
-    .slice(0, 4)
-    .map((item) => `${item.stage}:${item.outcome}:exit=${item.exit_code ?? "unknown"}:${item.category}`)
+    .slice(-4)
+    .map((item) => {
+      const location = item.substep === null ? item.stage : `${item.stage}/${item.substep}`;
+      return `${location}:${item.outcome}:exit=${item.exit_code ?? "unknown"}:${item.category}`;
+    })
     .join(",");
   return observations
-    ? `${diagnostic.capture_status}(${observations})`
+    ? `${diagnostic.capture_status}(terminal=${diagnostic.terminal_cause};${observations})`
     : `${diagnostic.capture_status}(${diagnostic.detail})`;
 }
 
@@ -1344,9 +1516,10 @@ export async function captureCfnBootstrapDiagnostic(input: {
     }
     lastStatus = typeof parsed.Status === "string" ? parsed.Status : lastStatus;
     if (lastStatus === "Success") {
-      const observations = parseCfnBootstrapDiagnosticOutput(
+      const parsedDiagnostic = parseCfnBootstrapDiagnosticOutput(
         typeof parsed.StandardOutputContent === "string" ? parsed.StandardOutputContent : "",
       );
+      const { observations } = parsedDiagnostic;
       if (observations.length === 0) {
         return emptyCfnBootstrapDiagnostic(
           stackNameHash,
@@ -1354,6 +1527,7 @@ export async function captureCfnBootstrapDiagnostic(input: {
           "no_allowlisted_observations",
           "no_allowlisted_observations",
           "Success",
+          parsedDiagnostic.terminal_cause,
         );
       }
       return {
@@ -1362,6 +1536,7 @@ export async function captureCfnBootstrapDiagnostic(input: {
         capture_status: "captured",
         detail: "captured",
         ssm_status: "Success",
+        terminal_cause: parsedDiagnostic.terminal_cause,
         observations,
       };
     }
@@ -1390,6 +1565,7 @@ function emptyCfnBootstrapDiagnostic(
   captureStatus: CfnBootstrapDiagnosticCaptureStatus,
   detail: CfnBootstrapDiagnostic["detail"],
   ssmStatus: CfnBootstrapDiagnostic["ssm_status"] = "Unavailable",
+  terminalCause: CfnBootstrapTerminalCause = "unknown",
 ): CfnBootstrapDiagnostic {
   return {
     stack_name_hash: stackNameHash,
@@ -1397,6 +1573,7 @@ function emptyCfnBootstrapDiagnostic(
     capture_status: captureStatus,
     detail,
     ssm_status: ssmStatus,
+    terminal_cause: terminalCause,
     observations: [],
   };
 }


### PR DESCRIPTION
## Summary

- Make explicit `cfn-init` terminal command status authoritative, so tolerated command output such as the failed `dnf` Compose lookup cannot overwrite a later successful fallback.
- Record fixed, secret-free bootstrap substep start/completion markers and represent an outer timeout as the last allowlisted started-but-unfinished stage/substep instead of guessing an inner failure.
- Normalize every diagnostic projection to bounded ASCII tokens, prioritize fixed outer/substep truth before context, and hard-cap aggregate SSM stdout at 20,000 bytes, below the 24,000-character provider response limit.
- Preserve the existing 18-minute outer deadline, shared poll deadline, structured redaction, artifact-before-delete ordering, and zero-survivor cleanup contract.

Follow-up for #1437. Implemented from exact qualification base `51cd43cfe386c0fcd8d5aa58f72d4206e5bad0ce`; this PR head is `cc9c56b6f5b6c94805fd0850acecbcc027e9a348`.

## Exact evidence receipt

- Strict run: https://github.com/proliferate-ai/proliferate/actions/runs/29704360192, `SH-CFN-WRAPPER`, exact source SHA `51cd43cfe386c0fcd8d5aa58f72d4206e5bad0ce`.
- The diagnostic SSM command completed with `Success`.
- `02-install-compose-plugin` had a tolerated `dnf` lookup miss, then installed fallback Docker Compose v2.39.4 and received an explicit successful `cfn-init` terminal status. The old parser falsely emitted a later failed observation from an adjacent stdout keyword and the summary selected early observations.
- The true last template stage was `02-bootstrap`, started at 2026-07-19 22:57:42 and unfinished when the existing 18-minute outer timeout fired. The inner bootstrap substep was not proven by that run.
- Cleanup evidence proved zero survivors across CloudFormation, EC2/network, Route53, S3, IAM, and GHCR.
- No provider action or workflow dispatch was performed by this PR.

## Independent review

- `CFN-DIAG-001`: reviewer found that SSM could truncate the prior diagnostic output before outer/substep markers. Resolved by priority-first fixed-token sections, bounded per-section tails, a 20,000-byte aggregate hard cap, parser source-state reset between passes, and deterministic command budget/order regression coverage.
- Independent re-review confirmed `CFN-DIAG-001` resolved and found no other actionable issues.
- `CFN-DIAG-CONTROL-002`: exact-head review found that character-counted per-line truncation could still exceed its byte allowance under UTF-8 and consume the aggregate cap before later marker classes. Follow-up commit `9a871f0104d7bf8e6d128752af6716039ada2af5` projects only fixed ASCII tokens, emits outer/substep markers first, retains the 20,000-byte hard cap, and adds an executed oversized-multibyte regression proving the old shape loses both markers while the repaired command preserves both below 24 KB.
- Independent exact-head delta re-review confirmed `CFN-DIAG-CONTROL-002` resolved at `9a871f0104d7bf8e6d128752af6716039ada2af5` with no actionable findings.
- `CFN-DIAG-CONTROL-003`: exact-head review found that a later authoritative named failure without a numeric code erased an earlier parsed nonzero exit, while later fixed context could not refine the generic category. Follow-up commit `cc9c56b6f5b6c94805fd0850acecbcc027e9a348` preserves that nonzero exit and permits category-only refinement of an already-failed generic `command_failed` stage to the first specific allowlisted category; completed/started outcomes and existing specific categories remain immutable.
- Independent exact-head delta re-review confirmed `CFN-DIAG-CONTROL-003` resolved at `cc9c56b6f5b6c94805fd0850acecbcc027e9a348` with no actionable findings.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm --dir tests/release exec tsx --test src/worlds/selfhost/cfn.test.ts` — 46/46 pass.
- `pnpm --dir tests/release test` — 1,479/1,479 pass.
- `pnpm --dir tests/release typecheck` — pass.
- `bash server/deploy/tests/bootstrap-markers.sh` — pass; real bootstrap script, fake helpers/Docker, no daemon/network/provider.
- `bash -n server/deploy/bootstrap.sh server/deploy/tests/bootstrap-markers.sh` — pass.
- `shellcheck --severity=warning server/deploy/bootstrap.sh server/deploy/tests/bootstrap-markers.sh` — pass.
- `python3 scripts/check_docs.py` — pass (221 Markdown files).
- `python3 scripts/check_max_lines.py` — pass.
- `git diff --cached --check` — pass before commit.

The broader `server/deploy/tests/run.sh` was attempted but its pre-existing partial-config fixture reaches the real health wait after appending a duplicate `E2B_API_KEY`; the first-match env reader sees the earlier blank value. That fixture/read behavior is unchanged from the exact base, so it was not expanded into this focused repair. The newly added offline bootstrap marker contract passes independently.

No Rust build, Docker daemon, live provider, workflow dispatch, or merge was performed.
