### PR TITLE
feat(settings): polish repo environment panes and cloud gates

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/repo/RepoActionsPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/repo/RepoActionsPane.tsx
@@ -27,7 +27,7 @@ import {
 } from "#product/components/settings/panes/repo/RepoScopeStates";
 
 const SCRIPT_PLACEHOLDER = "pnpm install\npnpm prisma generate";
-const RUN_COMMAND_INPUT_CLASS = "h-8 w-72 px-2.5 font-mono text-ui-sm";
+const RUN_COMMAND_INPUT_CLASS = "h-8 w-full rounded-lg px-2.5 font-mono text-ui-sm";
 
 /**
  * Repo → Actions: scripts that run around agent workspaces for this repo, per
@@ -58,10 +58,10 @@ export function RepoActionsPane({
     );
   }
   return (
-    <section className="space-y-6">
+    <section className="space-y-5">
       <SettingsPageHeader
         title="Actions"
-        description="Scripts that run around agent workspaces for this repo."
+        description="Commands that run in agent workspaces for this repo."
       />
       {context === "cloud" ? (
         <ActionsCloud
@@ -106,8 +106,11 @@ function ActionsCloud({
       cloudSignInChecking={cloudSignInChecking}
       cloudSignInAvailable={cloudSignInAvailable}
     >
-      <SettingsSection title="Setup script">
-        <div className="space-y-2 pt-2">
+      <SettingsSection
+        title="Setup script"
+        description="Runs once when a cloud workspace is created."
+      >
+        <div>
           <ScriptBlock
             ariaLabel="Cloud setup script"
             fileLabel="setup.sh"
@@ -116,16 +119,13 @@ function ActionsCloud({
             onChange={draft.setSetupScript}
             className="w-full"
           />
-          <p className="text-ui-sm text-muted-foreground/80">
-            Runs once when a cloud workspace is created.
-          </p>
         </div>
       </SettingsSection>
       <SettingsSection
         title="Run command"
-        description="Launched by the workspace Run action in cloud workspaces."
+        description="Runs from the workspace Run action."
       >
-        <div className="pt-2">
+        <div>
           <Input
             aria-label="Cloud run command"
             value={draft.runCommand}
@@ -184,8 +184,11 @@ function ActionsLocalEditor({ repository }: { repository: SettingsRepositoryEntr
 
   return (
     <>
-      <SettingsSection title="Setup script">
-        <div className="space-y-2 pt-2">
+      <SettingsSection
+        title="Setup script"
+        description="Runs once when a local worktree is created."
+      >
+        <div className="space-y-2">
           <ScriptBlock
             ariaLabel="Local setup script"
             fileLabel="setup.sh"
@@ -195,7 +198,7 @@ function ActionsLocalEditor({ repository }: { repository: SettingsRepositoryEntr
             className="w-full"
           />
           <p className="text-ui-sm text-muted-foreground/80">
-            Runs inside the new worktree. Available vars include{" "}
+            Available variables:{" "}
             <code>PROLIFERATE_WORKTREE_DIR</code>, <code>PROLIFERATE_REPO_DIR</code>,{" "}
             <code>PROLIFERATE_BRANCH</code>, and <code>PROLIFERATE_BASE_REF</code>.
           </p>
@@ -203,7 +206,7 @@ function ActionsLocalEditor({ repository }: { repository: SettingsRepositoryEntr
         {isDetecting || hasHints ? (
           <SettingsRow
             label="Suggestions"
-            description="Detected setup commands and ignored-file sync helpers."
+            description="Detected commands and ignored-file sync helpers."
             className="sm:flex-col sm:items-stretch"
           >
             {isDetecting ? (
@@ -231,7 +234,7 @@ function ActionsLocalEditor({ repository }: { repository: SettingsRepositoryEntr
         ) : null}
       </SettingsSection>
       <SettingsSection title="Run command">
-        <div className="w-72 space-y-2 pt-2">
+        <div className="space-y-2">
           <Input
             aria-label="Local run command"
             value={runCommandDraft}
@@ -276,7 +279,7 @@ function SetupHintRows({
           return (
             <Label
               key={hint.id}
-              className="mb-0 flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-foreground/5"
+              className="mb-0 flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 hover:bg-muted/50"
             >
               <Checkbox
                 checked={checked}

--- a/apps/packages/product-client/src/components/settings/panes/repo/RepoCloudGate.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/repo/RepoCloudGate.test.tsx
@@ -114,7 +114,7 @@ describe("RepoCloudGate operator gate (PR2-GATING-01)", () => {
       </RepoCloudGate>,
     );
 
-    expect(screen.queryByText(/isn't fully configured on this deployment/)).not.toBeNull();
+    expect(screen.queryByText("An operator must finish configuring proliferate-app access.")).not.toBeNull();
     // The user must NEVER see a user-auth CTA when the operator must configure.
     expect(screen.queryByRole("button", { name: /Connect GitHub App/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Reconnect GitHub App/i })).toBeNull();

--- a/apps/packages/product-client/src/components/settings/panes/repo/RepoCloudGate.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/repo/RepoCloudGate.tsx
@@ -2,8 +2,6 @@ import { type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { Cloud } from "lucide-react";
 import { SettingsEmptyState } from "@proliferate/product-ui/settings/SettingsEmptyState";
-import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
-import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { resolveRepositoryReadiness } from "@proliferate/product-domain/repos/repo-readiness";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
@@ -22,17 +20,19 @@ interface RepoCloudGateProps {
   children: ReactNode;
 }
 
-function CloudEnvironmentNotice({
-  label,
+function CloudGateState({
+  title,
   description,
 }: {
-  label: string;
+  title: string;
   description: string;
 }) {
   return (
-    <SettingsSection title="Cloud environment">
-      <SettingsRow label={label} description={description} />
-    </SettingsSection>
+    <SettingsEmptyState
+      icon={<Cloud aria-hidden="true" />}
+      title={title}
+      description={description}
+    />
   );
 }
 
@@ -72,18 +72,18 @@ export function RepoCloudGate({
 
   if (!editor.cloudRepository) {
     return (
-      <CloudEnvironmentNotice
-        label="Not available"
-        description="Cloud environments are available for GitHub-backed repositories."
+      <CloudGateState
+        title="GitHub repository required"
+        description="Cloud environments require a GitHub-backed repository."
       />
     );
   }
 
   if (!cloudEnabled) {
     return (
-      <CloudEnvironmentNotice
-        label="Unavailable"
-        description="Cloud environments are unavailable in this build or deployment."
+      <CloudGateState
+        title="Cloud unavailable"
+        description="This build does not support cloud environments."
       />
     );
   }
@@ -91,12 +91,12 @@ export function RepoCloudGate({
   if (readiness.gate === 1) {
     const appName = capabilities.githubRepositoryAccessDisplayName;
     return (
-      <CloudEnvironmentNotice
-        label="Not configured"
+      <CloudGateState
+        title="Cloud needs deployment setup"
         description={
           appName
-            ? `Cloud repository access for ${appName} isn't fully configured on this deployment. An operator must finish configuring it.`
-            : "Managed Cloud isn't fully configured on this deployment. An operator must finish configuring it before repositories can be set up in Cloud."
+            ? `An operator must finish configuring ${appName} access.`
+            : "An operator must finish configuring Managed Cloud."
         }
       />
     );
@@ -105,25 +105,25 @@ export function RepoCloudGate({
   if (readiness.gate === 2) {
     if (cloudSignInChecking) {
       return (
-        <CloudEnvironmentNotice
-          label="Checking sign-in"
-          description="Checking product sign-in before loading this environment."
+        <CloudGateState
+          title="Checking sign-in"
+          description="Loading Cloud access."
         />
       );
     }
     if (!cloudSignInAvailable) {
       return (
-        <CloudEnvironmentNotice
-          label="Unavailable"
-          description="Product sign-in is unavailable, so cloud environment settings cannot load."
+        <CloudGateState
+          title="Sign-in unavailable"
+          description="This build cannot open cloud environment settings."
         />
       );
     }
     return (
       <SettingsEmptyState
         icon={<Cloud aria-hidden="true" />}
-        title="Sign in to configure Cloud"
-        description="Sign in to continue setting up this repository in Proliferate Cloud."
+        title="Sign in to use Cloud"
+        description="Sign in to configure this repository's cloud environment."
         action={(
           <Button type="button" variant="secondary" onClick={() => navigate("/login")}>
             Sign in
@@ -135,9 +135,9 @@ export function RepoCloudGate({
 
   if (editor.repoConfigsLoading || (readiness.gate === 4 && readiness.action === "none")) {
     return (
-      <CloudEnvironmentNotice
-        label="Loading"
-        description="Loading saved cloud environment…"
+      <CloudGateState
+        title="Loading cloud environment"
+        description="Loading saved settings."
       />
     );
   }
@@ -146,8 +146,8 @@ export function RepoCloudGate({
     return (
       <SettingsEmptyState
         icon={<Cloud aria-hidden="true" />}
-        title="Access check failed"
-        description="GitHub App access for this repository could not be checked."
+        title="Could not check access"
+        description="GitHub App access is unavailable for this repository."
         action={(
           <Button
             type="button"
@@ -181,13 +181,12 @@ export function RepoCloudGate({
     return (
       <SettingsEmptyState
         icon={<Cloud aria-hidden="true" />}
-        title="Not set up in Proliferate Cloud"
-        description="This repo isn't materialized in Proliferate Cloud yet. Set it up so agents can run it in cloud workspaces without this machine."
+        title="Set up a Cloud environment"
+        description="Create a remote environment for agents to run this repository."
         action={
           <div className="flex flex-col items-center gap-2">
             <Button
               type="button"
-              variant="secondary"
               loading={editor.saving}
               disabled={editor.saving}
               onClick={() => {

--- a/apps/packages/product-client/src/components/settings/panes/repo/RepoConfigurePane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/repo/RepoConfigurePane.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { SettingsPageHeader } from "@proliferate/product-ui/settings/SettingsPageHeader";
-import { SettingsRow } from "@proliferate/product-ui/settings/SettingsRow";
+import {
+  SETTINGS_CONTROL_WIDTH_CLASS,
+  SettingsRow,
+} from "@proliferate/product-ui/settings/SettingsRow";
 import { SettingsSaveFooter } from "@proliferate/product-ui/settings/SettingsSaveFooter";
 import { SettingsSection } from "@proliferate/product-ui/settings/SettingsSection";
 import {
@@ -49,10 +52,10 @@ export function RepoConfigurePane({
     );
   }
   return (
-    <section className="space-y-6">
+    <section className="space-y-5">
       <SettingsPageHeader
         title="Configure"
-        description="Defaults applied when agents create workspaces for this repo."
+        description="Workspace defaults for this repo."
       />
       {context === "cloud" ? (
         <ConfigureCloud
@@ -104,13 +107,13 @@ function ConfigureCloud({
     {
       id: "__github__",
       label: "GitHub default",
-      detail: branches.defaultBranch ? `Currently ${branches.defaultBranch}` : null,
+      detail: branches.defaultBranch ? `Current: ${branches.defaultBranch}` : null,
       selected: savedBranch === null,
       onSelect: () => draft.setDefaultBranch(null),
     },
     ...(hasStaleSavedBranch && savedBranch ? [{
       id: savedBranch,
-      label: `${savedBranch} (saved, missing on GitHub)`,
+      label: `${savedBranch} · unavailable`,
       selected: true,
       onSelect: () => draft.setDefaultBranch(savedBranch),
     }] : []),
@@ -144,9 +147,9 @@ function ConfigureCloud({
               ?? (branches.defaultBranch ? `GitHub default (${branches.defaultBranch})` : "GitHub default")}
             options={branchOptions}
             searchPlaceholder="Search branches"
-            emptyLabel="No branches found"
-            className="w-64"
-            menuClassName="w-80"
+            emptyLabel="No branches"
+            className={SETTINGS_CONTROL_WIDTH_CLASS}
+            menuClassName={SETTINGS_CONTROL_WIDTH_CLASS}
             disabled={branchesLoading}
           />
         </SettingsRow>
@@ -180,12 +183,12 @@ function cloudBranchHelperText({
     return branchError;
   }
   if (branchesLoading) {
-    return "Loading GitHub branches...";
+    return "Loading branches…";
   }
   if (githubDefaultBranch) {
-    return `Leaving this on GitHub default follows ${githubDefaultBranch}.`;
+    return `Uses GitHub's default branch (${githubDefaultBranch}).`;
   }
-  return "Leaving this on GitHub default follows the repo's current default branch.";
+  return "Uses the repository's current default branch.";
 }
 
 function ConfigureLocal({
@@ -225,7 +228,7 @@ function ConfigureLocalEditor({ repository }: { repository: SettingsRepositoryEn
     {
       id: "__auto__",
       label: "Auto-detect",
-      detail: effectiveAutoDetectedBranch ? `Currently ${effectiveAutoDetectedBranch}` : "No branches found",
+      detail: effectiveAutoDetectedBranch ? `Current: ${effectiveAutoDetectedBranch}` : "No branches",
     },
     ...branches.map((branch) => ({
       id: branch.name,
@@ -239,14 +242,14 @@ function ConfigureLocalEditor({ repository }: { repository: SettingsRepositoryEn
       <SettingsSection title="Branch">
         <SettingsRow
           label="Default branch"
-          description={`Base branch for new worktrees and pull requests · Effective: ${effectiveBranchLabel}`}
+          description={`Base for new worktrees and pull requests · Effective: ${effectiveBranchLabel}`}
         >
           <EnvironmentSearchSelect
             label={branchButtonLabel}
             searchPlaceholder="Search branches"
-            emptyLabel="No branches found"
-            className="w-64"
-            menuClassName="w-80"
+            emptyLabel="No branches"
+            className={SETTINGS_CONTROL_WIDTH_CLASS}
+            menuClassName={SETTINGS_CONTROL_WIDTH_CLASS}
             options={branchOptions.map((option) => ({
               id: option.id,
               label: option.label,

--- a/apps/packages/product-client/src/components/settings/panes/repo/RepoEnvironmentPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/repo/RepoEnvironmentPane.tsx
@@ -41,10 +41,10 @@ export function RepoEnvironmentPane({
     );
   }
   return (
-    <section className="space-y-6">
+    <section className="space-y-5">
       <SettingsPageHeader
         title="Environment"
-        description="Variables and files synced into cloud workspaces for this repo."
+        description="Variables and files synced to this repo's cloud workspaces."
       />
       {context === "cloud" ? (
         <EnvironmentCloud
@@ -107,15 +107,15 @@ function EnvironmentLocal({
   return (
     <SettingsEmptyState
       icon={<KeyRound aria-hidden="true" />}
-      title="No local environment store"
-      description="Local workspaces read variables from your shell and checkout. Proliferate stores environment variables and files for cloud workspaces only."
+      title="Cloud only"
+      description="Local workspaces inherit variables from your shell and checkout; managed variables and files are available in Cloud."
       action={
         <Button
           type="button"
           variant="secondary"
           onClick={() => onSelectRepoContext("cloud")}
         >
-          View cloud variables
+          View Cloud environment
         </Button>
       }
     />

--- a/apps/packages/product-client/src/components/settings/screen/RepoScopeHeaderControls.tsx
+++ b/apps/packages/product-client/src/components/settings/screen/RepoScopeHeaderControls.tsx
@@ -43,7 +43,7 @@ export function RepoScopeHeaderControls({
     focus,
   });
   return (
-    <>
+    <div className="flex items-center gap-2">
       <RepoPicker
         items={repositories.map((entry) => ({
           id: entry.sourceRoot,
@@ -70,13 +70,14 @@ export function RepoScopeHeaderControls({
       />
       <SegmentedControl
         ariaLabel="Repository settings context"
+        className="shrink-0"
         value={context}
         items={[
-          { id: "cloud", label: "Cloud", icon: <Cloud /> },
-          { id: "local", label: "Local", icon: <Laptop /> },
+          { id: "cloud", label: "Cloud", icon: <Cloud aria-hidden="true" /> },
+          { id: "local", label: "Local", icon: <Laptop aria-hidden="true" /> },
         ]}
         onChange={onSelectRepoContext}
       />
-    </>
+    </div>
   );
 }

--- a/apps/packages/product-ui/src/environments/ScriptBlock.tsx
+++ b/apps/packages/product-ui/src/environments/ScriptBlock.tsx
@@ -30,9 +30,14 @@ export function ScriptBlock({
   className,
 }: ScriptBlockProps) {
   return (
-    <div className={twMerge("overflow-hidden rounded-lg border border-border bg-surface-editor", className)}>
-      <div className="flex h-8 items-center justify-between border-b border-border-light px-2.5">
-        <span className="font-mono text-ui-sm text-muted-foreground">{fileLabel}</span>
+    <div
+      className={twMerge(
+        "overflow-clip rounded-lg border border-input bg-surface-editor focus-within:ring-1 focus-within:ring-ring",
+        className,
+      )}
+    >
+      <div className="flex h-7 items-center justify-between border-b border-border-light px-2.5">
+        <span className="text-ui-sm text-muted-foreground">{fileLabel}</span>
         {headerAction}
       </div>
       <Textarea
@@ -41,7 +46,7 @@ export function ScriptBlock({
         value={value}
         placeholder={placeholder}
         disabled={disabled}
-        className="min-h-[120px] w-full resize-y px-3 py-2 font-mono text-ui-sm leading-relaxed"
+        className="min-h-[120px] w-full resize-y px-2.5 py-2 font-mono text-ui-sm leading-[1.45]"
         onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.currentTarget.value)}
       />
     </div>

--- a/apps/packages/product-ui/src/settings/RepoPicker.tsx
+++ b/apps/packages/product-ui/src/settings/RepoPicker.tsx
@@ -15,9 +15,9 @@ export interface RepoPickerItem {
 }
 
 /**
- * Repo-scope header picker (design-system RepoPicker): bordered 200px trigger
- * with a `--special` folder chip, opening an elevated menu of repositories plus
- * an "Add repository…" footer. Defaults to the first repo when none is picked.
+ * Repo-scope header picker: compact outline trigger opening an elevated menu
+ * of repositories plus an "Add repository…" footer. Defaults to the first repo
+ * when none is picked.
  */
 export function RepoPicker({
   items,
@@ -38,10 +38,10 @@ export function RepoPicker({
       trigger={
         <Button
           type="button"
-          variant="unstyled"
-          size="unstyled"
+          variant="outline"
+          size="sm"
           aria-label="Select repository"
-          className="flex h-8 w-[200px] items-center gap-2 rounded-md border border-input bg-background px-2 text-ui-sm transition-colors hover:bg-accent data-[state=open]:bg-accent"
+          className="h-[30px] w-52 justify-start gap-2 px-2 text-ui font-normal text-foreground data-[state=open]:bg-accent"
         >
           <RepoChip kind={selected?.kind ?? "local"} />
           <span className="min-w-0 flex-1 truncate text-left">
@@ -85,11 +85,11 @@ export function RepoPicker({
 }
 
 function RepoChip({ kind }: { kind: RepoPickerItem["kind"] }) {
-  // GitHub-backed repos read as a GitHub mark; cloud environments stay a Cloud
-  // glyph. Neutral chip, not the old blue folder.
+  // GitHub-backed repos read as a GitHub mark; cloud environments stay a
+  // Cloud glyph.
   const Icon = kind === "cloud" ? Cloud : GitHub;
   return (
-    <span className="flex size-[15px] shrink-0 items-center justify-center rounded bg-surface-control text-ui-sm text-muted-foreground [&>svg]:icon-compact">
+    <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground [&>svg]:icon-compact">
       <Icon />
     </span>
   );


### PR DESCRIPTION
Visual + copy polish of the live repo-scope environments settings surface (Settings → Repo → Configure / Actions / Environment). No behavior changes, no new endpoints.

- Tighter type/section rhythm and terser copy across the three panes, on the semantic type tokens
- Full-width run-command/setup-script controls; `ScriptBlock` chrome consistent with composer-family inputs (consumer-safe change in product-ui)
- All Cloud gate/empty states unified on one icon/title/meta/action anatomy, "Set up Cloud environment" as the primary CTA
- Repo picker normalized to the standard outline Button beside the segmented Cloud|Local control

Verified: product-client typecheck + build, repo pane tests (2/2), frontend boundaries, max-lines, design-system/appearance scaling checks, package builds. Bugs/gaps noticed during the pass were logged for follow-up slices (remove-environment in Settings, dead scaffolding tree, legacy error toasts) rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)