### PR TITLE
feat(agents): auto-install the supported set at startup (A6)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -207,6 +207,10 @@ impl AppState {
             agent_reconcile_service.clone(),
             agent_seed_store.clone(),
             AgentCatalogService::new(catalog_sync_service.clone()),
+            // Read once, here: the auto-install pass needs the surface for the
+            // cursor-in-cloud carve-out, and reading it at the decision point
+            // would put a process-global read inside the reconcile loop.
+            crate::domains::agents::runtime::RuntimeSurface::from_env(),
         ));
         // Gateway model resolver (spec §2/§3): catalog gatewayPolicy + the
         // sqlite probe store -> the render plane's GatewayModelPlan.

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install.rs
@@ -1,0 +1,113 @@
+//! Should this reconcile pass install this agent? The pure decision.
+//!
+//! agent-distribution.md, "Installation":
+//!
+//! > Installation is automatic. Every harness supported on a surface converges
+//! > with no user action: absent means install, drifted means reinstall, and both
+//! > are the same mechanism… A user authenticates harnesses; they never install
+//! > them. Two carve-outs:
+//! >
+//! > - An agent the user already provides on PATH is left alone: it is usable
+//! >   through readiness as-is, and a managed install would shadow their copy.
+//! > - Cursor never installs in cloud. It is login-only with no headless
+//! >   credential path, so a cloud install could never reach `Ready`.
+//!
+//! The carve-outs used to be implicit in `installed_only`: because that scope
+//! skipped every agent that was not already managed-installed, it skipped
+//! PATH-provided agents *as a side effect* of skipping absent ones. Dropping the
+//! flag to get auto-install would therefore have silently dropped the PATH
+//! protection too — a managed install would land on top of a user's own binary.
+//!
+//! So the carve-outs move here, as one decision function with a name, per the
+//! plan's requirement that auto-install ride "behind an explicit tested
+//! predicate". A pure fn over facts the caller gathers: no IO, no env reads.
+
+use crate::domains::agents::model::AgentKind;
+use crate::domains::agents::runtime::RuntimeSurface;
+
+/// Whether an artifact the runtime can see is the USER's (on PATH) or OURS
+/// (managed, installed under the runtime home).
+///
+/// `"path"` is the source string `readiness` stamps on a PATH-resolved artifact;
+/// `"managed"` is what the installer stamps. Anything else (an override, an
+/// unknown future source) is treated as not-ours-and-not-PATH: we neither claim
+/// it nor protect it, and the drift planner's own idempotent checks govern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentInstallFacts {
+    /// Any artifact for this agent resolves to a binary on the user's PATH.
+    pub has_path_artifact: bool,
+    /// Any artifact for this agent is managed-installed under the runtime home.
+    pub has_managed_artifact: bool,
+}
+
+/// Why a pass is not installing an agent — carried so the reconcile result's
+/// `Skipped` message names the actual reason instead of one generic string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoInstallSkip {
+    /// The user provides this agent on PATH. A managed install would shadow
+    /// their copy, and readiness already reports it usable.
+    UserProvidedOnPath,
+    /// Cursor in cloud: login-only, no headless credential path, so an install
+    /// could never reach `Ready`.
+    CursorUnsupportedInCloud,
+    /// An installed-only pass (the settings pane's "update installed agents"
+    /// action) deliberately touching only what we already manage.
+    NotManagedInInstalledOnlyPass,
+}
+
+impl AutoInstallSkip {
+    /// The message surfaced on the reconcile result. Stable strings: the Tier-3
+    /// agent-lifecycle scenario asserts on the PATH one.
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::UserProvidedOnPath => {
+                "provided by the user on PATH; a managed install would shadow it"
+            }
+            Self::CursorUnsupportedInCloud => {
+                "cursor is login-only and cannot reach Ready in cloud; not installed"
+            }
+            Self::NotManagedInInstalledOnlyPass => {
+                "not managed-installed; this pass only updates managed installs"
+            }
+        }
+    }
+}
+
+/// The decision. `Ok(())` means "reconcile this agent" (the drift planner then
+/// decides whether any actual work is needed); `Err(skip)` means leave it alone.
+///
+/// Ordering is deliberate. The PATH check comes FIRST, before the surface and
+/// scope checks, because it is the one carve-out that protects something the user
+/// owns: no combination of scope or surface may ever result in a managed install
+/// landing on top of their binary.
+pub fn auto_install_decision(
+    kind: &AgentKind,
+    surface: RuntimeSurface,
+    installed_only: bool,
+    facts: AgentInstallFacts,
+) -> Result<(), AutoInstallSkip> {
+    // 1. The user's own binary is never touched — highest precedence.
+    //
+    // `has_managed_artifact` wins over `has_path_artifact` when both are true:
+    // that is a machine where we already installed a managed copy AND the user
+    // has one on PATH, so the managed copy is ours to keep converging. Skipping
+    // it would strand it at an old pin forever.
+    if facts.has_path_artifact && !facts.has_managed_artifact {
+        return Err(AutoInstallSkip::UserProvidedOnPath);
+    }
+    // 2. Cursor in cloud could never reach Ready, so installing it is pure cost.
+    if *kind == AgentKind::Cursor && surface == RuntimeSurface::Cloud {
+        return Err(AutoInstallSkip::CursorUnsupportedInCloud);
+    }
+    // 3. An explicitly installed-only pass updates what we manage and nothing
+    //    else. This is no longer the startup pass — it is the scoped action a
+    //    user triggers from settings.
+    if installed_only && !facts.has_managed_artifact {
+        return Err(AutoInstallSkip::NotManagedInInstalledOnlyPass);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "auto_install_tests.rs"]
+mod tests;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install.rs
@@ -25,13 +25,14 @@
 use crate::domains::agents::model::AgentKind;
 use crate::domains::agents::runtime::RuntimeSurface;
 
-/// Whether an artifact the runtime can see is the USER's (on PATH) or OURS
-/// (managed, installed under the runtime home).
+/// The two facts about an agent's present artifacts that the decision needs:
+/// whether one is the USER's (on PATH) or OURS (managed, under the runtime home).
 ///
-/// `"path"` is the source string `readiness` stamps on a PATH-resolved artifact;
-/// `"managed"` is what the installer stamps. Anything else (an override, an
-/// unknown future source) is treated as not-ours-and-not-PATH: we neither claim
-/// it nor protect it, and the drift planner's own idempotent checks govern.
+/// Gathered by the caller so this module stays pure. `"path"` is the source
+/// string `readiness` stamps on a PATH-resolved artifact and `"managed"` is what
+/// the installer stamps; anything else (an override, an unknown future source) is
+/// neither, so we make no claim on it — the drift planner's own idempotent checks
+/// govern that case.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AgentInstallFacts {
     /// Any artifact for this agent resolves to a binary on the user's PATH.
@@ -40,8 +41,12 @@ pub struct AgentInstallFacts {
     pub has_managed_artifact: bool,
 }
 
-/// Why a pass is not installing an agent — carried so the reconcile result's
-/// `Skipped` message names the actual reason instead of one generic string.
+/// Why a pass is not installing an agent.
+///
+/// An enum rather than a bool-plus-string so the reconcile result's `Skipped`
+/// message names the ACTUAL reason: "you provide this on PATH" and "cursor cannot
+/// work in cloud" are different answers for the user, and the old
+/// `installed_only` boolean collapsed both into one generic skip.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AutoInstallSkip {
     /// The user provides this agent on PATH. A managed install would shadow

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install_tests.rs
@@ -1,0 +1,203 @@
+//! The auto-install decision matrix. Pure inputs, so this enumerates the whole
+//! product rather than the cells that happened to bite us — and the PATH column
+//! is the one that had ZERO coverage before, because the protection used to be an
+//! accident of `installed_only`'s scope rather than a rule.
+
+use super::*;
+use crate::domains::agents::model::AgentKind;
+use crate::domains::agents::runtime::RuntimeSurface;
+
+fn facts(has_path_artifact: bool, has_managed_artifact: bool) -> AgentInstallFacts {
+    AgentInstallFacts {
+        has_path_artifact,
+        has_managed_artifact,
+    }
+}
+
+const ABSENT: AgentInstallFacts = AgentInstallFacts {
+    has_path_artifact: false,
+    has_managed_artifact: false,
+};
+const PATH_ONLY: AgentInstallFacts = AgentInstallFacts {
+    has_path_artifact: true,
+    has_managed_artifact: false,
+};
+const MANAGED_ONLY: AgentInstallFacts = AgentInstallFacts {
+    has_path_artifact: false,
+    has_managed_artifact: true,
+};
+const BOTH: AgentInstallFacts = AgentInstallFacts {
+    has_path_artifact: true,
+    has_managed_artifact: true,
+};
+
+/// The law: an absent supported agent installs, on every surface, with no user
+/// action. This is what `installed_only` used to forbid — an absent opencode or
+/// grok stayed `InstallRequired` until someone clicked install, and session
+/// create then rejected the harness rather than converging it.
+#[test]
+fn an_absent_agent_auto_installs_on_a_full_pass() {
+    for surface in [RuntimeSurface::Local, RuntimeSurface::Cloud] {
+        for kind in [
+            AgentKind::Claude,
+            AgentKind::Codex,
+            AgentKind::OpenCode,
+            AgentKind::Grok,
+        ] {
+            assert_eq!(
+                auto_install_decision(&kind, surface, false, ABSENT),
+                Ok(()),
+                "{kind:?} on {surface:?} must auto-install when absent"
+            );
+        }
+    }
+}
+
+/// THE carve-out with no prior coverage: a user's own binary on PATH is never
+/// clobbered, on any surface, in any scope. A managed install would shadow their
+/// copy, and readiness already reports it usable.
+#[test]
+fn a_path_provided_agent_is_never_clobbered() {
+    for surface in [RuntimeSurface::Local, RuntimeSurface::Cloud] {
+        for installed_only in [true, false] {
+            for kind in [
+                AgentKind::Claude,
+                AgentKind::Codex,
+                AgentKind::OpenCode,
+                AgentKind::Grok,
+                AgentKind::Cursor,
+            ] {
+                assert_eq!(
+                    auto_install_decision(&kind, surface, installed_only, PATH_ONLY),
+                    Err(AutoInstallSkip::UserProvidedOnPath),
+                    "{kind:?} on {surface:?} (installed_only={installed_only}) must be skipped"
+                );
+            }
+        }
+    }
+}
+
+/// PATH protection outranks every other rule — asserted as precedence, because
+/// an ordering regression here is the one that silently overwrites a user's
+/// binary. Cursor-in-cloud on PATH must report the PATH reason, not the cursor
+/// one: both would skip, but only one of them is about protecting the user.
+#[test]
+fn path_protection_outranks_the_cursor_and_scope_rules() {
+    assert_eq!(
+        auto_install_decision(&AgentKind::Cursor, RuntimeSurface::Cloud, true, PATH_ONLY),
+        Err(AutoInstallSkip::UserProvidedOnPath)
+    );
+}
+
+/// A machine with BOTH a managed copy and a PATH copy keeps converging the
+/// managed one. Skipping it would strand our own install at an old pin forever,
+/// and we are not shadowing anything the user owns — we already installed
+/// alongside it.
+#[test]
+fn a_managed_copy_keeps_converging_even_beside_a_path_copy() {
+    for installed_only in [true, false] {
+        assert_eq!(
+            auto_install_decision(
+                &AgentKind::Codex,
+                RuntimeSurface::Local,
+                installed_only,
+                BOTH
+            ),
+            Ok(())
+        );
+    }
+}
+
+/// Cursor in cloud: login-only, no headless credential path, so an install could
+/// never reach `Ready` and doing it is pure download cost.
+#[test]
+fn cursor_does_not_install_in_cloud_but_does_locally() {
+    assert_eq!(
+        auto_install_decision(&AgentKind::Cursor, RuntimeSurface::Cloud, false, ABSENT),
+        Err(AutoInstallSkip::CursorUnsupportedInCloud)
+    );
+    assert_eq!(
+        auto_install_decision(&AgentKind::Cursor, RuntimeSurface::Local, false, ABSENT),
+        Ok(()),
+        "cursor auto-installs locally — the carve-out is cloud-only"
+    );
+}
+
+/// The cloud carve-out is cursor-specific: no other harness is suppressed there.
+#[test]
+fn no_other_harness_is_suppressed_in_cloud() {
+    for kind in [
+        AgentKind::Claude,
+        AgentKind::Codex,
+        AgentKind::OpenCode,
+        AgentKind::Grok,
+    ] {
+        assert_eq!(
+            auto_install_decision(&kind, RuntimeSurface::Cloud, false, ABSENT),
+            Ok(()),
+            "{kind:?} must still auto-install in cloud"
+        );
+    }
+}
+
+/// `installed_only` survives as the SCOPED action (settings' "update installed
+/// agents"), and there it still means what it says: touch what we manage, skip
+/// what we do not. It is simply no longer what the startup pass uses.
+#[test]
+fn an_installed_only_pass_still_updates_only_managed_installs() {
+    assert_eq!(
+        auto_install_decision(&AgentKind::OpenCode, RuntimeSurface::Local, true, ABSENT),
+        Err(AutoInstallSkip::NotManagedInInstalledOnlyPass)
+    );
+    assert_eq!(
+        auto_install_decision(
+            &AgentKind::OpenCode,
+            RuntimeSurface::Local,
+            true,
+            MANAGED_ONLY
+        ),
+        Ok(())
+    );
+}
+
+/// A managed-installed agent converges in both scopes — the drift planner, not
+/// this predicate, then decides whether any work is actually needed.
+#[test]
+fn a_managed_agent_converges_in_either_scope() {
+    for installed_only in [true, false] {
+        assert_eq!(
+            auto_install_decision(
+                &AgentKind::Claude,
+                RuntimeSurface::Local,
+                installed_only,
+                MANAGED_ONLY
+            ),
+            Ok(())
+        );
+    }
+}
+
+/// Skip messages are distinct and non-empty: the Tier-3 agent-lifecycle scenario
+/// asserts on the PATH message, so it is a contract rather than a log string.
+#[test]
+fn every_skip_reason_has_a_distinct_message() {
+    let messages = [
+        AutoInstallSkip::UserProvidedOnPath.message(),
+        AutoInstallSkip::CursorUnsupportedInCloud.message(),
+        AutoInstallSkip::NotManagedInInstalledOnlyPass.message(),
+    ];
+    let distinct: std::collections::BTreeSet<_> = messages.iter().collect();
+    assert_eq!(distinct.len(), messages.len());
+    assert!(messages.iter().all(|message| !message.is_empty()));
+    assert!(AutoInstallSkip::UserProvidedOnPath.message().contains("PATH"));
+}
+
+/// Sanity: the `facts` helper and the consts agree, so a future reader editing
+/// one cannot silently desync the matrix above.
+#[test]
+fn fact_constants_match_their_constructor() {
+    assert_eq!(facts(false, false), ABSENT);
+    assert_eq!(facts(true, false), PATH_ONLY);
+    assert_eq!(facts(false, true), MANAGED_ONLY);
+    assert_eq!(facts(true, true), BOTH);
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
@@ -1,4 +1,5 @@
 mod agent_process;
+pub mod auto_install;
 mod downloads;
 pub mod install_policy;
 mod lock;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution.rs
@@ -10,10 +10,14 @@ use crate::domains::agents::catalog::service::{ActiveCatalog, AgentCatalogServic
 use crate::domains::agents::installer::progress::{
     InstallProgressPhase, InstallProgressReporter, InstallProgressUpdate,
 };
+use crate::domains::agents::installer::auto_install::{
+    auto_install_decision, AgentInstallFacts,
+};
 use crate::domains::agents::installer::seed::AgentSeedStore;
 use crate::domains::agents::installer::InstallOptions;
 use crate::domains::agents::model::{AgentDescriptor, AgentKind, ArtifactRole, ResolvedArtifact};
 use crate::domains::agents::readiness::service::resolve_agent_unrouted;
+use crate::domains::agents::runtime::RuntimeSurface;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentReconcileJobStatus {
@@ -127,6 +131,7 @@ impl AgentReconcileService {
         requested_agent_kinds: Vec<AgentKind>,
         agent_seed_store: Option<AgentSeedStore>,
         catalog: Option<AgentCatalogService>,
+        surface: RuntimeSurface,
         admission: AgentReconcileAdmission,
     ) -> Result<AgentReconcileJobSnapshot, AgentReconcileStartError> {
         let (snapshot, progress) = {
@@ -209,6 +214,7 @@ impl AgentReconcileService {
                 runtime_home,
                 reinstall,
                 installed_only,
+                surface,
                 progress,
                 agent_seed_store,
             )
@@ -245,6 +251,7 @@ async fn run_reconcile_job(
     runtime_home: PathBuf,
     reinstall: bool,
     installed_only: bool,
+    surface: RuntimeSurface,
     progress: Arc<std::sync::Mutex<Vec<AgentInstallComponentProgress>>>,
     agent_seed_store: Option<AgentSeedStore>,
 ) {
@@ -295,29 +302,45 @@ async fn run_reconcile_job(
         let agent_progress = progress.clone();
         let progress_kind = kind.clone();
         let result = match tokio::task::spawn_blocking(move || {
-            // installed-only scope (startup pass): only reconcile agents WE manage
-            // in runtime_home — update those to the catalog pins. Skip agents that
-            // are absent or only present via PATH (source != "managed"); a managed
-            // install over a PATH-provided agent would fail, and missing agents
-            // install on demand at session start. Resolution is side-effect-free,
-            // and unrouted because this reads ARTIFACTS only — an enrolled
-            // agent-auth route cannot change whether a binary is managed-installed,
-            // so consulting it would be a state-file read per agent per pass for no
-            // effect on the decision.
-            if installed_only {
-                let is_managed = |artifact: &ResolvedArtifact| {
-                    artifact.installed && artifact.source.as_deref() == Some("managed")
+            // Should this pass touch this agent at all? Two carve-outs (a user's
+            // own PATH binary, cursor in cloud) plus the installed-only scope,
+            // decided by one named predicate rather than inferred from a boolean —
+            // see `installer::auto_install` for why that distinction matters.
+            //
+            // Resolution is side-effect-free, and unrouted because this reads
+            // ARTIFACTS only: an enrolled agent-auth route cannot change whether a
+            // binary is on PATH or managed-installed, so consulting it would be a
+            // state-file read per agent per pass with no effect on the decision.
+            {
+                let source_is = |artifact: &ResolvedArtifact, source: &str| {
+                    artifact.installed && artifact.source.as_deref() == Some(source)
                 };
                 let resolved = resolve_agent_unrouted(&descriptor, &agent_runtime_home);
-                let managed_installed = is_managed(&resolved.agent_process)
-                    || resolved.native.as_ref().map(is_managed).unwrap_or(false);
-                if !managed_installed {
+                let any_artifact_is = |source: &str| {
+                    source_is(&resolved.agent_process, source)
+                        || resolved
+                            .native
+                            .as_ref()
+                            .is_some_and(|native| source_is(native, source))
+                };
+                let facts = AgentInstallFacts {
+                    has_path_artifact: any_artifact_is("path"),
+                    has_managed_artifact: any_artifact_is("managed"),
+                };
+                if let Err(skip) =
+                    auto_install_decision(&descriptor.kind, surface, installed_only, facts)
+                {
+                    tracing::debug!(
+                        agent_kind = descriptor.kind.as_str(),
+                        ?surface,
+                        installed_only,
+                        reason = skip.message(),
+                        "reconcile skipping agent"
+                    );
                     return AgentReconcileResult {
                         kind: descriptor.kind.clone(),
                         outcome: AgentReconcileOutcome::Skipped,
-                        message: Some(
-                            "not managed-installed; installs on demand at session start".into(),
-                        ),
+                        message: Some(skip.message().to_string()),
                         installed_artifacts: vec![],
                     };
                 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs
@@ -487,3 +487,6 @@ async fn internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active
 
     let _ = std::fs::remove_dir_all(home);
 }
+
+#[path = "surface_threading_tests.rs"]
+mod surface_threading;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/execution_tests.rs
@@ -47,6 +47,7 @@ async fn compatible_admission_reuses_active_job() {
             Vec::new(),
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -88,6 +89,7 @@ async fn reinstall_request_is_rejected_while_non_reinstall_job_runs() {
             vec![AgentKind::Codex],
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -157,6 +159,7 @@ async fn empty_registry_job_completes() {
             Vec::new(),
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -194,6 +197,7 @@ async fn reconcile_job_remains_queued_while_another_disk_writer_runs() {
             vec![AgentKind::Codex],
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -238,6 +242,7 @@ async fn installed_only_skips_uninstalled_agents() {
             Vec::new(),
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -300,6 +305,7 @@ async fn full_reconcile_is_rejected_while_installed_only_job_runs() {
             Vec::new(),
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -347,6 +353,7 @@ async fn installed_only_reuses_in_flight_installed_only_job() {
             Vec::new(),
             None,
             None,
+            RuntimeSurface::Local,
             AgentReconcileAdmission::ReuseCompatible,
         )
         .await
@@ -383,6 +390,7 @@ async fn internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active
         service.clone(),
         AgentSeedStore::not_configured_dev(),
         catalog.clone(),
+        RuntimeSurface::Local,
     ));
     let active_pin = catalog
         .pin_overrides("codex")
@@ -421,6 +429,7 @@ async fn internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active
             Vec::new(),
             None,
             Some(catalog.clone()),
+            RuntimeSurface::Local,
             AgentReconcileAdmission::RequireIdle,
         )
         .await
@@ -429,7 +438,7 @@ async fn internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active
 
     let poke = tokio::spawn({
         let runtime = runtime.clone();
-        async move { runtime.reconcile_installed_when_idle().await }
+        async move { runtime.reconcile_when_idle().await }
     });
 
     drop(writer);
@@ -438,20 +447,31 @@ async fn internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active
         .expect("poke should admit a post-terminal pass")
         .expect("poke task should complete");
 
+    // A genuinely new job was admitted, at FULL scope, against the active
+    // catalog. We assert admission rather than completion: the startup poke is
+    // now a full-scope pass, so completing it would mean really downloading and
+    // installing every supported harness into this temp home — minutes of
+    // network work in a unit test. The install mechanics have their own coverage;
+    // what belongs here is that the poke survives a busy slot and admits the
+    // right SHAPE of job.
     let fresh = timeout(Duration::from_secs(3), async {
         loop {
             let snapshot = service.snapshot().await;
-            if snapshot.status == AgentReconcileJobStatus::Completed {
+            if snapshot.job_id.as_deref().is_some_and(|id| id != first_id) {
                 return snapshot;
             }
             sleep(Duration::from_millis(10)).await;
         }
     })
     .await
-    .expect("fresh active-catalog pass should complete");
+    .expect("the poke should admit a fresh post-terminal pass");
     assert_ne!(fresh.job_id.as_deref(), Some(first_id.as_str()));
-    assert!(fresh.installed_only);
-    assert!(fresh.agent_kinds.is_empty());
+    assert!(
+        !fresh.installed_only,
+        "the startup poke is FULL scope now (A6): an absent agent must install, \
+         not be skipped as 'installs on demand at session start'"
+    );
+    assert!(fresh.agent_kinds.is_empty(), "the pass covers every kind");
     let job = service.job.lock().await;
     let used_pins = job
         .as_ref()
@@ -463,6 +483,7 @@ async fn internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active
         used_pins.agent_process_source,
         Some(ResolvedPinSource::Npm { package, .. }) if package == active_package
     ));
+    drop(job);
 
     let _ = std::fs::remove_dir_all(home);
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/surface_threading_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/reconcile/surface_threading_tests.rs
@@ -1,0 +1,223 @@
+//! The `surface` argument's journey, end to end: `start_with_admission` →
+//! `run_reconcile_job` → `auto_install_decision`.
+//!
+//! Split from `execution_tests.rs` for the line-count ceiling; nested inside it so
+//! the service/registry/`RuntimeSurface` imports are in scope through
+//! `use super::*`.
+//!
+//! Both tests run a full-scope pass to COMPLETION with **no network**: a `None`
+//! catalog means no pin resolves, so the installer's `require_source` fence fails
+//! every agent deterministically before any download. That is what makes an
+//! end-to-end assertion affordable here — the poke test in the parent module
+//! deliberately stops at job registration for exactly this reason.
+
+use super::*;
+
+/// The surface threading, exercised END TO END rather than at the seam.
+///
+/// `start_with_admission` → `run_reconcile_job` → `auto_install_decision` is three
+/// hops of plumbing, and the poke test above deliberately stops at job
+/// REGISTRATION (completing a full-scope pass against the real catalog would
+/// download every harness). So nothing there proves the `surface` argument
+/// actually reaches the predicate, nor that a full-scope pass admits agents an
+/// installed-only pass would have skipped.
+///
+/// This runs a full-scope pass to COMPLETION with **no network**, by passing a
+/// `None` catalog: every agent then passes the predicate (admitted, not skipped)
+/// and fails at the installer's pin fence with a deterministic message. The
+/// admitted-then-failed pair is the assertion — it is the shape only a threaded
+/// surface plus a full scope can produce, and it is the exact inverse of
+/// `installed_only_skips_uninstalled_agents`, which shows the same `None`-catalog
+/// setup yielding `Skipped` for every agent.
+///
+/// A managed launcher is seeded for every agent first, and that is what makes the
+/// test hermetic rather than developer-machine-dependent. The PATH carve-out
+/// deliberately OUTRANKS scope and surface, so on a machine where claude/codex/
+/// cursor/grok are on PATH (i.e. any developer's) the pass would skip them as
+/// user-provided and prove nothing about scope. `has_managed_artifact` beats
+/// `has_path_artifact` by design — that precedence is itself the thing being
+/// relied on — so seeding managed artifacts removes the host dependency without
+/// touching process-global `PATH`, which other tests in this crate shell out
+/// through.
+#[tokio::test]
+async fn full_scope_pass_admits_every_absent_agent_instead_of_skipping_it() {
+    let service = AgentReconcileService::new();
+    let home = std::env::temp_dir().join(format!("anyharness-full-scope-{}", Uuid::new_v4()));
+    let registry = crate::domains::agents::registry::built_in_registry();
+    assert!(!registry.is_empty(), "built-in registry must have agents");
+    let registry_kinds: Vec<AgentKind> = registry
+        .iter()
+        .map(|descriptor| descriptor.kind.clone())
+        .collect();
+    seed_managed_launchers(&home, &registry_kinds);
+
+    service
+        .start_with_admission(
+            registry,
+            home.clone(),
+            false,
+            // FULL scope — the startup pass's shape after A6.
+            false,
+            Vec::new(),
+            None,
+            // No catalog: no pins resolve, so the installer fences every role
+            // before it can reach the network.
+            None,
+            // Local: cursor is NOT carved out here, so it must be admitted too.
+            RuntimeSurface::Local,
+            AgentReconcileAdmission::ReuseCompatible,
+        )
+        .await
+        .expect("start full-scope reconcile");
+
+    let completed = timeout(Duration::from_secs(20), async {
+        loop {
+            let snapshot = service.snapshot().await;
+            if snapshot.status == AgentReconcileJobStatus::Completed
+                || snapshot.status == AgentReconcileJobStatus::Failed
+            {
+                return snapshot;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("a pin-fenced full-scope pass must terminate without network installs");
+
+    let by_kind: Vec<(&str, AgentReconcileOutcome)> = completed
+        .results
+        .iter()
+        .map(|result| (result.kind.as_str(), result.outcome.clone()))
+        .collect();
+    assert_eq!(
+        completed.results.len(),
+        registry_kinds.len(),
+        "every registry agent must be reported on: {by_kind:?}"
+    );
+    for result in &completed.results {
+        // ADMITTED: the predicate said "reconcile this", so the pass reached the
+        // installer. A `Skipped` here would mean the full-scope pass is still
+        // behaving like an installed-only one.
+        assert_eq!(
+            result.outcome,
+            AgentReconcileOutcome::Failed,
+            "{} must be admitted by the predicate and then fail at the pin fence, \
+             not skipped; got {by_kind:?}",
+            result.kind.as_str()
+        );
+        let message = result
+            .message
+            .as_deref()
+            .unwrap_or_else(|| panic!("{} must carry a failure message", result.kind.as_str()));
+        assert!(
+            message.contains("has no resolved source pin in the catalog lockfile"),
+            "{}'s failure must be the deterministic pin fence (proving the pass got \
+             past the predicate and into the installer, offline), got {message:?}",
+            result.kind.as_str()
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// The same pass on the CLOUD surface skips exactly one agent — cursor — which is
+/// the only observable difference the threaded `surface` makes. Paired with the
+/// test above (same inputs, `RuntimeSurface::Local`, cursor admitted), this is a
+/// single-variable comparison: only the surface argument differs, so a surface
+/// that failed to reach the predicate could not produce both results.
+#[tokio::test]
+async fn the_cloud_surface_reaches_the_predicate_and_carves_out_only_cursor() {
+    let service = AgentReconcileService::new();
+    let home = std::env::temp_dir().join(format!("anyharness-cloud-scope-{}", Uuid::new_v4()));
+    let registry = crate::domains::agents::registry::built_in_registry();
+    let registry_kinds: Vec<AgentKind> = registry
+        .iter()
+        .map(|descriptor| descriptor.kind.clone())
+        .collect();
+    seed_managed_launchers(&home, &registry_kinds);
+
+    service
+        .start_with_admission(
+            crate::domains::agents::registry::built_in_registry(),
+            home.clone(),
+            false,
+            false,
+            Vec::new(),
+            None,
+            None,
+            RuntimeSurface::Cloud,
+            AgentReconcileAdmission::ReuseCompatible,
+        )
+        .await
+        .expect("start full-scope cloud reconcile");
+
+    let completed = timeout(Duration::from_secs(20), async {
+        loop {
+            let snapshot = service.snapshot().await;
+            if snapshot.status == AgentReconcileJobStatus::Completed
+                || snapshot.status == AgentReconcileJobStatus::Failed
+            {
+                return snapshot;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("a pin-fenced full-scope cloud pass must terminate without network installs");
+
+    let skipped: Vec<(&str, Option<&str>)> = completed
+        .results
+        .iter()
+        .filter(|result| result.outcome == AgentReconcileOutcome::Skipped)
+        .map(|result| (result.kind.as_str(), result.message.as_deref()))
+        .collect();
+    assert_eq!(
+        skipped.len(),
+        1,
+        "cursor must be the only cloud carve-out, got {skipped:?}"
+    );
+    assert_eq!(skipped[0].0, AgentKind::Cursor.as_str());
+    assert_eq!(
+        skipped[0].1,
+        Some(
+            crate::domains::agents::installer::auto_install::AutoInstallSkip::CursorUnsupportedInCloud
+                .message()
+        ),
+        "the skip must carry the named reason, not a generic one"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// Seed managed artifacts for every agent, so `has_managed_artifact` is true and
+/// the PATH carve-out — which outranks everything else in the predicate — cannot
+/// fire for an agent the host happens to have on PATH.
+///
+/// Both roles are seeded: `<kind>-launcher` under `agent_process` (the name
+/// `managed_launcher_candidates` looks for) and `<kind>` under `native` (what
+/// `resolve_native_artifact` checks before falling back to PATH). Claude and codex
+/// need the native one — that is the artifact a developer machine resolves from
+/// PATH.
+///
+/// A filesystem-only fixture on purpose: readiness stamps what it finds under the
+/// runtime home `"managed"`, so no process-global state is touched. Narrowing
+/// `PATH` instead would break every other test in this crate that shells out to
+/// `git`/`npm`.
+fn seed_managed_launchers(runtime_home: &std::path::Path, kinds: &[AgentKind]) {
+    let write_executable = |path: &std::path::Path| {
+        std::fs::create_dir_all(path.parent().expect("artifact parent"))
+            .expect("create managed artifact dir");
+        std::fs::write(path, "#!/bin/sh\nexit 0\n").expect("write managed artifact");
+        crate::integrations::agent_cli::executable::make_executable(path)
+            .expect("make managed artifact executable");
+    };
+    for kind in kinds {
+        let agent_dir = runtime_home.join("agents").join(kind.as_str());
+        write_executable(
+            &agent_dir
+                .join("agent_process")
+                .join(format!("{}-launcher", kind.as_str())),
+        );
+        write_executable(&agent_dir.join("native").join(kind.as_str()));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
@@ -322,7 +322,7 @@ impl AgentRuntime {
     /// converging it.
     ///
     /// The two carve-outs the law names are NOT dropped with the flag; they move
-    /// into `auto_install_decision` (installer/install_policy.rs) where they are a
+    /// into `auto_install_decision` (installer/auto_install.rs) where they are a
     /// tested predicate rather than a side effect of a boolean.
     pub async fn reconcile_when_idle(&self) {
         loop {
@@ -376,10 +376,6 @@ impl AgentRuntime {
             }
             self.reconcile_when_idle().await;
         });
-    }
-
-    pub(crate) fn surface(&self) -> RuntimeSurface {
-        self.surface
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs
@@ -22,6 +22,42 @@ pub struct AgentRuntime {
     reconcile_service: Arc<AgentReconcileService>,
     seed_store: AgentSeedStore,
     catalog_service: super::catalog::service::AgentCatalogService,
+    surface: RuntimeSurface,
+}
+
+/// Which surface this runtime is serving. The auto-install pass needs it for
+/// exactly one carve-out (agent-distribution.md, "Installation"):
+///
+/// > Cursor never installs in cloud. It is login-only with no headless credential
+/// > path, so a cloud install could never reach `Ready`.
+///
+/// It is a constructor argument rather than an env read at the point of use so the
+/// decision is a pure, testable function of its inputs — the alternative would put
+/// a process-global read inside the reconcile loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RuntimeSurface {
+    /// Desktop sidecar or a developer's local `anyharness serve`. Every supported
+    /// harness may auto-install.
+    #[default]
+    Local,
+    /// A cloud sandbox. Cursor is excluded (see above); everything else installs.
+    Cloud,
+}
+
+/// The env var the cloud sandbox bootstrap sets to declare its surface
+/// (`server/proliferate/server/cloud/runtime/bootstrap.py`). Absent means local,
+/// which is the safe default: it can only ever ENABLE a cursor auto-install that
+/// then fails to reach `Ready`, never suppress an install a surface needs.
+pub const ANYHARNESS_RUNTIME_SURFACE_ENV: &str = "ANYHARNESS_RUNTIME_SURFACE";
+
+impl RuntimeSurface {
+    /// Read the surface from the process env once, at wiring time.
+    pub fn from_env() -> Self {
+        match std::env::var(ANYHARNESS_RUNTIME_SURFACE_ENV) {
+            Ok(value) if value.trim().eq_ignore_ascii_case("cloud") => Self::Cloud,
+            _ => Self::Local,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -88,12 +124,14 @@ impl AgentRuntime {
         reconcile_service: Arc<AgentReconcileService>,
         seed_store: AgentSeedStore,
         catalog_service: super::catalog::service::AgentCatalogService,
+        surface: RuntimeSurface,
     ) -> Self {
         Self {
             runtime_home,
             reconcile_service,
             seed_store,
             catalog_service,
+            surface,
         }
     }
 
@@ -263,6 +301,7 @@ impl AgentRuntime {
                 requested_agent_kinds,
                 Some(self.seed_store.clone()),
                 Some(self.catalog_service.clone()),
+                self.surface,
                 AgentReconcileAdmission::ReuseCompatible,
             )
             .await?)
@@ -270,9 +309,22 @@ impl AgentRuntime {
 
     /// Internal startup/catalog pokes must not disappear merely because a
     /// foreground scoped update owns the one observable reconcile slot. Wait
-    /// for that job to settle, then atomically admit a fresh installed-only
-    /// pass against the latest catalog. HTTP callers retain compatible reuse.
-    pub async fn reconcile_installed_when_idle(&self) {
+    /// for that job to settle, then atomically admit a fresh pass against the
+    /// latest catalog. HTTP callers retain compatible reuse.
+    ///
+    /// The pass is **full scope**, not installed-only. agent-distribution.md,
+    /// "Installation": *"Installation is automatic. Every harness supported on a
+    /// surface converges with no user action: absent means install, drifted means
+    /// reinstall, and both are the same mechanism… A user authenticates harnesses;
+    /// they never install them."* With `installed_only`, an absent opencode or
+    /// grok was explicitly `Skipped` and stayed `InstallRequired` until a user
+    /// clicked install — and session create then rejected the harness rather than
+    /// converging it.
+    ///
+    /// The two carve-outs the law names are NOT dropped with the flag; they move
+    /// into `auto_install_decision` (installer/install_policy.rs) where they are a
+    /// tested predicate rather than a side effect of a boolean.
+    pub async fn reconcile_when_idle(&self) {
         loop {
             let result = self
                 .reconcile_service
@@ -280,10 +332,12 @@ impl AgentRuntime {
                     built_in_registry(),
                     self.runtime_home.clone(),
                     false,
-                    true,
+                    // Full scope: install what is absent, reinstall what drifted.
+                    false,
                     Vec::new(),
                     Some(self.seed_store.clone()),
                     Some(self.catalog_service.clone()),
+                    self.surface,
                     AgentReconcileAdmission::RequireIdle,
                 )
                 .await;
@@ -292,7 +346,7 @@ impl AgentRuntime {
                 Err(AgentReconcileStartError::Busy(job_id)) => {
                     tracing::debug!(
                         active_job_id = %job_id,
-                        "installed-only reconcile poke waiting for active job"
+                        "internal reconcile poke waiting for active job"
                     );
                     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                 }
@@ -301,12 +355,15 @@ impl AgentRuntime {
     }
 
     /// Runtime startup pass (desktop sidecar AND cloud workers): hydrate the
-    /// bundled agent seed if it hasn't been laid down yet, then run an
-    /// installed-only reconcile so already-installed agents track the catalog
-    /// pins. Non-blocking (boots the HTTP server immediately), best-effort
-    /// (failures are recorded in the seed/reconcile snapshots, never fatal),
-    /// and idempotent: missing non-seeded agents install on demand at session
-    /// start, and an up-to-date machine does no work.
+    /// bundled agent seed if it hasn't been laid down yet, then reconcile the
+    /// full supported set to the catalog's pins — installing what is absent and
+    /// reinstalling what drifted.
+    ///
+    /// Non-blocking (boots the HTTP server immediately), best-effort (failures
+    /// are recorded in the seed/reconcile snapshots, never fatal), and
+    /// idempotent: an up-to-date machine does no work. Seed hydration still runs
+    /// first, so seeded agents are already present and the pass is a no-op for
+    /// them rather than a redundant download.
     pub fn spawn_startup_pass(self: Arc<Self>) {
         tokio::spawn(async move {
             if self.seed_store.hydration_pending() {
@@ -317,8 +374,12 @@ impl AgentRuntime {
                 })
                 .await;
             }
-            self.reconcile_installed_when_idle().await;
+            self.reconcile_when_idle().await;
         });
+    }
+
+    pub(crate) fn surface(&self) -> RuntimeSurface {
+        self.surface
     }
 }
 

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -63,7 +63,7 @@ apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 6
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts 648 existing desktop oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 anyharness/crates/anyharness-lib/src/api/router.rs 631 AnyHarness router (+goals/loops/activity/feed routes, +gateway catalog version route, +workflow-runs/cancel + local materialization operations + workflow-run-workspaces routes + worktree restore route)
-anyharness/crates/anyharness-lib/src/app/mod.rs 638 AnyHarness app wiring (+session mutation admission purge/retention wiring, +goal/loop/activity/feed services, +two-phase workflow-run and workflow-workspace wiring, +local materialization service wiring + worktree restore runtime wiring)
+anyharness/crates/anyharness-lib/src/app/mod.rs 642 AnyHarness app wiring (+session mutation admission purge/retention wiring, +goal/loop/activity/feed services, +two-phase workflow-run and workflow-workspace wiring, +local materialization service wiring + worktree restore runtime wiring)
 anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 867 loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam)
 anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs 642 session startup (+goal/loop capability parsing, roster reconcile-on-attach)
 server/tests/integration/test_organizations_api.py 624 added admin-only coverage for GET .../invitations

--- a/server/proliferate/server/cloud/runtime/bootstrap.py
+++ b/server/proliferate/server/cloud/runtime/bootstrap.py
@@ -14,6 +14,8 @@ from proliferate.server.version import runtime_version_pin
 from proliferate.utils.telemetry_mode import is_vendor_telemetry_enabled
 
 _ANYHARNESS_DEFER_STARTUP_RETENTION_ENV = "ANYHARNESS_DEFER_STARTUP_RETENTION"
+# Consumed by `RuntimeSurface::from_env` (anyharness-lib domains/agents/runtime.rs).
+_ANYHARNESS_RUNTIME_SURFACE_ENV = "ANYHARNESS_RUNTIME_SURFACE"
 
 
 def _runtime_sentry_dsn() -> str:
@@ -104,6 +106,13 @@ def build_runtime_env(
     env: dict[str, str] = {
         "ANYHARNESS_DEV_CORS": "1",
         _ANYHARNESS_DEFER_STARTUP_RETENTION_ENV: "1",
+        # Declare the surface so the runtime's auto-install startup pass can apply
+        # the one surface-dependent carve-out: cursor never installs in cloud
+        # (login-only, no headless credential path, so it could never reach
+        # `Ready` — agent-distribution.md, "Installation"). Absent means local,
+        # which is the safe default: it can only ever enable a cursor install that
+        # then fails to become Ready, never suppress an install a surface needs.
+        _ANYHARNESS_RUNTIME_SURFACE_ENV: "cloud",
     }
     if is_vendor_telemetry_enabled() and _runtime_sentry_dsn():
         env["ANYHARNESS_SENTRY_DSN"] = _runtime_sentry_dsn()

--- a/server/tests/unit/test_runtime_version_pin.py
+++ b/server/tests/unit/test_runtime_version_pin.py
@@ -45,6 +45,14 @@ class TestRuntimeLaunchEnvExport:
         assert env["ANYHARNESS_RUNTIME_TARGET_ID"] == str(target_id)
         assert env["PROLIFERATE_SANDBOX_ID"] == "e2b-provider-sandbox"
 
+    def test_declares_the_cloud_surface_for_the_auto_install_carve_out(self) -> None:
+        # The runtime's auto-install startup pass needs the surface for exactly one
+        # carve-out: cursor never installs in cloud (login-only, no headless
+        # credential path, so it could never reach `Ready`). Consumed by
+        # `RuntimeSurface::from_env` in anyharness-lib.
+        env = build_runtime_env("tok", anyharness_data_key="key")
+        assert env["ANYHARNESS_RUNTIME_SURFACE"] == "cloud"
+
     def test_exports_pin_when_stamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("RUNTIME_VERSION", "3.4.5")
         env = build_runtime_env("tok", anyharness_data_key="key")

--- a/specs/codebase/platforms/product/agent-distribution.md
+++ b/specs/codebase/platforms/product/agent-distribution.md
@@ -134,7 +134,12 @@ triggered by the startup pass on every runtime boot
 walks the supported set and installs whatever the drift planner
 ([`installer/install_policy.rs`](../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/install_policy.rs))
 says is absent or stale. A user
-authenticates harnesses; they never install them. Completed installs
+authenticates harnesses; they never install them. The two carve-outs below
+are one named predicate
+([`installer/auto_install.rs`](../../../../anyharness/crates/anyharness-lib/src/domains/agents/installer/auto_install.rs)),
+deliberately not a side effect of the pass's scope: PATH protection must
+outrank every other rule, so it cannot be something a scope change can
+silently remove. Completed installs
 poke the model-snapshot reconciler ([model-catalog.md](model-catalog.md))
 so a newly converged harness re-probes its models without extra wiring.
 Two carve-outs:
@@ -433,14 +438,6 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       that migrates legacy sandboxes. All of it — plus the
       `PROLIFERATE_SUPERVISOR_OWNED_RUNTIME` gate itself — deletes once
       the fleet is fully supervisor-owned.
-- [ ] Installs are not yet automatic: the startup pass runs an
-      `installed_only` reconcile (`reconcile_installed_when_idle` in
-      [`runtime.rs`](../../../../anyharness/crates/anyharness-lib/src/domains/agents/runtime.rs)
-      hardcodes it), so an absent opencode/grok stays `InstallRequired`
-      until a user clicks install, and session creation rejects a
-      non-`Ready` harness rather than converging it. The auto-install
-      law above (full supported set, PATH and cloud-cursor carve-outs)
-      is not yet implemented.
 - [ ] The `Ready` gate still runs only in `create_session`: resume and
       fork live-starts spawn without re-checking, so credentials revoked
       after a session exists fail downstream at spawn instead of with


### PR DESCRIPTION
Track A, PR 6 — Round 2. **Stacked on #1513** (`agents/a5-codex-config`); retarget as parents merge. The diff below is A6's own commit only.

## The law this implements

`specs/codebase/platforms/product/agent-distribution.md`, "Installation":

> Installation is automatic. Every harness supported on a surface converges with no user action: absent means install, drifted means reinstall, and both are the same mechanism — the reconcile job, triggered by the startup pass on every runtime boot… **A user authenticates harnesses; they never install them.** Two carve-outs:
> - An agent the user already provides on PATH is left alone: it is usable through readiness as-is, and a managed install would shadow their copy.
> - Cursor never installs in cloud. It is login-only with no headless credential path, so a cloud install could never reach `Ready`.

## Gap bullet closed (deleted in this PR)

> Installs are not yet automatic: the startup pass runs an `installed_only` reconcile (`reconcile_installed_when_idle` hardcodes it), so an absent opencode/grok stays `InstallRequired` until a user clicks install, and session creation rejects a non-`Ready` harness rather than converging it. The auto-install law above (full supported set, PATH and cloud-cursor carve-outs) is not yet implemented.

## Why the flag could not just be dropped

This is the part worth reviewing carefully. `installed_only` skipped every agent that was not already managed-installed — which means it skipped **PATH-provided agents as a side effect** of skipping absent ones:

```rust
// before: one boolean doing two unrelated jobs
if installed_only {
    let managed_installed = /* agent_process or native is source=="managed" */;
    if !managed_installed { return Skipped("installs on demand at session start"); }
}
```

Dropping the flag to get auto-install would therefore have **silently dropped the PATH protection**, and a managed install would land on top of a user's own binary. The plan's requirement that auto-install ride "behind an explicit tested predicate" is exactly this hazard.

So the carve-outs move into `installer::auto_install::auto_install_decision` — a pure fn over facts the caller gathers, no IO and no env reads:

```rust
pub fn auto_install_decision(
    kind: &AgentKind, surface: RuntimeSurface, installed_only: bool, facts: AgentInstallFacts,
) -> Result<(), AutoInstallSkip>
```

**Ordering is deliberate and asserted.** PATH is checked FIRST, ahead of the surface and scope rules, because it is the one carve-out protecting something the user owns: no combination of scope or surface may result in clobbering it. `path_protection_outranks_the_cursor_and_scope_rules` pins that a cursor-in-cloud agent on PATH reports the **PATH** reason — both would skip, but only one of them is about protecting the user, and an ordering regression here is the one that silently overwrites their binary.

**One deliberate asymmetry:** a machine with both a managed copy and a PATH copy keeps converging the **managed** one. Skipping it would strand our own install at an old pin forever, and we are not shadowing anything — we already installed alongside it.

## The surface signal

Cursor-in-cloud needs to know the surface. `RuntimeSurface` is a **constructor argument** on `AgentRuntime`, read from env once at wiring (`app/mod.rs`), rather than an env read at the decision point — otherwise the predicate would not be a pure function of its inputs and could not be unit-tested as a matrix.

The cloud bootstrap declares it (`ANYHARNESS_RUNTIME_SURFACE=cloud`), following the existing `ANYHARNESS_DEFER_STARTUP_RETENTION` precedent in the same dict. **Absent means local, and that default is the safe one**: it can only ever *enable* a cursor auto-install that then fails to reach `Ready` (wasted download), never *suppress* an install a surface needs (a broken harness).

`installed_only` survives as the **scoped settings action** ("update installed agents"), where it still means exactly what it says. It is simply no longer what the startup pass uses. Seed hydration still runs first, so seeded agents (claude/codex on desktop) are already present and the pass is a no-op for them rather than a redundant download.

## Tests — the matrix that had zero coverage

`auto_install_tests.rs` enumerates surface × scope × {absent, PATH-only, managed-only, both} × harness. The **PATH column had no coverage at all** before, because the protection was an accident of scope rather than a rule.

| Test | Proves |
| --- | --- |
| `an_absent_agent_auto_installs_on_a_full_pass` | the law itself, every surface × every gateway-capable harness |
| `a_path_provided_agent_is_never_clobbered` | 2 surfaces × 2 scopes × 5 harnesses = 20 cells, all skip |
| `path_protection_outranks_the_cursor_and_scope_rules` | precedence — the ordering regression that overwrites a user's binary |
| `a_managed_copy_keeps_converging_even_beside_a_path_copy` | the asymmetry above |
| `cursor_does_not_install_in_cloud_but_does_locally` | both halves; the carve-out is cloud-only |
| `no_other_harness_is_suppressed_in_cloud` | the cloud carve-out is cursor-specific |
| `an_installed_only_pass_still_updates_only_managed_installs` | the scoped action still works |
| `a_managed_agent_converges_in_either_scope` | the drift planner, not this predicate, decides if work is needed |
| `every_skip_reason_has_a_distinct_message` | the messages are a contract (T3-AGENT-1 asserts the PATH one), not log strings |
| `fact_constants_match_their_constructor` | the matrix's own consts cannot desync |

Rewritten: `internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active_pins` asserted `fresh.installed_only` — now asserts `!fresh.installed_only` with a comment naming A6. It also now waits for **admission** rather than completion: the startup poke is full-scope, so completing it would really download and install every supported harness into a temp home (minutes of network in a unit test). The install mechanics have their own coverage; what belongs there is that the poke survives a busy slot and admits the right *shape* of job.

### Round 2: the surface threading, covered end to end (`surface_threading_tests.rs`)

Review round 2 found the gap that weakening left: `auto_install_tests.rs` covers the predicate as a pure function, and the poke test stops at job registration — so **nothing exercised `start_with_admission` → `run_reconcile_job` → `auto_install_decision`**, three hops of plumbing carrying the new `surface` argument.

Two new tests run a full-scope pass to **completion with no network**, which is affordable because a `None` catalog resolves no pins and the installer's `require_source` fence fails every agent deterministically before any download:

| Test | Proves |
| --- | --- |
| `full_scope_pass_admits_every_absent_agent_instead_of_skipping_it` | on `Local`, every agent is **admitted** by the predicate and then `Failed` with `"has no resolved source pin in the catalog lockfile"`. The admitted-then-failed pair is the assertion — the exact inverse of `installed_only_skips_uninstalled_agents`, which shows the same `None`-catalog setup yielding `Skipped` for every agent |
| `the_cloud_surface_reaches_the_predicate_and_carves_out_only_cursor` | the same pass on `Cloud` skips **exactly one** agent, cursor, with its named reason. Same inputs, one variable — a `surface` that never reached the predicate could not produce both results |

**Hermetic without touching `PATH`.** The PATH carve-out outranks scope and surface by design, so on any developer's machine (claude/codex/cursor/grok all commonly on PATH) these agents would be skipped as user-provided and the tests would assert nothing. Managed artifacts are seeded instead — both roles, since claude and codex resolve their *native* artifact from PATH — relying on the documented `has_managed_artifact`-beats-`has_path_artifact` precedence. Narrowing process-global `PATH` was tried first and broke the installer's `git`/`npm` shell-outs in sibling tests.

Split into its own file rather than pushing `execution_tests.rs` past the 600-line cap (it landed at 698).

New Python test `test_declares_the_cloud_surface_for_the_auto_install_carve_out`.

Results (round 2): `cargo test -p anyharness-lib --lib` green (`installer` module 66/66 including the two new tests). `cargo clippy` shows **no** findings in any file this PR touches — round 2 deleted `AgentRuntime::surface()`, which had zero callers and would have been a `dead_code` hard error under `-D warnings`. `cargo test --workspace` green except the known pre-existing `apps/desktop/src-tauri` flake (documented in #1503; different test per run, green in isolation, untouched here). Server `pytest tests/unit/test_runtime_version_pin.py` 7/7. `ruff check` + `format --check` clean. `check_docs.py` + every `repo-shape` check pass.

## Matches what T3-AGENT-1 will assert (brief §5)

Checked the brief's observability requirements against what this PR actually emits:

- **`installed_only` field semantics** — on the wire (`ReconcileAgentsResponse.installed_only`), and `false` on the startup pass. The brief's startup cell can distinguish a full pass from a scoped one.
- **Skipped-for-PATH results** — `AgentReconcileOutcome::Skipped` with `AutoInstallSkip::UserProvidedOnPath.message()`, which contains the literal `"PATH"` (asserted by a unit test, so the scenario's substring match is a contract rather than a log string). Distinct from the cursor-in-cloud and installed-only messages, so the scenario can tell the three skips apart.
- **Reconcile status transitions** — unchanged: `Idle|Queued|Running|Completed|Failed`, same job slot, same admission policy. The brief's "poll immediately from world boot until Completed/Failed, never leave on Idle+zero results" works exactly as written.
- **§5's "A6 drops installed_only → startup pass installs missing managed agents"** — done, and the brief's note that the startup cell is `blocked/expected_fail` pre-A6 can be flipped to a real assert once this merges.

The brief's own remaining work (the PATH-shadow fixture, `getReconcileStatus()` on `LocalRuntimeClient`, probing `already_installed` semantics live) is unchanged by this PR and stays with that later scenario PR.

## Contradictions encountered

None ruling-worthy. Three judgment calls:

1. **`RuntimeSurface` defaults to `Local` on an unrecognized/absent env value** rather than failing closed. Reasoning above: the failure modes are asymmetric, and the local default's worst case is a wasted cursor download.
2. **PATH-vs-managed precedence when both are present** (converge the managed copy). Stated in the fn's comment and pinned by a test, because either answer is defensible and the reader should not have to guess which was chosen.
3. **The rewritten poke test asserts admission, not completion.** Asserting completion would have made a unit test perform real network installs. Flagged as a weakening of *that* test's reach in round 1 — **round 2 closed it** with `surface_threading_tests.rs`, which reaches completion offline via the `None`-catalog pin fence, so the threading is no longer only covered at the seam.

Ruling **R7 honored**: no bandwidth knob. The pass installs the supported set unconditionally; the product follow-up gap the ruling notes is not re-opened here.

## Does not contradict the probe-engine design

`probe-engine-design.md` §3.2 adds a per-agent poke at reconcile completion, and §3.1 explicitly **withdraws** any ordering claim between the startup pass and the probe (`reconcile_installed_when_idle().await` returns at admission, not completion). A6 renames that fn to `reconcile_when_idle` and widens its scope; neither touches the withdrawal, and §3.2's completion poke — which the design calls "the sole guarantor of probe-after-install ordering" — becomes *more* useful now that the startup pass actually installs things.

