### PR TITLE
ci: gate cloud-SDK generated artifacts against drift, mirroring the anyharness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,12 @@ jobs:
       - name: Install server (venv, matches local layout)
         run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
 
+      - name: Regenerate cloud SDK artifacts
+        run: make cloud-client-generate
+
+      - name: Verify generated cloud SDK artifacts are committed
+        run: git diff --exit-code -- cloud/sdk/src/generated/openapi.ts
+
       - name: Install Playwright chromium
         run: pnpm -C tests/intent exec playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary
- The anyharness SDK has a CI drift gate (`.github/workflows/ci.yml:246`, `sdk-build` job): regenerate + `git diff --exit-code -- anyharness/sdk/generated/openapi.json anyharness/sdk/src/generated/openapi.ts`. The cloud SDK's generator (`cloud-client-generate` -> `cloud-openapi`, Makefile:1502-1513) has no equivalent — it's Makefile-only, with nothing in CI verifying the generated TS client is in sync with the server's OpenAPI schema.
- That asymmetry is the structural half of `codex/ledger-qa.md` §F-040: #1521 (agents/b4-snapshot-rekey) deleted the cloud catalog routes server-side but left `cloud/sdk/src/client/agent-gateway.ts` and `cloud/sdk/src/generated/openapi.ts` pointing at the old paths. CI was green because nothing regenerated or diffed the cloud SDK — a stale client that would 404 real traffic (Settings -> Agents -> a harness -> All Models) was invisible to CI.
- Adds a "Regenerate cloud SDK artifacts" (`make cloud-client-generate`) + "Verify generated cloud SDK artifacts are committed" (`git diff --exit-code -- cloud/sdk/src/generated/openapi.ts`) step pair to the `workflow-definition-lifecycle` job — the only `ci.yml` job that already provisions both the Node/pnpm toolchain and the server's Python/uv venv the generator needs (a pure FastAPI import + `app.openapi()` dump; no live server, no Docker, no DB connection required).

## Verification
- Confirmed `origin/main` is currently clean: ran `make cloud-client-generate` on a fresh worktree off `origin/main` and `git diff --exit-code -- cloud/sdk/src/generated/openapi.ts` returned 0 (no drift to fix).
- Confirmed the generator is deterministic: ran it twice back-to-back and diffed both `server/openapi.json` and `cloud/sdk/src/generated/openapi.ts` between runs — byte-identical.
- Ran `scripts/check_max_lines.py` and `scripts/check_docs.py` (plus their unit tests) — both pass; this change touches only `.github/workflows/ci.yml`.

## Test plan
- [x] `make cloud-client-generate` run locally on clean `origin/main`; `git diff --exit-code -- cloud/sdk/src/generated/openapi.ts` exits 0
- [x] Re-ran the generator twice to confirm deterministic output (JSON dump + generated TS identical byte-for-byte)
- [x] `python3 scripts/check_max_lines.py` passes
- [x] `python3 -m unittest scripts/test_check_docs.py` + `python3 scripts/check_docs.py` pass
- [ ] CI green on this PR (workflow-definition-lifecycle job specifically, since that's where the new steps live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)