### PR TITLE
docs(specs): systems truth pass + agent-systems overview (PR E)

### DIFF
--- a/specs/codebase/platforms/product/README.md
+++ b/specs/codebase/platforms/product/README.md
@@ -23,6 +23,7 @@ expectations, but it is not the owner of a full user workflow.
 | Billing | Credit authorization, Stripe subscription/refill behavior, budget reconciliation, billing state in product responses, and billing QA. | [billing.md](billing.md) |
 | Model catalog | Probe-first model truth: machine snapshots, cloud snapshots, shipped-catalog fallback, launch validation universe, visibility, and model identity. | [model-catalog.md](model-catalog.md) (Status: target) |
 | Agent distribution | Registry/catalog document contract, pinned auto-install and seed topology, binary-carried catalog convergence, supervisor-owned runtime binary convergence, the probe pipeline, and readiness projection. | [agent-distribution.md](agent-distribution.md) (Status: target) |
+| Agent systems overview | No contract — the narrative map of how agent distribution, agent auth, the model gateway, and the model catalog compose; read first when orienting. | [../../systems/product/agents/README.md](../../systems/product/agents/README.md) |
 
 ## Naming Notes
 

--- a/specs/codebase/platforms/product/integrations.md
+++ b/specs/codebase/platforms/product/integrations.md
@@ -5,10 +5,8 @@ integration MCP gateway, and the Worker identity that gives AnyHarness scoped
 access to that gateway. Provider credentials remain encrypted in Cloud;
 AnyHarness receives only a Proliferate gateway bearer.
 
-Harness model credentials and the LLM gateway are separate owners; see the
-Agent auth and Managed model gateway rows in [README.md](README.md) (their
-platform documents are being rewritten after the Bifrost-era versions were
-removed).
+Harness model credentials and the LLM gateway are separate owners:
+[agent-auth.md](agent-auth.md) and [model-gateway.md](model-gateway.md).
 
 ## Mental Model
 
@@ -141,8 +139,10 @@ publication does not have to race a matching server deployment.
 
 Heartbeat authenticates the opaque Worker bearer, updates `last_seen_at`, and
 persists any reported Worker and AnyHarness versions. Its response carries the
-desired Worker, AnyHarness, and agent-catalog versions. The Worker uses that
-response for heartbeat-driven convergence; see the
+desired Worker and AnyHarness versions (and, deletion-pending under the
+binary-only catalog ruling in
+[agent-distribution.md](agent-distribution.md), an agent-catalog version).
+The Worker uses that response for heartbeat-driven convergence; see the
 [Proliferate Worker structure](../../structures/proliferate-worker/README.md).
 
 The gateway token's `last_used_at` column is deliberately not updated on the
