### PR TITLE
fix(release): isolate sequential self-host world storage

### DIFF
--- a/tests/release/src/scenarios/selfhost-install-1.test.ts
+++ b/tests/release/src/scenarios/selfhost-install-1.test.ts
@@ -220,9 +220,22 @@ test("resolveSelfHostWorldInputs: ok with a complete context", () => {
   const result = resolveSelfHostWorldInputs(fakeCtx());
   assert.equal(result.ok, true);
   if (result.ok) {
+    assert.equal(result.value.runDir, "/tmp/run-1/worlds/selfhost-install-1");
     assert.equal(result.value.aws.region, "us-east-1");
     assert.equal(result.value.aws.zone, "qualification.proliferate.com");
     assert.equal(result.value.ssh.sshUser, "ubuntu");
+  }
+});
+
+test("resolveSelfHostWorldInputs: sequential scenarios own disjoint children of the candidate publication", () => {
+  const install = resolveSelfHostWorldInputs(fakeCtx(), "selfhost-install-1");
+  const qualification = resolveSelfHostWorldInputs(fakeCtx(), "selfhost-qual-1");
+  assert.equal(install.ok, true);
+  assert.equal(qualification.ok, true);
+  if (install.ok && qualification.ok) {
+    assert.equal(install.value.runDir, "/tmp/run-1/worlds/selfhost-install-1");
+    assert.equal(qualification.value.runDir, "/tmp/run-1/worlds/selfhost-qual-1");
+    assert.notEqual(install.value.runDir, qualification.value.runDir);
   }
 });
 

--- a/tests/release/src/scenarios/selfhost-install-1.ts
+++ b/tests/release/src/scenarios/selfhost-install-1.ts
@@ -76,6 +76,7 @@ import { AUTHENTICATED_READINESS_SELECTOR, BROWSER_AUTH_SESSION_KEY, type Produc
  */
 
 export const SELFHOST_INSTALL_1_ID = SELFHOST_INSTALL_1_SCENARIO_ID;
+export const SELFHOST_INSTALL_WORLD_SUBDIR = "selfhost-install-1";
 export const REPRESENTATIVE_HARNESS = "claude";
 
 /** The `cell` dimension values, in run order. */
@@ -834,7 +835,7 @@ export async function runSelfHostInstallCells(
   cells: readonly PlannedCellV1[],
   driver: SelfHostInstallDriver,
 ): Promise<ScenarioCellOutcome[]> {
-  const inputs = resolveSelfHostWorldInputs(ctx);
+  const inputs = resolveSelfHostWorldInputs(ctx, SELFHOST_INSTALL_WORLD_SUBDIR);
   if (!inputs.ok) {
     return cells.map(
       (cell): ScenarioCellOutcome => ({
@@ -979,6 +980,7 @@ function cleanupIsClean(cleanup: SelfHostWorldCleanupEvidence): boolean {
  */
 export function resolveSelfHostWorldInputs(
   ctx: ScenarioRunContext,
+  worldSubdir = SELFHOST_INSTALL_WORLD_SUBDIR,
 ): { ok: true; value: SelfHostWorldConstructionInputs } | { ok: false; reason: string } {
   const map = ctx.candidateBuildMap;
   if (!map) {
@@ -1013,7 +1015,11 @@ export function resolveSelfHostWorldInputs(
     value: {
       map,
       run: ctx.runIdentity,
-      runDir: ctx.runDir,
+      // `ctx.runDir` is the parent candidate publication: it owns the build
+      // map, ports sidecar, and source artifact bytes shared by sequential
+      // scenarios. A world finalizer must therefore own only its scenario
+      // subtree, never the parent publication it will need again.
+      runDir: path.join(ctx.runDir, "worlds", worldSubdir),
       ports: ctx.ports,
       aws: { region, instanceType, hostedZoneId, zone: "qualification.proliferate.com" },
       ssh: { sshUser },

--- a/tests/release/src/scenarios/selfhost-qual-1.test.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.test.ts
@@ -330,6 +330,19 @@ test("runSelfHostQualCells: SH-GATEWAY alone runs on the run-scoped origin", asy
   assert.deepEqual(probe.ownerEmails, [undefined]);
 });
 
+test("runSelfHostQualCells: the world owns only its scenario subtree", async () => {
+  const driver = allGreenDriver();
+  let runDir: string | undefined;
+  const buildWorld = driver.buildWorld;
+  driver.buildWorld = async (inputs, fixedSubdomain) => {
+    runDir = inputs.runDir;
+    return buildWorld(inputs, fixedSubdomain);
+  };
+
+  await runSelfHostQualCells(fakeCtx(), [cellFor(SH_GATEWAY)], driver);
+  assert.equal(runDir, "/tmp/run-1/worlds/selfhost-qual-1");
+});
+
 test("runSelfHostQualCells: a failed install/claim fails both cells cleanly", async () => {
   const driver = allGreenDriver();
   driver.installAndClaim = async () => ({ ok: false, reason: "shipped installer digest mismatch" });

--- a/tests/release/src/scenarios/selfhost-qual-1.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.ts
@@ -109,6 +109,7 @@ import {
  */
 
 export const SELFHOST_QUAL_1_ID = "SELFHOST-QUAL-1";
+export const SELFHOST_QUAL_WORLD_SUBDIR = "selfhost-qual-1";
 export const REPRESENTATIVE_HARNESS = "claude";
 
 export const SH_GITHUB_AUTH = "SH-GITHUB-AUTH";
@@ -383,7 +384,7 @@ export async function runSelfHostQualCells(
   cells: readonly PlannedCellV1[],
   driver: SelfHostQualDriver,
 ): Promise<ScenarioCellOutcome[]> {
-  const inputs = resolveSelfHostWorldInputs(ctx);
+  const inputs = resolveSelfHostWorldInputs(ctx, SELFHOST_QUAL_WORLD_SUBDIR);
   if (!inputs.ok) {
     return cells.map((cell) => failedOutcome(cell.cell_id, inputs.reason));
   }


### PR DESCRIPTION
## Summary

- Give SELFHOST-INSTALL-1 and SELFHOST-QUAL-1 disjoint child world directories beneath the shared candidate publication.
- Preserve the parent candidate map, ports sidecar, and artifact bytes across sequential scenarios.
- Add regression coverage for both self-host scenario paths.

The exact-main qualification run 29780440961 proved the defect: baseline cleanup removed the parent artifact publication, so SH-GATEWAY could not rematerialize server/linux/amd64.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship applies.

## Verification

- pnpm --dir tests/release exec tsx --test src/scenarios/selfhost-install-1.test.ts src/scenarios/selfhost-qual-1.test.ts (92 passed)
- pnpm --dir tests/release typecheck
- pnpm --dir tests/release test (1,512 passed)