### PR TITLE
fix(release): persist bootstrap timeout progress

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -323,6 +323,7 @@ jobs:
           # scripts, compose, and config the running stack needs.
           rm -rf "$bundle_root/proliferate-deploy/smoke"
           rm -rf "$bundle_root/proliferate-deploy/tests"
+          rm -f "$bundle_root/proliferate-deploy/.bootstrap-progress.log"
           printf '%s\n' "$VERSION" > "$bundle_root/proliferate-deploy/VERSION"
           tar czf artifacts/proliferate-deploy.tar.gz \
             --owner=0 --group=0 --numeric-owner \

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ e2b-connection.json
 .env.prod
 .env.prod.server
 .env.*.local
+/server/deploy/.bootstrap-progress.log
 
 reference/
 references/

--- a/scripts/ci-cd/build-selfhost-qualification-candidates.mjs
+++ b/scripts/ci-cd/build-selfhost-qualification-candidates.mjs
@@ -177,10 +177,10 @@ export function buildServerImageArchive({ outputPath, version, platform, exec = 
 /**
  * Builds `proliferate-deploy.tar.gz` + `self-hosted-assets.SHA256SUMS` EXACTLY
  * the way `server-ci.yml self-hosted-release-assets` builds the release bundle:
- * `cp -R server/deploy/. proliferate-deploy/`, drop the CI-only `smoke/` and
- * `tests/`, write `VERSION`, then a reproducible root-owned tar and a bare-name
- * checksum. This is never reconstructed ad-hoc from loose source — the shipped
- * installer checksum-verifies exactly this artifact.
+ * `cp -R server/deploy/. proliferate-deploy/`, drop the CI-only trees and
+ * host-local progress file, write `VERSION`, then a reproducible root-owned tar
+ * and a bare-name checksum. This is never reconstructed ad-hoc from loose
+ * source — the shipped installer checksum-verifies exactly this artifact.
  */
 export function buildSelfHostDeployBundle({
   bundleOutputPath,
@@ -202,6 +202,7 @@ export function buildSelfHostDeployBundle({
     // compose, and config the running stack needs (server-ci parity).
     exec("rm", ["-rf", path.join(stageDir, "smoke")]);
     exec("rm", ["-rf", path.join(stageDir, "tests")]);
+    exec("rm", ["-f", path.join(stageDir, ".bootstrap-progress.log")]);
     writeFileSync(path.join(stageDir, "VERSION"), `${version}\n`);
     // Archive as root:root, numeric owner (server-ci parity) so a root
     // extraction on the box does not hand ownership to the builder's uid.

--- a/scripts/ci-cd/build-selfhost-qualification-candidates.test.mjs
+++ b/scripts/ci-cd/build-selfhost-qualification-candidates.test.mjs
@@ -101,7 +101,7 @@ test("buildServerImageArchive uses buildx --load for the box platform and docker
   }
 });
 
-test("buildSelfHostDeployBundle mirrors the server-ci release bundle build (drop smoke/tests, VERSION, root-owned tar, sibling SHA256SUMS)", () => {
+test("buildSelfHostDeployBundle mirrors server-ci (drop CI/runtime files, VERSION, root-owned tar, sibling SHA256SUMS)", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "selfhost-bundle-"));
   try {
     const { exec, calls } = fakeExecFactory();
@@ -119,10 +119,11 @@ test("buildSelfHostDeployBundle mirrors the server-ci release bundle build (drop
     // cp -R server/deploy/. <stage>/
     const cpCall = calls.find((c) => c.command === "cp");
     assert.deepEqual(cpCall.args.slice(0, 2), ["-R", `${deployDir}/.`]);
-    // Drops the CI-only trees.
+    // Drops the CI-only trees and host-local bootstrap progress.
     const rmTargets = calls.filter((c) => c.command === "rm").map((c) => c.args[1]);
     assert.ok(rmTargets.some((t) => t.endsWith("/smoke")));
     assert.ok(rmTargets.some((t) => t.endsWith("/tests")));
+    assert.ok(rmTargets.some((t) => t.endsWith("/.bootstrap-progress.log")));
     // Reproducible root-owned archive (server-ci parity).
     const tarCall = calls.find((c) => c.command === "tar");
     assert.ok(tarCall.args.includes("--owner=0"));

--- a/server/deploy/README.md
+++ b/server/deploy/README.md
@@ -38,7 +38,7 @@ flags (`--version`, `--eval`, `--no-start`, `--dry-run`, `--yes`).
 | `docker-compose.production.yml` | The stack: `caddy`, `db`, `migrate`, `api`, and the profiled `litellm`/`litellm-db` (agent-gateway) and `redis` (cloud-workspaces). |
 | `Caddyfile` | Public HTTPS via Caddy (Let's Encrypt), plus the `/llm` route to the agent gateway when enabled. |
 | `.env.production.example` | Copy to `.env.static` and fill in; the installer does this for you. |
-| `bootstrap.sh` | First-run: generate secrets, migrate, boot, wait for health, print the claim token, and emit fixed secret-free substep progress markers for bounded AWS diagnostics. |
+| `bootstrap.sh` | First-run: generate secrets, migrate, boot, wait for health, print the claim token, and append fixed secret-free substep progress markers to `.bootstrap-progress.log` before also emitting them to stdout. |
 | `update.sh` | Pull + migrate + restart, including any enabled optional profile. |
 | `preflight.sh` | Validate config before replacing a running stack. |
 | `doctor.sh` | Redacting diagnostics for the running instance. |
@@ -62,6 +62,13 @@ docker compose --env-file .env.runtime -f docker-compose.production.yml logs -f
 Config lives in `.env.static` (operator settings) and `.env.local` (host-local
 overrides that survive infra rewrites). Secrets are generated into
 `.env.generated`; never commit either.
+
+`.bootstrap-progress.log` is reinitialized with mode `0600` at the start of
+each bootstrap invocation. Every allowlisted marker append closes before the
+corresponding stdout write or material action, so a later process kill leaves
+that completed append host-local for bounded AWS diagnostics. It does not
+promise recovery when termination interrupts the append itself or when the
+host/filesystem/storage fails.
 
 ## Optional add-ons
 

--- a/server/deploy/bootstrap.sh
+++ b/server/deploy/bootstrap.sh
@@ -9,6 +9,20 @@ STATIC_ENV_FILE="$SCRIPT_DIR/.env.static"
 LEGACY_ENV_FILE="$SCRIPT_DIR/.env"
 RUNTIME_ENV_FILE="$SCRIPT_DIR/.env.runtime"
 EXAMPLE_ENV_FILE="$SCRIPT_DIR/.env.production.example"
+BOOTSTRAP_PROGRESS_FILE="$SCRIPT_DIR/.bootstrap-progress.log"
+
+# This file is the deployment layer's host-local progress record. Reinitialize
+# it before any validation or material work so one invocation can never inherit
+# another invocation's markers. Reject links/non-files before writing because
+# CloudFormation runs this script as root.
+bootstrap_progress_init() {
+  if [[ -L "$BOOTSTRAP_PROGRESS_FILE" || ( -e "$BOOTSTRAP_PROGRESS_FILE" && ! -f "$BOOTSTRAP_PROGRESS_FILE" ) ]]; then
+    printf 'Refusing unsafe bootstrap progress path: %s\n' "$BOOTSTRAP_PROGRESS_FILE" >&2
+    return 1
+  fi
+  (umask 077 && : >"$BOOTSTRAP_PROGRESS_FILE")
+  chmod 0600 "$BOOTSTRAP_PROGRESS_FILE"
+}
 
 # Fixed, secret-free progress markers consumed by the bounded CloudFormation
 # failure diagnostic. Keep both token allowlists in sync; never place command
@@ -16,6 +30,7 @@ EXAMPLE_ENV_FILE="$SCRIPT_DIR/.env.production.example"
 bootstrap_substep_marker() {
   local substep="$1"
   local status="$2"
+  local marker
   case "$substep" in
     ensure-secrets|preflight|registry-login|runtime-install|db-up|migrate|api-caddy-up|optional-profiles|health-wait) ;;
     *) return 2 ;;
@@ -24,8 +39,16 @@ bootstrap_substep_marker() {
     started|completed) ;;
     *) return 2 ;;
   esac
-  printf '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:%s:%s\n' "$substep" "$status"
+  marker="__PROLIFERATE_BOOTSTRAP_SUBSTEP__:${substep}:${status}"
+  # Append and close the owned file before writing ordinary operator stdout.
+  # This guarantees that a later process termination cannot lose an append
+  # that already returned; it does not claim power-loss or filesystem-failure
+  # immunity, nor recovery if termination interrupts this append itself.
+  printf '%s\n' "$marker" >>"$BOOTSTRAP_PROGRESS_FILE"
+  printf '%s\n' "$marker"
 }
+
+bootstrap_progress_init
 
 if [[ -f "$STATIC_ENV_FILE" ]]; then
   ENV_FILE="$STATIC_ENV_FILE"

--- a/server/deploy/tests/bootstrap-markers.sh
+++ b/server/deploy/tests/bootstrap-markers.sh
@@ -21,7 +21,15 @@ cp "$FIXTURE/.env.static" "$FIXTURE/.env.runtime"
 cat >"$FIXTURE/helper" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$(basename "$0" .sh)" >>"$BOOTSTRAP_OPS"
+helper_name="$(basename "$0" .sh)"
+printf '%s\n' "$helper_name" >>"$BOOTSTRAP_OPS"
+if [[ "$helper_name" == "${BLOCK_HELPER:-}" ]]; then
+  printf '%s %s\n' "$$" "$PPID" >"$BLOCK_PIDS_FILE"
+  trap '' TERM
+  while :; do
+    sleep 1
+  done
+fi
 EOF
 chmod +x "$FIXTURE/helper"
 for helper in ensure-secrets preflight registry-login install-runtime wait-for-health; do
@@ -68,6 +76,8 @@ success_ops="$SCRATCH/success.ops"
 PATH="$FAKE_BIN:$PATH" BOOTSTRAP_OPS="$success_ops" bash "$FIXTURE/bootstrap.sh" >"$success_output"
 grep '^__PROLIFERATE_BOOTSTRAP_SUBSTEP__:' "$success_output" >"$SCRATCH/success.markers"
 diff -u "$expected_success" "$SCRATCH/success.markers"
+diff -u "$expected_success" "$FIXTURE/.bootstrap-progress.log"
+[[ "$(stat -f '%Lp' "$FIXTURE/.bootstrap-progress.log" 2>/dev/null || stat -c '%a' "$FIXTURE/.bootstrap-progress.log")" == "600" ]]
 
 failed_output="$SCRATCH/failed.out"
 failed_ops="$SCRATCH/failed.ops"
@@ -81,4 +91,67 @@ grep -qx '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:migrate:started' "$failed_output"
 if grep -qE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:migrate:completed|__PROLIFERATE_BOOTSTRAP_SUBSTEP__:api-caddy-up:' "$failed_output"; then
   printf 'bootstrap emitted completion/later markers after migrate failed\n' >&2
   exit 1
+fi
+
+# Model cfn-init's ProcessHelper/LoggingProcessHelper contract: the child stdout
+# stays in a command-substitution pipe and reaches cfn-init-cmd.log only after
+# the child returns. Kill the wrapper while preflight is blocked. The buffered
+# stdout path must lose the marker, while bootstrap.sh's owned append survives.
+buffered_log="$SCRATCH/cfn-init-cmd.log"
+block_pids="$SCRATCH/block.pids"
+timeout_ops="$SCRATCH/timeout.ops"
+wrapper="$SCRATCH/cfn-init-wrapper"
+cat >"$wrapper" <<EOF
+#!/usr/bin/env bash
+set +e
+output="\$(bash '$FIXTURE/bootstrap.sh' 2>&1)"
+status=\$?
+printf '%s\n' "\$output" >'$buffered_log'
+exit "\$status"
+EOF
+chmod +x "$wrapper"
+
+PATH="$FAKE_BIN:$PATH" BOOTSTRAP_OPS="$timeout_ops" BLOCK_HELPER=preflight \
+  BLOCK_PIDS_FILE="$block_pids" "$wrapper" &
+wrapper_pid=$!
+for _ in $(seq 1 500); do
+  if [[ -s "$block_pids" ]] && grep -qx '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started' "$FIXTURE/.bootstrap-progress.log"; then
+    break
+  fi
+  sleep 0.01
+done
+[[ -s "$block_pids" ]]
+grep -qx '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started' "$FIXTURE/.bootstrap-progress.log"
+read -r helper_pid bootstrap_pid <"$block_pids"
+
+# TERM is the outer deadline's first action; KILL models its bounded fallback.
+kill -TERM "$wrapper_pid" "$bootstrap_pid" "$helper_pid" 2>/dev/null || true
+kill -KILL "$wrapper_pid" "$bootstrap_pid" "$helper_pid" 2>/dev/null || true
+wait "$wrapper_pid" 2>/dev/null || true
+for pid in "$wrapper_pid" "$bootstrap_pid" "$helper_pid"; do
+  if kill -0 "$pid" 2>/dev/null; then
+    printf 'timeout regression left process %s alive\n' "$pid" >&2
+    exit 1
+  fi
+done
+
+grep -qx '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:ensure-secrets:completed' "$FIXTURE/.bootstrap-progress.log"
+grep -qx '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started' "$FIXTURE/.bootstrap-progress.log"
+if grep -qE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:completed|__PROLIFERATE_BOOTSTRAP_SUBSTEP__:registry-login:' "$FIXTURE/.bootstrap-progress.log"; then
+  printf 'durable progress invented completion/later work after wrapper termination\n' >&2
+  exit 1
+fi
+if [[ -f "$buffered_log" ]] && grep -q '__PROLIFERATE_BOOTSTRAP_SUBSTEP__' "$buffered_log"; then
+  printf 'stdout-only cfn-init emulation unexpectedly retained a pre-completion marker\n' >&2
+  exit 1
+fi
+
+# The release-runner regression consumes these exact kill-path artifacts and
+# executes the real bounded diagnostic command/parser over them.
+if [[ -n "${BOOTSTRAP_MARKER_EVIDENCE_DIR:-}" ]]; then
+  mkdir -p "$BOOTSTRAP_MARKER_EVIDENCE_DIR"
+  cp "$FIXTURE/.bootstrap-progress.log" "$BOOTSTRAP_MARKER_EVIDENCE_DIR/bootstrap-progress.log"
+  printf 'Running Command 02-bootstrap\n' >"$BOOTSTRAP_MARKER_EVIDENCE_DIR/cfn-init.log"
+  : >"$BOOTSTRAP_MARKER_EVIDENCE_DIR/cfn-init-cmd.log"
+  printf '__PROLIFERATE_CFN_OUTER__:timeout\n' >"$BOOTSTRAP_MARKER_EVIDENCE_DIR/cloud-init-output.log"
 fi

--- a/server/deploy/tests/bootstrap-markers.sh
+++ b/server/deploy/tests/bootstrap-markers.sh
@@ -77,7 +77,7 @@ PATH="$FAKE_BIN:$PATH" BOOTSTRAP_OPS="$success_ops" bash "$FIXTURE/bootstrap.sh"
 grep '^__PROLIFERATE_BOOTSTRAP_SUBSTEP__:' "$success_output" >"$SCRATCH/success.markers"
 diff -u "$expected_success" "$SCRATCH/success.markers"
 diff -u "$expected_success" "$FIXTURE/.bootstrap-progress.log"
-[[ "$(stat -f '%Lp' "$FIXTURE/.bootstrap-progress.log" 2>/dev/null || stat -c '%a' "$FIXTURE/.bootstrap-progress.log")" == "600" ]]
+[[ "$(stat -c '%a' "$FIXTURE/.bootstrap-progress.log" 2>/dev/null || stat -f '%Lp' "$FIXTURE/.bootstrap-progress.log")" == "600" ]]
 
 failed_output="$SCRATCH/failed.out"
 failed_ops="$SCRATCH/failed.ops"

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -568,7 +568,7 @@ user_data_status=$?
 [[ "$user_data_status" -eq 23 ]] && ok "template UserData preserves failed cfn-init exit code" || no "template UserData returned $user_data_status instead of cfn-init exit 23"
 grep -qx -- '-e' "$signal_args" \
   && grep -qx -- '23' "$signal_args" \
-  && grep -qx -- 'cfn-init bootstrap failed with exit code 23; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$signal_args" \
+  && grep -qx -- 'cfn-init bootstrap failed with exit code 23; inspect .bootstrap-progress.log and cfn-init logs through SSM.' "$signal_args" \
   && ok "template UserData failure invokes cfn-signal with bounded diagnostics" \
   || no "template UserData failure did not invoke cfn-signal with the expected bounded reason"
 
@@ -577,7 +577,7 @@ FAKE_CFN_BIN="$FAKE_CFN_BIN" FAKE_TIMEOUT_EXIT=124 CFN_SIGNAL_ARGS_FILE="$timeou
   bash "$user_data" >/dev/null 2>&1
 user_data_status=$?
 [[ "$user_data_status" -eq 124 ]] && ok "template UserData bounds an overlong cfn-init before the CreationPolicy timeout" || no "template UserData returned $user_data_status instead of timeout exit 124"
-grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$timeout_signal_args" \
+grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect .bootstrap-progress.log and cfn-init logs through SSM.' "$timeout_signal_args" \
   && ok "template UserData timeout invokes cfn-signal with bounded diagnostics" \
   || no "template UserData timeout did not invoke cfn-signal with the expected bounded reason"
 
@@ -587,7 +587,7 @@ FAKE_CFN_BIN="$FAKE_CFN_BIN" FAKE_TIMEOUT_EXIT=137 CFN_SIGNAL_ARGS_FILE="$kill_t
 user_data_status=$?
 [[ "$user_data_status" -eq 124 ]] && ok "template UserData normalizes kill-after exit 137 to timeout exit 124" || no "template UserData returned $user_data_status instead of normalized timeout exit 124"
 grep -qx -- '124' "$kill_timeout_signal_args" \
-  && grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$kill_timeout_signal_args" \
+  && grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect .bootstrap-progress.log and cfn-init logs through SSM.' "$kill_timeout_signal_args" \
   && ok "template UserData kill-after invokes cfn-signal with timeout diagnostics" \
   || no "template UserData kill-after did not invoke cfn-signal with normalized timeout diagnostics"
 
@@ -637,7 +637,7 @@ EOF
     [[ "$hard_deadline_status" -eq 124 ]] \
       && [[ "$signal_call_count" -eq 1 ]] \
       && grep -qx -- '124' "$hard_deadline_signal_args" \
-      && grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM.' "$hard_deadline_signal_args" \
+      && grep -qx -- 'cfn-init bootstrap exceeded the 18-minute limit; inspect .bootstrap-progress.log and cfn-init logs through SSM.' "$hard_deadline_signal_args" \
       && ok "template UserData hard-kills a TERM-resistant cfn-init and signals one bounded timeout" \
       || no "template UserData did not hard-bound and signal the TERM-resistant cfn-init (status=$hard_deadline_status calls=$signal_call_count)"
   else

--- a/server/deploy/tests/run.sh
+++ b/server/deploy/tests/run.sh
@@ -65,6 +65,7 @@ make_release() {
   mkdir -p "$staging/proliferate-deploy"
   cp -R "$DEPLOY_DIR/." "$staging/proliferate-deploy/"
   rm -rf "$staging/proliferate-deploy/smoke" "$staging/proliferate-deploy/tests"
+  rm -f "$staging/proliferate-deploy/.bootstrap-progress.log"
   printf '%s\n' "$version" >"$staging/proliferate-deploy/VERSION"
   tar czf "$dl/proliferate-deploy.tar.gz" -C "$staging" proliferate-deploy
   ( cd "$dl" && sha256sum proliferate-deploy.tar.gz >self-hosted-assets.SHA256SUMS )
@@ -146,9 +147,9 @@ printf 'AGENT_GATEWAY_ENABLED=true\nE2B_API_KEY=k\nE2B_TEMPLATE_NAME=t/x:product
 [[ "$(proliferate_enabled_profiles "$env_both")" == "agent-gateway cloud-workspaces" ]] && ok "gateway + cloud both on -> both profiles" || no "expected both profiles: got '$(proliferate_enabled_profiles "$env_both")'"
 
 if bash "$TESTS_DIR/bootstrap-markers.sh"; then
-  ok "bootstrap markers are ordered and stop without completion on failure"
+  ok "bootstrap markers are ordered, durable across wrapper kill, and stop without completion on failure"
 else
-  no "bootstrap marker ordering/failure contract regressed"
+  no "bootstrap marker ordering/durability/failure contract regressed"
 fi
 
 mv="$(printf '0.3.2\n0.3.18\n0.10.0\n2.0.0\n0.3.9\n' | proliferate_max_version)"
@@ -304,6 +305,7 @@ BSTAGE="$SCRATCH/bstage"
 mkdir -p "$BSTAGE/proliferate-deploy"
 cp -R "$DEPLOY_DIR/." "$BSTAGE/proliferate-deploy/"
 rm -rf "$BSTAGE/proliferate-deploy/smoke" "$BSTAGE/proliferate-deploy/tests"
+rm -f "$BSTAGE/proliferate-deploy/.bootstrap-progress.log"
 printf '0.3.18\n' >"$BSTAGE/proliferate-deploy/VERSION"
 tar czf "$BUNDLE_DIR/proliferate-deploy.tar.gz" -C "$BSTAGE" proliferate-deploy
 rm -rf "$BSTAGE"
@@ -427,6 +429,7 @@ BUNDLE_ROOT="$SCRATCH/bundle"
 mkdir -p "$BUNDLE_ROOT/proliferate-deploy"
 cp -R "$DEPLOY_DIR/." "$BUNDLE_ROOT/proliferate-deploy/"
 rm -rf "$BUNDLE_ROOT/proliferate-deploy/smoke" "$BUNDLE_ROOT/proliferate-deploy/tests"
+rm -f "$BUNDLE_ROOT/proliferate-deploy/.bootstrap-progress.log"
 printf '0.3.18\n' >"$BUNDLE_ROOT/proliferate-deploy/VERSION"
 tar czf "$SCRATCH/proliferate-deploy.tar.gz" -C "$BUNDLE_ROOT" proliferate-deploy
 members="$(tar tzf "$SCRATCH/proliferate-deploy.tar.gz")"
@@ -435,6 +438,7 @@ for want in proliferate-deploy/bootstrap.sh proliferate-deploy/update.sh prolife
 done
 echo "$members" | grep -q 'proliferate-deploy/smoke/' && no "bundle should NOT contain smoke/" || ok "bundle excludes smoke/"
 echo "$members" | grep -q 'proliferate-deploy/tests/' && no "bundle should NOT contain tests/" || ok "bundle excludes tests/"
+echo "$members" | grep -q 'proliferate-deploy/.bootstrap-progress.log' && no "bundle should NOT contain host progress" || ok "bundle excludes host progress"
 ( cd "$SCRATCH" && sha256sum proliferate-deploy.tar.gz >sums && sha256sum -c --ignore-missing sums >/dev/null 2>&1 ) \
   && ok "checksum round-trips (sha256sum -c)" || no "checksum round-trip failed"
 

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -391,8 +391,9 @@ Resources:
                   # the one owned deployment layer: the stack no longer embeds
                   # duplicate copies that could drift from server/deploy/**.
                   # Operator config/data (.env.static/.env.local/.env.generated/
-                  # .env.runtime) is written/managed outside the bundle and is
-                  # never present in it, so this cp never clobbers it.
+                  # .env.runtime) and the bootstrap-owned progress log are
+                  # written/managed outside the bundle and are never present in
+                  # it, so this extraction never clobbers them.
                   tmp="$(mktemp -d)"
                   trap 'rm -rf "$tmp"' EXIT
                   curl -fsSL "${ResolvedDeployBundleUrl}" -o "$tmp/proliferate-deploy.tar.gz"
@@ -568,10 +569,10 @@ Resources:
               # Normalize that hard-deadline path to the owned timeout status.
               if [ "$EXIT_CODE" -eq 124 ] || [ "$EXIT_CODE" -eq 137 ]; then
                 EXIT_CODE=124
-                FAILURE_REASON="cfn-init bootstrap exceeded the 18-minute limit; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+                FAILURE_REASON="cfn-init bootstrap exceeded the 18-minute limit; inspect .bootstrap-progress.log and cfn-init logs through SSM."
                 printf '__PROLIFERATE_CFN_OUTER__:timeout\n'
               else
-                FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect /var/log/cfn-init.log and /var/log/cfn-init-cmd.log through SSM."
+                FAILURE_REASON="cfn-init bootstrap failed with exit code $EXIT_CODE; inspect .bootstrap-progress.log and cfn-init logs through SSM."
                 printf '__PROLIFERATE_CFN_OUTER__:command_failure\n'
               fi
             }

--- a/specs/developing/deploying/self-hosted-aws.md
+++ b/specs/developing/deploying/self-hosted-aws.md
@@ -63,14 +63,26 @@ puts only a bounded stage and exit-code reason in the stack event. Inspect
 detail rather than copying those potentially secret-bearing logs into
 CloudFormation events.
 
-`bootstrap.sh` emits fixed, secret-free start/completion markers for its
-material substeps (secret resolution, preflight, registry login, runtime
-installation, database start/migration, API+Caddy start, optional profiles,
-and health wait). Qualification diagnostics accept only those allowlisted
-tokens. A timeout can therefore identify the last started substep without
-persisting command output, environment values, URLs, or provider payloads;
-absence of a completion marker is reported as unfinished rather than guessed
-as a command failure.
+`bootstrap.sh` initializes its owner-only
+`/opt/proliferate/server/deploy/.bootstrap-progress.log` at each invocation,
+then appends fixed, secret-free start/completion markers for its material
+substeps (secret resolution, preflight, registry login, runtime installation,
+database start/migration, API+Caddy start, optional profiles, and health wait).
+Each start append returns and closes before the same marker is printed to normal
+operator stdout and before material work begins; each completion append follows
+successful material work. A later `TERM`/`KILL` of the bootstrap process cannot
+remove an append that already returned. This is not a claim of recovery from a
+termination during the append, host power loss, filesystem failure, or storage
+corruption.
+
+Qualification diagnostics read that file directly before treating
+`cfn-init-cmd.log` as a compatibility fallback. This matters because the AWS
+helper buffers command stdout until the child exits, so an outer timeout can
+kill `cfn-init` before stdout markers reach that log. Diagnostics accept only
+the allowlisted marker tokens under the existing byte cap. A timeout can
+therefore identify the last started substep without persisting command output,
+environment values, URLs, or provider payloads; absence of a completion marker
+is reported as unfinished rather than guessed as a command failure.
 
 ## Required Inputs
 

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import {
@@ -51,6 +52,7 @@ import {
 import type { CleanupLedger, CleanupLedgerEntry, CleanupResourceKind } from "../local-workspace/cleanup-ledger.js";
 
 const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../../..");
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
 
@@ -397,6 +399,53 @@ test("parseCfnBootstrapDiagnosticOutput: identifies the last started bootstrap s
     ],
   );
   assert.equal(JSON.stringify(parsed).includes("secret-token"), false);
+});
+
+test("run 29710731437 / CFN-DIAG-CONTROL-004: wrapper kill preserves direct progress when buffered stdout is lost", async () => {
+  const evidenceDirectory = await mkdtemp(path.join(tmpdir(), "cfn-diagnostic-wrapper-kill-"));
+  const marker = "__PROLIFERATE_BOOTSTRAP_SUBSTEP__:preflight:started";
+
+  try {
+    await execFileAsync("bash", [path.join(REPO_ROOT, "server/deploy/tests/bootstrap-markers.sh")], {
+      env: { ...process.env, BOOTSTRAP_MARKER_EVIDENCE_DIR: evidenceDirectory },
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+
+    const bufferedStdout = await readFile(path.join(evidenceDirectory, "cfn-init-cmd.log"), "utf8");
+    const durableProgress = await readFile(path.join(evidenceDirectory, "bootstrap-progress.log"), "utf8");
+    assert.equal(bufferedStdout.includes(marker), false, "killed wrapper never flushes child stdout to its log");
+    assert.equal(durableProgress.includes(marker), true, "started append survives wrapper/child termination");
+    assert.equal(durableProgress.includes("preflight:completed"), false, "no completion is invented");
+
+    const command = buildCfnDiagnosticCommand({
+      logDirectory: evidenceDirectory,
+      bootstrapProgressFile: path.join(evidenceDirectory, "bootstrap-progress.log"),
+      elevated: false,
+    });
+    const { stdout } = await execFileAsync("bash", ["-c", command], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+    });
+    assert.ok(Buffer.byteLength(stdout, "utf8") <= CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET);
+    assert.equal(stdout.includes(marker), true, "diagnostic reads the owned progress file directly");
+
+    const parsed = parseCfnBootstrapDiagnosticOutput(stdout);
+    assert.equal(parsed.terminal_cause, "outer_timeout");
+    assert.deepEqual(
+      parsed.observations.find((item) => item.substep === "preflight"),
+      {
+        source: "bootstrap-progress.log",
+        stage: "02-bootstrap",
+        substep: "preflight",
+        outcome: "started",
+        exit_code: null,
+        category: "other",
+      },
+    );
+  } finally {
+    await rm(evidenceDirectory, { recursive: true, force: true });
+  }
 });
 
 test("CFN-DIAG-CONTROL-002: multibyte context cannot truncate fixed outer/substep markers", async () => {

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -93,6 +93,7 @@ const CFN_DIAGNOSTIC_MAX_OBSERVATIONS = 24;
 const CFN_DIAGNOSTIC_COMMAND_TIMEOUT_SECONDS = 30;
 /** SSM returns at most 24,000 stdout characters; stay below that hard provider cap. */
 export const CFN_DIAGNOSTIC_OUTPUT_BYTE_BUDGET = 20_000;
+const CFN_BOOTSTRAP_PROGRESS_FILE = "/opt/proliferate/server/deploy/.bootstrap-progress.log";
 
 function shellQuoteDiagnosticPath(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
@@ -101,18 +102,20 @@ function shellQuoteDiagnosticPath(value: string): string {
 /** Builds the fixed-token SSM command; configurable paths keep its byte bounds executable offline. */
 export function buildCfnDiagnosticCommand(options?: {
   logDirectory?: string;
+  bootstrapProgressFile?: string;
   elevated?: boolean;
 }): string {
   const logDirectory = options?.logDirectory ?? "/var/log";
+  const bootstrapProgressFile = options?.bootstrapProgressFile ?? CFN_BOOTSTRAP_PROGRESS_FILE;
   const elevated = options?.elevated ?? true;
   const sudo = elevated ? "sudo " : "";
   const logPath = (name: string): string => shellQuoteDiagnosticPath(path.posix.join(logDirectory, name));
 
   return [
     "{",
-    // Emit the two authoritative fixed-marker classes first. grep -o projects
-    // only bounded ASCII tokens, so multibyte log context can consume neither
-    // their per-section allowance nor the aggregate byte budget.
+    // Emit authoritative fixed-marker classes first. grep -o projects only
+    // bounded ASCII tokens, so multibyte log context can consume neither their
+    // per-section allowance nor the aggregate byte budget.
     `f=${logPath("cloud-init-output.log")}`,
     `if ${sudo}test -r \"$f\"; then`,
     "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
@@ -121,6 +124,14 @@ export function buildCfnDiagnosticCommand(options?: {
     "    printf '__PROLIFERATE_CFN_OUTER__:timeout\\n'",
     "  fi",
     "fi",
+    // bootstrap.sh writes these fixed markers directly before each material
+    // action. Read its owned file before cfn-init's buffered compatibility copy.
+    `f=${shellQuoteDiagnosticPath(bootstrapProgressFile)}`,
+    `if ${sudo}test -r \"$f\"; then`,
+    "  printf '__PROLIFERATE_CFN_LOG__:bootstrap-progress.log\\n'",
+    `  ${sudo}grep -aioE '__PROLIFERATE_BOOTSTRAP_SUBSTEP__:(ensure-secrets|preflight|registry-login|runtime-install|db-up|migrate|api-caddy-up|optional-profiles|health-wait):(started|completed)' \"$f\" 2>/dev/null | tail -n 24`,
+    "fi",
+    // Retain cfn-init-cmd.log as a compatibility fallback for older bundles.
     `f=${logPath("cfn-init-cmd.log")}`,
     `if ${sudo}test -r \"$f\"; then`,
     "  printf '__PROLIFERATE_CFN_LOG__:%s\\n' \"${f##*/}\"",
@@ -153,6 +164,7 @@ export type CfnBootstrapDiagnosticCaptureStatus =
   | "no_allowlisted_observations";
 
 export type CfnBootstrapDiagnosticSource =
+  | "bootstrap-progress.log"
   | "cfn-init.log"
   | "cfn-init-cmd.log"
   | "cloud-init-output.log"
@@ -609,6 +621,7 @@ export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiag
   const stages = new Map<CfnBootstrapStage, ResolvedState>();
   const substeps = new Map<CfnBootstrapSubstep, ResolvedState>();
   const activeStage: Record<Exclude<CfnBootstrapDiagnosticSource, "bootstrap.sh">, CfnBootstrapStage> = {
+    "bootstrap-progress.log": "unknown",
     "cfn-init.log": "unknown",
     "cfn-init-cmd.log": "unknown",
     "cloud-init-output.log": "unknown",
@@ -617,7 +630,7 @@ export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiag
   for (const rawLine of raw.split(/\r?\n/)) {
     order += 1;
     const marker = rawLine.match(
-      /^__PROLIFERATE_CFN_LOG__:(cfn-init\.log|cfn-init-cmd\.log|cloud-init-output\.log)$/,
+      /^__PROLIFERATE_CFN_LOG__:(bootstrap-progress\.log|cfn-init\.log|cfn-init-cmd\.log|cloud-init-output\.log)$/,
     );
     if (marker) {
       source = marker[1] as Exclude<CfnBootstrapDiagnosticSource, "bootstrap.sh">;
@@ -647,11 +660,11 @@ export function parseCfnBootstrapDiagnosticOutput(raw: string): CfnBootstrapDiag
     if (candidateSubstep && ALLOWED_CFN_BOOTSTRAP_SUBSTEPS.has(candidateSubstep)) {
       const outcome = substepMatch?.[2]?.toLowerCase() as "started" | "completed";
       const prior = substeps.get(candidateSubstep);
-      // The same command output can appear in both cfn-init logs. A later copy
-      // of STARTED must not regress an already observed completion.
-      if (!prior?.terminal || outcome === "completed") {
+      // Keep the first source for duplicate states, permit only a genuine
+      // started -> completed upgrade, and never regress a completion.
+      if (!prior || (!prior.terminal && outcome === "completed")) {
         substeps.set(candidateSubstep, {
-          source: "bootstrap.sh",
+          source: source === "bootstrap-progress.log" ? source : "bootstrap.sh",
           stage: "02-bootstrap",
           substep: candidateSubstep,
           outcome,


### PR DESCRIPTION
## Summary

- initialize a bootstrap-owned mode-0600 `.bootstrap-progress.log` on every invocation
- append each allowlisted started/completed token before stdout/material work and after successful work
- read the direct progress file ahead of the buffered `cfn-init-cmd.log` fallback under the unchanged 20,000-byte cap
- preserve `bootstrap-progress.log` source plus substep in reduced evidence, with no raw values
- exclude the host-local progress file from release and qualification bundles

## Root cause and exact-run receipt

Base: `80e8a681552e4a9104fcd2f2d56ba42988d6f2b1`
Head: `327ceebae5890af27be4f475e0c9f787e94a48bc`

Strict run [29710731437](https://github.com/proliferate-ai/proliferate/actions/runs/29710731437), artifact `selfhost-evidence` (8449517747), is exact for the base SHA. Schema v2 reports `terminal_cause=outer_timeout` at template stage `02-bootstrap`; all prior template stages completed with exit 0; no bootstrap substep was observed. The independent provider sweep proved zero survivors across CloudFormation, EC2/network, Route53, S3, IAM, and GHCR.

The official AWS `aws-cfn-bootstrap` Python source confirms the cause: `ProcessHelper` launches command stdout through `subprocess.PIPE`, waits through `communicate()`, and `LoggingProcessHelper` writes command output to `cfn-init-cmd.log` only after that call returns. The 18-minute outer timeout can therefore kill `cfn-init` and `bootstrap.sh` before child stdout is copied to that log.

The regression runs the real `bootstrap.sh` under a cfn-init-like buffering wrapper, blocks in `preflight`, sends TERM/KILL, proves the stdout-only log lacks the marker, proves the owned file retains `preflight:started`, and then executes the real SSM command/parser over those exact artifacts.

## Exact guarantee

Each validated fixed-token append opens, writes, returns, and closes before the corresponding operator stdout write or material action. A later process termination cannot remove an append that already returned. This does not claim recovery from termination during the append, host power loss, filesystem failure, or storage corruption.

The 18m timeout, 30s forced-kill fallback, PT20M CreationPolicy, 90s SSM diagnostic deadline, 20,000-byte cap, cleanup ordering, and evidence-before-cleanup ordering are unchanged.

## Verification

- `pnpm -C tests/release test` — 1480/1480
- focused CFN suite — 47/47
- `pnpm -C tests/release typecheck`
- `node --test scripts/ci-cd/build-selfhost-qualification-candidates.test.mjs` — 12/12
- `bash server/deploy/tests/bootstrap-markers.sh`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
- independent review — no findings

No Rust build, Docker, provider mutation, live E2E dispatch, or merge was performed.