### PR TITLE
fix(server): rename the pkey the webhook_event_receipt table rename left behind

### DIFF
--- a/server/alembic/versions/ab5316095737_webhook_event_receipt_pkey_rename.py
+++ b/server/alembic/versions/ab5316095737_webhook_event_receipt_pkey_rename.py
@@ -1,0 +1,92 @@
+"""webhook event receipt pkey rename
+
+Revision ID: ab5316095737
+Revises: 35fa0038d703
+Create Date: 2026-07-26 00:00:00.000000
+
+``9a0b1c2d3e4f_stripe_cloud_billing_foundation.py`` renamed
+``sandbox_event_receipt`` to ``webhook_event_receipt`` via ``op.rename_table``,
+which renames only the table. Postgres left the PRIMARY KEY constraint (and its
+backing index, since Postgres keeps the two names identical) on
+``sandbox_event_receipt_pkey``. A database that ran that migration therefore
+diverges from ``Base.metadata.create_all``, which names the constraint
+``webhook_event_receipt_pkey`` on a fresh install — forever, since nothing
+after 9a0b1c2d3e4f touched it.
+
+This is the same bug class B4 (``b7c1e4d9f082_agent_model_snapshot_rekey.py``)
+fixed for its own rename, and this migration follows that precedent: rename
+the constraint under its old name if present, do nothing if the name is
+already correct (fresh create_all, or a database that already ran this
+migration), and never touch a database that already has the new name.
+
+No FOREIGN KEY constraint exists on this table (no FK-typed columns), and
+``id`` has no server-side sequence (UUID default generated client-side), so
+the PRIMARY KEY is the only artifact the table rename left behind.
+
+Downgrade renames the constraint back, which is symmetric with the pre-B4-fix
+downgrade in 9a0b1c2d3e4f (that downgrade path recreates
+``sandbox_event_receipt`` and its ``_pkey`` from scratch via
+``op.rename_table``, so this migration's downgrade only has work to do when
+run against a database still on ``webhook_event_receipt``).
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ab5316095737"
+down_revision: str | Sequence[str] | None = "35fa0038d703"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "webhook_event_receipt"
+_OLD_PKEY = "sandbox_event_receipt_pkey"
+_NEW_PKEY = "webhook_event_receipt_pkey"
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _pkey_name(table_name: str) -> str | None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    name = inspector.get_pk_constraint(table_name).get("name")
+    return str(name) if name else None
+
+
+def _rename_pkey(table_name: str, old_name: str, new_name: str) -> None:
+    """Rename the PRIMARY KEY constraint when it is present under ``old_name``.
+
+    Postgres has no ``RENAME CONSTRAINT IF EXISTS``, hence the inspector check
+    first. A no-op when the table is missing (downgrade ran past this table
+    already), when the constraint is already named ``new_name`` (fresh
+    create_all, or this migration already ran), or when it carries neither
+    name (unexpected shape — left alone rather than guessed at).
+
+    Renaming the PRIMARY KEY constraint also renames its backing index, since
+    Postgres keeps the two names identical — no separate ``ALTER INDEX`` is
+    issued, since one would fail on a name that no longer exists.
+    """
+    if not _has_table(table_name):
+        return
+    current = _pkey_name(table_name)
+    if current != old_name:
+        return
+    op.execute(sa.text(f'ALTER TABLE {table_name} RENAME CONSTRAINT "{old_name}" TO "{new_name}"'))
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _rename_pkey(_TABLE, _OLD_PKEY, _NEW_PKEY)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    _rename_pkey(_TABLE, _NEW_PKEY, _OLD_PKEY)

--- a/server/tests/integration/test_webhook_event_receipt_pkey_migration.py
+++ b/server/tests/integration/test_webhook_event_receipt_pkey_migration.py
@@ -1,0 +1,104 @@
+"""Up/down proof for the webhook_event_receipt primary-key rename.
+
+``9a0b1c2d3e4f_stripe_cloud_billing_foundation.py`` renamed the table
+``sandbox_event_receipt`` to ``webhook_event_receipt`` via ``op.rename_table``,
+which renames only the table — Postgres left the PRIMARY KEY constraint (and
+its backing index, since Postgres keeps the two names identical) on
+``sandbox_event_receipt_pkey``. A database that ran that migration therefore
+diverges from ``Base.metadata.create_all`` (which names the constraint
+``webhook_event_receipt_pkey``) forever, since nothing after 9a0b1c2d3e4f
+touched it — the same bug class B4
+(``b7c1e4d9f082_agent_model_snapshot_rekey.py``) found and fixed for its own
+rename.
+
+The load-bearing assertion is ``_pkey_name`` compared against what a fresh
+``Base.metadata.create_all`` database produces for the same table: a
+shape-only test (columns alone) cannot see a leftover pkey.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from alembic import command
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from proliferate.db.migrations import build_alembic_config
+from proliferate.db.models.base import Base
+from tests.postgres import temporary_database
+
+_REVISION = "ab5316095737"
+_DOWN_REVISION = "35fa0038d703"
+_TABLE = "webhook_event_receipt"
+_OLD_PKEY = "sandbox_event_receipt_pkey"
+_NEW_PKEY = "webhook_event_receipt_pkey"
+
+
+async def _pkey_name(database_url: str, table: str) -> str | None:
+    engine = create_async_engine(database_url, echo=False)
+    try:
+        async with engine.begin() as conn:
+            return await conn.run_sync(
+                lambda sync_conn: inspect(sync_conn).get_pk_constraint(table).get("name")
+            )
+    finally:
+        await engine.dispose()
+
+
+async def test_webhook_event_receipt_pkey_rename_round_trips() -> None:
+    async with temporary_database("webhook_event_receipt_pkey") as (_name, database_url):
+        config = build_alembic_config(database_url)
+
+        # Before this migration, a database that ran 9a0b1c2d3e4f still carries
+        # the pre-rename constraint name.
+        await asyncio.to_thread(command.upgrade, config, _DOWN_REVISION)
+        assert await _pkey_name(database_url, _TABLE) == _OLD_PKEY
+
+        await asyncio.to_thread(command.upgrade, config, _REVISION)
+        assert await _pkey_name(database_url, _TABLE) == _NEW_PKEY
+
+        # Re-running the upgrade against an already-migrated database must be a
+        # true no-op (Postgres has no RENAME CONSTRAINT IF EXISTS, so the
+        # migration's own inspector guard is what makes this safe).
+        await asyncio.to_thread(command.upgrade, config, _REVISION)
+        assert await _pkey_name(database_url, _TABLE) == _NEW_PKEY
+
+        await asyncio.to_thread(command.downgrade, config, _DOWN_REVISION)
+        assert await _pkey_name(database_url, _TABLE) == _OLD_PKEY
+
+        await asyncio.to_thread(command.upgrade, config, "head")
+        assert await _pkey_name(database_url, _TABLE) == _NEW_PKEY
+
+
+async def test_webhook_event_receipt_pkey_matches_fresh_create_all() -> None:
+    """The migrated name must be name-for-name what create_all produces.
+
+    Comparing against a virgin ``create_all`` schema is the assertion class
+    that would have caught the original bug: a shape-only test (columns plus
+    index names) sees nothing wrong with a leftover pkey, since the column set
+    and the named indexes are unaffected by the constraint's name.
+    """
+    async with temporary_database("wer_pkey_fresh") as (_name, fresh_url):
+        fresh_engine = create_async_engine(fresh_url, echo=False)
+        try:
+            async with fresh_engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+                expected = await conn.run_sync(
+                    lambda sync_conn: inspect(sync_conn).get_pk_constraint(_TABLE).get("name")
+                )
+        finally:
+            await fresh_engine.dispose()
+        assert expected == _NEW_PKEY
+
+    async with temporary_database("wer_pkey_migrated") as (
+        _name,
+        migrated_url,
+    ):
+        config = build_alembic_config(migrated_url)
+        await asyncio.to_thread(command.upgrade, config, "head")
+        migrated = await _pkey_name(migrated_url, _TABLE)
+        assert migrated == expected, (
+            f"migrated {_TABLE} pkey diverges from Base.metadata.create_all: "
+            f"{migrated!r} != {expected!r}"
+        )


