### PR TITLE
fix(release): resolve local tier 3 false reds

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
@@ -63,3 +63,33 @@ it("identifies model rows by both harness kind and model id", () => {
   const codexRow = container.querySelector('button[data-model-kind="codex"][data-model-option="gpt-5.5"]');
   expect(codexRow).not.toBeNull();
 });
+
+it("reports the effective live model when the launch row remains selected", () => {
+  const props: ModelSelectorProps = {
+    connectionState: "healthy",
+    currentModel: { kind: "claude", displayName: "Haiku 4.5", pendingState: null },
+    groups: [
+      {
+        kind: "claude",
+        providerDisplayName: "Claude Code",
+        models: [
+          { kind: "claude", modelId: "claude-sonnet-4-5", displayName: "Sonnet 4.5", actionKind: "select", isSelected: true },
+          { kind: "claude", modelId: "haiku", displayName: "Haiku 4.5", actionKind: "update_current_chat", isSelected: false },
+        ],
+      },
+    ],
+    hasAgents: true,
+    isLoading: false,
+    onSelect: vi.fn(),
+  };
+
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl modelSelectorProps={props} />
+    </MemoryRouter>,
+  );
+
+  expect(
+    container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-composer-selected-model"),
+  ).toBe("haiku");
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -41,13 +41,25 @@ export function ComposerModelSelectorControl({
   } = modelSelectorProps;
   const selectorEnabled = connectionState === "healthy" && !isLoading && hasAgents;
   const triggerLabel = resolveTriggerLabel(modelSelectorProps);
-  // Stable qualification hook (attributes only): the id of the currently
-  // selected model, derived from the group items already rendered. Lets the
-  // local-world smoke driver assert the composer picker reflects its choice
-  // without adding a modelId to the display-only `currentModel`. No behavior
-  // change.
-  const selectedModelId =
-    groups.flatMap((group) => group.models).find((model) => model.isSelected)?.modelId ?? "";
+  // Stable qualification hook (attributes only): prefer the model whose
+  // rendered identity matches the current chip. During live-config restore,
+  // the requested launch row can remain selected while `currentModel` already
+  // reflects the effective model reported by the running session. The hook
+  // must describe the same effective model the user sees, then fall back to
+  // the ordinary selected row when the live label has no unique catalog match.
+  const modelsForCurrentKind = currentModel
+    ? groups
+      .filter((group) => group.kind === currentModel.kind)
+      .flatMap((group) => group.models)
+    : [];
+  const effectiveModelMatches = currentModel
+    ? modelsForCurrentKind.filter((model) => model.displayName === currentModel.displayName)
+    : [];
+  const selectedModelId = effectiveModelMatches.length === 1
+    ? effectiveModelMatches[0].modelId
+    : modelsForCurrentKind.find((model) => model.isSelected)?.modelId
+      ?? groups.flatMap((group) => group.models).find((model) => model.isSelected)?.modelId
+      ?? "";
 
   // UX_SPEC S5: adding a harness routes to Settings -> per-harness agent pages.
   const handleAddProvider = useCallback(() => {

--- a/tests/release/src/scenarios/local/chat-authroute.test.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.test.ts
@@ -19,6 +19,7 @@ import {
   collectLocal2GatewayCells,
   collectLocal3UserKeyCells,
   collectLocal6RouteChangeCell,
+  preflightLocalUserKey,
   turnErrorEvidenceMessage,
   type LocalRouteDriver,
   type RouteModelSelection,
@@ -290,6 +291,28 @@ test("turn errors retain only a fixed route and safe class in evidence", () => {
   const message = turnErrorEvidenceMessage("gateway", raw);
   assert.equal(message, "sendBoundedTurn route=gateway error_class=budget_exceeded");
   assert.doesNotMatch(message, /(?:sk-secret|current|\b5\b)/);
+});
+
+test("preflightLocalUserKey rejects an Anthropic key with a bounded status-only reason", async () => {
+  await assert.rejects(
+    preflightLocalUserKey("opencode", "sk-ant-secret", {
+      checkKey: async () => ({ status: 401 }),
+    }),
+    /opencode provider credential preflight failed: provider returned 401 on \/models/,
+  );
+});
+
+test("preflightLocalUserKey passes a valid Anthropic key and skips providers without a narrow probe", async () => {
+  let calls = 0;
+  const probe = {
+    checkKey: async () => {
+      calls += 1;
+      return { status: 200 };
+    },
+  };
+  await preflightLocalUserKey("claude", "sk-ant-secret", probe);
+  await preflightLocalUserKey("codex", "sk-openai-secret", probe);
+  assert.equal(calls, 1);
 });
 
 test("turn error classification is conservative and bounded", () => {

--- a/tests/release/src/scenarios/local/chat-authroute.ts
+++ b/tests/release/src/scenarios/local/chat-authroute.ts
@@ -7,6 +7,11 @@ import type { PlannedCellV1 } from "../../runner/result.js";
 import type { ReadyLocalWorld } from "../../worlds/local-workspace/world.js";
 import type { LocalWorldCleanupEvidence } from "../../worlds/local-workspace/cleanup.js";
 import { authenticatedActor, type AuthenticatedActor } from "../../fixtures/authenticated-actor.js";
+import {
+  defaultByokPreflightProbe,
+  preflightByokKey,
+  type ByokPreflightProbe,
+} from "../../fixtures/byok.js";
 import { preparedRepository, type PreparedRepository } from "../../fixtures/prepared-repository.js";
 import { productPage, type ProductPage } from "../../fixtures/product-page.js";
 import { findStructuredErrorEvent, findTurnEndedEvent } from "../../fixtures/local-runtime.js";
@@ -129,6 +134,29 @@ export const BYOK_ENV_BY_HARNESS: Readonly<Record<Exclude<LocalHarnessKind, "cur
   // second Anthropic key so the two Anthropic-consuming harnesses stay isolated).
   opencode: "RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY",
 };
+
+/**
+ * Preflights Anthropic-backed LOCAL-3 keys before the UI persists them. The
+ * provider check is a bounded, side-effect-free `GET /v1/models` and returns
+ * only a status-derived reason; neither the key nor a provider body can reach
+ * evidence. Other providers keep proving their credentials through the real
+ * turn until they have an equally narrow provider-owned probe.
+ */
+export async function preflightLocalUserKey(
+  harness: LocalHarnessKind,
+  rawKey: string,
+  probe: ByokPreflightProbe = defaultByokPreflightProbe,
+): Promise<void> {
+  if (harness !== "claude" && harness !== "opencode") {
+    return;
+  }
+  const result = await preflightByokKey(rawKey, {}, probe);
+  if (!result.ok) {
+    throw new Error(
+      `storeAndSelectUserKeyRoute: ${harness} provider credential preflight failed: ${result.reason ?? "unknown"}`,
+    );
+  }
+}
 
 /** The representative single-source harness LOCAL-6 uses (gateway and direct do
  * NOT coexist for it, so route switching is observable). OpenCode is excluded
@@ -299,6 +327,7 @@ export const defaultLocalRouteDriver: LocalRouteDriver = {
     if (!key) {
       throw new Error(`storeAndSelectUserKeyRoute: required provider key env "${envVar}" is not set.`);
     }
+    await preflightLocalUserKey(harness, key);
     const p = page.page;
     // The api_key route lives on the per-harness settings pane (fix round 3).
     await openHarnessSettings(p, harness);

--- a/tests/release/src/scenarios/local/integration-mcp.test.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.test.ts
@@ -377,3 +377,22 @@ test("approvePendingPermissionIfPresent prefers a non-destructive session-scoped
   assert.equal(await approvePendingPermissionIfPresent(page), true);
   assert.deepEqual(clicked, ["Allow all server tools for this session"]);
 });
+
+test("approvePendingPermissionIfPresent accepts the one-shot action emitted by Grok", async () => {
+  const clicked: string[] = [];
+  const page = {
+    getByRole: (_role: string, options: { name: string }) => {
+      const action = {
+        first: () => action,
+        isVisible: async () => options.name === "Allow once",
+        click: async () => {
+          clicked.push(options.name);
+        },
+      };
+      return action;
+    },
+  } as never;
+
+  assert.equal(await approvePendingPermissionIfPresent(page), true);
+  assert.deepEqual(clicked, ["Allow once"]);
+});

--- a/tests/release/src/scenarios/local/integration-mcp.ts
+++ b/tests/release/src/scenarios/local/integration-mcp.ts
@@ -783,6 +783,7 @@ export async function approvePendingPermissionIfPresent(page: Page): Promise<boo
     "Allow all server tools for this session",
     "Allow tool for this session",
     "Always Allow",
+    "Allow once",
     "Allow",
   ];
   for (const label of labels) {


### PR DESCRIPTION
## Summary

- make the composer qualification hook report the effective live model visible in the chip after reload
- approve Grok’s one-shot `Allow once` integration permission card
- preflight Anthropic-backed Local BYOK credentials with a bounded status-only `/models` check before persisting them

## Exact run evidence

Diagnosed from strict Local run 29734208953 at exact main `35cb6f2fa2a4f87661812f8872ba407a5ce08123`. The route-change and OpenCode gateway turns returned `pong` and visibly restored Haiku 4.5, but the stale test hook reported Sonnet. The Grok integration turn stalled on the visible `integrations.call_tool` permission card because its action label is `Allow once`. The OpenCode BYOK failure has repeated as `unclassified`; the preflight now fails with a bounded status-only provider result if the dedicated credential is rejected.

## Verification

- `pnpm --dir tests/release typecheck`
- `tests/release/node_modules/.bin/tsx --test src/scenarios/local/chat-authroute.test.ts src/scenarios/local/integration-mcp.test.ts` (43 passed)
- `pnpm --dir apps/packages/product-client test src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx` (2 passed)
- full release test suite incidentally exercised by package test invocation (1,496 passed)
- `git diff --check`

## Scope

This intentionally does not change Cursor/Grok live-config qualification semantics, Codex gateway catalog policy, or LiteLLM model-correlation acceptance.