### PR TITLE
docs(specs): verify IA truth-pass corrections, strike agent-auth's stale-IA gap (S2a)

### DIFF
--- a/specs/codebase/platforms/product/agent-auth.md
+++ b/specs/codebase/platforms/product/agent-auth.md
@@ -586,7 +586,3 @@ Deltas between this document and `main`, each struck by its follow-up PR:
 - [ ] **Org members launch on their personal key.** Cross-referenced from
       model-gateway.md's gaps: the renderer and budget gate resolve the
       personal enrollment even for org members.
-- [ ] **Stale IA references.** The settings information-architecture doc
-      still describes the removed Bifrost-era `agent-authentication`
-      pane (the shipped UI redirects it to `agent-api-keys`); its Agents
-      scope needs a truth pass (PR E).

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -310,6 +310,10 @@ profile/members/invitations, billing, secrets (personal + org), SSO,
 org integrations, environments, personal compute, worktree pruning,
 agent authentication, and agent defaults.
 
+(shipped: `agent-authentication` and `agent-defaults` are no longer connected
+panes — removed by PR #814 (`f0f8403fa`) and PR #1100 (`7d5894807`); the
+Agents scope ships as the per-harness panes plus `agent-api-keys`.)
+
 One page is intentionally scaffolded with `SettingsScaffoldPane`
 (registered in `copy/settings/settings-scaffold-copy.ts`) until its
 owning feature spec provides a connected body:
@@ -587,9 +591,11 @@ Legacy id:
                 needed.
 ```
 
-> Shipped correction: the "Agent Authentication" slice of this split
-> never shipped under that name; it landed as the per-harness panes
-> plus the `agent-api-keys` pool (see the staleness note at the top).
+> Shipped correction: this split did ship — `?section=cloud` redirected to
+> `agent-authentication` (`navigation.ts`, pre-#814). PR #814 (`f0f8403fa`)
+> then removed that pane, and the Agent Authentication slice now lands on the
+> per-harness panes plus the `agent-api-keys` pool; the `cloud` redirect is
+> focus-dependent (repo focus → `environments`, billing focus → `billing`).
 
 Preserved id:
 

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -114,6 +114,12 @@ every other spec owns its page content:
   Billing platform -> Billing and Usage & Limits pane content
 ```
 
+> Shipped correction: no pane named "Agent Authentication" was ever
+> shipped under spec 02. The Agents scope ships as the per-harness
+> panes (`agent-claude`/`agent-codex`/`agent-opencode`/`agent-grok`)
+> plus `agent-api-keys`; the old `agent-authentication` id redirects to
+> `agent-api-keys` (see the staleness note at the top).
+
 ## 3. Dependencies
 
 Hard:
@@ -568,6 +574,10 @@ Legacy id:
                 needed.
 ```
 
+> Shipped correction: the "Agent Authentication" slice of this split
+> never shipped under that name; it landed as the per-harness panes
+> plus the `agent-api-keys` pool (see the staleness note at the top).
+
 Preserved id:
 
 ```text
@@ -633,6 +643,9 @@ Agents
                                        agent_run_config rows; visible to
                                        chat, automations, Slack, web,
                                        mobile, Desktop
+  (shipped: AgentDefaultsPane was never built; the `agent-defaults` id
+   redirects to `agent-claude` — see `normalizeSettingsSection` in
+   navigation.ts:41-48.)
   agent-authentication      spec 02   CloudAgentAuthLibrary (per-org and
                                        personal credentials) + per-target
                                        ComputeTargetAgentAuthCard. The
@@ -827,6 +840,9 @@ AgentRunConfigSelector
     AgentDefaultsPane (spec 03)
     Automation create dialog (spec 06)
     Slack bot config (spec 07)
+  (shipped: never built — AgentDefaultsPane, its one listed consumer,
+   was never built either; the component is a zero-hit grep across
+   apps/desktop and apps/packages on main)
 
 RuntimeReadinessPanel
   apps/desktop/src/components/settings/shared/RuntimeReadinessPanel.tsx
