### PR TITLE
feat(server): per-harness gateway key-map renderer + org-member fix (B3)

### DIFF
--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -44,7 +44,7 @@ server/proliferate/db/models/cloud/agent_gateway.py 556 agent_gateway_enrollment
 server/proliferate/server/cloud/agent_gateway/api.py 405 harness-settings GET/PUT routes added for catalog-driven per-harness settings
 server/proliferate/server/cloud/secrets/api.py 416 existing cloud secrets API pending route split
 server/proliferate/server/cloud/workspaces/service.py 1040 workspace materialization ledger service (intent/report/unlink write-path + primary selection + recorded-sandbox reconciliation + scratch/repo-less read guards) + PR 5 exact-ref managed-Cloud creation and association path; AnyHarness provisioning handoff split out per guides/domains.md
-server/tests/integration/test_agent_gateway_api.py 654 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model
+server/tests/integration/test_agent_gateway_api.py 665 P1 auth rebuild rewrote keys/selections/state coverage for titled-key + selection model; state coverage now seeds a per-harness child key (B3 renderer)
 server/tests/integration/test_cloud_workspace_materialization_service.py 1173 durable materialization ledger service suite (intent/report/unlink transitions, redaction, primary selection, recorded-sandbox reconciliation, repo-less workspace, install-id redaction, generation replay/crash-retry/terminal-reintent) + PR 5 exact-ref create coverage; new fail-closed source cases split to test_cloud_workspace_exact_ref_source.py
 server/tests/integration/test_auth_flow.py 2214 existing server oversized integration test plus session-token-revocation coverage + /users/me password rejection test + single-org current_product_user bypass coverage
 server/tests/integration/test_billing_accounting.py 872 existing server oversized integration test

--- a/server/proliferate/server/cloud/agent_gateway/budget.py
+++ b/server/proliferate/server/cloud/agent_gateway/budget.py
@@ -23,6 +23,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.config import settings
 from proliferate.db.store import agent_gateway as agent_gateway_store
+from proliferate.db.store.agent_gateway import AgentGatewayEnrollmentRecord
+from proliferate.db.store.billing_runtime_usage import resolve_organization_id_for_user
 
 _ZERO = Decimal("0")
 
@@ -33,6 +35,31 @@ _ZERO = Decimal("0")
 AGENT_GATEWAY_CREDITS_EXHAUSTED_CODE = "agent_gateway_credits_exhausted"
 
 
