### PR TITLE
fix(release): materialize self-host checksum sidecar

### DIFF
--- a/scripts/ci-cd/build-selfhost-qualification-candidates.mjs
+++ b/scripts/ci-cd/build-selfhost-qualification-candidates.mjs
@@ -54,9 +54,10 @@
 //   {..., "second_ports_file":"<path>","second_ports":{...}}
 //
 // The `self-hosted-assets.SHA256SUMS` is written as a DETERMINISTIC SIBLING of
-// the bundle inside the map's artifacts dir; the self-host world derives its
-// path from the bundle locator (dirname(bundle)/self-hosted-assets.SHA256SUMS)
-// and scp's it to the box for the shipped installer's checksum-verify.
+// the bundle inside the map's artifacts dir; each self-host world derives that
+// source path from the bundle locator, copies the manifest into its own scoped
+// materialization directory, and scp's that copy to the box for the shipped
+// installer's checksum verification.
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";

--- a/tests/release/src/scenarios/selfhost-install-1.ts
+++ b/tests/release/src/scenarios/selfhost-install-1.ts
@@ -277,7 +277,7 @@ export const defaultSelfHostInstallDriver: SelfHostInstallDriver = {
       ssh: world.control.ssh,
       serverImageArchive: world.artifacts.serverImage,
       bundle: world.artifacts.bundle,
-      bundleSha256SumsPath: bundleSha256SumsPath(world.artifacts.bundle.path),
+      bundleSha256SumsPath: world.artifacts.bundleSha256SumsPath,
       siteAddress: originOf(world.api.baseUrl),
       candidateImageRepo,
       candidateImageTag,
@@ -1131,17 +1131,6 @@ function originOf(url: string): string {
   } catch {
     return url.replace(/^https?:\/\//, "").split(/[/?#]/)[0] ?? url;
   }
-}
-
-/**
- * `install.sh --bundle` verifies the bundle against its adjacent
- * `self-hosted-assets.SHA256SUMS` (the exact convention `server-ci.yml
- * self-hosted-release-assets` produces alongside `proliferate-deploy.tar.gz`).
- * ASSUMPTION (disclosed): the builder (workstream B) writes it next to the
- * materialized bundle archive under the same run-owned directory.
- */
-function bundleSha256SumsPath(materializedBundlePath: string): string {
-  return path.join(path.dirname(materializedBundlePath), "self-hosted-assets.SHA256SUMS");
 }
 
 /**

--- a/tests/release/src/scenarios/selfhost-qual-1.ts
+++ b/tests/release/src/scenarios/selfhost-qual-1.ts
@@ -319,7 +319,7 @@ export const defaultSelfHostQualDriver: SelfHostQualDriver = {
         ssh: world.control.ssh,
         serverImageArchive: world.artifacts.serverImage,
         bundle: world.artifacts.bundle,
-        bundleSha256SumsPath: bundleSha256SumsPath(world.artifacts.bundle.path),
+        bundleSha256SumsPath: world.artifacts.bundleSha256SumsPath,
         siteAddress: hostOf(world.api.baseUrl),
         candidateImageRepo: repo,
         candidateImageTag: tag,
@@ -1290,9 +1290,4 @@ function splitCandidateImageRef(serverImage: { version: string }): { repo: strin
     return { repo: CANDIDATE_SERVER_IMAGE_REPO, tag: value };
   }
   return { repo: value.slice(0, lastColon), tag: value.slice(lastColon + 1) };
-}
-
-/** The bundle's adjacent `self-hosted-assets.SHA256SUMS` path (installer verifies it). */
-function bundleSha256SumsPath(materializedBundlePath: string): string {
-  return path.join(path.dirname(materializedBundlePath), "self-hosted-assets.SHA256SUMS");
 }

--- a/tests/release/src/worlds/selfhost/world-pair.test.ts
+++ b/tests/release/src/worlds/selfhost/world-pair.test.ts
@@ -21,6 +21,7 @@ import type { Ec2Exec } from "./ec2.js";
 import type { Route53Exec } from "./dns.js";
 import {
   SECOND_WORLD_PORT_OFFSET,
+  SELFHOST_BUNDLE_SHA256SUMS_FILENAME,
   constructSelfHostWorldPair,
   offsetLocalWorldPorts,
   type SelfHostWorldDeps,
@@ -47,13 +48,18 @@ async function fileArtifact(dir: string, id: string, version: string, content: s
 }
 
 async function buildMap(dir: string): Promise<CandidateBuildMapV1> {
+  const bundle = await fileArtifact(dir, "selfhost-bundle/linux-amd64", "1.2.3", "deploy-bundle-bytes");
+  await writeFile(
+    path.join(dir, SELFHOST_BUNDLE_SHA256SUMS_FILENAME),
+    `${bundle.sha256}  proliferate-deploy.tar.gz\n`,
+  );
   return {
     schema_version: 1,
     kind: "proliferate.candidate-build",
     source_sha: "0".repeat(40),
     artifacts: [
       await fileArtifact(dir, "server/linux-amd64", "1.2.3", "server-archive-bytes"),
-      await fileArtifact(dir, "selfhost-bundle/linux-amd64", "1.2.3", "deploy-bundle-bytes"),
+      bundle,
       await fileArtifact(dir, "anyharness/host-target", ANYHARNESS_VERSION, "anyharness-bytes"),
       await fileArtifact(dir, "desktop-renderer/browser", "0.1.0", "renderer-tar-bytes"),
     ],

--- a/tests/release/src/worlds/selfhost/world.test.ts
+++ b/tests/release/src/worlds/selfhost/world.test.ts
@@ -268,6 +268,49 @@ test("a missing bundle checksum sibling fails before AWS provisioning", async ()
   }
 });
 
+test("an invalid bundle checksum manifest fails before AWS provisioning", async (t) => {
+  const cases = [
+    ["wrong bundle digest", () => `${"f".repeat(64)}  proliferate-deploy.tar.gz\n`],
+    ["missing bundle entry", () => `${"e".repeat(64)}  anyharness-aarch64-unknown-linux-musl.tar.gz\n`],
+    [
+      "duplicate bundle entry",
+      (sha: string) => `${sha}  proliferate-deploy.tar.gz\n${sha}  proliferate-deploy.tar.gz\n`,
+    ],
+    ["malformed checksum line", () => "not-a-checksum  proliferate-deploy.tar.gz\n"],
+  ] as const;
+
+  for (const [label, sumsContent] of cases) {
+    await t.test(label, async () => {
+      const src = await mkdtemp(path.join(os.tmpdir(), "sh-src-"));
+      const runDir = await mkdtemp(path.join(os.tmpdir(), "sh-run-"));
+      try {
+        const map = await buildMap(src);
+        const bundle = map.artifacts.find((artifact) => artifact.artifact_id === "selfhost-bundle/linux-amd64")!;
+        await writeFile(path.join(src, SELFHOST_BUNDLE_SHA256SUMS_FILENAME), sumsContent(bundle.sha256));
+        const h = harness();
+        await assert.rejects(
+          constructSelfHostWorld({
+            run: RUN,
+            map,
+            runDir,
+            ports: PORTS,
+            aws: AWS,
+            ssh: SSH,
+            tls: TEST_QUALIFICATION_TLS,
+            deps: h.deps,
+          }),
+          /does not contain exactly one valid proliferate-deploy\.tar\.gz entry/,
+        );
+        assert.equal(h.ec2Calls.length, 0);
+        assert.equal(h.route53Calls.length, 0);
+      } finally {
+        await rm(src, { recursive: true, force: true });
+        await rm(runDir, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
 test("an invalid candidate map starts no world (no dirs, no ledger, no AWS side effects)", async () => {
   const src = await mkdtemp(path.join(os.tmpdir(), "sh-src-"));
   const runDir = await mkdtemp(path.join(os.tmpdir(), "sh-run-"));

--- a/tests/release/src/worlds/selfhost/world.test.ts
+++ b/tests/release/src/worlds/selfhost/world.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -20,7 +20,12 @@ import type { ChromiumLauncher } from "../local-workspace/renderer.js";
 import { TEST_QUALIFICATION_TLS } from "../qualification-tls.test-fixture.js";
 import type { Ec2Exec } from "./ec2.js";
 import type { Route53Exec } from "./dns.js";
-import { constructSelfHostWorld, type SelfHostWorldDeps, type SshTransport } from "./world.js";
+import {
+  SELFHOST_BUNDLE_SHA256SUMS_FILENAME,
+  constructSelfHostWorld,
+  type SelfHostWorldDeps,
+  type SshTransport,
+} from "./world.js";
 
 const RUN: RunIdentityV1 = {
   run_id: "selfhost-run-1",
@@ -48,13 +53,18 @@ async function fileArtifact(dir: string, id: string, version: string, content: s
 }
 
 async function buildMap(dir: string): Promise<CandidateBuildMapV1> {
+  const bundle = await fileArtifact(dir, "selfhost-bundle/linux-amd64", "1.2.3", "deploy-bundle-bytes");
+  await writeFile(
+    path.join(dir, SELFHOST_BUNDLE_SHA256SUMS_FILENAME),
+    `${bundle.sha256}  proliferate-deploy.tar.gz\n`,
+  );
   return {
     schema_version: 1,
     kind: "proliferate.candidate-build",
     source_sha: "0".repeat(40),
     artifacts: [
       await fileArtifact(dir, "server/linux-amd64", "1.2.3", "server-archive-bytes"),
-      await fileArtifact(dir, "selfhost-bundle/linux-amd64", "1.2.3", "deploy-bundle-bytes"),
+      bundle,
       await fileArtifact(dir, "anyharness/host-target", ANYHARNESS_VERSION, "anyharness-bytes"),
       await fileArtifact(dir, "desktop-renderer/browser", "0.1.0", "renderer-tar-bytes"),
     ],
@@ -199,6 +209,10 @@ test("constructSelfHostWorld provisions infra + stands up runtime/renderer/contr
     assert.equal(world.artifacts.serverImage.version, "1.2.3");
     assert.equal(world.artifacts.anyharness.version, ANYHARNESS_VERSION);
     await access(world.artifacts.bundle.path);
+    assert.equal(
+      await readFile(world.artifacts.bundleSha256SumsPath, "utf8"),
+      `${world.artifacts.bundle.sha256}  proliferate-deploy.tar.gz\n`,
+    );
     await access(path.join(runDir, CLEANUP_LEDGER_FILENAME));
     // The SSH readiness probe ran (cloud-init gate), and the control handle is wired.
     assert.ok(h.sshCommands.some((c) => c.includes("selfhost-ready") && c.includes("docker compose version")));
@@ -220,6 +234,34 @@ test("constructSelfHostWorld provisions infra + stands up runtime/renderer/contr
     assert.equal(evidence.localPathsRemoved, true);
     assert.equal(h.browserState.closed, true);
     assert.ok(h.spawnState.killed >= 2); // anyharness + renderer terminated
+  } finally {
+    await rm(src, { recursive: true, force: true });
+    await rm(runDir, { recursive: true, force: true });
+  }
+});
+
+test("a missing bundle checksum sibling fails before AWS provisioning", async () => {
+  const src = await mkdtemp(path.join(os.tmpdir(), "sh-src-"));
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "sh-run-"));
+  try {
+    const map = await buildMap(src);
+    await rm(path.join(src, SELFHOST_BUNDLE_SHA256SUMS_FILENAME));
+    const h = harness();
+    await assert.rejects(
+      constructSelfHostWorld({
+        run: RUN,
+        map,
+        runDir,
+        ports: PORTS,
+        aws: AWS,
+        ssh: SSH,
+        tls: TEST_QUALIFICATION_TLS,
+        deps: h.deps,
+      }),
+      /Could not materialize self-hosted-assets\.SHA256SUMS/,
+    );
+    assert.equal(h.ec2Calls.length, 0);
+    await access(map.artifacts[0]!.locator.path);
   } finally {
     await rm(src, { recursive: true, force: true });
     await rm(runDir, { recursive: true, force: true });

--- a/tests/release/src/worlds/selfhost/world.ts
+++ b/tests/release/src/worlds/selfhost/world.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, rm } from "node:fs/promises";
+import { chmod, copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -9,7 +9,11 @@ import type { Browser } from "playwright";
 import { registerCancellationFinalizer } from "../../cli/cancellation-finalizer.js";
 
 import type { MaterializedArtifact } from "../../artifacts/local-candidate-set.js";
-import type { CandidateBuildMapV1 } from "../../artifacts/build-map.js";
+import {
+  BuildMapError,
+  type CandidateBuildArtifactV1,
+  type CandidateBuildMapV1,
+} from "../../artifacts/build-map.js";
 import {
   resolveSelfHostCandidateSet,
   type SelfHostCandidateSet,
@@ -47,6 +51,8 @@ import {
   type SelfHostWorldCleanupEvidence,
 } from "./cleanup-kinds.js";
 
+export const SELFHOST_BUNDLE_SHA256SUMS_FILENAME = "self-hosted-assets.SHA256SUMS";
+
 /**
  * The reusable self-host-world constructor (frozen spec "World construction
  * (ReadySelfHostWorld)"). It mirrors `ReadyLocalWorld`: it consumes validated
@@ -75,6 +81,8 @@ export interface ReadySelfHostWorld {
     serverImage: MaterializedArtifact;
     /** `selfhost-bundle/<platform>` proliferate-deploy.tar.gz + its SHA256SUMS. */
     bundle: MaterializedArtifact;
+    /** Scenario-owned copy of the builder's deterministic bundle checksum sibling. */
+    bundleSha256SumsPath: string;
     /** `anyharness/<host-target>` release executable (reused PR 1 build). */
     anyharness: MaterializedArtifact;
     /** `desktop-renderer/browser` archive (reused PR 1 build). */
@@ -324,6 +332,7 @@ export async function constructSelfHostWorld(
     // Materialize + re-hash the four mapped artifacts into run storage.
     const serverImage = await materialize(candidateSet.serverImage.artifact_id, options.map, artifactsDir);
     const bundle = await materialize(candidateSet.bundle.artifact_id, options.map, artifactsDir);
+    const bundleSha256SumsPath = await materializeBundleSha256Sums(candidateSet.bundle, artifactsDir);
     const anyharnessArtifact = await materialize(candidateSet.anyharness.artifact_id, options.map, artifactsDir);
     const rendererArtifact = await materialize(candidateSet.desktopRenderer.artifact_id, options.map, artifactsDir);
 
@@ -418,7 +427,13 @@ export async function constructSelfHostWorld(
     return {
       kind: "selfhost",
       run: options.run,
-      artifacts: { serverImage, bundle, anyharness: anyharnessArtifact, desktopRenderer: rendererArtifact },
+      artifacts: {
+        serverImage,
+        bundle,
+        bundleSha256SumsPath,
+        anyharness: anyharnessArtifact,
+        desktopRenderer: rendererArtifact,
+      },
       api: { baseUrl: apiOrigin, client: new ApiClient({ baseUrl: apiOrigin }) },
       runtime: { baseUrl: anyharness.baseUrl, client: new LocalRuntimeClient({ baseUrl: anyharness.baseUrl }) },
       renderer: { baseUrl: served.baseUrl, browser },
@@ -562,6 +577,25 @@ async function materialize(
   }
   const materializedPath = await materializeLocalArtifact(artifact, storageDir);
   return { artifact_id: artifact.artifact_id, version: artifact.version, sha256: artifact.sha256, path: materializedPath };
+}
+
+async function materializeBundleSha256Sums(
+  bundle: CandidateBuildArtifactV1,
+  storageDir: string,
+): Promise<string> {
+  const source = path.join(path.dirname(bundle.locator.path), SELFHOST_BUNDLE_SHA256SUMS_FILENAME);
+  const destination = path.join(storageDir, SELFHOST_BUNDLE_SHA256SUMS_FILENAME);
+  try {
+    await copyFile(source, destination);
+    await chmod(destination, 0o644);
+  } catch (error) {
+    throw new BuildMapError(
+      `Could not materialize ${SELFHOST_BUNDLE_SHA256SUMS_FILENAME} for artifact "${bundle.artifact_id}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  return destination;
 }
 
 /** Reads the one-time first-run setup token from the api container over SSH. */

--- a/tests/release/src/worlds/selfhost/world.ts
+++ b/tests/release/src/worlds/selfhost/world.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmod, copyFile, mkdir, rm } from "node:fs/promises";
+import { chmod, copyFile, mkdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -595,7 +595,46 @@ async function materializeBundleSha256Sums(
       }`,
     );
   }
+  const sumsContent = await readFile(destination, "utf8");
+  if (!bundleSha256SumsIntegrityBound(sumsContent, bundle.sha256)) {
+    throw new BuildMapError(
+      `${SELFHOST_BUNDLE_SHA256SUMS_FILENAME} does not contain exactly one valid ` +
+        `proliferate-deploy.tar.gz entry bound to artifact "${bundle.artifact_id}".`,
+    );
+  }
   return destination;
+}
+
+/**
+ * The shipped installer runs `sha256sum -c` from the directory containing the
+ * bare-name bundle. Fail before provider mutation unless every non-empty line
+ * is a canonical GNU sha256sum entry and exactly one entry binds that filename
+ * to the digest already validated by CandidateBuildMap materialization.
+ */
+function bundleSha256SumsIntegrityBound(sumsContent: string, candidateBundleSha256: string): boolean {
+  const want = candidateBundleSha256.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(want)) {
+    return false;
+  }
+
+  let bundleEntries = 0;
+  for (const rawLine of sumsContent.split(/\r?\n/)) {
+    if (rawLine.length === 0) {
+      continue;
+    }
+    const match = rawLine.match(/^([0-9a-f]{64}) ([ *])(.+)$/i);
+    if (!match) {
+      return false;
+    }
+    const [, digest, , filename] = match;
+    if (filename === "proliferate-deploy.tar.gz") {
+      bundleEntries += 1;
+      if (digest!.toLowerCase() !== want) {
+        return false;
+      }
+    }
+  }
+  return bundleEntries === 1;
 }
 
 /** Reads the one-time first-run setup token from the api container over SSH. */


### PR DESCRIPTION
## Summary

- copy the deterministic self-host bundle checksum sidecar into each scenario-owned world materialization
- bind its exact bare-name bundle entry to the already-validated candidate digest before any provider mutation
- pass that typed path to both SELFHOST-INSTALL-1 and SELFHOST-QUAL-1
- fail before AWS provisioning when the sidecar is absent, malformed, missing the bundle, duplicated, or digest-mismatched

## Exact failure repaired

Exact-main run [29783902749](https://github.com/proliferate-ai/proliferate/actions/runs/29783902749) proved the prior candidate-parent custody fix, then failed because each isolated world tried to scp a checksum file that had not been copied into its child artifact directory.

The failed run was audited after teardown: no non-terminated EC2 instances, security groups, key pairs, or Route53 records remained for its run identity.

## Verification

- focused self-host world/scenario tests: 105/105
- release TypeScript typecheck
- self-host candidate builder tests: 12/12
- full release suite: 1518/1518
- git diff --check