### PR TITLE
fix(agent-auth): fail closed on an unsatisfiable selection (A4)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs
@@ -276,7 +276,10 @@ pub async fn refresh_gateway_models(
         ));
     };
     let revision = document.revision;
-    let sources = document.sources_for(&kind);
+    // Absent harness and present-but-empty are the same answer here — either way
+    // there is no gateway source to refresh against, and the caller gets the
+    // typed NO_SELECTION rejection below.
+    let sources = document.sources_for(&kind).unwrap_or_default();
     let source = sources
         .iter()
         .find(|source| source.kind == SOURCE_KIND_GATEWAY)

--- a/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/sessions_errors.rs
@@ -153,7 +153,6 @@ pub(super) fn map_create_session_error(error: CreateAndStartSessionError) -> Api
 pub(super) fn map_route_auth_error(error: &RouteAuthError) -> ApiError {
     match error {
         RouteAuthError::SelectionMissing { .. }
-        | RouteAuthError::SelectionConflict { .. }
         | RouteAuthError::SelectionIncomplete { .. }
         | RouteAuthError::UnsupportedRoute { .. }
         | RouteAuthError::UnknownHarness { .. }
@@ -373,6 +372,28 @@ mod tests {
         })
         .into_response();
         assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    /// An unsatisfiable agent-auth selection must reach the client as a typed
+    /// **409 naming the auth failure**, not the generic 400 "session create
+    /// failed" the readiness gate would produce. The distinction is the whole
+    /// point: 400 SESSION_CREATE_FAILED reads as "fix your request", while this
+    /// says "the route you selected is dead" — and only that lets the UI send the
+    /// user to the auth pane instead of to an install button.
+    #[test]
+    fn an_unsatisfiable_selection_maps_to_a_typed_conflict() {
+        use crate::domains::agents::route_auth::RouteAuthError;
+
+        let mapped = super::map_create_session_error(CreateAndStartSessionError::RouteAuth(
+            RouteAuthError::SelectionMissing {
+                harness_kind: "claude".to_string(),
+                revision: 42,
+            },
+        ));
+
+        assert_eq!(mapped.status(), StatusCode::CONFLICT);
+        assert_eq!(mapped.code(), Some("AGENT_ROUTE_SELECTION_MISSING"));
+        assert_eq!(mapped.into_response().status(), StatusCode::CONFLICT);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs
@@ -320,8 +320,12 @@ impl GatewayModelResolver {
         runtime_home: &Path,
     ) -> Option<(String, String)> {
         let state = load_state_file(runtime_home).ok().flatten()?;
+        // Absent harness and present-but-empty are the same answer here: no
+        // gateway credentials to plan with. Fail-closed refusal is the launch
+        // path's job, not the model planner's.
         let source = state
             .sources_for(harness_kind)
+            .unwrap_or_default()
             .iter()
             .find(|source| source.kind == SOURCE_KIND_GATEWAY)?;
         let base_url = source

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/contract_fixture_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/contract_fixture_tests.rs
@@ -1,0 +1,170 @@
+//! Rust's half of the `agent-auth-state` contract fixture.
+//!
+//! Python produces `fixtures/contracts/agent-auth-state/v2.json`
+//! (`materialize/agent_auth.py::render_agent_auth_state`); this side asserts we
+//! parse it and resolve it to the profiles the fixture's README claims. Per
+//! `specs/developing/testing/README.md`, changing the shape means changing the
+//! fixture, which breaks whichever side has not caught up — the point is that the
+//! break is mechanical rather than a runtime surprise in a sandbox.
+//!
+//! Split from `render_tests.rs` for the line-count ceiling; nested inside it so
+//! its `TempHome` and resolver helpers are in scope.
+
+// The parent test module's helpers (`TempHome`, `HarnessPlanResolver`, …).
+use super::*;
+// The module under test, reached through its public re-exports.
+use crate::domains::agents::route_auth::state::{AgentAuthState, SOURCE_KIND_GATEWAY};
+use crate::domains::agents::route_auth::{
+    profile::ResolvedSource, resolve_launch_route_auth_for_server, AgentRuntimeAuthProfile,
+};
+
+const FIXTURE: &str =
+    include_str!("../../../../../../../fixtures/contracts/agent-auth-state/v2.json");
+
+fn fixture_state() -> AgentAuthState {
+    serde_json::from_str(FIXTURE).expect("the contract fixture must parse as a v2 document")
+}
+
+/// The document parses and its top-level shape is what the producer promises.
+/// Notably the wire is snake_case; a producer that emitted camelCase would fail
+/// here rather than silently rendering every harness native.
+#[test]
+fn the_contract_fixture_parses_as_a_v2_document() {
+    let state = fixture_state();
+
+    assert_eq!(state.version, 2);
+    assert_eq!(state.revision, 42);
+    assert_eq!(
+        state.user_id.as_deref(),
+        Some("20000000-0000-4000-8000-000000000001")
+    );
+    assert_eq!(
+        state.issuing_server_origin.as_deref(),
+        Some("https://api.proliferate.example")
+    );
+    assert_eq!(state.harnesses.len(), 5);
+}
+
+/// Contract point 1: every gateway source carries its OWN virtual key.
+///
+/// The keys are scoped per (subject, harness) by the gateway's access groups, so
+/// a producer that resolves one subject-wide key and fans it out is wrong. This
+/// asserts distinctness rather than exact values, so rotating the fixture's
+/// placeholder keys does not churn the test.
+#[test]
+fn every_gateway_source_carries_its_own_per_harness_key() {
+    let state = fixture_state();
+
+    let mut keys = Vec::new();
+    for harness in ["claude", "codex", "opencode"] {
+        let sources = state
+            .sources_for(harness)
+            .unwrap_or_else(|| panic!("{harness} entry present"));
+        let gateway = sources
+            .iter()
+            .find(|source| source.kind == SOURCE_KIND_GATEWAY)
+            .unwrap_or_else(|| panic!("{harness} gateway source"));
+        keys.push(gateway.key.clone().expect("gateway key"));
+    }
+
+    let distinct: std::collections::BTreeSet<_> = keys.iter().collect();
+    assert_eq!(
+        distinct.len(),
+        keys.len(),
+        "gateway keys must be per-harness, not one shared subject key: {keys:?}"
+    );
+}
+
+/// Contract point 2: the three-way empty-sources semantics, resolved end to end.
+///
+/// `grok` is present with `sources: []` in the fixture — a selection the producer
+/// could not satisfy — and must refuse the launch, while a harness the fixture
+/// omits entirely is native. If the producer ever "tidies up" by dropping empty
+/// entries, this test is what catches it.
+#[test]
+fn the_fixtures_empty_entry_fails_closed_while_an_absent_one_is_native() {
+    let state = fixture_state();
+
+    // Present with an empty list → refuse.
+    assert_eq!(state.sources_for("grok").map(<[_]>::len), Some(0));
+    let error = resolve_profile(Some(&state), "grok").expect_err("grok must fail closed");
+    assert!(matches!(
+        &error,
+        RouteAuthError::SelectionMissing { harness_kind, revision: 42 } if harness_kind == "grok"
+    ));
+
+    // Absent from the document → native.
+    assert!(state.sources_for("opencode-zen").is_none());
+    assert_eq!(
+        resolve_profile(Some(&state), "opencode-zen").expect("resolve"),
+        AgentRuntimeAuthProfile::Native
+    );
+}
+
+/// Every satisfiable entry resolves to the sources the README describes, in
+/// order: cursor's only route is `api_key`, and opencode composes a gateway plus
+/// a direct provider key simultaneously.
+#[test]
+fn the_fixtures_satisfiable_entries_resolve_to_the_documented_profiles() {
+    let state = fixture_state();
+
+    for harness in ["claude", "codex"] {
+        match resolve_profile(Some(&state), harness).expect("resolve") {
+            AgentRuntimeAuthProfile::Sources(sources) => {
+                assert_eq!(sources.revision, 42);
+                assert_eq!(sources.sources.len(), 1);
+                assert!(matches!(sources.sources[0], ResolvedSource::Gateway(_)));
+            }
+            other => panic!("{harness} should be routed, got {other:?}"),
+        }
+    }
+
+    match resolve_profile(Some(&state), "cursor").expect("resolve") {
+        AgentRuntimeAuthProfile::Sources(sources) => match &sources.sources[..] {
+            [ResolvedSource::ApiKey(profile)] => {
+                assert_eq!(profile.env_var_name, "CURSOR_API_KEY");
+            }
+            other => panic!("cursor should carry exactly one api_key source, got {other:?}"),
+        },
+        other => panic!("cursor should be routed, got {other:?}"),
+    }
+
+    match resolve_profile(Some(&state), "opencode").expect("resolve") {
+        AgentRuntimeAuthProfile::Sources(sources) => {
+            assert_eq!(sources.sources.len(), 2, "gateway + one direct api_key");
+            assert!(matches!(sources.sources[0], ResolvedSource::Gateway(_)));
+            assert!(matches!(sources.sources[1], ResolvedSource::ApiKey(_)));
+        }
+        other => panic!("opencode should be routed, got {other:?}"),
+    }
+}
+
+/// The consumer reads the fixture through the REAL file path, not just serde:
+/// written to a runtime home, `resolve_launch_route_auth` renders claude's
+/// gateway recipe from it. A fixture that parses but cannot drive a launch would
+/// otherwise pass the tests above.
+#[test]
+fn the_contract_fixture_drives_a_real_launch_render() {
+    let home = TempHome::new("contract-fixture");
+    home.write_state_raw(FIXTURE.as_bytes());
+
+    let rendered = resolve_launch_route_auth_for_server(
+        home.path(),
+        "claude",
+        &HarnessPlanResolver,
+        // The fixture is stamped with an origin, so the guard must be given the
+        // matching one or the document reads as absent.
+        Some("https://api.proliferate.example"),
+    )
+    .expect("the fixture must render a claude launch");
+
+    assert_eq!(
+        rendered.set.get("ANTHROPIC_AUTH_TOKEN").map(String::as_str),
+        Some("sk-vk-claude-0001"),
+        "claude's own per-harness key, not another harness's"
+    );
+    assert_eq!(
+        rendered.set.get("ANTHROPIC_BASE_URL").map(String::as_str),
+        Some("https://llm.proliferate.example")
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/contract_fixture_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/contract_fixture_tests.rs
@@ -131,9 +131,13 @@ fn the_fixtures_satisfiable_entries_resolve_to_the_documented_profiles() {
 
     match resolve_profile(Some(&state), "opencode").expect("resolve") {
         AgentRuntimeAuthProfile::Sources(sources) => {
-            assert_eq!(sources.sources.len(), 2, "gateway + one direct api_key");
-            assert!(matches!(sources.sources[0], ResolvedSource::Gateway(_)));
-            assert!(matches!(sources.sources[1], ResolvedSource::ApiKey(_)));
+            assert_eq!(sources.sources.len(), 2, "one direct api_key + gateway");
+            // The producer sorts a harness's sources by (kind, env_var_name), and
+            // "api_key" < "gateway" — so the api_key row comes FIRST. The fixture
+            // has to carry the order the producer actually emits, or it is a
+            // document no reconcile could ever write.
+            assert!(matches!(sources.sources[0], ResolvedSource::ApiKey(_)));
+            assert!(matches!(sources.sources[1], ResolvedSource::Gateway(_)));
         }
         other => panic!("opencode should be routed, got {other:?}"),
     }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/mod.rs
@@ -52,13 +52,19 @@ pub enum RouteAuthError {
          the persisted revision {current}"
     )]
     StaleStateRevision { incoming: i64, current: i64 },
+    /// The harness has an entry in the document whose sources could not be
+    /// satisfied — a selection the machine cannot honor. Constructed by
+    /// [`resolve_profile`] and refused at both create and launch, per
+    /// agent-auth.md's "present-but-empty fails closed".
+    ///
+    /// `SelectionConflict` used to sit beside this, for "N entries where one is
+    /// allowed". It is deleted rather than wired: source cardinality is a
+    /// per-harness SERVER rule (`selection_rules.py`) enforced before a document
+    /// is ever written, and the document's shape — one entry per harness with a
+    /// flat source list — cannot represent the conflict it described. There was
+    /// no input a correct runtime could construct it from.
     #[error("no agent-auth route selection for harness '{harness_kind}' at revision {revision}")]
     SelectionMissing { harness_kind: String, revision: i64 },
-    #[error(
-        "conflicting agent-auth selections for harness '{harness_kind}': \
-         {count} entries where one is allowed"
-    )]
-    SelectionConflict { harness_kind: String, count: usize },
     #[error("agent-auth source for '{harness_kind}' is incomplete: {detail}")]
     SelectionIncomplete { harness_kind: String, detail: String },
     #[error("agent-auth route for '{harness_kind}' is unsupported: {detail}")]
@@ -80,7 +86,6 @@ impl RouteAuthError {
             Self::MalformedStateFile { .. } => "AGENT_ROUTE_STATE_MALFORMED",
             Self::StaleStateRevision { .. } => "AGENT_ROUTE_STATE_STALE",
             Self::SelectionMissing { .. } => "AGENT_ROUTE_SELECTION_MISSING",
-            Self::SelectionConflict { .. } => "AGENT_ROUTE_SELECTION_CONFLICT",
             Self::SelectionIncomplete { .. } => "AGENT_ROUTE_SELECTION_INCOMPLETE",
             Self::UnsupportedRoute { .. } => "AGENT_ROUTE_UNSUPPORTED",
             Self::UnknownHarness { .. } => "AGENT_ROUTE_UNKNOWN_HARNESS",
@@ -219,4 +224,45 @@ fn launch_route_provides_credentials_for_server(
         resolve_profile(state.as_ref(), harness_kind),
         Ok(AgentRuntimeAuthProfile::Sources(_))
     )
+}
+
+/// Is `harness_kind`'s enrolled selection unsatisfiable right now?
+///
+/// `Some(error)` exactly when [`resolve_profile`] fails closed — the harness has
+/// an entry in the document whose sources the renderer could not satisfy
+/// (agent-auth.md: "present-but-empty fails closed"). `None` for native, for a
+/// usable route, and for any state the launcher itself tolerates.
+///
+/// Session create calls this so the refusal is a **typed 409 naming the auth
+/// problem** rather than the generic "agent is not ready" the readiness gate
+/// would otherwise produce. Both refuse the launch; only this one tells the user
+/// their selected route is dead instead of implying their CLI needs installing.
+/// The launch path (`start_live_session`) reaches the same conclusion through
+/// `resolve_launch_route_auth`, so a session that slips past create is still
+/// refused — this is the earlier, better-labelled gate, never the only one.
+pub fn launch_route_selection_failure(
+    runtime_home: &Path,
+    harness_kind: &str,
+) -> Option<RouteAuthError> {
+    launch_route_selection_failure_for_server(
+        runtime_home,
+        harness_kind,
+        current_server_origin().as_deref(),
+    )
+}
+
+fn launch_route_selection_failure_for_server(
+    runtime_home: &Path,
+    harness_kind: &str,
+    current_server_origin: Option<&str>,
+) -> Option<RouteAuthError> {
+    // A state file the launcher tolerates must not be turned into a create-time
+    // rejection here: an unreadable/origin-mismatched document is "no route",
+    // and native readiness governs (identical policy to
+    // `launch_route_provides_credentials_for_server`).
+    let state = load_effective_state(runtime_home, current_server_origin).ok()?;
+    match resolve_profile(state.as_ref(), harness_kind) {
+        Ok(_) => None,
+        Err(error) => Some(error),
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/profile.rs
@@ -67,11 +67,20 @@ pub struct GatewayProfile {
 
 /// Resolve the auth profile for `harness_kind` from the loaded state.
 ///
-/// - `state == None` (no file): `Native`.
-/// - harness absent, or present with no sources: `Native`. A harness the user
-///   never configured uses its own native login — the least-surprising default,
-///   and safe (native = the user's own CLI sign-in, never ambient/leaked
-///   credentials).
+/// The three-way answer is agent-auth.md's law "Absent means native;
+/// present-but-empty fails closed":
+///
+/// - `state == None` (no file): `Native`. Nothing was ever selected.
+/// - harness **absent** from the document: `Native`. The user never configured
+///   this harness, so its own CLI sign-in owns auth — the least-surprising
+///   default, and safe (never ambient or leaked credentials).
+/// - harness **present with an empty source list**:
+///   [`RouteAuthError::SelectionMissing`]. The user DID select a route and the
+///   renderer could not satisfy any of it (unsynced enrollment, exhausted
+///   budget, revoked key). Silently treating that as native is the
+///   silent-degradation bug: a desktop user with a native claude login whose
+///   gateway budget exhausts would start billing their personal Anthropic
+///   account mid-session with no signal.
 /// - harness present with sources: each source is validated + typed. An unknown
 ///   `kind`, or a source missing its required fields, is a typed error (the
 ///   server should never emit these).
@@ -82,9 +91,15 @@ pub fn resolve_profile(
     let Some(state) = state else {
         return Ok(AgentRuntimeAuthProfile::Native);
     };
-    let raw_sources = state.sources_for(harness_kind);
-    if raw_sources.is_empty() {
+    // Absent vs present-but-empty: `None` is native, `Some([])` fails closed.
+    let Some(raw_sources) = state.sources_for(harness_kind) else {
         return Ok(AgentRuntimeAuthProfile::Native);
+    };
+    if raw_sources.is_empty() {
+        return Err(RouteAuthError::SelectionMissing {
+            harness_kind: harness_kind.to_string(),
+            revision: state.revision,
+        });
     }
     let mut sources = Vec::with_capacity(raw_sources.len());
     for source in raw_sources {
@@ -199,11 +214,92 @@ mod tests {
         assert_eq!(profile, AgentRuntimeAuthProfile::Native);
     }
 
+    /// THE fail-closed case, and the one this rewrites: an entry the user
+    /// selected whose every source the renderer dropped as unsatisfiable.
+    ///
+    /// This test previously asserted `Native` — i.e. it pinned the
+    /// silent-degradation bug as intended behavior. A desktop user with a native
+    /// claude login whose gateway budget exhausts would have had the launch
+    /// silently succeed against their personal Anthropic account. It now asserts
+    /// the typed refusal, carrying the revision so the UI can say which document
+    /// generation was dead.
     #[test]
-    fn empty_sources_is_native() {
+    fn empty_sources_fails_closed_with_the_revision() {
         let state = state(4, vec![harness("claude", vec![])]);
-        let profile = resolve_profile(Some(&state), "claude").expect("resolve");
-        assert_eq!(profile, AgentRuntimeAuthProfile::Native);
+
+        let error = resolve_profile(Some(&state), "claude").expect_err("must fail closed");
+
+        assert!(matches!(
+            error,
+            RouteAuthError::SelectionMissing {
+                ref harness_kind,
+                revision: 4,
+            } if harness_kind == "claude"
+        ));
+        assert_eq!(error.code(), "AGENT_ROUTE_SELECTION_MISSING");
+    }
+
+    /// The distinction the whole change rests on, asserted as one comparison:
+    /// the same document, two harnesses, opposite answers. Absent → native;
+    /// present-but-empty → refused.
+    #[test]
+    fn absent_is_native_while_present_but_empty_is_refused() {
+        let state = state(
+            9,
+            vec![
+                harness("claude", vec![]),
+                harness("codex", vec![gateway_source("https://gw", "sk")]),
+            ],
+        );
+
+        // claude: selected, unsatisfiable → refuse.
+        assert!(matches!(
+            resolve_profile(Some(&state), "claude"),
+            Err(RouteAuthError::SelectionMissing { .. })
+        ));
+        // opencode: never configured → native. Same document.
+        assert_eq!(
+            resolve_profile(Some(&state), "opencode").expect("resolve"),
+            AgentRuntimeAuthProfile::Native
+        );
+        // codex: satisfiable → sources.
+        assert!(matches!(
+            resolve_profile(Some(&state), "codex").expect("resolve"),
+            AgentRuntimeAuthProfile::Sources(_)
+        ));
+    }
+
+    /// An empty entry for ANOTHER harness must not contaminate this one: the
+    /// refusal is per-harness, not per-document. Without this, one exhausted
+    /// budget would take every harness on the machine down with it.
+    #[test]
+    fn one_harnesss_dead_selection_does_not_refuse_another() {
+        let state = state(
+            11,
+            vec![
+                harness("opencode", vec![]),
+                harness("claude", vec![gateway_source("https://gw", "sk-vk")]),
+            ],
+        );
+
+        assert!(matches!(
+            resolve_profile(Some(&state), "claude").expect("resolve"),
+            AgentRuntimeAuthProfile::Sources(_)
+        ));
+        assert!(matches!(
+            resolve_profile(Some(&state), "opencode"),
+            Err(RouteAuthError::SelectionMissing { .. })
+        ));
+    }
+
+    /// No state file at all is still native — the fail-closed rule keys on a
+    /// PRESENT entry, so a machine that has never synced auth is unaffected.
+    #[test]
+    fn no_file_is_native_even_though_empty_entries_now_refuse() {
+        assert_eq!(
+            resolve_profile(None, "claude").expect("resolve"),
+            AgentRuntimeAuthProfile::Native
+        );
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs
@@ -8,7 +8,7 @@ use super::plan::{GatewayModelPlan, GatewayModelResolve};
 use super::render::render_profile;
 use super::state::state_file_path;
 use super::test_support::TempHome;
-use super::{load_state_file, resolve_launch_route_auth, resolve_profile};
+use super::{load_state_file, resolve_launch_route_auth, resolve_profile, RouteAuthError};
 
 const GATEWAY_BASE_URL: &str = "https://llm.proliferate.ai";
 const VK: &str = "sk-virtual-1234";
@@ -431,13 +431,27 @@ fn absent_harness_renders_native_delta() {
     assert!(rendered.files.is_empty());
 }
 
+/// A present-but-empty entry refuses the launch through the FULL render path,
+/// not just at the pure profile layer — the launcher must never receive an empty
+/// delta it would interpret as native.
+///
+/// This test previously asserted an empty (native) delta, which pinned the
+/// silent-degradation bug: the user selected the gateway, the renderer could not
+/// satisfy it, and the launch proceeded on their personal credentials.
 #[test]
-fn empty_sources_render_native_delta() {
+fn empty_sources_refuse_the_launch_instead_of_rendering_native() {
     let home = TempHome::new("empty-sources");
     home.write_state_json(&v2_state(4, vec![harness("claude", vec![])]));
-    let rendered = resolve_launch_route_auth(home.path(), "claude", &HarnessPlanResolver).expect("render");
-    assert!(rendered.set.is_empty());
-    assert!(rendered.remove.is_empty());
+
+    let error = resolve_launch_route_auth(home.path(), "claude", &HarnessPlanResolver)
+        .expect_err("a dead selection must refuse the launch");
+
+    assert!(matches!(
+        &error,
+        RouteAuthError::SelectionMissing { harness_kind, revision: 4 } if harness_kind == "claude"
+    ));
+    // Nothing was materialized on the way to the refusal.
+    assert!(!home.path().join("agent-auth/claude-config").exists());
 }
 
 #[test]
@@ -597,3 +611,6 @@ fn state_file_path_snapshot() {
 
 #[path = "cursor_render_tests.rs"]
 mod cursor_render;
+
+#[path = "contract_fixture_tests.rs"]
+mod contract_fixture;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs
@@ -111,14 +111,30 @@ pub struct AgentAuthState {
 }
 
 impl AgentAuthState {
-    /// The enabled sources for a harness kind. Absent harness → empty slice
-    /// (the render plane treats this as native — no rendered credentials).
-    pub fn sources_for(&self, harness_kind: &str) -> &[AuthSource] {
+    /// The enabled sources for a harness kind, distinguishing **absent** from
+    /// **present-but-empty** — the whole point of the return type.
+    ///
+    /// agent-auth.md, "Absent means native; present-but-empty fails closed": a
+    /// harness with no entry in the document runs on its own login, while a
+    /// harness whose entry is present but whose selected sources could not be
+    /// satisfied is a *selection the machine cannot honor* and a launch must be
+    /// refused rather than quietly falling back to the user's personal
+    /// credentials.
+    ///
+    /// - `None` — no entry for this harness. Native.
+    /// - `Some([])` — an entry exists and every source in it was dropped as
+    ///   unsatisfiable. Fail closed.
+    /// - `Some([..])` — usable sources.
+    ///
+    /// The old signature returned `&[]` for both of the first two cases, which
+    /// made the law unimplementable at this layer: the caller could not tell a
+    /// user who never configured the harness from a user whose gateway budget
+    /// just exhausted.
+    pub fn sources_for(&self, harness_kind: &str) -> Option<&[AuthSource]> {
         self.harnesses
             .iter()
             .find(|entry| entry.harness_kind == harness_kind)
             .map(|entry| entry.sources.as_slice())
-            .unwrap_or(&[])
     }
 
     /// Guards against injecting a PREVIOUS server's gateway tokens after a
@@ -338,23 +354,46 @@ mod tests {
         assert!(!json.contains("\"env_var_name\":null"));
     }
 
+    /// The three-way lookup that the fail-closed law needs: absent, present-but-
+    /// empty, and present-with-sources must be distinguishable AT THIS LAYER.
+    /// The old `&[AuthSource]` signature collapsed the first two, which is why
+    /// "present-but-empty fails closed" could not be implemented above it.
     #[test]
-    fn sources_lookup() {
+    fn sources_lookup_distinguishes_absent_from_present_but_empty() {
         let state = AgentAuthState {
             version: STATE_VERSION,
             revision: 5,
             user_id: None,
             issuing_server_origin: None,
-            harnesses: vec![HarnessAuth {
-                harness_kind: "codex".into(),
-                sources: vec![api_key_source("OPENAI_API_KEY", "sk-raw")],
-                settings: None,
-            }],
+            harnesses: vec![
+                HarnessAuth {
+                    harness_kind: "codex".into(),
+                    sources: vec![api_key_source("OPENAI_API_KEY", "sk-raw")],
+                    settings: None,
+                },
+                // A selected harness whose every source was dropped as
+                // unsatisfiable: the renderer keeps the entry, empty.
+                HarnessAuth {
+                    harness_kind: "opencode".into(),
+                    sources: vec![],
+                    settings: None,
+                },
+            ],
         };
-        assert_eq!(state.sources_for("codex").len(), 1);
-        assert_eq!(state.sources_for("codex")[0].kind, SOURCE_KIND_API_KEY);
-        // Absent harness → empty slice (native).
-        assert!(state.sources_for("claude").is_empty());
+
+        let codex = state.sources_for("codex").expect("codex entry present");
+        assert_eq!(codex.len(), 1);
+        assert_eq!(codex[0].kind, SOURCE_KIND_API_KEY);
+
+        // Present but empty → Some([]) (fails closed upstream).
+        assert_eq!(
+            state.sources_for("opencode").map(<[_]>::len),
+            Some(0),
+            "a present-but-empty entry must not read as absent"
+        );
+
+        // Absent harness → None (native upstream).
+        assert!(state.sources_for("claude").is_none());
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs
@@ -357,6 +357,9 @@ fn map_create_session_service_error(
             agent_kind,
             mode_id,
         },
+        crate::domains::sessions::service::CreateSessionError::RouteAuth(error) => {
+            CreateAndStartSessionError::RouteAuth(error)
+        }
         crate::domains::sessions::service::CreateSessionError::Invalid(detail) => {
             CreateAndStartSessionError::Invalid(detail)
         }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/create.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/create.rs
@@ -105,6 +105,25 @@ impl SessionService {
             read_materialized_launch_env(&self.runtime_home, Path::new(&workspace.path))
                 .map_err(CreateSessionError::Internal)?;
         let agent_resolution_started = Instant::now();
+        // Fail closed BEFORE the readiness gate, so an unsatisfiable selection is
+        // reported as the auth problem it is. The readiness gate would also refuse
+        // this launch, but as "agent is not ready" — which reads to a user as "go
+        // install something" when the real answer is "your gateway budget is
+        // exhausted". agent-auth.md: a selection never silently degrades to the
+        // user's personal credentials.
+        if let Some(error) = crate::domains::agents::route_auth::launch_route_selection_failure(
+            &self.runtime_home,
+            agent_kind,
+        ) {
+            tracing::warn!(
+                workspace_id = %workspace_id,
+                agent_kind = %agent_kind,
+                code = error.code(),
+                error = %error,
+                "agent-auth selection is unsatisfiable; refusing session create"
+            );
+            return Err(CreateSessionError::RouteAuth(error));
+        }
         // Launch-time readiness: folds in the enrolled agent-auth route so a
         // gateway/api_key route makes the agent ready exactly as the launcher
         // will inject it (issue #1106) — no workspace-env credential workaround.

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/mod.rs
@@ -76,6 +76,13 @@ pub enum CreateSessionError {
         agent_kind: String,
         mode_id: String,
     },
+    /// The harness's enrolled agent-auth selection cannot be satisfied
+    /// (agent-auth.md: "present-but-empty fails closed"). Distinct from
+    /// `Invalid`: the agent may be perfectly installed and the user's own login
+    /// may even work — the point is that they SELECTED a route which is now dead,
+    /// and honoring it silently with their personal credentials is the failure
+    /// this refuses. Maps to a 409 carrying route-auth's own code.
+    RouteAuth(crate::domains::agents::route_auth::RouteAuthError),
     Invalid(String),
     Internal(anyhow::Error),
 }

--- a/fixtures/contracts/agent-auth-state/README.md
+++ b/fixtures/contracts/agent-auth-state/README.md
@@ -1,0 +1,56 @@
+# `agent-auth-state` contract fixture
+
+The `agent-auth/state.json` document: **Python produces it, Rust consumes it.**
+
+Per `specs/developing/testing/README.md` ("Contract fixtures"), a shared JSON
+shape that crosses a language boundary gets a golden fixture here; the producing
+language asserts it produces this, each consuming language asserts it parses
+this, and a shape change is made by changing the fixture — which mechanically
+breaks the other side until it is updated.
+
+- Producer: `server/proliferate/server/cloud/materialization/materialize/agent_auth.py`
+  (`render_agent_auth_state`), for both the cloud-materialized and the
+  desktop-served surface.
+- Consumer: `anyharness-lib`'s `domains/agents/route_auth/` — `load_state_file`
+  → `resolve_profile` → `render_profile`.
+
+## What `v2.json` pins
+
+Two things the two sides could otherwise drift on silently:
+
+**1. Per-harness gateway keys, not one shared key.** Every gateway source
+carries its OWN virtual key (`sk-vk-claude-0001`, `sk-vk-codex-0002`,
+`sk-vk-opencode-0003` — all distinct). The keys are scoped per
+(subject, harness) by the gateway's access groups, so a renderer that resolves
+one subject-wide key and fans it out to every harness is wrong and this fixture
+makes that wrong-ness a test failure rather than a runtime surprise.
+
+**2. Empty-sources semantics.** `grok` is present with `"sources": []`. That is
+NOT the same as being absent, and the difference is a launch-refusal:
+
+| Document state | Meaning | Launch |
+| --- | --- | --- |
+| harness absent (there is no `opencode-zen` entry here) | never configured | native — the harness's own login |
+| `"sources": []` (grok, here) | selected, but nothing satisfiable | **refused**, `AGENT_ROUTE_SELECTION_MISSING` |
+| `"sources": [..]` | usable | routed |
+
+agent-auth.md, "Absent means native; present-but-empty fails closed". A harness
+whose selected sources could not be satisfied (unsynced enrollment, exhausted
+budget, revoked key) keeps its entry with the dead source omitted, and a launch
+that resolves zero usable sources for a still-selected route is refused with a
+typed error. A selection never silently degrades to the user's personal
+credentials.
+
+Also pinned incidentally, because they are easy to get wrong: the document is
+**snake_case** on the wire (`harness_kind`, `env_var_name`, `base_url`,
+`user_id`, `issuing_server_origin`) while `settings` values are the catalog's own
+camelCase keys; a harness may carry several sources at once (opencode: gateway +
+a direct `api_key`); and cursor's only route is `api_key` (it has no gateway
+story).
+
+## Reconciliation status
+
+Written by the Rust side (Track A / A4). **Track B's B3 must produce byte-identical
+output for these inputs** — if B3 has already landed a fixture at this path with a
+different shape, that shape wins and this consumer test is updated to it rather
+than the other way round. Do not let the two forks coexist.

--- a/fixtures/contracts/agent-auth-state/README.md
+++ b/fixtures/contracts/agent-auth-state/README.md
@@ -16,7 +16,7 @@ breaks the other side until it is updated.
 
 ## What `v2.json` pins
 
-Two things the two sides could otherwise drift on silently:
+Three things the two sides could otherwise drift on silently:
 
 **1. Per-harness gateway keys, not one shared key.** Every gateway source
 carries its OWN virtual key (`sk-vk-claude-0001`, `sk-vk-codex-0002`,
@@ -41,11 +41,20 @@ that resolves zero usable sources for a still-selected route is refused with a
 typed error. A selection never silently degrades to the user's personal
 credentials.
 
+**3. Source order within a harness.** The producer sorts a harness's sources by
+`(kind, env_var_name)`, and `"api_key"` sorts before `"gateway"` — so opencode's
+`api_key` row comes FIRST and its gateway row second. This is not cosmetic: a
+fixture in the other order is a document no reconcile could ever emit, so the
+consumer would be pinning a shape that never reaches a sandbox. Both sides assert
+the order (`test_the_fixtures_source_order_is_the_order_this_renderer_emits` on
+the producer, `the_fixtures_satisfiable_entries_resolve_to_the_documented_profiles`
+on the consumer).
+
 Also pinned incidentally, because they are easy to get wrong: the document is
 **snake_case** on the wire (`harness_kind`, `env_var_name`, `base_url`,
 `user_id`, `issuing_server_origin`) while `settings` values are the catalog's own
-camelCase keys; a harness may carry several sources at once (opencode: gateway +
-a direct `api_key`); and cursor's only route is `api_key` (it has no gateway
+camelCase keys; a harness may carry several sources at once (opencode: a direct
+`api_key` + gateway); and cursor's only route is `api_key` (it has no gateway
 story).
 
 ## Reconciliation status

--- a/fixtures/contracts/agent-auth-state/v2.json
+++ b/fixtures/contracts/agent-auth-state/v2.json
@@ -42,14 +42,14 @@
       "harness_kind": "opencode",
       "sources": [
         {
-          "kind": "gateway",
-          "base_url": "https://llm.proliferate.example",
-          "key": "sk-vk-opencode-0003"
-        },
-        {
           "kind": "api_key",
           "env_var_name": "ANTHROPIC_API_KEY",
           "value": "sk-ant-raw-0005"
+        },
+        {
+          "kind": "gateway",
+          "base_url": "https://llm.proliferate.example",
+          "key": "sk-vk-opencode-0003"
         }
       ],
       "settings": {

--- a/fixtures/contracts/agent-auth-state/v2.json
+++ b/fixtures/contracts/agent-auth-state/v2.json
@@ -1,0 +1,60 @@
+{
+  "version": 2,
+  "revision": 42,
+  "user_id": "20000000-0000-4000-8000-000000000001",
+  "issuing_server_origin": "https://api.proliferate.example",
+  "harnesses": [
+    {
+      "harness_kind": "claude",
+      "sources": [
+        {
+          "kind": "gateway",
+          "base_url": "https://llm.proliferate.example",
+          "key": "sk-vk-claude-0001"
+        }
+      ]
+    },
+    {
+      "harness_kind": "codex",
+      "sources": [
+        {
+          "kind": "gateway",
+          "base_url": "https://llm.proliferate.example",
+          "key": "sk-vk-codex-0002"
+        }
+      ]
+    },
+    {
+      "harness_kind": "cursor",
+      "sources": [
+        {
+          "kind": "api_key",
+          "env_var_name": "CURSOR_API_KEY",
+          "value": "cur-raw-0004"
+        }
+      ]
+    },
+    {
+      "harness_kind": "grok",
+      "sources": []
+    },
+    {
+      "harness_kind": "opencode",
+      "sources": [
+        {
+          "kind": "gateway",
+          "base_url": "https://llm.proliferate.example",
+          "key": "sk-vk-opencode-0003"
+        },
+        {
+          "kind": "api_key",
+          "env_var_name": "ANTHROPIC_API_KEY",
+          "value": "sk-ant-raw-0005"
+        }
+      ],
+      "settings": {
+        "reasoningEffort": "medium"
+      }
+    }
+  ]
+}

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -15,12 +15,12 @@ anyharness/crates/anyharness-lib/src/domains/materialization/service.rs 625 loca
 anyharness/crates/anyharness-lib/src/domains/workflows/service.rs 664 workflow durable rules (+run-control cancel-intent use case and helpers); split into service/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/workflows/service_tests.rs 1320 workflow-runs merge-gated domain suite (+2b partial-uniqueness contract on nonterminal session binding)
 anyharness/crates/anyharness-lib/src/api/workflow_runs_tests.rs 2790 workflow-runs HTTP + runtime/extension crossing suite (run-control PROOF-01 battery + 2b admission races: reservation/create/bind window, terminal release, PR1227-WORKSPACE-FENCE-01 purge/retire destruction-vs-late-bind proofs, and FENCE-02 bind->terminalize->destruction race proofs over the real executor)
-anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 632 gateway model enrichment (own vs foreign match) + catalog version endpoint
+anyharness/crates/anyharness-lib/src/api/http/agent_gateway_catalog.rs 635 gateway model enrichment (own vs foreign match) + catalog version endpoint
 anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 645 workspace retire lifecycle handlers (+PR1227-WORKSPACE-FENCE-01/02 under-exclusive-lease workflow-control re-check with admitted-set fail-closed membership + test-only proof seam module)
 anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs 665 workspace purge handlers (+2b fail-closed all-session admission, PR1227-WORKSPACE-FENCE-01/02 admitted-set carry + under-exclusive-lease re-check, test-only purge proof seam module)
 anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs 823 worktree retention sweep (+PR1227-RETENTION-FENCE-01 permit/lease fencing + test proof seam, +Workflow creator-context exclusion until an explicit cleanup policy exists)
 anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs 674 2b admission conflict-matrix + fail-closed purge/retire/mobility-export/destroy-source proofs + LOCK-01 permit-before-lease deadlock/source-order guards (+idempotent create)
-anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 704 provider filtering + family normalizer (bedrock/date/version forms) with tests
+anyharness/crates/anyharness-lib/src/domains/agents/catalog/gateway_resolver.rs 708 provider filtering + family normalizer (bedrock/date/version forms) with tests (+absent-vs-empty sources_for comment)
 anyharness/crates/anyharness-lib/src/domains/agents/catalog/validation.rs 609 existing catalog validator router; unattended-mode invariants live in a focused submodule
 anyharness/crates/anyharness-lib/src/domains/agents/auth/context_tests.rs 645 classifier tests incl. gateway route activation + bedrock flag-only detection
 anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1893 existing AnyHarness oversized file (catalog-owned unattended default replaces local fallback helper)
@@ -68,3 +68,5 @@ anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime 
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 642 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations
 anyharness/crates/anyharness-lib/src/domains/agents/model.rs 605 agents domain type barrel, previously exactly at the cap (+ResolvedAgent.credentials_from_route, the route-vs-native readiness provenance flag); split into model/ on next growth per guides/domains.md
+anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs 616 render-plane snapshot suite (+fail-closed rewrite, +the agent-auth-state contract-fixture submodule); split further on next growth
+server/tests/unit/test_agent_auth_materialization.py 617 renderer unit suite (+the agent-auth-state contract-fixture producer class, +fail-closed rewrites)

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -69,4 +69,4 @@ anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 642 session 
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations
 anyharness/crates/anyharness-lib/src/domains/agents/model.rs 605 agents domain type barrel, previously exactly at the cap (+ResolvedAgent.credentials_from_route, the route-vs-native readiness provenance flag); split into model/ on next growth per guides/domains.md
 anyharness/crates/anyharness-lib/src/domains/agents/route_auth/render_tests.rs 616 render-plane snapshot suite (+fail-closed rewrite, +the agent-auth-state contract-fixture submodule); split further on next growth
-server/tests/unit/test_agent_auth_materialization.py 617 renderer unit suite (+the agent-auth-state contract-fixture producer class, +fail-closed rewrites)
+server/tests/unit/test_agent_auth_materialization.py 614 renderer unit suite (+fail-closed rewrites, +the renderer-merge tripwire; the contract-fixture producer class split out to test_agent_auth_state_contract_fixture.py)

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -27,10 +27,11 @@ file lives at ``<anyharness home>/agent-auth/state.json`` (mode 0600):
       ]
     }
 
-``sources`` are the ENABLED rows only (disabled rows never leave the DB); a
-harness with no resolvable enabled source is omitted entirely. There is NO
-``model_catalog``, NO ``slot``, and NO ``provider`` on the wire — ``provider_hint``
-is a UI-only display field the renderer never emits.
+``sources`` are the ENABLED rows only (disabled rows never leave the DB). A
+harness whose every enabled row is unsatisfiable keeps its entry with
+``sources: []`` — absent means native, present-but-empty fails closed. There is
+NO ``model_catalog``, NO ``slot``, and NO ``provider`` on the wire —
+``provider_hint`` is a UI-only display field the renderer never emits.
 
 Two delivery surfaces share this one renderer: the cloud materialization worker
 writes the ``cloud`` surface into sandboxes, and ``GET /agent-gateway/state``
@@ -47,14 +48,15 @@ file without any row mutation, so change detection uses a sha256 fingerprint of
 the canonical JSON tracked in a server-owned manifest beside the home:
 unchanged fingerprint → no write.
 
-Empty state (contract §3): a harness absent from ``harnesses`` (or with empty
-``sources``) renders to the native delta at the read plane. When the whole
-surface resolves to zero harnesses, the state file and manifest are deleted so
-the reader finds no file (cloud launch fail-closes on its own — that is the Rust
-launcher's job, not this file's). A gateway source whose enrollment is not yet
-synced, or whose public base URL is unconfigured, is dropped (and logged) rather
-than raised, and a revoked ``api_key`` source's value simply vanishes at the next
-pass — one unsatisfiable source never aborts the whole reconcile.
+Empty state (contract §3): a harness ABSENT from ``harnesses`` renders to the
+native delta at the read plane; a harness PRESENT with ``sources: []`` fails the
+launch closed with a typed error. When the whole surface has no selection rows at
+all, the state file and manifest are deleted so the reader finds no file. A
+gateway source whose enrollment is not yet synced, or whose public base URL is
+unconfigured, is dropped (and logged) rather than raised, and a revoked
+``api_key`` source's value simply vanishes at the next pass — one unsatisfiable
+source never aborts the whole reconcile, but it does leave its harness entry
+empty rather than removing it.
 """
 
 from __future__ import annotations
@@ -111,23 +113,35 @@ class AgentAuthStateInputs:
 def render_agent_auth_state(inputs: AgentAuthStateInputs) -> tuple[dict[str, object], str]:
     """Render (state, fingerprint) as a v2 document from pre-scoped inputs.
 
-    The returned document is always a valid v2 shape. ``harnesses`` lists only
-    the harnesses that have at least one resolvable enabled source; a harness
-    whose every source is unsatisfiable (revoked key, unsynced gateway) is
-    omitted, which the read plane treats as native. The caller (cloud
-    materializer) deletes the file when ``harnesses`` is empty.
+    The returned document is always a valid v2 shape. ``harnesses`` lists every
+    harness the user has an enabled selection row for, INCLUDING one whose every
+    source turned out unsatisfiable (revoked key, unsynced gateway) — that entry
+    is kept with ``sources: []``, which the runtime reads as "a selection this
+    machine cannot honor" and refuses the launch. Only a harness with no
+    selection row at all is absent, which the read plane treats as native. The
+    caller deletes the file when ``harnesses`` is empty, i.e. when nothing is
+    selected on this surface at all.
 
     Never raises for an unsatisfiable source: it is dropped (and logged) so a
     single bad source can never abort the reconcile and leave stale key material
-    behind.
+    behind. Dropping a source is not the same as dropping its harness.
     """
-    by_harness: dict[str, list[tuple[str, dict[str, object]]]] = {}
+    # Every harness the user has SELECTED something for gets a key here, even
+    # when its value ends up empty. That distinction is the fail-closed law:
+    # `sources: []` says "you selected a route and we could not satisfy it", and
+    # the runtime refuses the launch; an ABSENT harness says "you never
+    # configured this one" and the runtime uses the native login. Dropping the
+    # harness entirely collapsed those two into one, so an exhausted gateway
+    # budget silently billed the user's personal provider account.
+    by_harness: dict[str, list[tuple[str, dict[str, object]]]] = {
+        selection.harness_kind: [] for selection in inputs.selections
+    }
     for selection in inputs.selections:
         source = _render_source(inputs, selection)
         if source is None:
             continue
         sort_key = (str(source["kind"]), selection.env_var_name or "")
-        by_harness.setdefault(selection.harness_kind, []).append((sort_key, source))
+        by_harness[selection.harness_kind].append((sort_key, source))
 
     harnesses: list[dict[str, object]] = []
     for harness_kind in sorted(by_harness):
@@ -328,9 +342,12 @@ async def materialize_agent_auth(
     manifest_path = paths.agent_auth_manifest_path()
 
     if not state["harnesses"]:
-        # No resolvable cloud sources: delete the file so the reader finds none
-        # (contract §3 — empty renders to native; cloud launch fail-closes in the
-        # runtime launcher, not here).
+        # NO SELECTIONS AT ALL for this surface — not "selections we could not
+        # satisfy". Since the renderer now keeps a `sources: []` entry for every
+        # selected harness, an empty `harnesses` list can only mean the user has
+        # selected nothing, and deleting the file is exactly right: absent means
+        # native. A surface with an unsatisfiable selection reaches the write
+        # below with `sources: []`, which the runtime fails closed on.
         await sandbox_io.remove_owned_files(
             ctx.target,
             operation_id=ctx.sandbox.id,

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -311,87 +311,6 @@ class TestRenderAgentAuthState:
         _ = key_id
 
 
-class TestAgentAuthStateContractFixture:
-    """Producer half of ``fixtures/contracts/agent-auth-state/v2.json``.
-
-    Python produces the document, Rust consumes it
-    (``route_auth/contract_fixture_tests.rs``). Per
-    ``specs/developing/testing/README.md``, the fixture is the shape's single
-    definition: change it and whichever side lags breaks mechanically.
-    """
-
-    def test_the_fixture_is_a_valid_v2_document_this_renderer_could_emit(self) -> None:
-        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
-
-        assert fixture["version"] == agent_auth.AGENT_AUTH_STATE_VERSION
-        assert isinstance(fixture["revision"], int)
-        # snake_case on the wire, and no UI-only fields leak into it.
-        serialized = json.dumps(fixture)
-        for forbidden in ("provider_hint", "harnessKind", "envVarName", "model_catalog"):
-            assert forbidden not in serialized, forbidden
-        for entry in fixture["harnesses"]:
-            assert set(entry) <= {"harness_kind", "sources", "settings"}
-            for source in entry["sources"]:
-                assert source["kind"] in ("gateway", "api_key")
-                if source["kind"] == "gateway":
-                    assert set(source) == {"kind", "base_url", "key"}
-                else:
-                    assert set(source) == {"kind", "env_var_name", "value"}
-
-    def test_this_renderer_produces_the_fixtures_empty_sources_semantics(self) -> None:
-        # The half of the contract this renderer owns TODAY: a selected harness
-        # whose sources are all unsatisfiable keeps its entry with an empty list
-        # (the fixture's `grok`), while a harness with no selection row is absent
-        # (the fixture has no `opencode-zen`).
-        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
-        fixture_kinds = {entry["harness_kind"] for entry in fixture["harnesses"]}
-        assert "grok" in fixture_kinds
-        assert "opencode-zen" not in fixture_kinds
-
-        state, _ = agent_auth.render_agent_auth_state(
-            _inputs(
-                (_selection(harness="grok", source_kind="gateway"),),
-                enrollment_sync_status="pending",
-                gateway_virtual_key=None,
-            )
-        )
-        rendered = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
-        assert rendered == {"grok": []}, (
-            "a selected-but-unsatisfiable harness must keep an empty entry, exactly "
-            "as the fixture's grok does"
-        )
-
-    def test_per_harness_gateway_keys_are_not_produced_yet(self) -> None:
-        # KNOWN GAP, owned by Track B (B3). The fixture gives every gateway source
-        # its own virtual key because the gateway scopes keys per
-        # (subject, harness); this renderer still resolves ONE subject-wide
-        # `gateway_virtual_key` and fans it out. That is the "one shared gateway
-        # key" bullet in agent-auth.md's Current gaps, and it is NOT closed here.
-        #
-        # This test asserts the gap as it stands so B3 has to delete it when it
-        # lands the per-harness key map — a passing suite after B3 would otherwise
-        # hide that the fixture and the producer disagree.
-        state, _ = agent_auth.render_agent_auth_state(
-            _inputs(
-                (
-                    _selection(harness="claude", source_kind="gateway"),
-                    _selection(harness="codex", source_kind="gateway"),
-                )
-            )
-        )
-        keys = [
-            source["key"]
-            for entry in state["harnesses"]
-            for source in entry["sources"]
-            if source["kind"] == "gateway"
-        ]
-        assert len(keys) == 2
-        assert len(set(keys)) == 1, (
-            "expected today's shared-key behavior; if this now fails, B3 has landed "
-            "per-harness keys — delete this test and assert distinctness instead"
-        )
-
-
 class _SandboxIOSpy:
     def __init__(self, previous_manifest: dict[str, object] | None) -> None:
         self.previous_manifest = previous_manifest
@@ -615,3 +534,81 @@ class TestMaterializeAgentAuth:
         serialized = json.dumps(state)
         assert "sk-live" in serialized
         assert str(revoked_id) not in serialized
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_selection_survives_renderer_merge_tripwire(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard both halves of the fail-closed fix against a careless B3 rebase.
+
+        ``agents/b3-renderer-key-map`` (Track B) touches THIS renderer for the
+        per-harness key map, and its branch point predates this PR: its copy still
+        carries the two lines this PR deleted —
+
+        1. ``by_harness.setdefault(selection.harness_kind, []).append(...)`` instead
+           of pre-seeding a key for every SELECTED harness, so a harness whose every
+           source is unsatisfiable disappears from ``harnesses`` entirely; and
+        2. a ``materialize_agent_auth`` delete branch whose comment reads "no
+           resolvable cloud sources", so the state file is removed for an exhausted
+           budget rather than only for "nothing selected".
+
+        Either one reverted turns a dead selection back into a silent native launch
+        on the user's personal credentials — and it reverts SILENTLY, because it is a
+        deletion of behavior rather than a conflicting edit. This test asserts the
+        two semantics together in one pass so a merge that resurrects either half
+        fails loudly here, naming the branch that would have done it.
+        """
+        # A harness whose EVERY source is unsatisfiable, and nothing else selected:
+        # the exact input where a `setdefault` renderer produces `harnesses: []` and
+        # a broad delete condition then removes the document.
+        inputs = _inputs(
+            (_selection(harness="claude", source_kind="gateway"),),
+            enrollment_sync_status="pending",
+            gateway_virtual_key=None,
+        )
+
+        # Half 1 — the renderer pre-seeds an entry per selected harness.
+        state, _ = agent_auth.render_agent_auth_state(inputs)
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}], (
+            "renderer regressed to dropping a fully-unsatisfiable harness "
+            "(by_harness.setdefault) — see agents/b3-renderer-key-map"
+        )
+
+        async def fake_load(db: object, *, user_id: uuid.UUID, surface: str = "cloud") -> Any:
+            return inputs
+
+        monkeypatch.setattr(agent_auth, "_load_state_inputs", fake_load)
+        spy = _install_spy(monkeypatch, previous_manifest=None)
+
+        # Half 2 — the delete branch is narrowed to "nothing selected at all", so
+        # this pass WRITES the empty entry instead of removing the document.
+        await agent_auth.materialize_agent_auth(object(), ctx=_ctx(), user_id=USER_ID)
+
+        assert spy.removed == set(), (
+            "materializer regressed to deleting the state file for an unsatisfiable "
+            "selection — see agents/b3-renderer-key-map"
+        )
+        assert [write["path"] for write in spy.writes] == [
+            paths.agent_auth_state_path(),
+            paths.agent_auth_manifest_path(),
+        ]
+        written = json.loads(str(spy.writes[0]["content"]))
+        assert written["harnesses"] == [{"harness_kind": "claude", "sources": []}]
+
+        # And the delete branch is still REACHABLE for its one legitimate case, so
+        # the narrowing did not simply disable it.
+        empty_inputs = _inputs(())
+
+        async def fake_load_empty(
+            db: object, *, user_id: uuid.UUID, surface: str = "cloud"
+        ) -> Any:
+            return empty_inputs
+
+        monkeypatch.setattr(agent_auth, "_load_state_inputs", fake_load_empty)
+        empty_spy = _install_spy(monkeypatch, previous_manifest=None)
+        await agent_auth.materialize_agent_auth(object(), ctx=_ctx(), user_id=USER_ID)
+        assert empty_spy.writes == []
+        assert empty_spy.removed == {
+            paths.agent_auth_state_path(),
+            paths.agent_auth_manifest_path(),
+        }

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -17,6 +18,9 @@ from proliferate.server.cloud.materialization.materialize import agent_auth
 USER_ID = uuid.uuid4()
 NOW = datetime(2026, 7, 1, tzinfo=UTC)
 REVISION = 4211
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_PATH = REPO_ROOT / "fixtures/contracts/agent-auth-state/v2.json"
 
 
 def _selection(
@@ -184,8 +188,13 @@ class TestRenderAgentAuthState:
                 api_key_values={live_id: "sk-live"},
             )
         )
-        # claude's only source was revoked -> the harness disappears entirely.
-        assert [entry["harness_kind"] for entry in state["harnesses"]] == ["codex"]
+        # claude's only source was revoked -> the ENTRY STAYS, empty. Dropping it
+        # would read as "never configured" at the runtime and silently launch on
+        # the user's own login (agent-auth.md: present-but-empty fails closed).
+        by_harness = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        assert sorted(by_harness) == ["claude", "codex"]
+        assert by_harness["claude"] == []
+        assert len(by_harness["codex"]) == 1
 
     def test_unsatisfiable_gateway_still_renders_satisfiable_api_key(self) -> None:
         live_id = uuid.uuid4()
@@ -205,9 +214,18 @@ class TestRenderAgentAuthState:
                 gateway_virtual_key=None,
             )
         )
-        assert [entry["harness_kind"] for entry in state["harnesses"]] == ["codex"]
+        # codex keeps its live key; claude keeps its entry with no sources, so the
+        # runtime refuses a claude launch rather than degrading it to native.
+        by_harness = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        assert sorted(by_harness) == ["claude", "codex"]
+        assert by_harness["claude"] == []
+        assert len(by_harness["codex"]) == 1
 
-    def test_all_unsatisfiable_renders_empty_harnesses(self) -> None:
+    def test_all_unsatisfiable_keeps_the_selected_harness_with_no_sources(self) -> None:
+        # The rewritten shape of the old `..._renders_empty_harnesses` test. An
+        # exhausted/unsynced gateway must NOT produce an empty document: an empty
+        # document is deleted by the materializer and reads as native, which is
+        # exactly the silent degradation the fail-closed law forbids.
         state, _ = agent_auth.render_agent_auth_state(
             _inputs(
                 (_selection(harness="claude", source_kind="gateway"),),
@@ -215,9 +233,16 @@ class TestRenderAgentAuthState:
                 gateway_virtual_key=None,
             )
         )
-        assert state["harnesses"] == []
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}]
         assert state["version"] == 2
         assert state["revision"] == REVISION
+
+    def test_no_selections_at_all_renders_an_empty_document(self) -> None:
+        # The one case that legitimately yields no harnesses — and therefore the
+        # only case in which the materializer deletes the state file. This is what
+        # keeps "absent means native" reachable at all.
+        state, _ = agent_auth.render_agent_auth_state(_inputs(()))
+        assert state["harnesses"] == []
 
     def test_gateway_without_public_base_url_logs_loud_warning(
         self, monkeypatch: pytest.MonkeyPatch
@@ -236,14 +261,14 @@ class TestRenderAgentAuthState:
                 gateway_base_url=None,
             )
         )
-        assert state["harnesses"] == []
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}]
         assert any(
             "gateway selection dropped" in message
             and "agent_gateway_litellm_public_base_url is not configured" in message
             for message in warnings
         )
 
-    def test_gateway_with_unsynced_enrollment_is_dropped(self) -> None:
+    def test_gateway_with_unsynced_enrollment_drops_the_source_not_the_harness(self) -> None:
         for status in ("pending", "failed", None):
             state, _ = agent_auth.render_agent_auth_state(
                 _inputs(
@@ -252,7 +277,9 @@ class TestRenderAgentAuthState:
                     gateway_virtual_key=None,
                 )
             )
-            assert state["harnesses"] == []
+            # The SOURCE is dropped; the harness entry survives empty so the
+            # runtime refuses the launch instead of falling back to native.
+            assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}], status
 
     def test_fingerprint_is_stable_across_renders(self) -> None:
         selections = (_selection(harness="claude", source_kind="gateway"),)
@@ -282,6 +309,87 @@ class TestRenderAgentAuthState:
         assert first == second
         assert fp1 == fp2
         _ = key_id
+
+
+class TestAgentAuthStateContractFixture:
+    """Producer half of ``fixtures/contracts/agent-auth-state/v2.json``.
+
+    Python produces the document, Rust consumes it
+    (``route_auth/contract_fixture_tests.rs``). Per
+    ``specs/developing/testing/README.md``, the fixture is the shape's single
+    definition: change it and whichever side lags breaks mechanically.
+    """
+
+    def test_the_fixture_is_a_valid_v2_document_this_renderer_could_emit(self) -> None:
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+        assert fixture["version"] == agent_auth.AGENT_AUTH_STATE_VERSION
+        assert isinstance(fixture["revision"], int)
+        # snake_case on the wire, and no UI-only fields leak into it.
+        serialized = json.dumps(fixture)
+        for forbidden in ("provider_hint", "harnessKind", "envVarName", "model_catalog"):
+            assert forbidden not in serialized, forbidden
+        for entry in fixture["harnesses"]:
+            assert set(entry) <= {"harness_kind", "sources", "settings"}
+            for source in entry["sources"]:
+                assert source["kind"] in ("gateway", "api_key")
+                if source["kind"] == "gateway":
+                    assert set(source) == {"kind", "base_url", "key"}
+                else:
+                    assert set(source) == {"kind", "env_var_name", "value"}
+
+    def test_this_renderer_produces_the_fixtures_empty_sources_semantics(self) -> None:
+        # The half of the contract this renderer owns TODAY: a selected harness
+        # whose sources are all unsatisfiable keeps its entry with an empty list
+        # (the fixture's `grok`), while a harness with no selection row is absent
+        # (the fixture has no `opencode-zen`).
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        fixture_kinds = {entry["harness_kind"] for entry in fixture["harnesses"]}
+        assert "grok" in fixture_kinds
+        assert "opencode-zen" not in fixture_kinds
+
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (_selection(harness="grok", source_kind="gateway"),),
+                enrollment_sync_status="pending",
+                gateway_virtual_key=None,
+            )
+        )
+        rendered = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        assert rendered == {"grok": []}, (
+            "a selected-but-unsatisfiable harness must keep an empty entry, exactly "
+            "as the fixture's grok does"
+        )
+
+    def test_per_harness_gateway_keys_are_not_produced_yet(self) -> None:
+        # KNOWN GAP, owned by Track B (B3). The fixture gives every gateway source
+        # its own virtual key because the gateway scopes keys per
+        # (subject, harness); this renderer still resolves ONE subject-wide
+        # `gateway_virtual_key` and fans it out. That is the "one shared gateway
+        # key" bullet in agent-auth.md's Current gaps, and it is NOT closed here.
+        #
+        # This test asserts the gap as it stands so B3 has to delete it when it
+        # lands the per-harness key map — a passing suite after B3 would otherwise
+        # hide that the fixture and the producer disagree.
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (
+                    _selection(harness="claude", source_kind="gateway"),
+                    _selection(harness="codex", source_kind="gateway"),
+                )
+            )
+        )
+        keys = [
+            source["key"]
+            for entry in state["harnesses"]
+            for source in entry["sources"]
+            if source["kind"] == "gateway"
+        ]
+        assert len(keys) == 2
+        assert len(set(keys)) == 1, (
+            "expected today's shared-key behavior; if this now fails, B3 has landed "
+            "per-harness keys — delete this test and assert distinctness instead"
+        )
 
 
 class _SandboxIOSpy:
