### PR TITLE
feat(server): litellm access-group tags per harness_kind (B1)

### DIFF
--- a/server/litellm/config.yaml
+++ b/server/litellm/config.yaml
@@ -21,51 +21,84 @@
 # This file is the one deployed config (dev and prod both run it as-is): any
 # dev-only shim/mock (LiteLLM `mock_response`, cross-provider test aliases)
 # belongs in a docker-compose dev overlay, never here.
+#
+# Access groups (model-gateway.md, R1): every entry carries
+# `model_info: {access_groups: [...]}` naming the harness group(s) it
+# belongs to. Group names are exactly the harness `harness_kind` identifiers
+# (`claude`, `codex`, `opencode`, `grok`) — no translation table. `cursor` is
+# intentionally absent from every access_groups list: it has no gateway
+# recipe (native-only) until it gets one, so no virtual key may ever be
+# scoped to a `cursor` group. This file is therefore also the harness-to-
+# model map; no client-side model filtering exists anywhere.
 
 model_list:
-  # Anthropic
+  # Anthropic. access_groups: claude is the direct-Anthropic harness; opencode
+  # composes the gateway additively alongside its own provider auth (its
+  # catalog gatewayPolicy carries no provider restriction — parity-preserving
+  # with the Rust client-side filter this replaces, see model-gateway.md §R1).
   - model_name: claude-sonnet-4-5
     litellm_params:
       model: anthropic/claude-sonnet-4-5-20250929
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: claude-sonnet-4-5-20250929
     litellm_params:
       model: anthropic/claude-sonnet-4-5-20250929
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: claude-haiku-4-5
     litellm_params:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: claude-haiku-4-5-20251001
     litellm_params:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: claude-opus-4-6
     litellm_params:
       model: anthropic/claude-opus-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: claude-opus-4-6-20260205
     litellm_params:
       model: anthropic/claude-opus-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      access_groups: [claude, opencode]
 
-  # OpenAI
+  # OpenAI. access_groups: codex is the direct-OpenAI harness; opencode again
+  # composes additively (see above).
   - model_name: gpt-5.2
     litellm_params:
       model: openai/gpt-5.2
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      access_groups: [codex, opencode]
   - model_name: gpt-5.2-2025-12-11
     litellm_params:
       model: openai/gpt-5.2
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      access_groups: [codex, opencode]
   - model_name: gpt-5-mini
     litellm_params:
       model: openai/gpt-5-mini
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      access_groups: [codex, opencode]
   - model_name: gpt-5-mini-2025-08-07
     litellm_params:
       model: openai/gpt-5-mini
       api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      access_groups: [codex, opencode]
 
   # xAI. The grok CLI discovers models via GET /v1/models and speaks plain
   # chat/completions, so it will send whatever model_name we advertise here —
@@ -76,24 +109,35 @@ model_list:
   #   - there is no plain "xai/grok-4-fast"; xai/grok-4-1-fast is the current
   #     (non-deprecated) fast-tier model, so grok-4-fast resolves there.
   #   - xai/grok-code-fast-1 exists as-is.
+  # access_groups: grok is the direct-xAI harness; opencode again composes
+  # additively (its catalog gatewayPolicy carries no provider restriction, so
+  # today's client-side filter already lets it see every family — see above).
   - model_name: grok-4
     litellm_params:
       model: xai/grok-4
       api_key: os.environ/XAI_API_KEY
+    model_info:
+      access_groups: [grok, opencode]
   - model_name: grok-4-fast
     litellm_params:
       model: xai/grok-4-1-fast
       api_key: os.environ/XAI_API_KEY
+    model_info:
+      access_groups: [grok, opencode]
   - model_name: grok-code-fast-1
     litellm_params:
       model: xai/grok-code-fast-1
       api_key: os.environ/XAI_API_KEY
+    model_info:
+      access_groups: [grok, opencode]
   # grok-build is the CLI's interactive/title-gen model — cheap to keep.
   # Same-provider alias only (never cross-provider): a small xAI model.
   - model_name: grok-build
     litellm_params:
       model: xai/grok-3-mini-latest
       api_key: os.environ/XAI_API_KEY
