### PR TITLE
feat(worker): sync fresh model snapshots to the cloud on every heartbeat (S2b)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/staleness_tests/projection_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/staleness_tests/projection_tests.rs
@@ -97,6 +97,17 @@ fn the_status_projection_shapes_every_field_and_never_exposes_the_fingerprint() 
     assert!(serialized.contains("\"snapshotAgeSeconds\":3600"));
     assert!(serialized.contains("\"identityComparable\":true"));
     assert!(serialized.contains("\"state\":\"idle\""));
+    // T-45 (S2b): the full models/modes lists ride alongside the counts —
+    // model-catalog.md:660 always said this route serves "model and mode
+    // lists off the same document read"; the shipped shape undershot that
+    // with counts only, and this closes the gap the Worker's
+    // model_snapshot_sync now depends on.
+    assert_eq!(status.models.len(), 1);
+    assert_eq!(status.models[0].id, "m-1");
+    assert_eq!(status.modes.len(), 1);
+    assert_eq!(status.modes[0].id, "build");
+    assert!(serialized.contains("\"models\":[{\"id\":\"m-1\""));
+    assert!(serialized.contains("\"modes\":[{\"id\":\"build\""));
 
     // An indeterminate identity must tell the UI to claim no version binding.
     let pre_field = entry(HOUR, None, secret_fingerprint);
@@ -137,7 +148,10 @@ fn the_status_projection_shapes_every_field_and_never_exposes_the_fingerprint() 
         next_attempt_at: Some(next),
     });
     assert_eq!(backoff.last_error.as_deref(), Some("timeout"));
-    assert_eq!(backoff.probed_at.as_deref(), Some(failed_probed_at.as_str()));
+    assert_eq!(
+        backoff.probed_at.as_deref(),
+        Some(failed_probed_at.as_str())
+    );
     assert_eq!(backoff.model_count, 1, "the last good list keeps serving");
     assert_eq!(backoff.state, LiveState::Backoff);
     assert_eq!(backoff.next_attempt_at, Some(next.to_rfc3339()));
@@ -190,6 +204,8 @@ fn a_context_with_no_entry_projects_as_missing() {
     assert_eq!(status.probed_at, None);
     assert_eq!(status.snapshot_age_seconds, None);
     assert_eq!(status.model_count, 0);
+    assert!(status.models.is_empty(), "no entry means no models to list");
+    assert!(status.modes.is_empty(), "no entry means no modes to list");
     let _unused: BTreeMap<String, String> = BTreeMap::new();
 }
 
@@ -205,22 +221,15 @@ fn a_context_with_no_entry_projects_as_missing() {
 /// of a silent client break.
 #[test]
 fn every_live_state_serializes_exactly_as_the_generated_schema_declares() {
-    let schema = serde_json::to_value(
-        utoipa::openapi::schema::Schema::from(
-            <LiveState as utoipa::PartialSchema>::schema(),
-        ),
-    )
+    let schema = serde_json::to_value(utoipa::openapi::schema::Schema::from(
+        <LiveState as utoipa::PartialSchema>::schema(),
+    ))
     .expect("serialize the generated schema");
     let declared: Vec<String> = schema["enum"]
         .as_array()
         .expect("the schema must declare an enum")
         .iter()
-        .map(|value| {
-            value
-                .as_str()
-                .expect("enum values are strings")
-                .to_string()
-        })
+        .map(|value| value.as_str().expect("enum values are strings").to_string())
         .collect();
 
     let wire: Vec<String> = [

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/status.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/status.rs
@@ -22,7 +22,9 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use super::document::{InstallIdentity, SnapshotAttempt, SnapshotEntry};
+use super::document::{
+    InstallIdentity, SnapshotAttempt, SnapshotEntry, SnapshotMode, SnapshotModel,
+};
 use super::staleness::{self, IdentityComparison};
 use super::ProbeEngineMode;
 
@@ -128,6 +130,20 @@ pub struct ContextStatus {
     pub attestation: Option<super::document::SnapshotAttestation>,
     pub model_count: usize,
     pub mode_count: usize,
+    /// The full model list off the same document read as `modelCount`. Added
+    /// alongside the count (never replacing it — model-catalog.md:660 always
+    /// said this route serves "model and mode lists off the same document
+    /// read"; the count-only shape undershot that, and this is the fix) so a
+    /// machineless-surface uploader (the Worker's `model_snapshot_sync`) has
+    /// something to read besides raw disk access to a document it should not
+    /// know the layout of.
+    #[serde(default)]
+    #[schema(value_type = Vec<Object>)]
+    pub models: Vec<SnapshotModel>,
+    /// The full mode list, same rationale as `models` above.
+    #[serde(default)]
+    #[schema(value_type = Vec<Object>)]
+    pub modes: Vec<SnapshotMode>,
     #[serde(default)]
     pub warnings: Vec<String>,
 }
@@ -177,7 +193,10 @@ pub fn context_status(inputs: ContextStatusInputs) -> ContextStatus {
     let snapshot_age_seconds = entry.as_ref().and_then(|entry| {
         DateTime::parse_from_rfc3339(&entry.probed_at)
             .ok()
-            .map(|parsed| now.signed_duration_since(parsed.with_timezone(&Utc)).num_seconds())
+            .map(|parsed| {
+                now.signed_duration_since(parsed.with_timezone(&Utc))
+                    .num_seconds()
+            })
     });
     let last_error = entry.as_ref().and_then(|entry| {
         matches!(
@@ -206,6 +225,14 @@ pub fn context_status(inputs: ContextStatusInputs) -> ContextStatus {
         attestation: entry.as_ref().and_then(|entry| entry.attestation.clone()),
         model_count: entry.as_ref().map(|entry| entry.models.len()).unwrap_or(0),
         mode_count: entry.as_ref().map(|entry| entry.modes.len()).unwrap_or(0),
+        models: entry
+            .as_ref()
+            .map(|entry| entry.models.clone())
+            .unwrap_or_default(),
+        modes: entry
+            .as_ref()
+            .map(|entry| entry.modes.clone())
+            .unwrap_or_default(),
         warnings: entry.map(|entry| entry.warnings).unwrap_or_default(),
     }
 }

--- a/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/cloud_client/mod.rs
@@ -113,6 +113,21 @@ pub struct HeartbeatResponse {
     pub supervisor_bridge: Option<SupervisorBridgeInputs>,
 }
 
+/// A Worker's upload of one changed model-snapshot entry (model-catalog.md
+/// "Write paths"/"Storage"): the ingest route absorbs today's separate
+/// `refresh`-with-payload and `mirror` routes. `snapshot_json` deliberately
+/// carries only the subset of the machine-document entry the cloud tier
+/// documents reading (`models`, `modes`, `attestation`, `warnings`) — see
+/// `model_snapshot_sync.rs` for why `authFingerprint`/`mechanism`/
+/// `installIdentity`/`lastAttempt` are never assembled here.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct IngestModelSnapshotRequest {
+    pub auth_context_id: String,
+    pub snapshot_json: String,
+    pub probed_at: String,
+}
+
 /// Server-delivered D5 bridge inputs (R9R-002). Carried on the heartbeat ack so
 /// an already-provisioned legacy Worker — whose on-disk config predates the
 /// supervisor-owned shape — can materialize the Supervisor config AND a
@@ -183,6 +198,41 @@ impl CloudClient {
             .send()
             .await?;
         parse_json_response(response).await
+    }
+
+    /// Upload one changed model-snapshot entry to the cloud ingest route
+    /// (model-catalog.md "Cloud routes": `POST /v1/cloud/agent-models/{harness}/refresh`).
+    /// The server resolves the owner from the Worker's own sandbox row, so the
+    /// request body carries no user identity — only the Worker's bearer proves
+    /// which sandbox this is. Non-2xx (including a 403 from a desktop worker,
+    /// or a 404 against a server that predates this route) surfaces as
+    /// `WorkerError::Cloud` for the caller to log-and-swallow; this method
+    /// itself never retries.
+    pub async fn ingest_model_snapshot(
+        &self,
+        worker_token: &str,
+        harness_kind: &str,
+        request: &IngestModelSnapshotRequest,
+    ) -> Result<(), WorkerError> {
+        let response = self
+            .http
+            .post(format!(
+                "{}/v1/cloud/agent-models/{harness_kind}/refresh",
+                self.base_url
+            ))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                auth::bearer_header(worker_token),
+            )
+            .json(request)
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WorkerError::Cloud { status, body });
+        }
+        Ok(())
     }
 
     /// Fetch a pinned worker artifact via the server's redirect endpoint,
@@ -345,7 +395,6 @@ impl CloudClient {
             size_bytes,
         })
     }