@@ -1164,6 +1180,9 @@ Manual smoke:
      -> Deep-linking an admin-only section redirects to General.
      -> Agents > Authentication is enabled (personal selection
         still allowed).
+     (shipped: there is no "Agents > Authentication" pane; the
+      per-harness panes and agent-api-keys have no admin gate, so
+      this is true in effect via the shipped path)
 
 2. Open Settings as an org owner.
      -> Org scope tab shows all admin rows, enabled.

--- a/specs/codebase/systems/product/settings/information-architecture.md
+++ b/specs/codebase/systems/product/settings/information-architecture.md
@@ -114,8 +114,10 @@ every other spec owns its page content:
   Billing platform -> Billing and Usage & Limits pane content
 ```
 
-> Shipped correction: no pane named "Agent Authentication" was ever
-> shipped under spec 02. The Agents scope ships as the per-harness
+> Shipped correction: a pane named "Agent Authentication" (sidebar label
+> "Authentication") did ship under spec 02, then was torn down by
+> PR #814 (`f0f8403fa`, "tear down Bifrost gateway stack") and replaced
+> by the API key pool page. The Agents scope ships as the per-harness
 > panes (`agent-claude`/`agent-codex`/`agent-opencode`/`agent-grok`)
 > plus `agent-api-keys`; the old `agent-authentication` id redirects to
 > `agent-api-keys` (see the staleness note at the top).
@@ -262,7 +264,10 @@ subfolders:
 ```
 
 > Shipped correction: `AgentAuthenticationPane.tsx` and the
-> `agent-authentication/` subfolder do not exist. The Agents scope ships
+> `agent-authentication/` subfolder do not exist; both were removed by
+> PR #814 (`f0f8403fa`). `AgentDefaultsPane.tsx` also does not exist; it
+> was removed by PR #1100 (`7d5894807`) — see the correction on the
+> `agent-defaults` ownership row in §5.2. The Agents scope ships
 > as `panes/agents/harness/` (per-harness pane, auth method cards, CLI
 > login details) and `panes/agents/api-keys/` (the key pool), with
 > selection/vault contracts owned by
@@ -559,6 +564,14 @@ SETTINGS_CONTENT_SECTIONS = [
 ]
 ```
 
+> Shipped correction: same as the §4.1 correction above — the registered
+> array
+> ([config/settings.ts](../../../../../apps/packages/product-client/src/config/settings.ts))
+> carries `agent-claude`/`agent-codex`/`agent-opencode`/`agent-grok`/
+> `agent-api-keys` instead of `agent-authentication`/`agent-defaults`,
+> plus `integrations`, `repo-actions`, and `repo-environment`; `keyboard`,
+> `archived-chats`, and `compute` were removed.
+
 Renamed ids:
 
 ```text
@@ -643,8 +656,12 @@ Agents
                                        agent_run_config rows; visible to
                                        chat, automations, Slack, web,
                                        mobile, Desktop
