### PR TITLE
fix(release): fail early on missing S3 cleanup authority

### DIFF
--- a/specs/developing/testing/release-worlds-and-fixtures.md
+++ b/specs/developing/testing/release-worlds-and-fixtures.md
@@ -793,7 +793,10 @@ summary beside the parent run logs after both setup failure and normal close.
 Deleting its nested ledger is therefore not itself treated as zero-survivor
 proof: the retained receipt must independently report stack and Route53
 absence, exact S3 `HEAD` absence, bounded GHCR tag-relist absence, local-path
-removal, and zero cleanup failures.
+removal, and zero cleanup failures. Before its first S3 write, the world also
+issues a bounded, read-only `HEAD` against a reserved never-written key in the
+run prefix. Only an exact missing-object response permits provisioning to
+continue; authorization failures stay red and fail before provider mutation.
 
 GitHub Actions cancellation and job timeout are a distinct failure boundary:
 steps on the cancelled runner, including `if: always()` cleanup and artifact

--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -643,9 +643,12 @@ test("parseGhcrVersions + ghcrVersionIdForTag: finds the version whose tags incl
 
 // ── S3 upload / presign ──────────────────────────────────────────────────────
 
-test("uploadBundleAndPresign: registers bundle, runtime, and sums BEFORE each cp and returns presigned URLs", async () => {
+test("uploadBundleAndPresign: a 404 authority probe passes before registered uploads and presigned URLs", async () => {
   const log: string[] = [];
   const exec = new FakeExec((args) => {
+    if (args[0] === "s3api" && args[1] === "head-object") {
+      throw new Error("An error occurred (404) when calling HeadObject: Not Found");
+    }
     if (args[0] === "s3" && args[1] === "cp") {
       log.push(`cp:${args[3]}`);
       return "";
@@ -667,6 +670,17 @@ test("uploadBundleAndPresign: registers bundle, runtime, and sums BEFORE each cp
       log.push(`register:${kind}:${providerId}`);
     },
   });
+  assert.deepEqual(exec.calls[0], [
+    "s3api",
+    "head-object",
+    "--bucket",
+    "bkt",
+    "--key",
+    "qualification/run-1/shard-0/.proliferate-exact-absence-authority-probe",
+    "--region",
+    "us-east-1",
+  ]);
+  assert.equal(exec.callOptions[0]?.timeoutMs, 30_000);
   // Registered-before-create: each s3_object intent precedes its cp.
   const bundleReg = log.indexOf("register:s3_object:s3://bkt/qualification/run-1/shard-0/proliferate-deploy.tar.gz");
   const bundleCp = log.indexOf("cp:s3://bkt/qualification/run-1/shard-0/proliferate-deploy.tar.gz");
@@ -685,6 +699,43 @@ test("uploadBundleAndPresign: registers bundle, runtime, and sums BEFORE each cp
     result.runtimeKey,
     "qualification/run-1/shard-0/anyharness-aarch64-unknown-linux-musl.tar.gz",
   );
+});
+
+test("uploadBundleAndPresign: a 403 authority probe fails before cleanup registration or S3 mutation", async () => {
+  const providerDetail =
+    "An error occurred (403) when calling the HeadObject operation: Forbidden request-id=secret-provider-detail";
+  const exec = new FakeExec(() => {
+    throw new Error(providerDetail);
+  });
+  let registrations = 0;
+
+  await assert.rejects(
+    uploadBundleAndPresign({
+      exec,
+      region: "us-east-1",
+      bucket: "bkt",
+      keyPrefix: "qualification/run-1/shard-0/",
+      bundlePath: "/tmp/proliferate-deploy.tar.gz",
+      runtimePath: "/tmp/anyharness-aarch64-unknown-linux-musl.tar.gz",
+      sumsPath: "/tmp/self-hosted-assets.SHA256SUMS",
+      registerCleanup: async () => {
+        registrations += 1;
+      },
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(
+        error.message,
+        "CFN readiness: S3 exact-absence authority is unproven; refusing provider mutation.",
+      );
+      assert.doesNotMatch(error.message, /AccessDenied|request-id|secret-provider-detail/);
+      return true;
+    },
+  );
+  assert.equal(registrations, 0);
+  assert.equal(exec.calls.length, 1);
+  assert.deepEqual(exec.calls[0]?.slice(0, 2), ["s3api", "head-object"]);
+  assert.equal(exec.calls.some((args) => args[0] === "s3" && args[1] === "cp"), false);
 });
 
 test("deleteS3Object: requires an exact post-delete absence observation", async () => {

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -83,6 +83,8 @@ export const STACK_WAIT_TIMEOUT_MS = 30 * 60_000;
 export const CFN_CANCELLATION_CALL_TIMEOUT_MS = 5_000;
 /** Individual ordinary cleanup delete/observer calls must also remain bounded. */
 const CFN_CLEANUP_PROVIDER_CALL_TIMEOUT_MS = 30_000;
+/** Reserved, never-written key used to prove exact missing-object observations before upload. */
+const S3_ABSENCE_AUTHORITY_PROBE_BASENAME = ".proliferate-exact-absence-authority-probe";
 /** Stack submission and failure-tail calls stay inside the 25s signal bridge. */
 const CFN_STACK_CONTROL_CALL_TIMEOUT_MS = 10_000;
 /** Bounded describe-stack-events tail on a create failure. */
@@ -1025,6 +1027,13 @@ export async function uploadBundleAndPresign(input: {
   const runtimeKey = `${keyPrefix}${CFN_RUNTIME_ARCHIVE_NAME}`;
   const sumsKey = `${keyPrefix}self-hosted-assets.SHA256SUMS`;
 
+  // Cleanup can be accepted only when a missing object produces an exact 404.
+  // Probe a reserved key that this controller never writes before registering
+  // cleanup custody or attempting the first S3 mutation. In particular, S3
+  // returns 403 for a missing key when the caller lacks bucket ListBucket
+  // authority; treating that as absence would create false-green evidence.
+  await assertS3ExactAbsenceAuthority(exec, region, bucket, keyPrefix);
+
   await input.registerCleanup("s3_object", `s3://${bucket}/${bundleKey}`, () =>
     deleteS3Object(exec, region, bucket, bundleKey),
   );
@@ -1062,6 +1071,33 @@ export async function uploadBundleAndPresign(input: {
     throw new Error("CFN: aws s3 presign returned an empty URL.");
   }
   return { deployBundleUrl, deployBundleChecksumUrl, runtimeBinaryUrl, runtimeKey, bundleKey, sumsKey };
+}
+
+/**
+ * Proves the caller can distinguish a missing object from an authorization
+ * failure. The reserved probe key is read-only and is never created by this
+ * controller. Provider payloads are deliberately excluded from the stable
+ * failure because CLI errors can contain account or request details.
+ */
+async function assertS3ExactAbsenceAuthority(
+  exec: CfnAwsExec,
+  region: string,
+  bucket: string,
+  keyPrefix: string,
+): Promise<void> {
+  const probeKey = `${keyPrefix}${S3_ABSENCE_AUTHORITY_PROBE_BASENAME}`;
+  try {
+    await exec.run(
+      ["s3api", "head-object", "--bucket", bucket, "--key", probeKey, "--region", region],
+      { timeoutMs: CFN_CLEANUP_PROVIDER_CALL_TIMEOUT_MS },
+    );
+  } catch (error) {
+    if (s3ObjectAbsentError(error)) {
+      return;
+    }
+    throw new Error("CFN readiness: S3 exact-absence authority is unproven; refusing provider mutation.");
+  }
+  throw new Error("CFN readiness: S3 exact-absence authority is unproven; refusing provider mutation.");
 }
 
 /** Deletes one S3 object and succeeds only after an exact HEAD observes absence. */


### PR DESCRIPTION
## Summary

- probe a reserved, never-written run-scoped S3 key with a bounded read-only `HEAD` before cleanup registration or the first upload
- permit provisioning only when the probe observes exact `404 Not Found`; collapse every other provider response into one stable, sanitized failure
- preserve the existing fail-closed post-delete `HEAD` proof and document the readiness contract

## Root cause

The self-host CFN qualification role can upload and delete run artifacts but cannot distinguish a missing object from denied access. Amazon S3 returns 403 for a missing object when the caller lacks `s3:ListBucket`, so run cleanup correctly stayed red even though independent provider inspection found no surviving objects. The old path discovered this only after provisioning and teardown.

## Required qualification IAM follow-up (not changed here)

Add only `s3:ListBucket` on `arn:aws:s3:::proliferate-qualification-artifacts`, constrained by `StringLike` `s3:prefix` = `qualification/*`. Existing `s3:GetObject` authority on `arn:aws:s3:::proliferate-qualification-artifacts/qualification/*` remains the object-side permission for `HeadObject`. No AWS IAM or GitHub state was changed by this PR.

AWS documents the missing-object distinction: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html

## Validation

- `pnpm --dir tests/release exec tsx --test src/worlds/selfhost/cfn.test.ts` (53/53)
- `pnpm --dir tests/release run typecheck`
- `python3 scripts/check_docs.py`
- `git diff --check`