@@ -414,9 +414,10 @@ and [`runtime_workers/api.py`](../../../../server/proliferate/server/cloud/runti
 
 ## Boundaries
 
-- The Worker currently enrolls, heartbeats, converges catalog and binaries,
-  and materializes the integration-gateway credential. It is not the owner of
-  workspace creation or repository materialization.
+- The Worker currently enrolls, heartbeats, writes mailbox update requests
+  for binary divergence (catalog convergence is deletion-pending under the
+  binary-only ruling), and materializes the integration-gateway credential.
+  It is not the owner of workspace creation or repository materialization.
 - Cloud directly creates or reconnects AnyHarness for managed sandboxes; the
   Worker sidecar is optional.
 - Generic MCP session assembly belongs to [MCP runtime](mcp-runtime.md).

--- a/specs/codebase/platforms/product/sandbox-provisioning.md
+++ b/specs/codebase/platforms/product/sandbox-provisioning.md
@@ -152,7 +152,13 @@ repository attempt owns its GitHub authority check and credential
 materialization, and remains best-effort so one repository failure cannot
 prevent the non-repository state from converging.
 
-The E2B launch path does not launch Proliferate Supervisor. A missing or
+The E2B launch path launches Proliferate Supervisor as the process parent of
+AnyHarness and the Worker when `supervisor_owned_runtime` is on
+(`_launch_supervisor_owned_runtime` in
+[runtime_launch.py](../../../../server/proliferate/server/cloud/materialization/sandbox_io/runtime_launch.py));
+the direct non-supervisor launch is the legacy branch, deletion-pending with
+the rest of the legacy topology
+([agent-distribution.md](agent-distribution.md) Current gaps). A missing or
 unhealthy Worker does not make direct AnyHarness access unavailable. Reusing an
 already-healthy AnyHarness does not currently restart or self-heal a missing
 Worker sidecar.

--- a/specs/codebase/structures/README.md
+++ b/specs/codebase/structures/README.md
@@ -12,7 +12,7 @@ operator procedures; those belong under `systems/`, `platforms/`, and
 | Frontend apps and shared packages | Desktop/Web/Mobile app structure, React layers, shared frontend packages, styling, copy, telemetry, access boundaries, and product UI/package dependency direction. | [frontend/README.md](frontend/README.md), [frontend/packages/README.md](frontend/packages/README.md), focused guides under [frontend/guides/](frontend/guides/) |
 | Desktop native | Tauri shell, native commands, bundled resources, AnyHarness sidecar launch, profile app identity, and desktop release resources. | [desktop-native/README.md](desktop-native/README.md), specs under [desktop-native/specs/](desktop-native/specs/) |
 | AnyHarness runtime | HTTP/SSE APIs, session/workspace orchestration, live runtime, harness adapters, MCP runtime integration, persistence, observability, contract schemas, and runtime crate ownership. | [anyharness/README.md](anyharness/README.md), [anyharness/contract.md](anyharness/contract.md), guides under [anyharness/guides/](anyharness/guides/), specs under [anyharness/specs/](anyharness/specs/) |
-| Proliferate Worker | Optional cloud/desktop runtime sidecar for enrollment, heartbeat, catalog convergence, Worker/AnyHarness version convergence, integration-gateway credentials, local identity, and update state. | [proliferate-worker/README.md](proliferate-worker/README.md), guides under [proliferate-worker/guides/](proliferate-worker/guides/) |
+| Proliferate Worker | Optional cloud/desktop runtime sidecar for enrollment, heartbeat, version-divergence observation (mailbox update requests for Proliferate Supervisor), integration-gateway credentials, and local identity. | [proliferate-worker/README.md](proliferate-worker/README.md), guides under [proliferate-worker/guides/](proliferate-worker/guides/) |
 | Proliferate Supervisor | Target process supervisor, worker/runtime spawn loops, install layout, service generation, update staging, rollback, and target smoke behavior. | [proliferate-supervisor/README.md](proliferate-supervisor/README.md) |
 | Server | FastAPI/cloud control plane domains, API/service/store layering, auth/resource access boundaries, database access, workers, integrations, config, and error shape. | [server/README.md](server/README.md), guides under [server/guides/](server/guides/) |
 | SDKs | AnyHarness TypeScript SDK generation/build ownership, generated-code boundaries, React SDK ownership, and contract-consumer rules. | [sdk/README.md](sdk/README.md) |
@@ -27,13 +27,11 @@ split by boundary:
   [../systems/product/auth/README.md](../systems/product/auth/README.md).
 - Server authentication, resource access, authorization helpers, and product
   policy layering live in [server/guides/auth.md](server/guides/auth.md).
-- Agent LLM auth (key vault, selections, `state.json` materialization) and the
-  LiteLLM-backed managed model gateway have no current platform document. The
-  prior `agent-auth.md` / `agent-auth-bifrost-byok.md` docs described the
-  retired Bifrost-era architecture and were removed; rewrites are planned. The
-  owning code is `server/proliferate/server/cloud/agent_gateway/`,
-  `server/proliferate/integrations/litellm/`, and
-  `anyharness/crates/anyharness-lib/src/domains/agents/route_auth/`.
+- Agent LLM auth (key vault, selections, `state.json` delivery, per-harness
+  application) is owned by
+  [../platforms/product/agent-auth.md](../platforms/product/agent-auth.md);
+  the LiteLLM-backed managed model gateway is owned by
+  [../platforms/product/model-gateway.md](../platforms/product/model-gateway.md).
 
 Create a dedicated `structures/auth-gateway/` spec only if the gateway becomes
 a separately deployed or separately owned codebase boundary. Until then, keep

--- a/specs/codebase/structures/anyharness/contract.md
+++ b/specs/codebase/structures/anyharness/contract.md
@@ -177,9 +177,9 @@ AnyHarness HTTP contract:
 
 | Worker purpose | AnyHarness route | Notes |
 | --- | --- | --- |
-| read active catalog version | `GET /v1/catalogs/agents/version` | Compares the running runtime with the version advertised by Cloud heartbeat. |
-| apply catalog document | `PUT /v1/catalogs/agents` | Pushes the Cloud catalog when versions differ. |
-| verify a relaunched runtime | `GET /health` | Requires the desired AnyHarness version before accepting an in-place runtime update. |
+| read active catalog version | `GET /v1/catalogs/agents/version` | Read-only observability; stays. |
+| apply catalog document | `PUT /v1/catalogs/agents` | Deletion-pending: the catalog is binary-only ([agent-distribution.md](../../platforms/product/agent-distribution.md) Current gaps), so the push route and the heartbeat catalog version go away together. |
+| verify a relaunched runtime | `GET /health` | Requires the desired AnyHarness version before accepting an in-place runtime update (legacy path; Proliferate Supervisor runs the same gate on supervisor-owned targets). |
 
 The Worker's download, checksum, preflight, swap, and relaunch orchestration
 lives outside the AnyHarness API. Only the final health/version gate uses the

--- a/specs/codebase/structures/anyharness/src/agent-mode-matrix.md
+++ b/specs/codebase/structures/anyharness/src/agent-mode-matrix.md
@@ -17,8 +17,10 @@ The field is curation, not a universal default. It must not change ordinary
 interactive session creation, stored user preferences, or the mode chosen by an
 agent process when `mode_id` is omitted.
 
-The runtime may start from the bundled `catalogs/agents/catalog.json` document
-or activate a newer validated catalog through control-plane sync. The active
+The runtime starts from the bundled `catalogs/agents/catalog.json` document —
+the binary is the catalog's only transport
+([agent-distribution.md](../../../platforms/product/agent-distribution.md);
+the legacy control-plane sync path is deletion-pending). The active
 document is projected into the target's resolved launch options. ProductClient
 combines those target-local options with cloud display metadata, but the
 selected local, cloud, or SSH runtime owns the effective unattended default.

--- a/specs/codebase/structures/anyharness/src/agents.md
+++ b/specs/codebase/structures/anyharness/src/agents.md
@@ -124,15 +124,15 @@ catalog path. Cloud product catalogs may be newer than these bundled runtime
 inputs; AnyHarness still validates creation against what the target runtime can
 actually launch.
 
-The two inputs converge on different tracks. The `catalog.json` document syncs live:
-the cloud worker watches the heartbeat `catalogVersion`, fetches the newer
-document, and `PUT`s it to the runtime, which validates and reconciles without
-a binary change. `registry.json` (install/launch/auth recipes) rides
-the binary only: it is `include_str!`'d, so a new registry ships iff a new
-runtime binary ships. In cloud sandboxes the binary itself can be swapped in
-place by the Worker (see
-`specs/codebase/structures/proliferate-worker/guides/lifecycle.md`); Desktop
-gets a new binary only via the app bundle.
+Both inputs ride the binary: `catalog.json` and `registry.json` are
+`include_str!`'d, so a new document ships iff a new runtime binary ships —
+the binary is the only catalog transport
+([agent-distribution.md](../../../platforms/product/agent-distribution.md)).
+In cloud sandboxes the binary is swapped by Proliferate Supervisor on a
+mailbox request; Desktop gets a new binary via the app bundle. (The legacy
+live catalog sync — cloud worker watching the heartbeat `catalogVersion`
+and `PUT`ing the newer document — is deletion-pending per
+agent-distribution.md's Current gaps.)
 
 The unattended mode is part of the active catalog rather than the trusted
 registry recipe. Catalog validation requires a non-blank value that exists in
@@ -233,9 +233,13 @@ Important install cases:
   bundled package spec; stale managed packages report `install_required` so
   normal setup/reconcile can update user-owned older ACP adapters
 - the update path for every installable agent process recipe is reconcile against
-  the catalog pins: the runtime startup pass does this automatically (installed-only),
-  and the desktop "update local installs" button / manual reinstall do it on demand. The
-  version + source come from the bundled catalog lockfile, resolved at probe time by
+  the catalog pins: the runtime startup pass does this automatically
+  (installed-only today; the settled target converges the full supported
+  set, installing absent agents too —
+  [agent-distribution.md](../../../platforms/product/agent-distribution.md)
+  Current gaps), and the desktop "update local installs" button / manual
+  reinstall do it on demand. The version + source come from the bundled
+  catalog lockfile, resolved at probe time by
   `scripts/agent-catalog/resolve-pins.mjs`
 - installer mutations are serialized by runtime-home file locks under
   `agents/<kind>/.install.lock` so desktop, CLI, and seed hydration do not
@@ -290,11 +294,15 @@ user's normal `HOME` and runs from the user home directory when available, so
 vendor CLIs write their usual local auth files.
 
 Cloud target enrollment, Git bootstrap, and workspace materialization do not
-install agents. A fresh cloud/SSH target may report worker and AnyHarness
-online while `start_session` still fails with an install/readiness error until
-the requested agent is installed through this API. The runtime startup pass keeps
-*already-installed* agents on a cloud worker current with the catalog pins, but it
-does not eagerly install missing agents — those still install on demand here.
+install agents. Today a fresh cloud/SSH target may report worker and
+AnyHarness online while `start_session` still fails with an
+install/readiness error until the requested agent is installed through this
+API, because the runtime startup pass reconciles *already-installed* agents
+only. That is a pinned gap, not the design: the settled target
+auto-installs the full supported set at startup reconcile
+([agent-distribution.md](../../../platforms/product/agent-distribution.md)
+Current gaps), after which the on-demand path here remains only as the
+explicit-reinstall hook.
 
 ### ACP Registry Flow (probe-time only)
 
@@ -332,8 +340,11 @@ Reconcile runs in two scopes, selected by the `installed_only` flag:
   managed install for every registry agent — installs missing ones too.
 - **installed-only** (`installed_only=true`): only agents already installed on disk
   (`resolve_agent(..).agent_process.installed`) are reconciled to the catalog pins; a
-  missing agent is `skipped` (it installs on demand at session start). This is the scope
-  used by the runtime startup pass and the desktop "update local installs" button.
+  missing agent is `skipped`. This is the scope used by the runtime startup
+  pass and the desktop "update local installs" button today; the settled
+  target flips the startup pass to the full-set scope (auto-install ruling,
+  [agent-distribution.md](../../../platforms/product/agent-distribution.md)
+  Current gaps).
 
 `POST /v1/agents/reconcile` also accepts an optional `agentKinds` list. Empty
 keeps the all-agent behavior; a single kind is the asynchronous manual
@@ -341,7 +352,8 @@ install/update path used by harness settings. Unknown kinds are rejected. An
 active job is reused only when its install mode and agent scope cover the new
 request; an incompatible request receives `409 AGENT_RECONCILE_BUSY` so the
 running download remains the single observable disk writer. Internal startup
-and catalog-applied installed-only pokes reject compatible reuse, wait for any
+pokes (and, until the binary-only catalog ruling deletes it, the
+catalog-applied poke) reject compatible reuse, wait for any
 active job to finish, and atomically admit a fresh pass against one latest-catalog
 snapshot, so a foreground update cannot drop or partially mix a pin refresh.
 
@@ -368,7 +380,11 @@ bundled seed if pending, then run an installed-only reconcile. It is non-blockin
 HTTP server boots and answers `/health` while it runs), best-effort (failures land in the
 reconcile snapshot, never fatal), and idempotent (an up-to-date agent short-circuits with
 no network — see `install_policy` version-drift detection). The catalog-applied poke (a
-newer cloud catalog synced at runtime) also kicks an installed-only reconcile.
+newer cloud catalog synced at runtime) also kicks an installed-only reconcile —
+deletion-pending with the heartbeat catalog transport
+([agent-distribution.md](../../../platforms/product/agent-distribution.md)
+Current gaps): under the binary-only ruling a new catalog always arrives with
+a fresh process start, so the startup pass is the only poke it needs.
 
 ### Bundled Agent Seed Flow
 