-
 }
 
 /// A downloaded worker artifact plus the CDN URL the server's redirect

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -6,6 +6,7 @@ mod identity;
 mod integration_gateway;
 mod lifecycle;
 mod logging;
+mod model_snapshot_sync;
 mod observability;
 mod process_lock;
 mod runtime;

--- a/anyharness/crates/proliferate-worker/src/model_snapshot_sync.rs
+++ b/anyharness/crates/proliferate-worker/src/model_snapshot_sync.rs
@@ -1,0 +1,320 @@
+//! Heartbeat-driven model-snapshot cloud sync (model-catalog.md "Write paths").
+//!
+//! Replaces the deleted gateway-catalog mirror push. On every successful
+//! heartbeat tick:
+//!
+//! 1. GET the runtime's list of agents (`GET /v1/agents`), then GET each
+//!    harness's polled model-snapshot status (`GET /v1/agents/{kind}/model-snapshot`)
+//!    over the same narrow local AnyHarness surface `catalog_sync.rs` used
+//!    (localhost + optional runtime bearer).
+//! 2. Compare each context's `probedAt` against the last-uploaded value held
+//!    in memory (this module's state, the `probedAt` analogue of
+//!    `catalog_sync`'s ETag cache) — worth at most one redundant upload after
+//!    a Worker restart, which the server's soft-versioned write absorbs
+//!    idempotently.
+//! 3. POST changed contexts to the cloud ingest route
+//!    (`POST /v1/cloud/agent-models/{harness}/refresh`) with the Worker's own
+//!    bearer; the server resolves the owner from the Worker's sandbox row, so
+//!    the payload carries no user identity.
+//! 4. Non-fatal like every convergence action: a failure at any step logs and
+//!    the next heartbeat tick retries — this module never wedges the loop and
+//!    never propagates an error upward.
+//!
+//! **Uploaded fields are a strict subset of the machine document's entry.**
+//! The runtime's status route deliberately never serves `authFingerprint`
+//! (model-catalog.md: "never on the wire ... the boolean `stale` plus its
+//! reason is the whole client contract") and has no per-context `mechanism`,
+//! `installIdentity`, or `lastAttempt` fields either — those stay local
+//! diagnostics. What IS uploaded — `probedAt`, `models`, `modes`,
+//! `attestation`, `warnings` — is exactly the list model-catalog.md's
+//! "Storage" section names for `snapshot_json`, so this is not a narrowed
+//! upload; it is the whole of what the wire projection ever carried.
+//!
+//! **Cloud-sandbox scoped.** The cloud ingest route's `resolve_upload_owner`
+//! refuses any worker whose `runtime_kind != "cloud_sandbox"` with a 403
+//! (server/proliferate/server/cloud/agent_models/snapshots.py). A desktop
+//! worker therefore always gets a 403 here — logged and swallowed like any
+//! other push failure, never a special case in this module. The desktop's
+//! local-surface document never needed to sync in the first place
+//! (model-catalog.md: "Desktop does not sync").
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use crate::{
+    cloud_client::{CloudClient, IngestModelSnapshotRequest},
+    config::WorkerConfig,
+    error::WorkerError,
+};
+
+/// In-memory state kept across heartbeats: the last successfully-uploaded
+/// `probedAt` per (harness_kind, auth_context_id). A restart loses this and
+/// re-uploads once — the server's soft-versioned write absorbs the repeat.
+pub struct ModelSnapshotSyncState {
+    last_pushed: Mutex<HashMap<(String, String), String>>,
+}
+
+impl ModelSnapshotSyncState {
+    pub fn new() -> Self {
+        Self {
+            last_pushed: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn snapshot(&self) -> HashMap<(String, String), String> {
+        self.last_pushed.lock().unwrap().clone()
+    }
+
+    fn record_pushed(&self, harness_kind: &str, auth_context_id: &str, probed_at: &str) {
+        self.last_pushed.lock().unwrap().insert(
+            (harness_kind.to_string(), auth_context_id.to_string()),
+            probed_at.to_string(),
+        );
+    }
+}
+
+impl Default for ModelSnapshotSyncState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Wire shapes read from the runtime (worker-local, minimal) ─────────────
+
+/// One entry of `GET /v1/agents` — only the field this module needs.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeAgentSummary {
+    kind: String,
+}
+
+/// The subset of `GET /v1/agents/{kind}/model-snapshot`'s response
+/// (`ModelSnapshotStatus` in anyharness-lib) this module reads. Deliberately
+/// not shared with anyharness-lib's type — the worker binary does not depend
+/// on anyharness-lib, mirroring how `catalog_sync.rs` declared its own
+/// `RuntimeCatalogVersion` rather than importing one.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeModelSnapshotStatus {
+    #[serde(default)]
+    contexts: Vec<RuntimeContextStatus>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeContextStatus {
+    auth_context_id: String,
+    /// Absent (`None`) means no entry has ever been probed for this context —
+    /// the "skip harnesses with no snapshot" case.
+    #[serde(default)]
+    probed_at: Option<String>,
+    #[serde(default)]
+    models: Vec<serde_json::Value>,
+    #[serde(default)]
+    modes: Vec<serde_json::Value>,
+    #[serde(default)]
+    attestation: Option<serde_json::Value>,
+    #[serde(default)]
+    warnings: Vec<String>,
+}
+
+// ─── Decision logic (pure, testable) ───────────────────────────────────────
+
+/// One upload this tick should perform.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingPush {
+    pub harness_kind: String,
+    pub auth_context_id: String,
+    pub probed_at: String,
+    pub snapshot_json: String,
+}
+
+/// Decide which contexts of one harness need an upload this tick: a context
+/// with no entry yet (`probed_at: None`) is skipped, and a context whose
+/// `probedAt` already matches the last-pushed value is skipped too. Order is
+/// the input order, so callers get deterministic push ordering for logging.
+fn plan_pushes(
+    harness_kind: &str,
+    contexts: &[RuntimeContextStatus],
+    last_pushed: &HashMap<(String, String), String>,
+) -> Vec<PendingPush> {
+    contexts
+        .iter()
+        .filter_map(|context| {
+            let probed_at = context.probed_at.as_deref()?;
+            let key = (harness_kind.to_string(), context.auth_context_id.clone());
+            if last_pushed.get(&key).map(String::as_str) == Some(probed_at) {
+                return None;
+            }
+            let entry = serde_json::json!({
+                "probedAt": probed_at,
+                "models": context.models,
+                "modes": context.modes,
+                "attestation": context.attestation,
+                "warnings": context.warnings,
+            });
+            Some(PendingPush {
+                harness_kind: harness_kind.to_string(),
+                auth_context_id: context.auth_context_id.clone(),
+                probed_at: probed_at.to_string(),
+                snapshot_json: entry.to_string(),
+            })
+        })
+        .collect()
+}
+
+// ─── Execution (async, side-effecting) ─────────────────────────────────────
+
+/// Run the model-snapshot sync flow for one heartbeat tick. Every failure is
+/// logged and swallowed — the heartbeat loop must never crash on a sync
+/// failure, and a failed push simply retries next tick because `state` is
+/// only updated on success.
+pub async fn maybe_sync(
+    config: &WorkerConfig,
+    cloud: &CloudClient,
+    worker_token: &str,
+    state: &ModelSnapshotSyncState,
+) {
+    let runtime_bearer = resolve_runtime_bearer_token(config);
+    let runtime_base = config.runtime_base_url.trim_end_matches('/');
+
+    let kinds = match list_runtime_agent_kinds(runtime_base, runtime_bearer.as_deref()).await {
+        Ok(kinds) => kinds,
+        Err(WorkerError::Cloud { status, .. }) if status == reqwest::StatusCode::NOT_FOUND => {
+            info!("model snapshot sync: runtime does not support model snapshots (old version)");
+            return;
+        }
+        Err(error) => {
+            warn!(?error, "model snapshot sync: failed to list runtime agents");
+            return;
+        }
+    };
+
+    for kind in kinds {
+        sync_one_harness(
+            cloud,
+            worker_token,
+            runtime_base,
+            runtime_bearer.as_deref(),
+            &kind,
+            state,
+        )
+        .await;
+    }
+}
+
+/// Sync one harness's contexts. Isolated per harness so one harness's
+/// failure (a 409 non-owner runtime, a probe never having run yet) never
+/// blocks another harness's upload this tick.
+async fn sync_one_harness(
+    cloud: &CloudClient,
+    worker_token: &str,
+    runtime_base: &str,
+    runtime_bearer: Option<&str>,
+    harness_kind: &str,
+    state: &ModelSnapshotSyncState,
+) {
+    let status = match fetch_runtime_status(runtime_base, runtime_bearer, harness_kind).await {
+        Ok(status) => status,
+        Err(error) => {
+            warn!(
+                ?error,
+                harness_kind, "model snapshot sync: failed to read runtime status"
+            );
+            return;
+        }
+    };
+
+    let last_pushed = state.snapshot();
+    let pushes = plan_pushes(harness_kind, &status.contexts, &last_pushed);
+    for push in pushes {
+        let request = IngestModelSnapshotRequest {
+            auth_context_id: push.auth_context_id.clone(),
+            snapshot_json: push.snapshot_json,
+            probed_at: push.probed_at.clone(),
+        };
+        match cloud
+            .ingest_model_snapshot(worker_token, &push.harness_kind, &request)
+            .await
+        {
+            Ok(()) => {
+                state.record_pushed(&push.harness_kind, &push.auth_context_id, &push.probed_at);
+                info!(
+                    harness_kind = %push.harness_kind,
+                    auth_context_id = %push.auth_context_id,
+                    "model snapshot sync: uploaded changed entry"
+                );
+            }
+            Err(error) => {
+                // Not recorded: the next tick's plan_pushes sees the same
+                // stale last_pushed value and retries this exact push.
+                warn!(
+                    ?error,
+                    harness_kind = %push.harness_kind,
+                    auth_context_id = %push.auth_context_id,
+                    "model snapshot sync: cloud upload failed; retrying next tick"
+                );
+            }
+        }
+    }
+}
+
+/// Resolve the runtime bearer token: config field takes precedence, then
+/// `ANYHARNESS_BEARER_TOKEN` env var. Mirrors the deleted `catalog_sync.rs`.
+fn resolve_runtime_bearer_token(config: &WorkerConfig) -> Option<String> {
+    config.runtime_bearer_token.clone().or_else(|| {
+        std::env::var("ANYHARNESS_BEARER_TOKEN")
+            .ok()
+            .filter(|v| !v.is_empty())
+    })
+}
+
+/// `GET /v1/agents`: the list of harness kinds this runtime knows about.
+async fn list_runtime_agent_kinds(
+    runtime_base: &str,
+    bearer_token: Option<&str>,
+) -> Result<Vec<String>, WorkerError> {
+    let client = reqwest::Client::new();
+    let mut request = client.get(format!("{runtime_base}/v1/agents"));
+    if let Some(token) = bearer_token {
+        request = request.header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"));
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(WorkerError::Cloud { status, body });
+    }
+    let agents: Vec<RuntimeAgentSummary> = response.json().await?;
+    Ok(agents.into_iter().map(|agent| agent.kind).collect())
+}
+
+/// `GET /v1/agents/{kind}/model-snapshot`: one harness's polled status,
+/// including the models/modes lists this sync uploads.
+async fn fetch_runtime_status(
+    runtime_base: &str,
+    bearer_token: Option<&str>,
+    harness_kind: &str,
+) -> Result<RuntimeModelSnapshotStatus, WorkerError> {
+    let client = reqwest::Client::new();
+    let mut request = client.get(format!(
+        "{runtime_base}/v1/agents/{harness_kind}/model-snapshot"
+    ));
+    if let Some(token) = bearer_token {
+        request = request.header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"));
+    }
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(WorkerError::Cloud { status, body });
+    }
+    Ok(response.json().await?)
+}
+
+#[cfg(test)]
+#[path = "model_snapshot_sync_tests.rs"]
+mod tests;