+    model_info:
+      access_groups: [grok, opencode]
 
   # AWS Bedrock. Credentials come from the AWS default credential chain:
   # deployed (prod/staging): the ECS task role with attached policy
@@ -104,48 +148,71 @@ model_list:
   # and Bedrock-pinned harness IDs resolve. LiteLLM's bedrock provider
   # accepts pass-through for cross-region inference profiles (us.*, eu.*,
   # global.*) — these IDs are verified to exist in the LiteLLM manifest.
+  # access_groups mirror the upstream family: Anthropic-on-Bedrock joins
+  # claude (+ opencode, same composition rule as direct Anthropic above);
+  # OpenAI-open-weight-on-Bedrock joins codex (+ opencode) — matching the
+  # provider-prefix matching the Rust gateway resolver already applies to
+  # these ids (PR #928/#955) so proxy-side grants preserve today's behavior.
   #
   # Anthropic on Bedrock (us. cross-region profiles):
   - model_name: us.anthropic.claude-sonnet-4-6
     litellm_params:
       model: bedrock/us.anthropic.claude-sonnet-4-6
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: us.anthropic.claude-sonnet-5
     litellm_params:
       model: bedrock/us.anthropic.claude-sonnet-5
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: us.anthropic.claude-opus-4-7
     litellm_params:
       model: bedrock/us.anthropic.claude-opus-4-7
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: us.anthropic.claude-opus-4-8
     litellm_params:
       model: bedrock/us.anthropic.claude-opus-4-8
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: us.anthropic.claude-fable-5
     litellm_params:
       model: bedrock/us.anthropic.claude-fable-5
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   - model_name: us.anthropic.claude-haiku-4-5-20251001-v1:0
     litellm_params:
       model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   #
   # Anthropic on Bedrock (global. cross-region profiles):
   - model_name: global.anthropic.claude-fable-5
     litellm_params:
       model: bedrock/global.anthropic.claude-fable-5
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [claude, opencode]
   #
   # OpenAI open-weight on Bedrock:
   - model_name: openai.gpt-oss-120b-1:0
     litellm_params:
       model: bedrock/openai.gpt-oss-120b-1:0
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [codex, opencode]
   - model_name: openai.gpt-oss-20b-1:0
     litellm_params:
       model: bedrock/openai.gpt-oss-20b-1:0
       aws_region_name: os.environ/AWS_BEDROCK_REGION