@@ -443,9 +459,12 @@ snapshot (`GET /v1/agents/reconcile`) to display per-agent status and refreshes 
 list once per terminal job. A bounded 30-second inactive poll discovers runtime-owned
 startup/catalog jobs that begin after the initial idle read; queued/running work polls at
 1.5 seconds and active byte transfer at 750 milliseconds. The UI renders the runtime target,
-aggregate bytes, and separate CLI/ACP rows. Missing non-seeded agents are not auto-installed
-at startup; they install on demand at session start or through a selected-agent reconcile
-from harness settings. The synchronous per-agent install endpoint remains available for
+aggregate bytes, and separate CLI/ACP rows. Today missing non-seeded agents are not
+auto-installed at startup — they install on demand at session start or through a
+selected-agent reconcile from harness settings — but that is a pinned gap: the settled
+target auto-installs the full supported set at the startup pass
+([agent-distribution.md](../../../platforms/product/agent-distribution.md)
+Current gaps). The synchronous per-agent install endpoint remains available for
 compatibility.
 
 Seed hydration verifies the archive `.sha256`, validates the manifest target and

--- a/specs/codebase/structures/proliferate-worker/README.md
+++ b/specs/codebase/structures/proliferate-worker/README.md
@@ -1,9 +1,12 @@
 # Proliferate Worker
 
 Proliferate Worker is an optional process beside AnyHarness. It enrolls with
-Cloud once, sends heartbeats, and converges the local catalog and, depending
-on target topology, either the AnyHarness/Worker binaries directly or a
-durable update request into a Proliferate Supervisor mailbox.
+Cloud once, sends heartbeats, and — when a heartbeat ack reports version
+divergence — writes a durable update request into a Proliferate Supervisor
+mailbox. The agent catalog is not converged here: it ships only inside the
+runtime binary
+([agent-distribution.md](../../platforms/product/agent-distribution.md)),
+so binary convergence is catalog convergence.
 
 It is not a Cloud command runner. It does not lease commands, materialize
 workspaces, upload session events, or maintain Cloud projections. Cloud
@@ -47,7 +50,10 @@ config + single-process lock + local SQLite
   -> after each successful heartbeat, repair that fresh gateway credential if
      a revoked predecessor overwrote the shared file
   -> use desiredVersions to converge, in order:
-       agent catalog
+       agent catalog (DELETION PENDING: binary-only transport ruling —
+         the catalog ships inside the runtime binary; catalog_sync.rs and
+         the heartbeat catalog version are scheduled for removal, see
+         agent-distribution.md Current gaps)
        AnyHarness binary:
          supervisor-owned target -> write a mailbox update request
          legacy target (when enabled) -> in-place swap (deprecated)
@@ -110,7 +116,7 @@ inventory, or materialization subsystems.
 | `main.rs`, `runtime.rs` | CLI entry, dependency construction, one heartbeat-and-convergence loop | Product workflows or background task supervision | [Runtime](guides/runtime.md) |
 | `identity/**` | Enrollment request, durable Worker credential, fingerprint | Sandbox identity, command identity, re-enrollment policy | [Identity](guides/identity.md) |
 | `lifecycle/heartbeat.rs` | Heartbeat cadence, request, and acknowledgement | Update execution or server-side liveness policy | [Lifecycle](guides/lifecycle.md) |
-| `catalog_sync.rs` | Compare catalog versions, fetch from Cloud, push to AnyHarness | General AnyHarness access | [Lifecycle](guides/lifecycle.md), [Clients](guides/clients.md) |
+| `catalog_sync.rs` | Compare catalog versions, fetch from Cloud, push to AnyHarness — **deletion pending**: the catalog is binary-only ([agent-distribution.md](../../platforms/product/agent-distribution.md) Current gaps); do not extend | General AnyHarness access | [Lifecycle](guides/lifecycle.md), [Clients](guides/clients.md) |
 | `self_update.rs` | Verify, preflight, swap, and exec the Worker binary on a **legacy** (non-supervisor-owned) target; deprecated, scheduled for deletion after the bridge window | AnyHarness or Supervisor updates, any behavior on a supervisor-owned target | [Lifecycle](guides/lifecycle.md) |
 | `anyharness_update.rs` | Verify, stop, swap, relaunch, health-gate, and roll back AnyHarness on a **legacy** target; deprecated, scheduled for deletion after the bridge window | General runtime lifecycle, any behavior on a supervisor-owned target | [Lifecycle](guides/lifecycle.md) |
 | `supervisor_bridge.rs` | Write one durable mailbox update request per diverging heartbeat on a supervisor-owned target; the one-time D5 bridge that hands an already-provisioned legacy target to Proliferate Supervisor | Update download, verification, activation, health-gating, or rollback (Supervisor owns all of that) | [Lifecycle](guides/lifecycle.md) |

--- a/specs/codebase/structures/proliferate-worker/guides/clients.md
+++ b/specs/codebase/structures/proliferate-worker/guides/clients.md
@@ -15,7 +15,7 @@ cloud_client/
 - `POST /v1/cloud/worker/heartbeat`
 - `GET /v1/cloud/worker/download/{target}/{asset}`
 - `GET /v1/cloud/runtime/download/{target}/{asset}`
