### PR TITLE
docs(specs): PR 0 — spec truth fixes (launcher guard, runtime catalog route, access-group naming)

### DIFF
--- a/specs/codebase/platforms/product/agent-distribution.md
+++ b/specs/codebase/platforms/product/agent-distribution.md
@@ -444,8 +444,11 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       with its catalog-applied reconcile poke, and the server-side
       [`server/proliferate/server/catalogs/`](../../../../server/proliferate/server/catalogs/)
       ETag serving that feeds it). All of it deletes under the
-      binary-only transport law above; the runtime keeps only the read
-      routes (`GET /v1/catalogs/agents{,/version}`).
+      binary-only transport law above; the deletion removes the `PUT`
+      handler — the runtime keeps only `GET /v1/catalogs/agents/version`
+      (there is no bare GET full-document route on the runtime; the
+      full-document GET is the cloud server's `read_agent_catalog`, a
+      separate component that stays).
 - [ ] Installs are not yet automatic: the startup pass runs an
       `installed_only` reconcile (`reconcile_installed_when_idle` in
       [`runtime.rs`](../../../../anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs)
@@ -463,4 +466,8 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       resolves native-only while launch resolves route-aware, so
       settings and launch can disagree for routed harnesses. Also
       known: claude's Node gate shells out uncached on every read, and
-      claude/codex lack cursor/grok's launcher-integrity guard.
+      the journal-protected atomic activation guard
+      ([`installer/downloads/activation.rs`](../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/downloads/activation.rs))
+      covers only `Archive`-sourced agent-process installs (cursor,
+      opencode) — claude's git install and codex/grok's npm installs
+      have no equivalent guard.

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -41,8 +41,9 @@ Config laws, enforced by review (the file's comments restate them):
   manifest, never invented. The manifest also prices spend for usage
   import; an unknown id can pass traffic while mispricing it.
 - Every entry carries `model_info: {access_groups: [...]}` naming the
-  harness group(s) it belongs to (`claude-code`, `codex`, `opencode`,
-  `cursor`, `grok-cli`); see LiteLLM's
+  harness group(s) it belongs to. Group names are exactly the harness
+  `harness_kind` identifiers (`claude`, `codex`, `opencode`, `cursor`,
+  `grok`) — no translation table; see LiteLLM's
   [model access groups](https://docs.litellm.ai/docs/proxy/model_access_groups).
   This one reviewed file is therefore also the harness-to-model map; no
   client-side model filtering exists anywhere.
@@ -116,7 +117,7 @@ subject; the budget lives on the team and mirrors the subject's remaining
 credit. Inside the team, one
 [virtual key](https://docs.litellm.ai/docs/proxy/virtual_keys) per
 (subject, harness), each granted its harness's access group by name
-(`{"models": ["claude-code"]}` at `/key/generate`). The key is the whole
+(`{"models": ["claude"]}` at `/key/generate`). The key is the whole
 differentiator: one deployment, one public URL, and what a key can see and
 invoke is determined proxy-side by its group grant and team budget.
 


### PR DESCRIPTION
This is a **spec-only truth-fix PR**. It implements nothing — it only makes
the spec prose in `specs/codebase/platforms/product/agent-distribution.md`
match code truth, ahead of the agent-auth/agent-distribution implementation
workflows that will read these specs as ground truth.

## Fix: launcher-guard

**Wrong claim (line 466):** "claude/codex lack cursor/grok's
launcher-integrity guard."

**Code truth:** the journal-protected atomic activation guard
(`ArchiveTreeActivation` in
[`anyharness/crates/anyharness-lib/src/domains/agents/installer/downloads/activation.rs:34-179`](https://github.com/proliferate-ai/proliferate/blob/main/anyharness/crates/anyharness-lib/src/domains/agents/installer/downloads/activation.rs))
is constructed only inside `download_and_extract_archive_tree_verified`
(`downloads.rs:277-356`), called from exactly one site:
`install_agent_process_from_pin`'s `ResolvedPinSource::Archive` arm
(`installer/pinned.rs:175-236`). Per `catalogs/agents/catalog.json`
(cross-checked against `catalogs/agents/registry.json`):

- claude → `"kind": "git"` → no guard
- codex → `"kind": "npm"` → no guard
- grok → `"kind": "npm"` → no guard
- cursor → `"kind": "archive"` → **has** the guard
- opencode → `"kind": "archive"` → **has** the guard (not mentioned by the
  old prose at all)

The real split is archive-sourced (cursor, opencode) vs. npm/git-sourced
(claude, codex, grok), not "claude/codex lack cursor/grok's guard" — that
claim was wrong on both named harnesses on the "has it" side (grok doesn't)
and silent on opencode (which does).

**Fix:** replaced the sentence with one that names the guard by its actual
mechanism, links to `installer/downloads/activation.rs`, and states the
split by install-source kind rather than by harness identity.

## Fix: runtime-get-route

**Wrong claim (lines 447-448):** "the runtime keeps only the read routes
(`GET /v1/catalogs/agents{,/version}`)."

**Code truth:** the runtime's catalogs HTTP handler
([`anyharness/crates/anyharness-lib/src/api/http/catalogs.rs`](https://github.com/proliferate-ai/proliferate/blob/main/anyharness/crates/anyharness-lib/src/api/http/catalogs.rs))
defines exactly two handlers — `apply_agent_catalog` (`PUT
/v1/catalogs/agents`) and `get_agent_catalog_version` (`GET
/v1/catalogs/agents/version`) — and the router
([`anyharness/crates/anyharness-lib/src/api/router.rs:75-79`](https://github.com/proliferate-ai/proliferate/blob/main/anyharness/crates/anyharness-lib/src/api/router.rs))
wires only those two. There is **no** bare `GET /v1/catalogs/agents`
full-document route on the runtime. The full-document GET exists only on
the cloud server (`read_agent_catalog` in
[`server/proliferate/server/catalogs/api.py`](https://github.com/proliferate-ai/proliferate/blob/main/server/proliferate/server/catalogs/api.py)),
a separate component unaffected by the heartbeat-transport deletion this
bullet describes.

**Fix:** replaced the sentence to name the `PUT` handler as what the
deletion removes (already named earlier in the same bullet), state that
only `GET /v1/catalogs/agents/version` survives on the runtime, and
disambiguate from the cloud server's same-shaped route so a reader doesn't
conflate the two components.

## Ruling-by-review

This PR now **does** include the "access-group naming" fix, as the
recommendation: access-group names equal harness `harness_kind` values
exactly (`claude`, `codex`, `opencode`, `cursor`, `grok`) — no translation
table. In `specs/codebase/platforms/product/model-gateway.md`, the
access-group list (previously `claude-code`, `codex`, `opencode`, `cursor`,
`grok-cli`) and the `/key/generate` example (previously
`{"models": ["claude-code"]}`) were updated to the `harness_kind`
vocabulary (`claude`, `codex`, `opencode`, `cursor`, `grok`; `{"models":
["claude"]}`), with prose stating explicitly that the group name is the
`harness_kind` identifier itself, not a separately maintained alias.

Drop this hunk (revert the `model-gateway.md` change) if Pablo prefers
harness-decoupled access-group names instead of naming groups directly
after `harness_kind`.

## Note

This PR intentionally implements nothing in code. It only corrects spec
prose so that implementation workflows reading these specs as ground truth
don't inherit the two inaccuracies above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
