### PR TITLE
test(agents): cursor api_key recipe is generic, runtime-side (A3)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/cursor_render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/cursor_render_tests.rs
@@ -1,0 +1,116 @@
+//! Cursor's `api_key` route, end to end through the real render plane.
+//!
+//! agent-auth.md's Current gaps: *"Cursor selections are rejected server-side.
+//! `selection_rules.py` lists cursor as native-only and the store's harness
+//! allow-list excludes it, even though the registry declares `CURSOR_API_KEY` as
+//! its credential slot; the `api_key` source needs enabling for cursor end to end
+//! (rules, allow-list, **recipe already generic**)."*
+//!
+//! "Recipe already generic" is the claim these tests make executable. Enabling
+//! cursor is a server + UI change (Track B/C); the runtime side is a claim that it
+//! needs no per-harness work, and an unverified claim is how the next reader ends
+//! up adding a carve-out "just in case". So: pin the generic path for cursor
+//! specifically, and pin that the ONE cursor branch in the render plane (no
+//! gateway route) is the only one — a future carve-out has to break a test.
+//!
+//! Split from `render_tests.rs` for the repo line-count ceiling; nested inside it
+//! so its `TempHome`, state-builder, and resolver helpers are in scope.
+
+use super::*;
+use crate::domains::agents::route_auth::RouteAuthError;
+
+/// The `api_key` route is one line of generic code (`rendered.set(env_var_name,
+/// value)`), so cursor gets exactly its registry-declared var, nothing else, and
+/// no files or removals — the same shape codex/grok/opencode assert.
+#[test]
+fn cursor_api_key_sets_exactly_its_var() {
+    let home = TempHome::new("cursor-key");
+    home.write_state_json(&v2_state(
+        1,
+        vec![harness(
+            "cursor",
+            vec![api_key_source("CURSOR_API_KEY", "cur-raw")],
+        )],
+    ));
+
+    let rendered =
+        resolve_launch_route_auth(home.path(), "cursor", &HarnessPlanResolver).expect("render");
+
+    assert_eq!(rendered.set.get("CURSOR_API_KEY").unwrap(), "cur-raw");
+    assert_eq!(rendered.set.len(), 1, "no extra env for cursor");
+    assert!(
+        rendered.remove.is_empty(),
+        "cursor needs no ambient sanitization"
+    );
+    assert!(
+        rendered.files.is_empty(),
+        "cursor needs no materialized config file"
+    );
+}
+
+/// The env var name is carried by the source, not by a per-harness table, so an
+/// operator-chosen var renders verbatim for cursor exactly as for every other
+/// harness. This is what makes the recipe generic rather than
+/// coincidentally-correct for one var name.
+#[test]
+fn cursor_api_key_honors_whatever_var_the_source_names() {
+    let home = TempHome::new("cursor-key-alt");
+    home.write_state_json(&v2_state(
+        1,
+        vec![harness(
+            "cursor",
+            vec![api_key_source("SOME_OTHER_CURSOR_VAR", "cur-alt")],
+        )],
+    ));
+
+    let rendered =
+        resolve_launch_route_auth(home.path(), "cursor", &HarnessPlanResolver).expect("render");
+
+    assert_eq!(rendered.set.get("SOME_OTHER_CURSOR_VAR").unwrap(), "cur-alt");
+    assert!(!rendered.set.contains_key("CURSOR_API_KEY"));
+}
+
+/// Native is still the absence of rows for cursor: a state file that configures
+/// another harness must leave cursor launching on its own login, not error.
+#[test]
+fn cursor_without_rows_renders_a_native_delta() {
+    let home = TempHome::new("cursor-native");
+    home.write_state_json(&v2_state(
+        1,
+        vec![harness(
+            "claude",
+            vec![api_key_source("ANTHROPIC_API_KEY", "sk-a")],
+        )],
+    ));
+
+    let rendered =
+        resolve_launch_route_auth(home.path(), "cursor", &HarnessPlanResolver).expect("render");
+
+    assert!(rendered.set.is_empty());
+    assert!(rendered.remove.is_empty());
+    assert!(rendered.files.is_empty());
+}
+
+/// The one legitimate cursor branch, pinned so it stays the only one: cursor has
+/// no gateway story (it is native-only in the gateway's access groups per R1), so
+/// a gateway source for it is a typed `UnsupportedRoute` — fail-closed, never a
+/// silent native fallback that would bill the user's own Cursor account.
+#[test]
+fn a_cursor_gateway_source_is_a_typed_unsupported_route() {
+    let home = TempHome::new("cursor-gateway");
+    home.write_state_json(&v2_state(
+        1,
+        vec![harness("cursor", vec![gateway_source()])],
+    ));
+
+    let error = resolve_launch_route_auth(home.path(), "cursor", &HarnessPlanResolver)
+        .expect_err("cursor has no gateway route");
+
+    assert!(
+        matches!(
+            &error,
+            RouteAuthError::UnsupportedRoute { harness_kind, .. } if harness_kind == "cursor"
+        ),
+        "expected a typed UnsupportedRoute for cursor, got {error:?}"
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -594,3 +594,6 @@ fn state_file_path_snapshot() {
         std::path::PathBuf::from("/home/u/.proliferate/anyharness/agent-auth/state.json")
     );
 }
+
+#[path = "cursor_render_tests.rs"]
+mod cursor_render;

--- a/specs/codebase/platforms/product/agent-auth.md
+++ b/specs/codebase/platforms/product/agent-auth.md
@@ -567,7 +567,10 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       lists cursor as native-only and the store's harness allow-list
       excludes it, even though the registry declares `CURSOR_API_KEY` as
       its credential slot; the `api_key` source needs enabling for
-      cursor end to end (rules, allow-list, recipe already generic).
+      cursor end to end. The runtime side needs nothing: the `api_key`
+      recipe is generic, and that is now asserted for cursor
+      specifically (`route_auth/cursor_render_tests.rs`), so only the
+      server rules, the store allow-list, and the settings UI remain.
 - [ ] **Cloud native login is not offered.** The cloud settings surface
       shows static "no auth configured" text instead of the Authenticate
       action, though the login-terminal mechanism is surface-agnostic;


### PR DESCRIPTION
Track A, PR 3 of the agents implementation program (Round 1). **Stacked on #1503** (`agents/a2-cred-ladder`, itself on #1499); retarget as the parents merge. The diff below is A3's own commit only.

## Scope and finding

A3's brief: *"cursor enablement (Rust side): confirm the cursor recipe is generic; remove any native-only carve-outs runtime-side. Small PR."*

**Finding: there are no runtime-side carve-outs to remove.** The recon, so the claim is reviewable rather than asserted:

- `route_auth/render.rs` — the `api_key` arm is one generic line, `rendered.set(&profile.env_var_name, &profile.value)`; it dispatches on nothing.
- The ONLY `AgentKind::Cursor` branch anywhere in the render plane is `render_gateway`'s typed `UnsupportedRoute`. That one is correct and stays: cursor genuinely has no gateway story (native-only in the gateway's access groups per R1/B1), and the typed error is the fail-closed behavior — a silent native fallback would bill the user's own Cursor account.
- `route_auth/{profile,state,materialize}.rs`: zero cursor mentions.
- `readiness/` + `auth/credentials.rs`: cursor is handled entirely through registry data — `CredentialDiscoveryKind::Cursor` discovery plus the registry's declared `CURSOR_API_KEY` slot and `.cursor/cli-config.json` synced-file path. No harness-name special-casing.
- The one live `NATIVE_ONLY_HARNESSES` gate is `server/proliferate/server/cloud/agent_gateway/selection_rules.py` — Python, and Track B/C's scope per the program plan.