### PR DESCRIPTION
## Summary

Follow-up to a bug found during B4 (#1521)'s review: `op.rename_table` renames only the table. Migration `9a0b1c2d3e4f` (`stripe cloud billing foundation`) renamed `sandbox_event_receipt` → `webhook_event_receipt`, but never renamed the PRIMARY KEY constraint — Postgres kept it (and its backing index, since Postgres keeps the two names identical) on `sandbox_event_receipt_pkey`.

Result: a database that ran `9a0b1c2d3e4f` diverges from `Base.metadata.create_all` forever — a migrated prod database carries `sandbox_event_receipt_pkey` on `webhook_event_receipt`, while a fresh `create_all` database (e.g. a test schema) gets `webhook_event_receipt_pkey`. Any later code assuming the create_all name (e.g. `drop_constraint("webhook_event_receipt_pkey")`) would pass against a fresh test schema and fail against prod.

B4 hit and fixed exactly this bug class for its own table rename (`agent_catalog_snapshot` → `agent_model_snapshot`, commit 229adcf73 on `agents/b4-snapshot-rekey`), and this migration follows that same precedent: an idempotent, inspector-guarded `ALTER TABLE ... RENAME CONSTRAINT`, with a symmetric downgrade. No FK or sequence needed renaming here — the table has no FK-typed columns, and `id`'s default is a client-side generated UUID, not a Postgres sequence — so the PRIMARY KEY (and its backing index) is the only leftover artifact.

Confirmed against the local dev database (read-only inspection) that the divergence is real today:
```
Indexes:
    "sandbox_event_receipt_pkey" PRIMARY KEY, btree (id)
    "ix_webhook_event_receipt_status" btree (status)
    "uq_webhook_event_receipt_provider_event_id" UNIQUE, btree (provider, event_id)
```

## Evidence — execution-based proof against local Postgres (scratch DBs, dev DB never touched)

**Scenario 1 — simulated migrated database** (upgrade to the previous head, then to this migration):
```
[migrated] pkey BEFORE our migration: 'sandbox_event_receipt_pkey'
[migrated] pkey AFTER upgrade to head: 'webhook_event_receipt_pkey'
[migrated] pkey AFTER downgrade to 35fa0038d703: 'sandbox_event_receipt_pkey'
[migrated] pkey AFTER re-upgrade: 'webhook_event_receipt_pkey'
[migrated] pkey AFTER redundant upgrade (no-op check): 'webhook_event_receipt_pkey'
```

**Scenario 2 — fresh `create_all`-shaped database** (this migration's `upgrade()` run directly against it):
```
[fresh create_all] pkey as created: 'webhook_event_receipt_pkey'
[fresh create_all] pkey AFTER running our migration's upgrade(): 'webhook_event_receipt_pkey'
```
No error, true no-op — confirming the migration is safe to run against a database that never had the old name.

Both scratch databases were dropped after; the local `proliferate` dev database was only ever read (never migrated/dropped) and still shows the pre-fix name, as expected.

## Test plan

- [x] Added `server/tests/integration/test_webhook_event_receipt_pkey_migration.py`, mirroring B4's pattern: an up/down round-trip test, plus a `create_all`-comparison test (the assertion class that actually catches a leftover pkey — a shape-only/column-only test cannot see it). Both pass.
- [x] `tests/integration/test_schema_migrations.py` (full chain to head, including `test_alembic_upgrade_creates_current_schema`) — 6 passed.
- [x] Webhook-adjacent suites (`test_cloud_webhook_recovery_races.py`, `test_cloud_webhook_service.py`, `test_stripe_webhooks.py`) — 41 passed, unaffected.
- [x] `ruff format --check` + `ruff check` on touched files — clean. (mypy is scoped to `proliferate/` only per the Makefile; alembic/tests aren't covered.)
- [x] `python3 scripts/check_max_lines.py` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)