### PR TITLE
docs(specs): reconcile the agent-stack specs to the landed trains

### DIFF
--- a/specs/codebase/platforms/product/agent-auth.md
+++ b/specs/codebase/platforms/product/agent-auth.md
@@ -257,8 +257,10 @@ applied document, and the UI says so:
 - **Running sessions are offered a restart.** Auth applies at launch only,
   so running sessions keep the old world — including billing the old route.
   After the ack, the surface shows a modal — *"Restart running sessions on
-  old auth?"* / **Restart now** / **No** — scoped to running sessions of the
-  switched harness on the switched surface. Restart is an in-place relaunch
+  old auth?"* with actions `"yes, restart now"` / `"no"` (founder-settled
+  copy, lowercase verbatim; the copy module marks it do-not-reword) —
+  scoped to running sessions of the switched harness on the switched
+  surface. Restart is an in-place relaunch
   (transcript kept; the resume path re-runs route_auth and the readiness
   gate). Declining leaves the sessions to run out their lives on the old
   auth.
@@ -315,14 +317,14 @@ pushes into its embedded runtime
   auth-state query. Sync requires only sign-in and a healthy local
   runtime — a self-hosted user with no cloud compute still gets gateway
   and BYOK routes locally.
-- **Onboarding blocks the step, never the signup.** Account creation never
+- **Onboarding shows a card, never a block.** Account creation never
   waits on LiteLLM (enrollment is fire-and-forget at signup). The desktop
   first-run flow — auto-install, then first-run adoption defaulting the
   gateway for harnesses without native logins, then this sync loop — is
-  what delivers the first `state.json`, and the onboarding "setting up"
-  step awaits the runtime's ack with a short grace window (~20s) before
-  degrading to a visible pending badge and letting the user proceed. It
-  never hard-blocks.
+  what delivers the first `state.json`, and a home-screen onboarding card
+  ("Setting up your agents…") awaits the runtime's ack with a short grace
+  window (~20s) before auto-advancing — degrading to a visible pending
+  badge and letting the user proceed. It never blocks.
 - **The loop.** `GET /v1/cloud/agent-auth/state?surface=local` (the same
   renderer as the cloud materializer, scoped to the `local`-surface
   selections) → fingerprint-compare against the last pushed document →
@@ -701,28 +703,14 @@ Delivery, acknowledgement, restart:
 Deltas between this document and the integration stack
 (`agents/integration-rc1`), each struck by its follow-up PR:
 
-- [ ] **Delivery is not acknowledged.** No pending→applied UI exists: a
-      selection write renders as done when the server commits, not when the
-      runtime confirms the applied document, and a failed desktop push is a
-      logged warning the user never sees. The whole
-      [Applied means acknowledged](#applied-means-acknowledged) contract —
-      the ack itself, the pending state, and the ack-fired probe — is
-      unimplemented.
-- [ ] **A cloud selection write does not ensure the sandbox.** The
-      materialization task still no-ops when the sandbox is asleep or
-      unprovisioned, so a cloud switch made from web/desktop settings lands
-      only at the next wake; the ensure-on-switch (provision-or-wake)
-      trigger is unimplemented.
-- [ ] **Enrollment sync does not poke the local surface.** Reaching
-      `synced` re-materializes cloud only; a desktop that pulled state
-      before sync completed keeps a keyless document until the next
-      unrelated mutation or app restart.
-- [ ] **No restart offer exists.** Nothing surfaces running sessions after
-      an auth switch; they silently continue (and bill) on the old world
-      with no modal and no way to see it.
-- [ ] **Onboarding has no ack-gated "setting up" step.** First-run adoption
-      fires and the state lands whenever it lands; nothing in onboarding
-      awaits the ack or renders the pending/degraded path.
+- [ ] **The cloud surface has no auth-applied probe poke.** The desktop
+      runtime's state PUT/DELETE fires the `AuthApplied` probe event, but
+      the cloud materializer writes `state.json` directly into the sandbox
+      and stamps the ack server-side, without poking an awake sandbox
+      runtime's probe engine — so a cloud observation lags an applied auth
+      change until the next wake/startup pass. Either the materialization
+      op grows a poke of the runtime's refresh seam, or this bounded lag
+      gets ruled acceptable (founder decision pending).
 - [ ] **Selections cannot yet reference a typed vault entry.** D3's python
       arm built the render half of this gap: `state.json` now has a
       `provider_config` wire source

--- a/specs/codebase/platforms/product/model-catalog.md
+++ b/specs/codebase/platforms/product/model-catalog.md
@@ -262,6 +262,14 @@ protect live sessions and the machine, not staleness bookkeeping:
   install reconcile's job slot, each bounded by the engine's timeout on the
   probe's own thread so a cancelled attempt kills its child rather than
   leaking it.
+- **Failure backoff.** A failed attempt arms an exponential backoff — 60s
+  doubling to a 6h ceiling, spread by a deterministic ±20% jitter keyed on
+  (harness, attempt) so the schedule stays assertable — that gates
+  admission of *automatic* event pokes after failures only. It is never a
+  freshness gate, a manual/forced refresh always bypasses it, and it is
+  not persisted across restarts
+  ([model_snapshot/config.rs](../../../../anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/config.rs),
+  [backoff.rs](../../../../anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/backoff.rs)).
 - **Orphan sweep.** At engine construction the owner sweeps abandoned scratch
   roots (a SIGKILLed probe runs no guard), age-thresholded.
 - **One engine per runtime home.** The engine holds an advisory exclusive
@@ -372,6 +380,9 @@ then alias, then variant forms; seed pre-first-probe) launches. One that
 does not is refused with `SESSION_MODEL_UNSUPPORTED` — protection against a
 harness silently substituting its own default on an unattended run, which is
 the one outcome worse than either refusal or loud in-session failure.
