### PR TITLE
feat(agent-auth): multi-field provider-config secret UI (Track D2)

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/agent-auth/ProviderConfigCreatorModal.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agent-auth/ProviderConfigCreatorModal.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ProviderConfigCreatorModal } from "#product/components/settings/panes/agent-auth/ProviderConfigCreatorModal";
+
+// Radix Dialog (ModalShell) touches DOM APIs jsdom doesn't implement.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = () => {};
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.releasePointerCapture = () => {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderModal(overrides: Partial<Parameters<typeof ProviderConfigCreatorModal>[0]> = {}) {
+  const onSubmit = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <ProviderConfigCreatorModal
+      open
+      onClose={onClose}
+      kind="aws_bedrock"
+      submitLabel="Save"
+      submitting={false}
+      onSubmit={onSubmit}
+      {...overrides}
+    />,
+  );
+  return { onSubmit, onClose };
+}
+
+describe("ProviderConfigCreatorModal", () => {
+  it("renders every field the aws_bedrock spec declares, region as text and bearer token masked", () => {
+    renderModal();
+
+    expect(screen.getByLabelText("Title")).toBeTruthy();
+    const region = screen.getByLabelText("AWS region") as HTMLInputElement;
+    const bearerToken = screen.getByLabelText("Bedrock bearer token") as HTMLInputElement;
+    expect(region.type).toBe("text");
+    expect(bearerToken.type).toBe("password");
+  });
+
+  it("renders the azure_openai spec's three fields with the api key masked", () => {
+    renderModal({ kind: "azure_openai" });
+
+    const endpoint = screen.getByLabelText("Resource endpoint") as HTMLInputElement;
+    const deployment = screen.getByLabelText("Deployment name") as HTMLInputElement;
+    const apiKey = screen.getByLabelText("API key") as HTMLInputElement;
+    expect(endpoint.type).toBe("text");
+    expect(deployment.type).toBe("text");
+    expect(apiKey.type).toBe("password");
+  });
+
+  it("blocks submit until every required field (incl. title) is filled", () => {
+    const { onSubmit } = renderModal();
+
+    expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", true);
+
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Work Bedrock" } });
+    fireEvent.change(screen.getByLabelText("AWS region"), { target: { value: "us-east-1" } });
+    // Bearer token still empty -> still blocked.
+    expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", true);
+
+    fireEvent.change(screen.getByLabelText("Bedrock bearer token"), {
+      target: { value: "bedrock-token-abc" },
+    });
+    expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "Work Bedrock",
+      kind: "aws_bedrock",
+      value: { region: "us-east-1", bearerToken: "bedrock-token-abc" },
+    });
+  });
+
+  it("produces a keyed value map shaped by the kind's field spec, not a single string", () => {
+    const { onSubmit } = renderModal({ kind: "azure_openai" });
+
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Work Azure" } });
+    fireEvent.change(screen.getByLabelText("Resource endpoint"), {
+      target: { value: "https://my-resource.openai.azure.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Deployment name"), { target: { value: "gpt-4o" } });
+    fireEvent.change(screen.getByLabelText("API key"), { target: { value: "azure-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "Work Azure",
+      kind: "azure_openai",
+      value: {
+        endpoint: "https://my-resource.openai.azure.com",
+        deployment: "gpt-4o",
+        apiKey: "azure-secret",
+      },
+    });
+  });
+
+  it("resets the form when reopened, so a prior draft never leaks into the next open", () => {
+    const { rerender } = (() => {
+      const onSubmit = vi.fn();
+      const onClose = vi.fn();
+      const view = render(
+        <ProviderConfigCreatorModal
+          open
+          onClose={onClose}
+          kind="aws_bedrock"
+          submitLabel="Save"
+          submitting={false}
+          onSubmit={onSubmit}
+        />,
+      );
+      return view;
+    })();
+
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Draft" } });
+    fireEvent.change(screen.getByLabelText("AWS region"), { target: { value: "eu-west-1" } });
+
+    rerender(
+      <ProviderConfigCreatorModal
+        open={false}
+        onClose={() => {}}
+        kind="aws_bedrock"
+        submitLabel="Save"
+        submitting={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+    rerender(
+      <ProviderConfigCreatorModal
+        open
+        onClose={() => {}}
+        kind="aws_bedrock"
+        submitLabel="Save"
+        submitting={false}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByLabelText("Title") as HTMLInputElement).value).toBe("");
+    expect((screen.getByLabelText("AWS region") as HTMLInputElement).value).toBe("");
+  });
+
+  it("shows the submit error message when provided", () => {
+    renderModal({ error: "Could not save this configuration." });
+    expect(screen.getByText("Could not save this configuration.")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/agent-auth/ProviderConfigCreatorModal.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agent-auth/ProviderConfigCreatorModal.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { Input } from "@proliferate/ui/primitives/Input";
+import { Label } from "@proliferate/ui/primitives/Label";
+import { ModalShell } from "@proliferate/ui/primitives/ModalShell";
+import {
+  getProviderConfigFieldSpec,
+  type ProviderConfigFieldSpec,
+  type ProviderConfigKind,
+} from "#product/lib/domain/settings/provider-config-fields";
+
+export interface ProviderConfigCreatorSubmit {
+  /** Human label for the vault key, same role as ApiKeyCreatorModal's title. */
+  title: string;
+  /** The typed provider-config kind this payload was collected for. */
+  kind: ProviderConfigKind;
+  /** field key -> entered value, keyed by the spec's `fields[].key`. */
+  value: Record<string, string>;
+}
+
+export interface ProviderConfigCreatorModalProps {
+  open: boolean;
+  onClose: () => void;
+  kind: ProviderConfigKind;
+  titleLabel?: string;
+  titlePlaceholder?: string;
+  submitLabel: string;
+  submitting: boolean;
+  error?: string | null;
+  onSubmit: (input: ProviderConfigCreatorSubmit) => void;
+}
+
+/**
+ * Multi-field sibling of {@link ApiKeyCreatorModal} for typed provider
+ * configs (Bedrock, Azure OpenAI, …): renders N named fields declared by
+ * {@link getProviderConfigFieldSpec} instead of ApiKeyCreatorModal's single
+ * secret string, then hands a keyed value map to the caller's `onSubmit`.
+ * Copies ApiKeyCreatorModal's shell/footer/reset pattern exactly — same
+ * `ModalShell`, same form-id-on-footer-button wiring, same reset-on-open
+ * effect — so this reads as ApiKeyCreatorModal's shape stretched to N fields,
+ * not a new pattern.
+ *
+ * D1/D3 SEAM: the field spec comes from `getProviderConfigFieldSpec`, a pure
+ * function of `kind` — see that module's header comment. This component
+ * never reads the registry directly, so D3's registry cutover cannot touch
+ * this file.
+ */
+export function ProviderConfigCreatorModal({
+  open,
+  onClose,
+  kind,
+  titleLabel = "Title",
+  titlePlaceholder = "Personal Bedrock account",
+  submitLabel,
+  submitting,
+  error = null,
+  onSubmit,
+}: ProviderConfigCreatorModalProps) {
+  const spec = getProviderConfigFieldSpec(kind);
+  const [title, setTitle] = useState("");
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  // Reset the form each time the modal opens (or the kind changes under an
+  // already-open modal) so a prior draft never leaks in, mirroring
+  // ApiKeyCreatorModal's reset effect.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setTitle("");
+    setValues({});
+  }, [open, kind]);
+
+  const trimmedTitle = title.trim();
+  const missingRequired = spec.fields.some(
+    (field) => field.required && (values[field.key] ?? "").trim().length === 0,
+  );
+  const canSubmit = trimmedTitle.length > 0 && !missingRequired && !submitting;
+
+  function setFieldValue(key: string, next: string) {
+    setValues((prev) => ({ ...prev, [key]: next }));
+  }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    const trimmedValues: Record<string, string> = {};
+    for (const field of spec.fields) {
+      trimmedValues[field.key] = (values[field.key] ?? "").trim();
+    }
+    onSubmit({ title: trimmedTitle, kind, value: trimmedValues });
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onClose}
+      disableClose={submitting}
+      telemetryBlocked
+      title={spec.displayName}
+      description={spec.description}
+      sizeClassName="max-w-lg"
+      footer={(
+        <>
+          <Button type="button" variant="ghost" disabled={submitting} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="provider-config-creator-form"
+            loading={submitting}
+            disabled={!canSubmit}
+          >
+            {submitLabel}
+          </Button>
+        </>
+      )}
+    >
+      <form id="provider-config-creator-form" className="space-y-4" onSubmit={submit}>
+        <div className="space-y-1.5">
+          <Label htmlFor="provider-config-title" className="text-ui font-medium text-foreground">
+            {titleLabel}
+          </Label>
+          <Input
+            id="provider-config-title"
+            value={title}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={titlePlaceholder}
+            onChange={(event) => setTitle(event.currentTarget.value)}
+          />
+        </div>
+
+        {spec.fields.map((field) => (
+          <ProviderConfigField
+            key={field.key}
+            field={field}
+            value={values[field.key] ?? ""}
+            onChange={(next) => setFieldValue(field.key, next)}
+          />
+        ))}
+
+        <p className="text-ui-sm text-muted-foreground">
+          Stored encrypted. Secret values are never displayed again after saving.
+        </p>
+
+        {error ? (
+          <div className="rounded-md border border-destructive/25 bg-destructive-subtle px-3 py-2 text-ui text-destructive">
+            {error}
+          </div>
+        ) : null}
+      </form>
+    </ModalShell>
+  );
+}
+
+function ProviderConfigField({
+  field,
+  value,
+  onChange,
+}: {
+  field: ProviderConfigFieldSpec;
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const inputId = `provider-config-field-${field.key}`;
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={inputId} className="text-ui font-medium text-foreground">
+        {field.label}
+        {field.required ? null : (
+          <span className="ml-1 font-normal text-muted-foreground">(optional)</span>
+        )}
+      </Label>
+      <Input
+        id={inputId}
+        type={field.secret ? "password" : "text"}
+        value={value}
+        data-telemetry-mask={field.secret ? true : undefined}
+        autoComplete="off"
+        spellCheck={false}
+        className={field.secret ? "font-mono" : undefined}
+        placeholder={field.placeholder}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+      {field.helpText ? (
+        <p className="text-ui-sm text-muted-foreground">{field.helpText}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthApiKeyDetails.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthApiKeyDetails.tsx
@@ -3,9 +3,18 @@ import { useCreateAgentApiKey } from "@proliferate/cloud-sdk-react";
 import { Plus } from "@proliferate/ui/icons";
 import { Button } from "@proliferate/ui/primitives/Button";
 import { ApiKeyCreatorModal } from "#product/components/settings/panes/agent-auth/ApiKeyCreatorModal";
+import {
+  ProviderConfigCreatorModal,
+  type ProviderConfigCreatorSubmit,
+} from "#product/components/settings/panes/agent-auth/ProviderConfigCreatorModal";
 import { getHarnessEnvVarSuggestions } from "#product/config/harness-env-vars";
 import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import type { HarnessAuthEditorApi } from "#product/hooks/agents/workflows/use-harness-auth-editor";
+import {
+  getProviderConfigFieldSpec,
+  getSupportedProviderConfigKinds,
+  type ProviderConfigKind,
+} from "#product/lib/domain/settings/provider-config-fields";
 import { useToastStore } from "#product/stores/toast/toast-store";
 import { HarnessPanelBlock, type HarnessBlockVariant } from "#product/components/settings/panes/agents/harness/HarnessPanelBlock";
 import { HarnessAuthApiKeyRow } from "#product/components/settings/panes/agents/harness/HarnessAuthApiKeyRow";
@@ -33,6 +42,16 @@ export function ApiKeyDetails({
     (candidate) => !usedEnvVars.has(candidate.envVarName),
   );
 
+  // Typed provider-config kinds (Bedrock/Azure) this harness may offer. Empty
+  // for EVERY harness until D1 lands registry.json's `providerConfig`
+  // declarations (agents-impl-plan.md §4) — see
+  // provider-config-fields.ts's module comment. The buttons below simply
+  // don't render while this stays empty, so the UI never promises a create
+  // flow the server can't yet store or launch on.
+  const providerConfigKinds = getSupportedProviderConfigKinds(harnessKind);
+  const [openProviderConfigKind, setOpenProviderConfigKind] =
+    useState<ProviderConfigKind | null>(null);
+
   function handleAddKeyModalSubmit(input: { title: string; value: string; envVarName: string }) {
     createKey.mutate(
       { title: input.title, value: input.value },
@@ -59,6 +78,16 @@ export function ApiKeyDetails({
     if (!editor.editorState.rows.some((row) => row.apiKeyId !== null && row.enabled)) {
       editor.setPendingMethod(null);
     }
+  }
+
+  // Placeholder submit: there is no server endpoint yet for a typed vault
+  // entry (D1's `kind` column + create-request shape land later), so this
+  // wires the collected payload nowhere — the button that opens this modal
+  // never renders today (providerConfigKinds is always []), so this path is
+  // unreachable in the shipped product. D3 replaces this with the real
+  // mutation once D1's request shape exists.
+  function handleProviderConfigSubmit(_input: ProviderConfigCreatorSubmit) {
+    setOpenProviderConfigKind(null);
   }
 
   const hasRows = editor.editorState.rows.length > 0;
@@ -112,6 +141,20 @@ export function ApiKeyDetails({
                 {HARNESS_PANE_COPY.addProvider}
               </Button>
             ) : null}
+            {providerConfigKinds.map((kind) => (
+              <Button
+                key={kind}
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="gap-1.5"
+                disabled={editor.busy}
+                onClick={() => setOpenProviderConfigKind(kind)}
+              >
+                <Plus className="icon-paired" />
+                {getProviderConfigFieldSpec(kind).displayName}
+              </Button>
+            ))}
           </div>
         </div>
       ) : (
@@ -119,7 +162,7 @@ export function ApiKeyDetails({
           <p className="py-3 text-ui-sm text-muted-foreground">
             No API key configured.
           </p>
-          <div>
+          <div className="flex flex-wrap gap-2">
             <Button
               type="button"
               variant="primary"
@@ -131,6 +174,20 @@ export function ApiKeyDetails({
               <Plus className="icon-paired" />
               {HARNESS_PANE_COPY.addApiKey}
             </Button>
+            {providerConfigKinds.map((kind) => (
+              <Button
+                key={kind}
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="gap-1.5"
+                disabled={editor.busy}
+                onClick={() => setOpenProviderConfigKind(kind)}
+              >
+                <Plus className="icon-paired" />
+                {getProviderConfigFieldSpec(kind).displayName}
+              </Button>
+            ))}
           </div>
         </div>
       )}
@@ -160,6 +217,18 @@ export function ApiKeyDetails({
           onClose={() => setProviderModalOpen(false)}
           onSelect={(provider) =>
             editor.addRow(provider.envVarNames[0] ?? "", provider.id)}
+        />
+      ) : null}
+
+      {openProviderConfigKind ? (
+        <ProviderConfigCreatorModal
+          open
+          onClose={() => setOpenProviderConfigKind(null)}
+          kind={openProviderConfigKind}
+          submitLabel="Save"
+          submitting={false}
+          error={null}
+          onSubmit={handleProviderConfigSubmit}
         />
       ) : null}
     </HarnessPanelBlock>

--- a/apps/packages/product-client/src/lib/domain/settings/provider-config-fields.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/provider-config-fields.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProviderConfigFieldSpec,
+  getSupportedProviderConfigKinds,
+  type ProviderConfigKind,
+} from "#product/lib/domain/settings/provider-config-fields";
+
+const KINDS: readonly ProviderConfigKind[] = ["aws_bedrock", "azure_openai"];
+
+describe("getProviderConfigFieldSpec", () => {
+  it("returns a spec for every known kind with at least one required field", () => {
+    for (const kind of KINDS) {
+      const spec = getProviderConfigFieldSpec(kind);
+      expect(spec.kind).toBe(kind);
+      expect(spec.displayName.length).toBeGreaterThan(0);
+      expect(spec.fields.length).toBeGreaterThan(0);
+      expect(spec.fields.some((field) => field.required)).toBe(true);
+    }
+  });
+
+  it("aws_bedrock declares region (plain) + bearer token (secret) per the vault contract", () => {
+    const spec = getProviderConfigFieldSpec("aws_bedrock");
+    const keys = spec.fields.map((field) => field.key);
+    expect(keys).toContain("region");
+    expect(keys).toContain("bearerToken");
+
+    const region = spec.fields.find((field) => field.key === "region");
+    expect(region?.secret).toBe(false);
+    const bearerToken = spec.fields.find((field) => field.key === "bearerToken");
+    expect(bearerToken?.secret).toBe(true);
+  });
+
+  it("azure_openai declares endpoint + deployment (plain) + api key (secret) per the vault contract", () => {
+    const spec = getProviderConfigFieldSpec("azure_openai");
+    const keys = spec.fields.map((field) => field.key);
+    expect(keys).toEqual(["endpoint", "deployment", "apiKey"]);
+
+    expect(spec.fields.find((field) => field.key === "endpoint")?.secret).toBe(false);
+    expect(spec.fields.find((field) => field.key === "deployment")?.secret).toBe(false);
+    expect(spec.fields.find((field) => field.key === "apiKey")?.secret).toBe(true);
+  });
+});
+
+describe("getSupportedProviderConfigKinds", () => {
+  it("is empty for every harness until D1 lands the registry declarations", () => {
+    for (const harnessKind of ["claude", "codex", "opencode", "cursor", "grok"]) {
+      expect(getSupportedProviderConfigKinds(harnessKind)).toEqual([]);
+    }
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/settings/provider-config-fields.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/provider-config-fields.ts
@@ -1,0 +1,125 @@
+// Typed provider-config field specs (Track D UI, D2/#agents-impl-plan.md §4).
+//
+// agent-auth.md's vault table ("The vault") says a typed vault entry's shape
+// comes from its KIND alone, never from the harness that will end up using
+// it — "the shape comes from the vault entry's kind" (not the harness). So
+// one field-spec per `ProviderConfigKind` covers every harness that declares
+// support for it; a harness's own render recipe (Rust, D3) is what maps
+// these same named fields onto ITS OWN env vars (e.g. claude's Foundry vs.
+// codex's Azure OpenAI provider block both consume the same azure_openai
+// fields, differently).
+//
+// SEAM (read this before touching D1/D3): `getSupportedProviderConfigKinds`
+// is the ONLY place that names which harness supports which kind, and it is
+// hardcoded to `[]` for every harness today because the source of truth —
+// registry.json `providerConfig` declarations — does not exist until D1
+// lands (agents-impl-plan.md §4 D1). Once D1 ships, replace this function's
+// body with a read of the harness's registry entry; nothing else in this
+// file, `ProviderConfigCreatorModal`, or its call site needs to change. That
+// is the one-file change the wiring PR (D3) gets to make.
+
+export type ProviderConfigKind = "aws_bedrock" | "azure_openai";
+
+export interface ProviderConfigFieldSpec {
+  /** Machine key; becomes a property of the submitted `value` map. */
+  key: string;
+  label: string;
+  placeholder?: string;
+  helpText?: string;
+  /** Masked input (type="password", telemetry-blocked), like a bare API key. */
+  secret: boolean;
+  required: boolean;
+}
+
+export interface ProviderConfigSpec {
+  kind: ProviderConfigKind;
+  displayName: string;
+  description?: string;
+  fields: readonly ProviderConfigFieldSpec[];
+}
+
+// Mirrors agent-auth.md's vault kind table exactly:
+//   aws_bedrock   -> "a JSON document: region + credentials"
+//   azure_openai  -> "a JSON document: endpoint, deployment, key"
+//
+// aws_bedrock is scoped to the bearer-token credential shape only
+// (AWS_BEARER_TOKEN_BEDROCK + AWS_REGION — the pair already referenced by
+// render.rs's sanitize_claude_ambient and catalog_probe.rs's
+// CREDENTIAL_ENV_VARS). The spec text also allows a static access-key pair
+// or an assumed role; D1 decides the final vault JSON shape, and this file
+// is the seam that absorbs that decision without touching the modal.
+const PROVIDER_CONFIG_SPECS: Readonly<Record<ProviderConfigKind, ProviderConfigSpec>> = {
+  aws_bedrock: {
+    kind: "aws_bedrock",
+    displayName: "AWS Bedrock",
+    description: "Use your own AWS Bedrock account.",
+    fields: [
+      {
+        key: "region",
+        label: "AWS region",
+        placeholder: "us-east-1",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "bearerToken",
+        label: "Bedrock bearer token",
+        placeholder: "sk-...",
+        helpText: "The Bedrock API key used as a bearer token (AWS_BEARER_TOKEN_BEDROCK).",
+        secret: true,
+        required: true,
+      },
+    ],
+  },
+  azure_openai: {
+    kind: "azure_openai",
+    displayName: "Azure OpenAI",
+    description: "Use your own Azure OpenAI (or Azure AI Foundry) resource.",
+    fields: [
+      {
+        key: "endpoint",
+        label: "Resource endpoint",
+        placeholder: "https://my-resource.openai.azure.com",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "deployment",
+        label: "Deployment name",
+        placeholder: "gpt-4o",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "apiKey",
+        label: "API key",
+        placeholder: "",
+        secret: true,
+        required: true,
+      },
+    ],
+  },
+};
+
+/** The one function per SCOPE: given a kind, its field spec. Never null — the map is exhaustive over the type. */
+export function getProviderConfigFieldSpec(kind: ProviderConfigKind): ProviderConfigSpec {
+  return PROVIDER_CONFIG_SPECS[kind];
+}
+
+/**
+ * Which typed provider-config kinds a harness offers on the UI today.
+ *
+ * HARDCODED TO EMPTY FOR EVERY HARNESS. R9's full Track D scope is claude x
+ * {azure(Foundry), bedrock}, codex x {azure, bedrock}, opencode x {azure,
+ * bedrock} — but that vocabulary lives in registry.json `providerConfig`
+ * declarations that D1 has not landed yet, and the server has no `kind`
+ * column to persist a typed entry against. Returning any kind here before
+ * then would offer creating a secret the server cannot store or launch on —
+ * exactly what the UI must not do. D3 replaces the body with a read of the
+ * harness's registry entry; see the module comment.
+ */
+export function getSupportedProviderConfigKinds(
+  _harnessKind: string,
+): readonly ProviderConfigKind[] {
+  return [];
+}


### PR DESCRIPTION
## Summary

Track D2 (agents-impl-plan.md §4): the UI half of typed provider-config secrets (Bedrock, Azure OpenAI). Adds a new `ProviderConfigCreatorModal` that generalizes `ApiKeyCreatorModal` from one opaque secret string to N named fields, and wires it into the harness auth pane's API-key details block behind a seam that stays empty (no server support exists yet).

**Scope: UI only.** No server/db changes — those belong to D1 (registry.json `providerConfig` declarations + `AgentApiKey.kind` column) and D3 (render-side wiring), per the plan of record.

## Spec (agent-auth.md, "The vault")

> **One table holds every kind of user-provided credential.** A typed provider configuration is not a separate table and not multiple rows: it is one `agent_api_key` row whose `kind` says how to interpret the encrypted payload.
>
> | `kind` | The ciphertext decrypts to | Applied as |
> | --- | --- | --- |
> | `api_key` (default) | one opaque secret string | the single env var named by the referencing selection |
> | `aws_bedrock` | a JSON document: region + credentials (static access key pair or a role to assume) | the harness's own Bedrock env set (for claude: `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, credential vars) |
> | `azure_openai` | a JSON document: endpoint, deployment, key | the harness's own Azure env set |
>
> Two rules keep typed kinds from sprawling:
>
> - The registry (agent-distribution's declare side) names which provider-config kinds each harness supports; the settings UI offers only those, and a typed entry selected for a harness that does not declare its kind is rejected at write time like any other invalid selection.
> - Application reuses the harness's *native* mechanism (the same env vars a user would set by hand), so a typed config is rendered by the same per-harness recipe table as every other source — no separate code path.

## What this PR builds

- `apps/packages/product-client/src/lib/domain/settings/provider-config-fields.ts` — a local field-spec type (`ProviderConfigKind`, `ProviderConfigFieldSpec`, `ProviderConfigSpec`) and one lookup function per kind (`getProviderConfigFieldSpec`), shaped to match the plan's `providerConfig` declarations (kind + `fields[]`, each with label/secret/placeholder/required). Two kinds today: `aws_bedrock` (region + bearer token, matching `AWS_BEARER_TOKEN_BEDROCK`/`AWS_REGION` already referenced by `render.rs`'s `sanitize_claude_ambient` and `catalog_probe.rs`'s credential list) and `azure_openai` (endpoint + deployment + key).
- `apps/packages/product-client/src/components/settings/panes/agent-auth/ProviderConfigCreatorModal.tsx` — a new component that copies `ApiKeyCreatorModal`'s shape exactly (same `ModalShell`, same footer/form-id wiring, same reset-on-open effect) but renders the spec's `fields[]` instead of one value field, producing a typed `{ title, kind, value: Record<string, string> }` payload.
- Wired into `HarnessAuthApiKeyDetails.tsx` (the pane where API keys are created today): a "Save {displayName}" button per supported kind, next to the existing "Add API key" / "Add provider" buttons, opening the new modal.

## The D1/D3 seam

`getSupportedProviderConfigKinds(harnessKind)` in `provider-config-fields.ts` is the **only** place that names which harness supports which provider-config kind, and it returns `[]` for every harness today — hardcoded, with a comment explaining why. Nothing else in this PR reads the registry. Consequences:

- **No provider-config buttons render in the shipped product today.** `providerConfigKinds` is always `[]`, so the `.map()` over it in `HarnessAuthApiKeyDetails.tsx` produces nothing, and the modal is never opened by a real user. The UI does not promise a create flow the server can't yet store or launch on (per the task's hard requirement).
- The modal's `onSubmit` handler (`handleProviderConfigSubmit`) is a placeholder that just closes the modal — there is no server endpoint yet for a typed vault entry (D1's `kind` column + create-request shape don't exist), so wiring a real mutation here would have nowhere to send the payload. It's dead code today for the same reason the buttons are unreachable.
- **D1** replaces `getSupportedProviderConfigKinds`'s body with a read of the harness's registry entry (one function, one file) — the buttons then start appearing for `claude`/`codex`/`opencode` × `{azure, bedrock}` per R9.
- **D3** replaces `handleProviderConfigSubmit`'s placeholder with the real `createAgentApiKey`-shaped mutation once D1's request shape (kind + typed payload) exists server-side.

This is a one-file change for D1 (`provider-config-fields.ts`) and a one-function change for D3 (`handleProviderConfigSubmit`) — no other file in this PR needs to move.

## UI conventions followed

- Copies `ApiKeyCreatorModal.tsx`'s structure exactly (ModalShell, Label/Input primitives, footer button wired to the form's id, reset-on-open effect) rather than inventing a new pattern.
- No colored left-border ownership treatments; uses only existing atoms (`Button`, `Input`, `Label`, `ModalShell`) already used throughout the harness auth pane.
- Secret fields use `type="password"` + `data-telemetry-mask`, matching `ApiKeyCreatorModal`'s value field exactly.
- Mono dark design system untouched — no new colors, no new component primitives.

## Tests

- `provider-config-fields.test.ts` (4 tests): every kind has a spec with ≥1 required field; `aws_bedrock` declares region (plain) + bearer token (secret); `azure_openai` declares endpoint + deployment (plain) + api key (secret); `getSupportedProviderConfigKinds` returns `[]` for every harness (pins the seam until D1 lands).
- `ProviderConfigCreatorModal.test.tsx` (6 tests): renders every field per kind with correct secret/plain input types; blocks submit until every required field (incl. title) is filled; submit produces the keyed value map shaped by the kind's spec (not a single string); form resets on reopen; shows a submit error when provided.
- Full `product-client` vitest suite: 633 files / 3833 tests passing (no regressions).
- `tsc -p tsconfig.json --noEmit`: clean.

## Test plan

- [x] `pnpm vitest run` in `apps/packages/product-client` — 633/633 files, 3833/3833 tests passing
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [ ] Pablo review