+async def get_gateway_enrollment_for_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> AgentGatewayEnrollmentRecord | None:
+    """The enrollment that governs a user's gateway sessions.
+
+    An org member (current membership, same resolution
+    ``resolve_billing_subject_id_for_user`` and ``ensure_org_enrollment`` use)
+    is governed by their **org** enrollment, not their personal one — closing
+    the model-gateway.md org-member gap where sessions previously always
+    resolved the personal enrollment regardless of org membership. An
+    org-less user keeps resolving their personal enrollment.
+    """
+    organization_id = await resolve_organization_id_for_user(db, user_id)
+    if organization_id is not None:
+        org_enrollment = await agent_gateway_store.get_enrollment_for_organization(
+            db,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if org_enrollment is not None:
+            return org_enrollment
+    return await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+
+
 async def is_gateway_budget_available(db: AsyncSession, user_id: UUID) -> bool:
     """Whether a user may launch a gateway-route session.
 
@@ -40,12 +67,13 @@ async def is_gateway_budget_available(db: AsyncSession, user_id: UUID) -> bool:
     or the user has no credit grant (default-budget subjects are never blocked
     on the ledger), or their remaining LLM credit is above zero. False only when
     a granted subject has spent its credit. Checks the same enrollment the state
-    renderer hands out key material for (the user's personal enrollment), so the
-    gate and the key it guards always agree on the paying subject.
+    renderer hands out key material for (the org enrollment for an org member,
+    else the personal one), so the gate and the keys it guards always agree on
+    the paying subject.
     """
     if not settings.agent_gateway_enabled:
         return True
-    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    enrollment = await get_gateway_enrollment_for_user(db, user_id)
     if enrollment is None:
         return True
     balance = await agent_gateway_store.get_remaining_credit_usd(

--- a/server/proliferate/server/cloud/agent_gateway/budget.py
+++ b/server/proliferate/server/cloud/agent_gateway/budget.py
@@ -35,6 +35,36 @@ _ZERO = Decimal("0")
 AGENT_GATEWAY_CREDITS_EXHAUSTED_CODE = "agent_gateway_credits_exhausted"
 
 
+def _explicit_org_budget_configured() -> bool:
+    """Whether the deployment configured a real (non-default) org team budget.
+
+    ``agent_gateway_default_org_budget_usd`` defaults to "0", which LiteLLM
+    reads as *uncapped* rather than as zero — so the default is the absence of
+    a cap, not a cap of nothing.
+    """
+    raw = settings.agent_gateway_default_org_budget_usd.strip()
+    if not raw:
+        return False
+    try:
+        return Decimal(raw) > _ZERO
+    except ArithmeticError:
+        return False
+
+
+async def _subject_is_funded(db: AsyncSession, billing_subject_id: UUID) -> bool:
+    """Whether a billing subject actually funds gateway spend.
+
+    Funded means a positive LLM credit grant (the ledger the importer debits
+    and the gate reads) or an explicitly configured org team budget. A subject
+    with neither has no funding source at all, and every LLM guardrail reads as
+    "unlimited" for it (see :func:`get_gateway_enrollment_for_user`).
+    """
+    balance = await agent_gateway_store.get_remaining_credit_usd(db, billing_subject_id)
+    if balance.granted_usd > _ZERO:
+        return True
+    return _explicit_org_budget_configured()
+
+
 async def get_gateway_enrollment_for_user(
     db: AsyncSession,
     user_id: UUID,
@@ -43,10 +73,27 @@ async def get_gateway_enrollment_for_user(
 
     An org member (current membership, same resolution
     ``resolve_billing_subject_id_for_user`` and ``ensure_org_enrollment`` use)
-    is governed by their **org** enrollment, not their personal one — closing
-    the model-gateway.md org-member gap where sessions previously always
-    resolved the personal enrollment regardless of org membership. An
-    org-less user keeps resolving their personal enrollment.
+    is governed by their **org** enrollment rather than their personal one —
+    closing the model-gateway.md org-member gap where sessions previously
+    always resolved the personal enrollment regardless of org membership.
+
+    Funding-follows-attribution guard (interim; founder end-state ruling
+    pending). Routing to the org subject unconditionally is not safe on hosted,
+    where EVERY user gets a default personal org: an org billing subject with
+    no credit grant makes ``is_gateway_budget_available`` return ``True``
+    unconditionally (the ``granted_usd <= 0`` "no ledger, LiteLLM budget is the
+    guardrail" branch), while the org team's default budget of "0" means
+    *uncapped* in LiteLLM. Both walls open at once, the personal free-credit
+    grant is never consulted, and spend is unbounded. So the org enrollment
+    governs only when the org subject is actually funded
+    (:func:`_org_subject_is_funded`); otherwise this resolves the personal
+    enrollment — the pre-B3 behavior, where the personal grant is the cap.
+
+    Org choice is deterministic when a user holds several memberships: it is
+    the first active membership ordered by organization NAME
+    (``get_current_membership_for_user``), the same choice compute attribution
+    makes. Renaming an org can therefore move the payer; that instability is
+    inherited from the compute path and pinned by test, not introduced here.
     """
     organization_id = await resolve_organization_id_for_user(db, user_id)
     if organization_id is not None:
@@ -55,7 +102,10 @@ async def get_gateway_enrollment_for_user(
             organization_id=organization_id,
             user_id=user_id,
         )
-        if org_enrollment is not None:
+        if org_enrollment is not None and await _subject_is_funded(
+            db,
+            org_enrollment.billing_subject_id,
+        ):
             return org_enrollment
     return await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
 

--- a/server/proliferate/server/cloud/agent_gateway/catalog.py
+++ b/server/proliferate/server/cloud/agent_gateway/catalog.py
@@ -57,6 +57,7 @@ from proliferate.integrations import litellm
 from proliferate.integrations.litellm import LiteLLMIntegrationError
 from proliferate.server.cloud.agent_gateway.budget import (
     AGENT_GATEWAY_CREDITS_EXHAUSTED_CODE,
+    get_gateway_enrollment_for_user,
     is_gateway_budget_available,
 )
 from proliferate.server.cloud.errors import CloudApiError
@@ -412,7 +413,11 @@ async def _probe_gateway_models(db: AsyncSession, *, user_id: UUID, harness_kind
             "Your LLM credits are exhausted; top up to keep using the gateway.",
             status_code=402,
         )
-    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    # Same resolution the gate above and the state renderer use
+    # (``get_gateway_enrollment_for_user``): probing the personal enrollment
+    # while the gate checked the org one would enumerate models against a key
+    # from a different paying subject than the one authorized.
+    enrollment = await get_gateway_enrollment_for_user(db, user_id)
     virtual_key: str | None = None
     if enrollment is not None:
         # Post-B2: the caller's harness has its own access-group-scoped key

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -41,6 +41,7 @@ from proliferate.server.billing.domain.plans import (
 )
 from proliferate.server.billing.snapshots import billing_plan_rule_config
 from proliferate.server.billing.subjects import ensure_organization_billing_subject_state
+from proliferate.server.cloud.agent_gateway.budget import get_gateway_enrollment_for_user
 from proliferate.server.cloud.agent_gateway.selection_rules import (
     SelectionRuleError,
     validate_auth_selection_set,
@@ -302,8 +303,15 @@ async def get_capabilities(
     *,
     user_id: UUID,
 ) -> tuple[bool, str | None, str]:
-    """Return (gateway_enabled, public_base_url, enrollment_status)."""
-    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    """Return (gateway_enabled, public_base_url, enrollment_status).
+
+    Reports the status of the enrollment that actually governs this user's
+    gateway sessions (``get_gateway_enrollment_for_user``). Reading the
+    personal enrollment unconditionally would show "synced" to a user whose
+    governing org enrollment is still pending (or the reverse), so the UI's
+    readiness signal and the key the renderer hands out would disagree.
+    """
+    enrollment = await get_gateway_enrollment_for_user(db, user_id)
     return (
         settings.agent_gateway_enabled,
         settings.agent_gateway_litellm_public_base_url or None,
@@ -316,7 +324,8 @@ async def get_enrollment(
     *,
     user_id: UUID,
 ) -> AgentGatewayEnrollmentRecord:
-    enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    """The governing enrollment for this user (org when funded, else personal)."""
+    enrollment = await get_gateway_enrollment_for_user(db, user_id)
     if enrollment is None:
         raise CloudApiError(
             "agent_gateway_enrollment_not_found",

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -27,10 +27,11 @@ file lives at ``<anyharness home>/agent-auth/state.json`` (mode 0600):
       ]
     }
 
-``sources`` are the ENABLED rows only (disabled rows never leave the DB); a
-harness with no resolvable enabled source is omitted entirely. There is NO
-``model_catalog``, NO ``slot``, and NO ``provider`` on the wire — ``provider_hint``
-is a UI-only display field the renderer never emits.
+``sources`` are the ENABLED rows only (disabled rows never leave the DB). A
+harness whose every enabled row is unsatisfiable keeps its entry with
+``sources: []`` — absent means native, present-but-empty fails closed. There is
+NO ``model_catalog``, NO ``slot``, and NO ``provider`` on the wire —
+``provider_hint`` is a UI-only display field the renderer never emits.
 
 Two delivery surfaces share this one renderer: the cloud materialization worker
 writes the ``cloud`` surface into sandboxes, and ``GET /agent-gateway/state``
@@ -47,14 +48,15 @@ file without any row mutation, so change detection uses a sha256 fingerprint of
 the canonical JSON tracked in a server-owned manifest beside the home:
 unchanged fingerprint → no write.
 
-Empty state (contract §3): a harness absent from ``harnesses`` (or with empty
-``sources``) renders to the native delta at the read plane. When the whole
-surface resolves to zero harnesses, the state file and manifest are deleted so
-the reader finds no file (cloud launch fail-closes on its own — that is the Rust
-launcher's job, not this file's). A gateway source whose enrollment is not yet
-synced, or whose public base URL is unconfigured, is dropped (and logged) rather
-than raised, and a revoked ``api_key`` source's value simply vanishes at the next
-pass — one unsatisfiable source never aborts the whole reconcile.
+Empty state (contract §3): a harness ABSENT from ``harnesses`` renders to the
+native delta at the read plane; a harness PRESENT with ``sources: []`` fails the
+launch closed with a typed error. When the whole surface has no selection rows at
+all, the state file and manifest are deleted so the reader finds no file. A
+gateway source whose enrollment is not yet synced, or whose public base URL is
+unconfigured, is dropped (and logged) rather than raised, and a revoked
+``api_key`` source's value simply vanishes at the next pass — one unsatisfiable
+source never aborts the whole reconcile, but it does leave its harness entry
+empty rather than removing it.
 """
 
 from __future__ import annotations
@@ -120,23 +122,35 @@ class AgentAuthStateInputs:
 def render_agent_auth_state(inputs: AgentAuthStateInputs) -> tuple[dict[str, object], str]:
     """Render (state, fingerprint) as a v2 document from pre-scoped inputs.
 
-    The returned document is always a valid v2 shape. ``harnesses`` lists only
-    the harnesses that have at least one resolvable enabled source; a harness
-    whose every source is unsatisfiable (revoked key, unsynced gateway) is
-    omitted, which the read plane treats as native. The caller (cloud
-    materializer) deletes the file when ``harnesses`` is empty.
+    The returned document is always a valid v2 shape. ``harnesses`` lists every
+    harness the user has an enabled selection row for, INCLUDING one whose every
+    source turned out unsatisfiable (revoked key, unsynced gateway) — that entry
+    is kept with ``sources: []``, which the runtime reads as "a selection this
+    machine cannot honor" and refuses the launch. Only a harness with no
+    selection row at all is absent, which the read plane treats as native. The
+    caller deletes the file when ``harnesses`` is empty, i.e. when nothing is
+    selected on this surface at all.
 
     Never raises for an unsatisfiable source: it is dropped (and logged) so a
     single bad source can never abort the reconcile and leave stale key material
-    behind.
+    behind. Dropping a source is not the same as dropping its harness.
     """
-    by_harness: dict[str, list[tuple[str, dict[str, object]]]] = {}
+    # Every harness the user has SELECTED something for gets a key here, even
+    # when its value ends up empty. That distinction is the fail-closed law:
+    # `sources: []` says "you selected a route and we could not satisfy it", and
+    # the runtime refuses the launch; an ABSENT harness says "you never
+    # configured this one" and the runtime uses the native login. Dropping the
+    # harness entirely collapsed those two into one, so an exhausted gateway
+    # budget silently billed the user's personal provider account.
+    by_harness: dict[str, list[tuple[str, dict[str, object]]]] = {
+        selection.harness_kind: [] for selection in inputs.selections
+    }
     for selection in inputs.selections:
         source = _render_source(inputs, selection)
         if source is None:
             continue
         sort_key = (str(source["kind"]), selection.env_var_name or "")
-        by_harness.setdefault(selection.harness_kind, []).append((sort_key, source))
+        by_harness[selection.harness_kind].append((sort_key, source))
 
     harnesses: list[dict[str, object]] = []
     for harness_kind in sorted(by_harness):
@@ -357,9 +371,12 @@ async def materialize_agent_auth(
     manifest_path = paths.agent_auth_manifest_path()
 
     if not state["harnesses"]:
-        # No resolvable cloud sources: delete the file so the reader finds none
-        # (contract §3 — empty renders to native; cloud launch fail-closes in the
-        # runtime launcher, not here).
+        # NO SELECTIONS AT ALL for this surface — not "selections we could not
+        # satisfy". Since the renderer now keeps a `sources: []` entry for every
+        # selected harness, an empty `harnesses` list can only mean the user has
+        # selected nothing, and deleting the file is exactly right: absent means
+        # native. A surface with an unsatisfiable selection reaches the write
+        # below with `sources: []`, which the runtime fails closed on.
         await sandbox_io.remove_owned_files(
             ctx.target,
             operation_id=ctx.sandbox.id,

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -80,7 +80,10 @@ from proliferate.constants.agent_gateway import (
 from proliferate.db.store import agent_gateway as agent_gateway_store
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
 from proliferate.db.store.agent_gateway import AgentAuthSelectionRecord
-from proliferate.server.cloud.agent_gateway.budget import is_gateway_budget_available
+from proliferate.server.cloud.agent_gateway.budget import (
+    get_gateway_enrollment_for_user,
+    is_gateway_budget_available,
+)
 from proliferate.server.cloud.cloud_sandboxes import transactions as cloud_sandbox_transactions
 from proliferate.server.cloud.materialization import operation, paths, sandbox_io
 
@@ -96,6 +99,12 @@ class AgentAuthStateInputs:
     row still advances it. ``api_key_values`` maps an ``api_key_id`` to its
     decrypted secret; a revoked or vanished key is simply absent (its source is
     then dropped).
+
+    ``gateway_virtual_keys`` is a per-harness map (model-gateway.md §Account
+    model, R2): each gateway-capable harness gets its own access-group-scoped
+    key, so there is no longer one shared virtual key for a whole scope. A
+    harness absent from the map (or whose enrollment isn't synced) has an
+    unsatisfiable gateway source.
     """
 
     user_id: UUID
@@ -103,7 +112,7 @@ class AgentAuthStateInputs:
     selections: tuple[AgentAuthSelectionRecord, ...]
     api_key_values: Mapping[UUID, str]
     enrollment_sync_status: str | None
-    gateway_virtual_key: str | None
+    gateway_virtual_keys: Mapping[str, str]  # keyed by harness_kind
     gateway_base_url: str | None
     harness_settings: Mapping[str, dict[str, object]]  # keyed by harness_kind
 
@@ -172,9 +181,12 @@ def _render_gateway_source(
 ) -> dict[str, object] | None:
     """Render a gateway source, or ``None`` if it cannot be satisfied.
 
-    An unsatisfiable gateway source is dropped rather than raised so the rest of
-    the state — including the removal of any now-revoked ``api_key`` material —
-    is still written; enrollment reaching ``synced`` re-triggers materialization.
+    Resolves the harness's own access-group-scoped key from the per-harness
+    map (model-gateway.md §Account model, R2) — never a single shared key.
+    An unsatisfiable gateway source is dropped rather than raised so the rest
+    of the state — including the removal of any now-revoked ``api_key``
+    material — is still written; enrollment reaching ``synced`` re-triggers
+    materialization.
     """
     if not inputs.gateway_base_url:
         # L7 (contract): a configured gateway selection that cannot be delivered
@@ -187,19 +199,20 @@ def _render_gateway_source(
         )
         return None
     synced = inputs.enrollment_sync_status == AGENT_GATEWAY_SYNC_STATUS_SYNCED
-    if not synced or not inputs.gateway_virtual_key:
+    virtual_key = inputs.gateway_virtual_keys.get(selection.harness_kind)
+    if not synced or not virtual_key:
         logger.warning(
             "Skipping unsatisfiable gateway agent-auth source harness=%s "
             "(enrollment status=%s, virtual key present=%s)",
             selection.harness_kind,
             inputs.enrollment_sync_status or "none",
-            inputs.gateway_virtual_key is not None,
+            virtual_key is not None,
         )
         return None
     return {
         "kind": AGENT_AUTH_SOURCE_GATEWAY,
         "base_url": inputs.gateway_base_url,
-        "key": inputs.gateway_virtual_key,
+        "key": virtual_key,
     }
 
 
@@ -265,31 +278,47 @@ async def _load_state_inputs(
             api_key_values[selection.api_key_id] = value
 
     enrollment_sync_status: str | None = None
-    gateway_virtual_key: str | None = None
-    needs_gateway = any(
-        selection.source_kind == AGENT_AUTH_SOURCE_GATEWAY for selection in enabled
-    )
-    if needs_gateway:
-        enrollment = await agent_gateway_store.get_enrollment_for_user(db, user_id=user_id)
+    gateway_virtual_keys: dict[str, str] = {}
+    gateway_harness_kinds = {
+        selection.harness_kind
+        for selection in enabled
+        if selection.source_kind == AGENT_AUTH_SOURCE_GATEWAY
+    }
+    if gateway_harness_kinds:
+        # Org-member gap fix (model-gateway.md): an org member's gateway
+        # sessions are governed by their ORG enrollment, not their personal
+        # one — same resolution `is_gateway_budget_available` uses below, so
+        # the gate and the keys it guards always agree on the paying subject.
+        enrollment = await get_gateway_enrollment_for_user(db, user_id)
         if enrollment is not None:
             enrollment_sync_status = enrollment.sync_status
             if enrollment.sync_status == AGENT_GATEWAY_SYNC_STATUS_SYNCED:
                 # Second enforcement wall for LLM-credit exhaustion (the first
-                # is the importer disabling the LiteLLM virtual key): an
-                # exhausted subject stops being handed the key at all, so a
+                # is the importer disabling the LiteLLM virtual keys): an
+                # exhausted subject stops being handed any key at all, so a
                 # lagging or failed key-disable cannot leak gateway access.
                 # The gateway source then renders unsatisfiable and is dropped;
                 # the runtime fails closed at launch.
                 if await is_gateway_budget_available(db, user_id):
-                    gateway_virtual_key = (
-                        await agent_gateway_store.get_enrollment_virtual_key_decrypted(
+                    for harness_kind in gateway_harness_kinds:
+                        enrollment_key = await agent_gateway_store.get_active_enrollment_key(
                             db,
                             enrollment_id=enrollment.id,
+                            harness_kind=harness_kind,
                         )
-                    )
+                        if enrollment_key is None:
+                            continue
+                        decrypted_key = (
+                            await agent_gateway_store.get_enrollment_key_virtual_key_decrypted(
+                                db,
+                                enrollment_key_id=enrollment_key.id,
+                            )
+                        )
+                        if decrypted_key is not None:
+                            gateway_virtual_keys[harness_kind] = decrypted_key
                 else:
                     logger.warning(
-                        "Withholding gateway virtual key: LLM credit exhausted "
+                        "Withholding gateway virtual keys: LLM credit exhausted "
                         "(user=%s, surface=%s)",
                         user_id,
                         surface,
@@ -307,7 +336,7 @@ async def _load_state_inputs(
         selections=enabled,
         api_key_values=api_key_values,
         enrollment_sync_status=enrollment_sync_status,
-        gateway_virtual_key=gateway_virtual_key,
+        gateway_virtual_keys=gateway_virtual_keys,
         gateway_base_url=settings.agent_gateway_litellm_public_base_url or None,
         harness_settings=harness_settings,
     )

--- a/server/tests/integration/test_agent_auth_materialization.py
+++ b/server/tests/integration/test_agent_auth_materialization.py
@@ -152,6 +152,17 @@ class TestBuildAgentAuthStateSyncedGateway:
             enrollment_id=enrollment.id,
             litellm_team_id="team-1",
             litellm_user_id=f"user-{user_id}",
+            virtual_key_id=None,
+            virtual_key=None,
+            sync_fingerprint="fp-1",
+        )
+        # Post-B2/B3: the renderer resolves the harness's own per-harness
+        # child key (model-gateway.md §Account model), not a key on the
+        # parent enrollment row.
+        await agent_gateway_store.upsert_enrollment_key(
+            db_session,
+            enrollment_id=enrollment.id,
+            harness_kind="claude",
             virtual_key_id="tok-1",
             virtual_key="sk-litellm-vk",
             sync_fingerprint="fp-1",

--- a/server/tests/integration/test_agent_auth_materialization.py
+++ b/server/tests/integration/test_agent_auth_materialization.py
@@ -185,3 +185,84 @@ class TestBuildAgentAuthStateSyncedGateway:
             }
         ]
         assert fingerprint == agent_auth.agent_auth_state_fingerprint(state)
+
+    @pytest.mark.asyncio
+    async def test_each_gateway_harness_renders_its_own_child_key(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two gateway harnesses → two distinct keys through the real loader.
+
+        The unit suite covers the renderer's map lookup; this drives
+        ``_load_state_inputs`` against real child-key rows, so a loader that
+        fanned one key out to every harness (or looked up the wrong harness's
+        row) fails here.
+        """
+        monkeypatch.setattr(
+            settings,
+            "agent_gateway_litellm_public_base_url",
+            "https://llm.proliferate.ai",
+        )
+        user_id = await _register_user_id(client)
+        for harness_kind in ("claude", "codex"):
+            await agent_gateway_store.put_auth_selections(
+                db_session,
+                user_id=user_id,
+                harness_kind=harness_kind,
+                surface="cloud",
+                sources=[DesiredAuthSource(source_kind="gateway")],
+            )
+
+        subject = await ensure_personal_billing_subject(db_session, user_id)
+        enrollment = await agent_gateway_store.ensure_enrollment_row(
+            db_session,
+            subject_kind="user",
+            billing_subject_id=subject.id,
+            user_id=user_id,
+        )
+        await agent_gateway_store.mark_enrollment_synced(
+            db_session,
+            enrollment_id=enrollment.id,
+            litellm_team_id="team-1",
+            litellm_user_id=f"user-{user_id}",
+            virtual_key_id=None,
+            virtual_key=None,
+            sync_fingerprint="fp-set",
+        )
+        for harness_kind in ("claude", "codex"):
+            await agent_gateway_store.upsert_enrollment_key(
+                db_session,
+                enrollment_id=enrollment.id,
+                harness_kind=harness_kind,
+                virtual_key_id=f"tok-{harness_kind}",
+                virtual_key=f"sk-litellm-{harness_kind}",
+                sync_fingerprint=f"fp-{harness_kind}",
+            )
+        await db_session.flush()
+
+        state, _ = await agent_auth.build_agent_auth_state(db_session, user_id)
+
+        assert state["harnesses"] == [
+            {
+                "harness_kind": "claude",
+                "sources": [
+                    {
+                        "kind": "gateway",
+                        "base_url": "https://llm.proliferate.ai",
+                        "key": "sk-litellm-claude",
+                    }
+                ],
+            },
+            {
+                "harness_kind": "codex",
+                "sources": [
+                    {
+                        "kind": "gateway",
+                        "base_url": "https://llm.proliferate.ai",
+                        "key": "sk-litellm-codex",
+                    }
+                ],
+            },
+        ]

--- a/server/tests/integration/test_agent_auth_org_member_gateway.py
+++ b/server/tests/integration/test_agent_auth_org_member_gateway.py
@@ -1,0 +1,190 @@
+"""Org-member gateway resolution (model-gateway.md org-member gap, closed by B3).
+
+Before this fix, an org member's gateway sessions always resolved their
+PERSONAL enrollment (state renderer and budget gate both called
+``get_enrollment_for_user`` unconditionally), so org members' gateway spend
+landed on their personal subject rather than the org's. These tests prove the
+fix: for a user with a current org membership, both
+``is_gateway_budget_available`` and the agent-auth state renderer resolve the
+ORG enrollment's key/budget, not the personal one.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.config import settings
+from proliferate.constants.agent_gateway import LLM_CREDIT_SOURCE_ADMIN
+from proliferate.db.models.auth import User
+from proliferate.db.models.organizations import Organization, OrganizationMembership
+from proliferate.db.store import agent_gateway as store
+from proliferate.db.store.agent_gateway import DesiredAuthSource
+from proliferate.db.store.agent_gateway.selections import put_auth_selections
+from proliferate.server.cloud.agent_gateway.budget import (
+    get_gateway_enrollment_for_user,
+    is_gateway_budget_available,
+)
+from proliferate.server.cloud.agent_gateway.enrollment import (
+    ensure_org_enrollment,
+    ensure_user_enrollment,
+)
+from proliferate.server.cloud.materialization.materialize.agent_auth import (
+    build_agent_auth_state,
+)
+from tests.integration.agent_gateway_topups_shared import StubLiteLLM
+
+
+async def _create_user(db_session: AsyncSession) -> uuid.UUID:
+    user = User(
+        email=f"org-member-{uuid.uuid4().hex[:10]}@example.com",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user.id
+
+
+async def _create_org_with_active_member(
+    db_session: AsyncSession, *, user_id: uuid.UUID
+) -> uuid.UUID:
+    organization = Organization(name=f"Gateway Org {uuid.uuid4().hex[:6]}")
+    db_session.add(organization)
+    await db_session.flush()
+    db_session.add(
+        OrganizationMembership(
+            organization_id=organization.id,
+            user_id=user_id,
+            role="member",
+            status="active",
+        )
+    )
+    await db_session.flush()
+    return organization.id
+
+
+@pytest.mark.asyncio
+async def test_org_member_gateway_governed_by_org_enrollment_not_personal(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """The resolved enrollment for a current org member is the org one."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    personal = await ensure_user_enrollment(db_session, user_id)
+    org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+    assert personal.id != org_enrollment.id
+
+    resolved = await get_gateway_enrollment_for_user(db_session, user_id)
+    assert resolved is not None
+    assert resolved.id == org_enrollment.id
+    assert resolved.subject_kind == "organization"
+
+
+@pytest.mark.asyncio
+async def test_org_less_user_still_resolves_personal_enrollment(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    user_id = await _create_user(db_session)
+
+    personal = await ensure_user_enrollment(db_session, user_id)
+
+    resolved = await get_gateway_enrollment_for_user(db_session, user_id)
+    assert resolved is not None
+    assert resolved.id == personal.id
+    assert resolved.subject_kind == "user"
+
+
+@pytest.mark.asyncio
+async def test_org_member_budget_gate_checks_org_credit_not_personal(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """Draining the PERSONAL subject's credit must not block an org member
+    whose org subject still has credit — and vice versa."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    personal = await ensure_user_enrollment(db_session, user_id)
+    await ensure_org_enrollment(db_session, org_id, user_id)
+
+    # Drain the PERSONAL subject only.
+    await store.create_llm_credit_grant(
+        db_session,
+        billing_subject_id=personal.billing_subject_id,
+        source=LLM_CREDIT_SOURCE_ADMIN,
+        amount_usd=Decimal("1"),
+    )
+    await store.insert_usage_event_once(
+        db_session,
+        litellm_request_id=f"req-{uuid.uuid4().hex[:12]}",
+        occurred_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        billing_subject_id=personal.billing_subject_id,
+        cost_usd=5.0,
+    )
+    personal_balance = await store.get_remaining_credit_usd(
+        db_session, personal.billing_subject_id
+    )
+    assert personal_balance.remaining_usd < Decimal("0")
+
+    # The org member's own gateway availability is unaffected: the org
+    # subject (default org budget, no grant of its own) is what's checked.
+    assert await is_gateway_budget_available(db_session, user_id) is True
+
+
+@pytest.mark.asyncio
+async def test_org_member_state_render_uses_org_enrollment_key(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """The rendered gateway source's key comes from the org enrollment's
+    per-harness child key, not the member's personal one."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(
+        settings,
+        "agent_gateway_litellm_public_base_url",
+        "https://llm.proliferate.ai",
+    )
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    await ensure_user_enrollment(db_session, user_id)
+    org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+    org_claude_key = await store.get_active_enrollment_key(
+        db_session, enrollment_id=org_enrollment.id, harness_kind="claude"
+    )
+    assert org_claude_key is not None
+    org_key_value = await store.get_enrollment_key_virtual_key_decrypted(
+        db_session, enrollment_key_id=org_claude_key.id
+    )
+    assert org_key_value is not None
+
+    await put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="cloud",
+        sources=[DesiredAuthSource(source_kind="gateway")],
+    )
+
+    state, _ = await build_agent_auth_state(db_session, user_id, surface="cloud")
+    sources = [s for h in state["harnesses"] for s in h["sources"]]
+    gateway_sources = [s for s in sources if s["kind"] == "gateway"]
+    assert len(gateway_sources) == 1
+    assert gateway_sources[0]["key"] == org_key_value

--- a/server/tests/integration/test_agent_auth_org_member_gateway.py
+++ b/server/tests/integration/test_agent_auth_org_member_gateway.py
@@ -3,10 +3,17 @@
 Before this fix, an org member's gateway sessions always resolved their
 PERSONAL enrollment (state renderer and budget gate both called
 ``get_enrollment_for_user`` unconditionally), so org members' gateway spend
-landed on their personal subject rather than the org's. These tests prove the
-fix: for a user with a current org membership, both
-``is_gateway_budget_available`` and the agent-auth state renderer resolve the
-ORG enrollment's key/budget, not the personal one.
+landed on their personal subject rather than the org's.
+
+The fix routes an org member to their ORG enrollment, but only when the org
+billing subject is actually FUNDED — the funding-follows-attribution guard
+(interim; founder end-state ruling pending). On hosted every user gets a
+default personal org, so unconditional org routing would send every user to a
+subject with no credit grant: ``is_gateway_budget_available`` returns ``True``
+unconditionally for a grant-less subject and the org team's default budget of
+"0" means *uncapped* in LiteLLM, so both walls open and the personal free
+credit is never consulted. An unfunded org therefore falls back to the personal
+enrollment (pre-B3 behavior); a funded org governs.
 """
 
 from __future__ import annotations
@@ -25,6 +32,7 @@ from proliferate.db.models.organizations import Organization, OrganizationMember
 from proliferate.db.store import agent_gateway as store
 from proliferate.db.store.agent_gateway import DesiredAuthSource
 from proliferate.db.store.agent_gateway.selections import put_auth_selections
+from proliferate.server.cloud.agent_gateway import service as gateway_service
 from proliferate.server.cloud.agent_gateway.budget import (
     get_gateway_enrollment_for_user,
     is_gateway_budget_available,
@@ -53,9 +61,9 @@ async def _create_user(db_session: AsyncSession) -> uuid.UUID:
 
 
 async def _create_org_with_active_member(
-    db_session: AsyncSession, *, user_id: uuid.UUID
+    db_session: AsyncSession, *, user_id: uuid.UUID, name: str | None = None
 ) -> uuid.UUID:
-    organization = Organization(name=f"Gateway Org {uuid.uuid4().hex[:6]}")
+    organization = Organization(name=name or f"Gateway Org {uuid.uuid4().hex[:6]}")
     db_session.add(organization)
     await db_session.flush()
     db_session.add(
@@ -70,13 +78,32 @@ async def _create_org_with_active_member(
     return organization.id
 
 
+async def _grant(db_session: AsyncSession, *, billing_subject_id: uuid.UUID, amount: str) -> None:
+    await store.create_llm_credit_grant(
+        db_session,
+        billing_subject_id=billing_subject_id,
+        source=LLM_CREDIT_SOURCE_ADMIN,
+        amount_usd=Decimal(amount),
+    )
+
+
+async def _drain(db_session: AsyncSession, *, billing_subject_id: uuid.UUID) -> None:
+    await store.insert_usage_event_once(
+        db_session,
+        litellm_request_id=f"req-{uuid.uuid4().hex[:12]}",
+        occurred_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        billing_subject_id=billing_subject_id,
+        cost_usd=1_000.0,
+    )
+
+
 @pytest.mark.asyncio
-async def test_org_member_gateway_governed_by_org_enrollment_not_personal(
+async def test_funded_org_governs_the_members_gateway(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
     stub_litellm: StubLiteLLM,
 ) -> None:
-    """The resolved enrollment for a current org member is the org one."""
+    """An org with a real credit grant is the subject that governs its members."""
     monkeypatch.setattr(settings, "agent_gateway_enabled", True)
     user_id = await _create_user(db_session)
     org_id = await _create_org_with_active_member(db_session, user_id=user_id)
@@ -84,11 +111,59 @@ async def test_org_member_gateway_governed_by_org_enrollment_not_personal(
     personal = await ensure_user_enrollment(db_session, user_id)
     org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
     assert personal.id != org_enrollment.id
+    await _grant(db_session, billing_subject_id=org_enrollment.billing_subject_id, amount="50")
 
     resolved = await get_gateway_enrollment_for_user(db_session, user_id)
     assert resolved is not None
     assert resolved.id == org_enrollment.id
     assert resolved.subject_kind == "organization"
+
+
+@pytest.mark.asyncio
+async def test_unfunded_org_falls_back_to_the_personal_enrollment(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """The guard: no org grant and no explicit org budget → personal governs.
+
+    Routing to the unfunded org subject would make the gate's ``granted <= 0``
+    branch return True unconditionally while LiteLLM reads the org team's "0"
+    budget as uncapped — unlimited spend with the personal grant never
+    consulted.
+    """
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_default_org_budget_usd", "0")
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    personal = await ensure_user_enrollment(db_session, user_id)
+    await ensure_org_enrollment(db_session, org_id, user_id)
+
+    resolved = await get_gateway_enrollment_for_user(db_session, user_id)
+    assert resolved is not None
+    assert resolved.id == personal.id
+    assert resolved.subject_kind == "user"
+
+
+@pytest.mark.asyncio
+async def test_explicit_org_budget_also_counts_as_funded(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """A deployment that configures a real org team cap has a funding source."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_default_org_budget_usd", "250")
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    await ensure_user_enrollment(db_session, user_id)
+    org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+
+    resolved = await get_gateway_enrollment_for_user(db_session, user_id)
+    assert resolved is not None
+    assert resolved.id == org_enrollment.id
 
 
 @pytest.mark.asyncio
@@ -109,42 +184,58 @@ async def test_org_less_user_still_resolves_personal_enrollment(
 
 
 @pytest.mark.asyncio
-async def test_org_member_budget_gate_checks_org_credit_not_personal(
+async def test_unfunded_org_member_is_blocked_by_a_drained_personal_grant(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
     stub_litellm: StubLiteLLM,
 ) -> None:
-    """Draining the PERSONAL subject's credit must not block an org member
-    whose org subject still has credit — and vice versa."""
+    """The money assertion: personal credit still caps an unfunded-org member.
+
+    This is what the pre-fix version of this suite asserted backwards — it
+    treated "drained personal grant does not block the member" as the desired
+    behavior, which is exactly the unlimited-spend hole (the member's only
+    funding source was drained, yet nothing stopped them).
+    """
     monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_default_org_budget_usd", "0")
     user_id = await _create_user(db_session)
     org_id = await _create_org_with_active_member(db_session, user_id=user_id)
 
     personal = await ensure_user_enrollment(db_session, user_id)
     await ensure_org_enrollment(db_session, org_id, user_id)
+    await _grant(db_session, billing_subject_id=personal.billing_subject_id, amount="1")
 
-    # Drain the PERSONAL subject only.
-    await store.create_llm_credit_grant(
-        db_session,
-        billing_subject_id=personal.billing_subject_id,
-        source=LLM_CREDIT_SOURCE_ADMIN,
-        amount_usd=Decimal("1"),
-    )
-    await store.insert_usage_event_once(
-        db_session,
-        litellm_request_id=f"req-{uuid.uuid4().hex[:12]}",
-        occurred_at=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
-        billing_subject_id=personal.billing_subject_id,
-        cost_usd=5.0,
-    )
-    personal_balance = await store.get_remaining_credit_usd(
-        db_session, personal.billing_subject_id
-    )
-    assert personal_balance.remaining_usd < Decimal("0")
-
-    # The org member's own gateway availability is unaffected: the org
-    # subject (default org budget, no grant of its own) is what's checked.
     assert await is_gateway_budget_available(db_session, user_id) is True
+
+    await _drain(db_session, billing_subject_id=personal.billing_subject_id)
+
+    assert await is_gateway_budget_available(db_session, user_id) is False
+
+
+@pytest.mark.asyncio
+async def test_funded_org_budgets_are_independent_of_personal_credit(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """Once the org funds the member, the two ledgers move independently."""
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(settings, "agent_gateway_default_org_budget_usd", "0")
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    personal = await ensure_user_enrollment(db_session, user_id)
+    org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+    await _grant(db_session, billing_subject_id=org_enrollment.billing_subject_id, amount="50")
+    await _grant(db_session, billing_subject_id=personal.billing_subject_id, amount="1")
+
+    # Draining the PERSONAL subject does not block a member the org funds.
+    await _drain(db_session, billing_subject_id=personal.billing_subject_id)
+    assert await is_gateway_budget_available(db_session, user_id) is True
+
+    # Draining the ORG subject does block them — that is the governing ledger.
+    await _drain(db_session, billing_subject_id=org_enrollment.billing_subject_id)
+    assert await is_gateway_budget_available(db_session, user_id) is False
 
 
 @pytest.mark.asyncio
@@ -153,7 +244,7 @@ async def test_org_member_state_render_uses_org_enrollment_key(
     monkeypatch: pytest.MonkeyPatch,
     stub_litellm: StubLiteLLM,
 ) -> None:
-    """The rendered gateway source's key comes from the org enrollment's
+    """The rendered gateway source's key comes from the funded org enrollment's
     per-harness child key, not the member's personal one."""
     monkeypatch.setattr(settings, "agent_gateway_enabled", True)
     monkeypatch.setattr(
@@ -166,6 +257,7 @@ async def test_org_member_state_render_uses_org_enrollment_key(
 
     await ensure_user_enrollment(db_session, user_id)
     org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+    await _grant(db_session, billing_subject_id=org_enrollment.billing_subject_id, amount="50")
     org_claude_key = await store.get_active_enrollment_key(
         db_session, enrollment_id=org_enrollment.id, harness_kind="claude"
     )
@@ -188,3 +280,108 @@ async def test_org_member_state_render_uses_org_enrollment_key(
     gateway_sources = [s for s in sources if s["kind"] == "gateway"]
     assert len(gateway_sources) == 1
     assert gateway_sources[0]["key"] == org_key_value
+
+
+@pytest.mark.asyncio
+async def test_every_gateway_key_reader_resolves_the_same_enrollment(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """Divergence guard: gate, renderer, probe, and capabilities must agree.
+
+    Four call sites read gateway key material or report its readiness. If any
+    one of them resolves a different enrollment than the others, the gate can
+    authorize one paying subject while a key from another is handed out (or the
+    UI reports a readiness that does not describe the key in use).
+    """
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    monkeypatch.setattr(
+        settings,
+        "agent_gateway_litellm_public_base_url",
+        "https://llm.proliferate.ai",
+    )
+    user_id = await _create_user(db_session)
+    org_id = await _create_org_with_active_member(db_session, user_id=user_id)
+
+    personal = await ensure_user_enrollment(db_session, user_id)
+    org_enrollment = await ensure_org_enrollment(db_session, org_id, user_id)
+    await _grant(db_session, billing_subject_id=org_enrollment.billing_subject_id, amount="50")
+
+    governing = await get_gateway_enrollment_for_user(db_session, user_id)
+    assert governing is not None
+    assert governing.id == org_enrollment.id
+
+    # The probe path (catalog._probe_gateway_models) reads its key off the same
+    # enrollment; assert on the key it would resolve for a harness.
+    org_key = await store.get_active_enrollment_key(
+        db_session, enrollment_id=governing.id, harness_kind="claude"
+    )
+    personal_key = await store.get_active_enrollment_key(
+        db_session, enrollment_id=personal.id, harness_kind="claude"
+    )
+    assert org_key is not None and personal_key is not None
+    assert org_key.virtual_key_id != personal_key.virtual_key_id
+
+    # get_capabilities / get_enrollment report the governing enrollment.
+    _, _, status = await gateway_service.get_capabilities(db_session, user_id=user_id)
+    assert status == governing.sync_status
+    reported = await gateway_service.get_enrollment(db_session, user_id=user_id)
+    assert reported.id == governing.id
+
+    # The renderer hands out the governing enrollment's key.
+    await put_auth_selections(
+        db_session,
+        user_id=user_id,
+        harness_kind="claude",
+        surface="cloud",
+        sources=[DesiredAuthSource(source_kind="gateway")],
+    )
+    state, _ = await build_agent_auth_state(db_session, user_id, surface="cloud")
+    rendered = [
+        source
+        for harness in state["harnesses"]
+        for source in harness["sources"]
+        if source["kind"] == "gateway"
+    ]
+    expected = await store.get_enrollment_key_virtual_key_decrypted(
+        db_session, enrollment_key_id=org_key.id
+    )
+    assert [source["key"] for source in rendered] == [expected]
+
+
+@pytest.mark.asyncio
+async def test_multi_org_membership_picks_the_first_org_by_name(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_litellm: StubLiteLLM,
+) -> None:
+    """Deterministic payer across several funded memberships.
+
+    ``get_current_membership_for_user`` orders active memberships by
+    organization NAME and takes the first, so the chosen payer is stable for a
+    fixed set of names — but renaming an org can move it. This pins the current
+    behavior (inherited from the compute attribution path) so a change is a
+    deliberate one.
+    """
+    monkeypatch.setattr(settings, "agent_gateway_enabled", True)
+    user_id = await _create_user(db_session)
+    suffix = uuid.uuid4().hex[:6]
+    alpha_id = await _create_org_with_active_member(
+        db_session, user_id=user_id, name=f"Alpha Org {suffix}"
+    )
+    zulu_id = await _create_org_with_active_member(
+        db_session, user_id=user_id, name=f"Zulu Org {suffix}"
+    )
+
+    await ensure_user_enrollment(db_session, user_id)
+    alpha_enrollment = await ensure_org_enrollment(db_session, alpha_id, user_id)
+    zulu_enrollment = await ensure_org_enrollment(db_session, zulu_id, user_id)
+    # Both orgs funded, so the guard does not decide between them.
+    await _grant(db_session, billing_subject_id=alpha_enrollment.billing_subject_id, amount="50")
+    await _grant(db_session, billing_subject_id=zulu_enrollment.billing_subject_id, amount="50")
+
+    resolved = await get_gateway_enrollment_for_user(db_session, user_id)
+    assert resolved is not None
+    assert resolved.id == alpha_enrollment.id
+    assert resolved.id != zulu_enrollment.id

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -579,6 +579,17 @@ class TestAgentAuthState:
             enrollment_id=enrollment.id,
             litellm_team_id="team-1",
             litellm_user_id=f"user-{user_id}",
+            virtual_key_id=None,
+            virtual_key=None,
+            sync_fingerprint="fp",
+        )
+        # Post-B2/B3: the renderer resolves the harness's own per-harness
+        # child key (model-gateway.md §Account model), not a key on the
+        # parent enrollment row.
+        await store.upsert_enrollment_key(
+            db_session,
+            enrollment_id=enrollment.id,
+            harness_kind="claude",
             virtual_key_id="token-1",
             virtual_key="sk-litellm-vk",
             sync_fingerprint="fp",

--- a/server/tests/integration/test_agent_gateway_usage_credits.py
+++ b/server/tests/integration/test_agent_gateway_usage_credits.py
@@ -469,15 +469,13 @@ async def test_exhausted_budget_withholds_gateway_key_from_state_render(
         sources=[DesiredAuthSource(source_kind="gateway")],
     )
 
-    # KNOWN INTERIM GAP (closed by B3, next in this stack): the renderer
-    # still resolves the parent enrollment's own key
-    # (`get_enrollment_virtual_key_decrypted(enrollment_id=...)`), which B2
-    # intentionally clears to `None` now that keys live on the child table —
-    # so with credit remaining the gateway source is (incorrectly, until B3)
-    # dropped rather than rendered. B3's per-harness key-map renderer fixes
-    # this; asserted honestly here rather than papered over.
+    # With credit remaining, the render hands out the claude harness's own
+    # per-harness gateway key (model-gateway.md §Account model). `claude_key_id`
+    # is the token hash (spend-log `api_key`), not the rendered secret value —
+    # only presence is asserted here.
     state, _ = await build_agent_auth_state(db_session, user_id, surface="local")
-    assert state["harnesses"] == []
+    sources = [s for h in state["harnesses"] for s in h["sources"]]
+    assert any(s["kind"] == "gateway" and s.get("key") for s in sources)
 
     # Drain the grant; simulate the first wall failing by NOT relying on the
     # key-disable — the render alone must now withhold the key regardless.
@@ -572,10 +570,6 @@ async def test_available_budget_leaves_state_render_and_no_grant_unblocked(
         sources=[DesiredAuthSource(source_kind="gateway")],
     )
     assert await is_gateway_budget_available(db_session, user_id) is True
-    # KNOWN INTERIM GAP (closed by B3, next in this stack): see the sibling
-    # withhold test above — the renderer still resolves the parent
-    # enrollment's own (now-cleared) key until B3's per-harness key-map
-    # renderer lands, so the gateway source renders unsatisfiable here even
-    # though the budget gate itself correctly reports available.
     state, _ = await build_agent_auth_state(db_session, user_id, surface="local")
-    assert state["harnesses"] == []
+    sources = [s for h in state["harnesses"] for s in h["sources"]]
+    assert any(s["kind"] == "gateway" and s.get("key") for s in sources)

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -275,6 +275,50 @@ class TestRenderAgentAuthState:
             )
             assert state["harnesses"] == []
 
+    def test_each_gateway_harness_carries_its_own_key(self) -> None:
+        """Two gateway harnesses render two DISTINCT keys (R2's whole point).
+
+        The key map is per (subject, harness) so each harness is granted only
+        its own access group. If the renderer collapsed the map to one value,
+        every harness would ship a key scoped to some other harness's group —
+        the pre-B2 one-shared-key behavior with none of the scoping.
+        """
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (
+                    _selection(harness="claude", source_kind="gateway"),
+                    _selection(harness="codex", source_kind="gateway"),
+                ),
+                gateway_virtual_keys={
+                    "claude": "sk-litellm-claude",
+                    "codex": "sk-litellm-codex",
+                },
+            )
+        )
+        rendered = {
+            harness["harness_kind"]: [
+                source["key"] for source in harness["sources"] if source["kind"] == "gateway"
+            ]
+            for harness in state["harnesses"]
+        }
+        assert rendered == {
+            "claude": ["sk-litellm-claude"],
+            "codex": ["sk-litellm-codex"],
+        }
+
+    def test_harness_missing_from_the_key_map_is_dropped_alone(self) -> None:
+        """A harness with no key of its own never borrows a sibling's key."""
+        state, _ = agent_auth.render_agent_auth_state(
+            _inputs(
+                (
+                    _selection(harness="claude", source_kind="gateway"),
+                    _selection(harness="codex", source_kind="gateway"),
+                ),
+                gateway_virtual_keys={"claude": "sk-litellm-claude"},
+            )
+        )
+        assert [harness["harness_kind"] for harness in state["harnesses"]] == ["claude"]
+
     def test_fingerprint_is_stable_across_renders(self) -> None:
         selections = (_selection(harness="claude", source_kind="gateway"),)
         first = agent_auth.render_agent_auth_state(_inputs(selections))

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -205,8 +205,13 @@ class TestRenderAgentAuthState:
                 api_key_values={live_id: "sk-live"},
             )
         )
-        # claude's only source was revoked -> the harness disappears entirely.
-        assert [entry["harness_kind"] for entry in state["harnesses"]] == ["codex"]
+        # claude's only source was revoked -> the ENTRY STAYS, empty. Dropping it
+        # would read as "never configured" at the runtime and silently launch on
+        # the user's own login (agent-auth.md: present-but-empty fails closed).
+        by_harness = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        assert sorted(by_harness) == ["claude", "codex"]
+        assert by_harness["claude"] == []
+        assert len(by_harness["codex"]) == 1
 
     def test_unsatisfiable_gateway_still_renders_satisfiable_api_key(self) -> None:
         live_id = uuid.uuid4()
@@ -226,9 +231,18 @@ class TestRenderAgentAuthState:
                 gateway_virtual_key=None,
             )
         )
-        assert [entry["harness_kind"] for entry in state["harnesses"]] == ["codex"]
+        # codex keeps its live key; claude keeps its entry with no sources, so the
+        # runtime refuses a claude launch rather than degrading it to native.
+        by_harness = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        assert sorted(by_harness) == ["claude", "codex"]
+        assert by_harness["claude"] == []
+        assert len(by_harness["codex"]) == 1
 
-    def test_all_unsatisfiable_renders_empty_harnesses(self) -> None:
+    def test_all_unsatisfiable_keeps_the_selected_harness_with_no_sources(self) -> None:
+        # The rewritten shape of the old `..._renders_empty_harnesses` test. An
+        # exhausted/unsynced gateway must NOT produce an empty document: an empty
+        # document is deleted by the materializer and reads as native, which is
+        # exactly the silent degradation the fail-closed law forbids.
         state, _ = agent_auth.render_agent_auth_state(
             _inputs(
                 (_selection(harness="claude", source_kind="gateway"),),
@@ -236,9 +250,16 @@ class TestRenderAgentAuthState:
                 gateway_virtual_key=None,
             )
         )
-        assert state["harnesses"] == []
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}]
         assert state["version"] == 2
         assert state["revision"] == REVISION
+
+    def test_no_selections_at_all_renders_an_empty_document(self) -> None:
+        # The one case that legitimately yields no harnesses — and therefore the
+        # only case in which the materializer deletes the state file. This is what
+        # keeps "absent means native" reachable at all.
+        state, _ = agent_auth.render_agent_auth_state(_inputs(()))
+        assert state["harnesses"] == []
 
     def test_gateway_without_public_base_url_logs_loud_warning(
         self, monkeypatch: pytest.MonkeyPatch
@@ -257,14 +278,14 @@ class TestRenderAgentAuthState:
                 gateway_base_url=None,
             )
         )
-        assert state["harnesses"] == []
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}]
         assert any(
             "gateway selection dropped" in message
             and "agent_gateway_litellm_public_base_url is not configured" in message
             for message in warnings
         )
 
-    def test_gateway_with_unsynced_enrollment_is_dropped(self) -> None:
+    def test_gateway_with_unsynced_enrollment_drops_the_source_not_the_harness(self) -> None:
         for status in ("pending", "failed", None):
             state, _ = agent_auth.render_agent_auth_state(
                 _inputs(
@@ -273,7 +294,9 @@ class TestRenderAgentAuthState:
                     gateway_virtual_key=None,
                 )
             )
-            assert state["harnesses"] == []
+            # The SOURCE is dropped; the harness entry survives empty so the
+            # runtime refuses the launch instead of falling back to native.
+            assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}], status
 
     def test_each_gateway_harness_carries_its_own_key(self) -> None:
         """Two gateway harnesses render two DISTINCT keys (R2's whole point).
@@ -306,8 +329,8 @@ class TestRenderAgentAuthState:
             "codex": ["sk-litellm-codex"],
         }
 
-    def test_harness_missing_from_the_key_map_is_dropped_alone(self) -> None:
-        """A harness with no key of its own never borrows a sibling's key."""
+    def test_harness_missing_from_the_key_map_never_borrows_a_sibling_key(self) -> None:
+        """Fails closed (``sources: []``, not dropped) and never borrows claude's key."""
         state, _ = agent_auth.render_agent_auth_state(
             _inputs(
                 (
@@ -315,9 +338,14 @@ class TestRenderAgentAuthState:
                     _selection(harness="codex", source_kind="gateway"),
                 ),
                 gateway_virtual_keys={"claude": "sk-litellm-claude"},
+                gateway_base_url="https://llm",
             )
         )
-        assert [harness["harness_kind"] for harness in state["harnesses"]] == ["claude"]
+        by_harness = {h["harness_kind"]: h["sources"] for h in state["harnesses"]}
+        assert by_harness["claude"] == [
+            {"kind": "gateway", "base_url": "https://llm", "key": "sk-litellm-claude"}
+        ]
+        assert by_harness["codex"] == []
 
     def test_fingerprint_is_stable_across_renders(self) -> None:
         selections = (_selection(harness="claude", source_kind="gateway"),)
@@ -473,17 +501,37 @@ class TestMaterializeAgentAuth:
         assert spy.read_count == 1
 
     @pytest.mark.asyncio
-    async def test_no_resolvable_sources_deletes_state_file(
+    async def test_unsatisfiable_selection_writes_an_empty_entry_instead_of_deleting(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # A cloud selection whose only source is unsatisfiable resolves to zero
-        # harnesses -> the file is deleted (empty renders to native; the runtime
-        # launcher fail-closes cloud on its own).
+        # Rewrite of `..._deletes_state_file`: deleting the file here silently
+        # degrades to native; the selection must ship as `sources: []` instead so
+        # the runtime refuses the launch (agent-auth.md: present-but-empty fails closed).
         inputs = _inputs(
             (_selection(harness="claude", source_kind="gateway"),),
             enrollment_sync_status="pending",
             gateway_virtual_key=None,
         )
+
+        async def fake_load(db: object, *, user_id: uuid.UUID, surface: str = "cloud") -> Any:
+            return inputs
+
+        monkeypatch.setattr(agent_auth, "_load_state_inputs", fake_load)
+        spy = _install_spy(monkeypatch, previous_manifest=None)
+
+        await agent_auth.materialize_agent_auth(object(), ctx=_ctx(), user_id=USER_ID)
+
+        assert spy.removed == set(), "the document must NOT be deleted"
+        state = json.loads(str(spy.writes[0]["content"]))
+        assert state["harnesses"] == [{"harness_kind": "claude", "sources": []}]
+
+    @pytest.mark.asyncio
+    async def test_no_selections_at_all_still_deletes_the_state_file(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The one remaining delete case, and the one that keeps "absent means
+        # native" reachable: the user has selected nothing on this surface.
+        inputs = _inputs(())
 
         async def fake_load(db: object, *, user_id: uuid.UUID, surface: str = "cloud") -> Any:
             return inputs
@@ -539,7 +587,14 @@ class TestMaterializeAgentAuth:
 
         assert spy.removed == set()
         state = json.loads(str(spy.writes[0]["content"]))
-        assert [entry["harness_kind"] for entry in state["harnesses"]] == ["grok"]
+        by_harness = {entry["harness_kind"]: entry["sources"] for entry in state["harnesses"]}
+        # grok's live key is delivered; claude (dead gateway) and codex (revoked
+        # key) keep EMPTY entries so their launches are refused rather than
+        # silently degraded. One bad source still does not abort the reconcile.
+        assert sorted(by_harness) == ["claude", "codex", "grok"]
+        assert by_harness["claude"] == []
+        assert by_harness["codex"] == []
+        assert len(by_harness["grok"]) == 1
         serialized = json.dumps(state)
         assert "sk-live" in serialized
         assert str(revoked_id) not in serialized

--- a/server/tests/unit/test_agent_auth_materialization.py
+++ b/server/tests/unit/test_agent_auth_materialization.py
@@ -50,15 +50,36 @@ def _inputs(
     api_key_values: dict[uuid.UUID, str] | None = None,
     enrollment_sync_status: str | None = "synced",
     gateway_virtual_key: str | None = "sk-litellm-vk",
+    gateway_virtual_keys: dict[str, str] | None = None,
     gateway_base_url: str | None = "https://llm.proliferate.ai",
 ) -> agent_auth.AgentAuthStateInputs:
+    """Build ``AgentAuthStateInputs``.
+
+    ``gateway_virtual_key`` (singular) is the convenience default: every
+    gateway-selection harness present in ``selections`` gets that same key
+    value (or none, when ``None``) — the per-harness key map
+    (model-gateway.md §Account model, R2) collapses to "one key" in tests
+    that don't care about per-harness distinctness. Pass
+    ``gateway_virtual_keys`` directly for tests that need distinct
+    per-harness values.
+    """
+    if gateway_virtual_keys is None:
+        gateway_virtual_keys = (
+            {
+                selection.harness_kind: gateway_virtual_key
+                for selection in selections
+                if selection.source_kind == "gateway"
+            }
+            if gateway_virtual_key is not None
+            else {}
+        )
     return agent_auth.AgentAuthStateInputs(
         user_id=USER_ID,
         revision=revision,
         selections=selections,
         api_key_values=api_key_values or {},
         enrollment_sync_status=enrollment_sync_status,
-        gateway_virtual_key=gateway_virtual_key,
+        gateway_virtual_keys=gateway_virtual_keys,
         gateway_base_url=gateway_base_url,
         harness_settings={},
     )

--- a/specs/codebase/platforms/product/agent-auth.md
+++ b/specs/codebase/platforms/product/agent-auth.md
@@ -522,14 +522,6 @@ anyharness/
 
 Deltas between this document and `main`, each struck by its follow-up PR:
 
-- [ ] **One shared gateway key, not per-harness scoped keys.** The state
-      renderer resolves a single enrollment virtual key and fans it out
-      to every gateway-selected harness
-      ([materialize/agent_auth.py](../../../../server/proliferate/server/cloud/materialization/materialize/agent_auth.py));
-      per-(subject, harness) access-group-scoped keys are the
-      model-gateway migration (its gaps list carries the enrollment and
-      `config.yaml` sides; this document owns the renderer's key lookup
-      and the harness-side deletion of client model filtering).
 - [ ] **Unsatisfiable sources silently degrade to native.** The renderer
       drops a dead source and omits an empty harness entry, and the
       runtime reads absence as native — so a desktop user with a native
@@ -583,9 +575,6 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       selections, but readiness still reports the structural
       `provider_managed` `Ready`; the selection set should be opencode's
       truth everywhere (composer launch options included).
-- [ ] **Org members launch on their personal key.** Cross-referenced from
-      model-gateway.md's gaps: the renderer and budget gate resolve the
-      personal enrollment even for org members.
 - [ ] **Stale IA references.** The settings information-architecture doc
       still describes the removed Bifrost-era `agent-authentication`
       pane (the shipped UI redirects it to `agent-api-keys`); its Agents

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -279,3 +279,18 @@ Deltas between this document and `main`, each struck by its follow-up PR:
 - [ ] `/v1/cloud/agent-gateway/` still carries the BYOK vault, selections,
       state, org policy, and catalog routes; `api.py`/`service.py`/
       `models.py` split along the same three-domain line.
+- [ ] Which subject pays for an org member is decided by an interim
+      funding-follows-attribution guard, not a ruled policy. A member's org
+      enrollment governs their gateway sessions only when the org billing
+      subject is funded (a positive credit grant, or an explicitly configured
+      non-default org team budget); otherwise resolution falls back to the
+      member's personal enrollment
+      ([budget.py](../../../../server/proliferate/server/cloud/agent_gateway/budget.py)
+      `get_gateway_enrollment_for_user`). The guard exists because hosted
+      gives every user a default personal org: routing to an unfunded org
+      subject would make both enforcement walls open at once (no grant means
+      the ledger gate never blocks, and an org team budget of "0" means
+      *uncapped* in LiteLLM), so the member's personal credit would never be
+      consulted. The end state — whether an unfunded org may spend at all,
+      and how a member's personal credit relates to their org's — is a
+      founder ruling still pending.

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -276,13 +276,6 @@ Deltas between this document and `main`, each struck by its follow-up PR:
 - [ ] Harness-to-model filtering is client-side (the Rust
       `provider_for_model` prefix-matcher and catalog
       `gatewayPolicy.providers`); both delete once proxy-side grants land.
-- [ ] `state.json`'s gateway payload carries one key, not a per-harness key
-      map (contract change owned by agent-auth).
 - [ ] `/v1/cloud/agent-gateway/` still carries the BYOK vault, selections,
       state, org policy, and catalog routes; `api.py`/`service.py`/
       `models.py` split along the same three-domain line.
-- [ ] Sessions for org members hand out the personal enrollment's key (the
-      state renderer and budget gate both resolve the personal
-      enrollment), so org members' gateway spend lands on their personal
-      subject today; org enrollment rows exist but are not what sessions
-      use.


### PR DESCRIPTION
Track B, PR 3 of 3 (B1→B2→**B3**, agents-impl-plan.md §4). Stacked; base =
`agents/b2-per-harness-keys` (#1508).

## Spec sections quoted

model-gateway.md, Account model:
> Inside the team, one virtual key per (subject, harness), each granted its
> harness's access group by name.

agent-auth.md, gap this PR closes:
> **One shared gateway key, not per-harness scoped keys.** The state
> renderer resolves a single enrollment virtual key and fans it out to
> every gateway-selected harness.

## What changed

- `AgentAuthStateInputs.gateway_virtual_key: str | None` →
  `gateway_virtual_keys: Mapping[str, str]` (keyed by `harness_kind`).
- `_load_state_inputs`: for every gateway-selected harness, looks up that
  harness's own `agent_gateway_enrollment_key` row (B2) and decrypts its
  own key — no more one key fanned out to every selected harness.
- `_render_gateway_source`: resolves `inputs.gateway_virtual_keys.get(harness_kind)`
  instead of a single shared value.
- New `budget.get_gateway_enrollment_for_user`: resolves the **org**
  enrollment for a user's current membership (same resolution
  `ensure_org_enrollment`/`resolve_billing_subject_id_for_user` use via
  `resolve_organization_id_for_user`), falling back to the personal
  enrollment for org-less users. Consumed by both
  `is_gateway_budget_available` and `_load_state_inputs`, so the budget
  gate and the keys it guards always agree on which subject pays.

## Gap bullets closed

model-gateway.md:
> Sessions for org members hand out the personal enrollment's key (the
> state renderer and budget gate both resolve the personal enrollment), so
> org members' gateway spend lands on their personal subject today.

agent-auth.md:
> **One shared gateway key, not per-harness scoped keys.**
> **Org members launch on their personal key.**

## Contract fixture — explicit decision, not an oversight

The task brief said to "Create/update the contract fixture at
`fixtures/contracts/agent-auth-state`." I found a more specific, later
dispatch note in `codex/agents-docs-rewrite-plan.md` ("ROUND 1 FIRED"
section) that overrides this for the actual round-1 scope:

> B3 python-only, state.json SCHEMA unchanged — per-harness values only,
> fixture change deferred to A4

Verified against the Rust side
(`anyharness/crates/anyharness-lib/src/domains/agents/route_auth/state.rs`):
the wire shape (`harnesses[].sources[].{kind,base_url,key}`) is byte-for-byte
unchanged by this PR — only which key *value* gets substituted per harness
changed (previously one shared value, now per-harness distinct values), not
the shape itself. There is nothing new to snapshot yet, so I followed the
more specific instruction and did not add a fixture here; A4 (Rust
consumer, a later PR by another operator) creates it when it has a shape
to assert against. Flagging this explicitly per the contradiction protocol
rather than silently picking one instruction over the other.

## Tests

- New `server/tests/integration/test_agent_auth_org_member_gateway.py` (4
  tests): org member resolves the org enrollment (not personal);
  org-less user still resolves personal; draining the personal subject's
  credit doesn't block an org member (independent budget gates); the
  rendered gateway source's key is the org enrollment's own child key.
- Updated `test_agent_auth_materialization.py` (unit + integration) to the
  per-harness key map; `_inputs()` test helper gained a `gateway_virtual_key`
  convenience default (fans one value to every gateway-selection harness)
  plus a `gateway_virtual_keys` param for tests needing distinct per-harness
  values.
- Updated `test_agent_gateway_api.py` (`test_seeded_gateway_and_api_key_render_valid_v2`)
  and `test_agent_gateway_usage_credits.py` to seed the per-harness child
  key instead of the (now key-less) parent enrollment row. The two
  usage-credits tests that B2's PR body flagged as documenting an interim
  B2→B3 gap now assert the key renders correctly (gap closed).
- Full run: `cd server && DEBUG=true uv run pytest tests/unit tests/integration -q -k "agent_gateway or agent_auth or billing_limit_enforcement_llm or litellm"`
  → 229 passed, 0 failed.
- `uv run ruff check` clean on every touched file. `uv run mypy` on touched
  modules shows zero new errors (one pre-existing baseline note in
  `agent_auth.py`, present identically on `origin/main`, confirmed via
  `git stash` diff).

## Contradictions

The fixture-scope one above, resolved per the more specific dispatch note
and documented rather than silently dropped.

---

## Adversarial review fixes (head `6c73f28b4`)

### 1. BLOCKER (money): org routing sent every hosted user to an unfunded subject

Routing an org member to their org enrollment unconditionally is not safe on
hosted, where **every** user gets a default personal org. The org billing
subject has no credit grant, and:

- `is_gateway_budget_available` returns `True` unconditionally for a grant-less
  subject (the `granted_usd <= 0` "no ledger, LiteLLM budget is the guardrail"
  branch), and
- the org team's default budget of `"0"` means **uncapped** in LiteLLM, not zero.

So both enforcement walls opened at once, the personal $2 free-credit grant was
never consulted, and spend was effectively unlimited.

**Funding-follows-attribution guard** (interim, conservative, reversible;
founder end-state ruling pending): `get_gateway_enrollment_for_user` uses the
org enrollment only when the org billing subject is actually funded — a positive
credit grant, or an explicitly configured non-default
`agent_gateway_default_org_budget_usd`. Otherwise it falls back to the personal
enrollment, i.e. pre-B3 behavior where the personal grant is the cap. Documented
in a docstring comment and as a new `model-gateway.md` gap bullet naming the
pending ruling.

The previous version of this suite **asserted the hole as a feature** — its
`test_org_member_budget_gate_checks_org_credit_not_personal` treated "draining
the member's personal grant does not block them" as desired, which is exactly
the unlimited-spend path (their only funding source was drained, yet nothing
stopped them). Replaced with assertions in both directions:

- `test_unfunded_org_member_is_blocked_by_a_drained_personal_grant` — unfunded
  org → the personal subject governs, so a drained personal grant blocks.
- `test_funded_org_budgets_are_independent_of_personal_credit` — funded org →
  the org subject governs; draining personal does not block, draining the org
  does.
- `test_funded_org_governs_the_members_gateway`,
  `test_unfunded_org_falls_back_to_the_personal_enrollment`,
  `test_explicit_org_budget_also_counts_as_funded`.

### 2. BLOCKER (divergence): other gateway-key readers resolved a different enrollment

Three call sites still used `get_enrollment_for_user` unconditionally while the
gate and renderer resolved the governing enrollment:

- `catalog.py` `_probe_gateway_models` — probed the **personal** key while the
  402 gate immediately above it checked the org subject, so enumeration ran
  against a key belonging to a different payer than the one authorized.
- `service.py` `get_capabilities` / `get_enrollment` — reported the personal
  `sync_status` while the renderer handed out the org enrollment's key, so the
  UI's readiness signal could describe an enrollment nobody uses.

All four readers now route through `get_gateway_enrollment_for_user`. New
`test_every_gateway_key_reader_resolves_the_same_enrollment` asserts gate,
probe-resolved key, capabilities/enrollment status, and the rendered key all
agree for a funded org member.

### 3. Missing per-harness distinctness coverage

`gateway_virtual_keys` had zero tests passing distinct values, so nothing proved
each harness carries its **own** key — the whole point of R2's scoping. Added:

- unit `test_each_gateway_harness_carries_its_own_key` and
  `test_harness_missing_from_the_key_map_is_dropped_alone` (a keyless harness
  never borrows a sibling's key), and
- integration `test_each_gateway_harness_renders_its_own_child_key`, driving
  `_load_state_inputs` against real child-key rows so a loader that fanned one
  key out (or read the wrong harness's row) fails.

### 4. Multi-org determinism pinned

Resolution takes the first active membership ordered by organization **name**
(`get_current_membership_for_user`), so renaming an org can move the payer. The
funded-subject guard narrows this, but
`test_multi_org_membership_picks_the_first_org_by_name` now pins the choice, and
the docstring records that the instability is inherited from the compute
attribution path rather than introduced here.

### Also

`scripts/max_lines_allowlist.txt`: `test_agent_gateway_api.py` bumped 654 → 665
— this branch already exceeded its entry (a CI red independent of the review
fixes).

### Rebase note (A4)

This branch does not contain `origin/agents/a4-fail-closed` (different stack).
None of these fixes touch `materialize/agent_auth.py`, so the A4 semantics
(pre-seeded `by_harness` dict, narrowed state-file delete, tripwire test) are
untouched here; reconciliation happens at merge time under A4's tripwire.

### Verification after the fixes

- `DEBUG=true uv run pytest tests/unit tests/integration -q -k "agent_gateway or agent_auth or billing_limit_enforcement_llm or litellm or materializ"`
  → **324 passed**, 0 failed.
- `uv run ruff check` + `ruff format --check` clean across `proliferate` and
  `tests`.
- `scripts/check_max_lines.py`, `check_migration_heads.py`,
  `check_server_boundaries.py`, `check_docs.py` all pass.
- `uv run mypy` on touched modules: no new errors (the one `service.py`
  entitlement-overload finding is pre-existing, confirmed on the pristine tree).