-- `GET /v1/catalogs/agents`
+- `GET /v1/catalogs/agents` (deletion-pending: heartbeat catalog transport)
 - a direct unauthenticated fetch from an already resolved CDN URL for the
   sibling checksum
 
@@ -32,8 +32,12 @@ update should happen, and it does not write the local store.
 There is no general `anyharness_client` module in the current Worker.
 
 - `catalog_sync.rs` directly owns its focused catalog version GET and catalog
-  PUT, including optional runtime bearer auth.
-- `anyharness_update.rs` directly owns the post-relaunch `/health` probe.
+  PUT, including optional runtime bearer auth — deletion-pending with the
+  rest of the heartbeat catalog transport
+  ([agent-distribution.md](../../../platforms/product/agent-distribution.md)
+  Current gaps).
+- `anyharness_update.rs` directly owns the post-relaunch `/health` probe
+  (legacy-target path only).
 
 These calls do not make the Worker the general execution client for
 AnyHarness. Cloud performs current workspace and session operations directly.

--- a/specs/codebase/structures/proliferate-worker/guides/lifecycle.md
+++ b/specs/codebase/structures/proliferate-worker/guides/lifecycle.md
@@ -1,7 +1,8 @@
 # Worker Lifecycle And Convergence
 
 The Worker heartbeat is both its liveness signal and the carrier for desired
-catalog and binary versions.
+binary versions (the catalog version it still carries is deletion-pending —
+see below).
 
 ```text
 POST /v1/cloud/worker/heartbeat
@@ -25,20 +26,22 @@ reasserting a revoked gateway token. A success returned immediately before
 revocation can race one final stale write, which the active successor repairs
 on its next successful heartbeat.
 
-## Catalog Convergence
+## Catalog Convergence (deletion pending)
 
-When `desiredVersions.catalogVersion` differs from AnyHarness's active
-catalog version:
+The settled target has no catalog convergence in this crate: the agent
+catalog ships only inside the runtime binary, so a runtime binary swap is
+the catalog update
+([agent-distribution.md](../../../platforms/product/agent-distribution.md)
+Current gaps owns the deletion of this path, the heartbeat
+`catalogVersion`, and the runtime's `PUT /v1/catalogs/agents` route).
 
-```text
-GET AnyHarness /v1/catalogs/agents/version
-  -> GET Cloud /v1/catalogs/agents (ETag-aware)
-  -> PUT the catalog bytes to AnyHarness /v1/catalogs/agents
-```
-
-Catalog state (the last ETag) is in memory. A 404 from the runtime version
-endpoint is treated as an older runtime without catalog-sync support. Other
-failures are logged and retried on a later heartbeat.
+Until that lands, the legacy mechanism still runs: when
+`desiredVersions.catalogVersion` differs from AnyHarness's active catalog
+version, the Worker does
+`GET AnyHarness /v1/catalogs/agents/version` →
+`GET Cloud /v1/catalogs/agents` (ETag-aware) →
+`PUT` the catalog bytes to AnyHarness. Catalog state (the last ETag) is in
+memory. Do not extend this path.
 
 ## Supervisor-Owned Convergence (mailbox)
 

--- a/specs/codebase/structures/proliferate-worker/guides/runtime.md
+++ b/specs/codebase/structures/proliferate-worker/guides/runtime.md
@@ -30,7 +30,8 @@ POST heartbeat
   -> on failure: log and retry next tick
   -> if this process freshly enrolled and the shared gateway file differs,
      restore its credential now that heartbeat authenticated it
-  -> catalog convergence (non-fatal)
+  -> catalog convergence (non-fatal; deletion-pending — the catalog ships
+     inside the runtime binary, see the Lifecycle guide)
   -> AnyHarness binary convergence (non-fatal; optional)
   -> Worker binary convergence (non-fatal; optional)
 ```

--- a/specs/codebase/structures/proliferate-worker/guides/store.md
+++ b/specs/codebase/structures/proliferate-worker/guides/store.md
@@ -32,6 +32,11 @@ anyharness_update (single row, id = 1)
 enrollment. `anyharness_update` records the runtime version last swapped and
 health-verified plus a pin explicitly marked after a relaunch or health-gate
 failure, preventing that recorded pin from being retried every heartbeat.
+The `anyharness_update` table serves only the legacy (non-supervisor-owned)
+swap path; on supervisor-owned targets the swap journal and failed-pin
+record live with Proliferate Supervisor
+([proliferate-supervisor/README.md](../../proliferate-supervisor/README.md)),
+and this table goes away with the legacy path.
 
 ## Source Ownership
 

--- a/specs/codebase/structures/server/architecture.md
+++ b/specs/codebase/structures/server/architecture.md
@@ -299,7 +299,10 @@ versions are no longer a single global pin: `record_heartbeat` overlays
 nullable per-target `desired_anyharness_version`/`desired_worker_version`
 columns on the target's `cloud_sandbox` row over the global pin (null
 inherits the pin). Catalog convergence reads/writes the AnyHarness catalog
-directly. On a legacy target, Worker self-update verifies and preflights a
+directly — deletion-pending: the catalog is binary-only
+([agent-distribution.md](../../platforms/product/agent-distribution.md)
+Current gaps), so the heartbeat's catalog version and this convergence go
+away together. On a legacy target, Worker self-update verifies and preflights a
 public artifact, atomically swaps the binary, then `exec`s it, and AnyHarness
 convergence stops, swaps, relaunches, health-checks, and can roll back the
 runtime binary — both deprecated paths. On a supervisor-owned target, that
@@ -418,5 +421,7 @@ projection ledger.
 backward; transactions are short and owned at the edge, with the outbox for
 external side effects.** Managed Cloud uses one personal `cloud_sandbox`,
 just-in-time E2B/AnyHarness materialization, and direct gateway access. The
-optional Worker enrolls, heartbeats, and converges catalog/binary versions; it
+optional Worker enrolls, heartbeats, and observes binary-version divergence
+(mailbox requests for Proliferate Supervisor; catalog convergence is
+deletion-pending under the binary-only ruling); it
 does not carry product commands or replicate runtime events.

--- a/specs/codebase/systems/product/README.md
+++ b/specs/codebase/systems/product/README.md
@@ -20,7 +20,7 @@ restating folder rules or low-level reusable contracts.
 | Workflows | User-owned workflow definitions, ordered stages and prompt steps, catalog-backed harness validation, revisioning, optional default repository configuration, and definition-authoring UX. | [workflows/definitions.md](workflows/definitions.md) |
 | Automations | Scheduled/manual automations and the parked Slack bot contract. | [automations/README.md](automations/README.md) |
 | Engagement | Customer.io transport, code-owned profile attributes and lifecycle events, and current enable/no-op gates. | [engagement/README.md](engagement/README.md) |
