### PR TITLE
fix(release): bind local qualification selectors

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -556,7 +556,9 @@ jobs:
           RELEASE_E2E_BYOK_XAI_API_KEY: ${{ secrets.RELEASE_E2E_BYOK_XAI_API_KEY }}
           RELEASE_E2E_INTEGRATION_NAMESPACE: ${{ vars.RELEASE_E2E_INTEGRATION_NAMESPACE }}
           RELEASE_E2E_INTEGRATION_API_KEY: ${{ secrets.RELEASE_E2E_INTEGRATION_API_KEY }}
-          SCENARIOS_INPUT: ${{ github.event.inputs.scenarios || 'all' }}
+          SCENARIOS_INPUT: ${{ inputs.scenarios }}
+          AGENTS_INPUT: ${{ inputs.agents }}
+          BEHAVIOR_INPUT: ${{ inputs.local_functional_behavior }}
         run: |
           node scripts/ci-cd/qualification-preflight.mjs \
             --world local \
@@ -565,6 +567,8 @@ jobs:
             --shard-id 1 \
             --attempt "${GITHUB_RUN_ATTEMPT}" \
             --scenarios "${SCENARIOS_INPUT}" \
+            --agents "${AGENTS_INPUT}" \
+            --behavior "${BEHAVIOR_INPUT}" \
             --artifact-mode build \
             --output "tests/release/.output/preflight/local/qualification-preflight.json"
       - uses: pnpm/action-setup@v6
@@ -625,9 +629,9 @@ jobs:
           # Same debug-log sibling-path convention as local-world-smoke-1
           # (outside the run dir the cleanup stack deletes on teardown).
           LOCAL_WORLD_SMOKE_DEBUG_DIR: ${{ github.workspace }}/tests/release/.output/local-world/qlf-ci-${{ github.run_id }}-${{ github.run_attempt }}/debug/logs
-          SCENARIOS: ${{ github.event.inputs.scenarios || 'all' }}
-          AGENTS: ${{ github.event.inputs.agents || 'all' }}
-          BEHAVIOR: ${{ github.event.inputs.local_functional_behavior || 'strict' }}
+          SCENARIOS: ${{ inputs.scenarios }}
+          AGENTS: ${{ inputs.agents }}
+          BEHAVIOR: ${{ inputs.local_functional_behavior }}
         run: |
           set -euo pipefail
           profile="ci-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/Makefile
+++ b/Makefile
@@ -998,6 +998,7 @@ qualification-local-workspace:
 		--desktop web \
 		--agents claude \
 		--scenarios LOCAL-WORLD-SMOKE-1 \
+		--qualification-world local \
 		--candidate-build-map "$$candidate_map" \
 		--run-id "$$run_id" --shard-id "$$shard_id" \
 		--output-dir "$$run_dir/evidence"
@@ -1150,6 +1151,7 @@ qualification-local-functional:
 		--desktop web \
 		--agents $(AGENTS) \
 		--scenarios "$$scenarios" \
+		--qualification-world local \
 		--candidate-build-map "$$candidate_map" \
 		--run-id "$$run_id" --shard-id "$$shard_id" \
 		--output-dir "$$evidence_dir"

--- a/Makefile
+++ b/Makefile
@@ -971,13 +971,13 @@ qualification-local-workspace:
 	if [ -n "$(REUSE_CANDIDATES)" ]; then \
 		node scripts/ci-cd/qualification-preflight.mjs \
 			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
-			--scenarios LOCAL-WORLD-SMOKE-1 --artifact-mode reuse \
+			--scenarios LOCAL-WORLD-SMOKE-1 --agents claude --behavior "$(BEHAVIOR)" --artifact-mode reuse \
 			--candidate-build-map "$(REUSE_CANDIDATES)/candidate-build.json" \
 			--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
 	else \
 		node scripts/ci-cd/qualification-preflight.mjs \
 			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
-			--scenarios LOCAL-WORLD-SMOKE-1 --artifact-mode build \
+			--scenarios LOCAL-WORLD-SMOKE-1 --agents claude --behavior "$(BEHAVIOR)" --artifact-mode build \
 			--output "$$run_dir/preflight/qualification-preflight.json" || exit $$?; \
 	fi; \
 	pnpm install --silent; \
@@ -1122,13 +1122,13 @@ qualification-local-functional:
 	if [ -n "$(REUSE_CANDIDATES)" ]; then \
 		node scripts/ci-cd/qualification-preflight.mjs \
 			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
-			--scenarios "$$scenarios" --artifact-mode reuse \
+			--scenarios "$$scenarios" --agents "$(AGENTS)" --behavior "$(BEHAVIOR)" --artifact-mode reuse \
 			--candidate-build-map "$(REUSE_CANDIDATES)/candidate-build.json" \
 			--output "$$build_dir/preflight/qualification-preflight.json" || exit $$?; \
 	else \
 		node scripts/ci-cd/qualification-preflight.mjs \
 			--world local --source-sha "$$source_sha" --run-id "$$run_id" --shard-id "$$shard_id" --attempt "$$attempt" \
-			--scenarios "$$scenarios" --artifact-mode build \
+			--scenarios "$$scenarios" --agents "$(AGENTS)" --behavior "$(BEHAVIOR)" --artifact-mode build \
 			--output "$$build_dir/preflight/qualification-preflight.json" || exit $$?; \
 	fi; \
 	pnpm install --silent; \

--- a/scripts/ci-cd/qualification-preflight.mjs
+++ b/scripts/ci-cd/qualification-preflight.mjs
@@ -2,19 +2,24 @@
 
 import { createHash, createPrivateKey, createPublicKey, X509Certificate } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { loadCandidateBuildMapForReuse } from "./assemble-candidate-build-map.mjs";
 
 export const PREFLIGHT_KIND = "proliferate.qualification-preflight";
