### PR TITLE
fix(release): inspect the running CFN image digest

### DIFF
--- a/tests/release/src/worlds/selfhost/cfn.test.ts
+++ b/tests/release/src/worlds/selfhost/cfn.test.ts
@@ -1600,8 +1600,12 @@ test("parseCfnInstanceIdEventProjection: accepts one signaling instance and reje
 test("ssmInspectRunningImageDigest: send-command then poll to Success returns the sha256 digest", async () => {
   const sha = `sha256:${"d".repeat(64)}`;
   let polls = 0;
+  let sentCommand = "";
   const exec = new FakeExec((args) => {
     if (args[1] === "send-command") {
+      const parametersIndex = args.indexOf("--parameters");
+      const parameters = JSON.parse(args[parametersIndex + 1] ?? "{}") as { commands?: string[] };
+      sentCommand = parameters.commands?.[0] ?? "";
       return "cmd-123\n";
     }
     if (args[1] === "get-command-invocation") {
@@ -1618,9 +1622,12 @@ test("ssmInspectRunningImageDigest: send-command then poll to Success returns th
     pollTimeoutMs: 5_000,
   });
   assert.equal(digest, sha);
+  assert.match(sentCommand, /label=com\.docker\.compose\.service=api/);
+  assert.match(sentCommand, /docker inspect --format '\{\{\.Image\}\}'/);
+  assert.match(sentCommand, /docker image inspect --format '\{\{index \.RepoDigests 0\}\}'/);
 });
 
-test("ssmInspectRunningImageDigest: a terminal Failed status throws (so the cell's fallback engages)", async () => {
+test("ssmInspectRunningImageDigest: a terminal Failed status fails closed", async () => {
   const exec = new FakeExec((args) => {
     if (args[1] === "send-command") {
       return "cmd-1\n";

--- a/tests/release/src/worlds/selfhost/cfn.ts
+++ b/tests/release/src/worlds/selfhost/cfn.ts
@@ -1955,9 +1955,12 @@ function emptyCfnBootstrapDiagnostic(
 /**
  * Reads the RUNNING api container's image RepoDigest on the stack's host over
  * SSM (`aws ssm send-command` → poll `get-command-invocation`) and returns its
- * `sha256:<hex>` component. The template provisions an SSM-enabled instance role
+ * `sha256:<hex>` component. Container inspection only exposes an image ID;
+ * `RepoDigests` belongs to the image object, so the command deliberately
+ * resolves the Compose service container → image ID → immutable repo digest.
+ * The template provisions an SSM-enabled instance role
  * (`AmazonSSMManagedInstanceCore`), so this needs no SSH/key pair. Bounded poll;
- * throws (so the caller's fallback engages) if SSM never yields a digest.
+ * throws and fails closed if SSM never yields a digest.
  */
 export async function ssmInspectRunningImageDigest(input: {
   exec: CfnAwsExec;
@@ -1969,7 +1972,11 @@ export async function ssmInspectRunningImageDigest(input: {
   const { exec, instanceId, region } = input;
   const pollTimeoutMs = input.pollTimeoutMs ?? SSM_POLL_TIMEOUT_MS;
   const command =
-    "sudo docker inspect --format '{{index .RepoDigests 0}}' \"$(sudo docker ps -qf name=api | head -n1)\"";
+    "set -eu; " +
+    "container_id=\"$(sudo docker ps -q --filter label=com.docker.compose.service=api | head -n1)\"; " +
+    "test -n \"$container_id\"; " +
+    "image_id=\"$(sudo docker inspect --format '{{.Image}}' \"$container_id\")\"; " +
+    "sudo docker image inspect --format '{{index .RepoDigests 0}}' \"$image_id\"";
   const commandId = (
     await exec.run([
       "ssm",


### PR DESCRIPTION
## Summary
- resolve the running Compose `api` service container by its service label
- read that container's image ID, then inspect the image object for its immutable `RepoDigests` entry
- keep the digest binding fail-closed and add a regression over the exact SSM command

Exact-main run [29757709372](https://github.com/proliferate-ai/proliferate/actions/runs/29757709372) proved the repaired CFN stack reached public health and reconciled all seven cleanup resources with zero survivors, then failed at the digest proof. The old command incorrectly requested `.RepoDigests` from a container object; Docker exposes that field on the image object.

## Proof
- `pnpm exec tsx --test src/worlds/selfhost/cfn.test.ts src/scenarios/selfhost-cfn-1.test.ts` (74 passed)
- `pnpm --dir tests/release typecheck`
- `git diff --check`