-| Delegated work and artifacts | Delegated-work UX and cowork artifact lifecycle. | [agents/README.md](agents/README.md) |
+| Agents | The agent-systems overview map (distribution, auth, gateway, model catalog), plus delegated-work UX and cowork artifact lifecycle. | [agents/README.md](agents/README.md) |
 | Settings and appearance | Settings/admin information architecture, Appearance scaling, billing/account/team/config surfaces, filtering, origins, and admin-facing state. | [settings/README.md](settings/README.md) |
 | Support reporting | Currently shipped private support capture. | [support/README.md](support/README.md) |
 | Web/Desktop client unification | Shared client ownership, thin Desktop/Web hosts, capability policy, and migration governance. | [clients/web-desktop-unification/README.md](clients/web-desktop-unification/README.md) |
@@ -32,7 +32,7 @@ Use this map before creating a new spec:
 
 | Planning topic | Current owner |
 | --- | --- |
-| Onboarding | [onboarding/README.md](onboarding/README.md), with lower-level slices in [auth/README.md](auth/README.md), [../../platforms/product/billing.md](../../platforms/product/billing.md), [../../platforms/product/workspace-provisioning.md](../../platforms/product/workspace-provisioning.md), and [settings/information-architecture.md](settings/information-architecture.md). The managed model gateway platform document was removed as stale (Bifrost-era); a rewrite is planned. |
+| Onboarding | [onboarding/README.md](onboarding/README.md), with lower-level slices in [auth/README.md](auth/README.md), [../../platforms/product/billing.md](../../platforms/product/billing.md), [../../platforms/product/workspace-provisioning.md](../../platforms/product/workspace-provisioning.md), and [settings/information-architecture.md](settings/information-architecture.md). The managed model gateway is owned by [../../platforms/product/model-gateway.md](../../platforms/product/model-gateway.md). |
 | Browsers | No dedicated browser system spec yet. Product MCP ownership is in [Product Agent Features](../../platforms/product/agent-features/README.md); runtime/domain ownership remains under [AnyHarness](../../structures/anyharness/README.md). Create a browser system spec before adding user-visible browser workflows. |
 | Terminals | [workspaces/terminals.md](workspaces/terminals.md) owns terminal pane UX and the creation grid contract. Runtime ownership remains under [AnyHarness](../../structures/anyharness/README.md). |
 | Computer Use | No dedicated computer-use system spec yet. Product MCP ownership is in [Product Agent Features](../../platforms/product/agent-features/README.md); create a system spec before adding user-visible Computer Use workflow, permissions, or QA behavior. |

--- a/specs/codebase/systems/product/agents/README.md
+++ b/specs/codebase/systems/product/agents/README.md
@@ -1,9 +1,83 @@
 # Agent Systems
 
+Start here for anything agent-shaped. This document owns no contract: it is
+the narrative map of how the agent platform documents fit together, so a
+reader knows which one to open. Each claim below is one sentence; the
+linked document is the authority.
+
+## The four platform documents
+
+| Document | One-line ownership | Status |
+| --- | --- | --- |
+| [agent-distribution.md](../../../platforms/product/agent-distribution.md) | What a harness *is* and how it gets onto a machine: the registry/catalog document pair, pinned auto-installs, binary-carried catalog convergence, supervisor-owned runtime swaps, the probe pipeline, readiness projection. | target |
+| [agent-auth.md](../../../platforms/product/agent-auth.md) | How a harness gets *credentials* at launch: auth source selections, the key vault, `state.json` delivery, per-harness application recipes, fail-closed launch. | target |
+| [model-gateway.md](../../../platforms/product/model-gateway.md) | The managed inference proxy: LiteLLM artifact and deployment, enrollment/teams/virtual keys, access-group model gating, budgets, usage import. | target |
+| [model-catalog.md](../../../platforms/product/model-catalog.md) | Which *models* a ready, authenticated harness can run: probe-generated per-user snapshots, projection to pickers, availability. | target |
+
+Two lifecycle documents ride along:
+
+- [agent-catalog-update.md](../../../../developing/operating/agent-catalog-update.md)
+  — the operator runbook for shipping a new agent catalog.
+- [catalog-probe.md](../../../../developing/operating/catalog-probe.md) — the
+  scheduled probe's credential lifecycle.
+
+## The journey of a session
+
+Everything composes into one story; each arrow names the document that owns
+the step.
+
+```text
+registry.json (how to install/run/authenticate a harness)
+  └─ probe pipeline pins exact versions ──────────────► agent-distribution
+catalog.json (the lockfile), compiled into the runtime binary
+  └─ binary ships: app bundle (desktop) or supervisor
+     swap on heartbeat divergence (cloud) ─────────────► agent-distribution
+runtime startup reconcile installs/updates harnesses ──► agent-distribution
+user picks an auth source per harness ─────────────────► agent-auth
+  └─ gateway sources use per-(subject, harness) keys
+     minted by enrollment ─────────────────────────────► model-gateway
+state.json delivers resolved key material ─────────────► agent-auth
+readiness projects install + credential state ─────────► agent-distribution
+model probe snapshots what this auth context serves ───► model-catalog
+session launch: route_auth builds the harness's world,
+  fail-closed; the harness calls the proxy or provider ► agent-auth / model-gateway
+```
+
+## Boundary one-liners
+
+The fences that keep one fact in one document:
+
+- **Declare vs apply**: agent-distribution *declares* a harness's auth
+  vocabulary (registry slots, env var names, login policy);
+  agent-auth *applies* a selected source. A new harness touches both.
+- **Key vs models**: agent-auth delivers the gateway key as an opaque
+  value; which models that key can see is proxy-side access-group
+  enforcement owned by model-gateway.
+- **Harness truth vs model truth**: agent-distribution's catalog pins
+  harness versions and ships in the binary; model-catalog's snapshots are
+  probed per user at runtime and never ship in a binary.
+- **One transport each**: the agent catalog's only transport is the
+  runtime binary; auth's only transport is `state.json`; neither has a
+  live mid-session push — changes land at the next restart or launch.
+
+## Agent-experience systems in this folder
+
 - [Cowork Artifacts](cowork-artifacts.md) — current artifact lifecycle and
   product behavior.
-- [Delegated Work](delegated-work.md) — target UX for delegated work and review
-  agents.
+- [Delegated Work](delegated-work.md) — target UX for delegated work and
+  review agents.
 
 Reusable Product MCP contracts live under
 [Product Agent Features](../../../platforms/product/agent-features/README.md).
+
+## Neighboring owners
+
+- Runtime binary *mechanics* (mailbox, swap state machine, rollback):
+  [proliferate-supervisor](../../../structures/proliferate-supervisor/README.md)
+  and [proliferate-worker](../../../structures/proliferate-worker/README.md)
+  structure docs, under agent-distribution's contract.
+- The `agents` domain source layout:
+  [anyharness/src/agents.md](../../../structures/anyharness/src/agents.md).
+- Billing of gateway spend:
+  [billing.md](../../../platforms/product/billing.md), integrated through
+  model-gateway's account model.

--- a/specs/codebase/systems/product/onboarding/README.md
+++ b/specs/codebase/systems/product/onboarding/README.md
@@ -22,10 +22,10 @@ Out of scope:
   [Product Auth](../auth/README.md)
 - server auth/resource-access structure, owned by
   [../../../structures/server/guides/auth.md](../../../structures/server/guides/auth.md)