-export const PREFLIGHT_SCHEMA_VERSION = 1;
+export const PREFLIGHT_SCHEMA_VERSION = 2;
 export const PREFLIGHT_DEADLINE_MS = 120_000;
 
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const WORLDS = new Set(["local", "managed-cloud", "self-host", "tier4"]);
+const LOCAL_AGENT_KINDS = new Set(
+  JSON.parse(
+    readFileSync(new URL("../../catalogs/agents/catalog.json", import.meta.url), "utf8"),
+  ).agents.map((agent) => agent.kind),
+);
 const SECRET_NAMES = new Set([
   "AGENT_GATEWAY_LITELLM_MASTER_KEY",
   "RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY",
@@ -153,8 +158,25 @@ export function runQualificationPreflight(options, deps = {}) {
   }
   validateIdentity(options, pass, fail);
 
-  const scenarioIds = parseSelector(options.scenarios ?? "all", "scenario_selection", fail);
+  const behavior = options.world === "local" && ["diagnostic", "strict"].includes(options.behavior)
+    ? options.behavior
+    : null;
+  if (options.world === "local" && !behavior) {
+    fail("behavior", "Local behavior must be diagnostic or strict.");
+  }
+  const strictLocal = options.world === "local" && behavior === "strict";
+  const scenarioIds = parseSelector(
+    options.scenarios ?? (strictLocal ? "" : "all"),
+    "scenario_selection",
+    fail,
+  );
   const cellIds = parseSelector(options.cells ?? "all", "cell_selection", fail);
+  const agentIds = options.world === "local"
+    ? parseSelector(options.agents ?? "", "agent_selection", fail)
+    : null;
+  if (options.world === "local") {
+    validateLocalAgentSelection(agentIds, pass, fail);
+  }
   const requirements = WORLD_REQUIREMENTS[options.world] ?? [];
   for (const [name, shape] of requirements) {
     validateEnv(name, shape, env, pass, fail);
@@ -267,8 +289,10 @@ export function runQualificationPreflight(options, deps = {}) {
       source_sha: SHA.test(options.sourceSha ?? "") ? options.sourceSha : null,
     },
     world: WORLDS.has(options.world) ? options.world : null,
+    behavior,
     selected_scenarios: scenarioIds,
     selected_cells: cellIds,
+    selected_agents: agentIds,
     artifact_mode: options.artifactMode ?? null,
     candidate_build: candidateBuild,
     cleanup_authorization_revision: cleanupAuthorizationRevision,
@@ -293,11 +317,31 @@ function parseSelector(raw, checkId, fail) {
     .map((value) => value.trim())
     .filter(Boolean);
   if (ids.length === 0 || ids.some((id) => !SAFE_ID.test(id)) || new Set(ids).size !== ids.length) {
-    const label = checkId === "cell_selection" ? "Cell" : "Scenario";
+    const label = checkId === "cell_selection"
+      ? "Cell"
+      : checkId === "agent_selection"
+        ? "Agent"
+        : "Scenario";
     fail(checkId, `${label} selector is empty, duplicated, or malformed.`);
     return [];
   }
   return ids.sort();
+}
+
+function validateLocalAgentSelection(agentIds, pass, fail) {
+  if (agentIds === "all") {
+    pass("agent_catalog", `All ${LOCAL_AGENT_KINDS.size} catalog agent kinds are selected.`);
+    return;
+  }
+  if (!Array.isArray(agentIds) || agentIds.length === 0) {
+    return;
+  }
+  const unknown = agentIds.filter((agent) => !LOCAL_AGENT_KINDS.has(agent));
+  if (unknown.length > 0) {
+    fail("agent_catalog", `Agent selector contains ${unknown.length} unknown catalog kind(s).`);
+    return;
+  }
+  pass("agent_catalog", `${agentIds.length} explicit catalog agent kind(s) are selected.`);
 }
 
 function validateEnv(name, shape, env, pass, fail) {
@@ -496,6 +540,8 @@ function parseArgs(argv) {
     ["--shard-id", "shardId"],
     ["--attempt", "attempt"],
     ["--scenarios", "scenarios"],
+    ["--agents", "agents"],
+    ["--behavior", "behavior"],
     ["--cells", "cells"],
     ["--artifact-mode", "artifactMode"],
     ["--candidate-build-map", "candidateBuildMap"],
@@ -537,8 +583,10 @@ function main() {
       kind: PREFLIGHT_KIND,
       run: { run_id: null, shard_id: null, attempt: null, source_sha: null },
       world: null,
+      behavior: null,
       selected_scenarios: [],
       selected_cells: [],
+      selected_agents: [],
       artifact_mode: null,
       candidate_build: null,
       cleanup_authorization_revision: null,

--- a/scripts/ci-cd/qualification-preflight.mjs
+++ b/scripts/ci-cd/qualification-preflight.mjs
@@ -15,6 +15,21 @@ export const PREFLIGHT_DEADLINE_MS = 120_000;
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const WORLDS = new Set(["local", "managed-cloud", "self-host", "tier4"]);
+const CORE_RELEASE_SCENARIO_IDS = new Set(
+  JSON.parse(
+    readFileSync(
+      new URL("../../specs/developing/testing/core-release-scenario-manifest.json", import.meta.url),
+      "utf8",
+    ),
+  ).requiredScenarios
+    .filter((scenario) => scenario.tier === 3)
+    .map((scenario) => scenario.id),
+);
+const LOCAL_SCENARIO_IDS = new Set([
+  ...CORE_RELEASE_SCENARIO_IDS,
+  // Provisional infrastructure proof registered beside the core scenarios.
+  "LOCAL-WORLD-SMOKE-1",
+]);
 const LOCAL_AGENT_KINDS = new Set(
   JSON.parse(
     readFileSync(new URL("../../catalogs/agents/catalog.json", import.meta.url), "utf8"),
@@ -175,6 +190,7 @@ export function runQualificationPreflight(options, deps = {}) {
     ? parseSelector(options.agents ?? "", "agent_selection", fail)
     : null;
   if (options.world === "local") {
+    validateLocalScenarioSelection(scenarioIds, pass, fail);
     validateLocalAgentSelection(agentIds, pass, fail);
   }
   const requirements = WORLD_REQUIREMENTS[options.world] ?? [];
@@ -342,6 +358,22 @@ function validateLocalAgentSelection(agentIds, pass, fail) {
     return;
   }
   pass("agent_catalog", `${agentIds.length} explicit catalog agent kind(s) are selected.`);
+}
+
+function validateLocalScenarioSelection(scenarioIds, pass, fail) {
+  if (scenarioIds === "all") {
+    pass("scenario_catalog", `All ${LOCAL_SCENARIO_IDS.size} known Tier 3/Local infrastructure scenario ids are selectable.`);
+    return;
+  }
+  if (!Array.isArray(scenarioIds) || scenarioIds.length === 0) {
+    return;
+  }
+  const unknown = scenarioIds.filter((scenario) => !LOCAL_SCENARIO_IDS.has(scenario));
+  if (unknown.length > 0) {
+    fail("scenario_catalog", `Scenario selector contains ${unknown.length} unknown machine-inventory id(s).`);
+    return;
+  }
+  pass("scenario_catalog", `${scenarioIds.length} explicit machine-inventory scenario id(s) are selected.`);
 }
 
 function validateEnv(name, shape, env, pass, fail) {

--- a/scripts/ci-cd/qualification-preflight.mjs
+++ b/scripts/ci-cd/qualification-preflight.mjs
@@ -15,21 +15,30 @@ export const PREFLIGHT_DEADLINE_MS = 120_000;
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const WORLDS = new Set(["local", "managed-cloud", "self-host", "tier4"]);
-const CORE_RELEASE_SCENARIO_IDS = new Set(
-  JSON.parse(
-    readFileSync(
-      new URL("../../specs/developing/testing/core-release-scenario-manifest.json", import.meta.url),
-      "utf8",
+const QUALIFICATION_WORLD_SCENARIOS = JSON.parse(
+  readFileSync(
+    new URL(
+      "../../tests/release/src/scenarios/qualification-world-scenarios.json",
+      import.meta.url,
     ),
-  ).requiredScenarios
-    .filter((scenario) => scenario.tier === 3)
-    .map((scenario) => scenario.id),
+    "utf8",
+  ),
 );
-const LOCAL_SCENARIO_IDS = new Set([
-  ...CORE_RELEASE_SCENARIO_IDS,
-  // Provisional infrastructure proof registered beside the core scenarios.
-  "LOCAL-WORLD-SMOKE-1",
-]);
+if (
+  QUALIFICATION_WORLD_SCENARIOS.schema_version !== 1
+  || QUALIFICATION_WORLD_SCENARIOS.kind !== "proliferate.qualification-world-scenario-inventory"
+  || QUALIFICATION_WORLD_SCENARIOS.worlds?.local?.runtime_lane !== "local"
+  || !Array.isArray(QUALIFICATION_WORLD_SCENARIOS.worlds.local.scenario_ids)
+  || QUALIFICATION_WORLD_SCENARIOS.worlds.local.scenario_ids.length === 0
+  || QUALIFICATION_WORLD_SCENARIOS.worlds.local.scenario_ids.some(
+    (scenarioId) => typeof scenarioId !== "string" || !SAFE_ID.test(scenarioId),
+  )
+  || new Set(QUALIFICATION_WORLD_SCENARIOS.worlds.local.scenario_ids).size
+    !== QUALIFICATION_WORLD_SCENARIOS.worlds.local.scenario_ids.length
+) {
+  throw new Error("Local qualification scenario inventory is malformed.");
+}
+const LOCAL_SCENARIO_IDS = new Set(QUALIFICATION_WORLD_SCENARIOS.worlds.local.scenario_ids);
 const LOCAL_AGENT_KINDS = new Set(
   JSON.parse(
     readFileSync(new URL("../../catalogs/agents/catalog.json", import.meta.url), "utf8"),
@@ -362,7 +371,7 @@ function validateLocalAgentSelection(agentIds, pass, fail) {
 
 function validateLocalScenarioSelection(scenarioIds, pass, fail) {
   if (scenarioIds === "all") {
-    pass("scenario_catalog", `All ${LOCAL_SCENARIO_IDS.size} known Tier 3/Local infrastructure scenario ids are selectable.`);
+    pass("scenario_catalog", `All ${LOCAL_SCENARIO_IDS.size} executable Local qualification scenario ids are selected.`);
     return;
   }
   if (!Array.isArray(scenarioIds) || scenarioIds.length === 0) {
@@ -370,10 +379,10 @@ function validateLocalScenarioSelection(scenarioIds, pass, fail) {
   }
   const unknown = scenarioIds.filter((scenario) => !LOCAL_SCENARIO_IDS.has(scenario));
   if (unknown.length > 0) {
-    fail("scenario_catalog", `Scenario selector contains ${unknown.length} unknown machine-inventory id(s).`);
+    fail("scenario_catalog", `Scenario selector contains ${unknown.length} id(s) outside the executable Local qualification inventory.`);
     return;
   }
-  pass("scenario_catalog", `${scenarioIds.length} explicit machine-inventory scenario id(s) are selected.`);
+  pass("scenario_catalog", `${scenarioIds.length} explicit executable Local qualification scenario id(s) are selected.`);
 }
 
 function validateEnv(name, shape, env, pass, fail) {

--- a/scripts/ci-cd/qualification-preflight.test.mjs
+++ b/scripts/ci-cd/qualification-preflight.test.mjs
@@ -26,6 +26,15 @@ const LOCAL_ENV = {
   AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "https://gateway.qualification.invalid",
   AGENT_GATEWAY_LITELLM_MASTER_KEY: "super-secret-master-value",
 };
+const FULL_LOCAL_ENV = {
+  ...LOCAL_ENV,
+  RELEASE_E2E_BYOK_ANTHROPIC_A_API_KEY: "anthropic-a-secret",
+  RELEASE_E2E_BYOK_ANTHROPIC_B_API_KEY: "anthropic-b-secret",
+  RELEASE_E2E_BYOK_OPENAI_API_KEY: "openai-secret",
+  RELEASE_E2E_BYOK_XAI_API_KEY: "xai-secret",
+  RELEASE_E2E_INTEGRATION_NAMESPACE: "exa",
+  RELEASE_E2E_INTEGRATION_API_KEY: "integration-secret",
+};
 const TEST_TLS_MATERIAL = JSON.parse(
   readFileSync(
     new URL("../../tests/release/fixtures/qualification-tls-test-material.json", import.meta.url),
@@ -107,31 +116,59 @@ test("strict local preflight rejects missing, malformed, and unknown selectors b
   }
 });
 
-test("the preflight command rejects an unknown Local scenario before install/build/provider seams", () => {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-unknown-local-"));
-  try {
-    const output = path.join(dir, "qualification-preflight.json");
-    const result = spawnSync(
-      process.execPath,
-      [
-        fileURLToPath(new URL("./qualification-preflight.mjs", import.meta.url)),
-        "--world", "local",
-        "--source-sha", SHA,
-        "--run-id", "ql-unknown",
-        "--shard-id", "1",
-        "--attempt", "1",
-        "--scenarios", "T3-NOT-REAL",
-        "--agents", "claude",
-        "--behavior", "strict",
-        "--artifact-mode", "build",
-        "--output", output,
-      ],
-      { encoding: "utf8", env: { ...process.env, ...LOCAL_ENV } },
-    );
-    assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
-    const receipt = JSON.parse(readFileSync(output, "utf8"));
+test("strict local preflight accepts every executable Local scenario and the all selector", () => {
+  const executable = [
+    "LOCAL-WORLD-SMOKE-1",
+    "T3-WT-1",
+    "T3-REPO-1",
+    "T3-CHAT-1",
+    "T3-AUTHROUTE-1",
+    "T3-CFG-1",
+    "T3-SESSION-1",
+    "T3-INT-1",
+  ];
+  for (const scenarios of [...executable, "all"]) {
+    const receipt = runQualificationPreflight({ ...BASE, scenarios }, { env: FULL_LOCAL_ENV });
+    assert.equal(receipt.verdict, "passed", `${scenarios}: ${JSON.stringify(receipt.checks)}`);
+    assert.ok(receipt.checks.some((check) => check.id === "scenario_catalog" && check.status === "passed"));
+  }
+});
+
+test("strict local preflight rejects manifest-known deferred and non-Local selectors before spend", () => {
+  for (const scenarios of ["T3-AUTH-1", "T3-MOBILITY-1", "T3-SH-2"]) {
+    const receipt = runQualificationPreflight({ ...BASE, scenarios }, { env: FULL_LOCAL_ENV });
     assert.equal(receipt.verdict, "failed");
     assert.ok(receipt.checks.some((check) => check.id === "scenario_catalog" && check.status === "failed"));
+  }
+});
+
+test("the preflight command rejects out-of-inventory Local scenarios before install/build/provider seams", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-unknown-local-"));
+  try {
+    for (const scenario of ["T3-AUTH-1", "T3-MOBILITY-1", "T3-SH-2", "T3-NOT-REAL"]) {
+      const output = path.join(dir, `${scenario}.json`);
+      const result = spawnSync(
+        process.execPath,
+        [
+          fileURLToPath(new URL("./qualification-preflight.mjs", import.meta.url)),
+          "--world", "local",
+          "--source-sha", SHA,
+          "--run-id", "ql-unknown",
+          "--shard-id", "1",
+          "--attempt", "1",
+          "--scenarios", scenario,
+          "--agents", "claude",
+          "--behavior", "strict",
+          "--artifact-mode", "build",
+          "--output", output,
+        ],
+        { encoding: "utf8", env: { ...process.env, ...FULL_LOCAL_ENV } },
+      );
+      assert.equal(result.status, 2, `${scenario}: ${result.stdout}\n${result.stderr}`);
+      const receipt = JSON.parse(readFileSync(output, "utf8"));
+      assert.equal(receipt.verdict, "failed");
+      assert.ok(receipt.checks.some((check) => check.id === "scenario_catalog" && check.status === "failed"));
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/ci-cd/qualification-preflight.test.mjs
+++ b/scripts/ci-cd/qualification-preflight.test.mjs
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { assembleCandidateBuildMapFromArtifacts } from "./assemble-candidate-build-map.mjs";
 import { PREFLIGHT_DEADLINE_MS, runQualificationPreflight, writePreflightReceipt } from "./qualification-preflight.mjs";
@@ -94,6 +95,8 @@ test("strict local preflight rejects missing, malformed, and unknown selectors b
   const invalid = [
     [{ ...BASE, agents: undefined }, "agent_selection"],
     [{ ...BASE, scenarios: undefined }, "scenario_selection"],
+    [{ ...BASE, scenarios: "T3-CHAT-1,T3-CHAT-1" }, "scenario_selection"],
+    [{ ...BASE, scenarios: "T3-CHAT-1,not valid!" }, "scenario_selection"],
     [{ ...BASE, agents: "claude,claude" }, "agent_selection"],
     [{ ...BASE, agents: "claude,not-a-shipped-agent" }, "agent_catalog"],
   ];
@@ -101,6 +104,36 @@ test("strict local preflight rejects missing, malformed, and unknown selectors b
     const receipt = runQualificationPreflight(options, { env: LOCAL_ENV });
     assert.equal(receipt.verdict, "failed");
     assert.ok(receipt.checks.some((check) => check.id === failedCheckId && check.status === "failed"));
+  }
+});
+
+test("the preflight command rejects an unknown Local scenario before install/build/provider seams", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-preflight-unknown-local-"));
+  try {
+    const output = path.join(dir, "qualification-preflight.json");
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("./qualification-preflight.mjs", import.meta.url)),
+        "--world", "local",
+        "--source-sha", SHA,
+        "--run-id", "ql-unknown",
+        "--shard-id", "1",
+        "--attempt", "1",
+        "--scenarios", "T3-NOT-REAL",
+        "--agents", "claude",
+        "--behavior", "strict",
+        "--artifact-mode", "build",
+        "--output", output,
+      ],
+      { encoding: "utf8", env: { ...process.env, ...LOCAL_ENV } },
+    );
+    assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
+    const receipt = JSON.parse(readFileSync(output, "utf8"));
+    assert.equal(receipt.verdict, "failed");
+    assert.ok(receipt.checks.some((check) => check.id === "scenario_catalog" && check.status === "failed"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/scripts/ci-cd/qualification-preflight.test.mjs
+++ b/scripts/ci-cd/qualification-preflight.test.mjs
@@ -16,6 +16,8 @@ const BASE = {
   shardId: "1",
   attempt: 1,
   scenarios: "LOCAL-WORLD-SMOKE-1",
+  agents: "claude",
+  behavior: "strict",
   artifactMode: "build",
 };
 const LOCAL_ENV = {
@@ -60,6 +62,45 @@ test("secret values never enter passed or failed machine-readable evidence", () 
     const serialized = JSON.stringify(receipt);
     assert.doesNotMatch(serialized, /super-secret-master-value/);
     assert.doesNotMatch(serialized, /super-secret-url/);
+  }
+});
+
+test("strict local preflight binds an explicit four-agent selector before spend", () => {
+  const receipt = runQualificationPreflight(
+    {
+      ...BASE,
+      scenarios: "T3-CHAT-1,T3-CFG-1,T3-INT-1",
+      agents: "claude,codex,grok,opencode",
+    },
+    {
+      env: {
+        ...LOCAL_ENV,
+        RELEASE_E2E_INTEGRATION_NAMESPACE: "exa",
+        RELEASE_E2E_INTEGRATION_API_KEY: "integration-secret",
+      },
+    },
+  );
+  assert.equal(receipt.verdict, "passed");
+  assert.equal(receipt.behavior, "strict");
+  assert.deepEqual(receipt.selected_agents, ["claude", "codex", "grok", "opencode"]);
+  assert.ok(
+    receipt.checks.some(
+      (check) => check.id === "agent_catalog" && check.status === "passed" && /4 explicit/.test(check.message),
+    ),
+  );
+});
+
+test("strict local preflight rejects missing, malformed, and unknown selectors before spend", () => {
+  const invalid = [
+    [{ ...BASE, agents: undefined }, "agent_selection"],
+    [{ ...BASE, scenarios: undefined }, "scenario_selection"],
+    [{ ...BASE, agents: "claude,claude" }, "agent_selection"],
+    [{ ...BASE, agents: "claude,not-a-shipped-agent" }, "agent_catalog"],
+  ];
+  for (const [options, failedCheckId] of invalid) {
+    const receipt = runQualificationPreflight(options, { env: LOCAL_ENV });
+    assert.equal(receipt.verdict, "failed");
+    assert.ok(receipt.checks.some((check) => check.id === failedCheckId && check.status === "failed"));
   }
 });
 

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -193,6 +193,11 @@ Current execution reliability is deliberately bounded:
   bounded remote-default-branch identity lookup. It writes a redacted
   machine-readable receipt and exits `2` on failure. It does not authenticate
   to product providers or prove reachability.
+- The Local preflight and runner both consume
+  `tests/release/src/scenarios/qualification-world-scenarios.json` as the
+  machine-owned executable world inventory. The broader
+  `core-release-scenario-manifest.json` is a target-guarantee inventory and is
+  not an executable selector allowlist.
 - Managed-cloud preflight validates only the GitHub App inputs the current
   candidate-world constructor actually consumes. The complete six-field Server
   gate (including webhook secret instead of the current hard-coded/partial

--- a/specs/developing/testing/README.md
+++ b/specs/developing/testing/README.md
@@ -185,8 +185,9 @@ Current execution reliability is deliberately bounded:
 - `qualification-preflight.mjs` runs before dependency installation, candidate
   builds, or provider mutation in the current local, managed-cloud, self-host,
   and Tier-4 artifact-chain entrypoints. It checks required world/scenario
-  inputs and the deterministic prerequisites of an explicitly selected
-  self-host cell,
+  inputs, binds the manual local world's typed behavior and catalog agent
+  selectors into its receipt, and checks the deterministic prerequisites of an
+  explicitly selected self-host cell,
   complete supported AWS credential postures, exact candidate-map hashes on a
   reuse request, and cleanup authorization using local operations plus one
   bounded remote-default-branch identity lookup. It writes a redacted

--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -700,7 +700,12 @@ and reachability are world-readiness checks.
 The current shared preflight is `scripts/ci-cd/qualification-preflight.mjs`.
 Its receipt records names/statuses, exact run/source identity, safe candidate
 artifact identities and digests when a local map is reused, and the trusted
-cleanup revision; it never records environment values or locator paths. Artifact
+cleanup revision; for the manual local world it also records the validated
+strict/diagnostic behavior and the exact catalog agent selector before any
+installation, build, or provider-spend seam. A strict local run fails preflight
+when its scenario or agent selector is missing, empty, duplicated, malformed, or
+names an unshipped agent kind. The receipt never records environment values or
+locator paths. Artifact
 mode `external` is accepted only for read-only Tier 4 validation: it records a
 null candidate build and explicitly delegates published-CDN/git artifact
 identity and availability checks to the selected scenario, without claiming a

--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -704,7 +704,11 @@ cleanup revision; for the manual local world it also records the validated
 strict/diagnostic behavior and the exact catalog agent selector before any
 installation, build, or provider-spend seam. A strict local run fails preflight
 when its scenario or agent selector is missing, empty, duplicated, malformed, or
-names an unshipped agent kind. The receipt never records environment values or
+names an unshipped agent kind. Local preflight and executor selection share
+`tests/release/src/scenarios/qualification-world-scenarios.json`; this bounded
+inventory names only executable Local-world scenarios, while
+`core-release-scenario-manifest.json` remains the broader target-guarantee
+inventory. The receipt never records environment values or
 locator paths. Artifact
 mode `external` is accepted only for read-only Tier 4 validation: it records a
 null candidate build and explicitly delegates published-CDN/git artifact

--- a/tests/release/src/cli/args.test.ts
+++ b/tests/release/src/cli/args.test.ts
@@ -80,6 +80,18 @@ test("--only remains an alias for --scenarios", () => {
   assert.deepEqual(args.scenarios, ["T3-WT-1"]);
 });
 
+test("--qualification-world accepts only the executable Local world scope", () => {
+  assert.equal(
+    parseArgs(["--behavior", "diagnostic", "--qualification-world", "local"]).qualificationWorld,
+    "local",
+  );
+  assert.equal(parseArgs(["--behavior", "diagnostic"]).qualificationWorld, undefined);
+  assert.throws(
+    () => parseArgs(["--behavior", "diagnostic", "--qualification-world", "self-host"]),
+    CliUsageError,
+  );
+});
+
 test("--cells parses a matrix-cell filter and defaults to all", () => {
   assert.equal(parseArgs(["--behavior", "diagnostic"]).cells, "all");
   assert.deepEqual(

--- a/tests/release/src/cli/args.ts
+++ b/tests/release/src/cli/args.ts
@@ -1,4 +1,11 @@
-import { parseDesktopMode, parseTargetLane, type DesktopMode, type TargetLane } from "../config/types.js";
+import {
+  parseDesktopMode,
+  parseQualificationWorld,
+  parseTargetLane,
+  type DesktopMode,
+  type QualificationWorld,
+  type TargetLane,
+} from "../config/types.js";
 import type { ResultBehavior } from "../runner/result.js";
 
 export interface CliArgs {
@@ -6,6 +13,8 @@ export interface CliArgs {
   desktop: DesktopMode;
   agents: string[] | "all";
   scenarios: string[] | "all";
+  /** Bound the selector to one shipped qualification world's executable inventory. */
+  qualificationWorld?: QualificationWorld;
   /**
    * Optional matrix-cell filter: keep only planned cells whose `cell` dimension
    * is in this list (e.g. `SH-GATEWAY`). Leaf (non-matrix) scenarios are
@@ -90,6 +99,10 @@ export function parseArgs(argv: readonly string[]): CliArgs {
         // --only is sugar for --scenarios (per the tier-3 build task: "runner
         // should support --only <id>"); both set the same field.
         args.scenarios = parseListFlag(arg, requireValue(argv, i, arg));
+        i += 1;
+        break;
+      case "--qualification-world":
+        args.qualificationWorld = wrapUsage(() => parseQualificationWorld(requireValue(argv, i, arg)));
         i += 1;
         break;
       case "--cells":
@@ -223,6 +236,7 @@ Flags:
   --desktop <web|native>     Desktop lane to drive (default: web)
   --agents <list|all>        Comma-separated harness kinds, or "all" (default: all)
   --scenarios <list|all>     Comma-separated scenario ids, or "all" (default: all)
+  --qualification-world <local>  Bound selection to the shipped executable inventory for that world
   --only <id>                Alias for --scenarios with a single id (e.g. --only T3-WT-1)
   --cells <list|all>         Narrow MATRIX cells to those whose 'cell' dimension is listed (e.g. SH-GATEWAY);
                              leaf (non-matrix) cells of a selected scenario are always kept; "all" = no filter (default: all)

--- a/tests/release/src/cli/command.test.ts
+++ b/tests/release/src/cli/command.test.ts
@@ -157,6 +157,31 @@ test("a valid supplied map is loaded after selection and before any setup side e
   assert.deepEqual(calls, ["identity", "select", "loadBuildMap", "loadLocalWorldPorts", "seed", "gateway", "envManifest", "execute", "write"]);
 });
 
+test("qualification-world scope reaches selection before any setup side effect", async () => {
+  const { deps, calls } = makeDeps();
+  let seenSelector: readonly string[] | "all" | undefined;
+  let seenWorld: string | undefined;
+  deps.selectScenarios = (selector, qualificationWorld) => {
+    calls.push("select");
+    seenSelector = selector;
+    seenWorld = qualificationWorld;
+    return [SCENARIO];
+  };
+  const exit = await runReleaseCommand(
+    [
+      "--behavior", "diagnostic",
+      "--qualification-world", "local",
+      "--scenarios", "T3-WT-1",
+      "--dry-run",
+    ],
+    deps,
+  );
+  assert.equal(exit, 0);
+  assert.deepEqual(seenSelector, ["T3-WT-1"]);
+  assert.equal(seenWorld, "local");
+  assert.deepEqual(calls.slice(0, 2), ["identity", "select"]);
+});
+
 test("an invalid supplied map exits 2 with zero setup, execution, or report side effects", async () => {
   const { deps, calls } = makeDeps();
   deps.loadBuildMap = async () => {

--- a/tests/release/src/cli/command.ts
+++ b/tests/release/src/cli/command.ts
@@ -19,6 +19,7 @@ import {
   type CandidateBuildMapV1,
 } from "../artifacts/build-map.js";
 import type { FinalCellResultV2, TestRunReportV3, TestRunReportV4 } from "../evidence/schema.js";
+import type { QualificationWorld } from "../config/types.js";
 
 /**
  * Testable command orchestration
@@ -35,7 +36,10 @@ export interface CommandDeps {
     shardId?: string;
     attempt?: number;
   }) => Promise<RunIdentityV1>;
-  selectScenarios: (selector: readonly string[] | "all") => ScenarioDefinition[];
+  selectScenarios: (
+    selector: readonly string[] | "all",
+    qualificationWorld?: QualificationWorld,
+  ) => ScenarioDefinition[];
   loadBuildMap: (path: string, expectedSourceSha: string) => Promise<CandidateBuildMapV1>;
   /**
    * Loads the `local-world-ports.json` sidecar the candidate builder wrote into
@@ -94,7 +98,7 @@ export async function runReleaseCommand(argv: readonly string[], deps: CommandDe
 
   let scenarios: ScenarioDefinition[];
   try {
-    scenarios = deps.selectScenarios(args.scenarios);
+    scenarios = deps.selectScenarios(args.scenarios, args.qualificationWorld);
     if (scenarios.length === 0) {
       throw new SelectionError("Selection resolved to zero scenarios.");
     }

--- a/tests/release/src/config/types.ts
+++ b/tests/release/src/config/types.ts
@@ -39,6 +39,14 @@ export type TargetLane = "local" | "staging" | "cloud" | "selfhost";
  */
 export type RuntimeLane = "local" | "sandbox" | "selfhost";
 
+/**
+ * A shipped qualification entrypoint's bounded executable scenario inventory.
+ * This is deliberately separate from both target and runtime lanes: other
+ * release targets also use `--lane local`, but must not inherit the Local
+ * qualification world's allowlist.
+ */
+export type QualificationWorld = "local";
+
 export const ALL_RUNTIME_LANES: readonly RuntimeLane[] = ["local", "sandbox", "selfhost"];
 
 export type DesktopMode = "web" | "native";
@@ -55,4 +63,11 @@ export function parseDesktopMode(value: string): DesktopMode {
     return value;
   }
   throw new Error(`--desktop must be "web" or "native", got "${value}"`);
+}
+
+export function parseQualificationWorld(value: string): QualificationWorld {
+  if (value === "local") {
+    return value;
+  }
+  throw new Error(`--qualification-world must be "local", got "${value}"`);
 }

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -87,6 +87,20 @@ test("the manual local world builds and publishes once, then reuses exact candid
   assert.doesNotMatch(release, /^  release-e2e-local-world-smoke:/m);
 });
 
+test("the manual local world preserves the typed agent selector through preflight and execution", () => {
+  const local = job(release, "release-e2e-local-functional");
+  const preflight = local.slice(0, local.indexOf("pnpm/action-setup"));
+  const execution = local.slice(local.indexOf("Build once, run the smoke"));
+
+  assert.match(preflight, /AGENTS_INPUT: \$\{\{ inputs\.agents \}\}/);
+  assert.match(preflight, /--agents "\$\{AGENTS_INPUT\}"/);
+  assert.match(preflight, /BEHAVIOR_INPUT: \$\{\{ inputs\.local_functional_behavior \}\}/);
+  assert.match(preflight, /--behavior "\$\{BEHAVIOR_INPUT\}"/);
+  assert.match(execution, /AGENTS: \$\{\{ inputs\.agents \}\}/);
+  assert.match(execution, /BEHAVIOR: \$\{\{ inputs\.local_functional_behavior \}\}/);
+  assert.doesNotMatch(local, /github\.event\.inputs\.agents \|\|/);
+});
+
 test("the manual local world reuses candidates only after a clean smoke exit", () => {
   const local = job(release, "release-e2e-local-functional");
   const smoke = local.indexOf("make qualification-local-workspace");

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
@@ -21,6 +22,18 @@ function job(source: string, id: string): string {
   const nextJob = /^  [a-zA-Z0-9_-]+:\s*$/m.exec(remainder);
   const end = nextJob?.index === undefined ? undefined : start + id.length + 3 + nextJob.index;
   return source.slice(start, end);
+}
+
+function makeTarget(name: string): string {
+  const startMatch = new RegExp(`^${name}:\\s*$`, "m").exec(makefile);
+  assert.ok(startMatch?.index !== undefined, `missing Make target ${name}`);
+  const start = startMatch.index;
+  const remainder = makefile.slice(start + startMatch[0].length);
+  const nextTarget = /^[-A-Za-z0-9_.]+:\s*$/m.exec(remainder);
+  const end = nextTarget?.index === undefined
+    ? undefined
+    : start + startMatch[0].length + nextTarget.index;
+  return makefile.slice(start, end);
 }
 
 test("release qualification has stable independent concurrency groups by world", () => {
@@ -99,6 +112,88 @@ test("the manual local world preserves the typed agent selector through prefligh
   assert.match(execution, /AGENTS: \$\{\{ inputs\.agents \}\}/);
   assert.match(execution, /BEHAVIOR: \$\{\{ inputs\.local_functional_behavior \}\}/);
   assert.doesNotMatch(local, /github\.event\.inputs\.agents \|\|/);
+});
+
+test("the real Local Make entrypoints pass matching selectors through their mandatory preflights", () => {
+  const smokeTarget = makeTarget("qualification-local-workspace");
+  const functionalTarget = makeTarget("qualification-local-functional");
+  assert.equal((smokeTarget.match(/--agents claude --behavior "\$\(BEHAVIOR\)"/g) ?? []).length, 2);
+  assert.equal((functionalTarget.match(/--agents "\$\(AGENTS\)" --behavior "\$\(BEHAVIOR\)"/g) ?? []).length, 2);
+
+  const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-local-make-selectors-"));
+  try {
+    const nodeShim = path.join(dir, "node");
+    const pnpmShim = path.join(dir, "pnpm");
+    writeFileSync(
+      nodeShim,
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "scripts/ci-cd/build-local-qualification-candidates.mjs" ]; then',
+        "  printf '%s\\n' '{\"candidate_build_map\":\"/tmp/fake-local-candidate-build.json\"}'",
+        "  exit 0",
+        "fi",
+        'exec "$REAL_NODE" "$@"',
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(pnpmShim, "#!/bin/sh\nexit 0\n");
+    chmodSync(nodeShim, 0o755);
+    chmodSync(pnpmShim, 0o755);
+
+    const baseDir = path.join(dir, "output");
+    const env = {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH ?? ""}`,
+      REAL_NODE: process.execPath,
+      GITHUB_ACTIONS: "true",
+      AGENT_GATEWAY_LITELLM_BASE_URL: "https://admin.qualification.invalid",
+      AGENT_GATEWAY_LITELLM_PUBLIC_BASE_URL: "https://gateway.qualification.invalid",
+      AGENT_GATEWAY_LITELLM_MASTER_KEY: "test-master-secret",
+      RELEASE_E2E_INTEGRATION_NAMESPACE: "exa",
+      RELEASE_E2E_INTEGRATION_API_KEY: "test-integration-secret",
+    };
+    const smoke = spawnSync(
+      "make",
+      [
+        "qualification-local-workspace",
+        "PROFILE=selector-smoke",
+        "BEHAVIOR=strict",
+        `QUALIFICATION_LOCAL_WORLD_BASE_DIR=${baseDir}`,
+      ],
+      { cwd: REPO_ROOT, encoding: "utf8", env },
+    );
+    assert.equal(smoke.status, 0, `${smoke.stdout}\n${smoke.stderr}`);
+    const smokeReceipt = JSON.parse(
+      readFileSync(path.join(baseDir, "ql-selector-smoke", "1", "preflight", "qualification-preflight.json"), "utf8"),
+    );
+    assert.equal(smokeReceipt.verdict, "passed");
+    assert.equal(smokeReceipt.behavior, "strict");
+    assert.deepEqual(smokeReceipt.selected_scenarios, ["LOCAL-WORLD-SMOKE-1"]);
+    assert.deepEqual(smokeReceipt.selected_agents, ["claude"]);
+
+    const functional = spawnSync(
+      "make",
+      [
+        "qualification-local-functional",
+        "PROFILE=selector-functional",
+        "BEHAVIOR=strict",
+        "AGENTS=claude,codex,grok,opencode",
+        "SCENARIOS=T3-CHAT-1,T3-CFG-1,T3-INT-1",
+        `QUALIFICATION_LOCAL_WORLD_BASE_DIR=${baseDir}`,
+      ],
+      { cwd: REPO_ROOT, encoding: "utf8", env },
+    );
+    assert.equal(functional.status, 0, `${functional.stdout}\n${functional.stderr}`);
+    const functionalReceipt = JSON.parse(
+      readFileSync(path.join(baseDir, "qlf-selector-functional", "1", "preflight", "qualification-preflight.json"), "utf8"),
+    );
+    assert.equal(functionalReceipt.verdict, "passed");
+    assert.equal(functionalReceipt.behavior, "strict");
+    assert.deepEqual(functionalReceipt.selected_scenarios, ["T3-CFG-1", "T3-CHAT-1", "T3-INT-1"]);
+    assert.deepEqual(functionalReceipt.selected_agents, ["claude", "codex", "grok", "opencode"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("the manual local world reuses candidates only after a clean smoke exit", () => {

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -119,6 +119,8 @@ test("the real Local Make entrypoints pass matching selectors through their mand
   const functionalTarget = makeTarget("qualification-local-functional");
   assert.equal((smokeTarget.match(/--agents claude --behavior "\$\(BEHAVIOR\)"/g) ?? []).length, 2);
   assert.equal((functionalTarget.match(/--agents "\$\(AGENTS\)" --behavior "\$\(BEHAVIOR\)"/g) ?? []).length, 2);
+  assert.equal((smokeTarget.match(/--qualification-world local/g) ?? []).length, 1);
+  assert.equal((functionalTarget.match(/--qualification-world local/g) ?? []).length, 1);
 
   const dir = mkdtempSync(path.join(os.tmpdir(), "qualification-local-make-selectors-"));
   try {

--- a/tests/release/src/scenarios/qualification-world-scenarios.json
+++ b/tests/release/src/scenarios/qualification-world-scenarios.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "kind": "proliferate.qualification-world-scenario-inventory",
+  "worlds": {
+    "local": {
+      "runtime_lane": "local",
+      "scenario_ids": [
+        "LOCAL-WORLD-SMOKE-1",
+        "T3-WT-1",
+        "T3-REPO-1",
+        "T3-CHAT-1",
+        "T3-AUTHROUTE-1",
+        "T3-CFG-1",
+        "T3-SESSION-1",
+        "T3-INT-1"
+      ]
+    }
+  }
+}

--- a/tests/release/src/scenarios/qualification-world-scenarios.test.ts
+++ b/tests/release/src/scenarios/qualification-world-scenarios.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { qualificationWorldScenarioIds, selectScenarios } from "./registry.js";
+
+const LOCAL_EXECUTABLE_SCENARIOS = [
+  "LOCAL-WORLD-SMOKE-1",
+  "T3-WT-1",
+  "T3-REPO-1",
+  "T3-CHAT-1",
+  "T3-AUTHROUTE-1",
+  "T3-CFG-1",
+  "T3-SESSION-1",
+  "T3-INT-1",
+] as const;
+
+test("the Local qualification world inventory selects every and only executable scenarios", () => {
+  assert.deepEqual(qualificationWorldScenarioIds("local"), LOCAL_EXECUTABLE_SCENARIOS);
+  assert.deepEqual(
+    selectScenarios("all", "local").map((scenario) => scenario.id),
+    LOCAL_EXECUTABLE_SCENARIOS,
+  );
+  for (const id of LOCAL_EXECUTABLE_SCENARIOS) {
+    assert.deepEqual(selectScenarios([id], "local").map((scenario) => scenario.id), [id]);
+  }
+});
+
+test("the Local qualification world rejects manifest-known deferred and non-Local scenarios", () => {
+  assert.throws(() => selectScenarios(["T3-AUTH-1"], "local"), /Unknown scenario/);
+  assert.throws(() => selectScenarios(["T3-MOBILITY-1"], "local"), /Unknown scenario/);
+  assert.throws(() => selectScenarios(["T3-SH-2"], "local"), /not executable in qualification world/);
+});

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -1,4 +1,6 @@
 import type { ScenarioDefinition } from "./types.js";
+import type { QualificationWorld } from "../config/types.js";
+import qualificationWorldInventory from "./qualification-world-scenarios.json";
 import { t3Prov1 } from "./t3-prov-1.js";
 import { t3Prov2 } from "./t3-prov-2.js";
 import { t3Wt1 } from "./t3-wt-1.js";
@@ -87,23 +89,56 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   selfhostCfn1,
 ];
 
+interface QualificationWorldEntry {
+  runtime_lane: string;
+  scenario_ids: string[];
+}
+
+interface QualificationWorldInventory {
+  schema_version: number;
+  kind: string;
+  worlds: Record<QualificationWorld, QualificationWorldEntry>;
+}
+
+const QUALIFICATION_WORLD_INVENTORY = qualificationWorldInventory as unknown as QualificationWorldInventory;
+const SCENARIOS_BY_ID = new Map(SCENARIOS.map((scenario) => [scenario.id, scenario]));
+const QUALIFICATION_WORLD_SCENARIO_IDS = validateQualificationWorldInventory();
+
+/** Exact executable scenario ids owned by a qualification world. This is the
+ * runner-side reader for the same pre-install JSON inventory the shared
+ * qualification preflight consumes. */
+export function qualificationWorldScenarioIds(world: QualificationWorld): readonly string[] {
+  return QUALIFICATION_WORLD_SCENARIO_IDS.get(world) ?? [];
+}
+
 export function allScenarioIds(): string[] {
   return SCENARIOS.map((scenario) => scenario.id);
 }
 
-export function selectScenarios(selector: readonly string[] | "all"): ScenarioDefinition[] {
+export function selectScenarios(
+  selector: readonly string[] | "all",
+  qualificationWorld?: QualificationWorld,
+): ScenarioDefinition[] {
+  const worldIds = qualificationWorld === undefined
+    ? null
+    : qualificationWorldScenarioIds(qualificationWorld);
   if (selector === "all" || (selector.length === 1 && selector[0] === "all")) {
-    return [...SCENARIOS];
+    return worldIds === null
+      ? [...SCENARIOS]
+      : worldIds.map((id) => SCENARIOS_BY_ID.get(id)!);
   }
-  const byId = new Map(SCENARIOS.map((scenario) => [scenario.id, scenario]));
+  const allowed = worldIds === null ? null : new Set(worldIds);
   const selected: ScenarioDefinition[] = [];
   const unknown: string[] = [];
+  const outsideWorld: string[] = [];
   for (const id of selector) {
-    const scenario = byId.get(id);
-    if (scenario) {
-      selected.push(scenario);
-    } else {
+    const scenario = SCENARIOS_BY_ID.get(id);
+    if (!scenario) {
       unknown.push(id);
+    } else if (allowed !== null && !allowed.has(id)) {
+      outsideWorld.push(id);
+    } else {
+      selected.push(scenario);
     }
   }
   if (unknown.length > 0) {
@@ -111,5 +146,43 @@ export function selectScenarios(selector: readonly string[] | "all"): ScenarioDe
       `Unknown scenario id(s): ${unknown.join(", ")}. Known scenarios: ${allScenarioIds().join(", ")}`,
     );
   }
+  if (outsideWorld.length > 0) {
+    throw new Error(
+      `Scenario id(s) not executable in qualification world "${qualificationWorld}": ${outsideWorld.join(", ")}. ` +
+        `Allowed scenarios: ${worldIds!.join(", ")}`,
+    );
+  }
   return selected;
+}
+
+function validateQualificationWorldInventory(): ReadonlyMap<QualificationWorld, readonly string[]> {
+  if (
+    QUALIFICATION_WORLD_INVENTORY.schema_version !== 1
+    || QUALIFICATION_WORLD_INVENTORY.kind !== "proliferate.qualification-world-scenario-inventory"
+  ) {
+    throw new Error("Qualification-world scenario inventory has an unsupported kind or schema version.");
+  }
+  const validated = new Map<QualificationWorld, readonly string[]>();
+  for (const world of ["local"] as const) {
+    const entry = QUALIFICATION_WORLD_INVENTORY.worlds[world];
+    if (!entry || entry.runtime_lane !== "local" || !Array.isArray(entry.scenario_ids)) {
+      throw new Error(`Qualification-world scenario inventory entry "${world}" is malformed.`);
+    }
+    if (entry.scenario_ids.length === 0 || new Set(entry.scenario_ids).size !== entry.scenario_ids.length) {
+      throw new Error(`Qualification-world scenario inventory entry "${world}" is empty or duplicated.`);
+    }
+    for (const id of entry.scenario_ids) {
+      const scenario = SCENARIOS_BY_ID.get(id);
+      if (!scenario) {
+        throw new Error(`Qualification-world scenario inventory names unregistered scenario "${id}".`);
+      }
+      if (!scenario.lanes.includes("local")) {
+        throw new Error(
+          `Qualification-world scenario "${id}" does not declare runtime lane "${entry.runtime_lane}".`,
+        );
+      }
+    }
+    validated.set(world, Object.freeze([...entry.scenario_ids]));
+  }
+  return validated;
 }

--- a/tests/release/src/scenarios/t3-chat-1.test.ts
+++ b/tests/release/src/scenarios/t3-chat-1.test.ts
@@ -33,6 +33,13 @@ test("explicit --agents selection produces one cell per selected harness", async
   );
 });
 
+test("the explicit strict qualification selector expands exactly the four supported agent cells", async () => {
+  const selected = ["claude", "codex", "grok", "opencode"];
+  const specs = await chatCellSpecs(selected);
+  assert.equal(specs.length, 4);
+  assert.deepEqual(specs.map((spec) => spec.dimensions.harness), selected);
+});
+
 test("T3-CHAT-1 --agents all plans every catalog harness exactly once per lane", async () => {
   const expected = await catalogKinds();
   const cells = await buildPlannedCells([t3Chat1], { desktop: "web", agents: ["all"] });


### PR DESCRIPTION
## What changed

- pass the typed `workflow_dispatch` scenario, agent, and behavior inputs unchanged into both Local preflight and execution
- fail Local preflight on missing/malformed selectors and validate explicit agent kinds against the shipped catalog
- bind behavior and the exact selected agent selector into the redacted preflight receipt (schema v2)
- prove the explicit `claude,codex,grok,opencode` selector expands to exactly four functional cells
- document the fail-before-install/build/provider-spend contract

## Why

The Local workflow previously validated only scenarios and used fallback expressions in a different GitHub context at execution time. That left no machine-readable custody proof that the exact agent selector accepted at dispatch was the selector expanded by the runner, and malformed or missing selectors could reach later seams.

## Impact

Strict Local qualification now fails before dependency installation, candidate builds, or provider spend unless both scenario and agent selectors are valid. Explicit selector receipts are redacted and catalog-backed; normal `all` behavior remains supported.

## Verification

- `node --test scripts/ci-cd/qualification-preflight.test.mjs` (12 passed)
- `./tests/release/node_modules/.bin/tsx --test tests/release/src/runner/qualification-execution-workflow.test.ts tests/release/src/scenarios/t3-chat-1.test.ts` (23 passed)
- `pnpm --dir tests/release typecheck`
- `actionlint .github/workflows/release-e2e.yml`
- `python3 scripts/check_docs.py`
- `git diff --check`