--- a/anyharness/crates/proliferate-worker/src/model_snapshot_sync_tests.rs
+++ b/anyharness/crates/proliferate-worker/src/model_snapshot_sync_tests.rs
@@ -1,0 +1,303 @@
+use super::*;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+
+fn context(auth_context_id: &str, probed_at: Option<&str>) -> RuntimeContextStatus {
+    RuntimeContextStatus {
+        auth_context_id: auth_context_id.to_string(),
+        probed_at: probed_at.map(str::to_string),
+        models: vec![serde_json::json!({"id": "m1"})],
+        modes: vec![serde_json::json!({"id": "default", "name": "Default"})],
+        attestation: None,
+        warnings: Vec::new(),
+    }
+}
+
+// ── plan_pushes: pure decision tests ────────────────────────────────
+
+#[test]
+fn plan_pushes_uploads_when_probed_at_advances() {
+    let contexts = vec![context("gateway", Some("2026-07-27T00:00:00Z"))];
+    let mut last_pushed = HashMap::new();
+    last_pushed.insert(
+        ("opencode".to_string(), "gateway".to_string()),
+        "2026-07-26T00:00:00Z".to_string(),
+    );
+    let pushes = plan_pushes("opencode", &contexts, &last_pushed);
+    assert_eq!(pushes.len(), 1);
+    assert_eq!(pushes[0].auth_context_id, "gateway");
+    assert_eq!(pushes[0].probed_at, "2026-07-27T00:00:00Z");
+    assert!(pushes[0].snapshot_json.contains("\"m1\""));
+}
+
+#[test]
+fn plan_pushes_does_not_repush_unchanged_probed_at() {
+    let contexts = vec![context("gateway", Some("2026-07-27T00:00:00Z"))];
+    let mut last_pushed = HashMap::new();
+    last_pushed.insert(
+        ("opencode".to_string(), "gateway".to_string()),
+        "2026-07-27T00:00:00Z".to_string(),
+    );
+    let pushes = plan_pushes("opencode", &contexts, &last_pushed);
+    assert!(pushes.is_empty(), "unchanged probedAt must not re-push");
+}
+
+#[test]
+fn plan_pushes_skips_a_context_with_no_snapshot_yet() {
+    let contexts = vec![context("gateway", None)];
+    let pushes = plan_pushes("opencode", &contexts, &HashMap::new());
+    assert!(pushes.is_empty(), "no probedAt means no entry to upload");
+}
+
+#[test]
+fn plan_pushes_treats_each_harness_independently() {
+    let contexts = vec![context("gateway", Some("2026-07-27T00:00:00Z"))];
+    let mut last_pushed = HashMap::new();
+    // Same probedAt, but recorded under a DIFFERENT harness — must not
+    // suppress this harness's push.
+    last_pushed.insert(
+        ("grok".to_string(), "gateway".to_string()),
+        "2026-07-27T00:00:00Z".to_string(),
+    );
+    let pushes = plan_pushes("opencode", &contexts, &last_pushed);
+    assert_eq!(pushes.len(), 1);
+}
+
+#[test]
+fn plan_pushes_handles_no_contexts_at_all() {
+    let pushes = plan_pushes("opencode", &[], &HashMap::new());
+    assert!(pushes.is_empty());
+}
+
+// ── resolve_runtime_bearer_token ─────────────────────────────────────
+
+fn minimal_config() -> WorkerConfig {
+    WorkerConfig {
+        cloud_base_url: "https://cloud.test".to_string(),
+        enrollment_token: None,
+        worker_db_path: "/tmp/worker.sqlite3".into(),
+        integration_gateway_home: None,
+        heartbeat_interval_seconds: 30,
+        self_update_enabled: false,
+        anyharness_update_enabled: false,
+        anyharness_binary_path: None,
+        anyharness_launcher_path: None,
+        anyharness_workdir: None,
+        runtime_base_url: "http://127.0.0.1:8457".to_string(),
+        runtime_bearer_token: None,
+        supervisor_update_request_dir: None,
+        supervisor_binary_path: None,
+        supervisor_config_path: None,
+        supervisor_config_toml: None,
+        supervisor_bridge_marker_dir: None,
+        config_path: None,
+    }
+}
+
+#[test]
+fn resolve_runtime_bearer_token_prefers_config_over_env() {
+    let mut config = minimal_config();
+    config.runtime_bearer_token = Some("from-config".to_string());
+    assert_eq!(
+        resolve_runtime_bearer_token(&config),
+        Some("from-config".to_string())
+    );
+}
+
+#[test]
+fn resolve_runtime_bearer_token_falls_back_to_env() {
+    let config = minimal_config();
+    std::env::remove_var("ANYHARNESS_BEARER_TOKEN");
+    assert_eq!(resolve_runtime_bearer_token(&config), None);
+}
+
+// ── Integration: fake HTTP servers for the runtime + the cloud ──────
+
+struct CapturedRequest {
+    method: String,
+    path: String,
+    headers: HashMap<String, String>,
+    body: String,
+}
+
+fn parse_request(raw: &str) -> CapturedRequest {
+    let mut parts = raw.splitn(2, "\r\n\r\n");
+    let head = parts.next().unwrap_or_default();
+    let body = parts
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('\0')
+        .to_string();
+    let mut lines = head.lines();
+    let request_line = lines.next().unwrap_or_default();
+    let mut request_parts = request_line.split(' ');
+    let method = request_parts.next().unwrap_or_default().to_string();
+    let path = request_parts.next().unwrap_or_default().to_string();
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((key, value)) = line.split_once(':') {
+            headers.insert(key.trim().to_lowercase(), value.trim().to_string());
+        }
+    }
+    CapturedRequest {
+        method,
+        path,
+        headers,
+        body,
+    }
+}
+
+/// Accept exactly `responses.len()` connections in order, one response
+/// per connection, and return every captured request. Mirrors the
+/// hand-rolled `TcpListener` pattern in
+/// `anyharness-lib`'s `installer/downloads_tests.rs` — this crate has no
+/// HTTP-mocking dependency.
+fn spawn_fake_server(
+    responses: Vec<(u16, &'static str, String)>,
+) -> (
+    std::net::SocketAddr,
+    std::thread::JoinHandle<Vec<CapturedRequest>>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
+    let address = listener.local_addr().expect("fake server address");
+    let handle = std::thread::spawn(move || {
+        let mut captured = Vec::new();
+        for (status, reason, body) in responses {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = vec![0u8; 65536];
+            let read = stream.read(&mut buffer).expect("read request");
+            let raw = String::from_utf8_lossy(&buffer[..read]).to_string();
+            captured.push(parse_request(&raw));
+            write!(
+                stream,
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("write response");
+        }
+        captured
+    });
+    (address, handle)
+}
+
+fn runtime_responses(
+    harness_kind: &str,
+    contexts_json: &str,
+) -> Vec<(u16, &'static str, String)> {
+    vec![
+        (
+            200,
+            "OK",
+            serde_json::json!([{ "kind": harness_kind }]).to_string(),
+        ),
+        (200, "OK", format!("{{\"contexts\":{contexts_json}}}")),
+    ]
+}
+
+fn cloud_config_for(
+    runtime_addr: std::net::SocketAddr,
+    cloud_addr: std::net::SocketAddr,
+) -> WorkerConfig {
+    let mut config = minimal_config();
+    config.cloud_base_url = format!("http://{cloud_addr}");
+    config.runtime_base_url = format!("http://{runtime_addr}");
+    config
+}
+
+#[tokio::test]
+async fn maybe_sync_uploads_a_changed_context_with_the_workers_bearer() {
+    let contexts_json = serde_json::json!([
+        {
+            "authContextId": "gateway",
+            "probedAt": "2026-07-27T00:00:00Z",
+            "models": [{"id": "m1"}],
+            "modes": [{"id": "default", "name": "Default"}],
+            "warnings": []
+        }
+    ])
+    .to_string();
+    let (runtime_addr, runtime_handle) =
+        spawn_fake_server(runtime_responses("opencode", &contexts_json));
+    let (cloud_addr, cloud_handle) = spawn_fake_server(vec![(
+        200,
+        "OK",
+        serde_json::json!({"ok": true}).to_string(),
+    )]);
+
+    let config = cloud_config_for(runtime_addr, cloud_addr);
+    let cloud = CloudClient::new(&config).expect("build cloud client");
+    let state = ModelSnapshotSyncState::new();
+
+    maybe_sync(&config, &cloud, "worker-secret-token", &state).await;
+
+    let runtime_requests = runtime_handle.join().expect("runtime server thread");
+    assert_eq!(runtime_requests[0].path, "/v1/agents");
+    assert_eq!(
+        runtime_requests[1].path,
+        "/v1/agents/opencode/model-snapshot"
+    );
+
+    let cloud_requests = cloud_handle.join().expect("cloud server thread");
+    assert_eq!(cloud_requests.len(), 1, "exactly one context changed");
+    let push = &cloud_requests[0];
+    assert_eq!(push.method, "POST");
+    assert_eq!(push.path, "/v1/cloud/agent-models/opencode/refresh");
+    assert_eq!(
+        push.headers.get("authorization").map(String::as_str),
+        Some("Bearer worker-secret-token"),
+        "the worker's own bearer must authenticate the cloud upload"
+    );
+    assert!(push.body.contains("\"authContextId\":\"gateway\""));
+    assert!(push.body.contains("\"probedAt\":\"2026-07-27T00:00:00Z\""));
+
+    // Success is recorded, so an identical status next tick would not
+    // re-push (verified against the pure decision fn directly).
+    let recorded = state.snapshot();
+    assert_eq!(
+        recorded.get(&("opencode".to_string(), "gateway".to_string())),
+        Some(&"2026-07-27T00:00:00Z".to_string())
+    );
+}
+
+#[tokio::test]
+async fn maybe_sync_does_not_wedge_on_a_cloud_error_and_leaves_the_push_pending() {
+    let contexts_json = serde_json::json!([
+        {
+            "authContextId": "gateway",
+            "probedAt": "2026-07-27T00:00:00Z",
+            "models": [{"id": "m1"}],
+            "modes": [],
+            "warnings": []
+        }
+    ])
+    .to_string();
+    let (runtime_addr, runtime_handle) =
+        spawn_fake_server(runtime_responses("opencode", &contexts_json));
+    let (cloud_addr, cloud_handle) = spawn_fake_server(vec![(
+        500,
+        "Internal Server Error",
+        serde_json::json!({"error": "boom"}).to_string(),
+    )]);
+
+    let config = cloud_config_for(runtime_addr, cloud_addr);
+    let cloud = CloudClient::new(&config).expect("build cloud client");
+    let state = ModelSnapshotSyncState::new();
+
+    // Must return normally — never panic, never propagate an error.
+    maybe_sync(&config, &cloud, "worker-secret-token", &state).await;
+
+    runtime_handle.join().expect("runtime server thread");
+    let cloud_requests = cloud_handle.join().expect("cloud server thread");
+    assert_eq!(cloud_requests.len(), 1, "the push was attempted");
+
+    // Not recorded on failure, so the next tick's plan_pushes sees the
+    // same context as still needing an upload.
+    let recorded = state.snapshot();
+    assert!(
+        recorded.is_empty(),
+        "a failed push must not be recorded as pushed"
+    );
+    let contexts = vec![context("gateway", Some("2026-07-27T00:00:00Z"))];
+    let retry = plan_pushes("opencode", &contexts, &recorded);
+    assert_eq!(retry.len(), 1, "the next tick must retry the failed push");
+}

--- a/anyharness/crates/proliferate-worker/src/runtime.rs
+++ b/anyharness/crates/proliferate-worker/src/runtime.rs
@@ -9,6 +9,7 @@ use crate::{
     identity,
     identity::credentials::WorkerIdentity,
     integration_gateway, lifecycle,
+    model_snapshot_sync::{self, ModelSnapshotSyncState},
     process_lock::WorkerProcessLock,
     self_update,
     store::WorkerStore,
@@ -42,12 +43,14 @@ pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
         );
     }
 
+    let model_snapshot_sync_state = ModelSnapshotSyncState::new();
     if heartbeat_and_converge(
         &config,
         &cloud,
         &store,
         &identity,
         integration_gateway.as_ref(),
+        &model_snapshot_sync_state,
         once,
     )
     .await
@@ -66,6 +69,7 @@ pub async fn run(config: WorkerConfig, once: bool) -> Result<(), WorkerError> {
             &store,
             &identity,
             integration_gateway.as_ref(),
+            &model_snapshot_sync_state,
             false,
         )
         .await
@@ -86,6 +90,7 @@ async fn heartbeat_and_converge(
     store: &WorkerStore,
     identity: &WorkerIdentity,
     gateway: Option<&crate::cloud_client::IntegrationGatewayConfig>,
+    model_snapshot_sync_state: &ModelSnapshotSyncState,
     dry_run: bool,
 ) -> TickControl {
     let anyharness_version = anyharness_update::running_anyharness_version(store);
@@ -112,6 +117,16 @@ async fn heartbeat_and_converge(
             Err(error) => warn!(?error, "failed to repair integration-gateway dotfile"),
         }
     }
+
+    // Model-snapshot sync: non-fatal, runs first (a worker binary swap
+    // exec's and never returns, so anything on this tick must precede it).
+    model_snapshot_sync::maybe_sync(
+        config,
+        cloud,
+        &identity.worker_token,
+        model_snapshot_sync_state,
+    )
+    .await;
 
     // D5 bridge (decision 6) is reachable from BOTH the supervisor-owned and the
     // legacy branch: an already-provisioned *legacy* Worker that receives the

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -9238,6 +9238,20 @@
             "type": "integer",
             "minimum": 0
           },
