### PR TITLE
fix(ci): repair main's red Server CI (format drift + stale agent-auth test)

### DIFF
--- a/server/tests/integration/test_agent_auth_delivery_ack.py
+++ b/server/tests/integration/test_agent_auth_delivery_ack.py
@@ -337,9 +337,7 @@ class TestDesktopAckFlipsPendingToApplied:
                 db_session, user_id=uuid.UUID(user_id), surface="local"
             )
         ) is None
-        assert {record["applied"] for record in await _list_selections(client, headers)} == {
-            False
-        }
+        assert {record["applied"] for record in await _list_selections(client, headers)} == {False}
 
         # The normal flow — echoing the served identity — still acks.
         acked = await _ack_state(
@@ -350,9 +348,7 @@ class TestDesktopAckFlipsPendingToApplied:
             fingerprint=state["fingerprint"],
         )
         assert acked.status_code == 200, acked.text
-        assert {record["applied"] for record in await _list_selections(client, headers)} == {
-            True
-        }
+        assert {record["applied"] for record in await _list_selections(client, headers)} == {True}
 
     @pytest.mark.asyncio
     async def test_ack_validation_and_auth(self, client: AsyncClient) -> None:

--- a/server/tests/integration/test_cloud_repo_materialization_transactions.py
+++ b/server/tests/integration/test_cloud_repo_materialization_transactions.py
@@ -218,15 +218,24 @@ async def test_agent_auth_releases_transaction_before_sandbox_io(
 
     async def build(db: AsyncSession, _user_id):  # type: ignore[no-untyped-def]
         await db.execute(text("SELECT 1"))
-        return {"harnesses": {}}, "fingerprint"
+        return {"harnesses": {}, "revision": 0}, "fingerprint"
 
     async def remove(_target, **_kwargs):  # type: ignore[no-untyped-def]
         nonlocal external_calls
         assert not db_session.in_transaction()
         external_calls += 1
 
+    ack_calls = 0
+
+    async def record_ack(_db, **_kwargs):  # type: ignore[no-untyped-def]
+        # The real write needs a persisted user row; this test's user is a
+        # bare uuid, so stub the store call and keep the seam observable.
+        nonlocal ack_calls
+        ack_calls += 1
+
     monkeypatch.setattr(agent_auth, "build_agent_auth_state", build)
     monkeypatch.setattr(agent_auth.sandbox_io, "remove_owned_files", remove)
+    monkeypatch.setattr(agent_auth.agent_gateway_store, "record_delivery_ack", record_ack)
 
     await agent_auth.materialize_agent_auth(
         db_session,
@@ -238,6 +247,7 @@ async def test_agent_auth_releases_transaction_before_sandbox_io(
     )
 
     assert external_calls == 1
+    assert ack_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Main's HEAD (`15098c21a`, #1558) has a red Server CI: the `lint` and `test` jobs fail on every PR too, since merge-ref runs include main's tree. Both failures shipped with the agent-auth trains and reproduce on a pristine `origin/main` checkout:

1. **lint** — `tests/integration/test_agent_auth_delivery_ack.py` fails `ruff format --check` (one over-wrapped assert around line 340). Reformatted with the repo's ruff (0.15.22).
2. **test** — `test_agent_auth_releases_transaction_before_sandbox_io` predates C-2 (#1553) adding the cloud delivery-ack write at the end of `materialize_agent_auth`:
   - the stubbed state dict has no `revision` key → `KeyError: 'revision'` at `agent_auth.py:665`;
   - fixing only that hits the ack row's `user_id` FK, because the test drives materialization with a bare `uuid4()` user.

   Fix: stub the `record_delivery_ack` store seam (the test is about transaction-release choreography around sandbox IO, not ack persistence) and assert it fires exactly once; add `revision` to the stubbed state.

Verified locally: the failing test now passes, the whole file passes (6/6), and `ruff format --check` + `ruff check` are clean over `proliferate/ tests/`.

This unblocks the cloud/sandbox fix stack (#1500–#1534): their merge-ref CI runs inherit these two failures from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)