+    model_info:
+      access_groups: [codex, opencode]
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/server/tests/unit/test_litellm_config_access_groups.py
+++ b/server/tests/unit/test_litellm_config_access_groups.py
@@ -1,0 +1,78 @@
+"""Config-as-contract tests for the deployed LiteLLM proxy config.
+
+Enforces the model-gateway spec's access-group law (R1, agents-impl-plan.md
+§4 B1): every `model_list` entry must carry `model_info.access_groups`, group
+names are exactly harness `harness_kind` identifiers, and `cursor` — which has
+no gateway recipe (native-only) — must never appear in any entry's groups.
+
+`server/litellm/config.yaml` is the one deployed config (dev and prod both
+run it as-is; see model-gateway.md "The artifact"), so this is a pure static
+check of a reviewed YAML file — no LiteLLM proxy involved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from proliferate.constants.agent_gateway import AGENT_AUTH_HARNESS_KINDS
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "litellm" / "config.yaml"
+
+# cursor is explicitly excluded from AGENT_AUTH_HARNESS_KINDS (no gateway
+# route exists for it); the config must never grant it a model access group.
+_CURSOR_HARNESS_KIND = "cursor"
+
+
+def _load_model_list() -> list[dict[str, Any]]:
+    with _CONFIG_PATH.open() as handle:
+        document = yaml.safe_load(handle)
+    model_list = document["model_list"]
+    assert isinstance(model_list, list)
+    assert model_list, "config.yaml model_list must not be empty"
+    return model_list
+
+
+class TestLitellmConfigAccessGroups:
+    def test_every_model_carries_access_groups(self) -> None:
+        for entry in _load_model_list():
+            model_info = entry.get("model_info")
+            assert isinstance(model_info, dict), (
+                f"{entry.get('model_name')} is missing model_info.access_groups"
+            )
+            access_groups = model_info.get("access_groups")
+            assert isinstance(access_groups, list) and access_groups, (
+                f"{entry.get('model_name')} has no access_groups"
+            )
+
+    def test_access_group_names_are_exactly_harness_kinds(self) -> None:
+        allowed = set(AGENT_AUTH_HARNESS_KINDS)
+        for entry in _load_model_list():
+            access_groups = entry["model_info"]["access_groups"]
+            unknown = set(access_groups) - allowed
+            assert not unknown, (
+                f"{entry['model_name']} carries unknown access group(s) {unknown}; "
+                f"group names must be exactly a harness_kind in {sorted(allowed)}"
+            )
+
+    def test_cursor_is_never_granted_a_model(self) -> None:
+        # cursor is native-only (no gateway recipe) until it has one; a virtual
+        # key must never be mintable with a `cursor` group because no model
+        # would ever be scoped to it accidentally.
+        for entry in _load_model_list():
+            access_groups = entry["model_info"]["access_groups"]
+            assert _CURSOR_HARNESS_KIND not in access_groups, (
+                f"{entry['model_name']} must not carry the cursor access group"
+            )
+
+    def test_every_supported_harness_has_at_least_one_model(self) -> None:
+        # Every gateway-capable harness_kind (all of AGENT_AUTH_HARNESS_KINDS,
+        # since cursor is excluded from that tuple already) must be able to
+        # resolve at least one model once it is granted its group.
+        granted: set[str] = set()
+        for entry in _load_model_list():
+            granted.update(entry["model_info"]["access_groups"])
+        missing = set(AGENT_AUTH_HARNESS_KINDS) - granted
+        assert not missing, f"harness kinds with zero gateway models: {missing}"

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -42,11 +42,14 @@ Config laws, enforced by review (the file's comments restate them):
   import; an unknown id can pass traffic while mispricing it.
 - Every entry carries `model_info: {access_groups: [...]}` naming the
   harness group(s) it belongs to. Group names are exactly the harness
-  `harness_kind` identifiers (`claude`, `codex`, `opencode`, `cursor`,
-  `grok`) — no translation table; see LiteLLM's
+  `harness_kind` identifiers of the gateway-capable harnesses (`claude`,
+  `codex`, `opencode`, `grok`) — no translation table; see LiteLLM's
   [model access groups](https://docs.litellm.ai/docs/proxy/model_access_groups).
   This one reviewed file is therefore also the harness-to-model map; no
-  client-side model filtering exists anywhere.
+  client-side model filtering exists anywhere. `cursor` is deliberately
+  absent from the vocabulary: it is native-only (no gateway recipe exists
+  for it), so no model belongs to a `cursor` group and no `cursor` virtual
+  key is ever minted.
 - No dev shims. Because dev and prod run this exact file, any local
   convenience placed in it ships to production verbatim. Two shims are
   banned by name:

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -260,6 +260,11 @@ change detection and the promote flow.
 - Scoped-key verification: mint a key granted one group, assert
   `GET /v1/models` returns exactly that group and an out-of-group invoke
   403s. Verified live against the pinned image (v1.93.0, 2026-07-24).
+- Team-budget aggregation: spend from every key in a team aggregates against
+  that team's budget (the mechanism the whole per-harness-key account model
+  depends on) — confirmed standard LiteLLM behavior, live-verified against
+  the pinned image (v1.93.0, 2026-07-25) ahead of B2's per-(subject,harness)
+  minting.
 
 ## Current gaps
 
@@ -276,9 +281,6 @@ Deltas between this document and `main`, each struck by its follow-up PR:
 - [ ] `/v1/cloud/agent-gateway/` still carries the BYOK vault, selections,
       state, org policy, and catalog routes; `api.py`/`service.py`/
       `models.py` split along the same three-domain line.
-- [ ] Team-budget aggregation across multiple keys is standard LiteLLM but
-      not yet live-proven on the pinned image (a short check before the
-      enrollment code PR freezes).
 - [ ] Enrollment copies `max_budget` onto the virtual key as well as the
       team; keys must stop carrying budgets (the team cap already
       aggregates, and N per-key copies of the mirror would drift).

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -265,7 +265,6 @@ change detection and the promote flow.
 
 Deltas between this document and `main`, each struck by its follow-up PR:
 
-- [ ] `config.yaml` entries carry no `access_groups` tags.
 - [ ] Enrollment mints one unscoped key per subject (it sees all models)
       instead of per-harness group-scoped keys; existing enrollments need
       rotation at migration.


### PR DESCRIPTION
Track B, PR 1 of 3 (B1→B2→B3, agents-impl-plan.md §4). Stacked-PR program;
this PR is the root (base `main`).

## Spec section quoted (model-gateway.md, Config laws)

> Every entry carries `model_info: {access_groups: [...]}` naming the
> harness group(s) it belongs to. Group names are exactly the harness
> `harness_kind` identifiers (`claude`, `codex`, `opencode`, `cursor`,
> `grok`) — no translation table... This one reviewed file is therefore
> also the harness-to-model map; no client-side model filtering exists
> anywhere.

Ruling R1 (agents-impl-plan.md §1): access-group names = harness_kind
exactly. Gateway-capable harnesses get their group tag; `cursor` stays
native-only (no gateway recipe) and is never granted a group.

## What changed

- `server/litellm/config.yaml`: every one of the 23 `model_list` entries now
  carries `model_info.access_groups`.
  - `claude` (direct-Anthropic + Bedrock Anthropic ids)
  - `codex` (direct-OpenAI + Bedrock OpenAI-open-weight ids)
  - `grok` (xAI ids)
  - `opencode` composes additively across every family — its catalog
    `gatewayPolicy.providers` carries no restriction today
    (`catalogs/agents/catalog.json`), so this preserves the current
    client-side-filter behavior (empty `providers` == all) 1:1 rather than
    narrowing opencode's model set as a side effect of this PR.
  - `cursor` appears in **zero** access_groups — it has no gateway route
    (agent-auth.md selection-cardinality law: cursor's only source can be
    `api_key`, never `gateway`).
- `specs/codebase/platforms/product/model-gateway.md`: deleted the
  "`config.yaml` entries carry no `access_groups` tags" gap bullet.

## Gap bullet closed

> `config.yaml` entries carry no `access_groups` tags.

## Tests

- Tier 1 (new): `server/tests/unit/test_litellm_config_access_groups.py` —
  static contract test over the reviewed YAML (no LiteLLM proxy involved):
  every entry carries non-empty `access_groups`; group names are exactly a
  member of `AGENT_AUTH_HARNESS_KINDS`; `cursor` never appears in any
  entry's groups; every supported harness_kind has at least one model.
  `cd server && DEBUG=true uv run pytest tests/unit/test_litellm_config_access_groups.py -q`
  → 4 passed.
- Regression: `cd server && DEBUG=true uv run pytest tests/unit tests/integration -q -k "agent_gateway or agent_auth or litellm_config"`
  → 193 passed (189 baseline + 4 new), 0 failed.
- `node --test scripts/ci-cd/litellm-image-pin.test.mjs` still green (pin
  test doesn't touch `model_list`, unaffected by this change).

## Not in scope (later PRs in this stack)

- B2 (next, base = this branch): per-(subject, harness) key minting so a
  virtual key actually receives exactly one access group instead of today's
  one-unscoped-key-per-subject.
- B3: renderer per-harness key map + org-member fix.
- Proxy-side scoped-key live verification (LiteLLM `/v1/models` returning
  exactly one group, 403 out-of-group) is the model-gateway.md "Proof"
  section's existing live check — already verified per that doc against
  v1.93.0; this PR doesn't re-run that, since it's a static config change
  with no running proxy in the merge gate.

## Contradictions

None — this PR followed the plan and R1 exactly. One judgment call: the
spec's harness-to-model-map description implies groups are the *only*
determinant of visibility, but no code currently mints group-scoped keys
(that's B2), so this PR only sets up the proxy-side data; it changes zero
runtime behavior until B2 lands (today's one-unscoped-key still sees every
model regardless of group tags, since LiteLLM only enforces group
membership against a key that itself carries a group grant).