-  (shipped: AgentDefaultsPane was never built; the `agent-defaults` id
-   redirects to `agent-claude` — see `normalizeSettingsSection` in
+  (shipped: `AgentDefaultsPane` was built (added by `ec1271420`, "Add
+   agent launch defaults settings"), registered, and rendered with a
+   "Defaults" sidebar row, then removed by PR #1100 (`7d5894807`,
+   "remove Agent Defaults settings page; defaults from catalog +
+   last-used-wins"); the `agent-defaults` id now redirects to
+   `agent-claude` — see `normalizeSettingsSection` in
    navigation.ts:41-48.)
   agent-authentication      spec 02   CloudAgentAuthLibrary (per-org and
                                        personal credentials) + per-target
@@ -840,9 +857,10 @@ AgentRunConfigSelector
     AgentDefaultsPane (spec 03)
     Automation create dialog (spec 06)
     Slack bot config (spec 07)
-  (shipped: never built — AgentDefaultsPane, its one listed consumer,
-   was never built either; the component is a zero-hit grep across
-   apps/desktop and apps/packages on main)
+  (shipped: `AgentRunConfigSelector` was never built — a zero-hit grep
+   across apps/desktop and apps/packages on main. Its one listed
+   consumer, `AgentDefaultsPane`, was built but was removed by PR #1100
+   (`7d5894807`); see the correction on the `agent-defaults` row above.)
 
 RuntimeReadinessPanel
   apps/desktop/src/components/settings/shared/RuntimeReadinessPanel.tsx
@@ -1130,6 +1148,9 @@ apps/desktop/src/lib/domain/telemetry/events.ts
 8. Deep-link params (`?section=…&target=…`, `&credential=…`,
    `&kind=…`, `&repo=…`) work: opening a deep link scrolls the focus
    element into view and opens the relevant detail card.
+   (shipped: `&credential=` and `&kind=` do not exist — `FOCUS_PARAM_NAMES`
+    in navigation.ts has neither; see the §5.7 correction. Only
+    `&target=` and `&repo=` are real deep-link params.)
 9. Telemetry events `settings_pane_opened`, `settings_pane_closed`,
     `admin_gate_blocked` are emitted with the new section ids and
     use vocabulary from §5.3.


### PR DESCRIPTION
## Summary

agent-auth.md's Current-gaps list carried a bullet: "Stale IA references — the settings information-architecture doc still describes the removed Bifrost-era `agent-authentication` pane... its Agents scope needs a truth pass (PR E)." This PR does that verification.

`information-architecture.md` was already trued up in #1489 with a staleness note + 5 "Shipped correction" blocks. I re-verified every UI-structure claim in those blocks against main's current shipped code, and checked for any newer drift (the C1/D1/D2 program branches) the doc might be missing.

**Outcome A: all 5 corrections are still accurate against `main`. No drift found.** Struck the gap bullet; no new correction block needed.

## Claim-by-claim verification

| # | Doc claim (information-architecture.md) | Verified against | Result |
|---|---|---|---|
| 1 | Agents scope ships as `agent-claude`/`agent-codex`/`agent-opencode`/`agent-grok`/`agent-api-keys`; `agent-defaults`/`agent-authentication` removed | `apps/packages/product-client/src/config/settings.ts:1-26` (`SETTINGS_CONTENT_SECTIONS`, the section-id union); `navigation-presentation.ts:141-145` (sidebar rows) | Confirmed |
| 2 | Legacy `agent-authentication` → `agent-api-keys`; `agent-defaults`/`defaults`/`advanced` → `agent-claude` redirects | `apps/packages/product-client/src/lib/domain/settings/navigation.ts:41-48` (`normalizeSettingsSection`) | Confirmed |
| 3 | `SETTINGS_CONTENT_SECTIONS` carries the 5 harness/api-keys ids plus `integrations`/`repo-actions`/`repo-environment`; `keyboard`/`archived-chats`/`compute` removed | `apps/packages/product-client/src/config/settings.ts:1-26` | Confirmed |
| 4 | `AgentAuthenticationPane.tsx` and `agent-authentication/` subfolder do not exist; UI ships as `panes/agents/harness/` (`HarnessPane.tsx` + 3 method cards) and `panes/agents/api-keys/` (`ApiKeysPane.tsx`) | `find` for both paths → zero hits; `apps/packages/product-client/src/components/settings/panes/agents/{harness,api-keys}/` both present; `HarnessAuthSection.tsx:33-36,54-56` shows gateway/api_key/cli method set | Confirmed |
| 5 | Agent-auth copy lives in `harness-pane.ts`/`agent-auth-copy.ts`/`agent-api-keys-copy.ts`; no `agent-authentication-copy.ts` | `apps/packages/product-client/src/copy/settings/` listing — the 3 named files exist, no `agent-authentication-copy.ts` | Confirmed |
| 6 | The two `agent-authentication` deep-link params (`&credential=`, `&kind=`) no longer exist | `navigation.ts:15-28` (`FOCUS_PARAM_NAMES`) contains neither `credential` nor `kind`; grep for `credential=`/`kind=` across `apps/desktop`+`apps/packages/product-client/src` finds 0 `credential=` hits and the `kind=` hits are unrelated JSX props (`<ProviderIcon kind={...}>`, `<UsageBarChart kind={...}>`), not URL params | Confirmed |
| 7 | `CredentialPicker`, `WhereUsedDrawer` (agent-auth consumers), `CloudAgentAuthLibrary` were never built / were removed | `find` for all three across `apps/desktop`+`apps/packages` → zero hits | Confirmed |

## Drift check (C1/D1/D2/D3 program branches)

The task flagged two possible sources of newer UI drift the doc might not cover:

- **C1** (`agents/c1-cloud-login-cursor-ui`): cursor cloud-login settings card
- **D1/D2/D3** (`agents/d1-provider-configs`, `agents/d2-multifield-secret-ui`, `agents/d3-rust-provider-config`): provider-config multi-field vault UI (Bedrock/Azure)

Checked merge status: `git merge-base --is-ancestor origin/<branch> origin/main` returns false for all four — **none are merged into `main`**. Confirmed by grep: no `CloudLoginCursor`/cursor-cloud-login references, no `ProviderConfigForm`/Bedrock/Azure vault UI anywhere under `apps/desktop` or `apps/packages/product-client/src` on `main`. Since nothing is shipped yet, the doc correctly says nothing about them — no correction block added. These will need a follow-up IA note when those PRs actually merge; noted here rather than pre-documenting unshipped UI.

## What changed

`specs/codebase/platforms/product/agent-auth.md`: struck the "Stale IA references" bullet from Current-gaps (verification above shows the truth pass it asked for is done and confirmed current). No other bullet touched, per the coordination note below.

`information-architecture.md`: the review round found this doc's own top-note promise ("each such block below carries a correction") wasn't fully true yet — 5 stale references in the Agents scope had no inline correction. Fix cycle 1 adds `(shipped: ...)` annotations at each, matching the voice/format of the 7 existing shipped-notes added in #1489 (2 of which the reviewer spot-checked and confirmed accurate):

1. §2 ownership rule, `spec 02 -> Agent Authentication pane` — noted no pane by that name ever shipped; the Agents scope is the per-harness panes + `agent-api-keys`.
2. §5.1 legacy `cloud` id note ("migrate into Compute + Agent Authentication + Environments") — noted the Agent Authentication slice landed as the per-harness panes/api-keys pool instead.
3. §5.2 `agent-defaults` ownership row — added a note that `AgentDefaultsPane` was never built; `agent-defaults` redirects to `agent-claude` (`navigation.ts:41-48`).
4. §5.4 `AgentRunConfigSelector`'s "Used by: AgentDefaultsPane" — added the same never-built note its siblings `CredentialPicker` and `WhereUsedDrawer` already carry (all three are zero-hit greps against `main`).
5. §9 manual smoke step 1, "Agents > Authentication is enabled" — annotated like steps 3/4 already were: there's no such pane; the per-harness panes/api-keys carry no admin gate, so the claim holds in effect via the shipped path.

Re-scanned the whole Agents scope afterward (grepped for `Agent Authentication`, `AgentDefaults`, `agent-defaults`, `AgentRunConfigSelector`, `CredentialPicker`, `WhereUsedDrawer`, `CloudAgentAuthLibrary`) — every remaining hit sits inside an already-annotated block. No other unannotated stale references found.

## Branch coordination note

This is `main`'s copy of `agent-auth.md`. Per the S2a brief, only the "Stale IA references" bullet was touched to minimize conflict surface. Correction on the original claim: this bullet is not reliably at the tail of every branch's Current-gaps list — `agents/c1-cloud-login-cursor-ui` appends a new bullet ("Cursor's api_key route reports a false Ready") immediately after it. Excluding this branch itself, there are 24 other `agents/*` branches: 21 (including c1) carry the "Stale IA references" bullet verbatim, unstruck; 3 (`catalog-settings-chrome`, `native-auth-expiry`, `opencode-native-coexist`) predate the Current-gaps section entirely (different file path, no gaps list yet) and so have neither the bullet nor a conflict. Reconciliation against any of the 21 is a trivial 4-line delete on rebase; against c1 specifically it's the same 4-line delete, with c1's own trailing bullet left intact — no real conflict either way.

## Verified surface (#1489 + this PR)

`information-architecture.md` carries two annotation styles from #1489: 5 "> Shipped correction:" blockquotes (re-verified accurate in the claim-by-claim table above — Outcome A) and 7 inline `(shipped: ...)` parenthetical notes (covering the Agents-pane row, the agent-authentication ownership row, `CredentialPicker`, `WhereUsedDrawer`, and the §5.7/§9 redirect/smoke corrections) — 12 annotations total. Fix cycle 1 added 3 more inline `(shipped: ...)` notes plus 2 more "> Shipped correction:" blockquotes to close the gap the reviewer found, bringing totals to 10 inline + 7 blockquotes = 17. The reviewer spot-checked two of the original 7 inline notes and found them accurate; all 7 remain unedited and are part of the surface this PR's re-scan covered. (Superseded — see Review cycle 2 and Review cycle 3 below; final grep-verified totals are 12 inline + 8 blockquotes = 20.)

## Review cycle 1

An adversarial review of the original PR found 1 FIX REQUIRED (the doc's top-note promise wasn't met — 5 stale Agents-scope references had no correction block) and 4 body nits (a wrong line-range citation for claim 1, weak evidence for claim 6, an overstated rebase-tail claim, and no mention that #1489's 7 shipped-notes were part of the verified surface). This cycle:

- Added the 5 missing `(shipped: ...)` annotations listed above and re-scanned the doc for any others (found none).
- Fixed claim 1's citation to point at the actual section-id union (`config/settings.ts:1-26`) instead of the icon-id union.
- Replaced claim 6's weak "grep for credential= → zero hits" evidence with the `FOCUS_PARAM_NAMES` union check plus an explicit note on the unrelated `kind=` JSX-prop hits.
- Corrected the rebase-tail claim (c1 appends a bullet right after it; 21 of the other 24 `agents/*` branches carry the bullet unstruck, including c1).
- Called out the 17 total shipped-notes (12 from #1489 + 5 new: 3 inline + 2 blockquotes) as the fully verified surface.

## Review cycle 2

A second adversarial verification found 3 factually-false annotations, 3 residual unannotated stale references, and 2 body arithmetic errors. This cycle:

- **Fixed 3 of 4 false "never built"/"never shipped" annotations** — cycle 1's framing conflated "never built"/"never shipped" with "removed" for two components that did ship and were later torn down (a 4th instance of the same defect, the §5.7 blockquote's "never shipped under that name" framing, was not caught here — it wasn't fixed until cycle 3):
  - §2 ownership row (`spec 02 -> Agent Authentication pane`): a pane literally named "Agent Authentication" (sidebar label "Authentication") did ship, then was removed by **PR #814** (`f0f8403fa`, "tear down Bifrost gateway stack") and replaced by the API key pool page.
  - §5.2 `agent-defaults` ownership row: `AgentDefaultsPane` was built (added by `ec1271420`, "Add agent launch defaults settings" — registered, rendered, with a "Defaults" sidebar row), then removed by **PR #1100** (`7d5894807`, "remove Agent Defaults settings page; defaults from catalog + last-used-wins").
  - §5.4 `AgentRunConfigSelector`'s note: kept "never built" for `AgentRunConfigSelector` itself (true — zero-hit grep across `apps/desktop`/`apps/packages` on `main`), but fixed the claim that its listed consumer `AgentDefaultsPane` "was never built either" — it was built and removed by PR #1100, same as above.
  - §4.1 panes-listing blockquote (`AgentAuthenticationPane.tsx`/`agent-authentication/` correction) extended to also cover `AgentDefaultsPane.tsx`, attributing both removals to their respective PRs (#814, #1100).
- **Annotated 3 residual stale references** that had no correction at all:
  - A second, duplicate copy of the stale `SETTINGS_CONTENT_SECTIONS` array (§5.1, listing `keyboard`/`compute`/`archived-chats`/`agent-authentication`/`agent-defaults`) — added a blockquote mirroring the existing §4.1 correction on the first copy.
  - Acceptance criterion 8 (`&credential=`/`&kind=` deep-link params "work") — annotated: neither param exists in `FOCUS_PARAM_NAMES`, contradicting the §5.7 correction; only `&target=` and `&repo=` are real.
  - (The §4.1 panes-listing fix above also closes the `AgentDefaultsPane.tsx` gap that was previously unannotated.)
- **Fixed body arithmetic**: the original body claimed cycle 1 brought the annotation count to "12" — wrong, because 12 was already `main`'s baseline (7 inline `(shipped: ...)` notes + 5 "> Shipped correction:" blockquotes) before cycle 1 touched anything. Cycle 1 actually added 3 inline notes + 2 blockquotes, bringing totals to 10 inline + 7 blockquotes = 17. Cycle 2 adds 1 more blockquote (duplicate-array mirror at the second `SETTINGS_CONTENT_SECTIONS` copy) + 1 more inline note (AC8) → **final: 11 inline + 8 blockquotes = 19 total**, verified by direct grep count against the file (`grep -c "(shipped:"` / `grep -c "^> Shipped correction:"`), not narrative arithmetic. The "229 Markdown files" figure in Verification below was independently re-checked against a fresh `python3 scripts/check_docs.py` run and `git ls-files '*.md'` — it is correct, not stale; no fix was needed there.
- Re-checked the top staleness note's promise ("each such block below carries a correction") for raw mentions of `agent-authentication`/`AgentDefaultsPane`/`AgentAuthenticationPane`/`AgentRunConfigSelector`/`CredentialPicker`/`WhereUsedDrawer`/`CloudAgentAuthLibrary`/`&credential=`/`&kind=` in the Agents scope. **This check was incomplete** (corrected in cycle 3): it missed the §4.2 "agent authentication, and agent defaults" mention, which remained unannotated, and it did not re-examine the §5.7 blockquote's own prose for accuracy — that blockquote's "never shipped under that name" framing was itself false and stayed false through this cycle.

## Review cycle 3

A third pass found the §5.7 blockquote's "never shipped under that name" framing was still false — the same never-built-vs-removed defect class cycle 2 fixed at §2/§5.2/§5.4/§4.1, but missed here — and found one Agents-scope mention in §4.2 that was still unannotated. This cycle:

- **Fixed the §5.7 blockquote** (:590, `information-architecture.md`, commit `739f36596cbcf016bc1e95ee3eaf10bf995b4867`): replaced the false "never shipped under that name" framing with the accurate one — the Agent Authentication pane did ship and was reachable via the `?section=cloud` redirect (`navigation.ts`) pre-#814; PR #814 (`f0f8403fa`) then removed it, landing the slice on the per-harness panes plus `agent-api-keys`. Also made explicit that the `cloud` redirect is focus-dependent — repo focus routes to `environments`, billing focus routes to `billing` — confirmed directly against `cloudRedirectSection()` in `apps/packages/product-client/src/lib/domain/settings/navigation.ts`.
- **Annotated §4.2** (:311, same commit `739f36596cbcf016bc1e95ee3eaf10bf995b4867`): added a `(shipped: ...)` note that `agent-authentication` and `agent-defaults` are no longer connected panes — removed by PR #814 (`f0f8403fa`) and PR #1100 (`7d5894807`) — matching the inline-annotation format used at the file's other prose-level `(shipped: ...)` notes (e.g. the §9 acceptance-criterion-8 note).

New totals (grep-verified against the file, not narrative arithmetic): `grep -c '(shipped:'` = 12, `grep -c '^> Shipped correction:'` = 8 → **20 total**.

## Verification

```
python3 scripts/check_docs.py
# Documentation integrity check passed (229 Markdown files).
```

Docs-only change; no code/build verification applicable.


