### PR TITLE
feat(product-ui): BillingGateState — typed upgrade/refill blocked states

### DIFF
--- a/apps/packages/product-client/src/components/playground/library/product-patterns.tsx
+++ b/apps/packages/product-client/src/components/playground/library/product-patterns.tsx
@@ -1,4 +1,9 @@
 import { useState } from "react";
+import {
+  BillingBalanceNotice,
+  BillingGateState,
+  billingGateView,
+} from "@proliferate/product-ui/patterns/BillingGateState";
 import { ModelTable } from "@proliferate/product-ui/patterns/ModelTable";
 import { PrStatusDot } from "@proliferate/product-ui/patterns/PrStatusBadge";
 import { ProductPageShell } from "@proliferate/product-ui/patterns/ProductPageShell";
@@ -86,7 +91,32 @@ function SecretManagementPanelDemo() {
   );
 }
 
+function BillingGateStateDemo() {
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <BillingGateState
+        size="compact"
+        view={billingGateView("credits_exhausted", {
+          isPaidPlan: false,
+          canManageBilling: true,
+          onUpgrade: noop,
+          onOpenBilling: noop,
+        })}
+      />
+      <BillingBalanceNotice
+        view={{
+          kind: "refill",
+          title: "Credits running low",
+          description: "2 hours of compute remaining this period.",
+          primaryAction: { label: "Add credits", onClick: noop },
+        }}
+      />
+    </div>
+  );
+}
+
 export const PRODUCT_PATTERNS_ENTRIES: LibraryEntry[] = [
+  { name: "BillingGateState", subpath: "@proliferate/product-ui/patterns/BillingGateState", render: BillingGateStateDemo },
   { name: "ModelTable", subpath: "@proliferate/product-ui/patterns/ModelTable", render: ModelTableDemo },
   { name: "PrStatusBadge", subpath: "@proliferate/product-ui/patterns/PrStatusBadge", render: () => (
     <PrStatusDot status={{ kind: "open", number: 42 }} />

--- a/apps/packages/product-ui/package.json
+++ b/apps/packages/product-ui/package.json
@@ -207,6 +207,10 @@
       "types": "./dist/patterns/SettingsEmptyState.d.ts",
       "import": "./dist/patterns/SettingsEmptyState.js"
     },
+    "./patterns/BillingGateState": {
+      "types": "./dist/patterns/BillingGateState.d.ts",
+      "import": "./dist/patterns/BillingGateState.js"
+    },
     "./patterns/SettingsEyebrow": {
       "types": "./dist/patterns/SettingsEyebrow.d.ts",
       "import": "./dist/patterns/SettingsEyebrow.js"

--- a/apps/packages/product-ui/src/patterns/BillingGateState.test.tsx
+++ b/apps/packages/product-ui/src/patterns/BillingGateState.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import {
+  BillingBalanceNotice,
+  BillingGateState,
+  billingGateView,
+  type BillingGateReason,
+} from "./BillingGateState";
+
+const noop = () => {};
+
+const MANAGER = {
+  isPaidPlan: false,
+  canManageBilling: true,
+  onUpgrade: noop,
+  onRefill: noop,
+  onOpenBilling: noop,
+};
+
+describe("billingGateView", () => {
+  it("routes a free subject's exhausted credits to upgrade", () => {
+    const view = billingGateView("credits_exhausted", MANAGER);
+    expect(view.kind).toBe("upgrade");
+    expect(view.primaryAction?.label).toBe("Upgrade");
+    expect(view.secondaryAction?.label).toBe("Billing settings");
+  });
+
+  it("routes a paid subject's exhausted credits to refill", () => {
+    const view = billingGateView("credits_exhausted", { ...MANAGER, isPaidPlan: true });
+    expect(view.kind).toBe("refill");
+    expect(view.primaryAction?.label).toBe("Add credits");
+  });
+
+  it("gives non-admin members admin-managed copy and no action (U3: members cannot repair)", () => {
+    const view = billingGateView("credits_exhausted", {
+      ...MANAGER,
+      canManageBilling: false,
+    });
+    expect(view.kind).toBe("admin");
+    expect(view.primaryAction).toBeNull();
+    expect(view.description).toContain("organization admin");
+  });
+
+  it("keeps limit_reached distinct from exhausted: limits point at settings, never refill (N3)", () => {
+    const view = billingGateView("llm_limit_reached", { ...MANAGER, isPaidPlan: true });
+    expect(view.kind).toBe("limit");
+    expect(view.primaryAction?.label).toBe("Billing settings");
+  });
+
+  it("payment failure points at the portal path, not upgrade", () => {
+    const view = billingGateView("payment_failed", { ...MANAGER, isPaidPlan: true });
+    expect(view.kind).toBe("payment");
+    expect(view.primaryAction?.label).toBe("Billing settings");
+  });
+
+  it("admin hold offers no self-service repair", () => {
+    const view = billingGateView("admin_hold", MANAGER);
+    expect(view.primaryAction).toBeNull();
+  });
+
+  it("never leaks a raw reason code: unknown reasons render the generic state", () => {
+    const view = billingGateView("unknown", MANAGER);
+    expect(view.title).toBe("Cloud usage paused");
+  });
+
+  it("falls back to billing settings when the surface has no checkout wiring", () => {
+    const view = billingGateView("credits_exhausted", {
+      isPaidPlan: false,
+      canManageBilling: true,
+      onOpenBilling: noop,
+    });
+    expect(view.primaryAction?.label).toBe("Billing settings");
+    expect(view.secondaryAction).toBeNull();
+  });
+
+  it("covers every typed reason without throwing", () => {
+    const reasons: BillingGateReason[] = [
+      "credits_exhausted",
+      "overage_disabled",
+      "cap_exhausted",
+      "payment_failed",
+      "external_billing_hold",
+      "admin_hold",
+      "llm_credits_exhausted",
+      "llm_limit_reached",
+      "unknown",
+    ];
+    for (const reason of reasons) {
+      const view = billingGateView(reason, MANAGER);
+      expect(view.title.length).toBeGreaterThan(0);
+      expect(view.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("BillingGateState", () => {
+  it("renders title, description, and both actions", () => {
+    render(
+      <BillingGateState
+        view={billingGateView("credits_exhausted", MANAGER)}
+      />,
+    );
+    expect(screen.getByText("Out of free credits")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Upgrade" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Billing settings" })).toBeTruthy();
+  });
+
+  it("renders no buttons when the view offers no actions", () => {
+    const { container } = render(
+      <BillingGateState
+        view={billingGateView("credits_exhausted", {
+          isPaidPlan: false,
+          canManageBilling: false,
+        })}
+      />,
+    );
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+});
+
+describe("BillingBalanceNotice", () => {
+  it("renders the inline action", () => {
+    render(
+      <BillingBalanceNotice
+        view={{
+          kind: "refill",
+          title: "Credits running low",
+          description: "2 hours of compute remaining this period.",
+          primaryAction: { label: "Add credits", onClick: noop },
+        }}
+      />,
+    );
+    expect(screen.getByText("Credits running low")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add credits" })).toBeTruthy();
+  });
+});

--- a/apps/packages/product-ui/src/patterns/BillingGateState.test.tsx
+++ b/apps/packages/product-ui/src/patterns/BillingGateState.test.tsx
@@ -58,6 +58,34 @@ describe("billingGateView", () => {
   it("admin hold offers no self-service repair", () => {
     const view = billingGateView("admin_hold", MANAGER);
     expect(view.primaryAction).toBeNull();
+    expect(view.secondaryAction?.label).toBe("Billing settings");
+  });
+
+  it("admin hold hides even the settings link from non-admin members", () => {
+    const view = billingGateView("admin_hold", { ...MANAGER, canManageBilling: false });
+    expect(view.primaryAction).toBeNull();
+    expect(view.secondaryAction).toBeNull();
+  });
+
+  it("concurrency limit is not a billing repair: no billing CTA", () => {
+    const view = billingGateView("concurrency_limit", MANAGER);
+    expect(view.title).toBe("Sandbox limit reached");
+    expect(view.primaryAction).toBeNull();
+    expect(view.secondaryAction).toBeNull();
+  });
+
+  it("overage_disabled and cap_exhausted point admins at settings only", () => {
+    for (const reason of ["overage_disabled", "cap_exhausted"] as const) {
+      const view = billingGateView(reason, { ...MANAGER, isPaidPlan: true });
+      expect(view.primaryAction?.label).toBe("Billing settings");
+      expect(view.secondaryAction).toBeNull();
+    }
+  });
+
+  it("external_billing_hold renders the payment path like payment_failed", () => {
+    const view = billingGateView("external_billing_hold", { ...MANAGER, isPaidPlan: true });
+    expect(view.kind).toBe("payment");
+    expect(view.primaryAction?.label).toBe("Billing settings");
   });
 
   it("never leaks a raw reason code: unknown reasons render the generic state", () => {
@@ -83,6 +111,7 @@ describe("billingGateView", () => {
       "payment_failed",
       "external_billing_hold",
       "admin_hold",
+      "concurrency_limit",
       "llm_credits_exhausted",
       "llm_limit_reached",
       "unknown",

--- a/apps/packages/product-ui/src/patterns/BillingGateState.tsx
+++ b/apps/packages/product-ui/src/patterns/BillingGateState.tsx
@@ -1,0 +1,304 @@
+/**
+ * Billing gate states: what the user sees when spend is blocked or running
+ * low, with the one action that actually repairs it (billing.md T2: out of
+ * credit at spend time is typed and actionable on every surface — never raw
+ * provider noise).
+ *
+ * Two render modes:
+ *  - `BillingGateState` — full panel for blocked screens (workspace start
+ *    refused with a 402, LLM key disabled). Centered, flat, no card —
+ *    the SettingsEmptyState anatomy with a tone-colored icon.
+ *  - `BillingBalanceNotice` — inline banner for low-but-not-blocked
+ *    balances (sidebar consumption card, billing pane).
+ *
+ * `billingGateView` is the single mapping from the server's typed
+ * start-block reasons to a view; surfaces feed it the reason and their
+ * navigation actions rather than re-deriving copy per callsite.
+ */
+import type { ReactNode } from "react";
+import { twMerge } from "@proliferate/ui/utils/tw-merge";
+import { Button } from "@proliferate/ui/primitives/Button";
+import { CreditCard, Zap, CircleAlert, Building2 } from "@proliferate/ui/icons";
+
+export type BillingGateKind = "upgrade" | "refill" | "payment" | "admin" | "limit";
+
+export interface BillingGateAction {
+  label: string;
+  onClick: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+export interface BillingGateStateView {
+  kind: BillingGateKind;
+  title: string;
+  description: string;
+  /** The one action that repairs the state; absent when only an admin can act. */
+  primaryAction?: BillingGateAction | null;
+  /** Optional escape hatch (open billing settings, contact admin). */
+  secondaryAction?: BillingGateAction | null;
+}
+
+const GATE_ICON: Record<BillingGateKind, ReactNode> = {
+  upgrade: <Zap className="icon-paired" />,
+  refill: <Zap className="icon-paired" />,
+  payment: <CreditCard className="icon-paired" />,
+  admin: <Building2 className="icon-paired" />,
+  limit: <CircleAlert className="icon-paired" />,
+};
+
+export function BillingGateState({
+  view,
+  size = "full",
+  className,
+}: {
+  view: BillingGateStateView;
+  /** Compact gates sit inside a pane; full-height states fill a screen. */
+  size?: "compact" | "full";
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      className={twMerge(
+        "flex flex-col items-center justify-center gap-2 text-center",
+        size === "full" ? "min-h-[280px] px-6 py-16" : "py-8",
+        className,
+      )}
+    >
+      <div className="mb-1 flex items-center justify-center text-warning-foreground [&>svg]:icon-paired">
+        {GATE_ICON[view.kind]}
+      </div>
+      <div className="text-ui font-medium leading-5 text-foreground">{view.title}</div>
+      <div className="max-w-[48ch] text-ui-sm text-muted-foreground">{view.description}</div>
+      {view.primaryAction || view.secondaryAction ? (
+        <div className="mt-2 flex items-center gap-2">
+          {view.primaryAction ? (
+            <Button
+              type="button"
+              variant="primary"
+              loading={view.primaryAction.loading}
+              disabled={view.primaryAction.disabled}
+              onClick={view.primaryAction.onClick}
+            >
+              {view.primaryAction.label}
+            </Button>
+          ) : null}
+          {view.secondaryAction ? (
+            <Button
+              type="button"
+              variant="outline"
+              loading={view.secondaryAction.loading}
+              disabled={view.secondaryAction.disabled}
+              onClick={view.secondaryAction.onClick}
+            >
+              {view.secondaryAction.label}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function BillingBalanceNotice({
+  view,
+  tone = "warning",
+  className,
+}: {
+  view: BillingGateStateView;
+  tone?: "warning" | "destructive";
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      className={twMerge(
+        "flex items-start gap-3 rounded-lg border p-3 text-body",
+        tone === "destructive"
+          ? "border-destructive/30 bg-destructive/10 text-destructive"
+          : "border-warning/30 bg-warning/10 text-warning-foreground",
+        className,
+      )}
+    >
+      <span className="mt-0.5 shrink-0 [&>svg]:icon-paired">{GATE_ICON[view.kind]}</span>
+      <div className="min-w-0 flex-1">
+        <div className="font-medium">{view.title}</div>
+        <div className="mt-0.5 leading-5 opacity-90">{view.description}</div>
+      </div>
+      {view.primaryAction ? (
+        <Button
+          type="button"
+          variant="outline"
+          className="ml-auto shrink-0"
+          loading={view.primaryAction.loading}
+          disabled={view.primaryAction.disabled}
+          onClick={view.primaryAction.onClick}
+        >
+          {view.primaryAction.label}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The server's typed start-block reasons
+ * (`server/proliferate/constants/billing.py` start-block kinds; also carried
+ * on `BillingPlanInfo.startBlockReason`). `unknown` renders the generic
+ * blocked state rather than leaking a raw code.
+ */
+export type BillingGateReason =
+  | "credits_exhausted"
+  | "overage_disabled"
+  | "cap_exhausted"
+  | "payment_failed"
+  | "external_billing_hold"
+  | "admin_hold"
+  | "llm_credits_exhausted"
+  | "llm_limit_reached"
+  | "unknown";
+
+export interface BillingGateViewOptions {
+  /** Paid subjects refill; free subjects upgrade. */
+  isPaidPlan: boolean;
+  /** Whether the viewer can act on billing (org admin or personal owner). */
+  canManageBilling: boolean;
+  onUpgrade?: () => void;
+  onRefill?: () => void;
+  onOpenBilling?: () => void;
+  actionLoading?: boolean;
+}
+
+const ADMIN_MANAGED_DESCRIPTION =
+  "An organization admin manages billing for this workspace.";
+
+export function billingGateView(
+  reason: BillingGateReason,
+  opts: BillingGateViewOptions,
+): BillingGateStateView {
+  const openBilling: BillingGateAction | null = opts.onOpenBilling
+    ? { label: "Billing settings", onClick: opts.onOpenBilling }
+    : null;
+  const upgrade: BillingGateAction | null = opts.onUpgrade
+    ? { label: "Upgrade", onClick: opts.onUpgrade, loading: opts.actionLoading }
+    : null;
+  const refill: BillingGateAction | null = opts.onRefill
+    ? { label: "Add credits", onClick: opts.onRefill, loading: opts.actionLoading }
+    : null;
+  const memberView = (title: string, description: string): BillingGateStateView => ({
+    kind: "admin",
+    title,
+    description: `${description} ${ADMIN_MANAGED_DESCRIPTION}`,
+    primaryAction: null,
+    secondaryAction: null,
+  });
+
+  switch (reason) {
+    case "credits_exhausted":
+      if (!opts.canManageBilling) {
+        return memberView("Out of credits", "This workspace's included credits are used up.");
+      }
+      return opts.isPaidPlan
+        ? {
+            kind: "refill",
+            title: "Out of credits",
+            description:
+              "Your included credits for this period are used up. Add credits to keep working.",
+            primaryAction: refill ?? openBilling,
+            secondaryAction: refill ? openBilling : null,
+          }
+        : {
+            kind: "upgrade",
+            title: "Out of free credits",
+            description:
+              "You've used your free included credits. Upgrade to keep working in the cloud.",
+            primaryAction: upgrade ?? openBilling,
+            secondaryAction: upgrade ? openBilling : null,
+          };
+    case "overage_disabled":
+      if (!opts.canManageBilling) {
+        return memberView("Usage paused", "Included credits are used up and overage is off.");
+      }
+      return {
+        kind: "refill",
+        title: "Usage paused",
+        description:
+          "Included credits are used up and overage is turned off. Enable overage or add credits to continue.",
+        primaryAction: openBilling,
+        secondaryAction: null,
+      };
+    case "cap_exhausted":
+      if (!opts.canManageBilling) {
+        return memberView("Spending cap reached", "This period's spending cap has been reached.");
+      }
+      return {
+        kind: "limit",
+        title: "Spending cap reached",
+        description:
+          "This period's spending cap has been reached. Raise the cap in billing settings to continue.",
+        primaryAction: openBilling,
+        secondaryAction: null,
+      };
+    case "payment_failed":
+    case "external_billing_hold":
+      if (!opts.canManageBilling) {
+        return memberView("Billing needs attention", "Cloud usage is paused.");
+      }
+      return {
+        kind: "payment",
+        title: "Billing needs attention",
+        description:
+          "Cloud usage is paused because the last payment didn't go through. Update your payment method to resume.",
+        primaryAction: openBilling,
+        secondaryAction: null,
+      };
+    case "admin_hold":
+      return {
+        kind: "admin",
+        title: "Account on hold",
+        description: "Cloud usage is paused on this account. Contact support to resolve the hold.",
+        primaryAction: null,
+        secondaryAction: openBilling,
+      };
+    case "llm_credits_exhausted":
+      if (!opts.canManageBilling) {
+        return memberView("Out of LLM credits", "Model usage is paused until credits are added.");
+      }
+      return opts.isPaidPlan
+        ? {
+            kind: "refill",
+            title: "Out of LLM credits",
+            description: "Model usage is paused. Add credits to keep your agents running.",
+            primaryAction: refill ?? openBilling,
+            secondaryAction: refill ? openBilling : null,
+          }
+        : {
+            kind: "upgrade",
+            title: "Out of LLM credits",
+            description: "Model usage is paused. Upgrade to keep your agents running.",
+            primaryAction: upgrade ?? openBilling,
+            secondaryAction: upgrade ? openBilling : null,
+          };
+    case "llm_limit_reached":
+      if (!opts.canManageBilling) {
+        return memberView("Usage limit reached", "A spending limit for this period has been reached.");
+      }
+      return {
+        kind: "limit",
+        title: "Usage limit reached",
+        description:
+          "A spending limit for this period has been reached. Adjust limits in billing settings to continue.",
+        primaryAction: openBilling,
+        secondaryAction: null,
+      };
+    default:
+      return {
+        kind: "limit",
+        title: "Cloud usage paused",
+        description: "Usage is paused for a billing reason. Check billing settings for details.",
+        primaryAction: openBilling,
+        secondaryAction: null,
+      };
+  }
+}

--- a/apps/packages/product-ui/src/patterns/BillingGateState.tsx
+++ b/apps/packages/product-ui/src/patterns/BillingGateState.tsx
@@ -143,10 +143,13 @@ export function BillingBalanceNotice({
 }
 
 /**
- * The server's typed start-block reasons
- * (`server/proliferate/constants/billing.py` start-block kinds; also carried
- * on `BillingPlanInfo.startBlockReason`). `unknown` renders the generic
- * blocked state rather than leaking a raw code.
+ * Typed gate reasons. The seven compute values are the server's start-block
+ * kinds verbatim (`server/proliferate/constants/billing.py`, carried on
+ * `BillingPlanInfo.startBlockReason`). The two `llm_*` values are UI-level:
+ * the server's LLM vocabulary is `budget_status` `"exhausted"` /
+ * `"limit_reached"` (`constants/agent_gateway.py`), so an LLM surface must
+ * map that status here rather than passing it through. `unknown` renders
+ * the generic blocked state rather than leaking a raw code.
  */
 export type BillingGateReason =
   | "credits_exhausted"
@@ -155,6 +158,7 @@ export type BillingGateReason =
   | "payment_failed"
   | "external_billing_hold"
   | "admin_hold"
+  | "concurrency_limit"
   | "llm_credits_exhausted"
   | "llm_limit_reached"
   | "unknown";
@@ -254,12 +258,26 @@ export function billingGateView(
         secondaryAction: null,
       };
     case "admin_hold":
+      if (!opts.canManageBilling) {
+        return memberView("Account on hold", "Cloud usage is paused on this account.");
+      }
       return {
         kind: "admin",
         title: "Account on hold",
         description: "Cloud usage is paused on this account. Contact support to resolve the hold.",
         primaryAction: null,
         secondaryAction: openBilling,
+      };
+    case "concurrency_limit":
+      // Not a billing repair: the fix is freeing a sandbox slot, so no
+      // billing CTA (matches cloud-workspace-status-presentation copy).
+      return {
+        kind: "limit",
+        title: "Sandbox limit reached",
+        description:
+          "Archive or delete another cloud workspace before starting this one.",
+        primaryAction: null,
+        secondaryAction: null,
       };
     case "llm_credits_exhausted":
       if (!opts.canManageBilling) {


### PR DESCRIPTION
## What

New `@proliferate/product-ui/patterns/BillingGateState`: the sanctioned upgrade/refill startup-state components for billing gates, plus playground library registration.

- **`billingGateView(reason, opts)`** — the single mapping from the server's typed start-block reasons (`credits_exhausted`, `overage_disabled`, `cap_exhausted`, `payment_failed`, `external_billing_hold`, `admin_hold`, `llm_credits_exhausted`, `llm_limit_reached`) to an actionable view. Laws it encodes:
  - Free subjects **upgrade**; paid subjects **refill** (Add credits).
  - `limit_reached` stays distinct from `exhausted` — a limit never offers refill as the repair (buying credit does not bypass an active budget limit).
  - Members without billing access get admin-managed copy with **no dead button**.
  - Unknown reasons render the generic paused state — raw reason codes never leak.
- **`BillingGateState`** — full/compact centered panel (SettingsEmptyState anatomy) for blocked screens (compute 402, LLM key disabled).
- **`BillingBalanceNotice`** — inline banner for low-but-not-blocked balances.
- Registered in the playground component library (`/playground/library`); the registry drift gate covers the new export.

## Why

Part of the billing launch-hardening pass (`codex/billing-launch-hardening-plan.md`, assertion U3): out-of-credit at spend time must be typed + actionable on every surface. Today each surface hand-rolls its blocked copy; this gives them one view-model to consume.

## Tests

- `BillingGateState.test.tsx` — 12 tests: routing per reason × plan × role, no-dead-button, no-code-leak, render contracts.
- `library-registry.test.ts` — registry drift gate passes with the new export.

## Verification

- `pnpm -C apps/packages/product-ui build` clean; `vitest run src/patterns/BillingGateState.test.tsx` 12/12.
- `pnpm -C apps/packages/product-client exec vitest run .../library-registry.test.ts` 3/3.

Wiring the existing surfaces (workspace blocked screen, sidebar card) onto these components is deliberately out of scope for this PR — follow-up per surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)