+Catalog rows marked trial-verified stay launchable even when absent from the
+observation — the pre-existing asymmetry in the safe direction, since the
+shipped catalog carries trial-verified models a harness does not advertise.
 
 The gated taxonomy is deleted: no `SESSION_MODEL_GATED`, no
 `required_contexts`, no enumeration of which auth would serve a model. An
@@ -467,9 +478,10 @@ anyharness-lib/src/domains/agents/model_snapshot/
 ```
 
 Deleted from the per-context design: `fingerprint.rs`, `staleness.rs` and its
-test tree, `universe.rs`'s cross-context union, per-context slots and
-backoff, and `route_auth/probe_materialization/scoping.rs` with the
-attribution scrub — the probe materializes the full composed profile through
+test tree, per-context slots, and
+`route_auth/probe_materialization/scoping.rs` with the attribution scrub
+(`universe.rs` is not deleted but re-cut in place to the composed
+`ObservedUniverse`) — the probe materializes the full composed profile through
 the same
 [probe_materialization.rs](../../../../anyharness/crates/anyharness-lib/src/domains/agents/route_auth/probe_materialization.rs)
 seam (phase A shrinks to a state read; phase B and the scratch are
@@ -541,45 +553,13 @@ are stable — tests reference them by name.
 ## Current gaps
 
 Deltas between this document and the integration stack
-(`agents/integration-rc1`), each struck by its follow-up PR. The stack
-implements the superseded per-context design; these gaps are the re-cut.
+(`agents/integration-rc1`), each struck by its follow-up PR:
 
-- [ ] **The document and engine are per-context.** `model-snapshot.json`
-      carries an `entries` map keyed by auth-context id with per-entry
-      `authFingerprint`; the engine's slots, backoff, and status are keyed
-      per (harness, context); `targets.rs` enumerates active contexts. All
-      of it collapses to one composed observation per harness
-      (schemaVersion 2).
-- [ ] **Staleness machinery exists and deletes.** `fingerprint.rs`,
-      `staleness.rs` (identity comparison, TTL with jitter, the
-      completed-attempt floor as a staleness input), and the gate-evaluation
-      phase-A credential hashing all delete under the event model. The
-      startup pass becomes an unconditional background re-probe; the other
-      events fire on their own triggers. (The single-flight, scratch,
-      sweep, lock, and cursor rules all survive unchanged.)
-- [ ] **Per-context scoping and the attribution scrub exist and delete.**
-      `route_auth/probe_materialization/scoping.rs` and `attribution_scrub`
-      go; `materialize_for_probe` renders the full composed profile.
-- [ ] **The probe is not wired to the auth-apply ack or the login terminal.**
-      The apply handler pokes on state application (pre-ack) and no poke
-      exists on login-terminal exit; both move to the event set above once
-      agent-auth's ack-gated delivery lands.
-- [ ] **The cross-context universe union exists and deletes.**
-      `catalog/universe.rs`'s union and `validate_launch_in_universe`'s
-      context handling reduce to observation-first resolution with the
-      single `SESSION_MODEL_UNSUPPORTED` refusal; `SESSION_MODEL_GATED`,
-      `SelectionUnsupported::ModelGated`, and `required_contexts` delete.
-- [ ] **The cloud store carries `auth_context_id`.** `agent_model_snapshot`
-      re-keys to (harness_kind, owner_user_id) and `snapshot_json` holds the
-      whole machine document; the cloud routes and the Worker sync drop
-      their per-context parameters and diffs.
-- [ ] **The status UI is per-context.** The All Models surface (C3) polls
-      and renders per-context status; it becomes one per-harness
-      status/refresh row.
 - [ ] The picker does not project the machine observation yet: launch
-      validation reads it, but `models`/`visible_models` and the runtime's
-      launch options still read the shipped catalog alone. Closing this is
-      the [enrichment join](#enrichment-join); the pre-existing asymmetry is
+      validation and the runtime's launch options gate against the observed
+      universe, but the projected menu (`models`/`visible_models`) still
+      reads the shipped catalog alone. Closing this is the
+      [enrichment join](#enrichment-join); the pre-existing asymmetry is
       in the safe direction.
 - [ ] The composer's provider badge still calls
       `getProviderDisplayName(harnessKind)` instead of reading the model's
@@ -589,9 +569,9 @@ implements the superseded per-context design; these gaps are the re-cut.
       the sweep that enforces it.
 - [ ] The legacy gateway-models routes (`GET .../catalog/gateway-models`,
       `POST .../catalog/refresh-gateway`) still serve beside the snapshot
-      surface; they delete with the C-track cutover of the All Models tab.
-      The desktop mirror-sync hook (`useGatewayCatalogMirrorSync`) and its
+      surface. The All Models cutover has happened, so their only remaining
+      consumers are release fixtures plus an orphaned frontend access
+      client — deletion is now unblocked cleanup. The desktop mirror-sync
+      hook (`useGatewayCatalogMirrorSync`) and its
       `gateway-catalog-mirror.ts` push are already gone — the route cutover
       on the integration branch deleted them.
-- [ ] Onboarding contains no "checking for latest models" step (the surface
-      rendering the install-completed and auth-applied events).

--- a/specs/codebase/platforms/product/model-gateway.md
+++ b/specs/codebase/platforms/product/model-gateway.md
@@ -357,22 +357,3 @@ Deltas between this document and `main`, each struck by its follow-up PR:
       (`managed-cloud-fixture-smoke-1.ts`, `t3-bill-4.ts`). The code's only
       product-server producer was the server-side catalog prober, which the
       model-catalog re-key deleted.
-- [ ] **The account model is not org-only yet.** Personal enrollments
-      (`subject_kind='user'`, `user-<uuid>` teams) exist beside org rows;
-      the free signup grant lands on a personal billing subject; and both
-      enrollment paths mint the same shared LiteLLM user id
-      (`user-<uuid>`, `enrollment.py`) rather than per-(org, member)
-      identities. The unification: delete the personal subject shape,
-      re-parent existing personal teams onto each user's default org, move
-      grants to the org subject, mint per-org LiteLLM users, and re-mint
-      keys under them (the enrollment fingerprint machinery absorbs the
-      re-mint as ordinary shape drift).
-- [ ] **The interim funding-follows-attribution guard deletes with the
-      unification.** Today a member's org enrollment governs only when the
-      org subject is funded, else the personal enrollment
-      ([budget.py](../../../../server/proliferate/server/cloud/agent_gateway/budget.py)
-      `get_gateway_enrollment_for_user`, including the unstable
-      first-membership-by-org-name choice); under the ruling, sessions
-      always resolve the default org's enrollment, and the guard — plus its
-      "no grant means unlimited" branch — is replaced by the fail-closed
-      unfunded-org law in the body.


### PR DESCRIPTION
## Summary

Docs-only. The three re-cut specs are reconciled to what actually landed in the D (#1551), B (#1552), and C (#1553) trains, per a full audit of every Proof ID (31/31 verified) and gap bullet against main:

- **Gap lists shrink to the truth**: 15 landed bullets struck across the three docs (per-context probe machinery, staleness, universe union, cloud `auth_context_id`, delivery ack, ensure-on-switch, both-surface pokes, restart offer, onboarding step, org-only account model, funding guard, …). What remains open stays: picker-menu projection, composer badge, retention bound, legacy route deletion (now unblocked cleanup — the B train removed its last product consumer), typed-vault gate (PR in flight), codex azure pending, module splits, `agent_gateway_credits_exhausted` producer.
- **Spec meets shipped reality** where implementation surfaced better facts: the restart modal's action copy is the founder-settled lowercase verbatim ("yes, restart now" / "no"); the onboarding "step" is the home-screen card; the trial-verified launch exemption and the engine's failure backoff (60s→6h, deterministic jitter, automatic-pokes-only, never a freshness gate) are now stated in the body instead of living only in code.
- **One new gap recorded** (founder ruling pending): the cloud surface has no auth-applied probe poke — the desktop runtime's state apply fires `AuthApplied`, but the cloud materializer writes `state.json` and acks server-side without poking an awake sandbox's probe engine, so a cloud observation lags until the next wake/startup pass. Either the materialization op pokes the refresh seam, or the bounded lag is ruled acceptable.

Deliberately untouched (owned by #1554): the cursor gap bullet, vault field-set wording, and everything in its settings-surface layer.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `python3 scripts/check_docs.py` — passed (228 Markdown files).
- Audit basis: all 31 Proof IDs located on main (24 implemented, 6 partial with deferred live halves, D5 deferred); every struck bullet verified landed with file/commit evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVmTVqmuhLp2dABiwNHCbx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVmTVqmuhLp2dABiwNHCbx)_