### PR TITLE
fix(release): verify managed retry evidence

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -1195,11 +1195,12 @@ jobs:
           set -euo pipefail
           run_id="qlc-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           run_dir="${GITHUB_WORKSPACE}/tests/release/.output/managed-cloud-world/${run_id}/1"
+          attempt_dir="attempt-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${run_dir}/evidence"
           cd tests/release
           pnpm exec tsx src/cli/verify-managed-cloud-handoff.ts \
-            --cp1-report "${run_dir}/evidence/cp1/${run_id}/1/attempt-1/qualification-evidence.json" \
-            --smoke-report "${run_dir}/evidence/fixture-smoke/${run_id}/1/attempt-1/qualification-evidence.json" \
+            --cp1-report "${run_dir}/evidence/cp1/${run_id}/1/${attempt_dir}/qualification-evidence.json" \
+            --smoke-report "${run_dir}/evidence/fixture-smoke/${run_id}/1/${attempt_dir}/qualification-evidence.json" \
             --custody "${run_dir}/cleanup-custody/shared-e2b-template-custody.json" \
             | tee "${run_dir}/evidence/managed-cloud-handoff-verification.json"
 

--- a/tests/release/src/runner/qualification-execution-workflow.test.ts
+++ b/tests/release/src/runner/qualification-execution-workflow.test.ts
@@ -226,11 +226,15 @@ test("the managed-cloud derivative world refreshes trusted cleanup authority aft
   const cp1 = managed.indexOf("Build candidates and run CLOUD-PROVISION-1 (strict)");
   const refresh = managed.indexOf("Refresh trusted default-branch cleanup authorization before fixture smoke");
   const fixtureSmoke = managed.indexOf("Reuse candidates and run MANAGED-CLOUD-FIXTURE-SMOKE-1 (strict)");
+  const handoff = managed.slice(managed.indexOf("Verify exact CP1 → fixture-smoke handoff"));
 
   assert.ok(cp1 >= 0);
   assert.ok(refresh > cp1);
   assert.ok(fixtureSmoke > refresh);
   assert.equal((managed.match(/path: \.qualification-trusted-default/g) ?? []).length, 2);
+  assert.match(handoff, /attempt_dir="attempt-\$\{GITHUB_RUN_ATTEMPT\}"/);
+  assert.equal((handoff.match(/\$\{attempt_dir\}\/qualification-evidence\.json/g) ?? []).length, 2);
+  assert.doesNotMatch(handoff, /attempt-1\/qualification-evidence\.json/);
 });
 
 test("the Tier 4 artifact-chain preflight describes read-only published artifacts", () => {


### PR DESCRIPTION
## Summary

- resolve managed-cloud CP1 and fixture-smoke reports from the current `GITHUB_RUN_ATTEMPT`
- add a workflow regression assertion that rejects hard-coded `attempt-1` report paths

## Root cause

Exact candidate run 29820131937 attempt 2 completed CP1 (1/1 green) and fixture smoke (5/5 green), released shared-template custody, and reconciled both base cleanup ledgers with zero remaining entries. The final handoff verifier nevertheless read `attempt-1/.../qualification-evidence.json`, while both valid reports were correctly written under `attempt-2`, producing `invalid_cp1_report`.

## Impact

Retries now verify the evidence generated by their own attempt instead of failing after successful provider execution and cleanup.

## Proof

- `pnpm --dir tests/release exec tsx --test src/runner/qualification-execution-workflow.test.ts`
- `actionlint .github/workflows/release-e2e.yml`
- `git diff --check`