## Why this is tests-only rather than empty

An unverified "already generic" is how the next reader ends up adding a carve-out just in case. So the claim becomes executable, exercised through the real loader → profile → render → apply chain against a real filesystem (the same path the other per-harness render snapshots use), not through a unit of the render function alone.

New file `route_auth/cursor_render_tests.rs` (tier 1):

| Test | Proves |
| --- | --- |
| `cursor_api_key_sets_exactly_its_var` | cursor gets exactly its registry-declared `CURSOR_API_KEY` — `set.len() == 1`, no removals, no materialized files. The same shape codex/grok/claude/opencode already assert. |
| `cursor_api_key_honors_whatever_var_the_source_names` | the env var name comes from the SOURCE, not a per-harness table. This is the assertion that distinguishes "generic" from "coincidentally correct for one hardcoded var name". |
| `cursor_without_rows_renders_a_native_delta` | native is still the absence of rows for cursor: another harness configured must leave cursor on its own login, not error. |
| `a_cursor_gateway_source_is_a_typed_unsupported_route` | pins the one legitimate cursor branch as fail-closed AND as the only one — a future carve-out has to break a test. |

Results: `cargo test -p anyharness-lib --lib -- route_auth` 70/70 (4 new). `cargo test --workspace` fully green (1315 + 90 + all others, 0 failures). `check_docs.py`, `check_max_lines.py`, `check_anyharness_boundaries.py` pass.

## Gap bullet

`specs/codebase/platforms/product/agent-auth.md`'s cursor bullet is **not** struck — the gap is real and server-side. It is narrowed to say what remains and to record that the runtime half is now asserted rather than assumed:

> The runtime side needs nothing: the `api_key` recipe is generic, and that is now asserted for cursor specifically (`route_auth/cursor_render_tests.rs`), so only the server rules, the store allow-list, and the settings UI remain.

## Contradictions encountered

None. One judgment call: A3's brief said "remove any native-only carve-outs runtime-side", and the gateway `UnsupportedRoute` branch is technically a cursor-specific native-only carve-out. It was **kept** — deleting it would make a cursor gateway selection fall through to a silent native launch, contradicting agent-auth.md's fail-closed law and R1's exclusion of cursor from gateway access groups. Pinned with a test instead, so the distinction between "the carve-out that should not exist" and "the carve-out that is the law" is recorded in code.