+          "models": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "The full model list off the same document read as `modelCount`. Added\nalongside the count (never replacing it — model-catalog.md:660 always\nsaid this route serves \"model and mode lists off the same document\nread\"; the count-only shape undershot that, and this is the fix) so a\nmachineless-surface uploader (the Worker's `model_snapshot_sync`) has\nsomething to read besides raw disk access to a document it should not\nknow the layout of."
+          },
+          "modes": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "The full mode list, same rationale as `models` above."
+          },
           "nextAttemptAt": {
             "type": [
               "string",

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -2509,6 +2509,18 @@ export interface components {
             lastError?: string | null;
             modeCount: number;
             modelCount: number;
+            /**
+             * @description The full model list off the same document read as `modelCount`. Added
+             *     alongside the count (never replacing it — model-catalog.md:660 always
+             *     said this route serves "model and mode lists off the same document
+             *     read"; the count-only shape undershot that, and this is the fix) so a
+             *     machineless-surface uploader (the Worker's `model_snapshot_sync`) has
+             *     something to read besides raw disk access to a document it should not
+             *     know the layout of.
+             */
+            models?: Record<string, never>[];
+            /** @description The full mode list, same rationale as `models` above. */
+            modes?: Record<string, never>[];
             /** @description Set iff `state == backoff`. */
             nextAttemptAt?: string | null;
             /** @description Last SUCCESSFUL observation. Never regresses on failure. */

--- a/specs/codebase/platforms/product/model-catalog.md
+++ b/specs/codebase/platforms/product/model-catalog.md
@@ -657,7 +657,12 @@ replace the runtime's gateway-models-only endpoints:
   per-context `probedAt`, `snapshotAgeSeconds`, `lastAttempt`, `lastError`,
   `stale`/`staleReason`, `identityComparable`, the engine's `state` and
   `nextAttemptAt`, the manifest-derived `installIdentity`, and the engine's
-  ownership mode. Model and mode lists come off the same document read.
+  ownership mode. Model and mode lists come off the same document read — the
+  `models`/`modes` arrays ride alongside `modelCount`/`modeCount` (S2b added
+  the arrays; the counts predate them and stay for whatever already reads
+  just a badge). The Worker's `model_snapshot_sync.rs` is this route's first
+  consumer of the arrays: it has no other local surface to read the full
+  entry from.
 - `POST /v1/agents/{kind}/model-snapshot/refresh?authContextId=`: force a
   re-probe of ONE context (the manual-refresh poke), awaiting it. The
   parameter is required: a forced refresh of every active context would hold
@@ -856,3 +861,26 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       [HarnessAllModelsSection](../../../../apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx)).
 - [ ] Onboarding contains no "checking for latest models" step (the
       surface rendering the install-completed and auth-applied pokes).
+- [x] ~~Nothing uploads the cloud sandbox's fresh machine snapshot yet: the
+      Worker's heartbeat tick has no~~
+      [model_snapshot_sync.rs](../../../../anyharness/crates/proliferate-worker/src/model_snapshot_sync.rs)
+      ~~step, so every machineless consumer (web new-chat, mobile,
+      automations, workflow editors) serves whatever the cloud snapshot last
+      held — stale or entirely absent for a harness that has never been
+      manually refreshed through the legacy route. Closing this means the
+      module this doc already names in "Write paths"/"Code map".~~ **Closed
+      by S2b**: the module now runs on every heartbeat tick, GETs the
+      runtime's model-snapshot status per harness
+      (`GET /v1/agents/{kind}/model-snapshot`, whose response this same PR
+      extends with the `models`/`modes` arrays the route's own doc comment
+      always promised — see the "Runtime routes" note below), diffs
+      `probedAt` against an in-memory last-pushed cache, and POSTs changed
+      contexts to `POST /v1/cloud/agent-models/{harness}/refresh` with the
+      Worker's bearer. **Narrowing, not fully closing**: the cloud route
+      itself ships on a separate branch (B4/C2) not yet merged as of this
+      PR, so against today's `main` the POST 404s and is logged-and-swallowed
+      like any other convergence failure — the sync is inert, not broken,
+      until that route lands. It is also inherently cloud-sandbox-only: the
+      ingest route's `resolve_upload_owner` refuses `runtime_kind !=
+      "cloud_sandbox"` with a 403, so a desktop Worker's attempt always logs
+      a swallowed 403, which is correct — "Desktop does not sync" above.


### PR DESCRIPTION
## Spec anchor

specs/codebase/platforms/product/model-catalog.md, "Write paths" (worker
sync design), "Runtime routes" (the status route's fields), "Cloud routes"
(the ingest route's shape), "Code map" (`model_snapshot_sync.rs`'s home).

## Spec contradiction resolved

model-catalog.md:660 already claimed `GET /v1/agents/{kind}/model-snapshot`
serves "model and mode lists off the same document read", but the shipped
`ContextStatus` projection (`status.rs`) carried only `modelCount`/
`modeCount` — no route anywhere on this branch, or any sibling in-flight
`agents/*` branch, exposed the actual model/mode arrays. The Worker sync this
PR adds had nothing to read.

Per the brief's own instruction ("If the cloud route expects a different
shape than assumed, follow the code, not the brief — and say so"), the same
principle applies on the runtime side: this PR **completes the route
model-catalog.md already documents**, additively — `modelCount`/`modeCount`
stay untouched for existing consumers, `models`/`modes` ride alongside as the
`SnapshotModel`/`SnapshotMode` arrays already sitting on `SnapshotEntry`. No
new route, no schema break, `authFingerprint` stays off the wire (existing
law, now pinned by an added assertion). OpenAPI + generated SDK types were
regenerated in the same PR (`pnpm run generate` in `anyharness/sdk`) —
diff is additive-only.

## Gap bullet

Added and struck in this PR (program convention: the PR that closes a gap
usually also names it, if no earlier PR did). See "Current gaps" in the
spec — narrowed rather than fully closed, because the cloud ingest route
itself ships on a separate branch not yet merged into this one's base (see
Deploy notes).

## Design summary

Replaces the deleted gateway-catalog mirror push (`796ff1f08`), mirroring
`catalog_sync.rs`'s exact shape and heartbeat wiring:

- `ModelSnapshotSyncState`: in-memory last-pushed `probedAt` per
  `(harness_kind, auth_context_id)` — the `probedAt` analogue of
  `catalog_sync`'s ETag cache.
- Pure `plan_pushes()` decides which contexts changed; async `maybe_sync()`
  does the GET/POST work and never propagates an error.
- Runs first in `heartbeat_and_converge` (before the D5 bridge — a
  self-update exec never returns, so anything this tick must precede it).
- `CloudClient::ingest_model_snapshot` — new method, `POST
  /v1/cloud/agent-models/{harness}/refresh`, body
  `{authContextId, snapshotJson, probedAt}` (confirmed against B4's actual
  shipped `AgentModelSnapshotIngestRequest`, not just the spec prose).

## Deviations from the brief

1. **Cloud route not on this branch's base.** B4 (`agents/b4-snapshot-rekey`)
   ships the ingest route on a separate, unmerged branch. Against today's
   server (or anything built from this branch's base) the POST 404s —
   logged and swallowed exactly like every other convergence failure. The
   sync is **inert, not broken**, until B4 + the route cutover (C2) land.
2. **Cloud-sandbox scoped, not "desktop worker".** The brief's framing
   ("desktop worker's model-snapshot sync job") undersold a restriction
   already in B4's server code: `resolve_upload_owner` 403s any worker whose
   `runtime_kind != "cloud_sandbox"`. This sync module doesn't special-case
   that — a desktop Worker's attempt just logs a swallowed 403 like any other
   push failure — but the module doc comment and this PR body say so
   plainly rather than imply desktop uploads succeed. This is also exactly
   what model-catalog.md's own "Desktop does not sync" law already says.
3. **Runtime status route extended** (see "Spec contradiction resolved"
   above) — the one piece of scope beyond the worker-side file list the
   brief named, and the smallest change that makes the spec's existing
   claim true.

## Tests

| Area | Test | Proves |
| --- | --- | --- |
| `plan_pushes` | `plan_pushes_uploads_when_probed_at_advances` | pushes when `probedAt` advances |
| `plan_pushes` | `plan_pushes_does_not_repush_unchanged_probed_at` | no re-push on unchanged `probedAt` |
| `plan_pushes` | `plan_pushes_skips_a_context_with_no_snapshot_yet` | skips harnesses/contexts with no entry |
| `plan_pushes` | `plan_pushes_treats_each_harness_independently` | same `probedAt` under a different harness still pushes |
| `plan_pushes` | `plan_pushes_handles_no_contexts_at_all` | empty input is a no-op |
| bearer resolution | `resolve_runtime_bearer_token_prefers_config_over_env` | config wins over env |
| bearer resolution | `resolve_runtime_bearer_token_falls_back_to_env` | env fallback when config absent |
| integration (`TcpListener`) | `maybe_sync_uploads_a_changed_context_with_the_workers_bearer` | end-to-end GET→diff→POST, worker's own bearer on the cloud request |
| integration (`TcpListener`) | `maybe_sync_does_not_wedge_on_a_cloud_error_and_leaves_the_push_pending` | a cloud 500 doesn't panic/wedge, and the unrecorded push retries next tick |
| status projection | extended `the_status_projection_shapes_every_field_and_never_exposes_the_fingerprint` (T-45) | `models`/`modes` serialize with content, `authFingerprint` still absent |
| status projection | extended `a_context_with_no_entry_projects_as_missing` | no entry ⇒ empty `models`/`modes` |

**9 new tests** in `proliferate-worker` (77 total pass, was 68); 0 new test
*functions* in `anyharness-lib` (2 existing tests extended with new
assertions; 57 model-snapshot tests pass, same count as before). SDK: 126
vitest tests + `tsc` typecheck pass unchanged.

`cargo test -p proliferate-worker`: 77 passed, 0 failed.
`cargo test -p anyharness-lib model_snapshot`: 57 passed, 0 failed.
`pnpm run typecheck && pnpm run test` in `anyharness/sdk`: pass.
`python3 scripts/check_max_lines.py` / `check_docs.py`: pass (new
`model_snapshot_sync.rs` split into a sibling `_tests.rs`, mirroring
`installer/downloads.rs`/`downloads_tests.rs`, to stay under 600 lines).

## Deploy notes (worker-side)

- **Harmless against a server that predates this design.** A 404 on
  `GET /v1/agents` or the model-snapshot route (an old runtime) short-circuits
  with a log line, same as `catalog_sync.rs`'s old-runtime handling. A 403 or
  404 on the cloud POST (old server, or a desktop worker) logs and swallows;
  the next heartbeat tick retries from scratch since nothing was recorded as
  pushed.
- **Must not ship user-visible expectations ahead of B4/C2.** This PR alone
  makes the Worker attempt uploads that 404 against today's deployed server.
  That's inert (no user harm, no crash), but the gap bullet this PR strikes
  is only honestly closed once B4 + the route cutover deploy in the same
  release train — flagging this the same way the "legacy gateway-models
  route" gap bullet above it already flags its own train dependency.
- No new worker config fields; `runtime_base_url`/`runtime_bearer_token`
  already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)