-- managed-credit and LiteLLM gateway contracts (platform document removed as
-  stale Bifrost-era content; rewrite planned — owning code is
-  `server/proliferate/server/cloud/agent_gateway/` and
-  `server/proliferate/integrations/litellm/`)
+- managed-credit and LiteLLM gateway contracts, owned by
+  [../../../platforms/product/model-gateway.md](../../../platforms/product/model-gateway.md)
+  (auth selections and key delivery:
+  [../../../platforms/product/agent-auth.md](../../../platforms/product/agent-auth.md))
 - billing authorization and Stripe subscription/refill behavior, owned by
   [../../../platforms/product/billing.md](../../../platforms/product/billing.md)
 - managed workspace creation, owned by

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -7,8 +7,15 @@ Current gap: the managed-Target UI described here is not implemented.
 Date: 2026-05-20.
 
 Depends on: [`sandbox-provisioning.md`](../../../platforms/product/sandbox-provisioning.md),
-[`mcp-skills.md`](../../../platforms/product/mcp-skills.md), and the agent auth
-platform (its Bifrost-era document was removed; a rewrite is planned).
+[`mcp-skills.md`](../../../platforms/product/mcp-skills.md), and
+[`agent-auth.md`](../../../platforms/product/agent-auth.md).
+
+Staleness note (2026-07-25): this document predates the Bifrost removal.
+Its Agents-scope content (the `agent-authentication` pane, its panes,
+primitives, deep links, copy files, and smoke steps) describes removed UI;
+each such block below carries a correction to the shipped per-harness
+sections. The authoritative auth contract is
+[`agent-auth.md`](../../../platforms/product/agent-auth.md).
 
 This spec defines the settings shell, sidebar navigation, page ownership,
 shared UI primitives, and shared vocabulary used by every other spec
@@ -116,11 +123,15 @@ Hard:
 - [`mcp-skills.md`](../../../platforms/product/mcp-skills.md): Plugins page
   rows show `enabled`, `public_to_org`, `auth_status`,
   `runtime_apply_status`.
-- Agent auth platform (document removed; rewrite planned): this spec's Agent
-  Authentication pane (`CloudAgentAuthLibrary` + `ComputeTargetAgentAuthCard`,
-  `CredentialPicker`) described the removed Bifrost-era UI. The shipped UI is
-  per-harness settings sections (`agent-claude`, `agent-codex`,
-  `agent-opencode`, `agent-grok`, `agent-api-keys`).
+- [`agent-auth.md`](../../../platforms/product/agent-auth.md): this spec's
+  Agent Authentication pane (`CloudAgentAuthLibrary` +
+  `ComputeTargetAgentAuthCard`, `CredentialPicker`) described the removed
+  Bifrost-era UI. The shipped UI is per-harness settings sections
+  (`agent-claude`, `agent-codex`, `agent-opencode`, `agent-grok`,
+  `agent-api-keys`), rendered by
+  [HarnessPane.tsx](../../../../../apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.tsx)
+  with three method cards (gateway / API key / CLI login) per
+  agent-auth.md's selection model.
 
 Soft:
 
@@ -175,6 +186,14 @@ Repo      environments, compute ("Personal compute")
 Agents    agent-defaults, agent-authentication
 ```
 
+> Shipped correction: the Agents scope is per-harness pages plus the key
+> pool — `agent-claude`, `agent-codex`, `agent-opencode`, `agent-grok`,
+> `agent-api-keys`
+> ([navigation-presentation.ts](../../../../../apps/packages/product-client/src/lib/domain/settings/navigation-presentation.ts)).
+> `agent-defaults` and `agent-authentication` were removed; legacy links
+> redirect to `agent-claude` and `agent-api-keys` respectively
+> ([navigation.ts](../../../../../apps/packages/product-client/src/lib/domain/settings/navigation.ts)).
+
 **Routing**: URL search param `?section=<id>`. Active section is
 managed by `useSettingsNavigation()`; the active scope tab is derived
 from the section. Sections are defined in
@@ -191,6 +210,13 @@ SETTINGS_CONTENT_SECTIONS = [
   // parked (kept in code, unregistered): "slack-bot"
 ]
 ```
+
+> Shipped correction: the registered array
+> ([config/settings.ts](../../../../../apps/packages/product-client/src/config/settings.ts))
+> carries `agent-claude`/`agent-codex`/`agent-opencode`/`agent-grok`/
+> `agent-api-keys` instead of `agent-authentication`/`agent-defaults`,
+> plus `integrations`, `repo-actions`, and `repo-environment`; `keyboard`,
+> `archived-chats`, and `compute` were removed.
 
 **Shortcuts**: Cmd-digit section shortcuts are per-scope.
 `SETTINGS_SHORTCUT_SECTION_ORDER` is filtered to the sections visible in
