### PR TITLE
chore(anyharness): drop dead gateway-models/catalog leftovers after F-039/F-040

### DIFF
--- a/anyharness/sdk-react/src/hooks/agent-gateway-catalog.ts
+++ b/anyharness/sdk-react/src/hooks/agent-gateway-catalog.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AnyHarnessClient } from "@anyharness/sdk";
 import {
   useAnyHarnessRuntimeContext,
@@ -16,7 +16,7 @@ interface RuntimeQueryOptions {
   refetchInterval?: number | false;
 }
 
-/** Shared query definition so the singular and plural (`useQueries`) hooks below stay in lockstep. */
+/** Shared query definition, factored out for the singular hook below. */
 function gatewayModelsQueryOptions(
   runtime: AnyHarnessRuntimeContextValue,
   kind: string,
@@ -51,23 +51,6 @@ export function useAgentGatewayModelsQuery(
 ) {
   const runtime = useAnyHarnessRuntimeContext();
   return useQuery(gatewayModelsQueryOptions(runtime, kind, options));
-}
-
-/**
- * The same resolved plan as [`useAgentGatewayModelsQuery`], but for a
- * variable-length set of harness kinds in one hook call (`useQueries`, so the
- * kind count can change across renders without breaking the rules of hooks).
- * Used by the desktop's runtime -> cloud mirror sync (contract §4), which
- * needs to watch every gateway-capable harness for a fresh probe result.
- */
-export function useAgentGatewayModelsQueries(
-  kinds: readonly string[],
-  options?: RuntimeQueryOptions,
-) {
-  const runtime = useAnyHarnessRuntimeContext();
-  return useQueries({
-    queries: kinds.map((kind) => gatewayModelsQueryOptions(runtime, kind, options)),
-  });
 }
 
 /** Re-probes the gateway now (the desktop Refresh button for local+gateway). */

--- a/anyharness/sdk-react/src/index.ts
+++ b/anyharness/sdk-react/src/index.ts
@@ -106,7 +106,6 @@ export {
 } from "./hooks/agents.js";
 export {
   useAgentGatewayModelsQuery,
-  useAgentGatewayModelsQueries,
   useRefreshAgentGatewayModelsMutation,
 } from "./hooks/agent-gateway-catalog.js";
 export {

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -114,8 +114,6 @@ export const HARNESS_PANE_COPY = {
     `Could not update ${displayName} authentication.`,
   catalogRefreshError: (displayName: string) =>
     `Could not refresh the ${displayName} model catalog.`,
-  catalogRefreshRuntimeUnavailable: (displayName: string) =>
-    `Local runtime unavailable — could not read ${displayName} models.`,
   catalogOverrideError: (displayName: string) =>
     `Could not update the ${displayName} model catalog.`,
   installAction: (displayName: string) => `Install ${displayName}`,

--- a/apps/packages/product-client/src/lib/domain/settings/harness-catalog.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-catalog.test.ts
@@ -2,7 +2,6 @@ import type { AgentLaunchOptionsResponse, GatewayModelEntry } from "@anyharness/
 import type { AgentAuthSelection } from "@proliferate/cloud-sdk";
 import { describe, expect, it } from "vitest";
 import {
-  buildRuntimeCatalogModelsJson,
   catalogRouteForSurface,
   defaultRouteForSurface,
   normalizeCatalogModels,
@@ -252,109 +251,5 @@ describe("normalizeRuntimeLaunchModels", () => {
     };
 
     expect(normalizeRuntimeLaunchModels("codex", launchOptions)).toEqual([]);
-  });
-});
-
-describe("buildRuntimeCatalogModelsJson", () => {
-  function launchOptions(
-    agents: AgentLaunchOptionsResponse["agents"],
-  ): AgentLaunchOptionsResponse {
-    return { agents, workspaceId: null };
-  }
-
-  it("serializes the runtime's resolved models for the requested harness", () => {
-    const result = buildRuntimeCatalogModelsJson(
-      "claude",
-      launchOptions([
-        {
-          kind: "claude",
-          displayName: "Claude Code",
-          defaultModelId: "sonnet",
-          models: [
-            { id: "sonnet", displayName: "Sonnet 4.6", isDefault: true },
-            { id: "haiku", displayName: "Haiku 4.5", aliases: ["haiku-latest"], isDefault: false },
-          ],
-        },
-      ]),
-    );
-
-    expect(result).toBe(
-      JSON.stringify([
-        { id: "sonnet", displayName: "Sonnet 4.6" },
-        { id: "haiku", displayName: "Haiku 4.5", aliases: ["haiku-latest"] },
-      ]),
-    );
-  });
-
-  it("forwards the runtime-enriched catalog fields into the snapshot payload", () => {
-    const result = buildRuntimeCatalogModelsJson(
-      "claude",
-      launchOptions([
-        {
-          kind: "claude",
-          displayName: "Claude Code",
-          defaultModelId: "sonnet",
-          models: [
-            {
-              id: "sonnet",
-              displayName: "Sonnet 4.6",
-              isDefault: true,
-              description: "Balanced coding model",
-              provider: "anthropic",
-              status: "active",
-              effort: { values: ["low", "medium", "high"], default: "medium" },
-              fastMode: true,
-              modes: ["default", "acceptEdits", "plan"],
-            },
-          ],
-        },
-      ]),
-    );
-
-    expect(result).toBe(
-      JSON.stringify([
-        {
-          id: "sonnet",
-          displayName: "Sonnet 4.6",
-          description: "Balanced coding model",
-          provider: "anthropic",
-          status: "active",
-          effort: { values: ["low", "medium", "high"], default: "medium" },
-          fastMode: true,
-          modes: ["default", "acceptEdits", "plan"],
-        },
-      ]),
-    );
-  });
-
-  it("returns null when the runtime has no entry for the harness", () => {
-    const result = buildRuntimeCatalogModelsJson(
-      "codex",
-      launchOptions([
-        {
-          kind: "claude",
-          displayName: "Claude Code",
-          defaultModelId: null,
-          models: [{ id: "sonnet", displayName: "Sonnet 4.6", isDefault: true }],
-        },
-      ]),
-    );
-
-    expect(result).toBeNull();
-  });
-
-  it("returns null when the harness has zero ready models", () => {
-    const result = buildRuntimeCatalogModelsJson(
-      "claude",
-      launchOptions([
-        { kind: "claude", displayName: "Claude Code", defaultModelId: null, models: [] },
-      ]),
-    );
-
-    expect(result).toBeNull();
-  });
-
-  it("returns null when the runtime data is unavailable", () => {
-    expect(buildRuntimeCatalogModelsJson("claude", undefined)).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
@@ -140,39 +140,6 @@ export function normalizeRuntimeLaunchModels(
   }));
 }
 
-// native/api_key routes probe on the CLIENT (catalog.py's refresh_catalog
-// contract): rich live probing is deferred, so v1 sources the payload from the
-// local AnyHarness runtime's already-resolved launch catalog (the same
-// bundled catalog-v2 model list `useAgentLaunchOptionsQuery` feeds the session
-// model picker) instead of spawning a harness process. Returns null when the
-// runtime has no ready models for this harness — the caller should show a
-// "runtime unavailable" toast and skip the server call rather than upload an
-// empty snapshot.
-export function buildRuntimeCatalogModelsJson(
-  harnessKind: string,
-  launchOptions: AgentLaunchOptionsResponse | undefined,
-): string | null {
-  const agent = launchOptions?.agents.find((entry) => entry.kind === harnessKind);
-  if (!agent || agent.models.length === 0) {
-    return null;
-  }
-  const entries = agent.models.map((model) => ({
-    id: model.id,
-    displayName: model.displayName,
-    ...(model.aliases && model.aliases.length > 0 ? { aliases: model.aliases } : {}),
-    // Forward the runtime-enriched catalog fields so cloud snapshots stored from
-    // this upload carry the same richness as the gateway-models endpoint (the
-    // server's parse_models_json preserves arbitrary keys beside `id`).
-    ...(model.description != null ? { description: model.description } : {}),
-    ...(model.provider != null ? { provider: model.provider } : {}),
-    ...(model.status != null ? { status: model.status } : {}),
-    ...(model.effort != null ? { effort: model.effort } : {}),
-    ...(model.fastMode != null ? { fastMode: model.fastMode } : {}),
-    ...(model.modes != null ? { modes: model.modes } : {}),
-  }));
-  return JSON.stringify(entries);
-}
-
 // Overrides have no GET endpoint, so the enabled-set is reconstructed from the
 // layered catalog (this pane is the only override writer) and re-upserted as a
 // whole `update` patch on every toggle.


### PR DESCRIPTION
## Summary

**Restructured per F-039's ruling (`codex/ledger-qa.md` §F-039, `codex/agents-impl-ledger.md`
2026-07-26 "QA integration findings intake").** C2 and B4 (#1521) independently implemented
the same `model-catalog.md` route-rename gap item — C2 in place (`agent_models_router`
alongside the existing `agent_gateway/api.py` handlers), B4 by relocation (new
`cloud/agent_models/` package, worker-authenticated ingest, refresh absorbs mirror). Pablo
ruled **B4's implementation survives**; this PR now carries only the sliver of C2's original
diff that B4 does not own.

This PR's base is `agents/b4-snapshot-rekey` (B4's head, including its F-040 fix that cut the
TS clients over to `/v1/cloud/agent-models`). **Deploy pairing: this PR ships in the same
train as B4 (#1521) — it is not independently deployable**, since B4 owns the server-side
route relocation this branch used to duplicate.

## What moved to B4 (dropped here)

Everything C2 originally built for the route rename itself now lives on B4 instead, including
B4's own F-040 fix that closed the gap F-039 flagged (B4 shipped the server-side move but
initially left every TS consumer on the old path — fixed on B4, head `6a8c6eb5d`):

- The duplicate `agent_models_router` in `server/proliferate/server/cloud/agent_gateway/api.py`
  and its mount in `cloud/api.py` — B4's `cloud/agent_models/` package is the one namespace now.
- `cloud/sdk/src/client/agent-gateway.ts`'s `agentModelsPath`/`getAgentModels`/override
  functions, `cloud/sdk-react`'s `useAgentModels`/`useUpsertAgentModelOverride` hooks, and the
  regenerated `cloud/sdk/src/generated/openapi.ts` — B4 owns the real (worker-authenticated
  refresh, no mirror) contract.
- The `use-gateway-catalog-mirror-sync.ts` / `gateway-catalog-mirror.ts` deletion and the
  `ProductLifecycleRoot.tsx` wiring removal — B4 deleted the same dead code in its F-040 fix.
- `test_agent_gateway_catalog_api.py` / `test_agent_gateway_catalog_mirror_api.py` deletion —
  B4 deletes the same two files (its integration tests assert the old routes 404).
- The `agents-playground-cloud-client.ts`/`.test.tsx` route-literal updates — B4's version is
  byte-identical to what this branch needed, so it's taken wholesale from B4.
- The `model-catalog.md`/`model-gateway.md` gap-bullet edits — B4 already checked off the
  route-rename item once; this branch does not check it off again (per the ruling: "gap item
  gets checked off exactly once").
- `scripts/max_lines_allowlist.txt`'s `agent_gateway/api.py` entry — gone, because B4's
  `api.py` shrank below the line threshold (no allowlist entry needed).

## What C2 keeps (this PR's actual diff)

Genuinely distinct cleanup B4 doesn't carry:

1. **Dead plural gateway-models hook** (`anyharness/sdk-react/src/hooks/agent-gateway-catalog.ts`,
   `index.ts`): `useAgentGatewayModelsQueries` (plural, `useQueries`-based) had its only caller
   — the deleted `useGatewayCatalogMirrorSync` — removed by B4's F-040 fix, but B4 never
   deleted the now-dead plural hook itself. Deleted here, along with its `index.ts` export.
   The singular `useAgentGatewayModelsQuery` (live in `HarnessAllModelsSection.tsx`) is
   untouched.
2. **Two more F-040 dead-code leftovers**, found during B4's verify pass and added to this
   PR's scope since they're product-client files this branch already touches:
   - `buildRuntimeCatalogModelsJson` (`apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts`)
     — no caller left after the client cutover; only its own test exercised it. Deleted along
     with its ~5 test cases in `harness-catalog.test.ts`. `authContextIdForRoute` /
     `apiKeyProviderHintForSurface` in the same file are live and untouched.
   - `catalogRefreshRuntimeUnavailable` (`apps/packages/product-client/src/copy/settings/harness-pane.ts`)
     — zero callers, test or otherwise. Deleted.

Net diff vs `agents/b4-snapshot-rekey`: 5 files, 2 insertions / 160 deletions, all dead-code
removal. Zero server route duplication, zero re-additions of files B4 deleted, zero net-new
behavior.

## Tests

- `pnpm --filter @proliferate/cloud-sdk build` (`tsc`): clean, no changes needed (this PR
  doesn't touch the SDK anymore — that's B4's).
- `anyharness/sdk-react`: `pnpm run typecheck` clean; `pnpm run test` (vitest) — 9 files / 30
  tests passed.
- product-client: full `pnpm run typecheck` (shared-package build chain + `tsc --noEmit`) —
  clean. Targeted vitest: `harness-catalog.test.ts` (12 tests), the `harness/*` settings-pane
  suite (5 files / 37 tests, incl. `HarnessAllModelsSection.test.tsx` and
  `HarnessPane.test.tsx`), `agents-playground-cloud-client.test.tsx` +
  `ProductLifecycleRoot.test.tsx` (3 files / 8 tests) — all passed.
- `python3 scripts/check_max_lines.py`: passed, no allowlist changes needed (no touched file
  crosses a threshold).
- `python3 scripts/check_docs.py`: passed.
- Machine rules honored: zero cargo/rustc/Docker.

## Coordination

- Rebased onto `agents/b4-snapshot-rekey` at head `934360cd4` (B4's F-040 fix commit
  `6a8c6eb5d` plus a small doc de-link `934360cd4`).
- Pair-deploy note for the merge queue: **this PR deploys with B4 (#1521) in the same train.**
  It has no server-side content of its own anymore; its value depends entirely on B4's route
  relocation already being in place.