@@ -408,17 +516,39 @@ class TestMaterializeAgentAuth:
         assert spy.read_count == 1
 
     @pytest.mark.asyncio
-    async def test_no_resolvable_sources_deletes_state_file(
+    async def test_unsatisfiable_selection_writes_an_empty_entry_instead_of_deleting(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # A cloud selection whose only source is unsatisfiable resolves to zero
-        # harnesses -> the file is deleted (empty renders to native; the runtime
-        # launcher fail-closes cloud on its own).
+        # Rewrite of `..._deletes_state_file`. Deleting the file here was the
+        # silent-degradation bug at the delivery layer: the sandbox reader then
+        # finds NO document and launches claude on whatever ambient credential it
+        # has. The selection must instead be delivered as `sources: []` so the
+        # runtime refuses (agent-auth.md: present-but-empty fails closed).
         inputs = _inputs(
             (_selection(harness="claude", source_kind="gateway"),),
             enrollment_sync_status="pending",
             gateway_virtual_key=None,
         )
+
+        async def fake_load(db: object, *, user_id: uuid.UUID, surface: str = "cloud") -> Any:
+            return inputs
+
+        monkeypatch.setattr(agent_auth, "_load_state_inputs", fake_load)
+        spy = _install_spy(monkeypatch, previous_manifest=None)
+
+        await agent_auth.materialize_agent_auth(object(), ctx=_ctx(), user_id=USER_ID)
+
+        assert spy.removed == set(), "the document must NOT be deleted"
+        state = json.loads(str(spy.writes[0]["content"]))
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}]
+
+    @pytest.mark.asyncio
+    async def test_no_selections_at_all_still_deletes_the_state_file(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The one remaining delete case, and the one that keeps "absent means
+        # native" reachable: the user has selected nothing on this surface.
+        inputs = _inputs(())
 
         async def fake_load(db: object, *, user_id: uuid.UUID, surface: str = "cloud") -> Any:
             return inputs
@@ -474,7 +604,14 @@ class TestMaterializeAgentAuth:
 
         assert spy.removed == set()
         state = json.loads(str(spy.writes[0]["content"]))
-        assert [entry["harness_kind"] for entry in state["harnesses"]] == ["grok"]
+        by_harness = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        # grok's live key is delivered; claude (dead gateway) and codex (revoked
+        # key) keep EMPTY entries so their launches are refused rather than
+        # silently degraded. One bad source still does not abort the reconcile.
+        assert sorted(by_harness) == ["claude", "codex", "grok"]
+        assert by_harness["claude"] == []
+        assert by_harness["codex"] == []
+        assert len(by_harness["grok"]) == 1
         serialized = json.dumps(state)
         assert "sk-live" in serialized
         assert str(revoked_id) not in serialized

--- a/server/tests/unit/test_agent_auth_state_contract_fixture.py
+++ b/server/tests/unit/test_agent_auth_state_contract_fixture.py
@@ -1,0 +1,138 @@
+"""Producer half of ``fixtures/contracts/agent-auth-state/v2.json``.
+
+Python produces the document, Rust consumes it
+(``route_auth/contract_fixture_tests.rs``). Per
+``specs/developing/testing/README.md``, the fixture is the shape's single
+definition: change it and whichever side lags breaks mechanically.
+
+Split out of ``test_agent_auth_materialization.py`` (which sat at its line-count
+ceiling) and sharing that module's ``_inputs``/``_selection`` builders so the
+producer under test is configured exactly as the renderer suite configures it.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from proliferate.server.cloud.materialization.materialize import agent_auth
+from tests.unit.test_agent_auth_materialization import (
+    FIXTURE_PATH,
+    _inputs,
+    _selection,
+)
+
+
+class TestAgentAuthStateContractFixture:
+    def test_the_fixture_is_a_valid_v2_document_this_renderer_could_emit(self) -> None:
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+        assert fixture["version"] == agent_auth.AGENT_AUTH_STATE_VERSION
+        assert isinstance(fixture["revision"], int)
+        # snake_case on the wire, and no UI-only fields leak into it.
+        serialized = json.dumps(fixture)
+        for forbidden in ("provider_hint", "harnessKind", "envVarName", "model_catalog"):
+            assert forbidden not in serialized, forbidden
+        for entry in fixture["harnesses"]:
+            assert set(entry) <= {"harness_kind", "sources", "settings"}
+            for source in entry["sources"]:
+                assert source["kind"] in ("gateway", "api_key")
+                if source["kind"] == "gateway":
+                    assert set(source) == {"kind", "base_url", "key"}
+                else:
+                    assert set(source) == {"kind", "env_var_name", "value"}
+
+    def test_this_renderer_produces_the_fixtures_empty_sources_semantics(self) -> None:
+        # The half of the contract this renderer owns TODAY: a selected harness
+        # whose sources are all unsatisfiable keeps its entry with an empty list
+        # (the fixture's `grok`), while a harness with no selection row is absent
+        # (the fixture has no `opencode-zen`).
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        fixture_kinds = {entry["harness_kind"] for entry in fixture["harnesses"]}
+        assert "grok" in fixture_kinds
+        assert "opencode-zen" not in fixture_kinds
+
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (_selection(harness="grok", source_kind="gateway"),),
+                enrollment_sync_status="pending",
+                gateway_virtual_key=None,
+            )
+        )
+        rendered = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        assert rendered == {"grok": []}, (
+            "a selected-but-unsatisfiable harness must keep an empty entry, exactly "
+            "as the fixture's grok does"
+        )
+
+    def test_the_fixtures_source_order_is_the_order_this_renderer_emits(self) -> None:
+        # A fixture the producer could never emit is worse than no fixture: the
+        # consumer would pin a document shape that never reaches a sandbox. This
+        # renderer sorts a harness's sources by (kind, env_var_name), and
+        # "api_key" < "gateway" — so opencode's api_key row comes FIRST. Feed the
+        # renderer the fixture's own opencode inputs and compare kind-for-kind.
+        fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        fixture_opencode = next(
+            entry for entry in fixture["harnesses"] if entry["harness_kind"] == "opencode"
+        )
+        anthropic_id = uuid.uuid4()
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (
+                    # Deliberately fed gateway-first, so the assertion is about the
+                    # renderer's sort rather than about input order.
+                    _selection(harness="opencode", source_kind="gateway"),
+                    _selection(
+                        harness="opencode",
+                        source_kind="api_key",
+                        api_key_id=anthropic_id,
+                        env_var_name="ANTHROPIC_API_KEY",
+                    ),
+                ),
+                api_key_values={anthropic_id: "sk-ant-raw"},
+            )
+        )
+        rendered_opencode = next(
+            entry for entry in state["harnesses"] if entry["harness_kind"] == "opencode"
+        )
+        assert [source["kind"] for source in rendered_opencode["sources"]] == [
+            source["kind"] for source in fixture_opencode["sources"]
+        ], (
+            "the fixture's per-harness source order must be the order this renderer "
+            "emits — api_key before gateway, by the (kind, env_var_name) sort"
+        )
+        assert [source["kind"] for source in fixture_opencode["sources"]] == [
+            "api_key",
+            "gateway",
+        ]
+
+    def test_per_harness_gateway_keys_are_not_produced_yet(self) -> None:
+        # KNOWN GAP, owned by Track B (B3, branch `agents/b3-renderer-key-map`).
+        # The fixture gives every gateway source its own virtual key because the
+        # gateway scopes keys per (subject, harness); this renderer still resolves
+        # ONE subject-wide `gateway_virtual_key` and fans it out. That is the "one
+        # shared gateway key" bullet in agent-auth.md's Current gaps, and it is NOT
+        # closed here.
+        #
+        # This test asserts the gap as it stands so B3 has to delete it when it
+        # lands the per-harness key map — a passing suite after B3 would otherwise
+        # hide that the fixture and the producer disagree.
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (
+                    _selection(harness="claude", source_kind="gateway"),
+                    _selection(harness="codex", source_kind="gateway"),
+                )
+            )
+        )
+        keys = [
+            source["key"]
+            for entry in state["harnesses"]
+            for source in entry["sources"]
+            if source["kind"] == "gateway"
+        ]
+        assert len(keys) == 2
+        assert len(set(keys)) == 1, (
+            "expected today's shared-key behavior; if this now fails, B3 has landed "
+            "per-harness keys — delete this test and assert distinctness instead"
+        )

--- a/specs/codebase/platforms/product/agent-auth.md
+++ b/specs/codebase/platforms/product/agent-auth.md
@@ -509,9 +509,16 @@ anyharness/
     │   ├── materialize.rs                     atomic writes, revision dirs, GC
     │   └── mod.rs                             pipeline, origin guard, typed errors
     ├── domains/agents/readiness/service.rs    route-aware readiness upgrade
+    ├── domains/sessions/service/create.rs     create-time fail-closed refusal (409)
     ├── domains/sessions/runtime/startup.rs    launch integration, fail-closed refusal
     └── live/sessions/driver/process.rs        env layering + ambient removal at spawn
 ```
+
+The wire shape crossing the Python↔Rust boundary is pinned by the
+`agent-auth-state` contract fixture
+([fixtures/contracts/agent-auth-state/](../../../../fixtures/contracts/agent-auth-state/)):
+the renderer asserts it produces it, `route_auth/` asserts it consumes it, and a
+shape change is made by changing the fixture — which breaks whichever side lags.
 
 | Layer | Owns |
 | --- | --- |
@@ -550,13 +557,6 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       model-gateway migration (its gaps list carries the enrollment and
       `config.yaml` sides; this document owns the renderer's key lookup
       and the harness-side deletion of client model filtering).
-- [ ] **Unsatisfiable sources silently degrade to native.** The renderer
-      drops a dead source and omits an empty harness entry, and the
-      runtime reads absence as native — so a desktop user with a native
-      claude login whose gateway budget exhausts silently starts billing
-      their personal Anthropic account. The body's
-      "present-but-empty fails closed" law is not implemented; today
-      only render-stage errors refuse the launch.
 - [ ] **Typed provider configurations do not exist.** The vault has no
       `kind` column and stores exactly one opaque string per entry; no
       Bedrock/Azure payloads, no `provider_config` wire source, no
@@ -597,10 +597,6 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       `/v1/cloud/agent-auth/` (with catalog routes to the model-catalog
       platform) is pending, including the matching
       `api.py`/`service.py`/`models.py` three-domain split.
-- [ ] **Dead error variants.** `RouteAuthError::SelectionMissing` and
-      `SelectionConflict` are never constructed (leftovers of the
-      pre-`sources[]` design); delete them or wire them to the
-      fail-closed law above.
 - [ ] **Opencode's method state is projection-derived on some read
       surfaces.** Settings derives opencode's active methods from
       selections, but readiness still reports the structural


### PR DESCRIPTION
Track A, PR 4 — Round 2 first segment. **Stacked on #1504** (`agents/a3-cursor-rust` → #1503 → #1499); retarget as parents merge. The diff below is A4's own commit only.

## The law this implements

`specs/codebase/platforms/product/agent-auth.md`, "Delivery laws":

> **Absent means native; present-but-empty fails closed.** A harness with no entry in the document runs on its own login. A harness whose entry is present but whose selected sources could not be satisfied (unsynced enrollment, exhausted budget, revoked key) keeps its entry with the dead source omitted — and a launch that then resolves zero usable sources for a still-selected route is refused with a typed error. **A selection never silently degrades to the user's personal credentials.**

## Gap bullets closed (deleted in this PR)

1. **"Unsatisfiable sources silently degrade to native."** — *"The renderer drops a dead source and omits an empty harness entry, and the runtime reads absence as native — so a desktop user with a native claude login whose gateway budget exhausts silently starts billing their personal Anthropic account. The body's 'present-but-empty fails closed' law is not implemented."*
2. **"Dead error variants."** — `SelectionMissing` and `SelectionConflict` never constructed.

## Why this needed three layers

The law was not merely unimplemented — it was **unimplementable**, because the information it depends on was destroyed at the bottom:

```rust
// before
pub fn sources_for(&self, harness_kind: &str) -> &[AuthSource] { … .unwrap_or(&[]) }
```

A caller could not distinguish "the user never configured this harness" from "the user selected the gateway and we could not satisfy it". Both were `&[]`. So:

**Layer 1 — the type (ruling R3).** `sources_for` returns `Option<&[AuthSource]>`: `None` = absent, `Some([])` = present-but-empty. The distinction now lives in the type rather than in a caller's convention.

**Layer 2 — `resolve_profile`.** `Some([])` → `RouteAuthError::SelectionMissing { harness_kind, revision }`. The revision rides along so a UI can say which document generation was dead.

**Layer 3 — the Python renderer, which had the same bug twice.** `render_agent_auth_state` dropped the whole harness entry when its every source was unsatisfiable; it now keeps an entry for every *selected* harness, empty if need be. And `materialize_agent_auth` deleted the state file whenever `harnesses` was empty — for an exhausted budget that meant the sandbox found **no document at all**, which reads as native. It now deletes only when nothing is selected on the surface, which is the one case where "absent means native" is the right answer.

Two non-obvious call sites (`gateway_resolver.rs`'s credential lookup, the manual-refresh endpoint) legitimately want "usable gateway source or nothing" and use `.unwrap_or_default()` with a comment saying why — fail-closed refusal is the launch path's job, not the model planner's.

## Create-time typed 409

Session create now checks `launch_route_selection_failure` **before** the readiness gate. The readiness gate would also refuse this launch — but as `400 SESSION_CREATE_FAILED` "agent 'claude' is not ready", which reads to a user as *go install something* when the real answer is *your gateway budget is exhausted*. The new path returns `409 AGENT_ROUTE_SELECTION_MISSING`, which is what lets the UI route the user to the auth pane. The launch path (`start_live_session`) still reaches the same conclusion independently, so this is the earlier, better-labelled gate and never the only one.

New `CreateSessionError::RouteAuth` carries route-auth's own error so the code and message are not re-invented at the boundary.

## `SelectionConflict` deleted, not wired

The gap bullet offered "delete them or wire them to the fail-closed law". `SelectionMissing` is wired. `SelectionConflict` ("N entries where one is allowed") is **deleted**: source cardinality is a per-harness *server* rule (`selection_rules.py`) enforced before a document is ever written, and the document's shape — one entry per harness with a flat source list — cannot represent the conflict it described. There was no input a correct runtime could construct it from. Grepped for consumers of `AGENT_ROUTE_SELECTION_CONFLICT` across Rust/Python/TS: none.

## Contract fixture — `fixtures/contracts/agent-auth-state/`

New, with a README stating what it pins and why. Python produces, Rust consumes, per `specs/developing/testing/README.md`'s contract-fixture rule.

It pins the two things the languages can silently drift on:
1. **Per-harness gateway keys** — three distinct virtual keys, because the gateway scopes keys per (subject, harness).
2. **Empty-sources semantics** — `grok` present with `"sources": []` (must refuse), no `opencode-zen` entry at all (must be native).

Incidentally pinned because they are easy to get wrong: the document is snake_case on the wire while `settings` values are the catalog's camelCase; opencode composes a direct `api_key` + gateway, **in the producer's own `(kind, env_var_name)` sort order** (`api_key` sorts before `gateway`, so a gateway-first fixture would be a document no reconcile could emit — caught in review round 2 and now asserted on both sides); cursor's only route is `api_key`.

### ⚠️ B3 reconciliation required — flagging rather than forking

**Correction (review round 2).** An earlier version of this section claimed no B3 branch existed on the remote. That was wrong: `origin/agents/b3-renderer-key-map` (**#1512**) exists and branched from `origin/main`, i.e. *before* this PR. I read its renderer. The reconciliation picture:

| | B3 (#1512) | this PR (A4) | verdict |
| --- | --- | --- | --- |
| per-harness gateway key map | implements it (`gateway_virtual_keys: Mapping[str, str]`) | not implemented — one subject-wide key fanned out | **agree on the fixture's shape**; B3 closes the gap this PR pins as open |
| empty-sources semantics | still the OLD behavior: `by_harness.setdefault(...)` drops a fully-unsatisfiable harness, and `materialize_agent_auth` deletes the state file whenever `harnesses` is empty | keeps a `sources: []` entry per selected harness; deletes only when nothing is selected | **B3 carries the bug this PR fixes** — its branch point predates the fix |

So the two branches do not conflict on the fixture's *shape*; they collide on the fail-closed behavior, and the collision is dangerous because B3's version is a *deletion* of behavior — a careless rebase resolves cleanly and silently re-opens the silent-degradation gap. Two guards:

- `test_per_harness_gateway_keys_are_not_produced_yet` asserts **today's shared-key behavior** with a comment instructing B3 to delete it and assert distinctness instead — so a passing suite after B3 cannot conceal a producer/fixture disagreement.
- `test_unsatisfiable_selection_survives_renderer_merge_tripwire` (new) asserts **both halves of the fail-closed fix in one pass** — the pre-seeded `by_harness` entry per selected harness, *and* the narrowed delete condition, *and* that the delete branch is still reachable for its one legitimate case (nothing selected). Its name and failure messages both point at `agents/b3-renderer-key-map`, so whoever rebases B3 gets told exactly what they reverted.

**B3 must produce byte-identical output for these inputs**, and must keep this PR's renderer semantics when it rebases (per the plan's `materialize/agent_auth.py` collision corridor, B3 lands first in principle — in practice A4 got there first, so the rebase direction is B3-onto-this).

## Tests

Rewritten because they pinned the bug as intended behavior (all three asserted native for a dead selection):
- `profile.rs::empty_sources_is_native` → `empty_sources_fails_closed_with_the_revision`
- `render_tests.rs::empty_sources_render_native_delta` → `empty_sources_refuse_the_launch_instead_of_rendering_native` (full render path; also asserts nothing was materialized on the way to the refusal)
- `test_all_unsatisfiable_renders_empty_harnesses` → `test_all_unsatisfiable_keeps_the_selected_harness_with_no_sources`
- `test_no_resolvable_sources_deletes_state_file` → `test_unsatisfiable_selection_writes_an_empty_entry_instead_of_deleting`
- plus `test_revoked_api_key_source_is_omitted`, `test_unsatisfiable_gateway_still_renders_satisfiable_api_key`, `test_gateway_with_unsynced_enrollment_is_dropped`, `test_bad_gateway_still_purges_revoked_key_and_writes_rest`, and the base-url warning test — all re-asserted against the empty-entry shape

New (tier 1 throughout):

| Test | Proves |
| --- | --- |
| `state.rs::sources_lookup_distinguishes_absent_from_present_but_empty` | the three-way lookup at the layer where it was destroyed |
| `profile.rs::absent_is_native_while_present_but_empty_is_refused` | opposite answers from ONE document — the distinction as a single comparison |
| `profile.rs::one_harnesss_dead_selection_does_not_refuse_another` | the refusal is per-harness; one exhausted budget must not take the machine down |
| `profile.rs::no_file_is_native_even_though_empty_entries_now_refuse` | a never-synced machine is unaffected |
| `sessions_errors.rs::an_unsatisfiable_selection_maps_to_a_typed_conflict` | 409 + `AGENT_ROUTE_SELECTION_MISSING`, not 400 |
| 5 × `contract_fixture_tests.rs` | fixture parses; gateway keys distinct; empty-vs-absent resolved end to end; satisfiable entries resolve as documented; and the fixture **drives a real launch render** (a fixture that parses but cannot drive a launch would pass the others) |
| `test_no_selections_at_all_renders_an_empty_document` / `..._still_deletes_the_state_file` | the one remaining delete case, so "absent means native" stays reachable |
| 4 × `TestAgentAuthStateContractFixture` | producer half: fixture is a shape this renderer could emit; empty-sources semantics match; **the fixture's per-harness source order is the order this renderer emits**; the per-harness-key gap is asserted as open (B3's tripwire) |
| `test_unsatisfiable_selection_survives_renderer_merge_tripwire` | both halves of the fail-closed fix at once (pre-seeded entry + narrowed delete + the delete branch still reachable), so a B3 rebase that reverts either fails loudly |

Results: `cargo test -p anyharness-lib --lib` **1327/1327**. `cargo test --workspace` green except the known pre-existing `apps/desktop/src-tauri` flake (documented in #1503; a different test fails per run, green 3/3 in isolation, nanosecond `temp_path` collision + a 5s subprocess-lock deadline; untouched by this PR). Server `pytest tests/unit` **1172/1172**. `ruff check` + `format --check` clean. Every `repo-shape` check passes.

## Contradictions encountered

None ruling-worthy. Three judgment calls:

1. **`launch_route_selection_failure` tolerates an unreadable document.** It returns `None` for a malformed or origin-mismatched state, matching `launch_route_provides_credentials`'s existing policy exactly. Making create *reject* on a document the launcher itself tolerates would be a new fail-closed rule the spec does not ask for, and would brick session creation on a state file the next push heals.
2. **Where the create-time check goes.** Before the readiness gate, so the better-labelled error wins. Placing it after would have left the generic "not ready" as the user-visible answer in exactly the case this PR exists to explain.
3. **Allowlist growth.** `render_tests.rs` (616) crossed the 600 cap and is allowlisted with an explicit split-on-next-growth note, since splitting it mid-change would have obscured the behavioral diff. `test_agent_auth_materialization.py` was allowlisted at 617 in round 1; in round 2 the new tripwire test would have pushed it further, so **the contract-fixture producer class was split out** to `test_agent_auth_state_contract_fixture.py` and the allowlist entry drops to 614 rather than growing. Per the carry-over note, `model.rs` did **not** grow in this PR (it is untouched), so no second bump there. `gateway_resolver.rs` (+4) and `agent_gateway_catalog.rs` (+3) are comment-only growth on already-allowlisted files.

## Does not contradict the probe-engine design

Read `codex/probe-engine-design.md` before starting. A4 touches two things A7/A8 build on, and both stay compatible:
- **`resolve_profile`'s contract.** The design's §1.3 phase A calls `resolve_profile` and already routes "no matching source found for an env/route context" to `Err(SelectionMissing)` → `lastAttempt.outcome="failed"`, no spawn. A4 makes that variant *actually reachable*, which is what the design assumed.
- **`sources_for`'s signature.** The design does not call it directly (it goes through `resolve_profile`), so the `Option` change is invisible to it.