@@ -228,6 +254,13 @@ subfolders:
   organization/                  Members/Invitations/Logo/budget rows
   repo/                          CloudRepoSection.tsx, LocalRepoSection.tsx
 ```
+
+> Shipped correction: `AgentAuthenticationPane.tsx` and the
+> `agent-authentication/` subfolder do not exist. The Agents scope ships
+> as `panes/agents/harness/` (per-harness pane, auth method cards, CLI
+> login details) and `panes/agents/api-keys/` (the key pool), with
+> selection/vault contracts owned by
+> [`agent-auth.md`](../../../platforms/product/agent-auth.md).
 
 **Existing shared primitives**: page chrome lives in
 `apps/packages/product-ui/src/settings/`:
@@ -487,6 +520,8 @@ Repo
 Agents
   agent-defaults           AgentDefaultsPane              per-person agent defaults
   agent-authentication     AgentAuthenticationPane        local + cloud auth by person
+  (shipped: agent-claude/-codex/-opencode/-grok HarnessPane + agent-api-keys;
+   the two rows above were removed — see the staleness note at the top)
 
 Slack bot                  SlackBotPane                   (parked/disabled;
                                                            spec 07 logic is
@@ -542,11 +577,14 @@ Preserved id:
 
 The `?section=<id>` URL scheme is preserved. Old urls that point at
 `?section=repo` or `?section=cloudRepo` redirect to
-`?section=environments`; `?section=cloud` redirects to
-`?section=agent-authentication`; removed `shared-environments` and
-parked `slack-bot` redirect to the default section
-(`normalizeSettingsSection` in
-`apps/desktop/src/lib/domain/settings/navigation.ts`).
+`?section=environments`; removed `shared-environments` and parked
+`slack-bot` redirect to the default section. Shipped redirects differ
+from this spec's originals: `?section=agent-authentication` goes to
+`agent-api-keys`, `agent-defaults` to `agent-claude`, and
+`?section=cloud` is focus-dependent (repo focus → `environments`,
+billing focus → `billing`) — see `normalizeSettingsSection` and
+`cloudRedirectSection` in
+[navigation.ts](../../../../../apps/packages/product-client/src/lib/domain/settings/navigation.ts).
 
 ### 5.2 Per-page ownership
 
@@ -601,6 +639,9 @@ Agents
                                        same pane is sandbox-aware:
                                        admins see selection for shared
                                        sandbox; everyone sees personal.
+  (shipped: the row above was removed. Per-harness pages own auth via
+   method cards; the key pool is agent-api-keys. Contract:
+   agent-auth.md — see the staleness note at the top.)
 
 Slack bot (parked)          spec 07   install/reconnect, repo routing,
                                        default agent_run_config, shared
@@ -767,6 +808,9 @@ CredentialPicker
   Used by:
     AgentAuthenticationPane (spec 02)
     ComputeTargetAgentAuthCard (spec 02)
+  (shipped: never built — both consumers were removed with the
+   Bifrost-era pane; the per-harness key picker lives in the harness
+   pane's API-key details instead)
 
 AgentRunConfigSelector
   apps/desktop/src/components/settings/shared/AgentRunConfigSelector.tsx
@@ -824,6 +868,8 @@ WhereUsedDrawer
   Used by:
     PluginsPage detail
     CloudAgentAuthLibrary credential detail
+  (shipped: the CloudAgentAuthLibrary consumer was removed with the
+   Bifrost-era pane)
 ```
 
 **Status badge convention** (existing `Badge` primitive, new shared
@@ -935,6 +981,11 @@ URL search param `?section=<id>` is preserved. Two clean-ups:
 ?section=shared-environments&repo=<normalized_repo_key>
 ```
 
+> Shipped correction: the two `agent-authentication` deep links do not
+> exist (the pane was removed); legacy hits redirect to
+> `agent-api-keys`. Per-harness pages are their own sections
+> (`?section=agent-claude` etc.), no `kind` param.
+
 `useSettingsNavigation()` exposes the focus param so panes can scroll
 to / open the right card.
 
@@ -953,6 +1004,13 @@ apps/desktop/src/copy/settings/shared-environments-copy.ts
 apps/desktop/src/copy/settings/agent-authentication-copy.ts
 apps/desktop/src/copy/settings/slack-bot-copy.ts
 ```
+
+> Shipped correction: agent auth copy lives in
+> [harness-pane.ts](../../../../../apps/packages/product-client/src/copy/settings/harness-pane.ts),
+> [agent-auth-copy.ts](../../../../../apps/packages/product-client/src/copy/settings/agent-auth-copy.ts),
+> and
+> [agent-api-keys-copy.ts](../../../../../apps/packages/product-client/src/copy/settings/agent-api-keys-copy.ts);
+> no `agent-authentication-copy.ts` exists.
 
 Existing `copy/settings/*` files are kept; rename inside copy follows
 the section-id renames.
@@ -1083,6 +1141,7 @@ apps/desktop/src/components/settings/sidebar/SettingsSidebar.test.tsx
 apps/desktop/src/components/settings/SettingsScreen.test.tsx
   - ?section=repo redirects to ?section=environments
   - ?section=cloud redirects to ?section=agent-authentication
+    (shipped: focus-dependent, see 5.7 correction)
   - ?section=worktrees resolves to Pruning (User scope)
 
 apps/desktop/src/hooks/access/cloud/organizations/use-is-admin.test.ts
@@ -1111,10 +1170,14 @@ Manual smoke:
 
 3. Open Settings with ?section=cloud.
      -> redirects to ?section=agent-authentication.
+     (shipped: focus-dependent redirect — repo focus to environments,
+      billing focus to billing)
 
 4. Open ?section=agent-authentication&kind=claude.
      -> AgentAuthenticationPane opens with the Claude agent kind
         preselected.
+     (shipped: redirects to ?section=agent-api-keys; the per-harness
+      page is ?section=agent-claude)
 
 5. Open Plugins (top-level page).
      -> Still works; not in Settings sidebar.

--- a/specs/developing/operating/worker-enrollment-failure.md
+++ b/specs/developing/operating/worker-enrollment-failure.md
@@ -4,9 +4,16 @@ Status: authoritative for first-response triage of Proliferate Worker
 enrollment, heartbeat, and version convergence failures.
 
 Use this runbook after an E2B sandbox and AnyHarness are reachable but the
-optional Worker sidecar does not enroll, heartbeat, synchronize catalogs, or
-converge Worker/AnyHarness versions. Worker ownership is documented in
-[`proliferate-worker/README.md`](../../codebase/structures/proliferate-worker/README.md).
+optional Worker sidecar does not enroll, heartbeat, or converge
+Worker/AnyHarness versions. Worker ownership is documented in
+[`proliferate-worker/README.md`](../../codebase/structures/proliferate-worker/README.md);
+on a supervisor-owned target the swap itself belongs to
+[`proliferate-supervisor/README.md`](../../codebase/structures/proliferate-supervisor/README.md).
+The agent catalog is not a separate convergence axis: it ships inside the
+runtime binary ([agent-distribution.md](../../codebase/platforms/product/agent-distribution.md)),
+so a catalog complaint is a binary-version complaint. (The legacy heartbeat
+catalog sync still runs until its deletion lands; its evidence path is kept
+below, marked legacy.)
 Use [`cloud-provisioning-failure.md`](cloud-provisioning-failure.md) when the
 provider sandbox or AnyHarness is not independently healthy.
 
@@ -28,9 +35,20 @@ enrollment, Worker, request, release, and sanitized evidence identifiers.
 
 The Worker enrolls once through `/v1/cloud/worker/enroll`, stores its durable
 identity locally, and heartbeats through `/v1/cloud/worker/heartbeat`. Heartbeat
-returns desired Worker, AnyHarness, and catalog versions. Liveness is derived
+returns desired Worker and AnyHarness versions (plus, until the binary-only
+catalog deletion lands, a legacy catalog version). Liveness is derived
 at read time from `status = 'online'` and `last_seen_at` within 90 seconds; the
 application does not eagerly write `offline`.
+
+Two convergence topologies exist. On a **supervisor-owned target**
+(`supervisor_update_request_dir` set; the server's
+`supervisor_owned_runtime` provisioning), the Worker only *writes* a durable
+update request into `.proliferate/supervisor/updates`; Proliferate
+Supervisor consumes it (verify → download → re-verify → stage → atomic
+activate → dependency-ordered restart → health-gate → rollback) and writes a
+result file beside it. On a **legacy target**, the Worker still performs the
+in-place swap itself (deprecated, deletion-pending). Triage must first
+establish which topology the target runs, from the Worker config key names.
 
 Fresh enrollment also writes the integration-gateway credential file. Restart
 from durable identity does not recreate a missing gateway file, and an invalid
@@ -133,6 +151,9 @@ sqlite3 -readonly "$HOME/.proliferate/worker/worker.sqlite3" \
   'select worker_id, updated_at from identity where id = 1;'
 sqlite3 -readonly "$HOME/.proliferate/worker/worker.sqlite3" \
   'select converged_version, failed_pin, updated_at from anyharness_update where id = 1;'
+# (anyharness_update is legacy-topology state only; on a supervisor-owned
+#  target inspect the mailbox instead:)
+ls -la "$HOME/.proliferate/supervisor/updates" 2>/dev/null
 tail -n 200 "$HOME/proliferate-worker.log"
 test -e "$HOME/.proliferate/anyharness/integration-gateway.json" && \
   stat -c '%U %G %a %n' \
@@ -149,7 +170,9 @@ missing.
 the request path, so a null or old value is not evidence that the token is
 unused.
 
-Catalog convergence has separate evidence from binary convergence:
+Legacy catalog convergence (deletion-pending — under the binary-only ruling
+the catalog rides the runtime binary and this whole path goes away) has
+separate evidence from binary convergence while it still runs:
 
 ```text
 heartbeat desiredVersions.catalogVersion
@@ -161,7 +184,9 @@ heartbeat desiredVersions.catalogVersion
 The Worker row does not persist the desired or active catalog version. Capture
 the advertised `catalogVersion` from the heartbeat/catalog response and the
 active version from AnyHarness using approved authenticated access; compare
-them with the Worker's bounded catalog-sync log lines.
+them with the Worker's bounded catalog-sync log lines. Once the deletion
+lands, the only catalog question is "which runtime version is this sandbox
+running" — `GET /v1/catalogs/agents/version` stays as the read-only answer.
 
 ## First response
 
@@ -173,24 +198,29 @@ them with the Worker's bounded catalog-sync log lines.
 | Worker exists but heartbeat is stale | Inspect Worker logs, Cloud URL/network reachability, and durable identity loading. Do not infer liveness from the stored `online` value alone. |
 | Worker token is revoked or invalid | Escalate. The Worker does not automatically re-enroll, and deleting local SQLite is destructive. |
 | Gateway credential file is missing after a restart | Check only the local file's existence, owner, and mode. A durable-identity restart does not recreate it, even when the Cloud gateway-token row remains active. Escalate credential repair. |
-| Catalog version does not converge | Compare advertised and active catalog versions, then inspect the AnyHarness version GET, Cloud catalog fetch, authenticated AnyHarness PUT, and catalog-sync logs. Binary update gates and artifact downloads do not govern catalog sync. |
-| Worker or AnyHarness binary version does not converge | Compare the heartbeat response, configured update gates, artifact download availability, and update logs. |
-| Worker update fails | Inspect checksum/preflight/swap evidence; Worker self-update has no post-exec `.prev` health rollback. |
-| AnyHarness update fails | Inspect stop/swap/relaunch/health evidence; this updater can restore the `.prev` binary. |
+| Catalog version does not converge (legacy path) | Compare advertised and active catalog versions, then inspect the AnyHarness version GET, Cloud catalog fetch, authenticated AnyHarness PUT, and catalog-sync logs. Binary update gates and artifact downloads do not govern catalog sync. On a target where the deletion has landed, treat this as a binary-version complaint instead. |
+| Binary version does not converge (supervisor-owned target) | Inspect the mailbox: a missing request file means the Worker never observed divergence (heartbeat/logs); a pending request with no result means the Supervisor did not drain it (Supervisor logs, one drain per supervise cycle); a result file records the verify/download/stage/activate/health outcome, including rollback to `.prev`. A recorded failed pin is not retried until a newer pin arrives. |
+| Binary version does not converge (legacy target) | Compare the heartbeat response, configured update gates, artifact download availability, and update logs. |
+| Worker update fails (legacy target) | Inspect checksum/preflight/swap evidence; legacy Worker self-update has no post-exec `.prev` health rollback. |
+| AnyHarness update fails (legacy target) | Inspect stop/swap/relaunch/health evidence; the legacy updater can restore the `.prev` binary. |
 
 Do not manually mutate database rows, rotate tokens, delete Worker-local
-SQLite, destroy the provider sandbox, or replace a sandbox as routine recovery.
-There is no current command lease, control long-poll, event tail, or Supervisor
-update mailbox to inspect.
+SQLite, delete or hand-write mailbox request/result files, destroy the
+provider sandbox, or replace a sandbox as routine recovery. There is no
+command lease, control long-poll, or event tail to inspect; the Supervisor
+update mailbox (`.proliferate/supervisor/updates`) is the one durable
+update-coordination surface, and it is read-only for operators.
 
 ## Verification
 
 Recovery is complete when AnyHarness remains healthy independently, the active
 Worker is live by the 90-second rule, heartbeats persist the observed Worker
-and AnyHarness versions, the active AnyHarness catalog version matches the
-version advertised by Cloud, and the enabled binary convergence operations
-succeed. Verify the integration gateway separately when it was part of the
-symptom.
+and AnyHarness versions, and the running versions match the desired versions
+(on a supervisor-owned target: the mailbox is drained with a success result
+and `/health` reports the desired version; the catalog follows the binary).
+While the legacy catalog sync still exists, also confirm the active catalog
+version matches the advertised one. Verify the integration gateway separately
+when it was part of the symptom.
 
 ## Final report
 

--- a/specs/developing/testing/core-release-validation.md
+++ b/specs/developing/testing/core-release-validation.md
@@ -677,10 +677,12 @@ The remaining enforcement exceptions are:
   metadata and accepted evidence;
 - hosted Web is not booted by the existing Tier 2 world;
 - the Tier 4 Desktop and cloud update journeys cannot qualify in CI today;
-- canonical agent-auth primitive docs still describe Bifrost as the managed
-  data plane even though the settled target is LiteLLM only. Those product
-  specs and owning code must be reconciled before their collectors can be
-  audited; the stale Bifrost contract does not override this target; and
+- the agent-auth and model-gateway platform contracts are now written
+  ([agent-auth.md](../../codebase/platforms/product/agent-auth.md),
+  [model-gateway.md](../../codebase/platforms/product/model-gateway.md),
+  both Status: target with pinned gaps); collectors for these areas audit
+  against those documents' bodies, treating their Current-gaps items as
+  known deltas rather than failures; and
 - server billing policy now encodes the settled `$2` lifetime free
   managed-LLM grant and Core `$5 LLM + $15 compute` allocation, but the upgrade
   surface still advertises the prior fixed twenty managed-cloud hours per seat


### PR DESCRIPTION
PR E — the final spec PR of the agents/auth/catalog documentation rewrite (stacked on #1486 → #1482).

Two deliverables:

**`specs/codebase/platforms/product/agent-systems.md`** (new): the narrative overview map of how the four agent platform documents compose — the one-line ownership table, the journey-of-a-session flow, boundary one-liners (declare-vs-apply, key-vs-models, one-transport-each), and neighboring owners. Owns no contract; every claim defers to a linked document.

**Truth pass** across 18 files, aligning the rest of the spec tree with the rulings frozen in PRs A–C:
- Binary-only catalog transport: proliferate-worker README + 4 guides, anyharness contract/agents/mode-matrix, server architecture, integrations — heartbeat catalog sync marked deletion-pending everywhere, pointing at agent-distribution's Current gaps.
- Supervisor-owned swaps: legacy swap text marked legacy/deletion-pending; two factual errors fixed (enrollment runbook claimed no Supervisor mailbox exists; sandbox-provisioning claimed E2B never launches the Supervisor — verified the gated branch in runtime_launch.py).
- worker-enrollment-failure runbook reworked: topology-split mental model, mailbox triage rows, binary-carries-catalog framing.
- Agent-auth rewrite pointers: five "rewrite is planned" stubs now link agent-auth.md/model-gateway.md; settings information-architecture got the minimal truth patch (staleness note + 11 shipped-correction blocks verified against navigation.ts/config/settings.ts/panes).
- Auto-install ruling: agents.md's "not auto-installed at startup" statements restated as pinned gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)