### PR TITLE
fix(self-host): deploy-script and CFN fixes from live self-hosting QA

### DIFF
--- a/server/deploy/common.sh
+++ b/server/deploy/common.sh
@@ -13,9 +13,9 @@
 # --- env-file reading --------------------------------------------------------
 
 # proliferate_read_env <file> <key>: print the raw value of KEY= from an env
-# file (empty when the file or key is absent). Reads the first match only, so a
-# generated override that appends KEY= later would need a dedicated reader; the
-# deploy scripts never do that.
+# file (empty when the file or key is absent). Reads the LAST match, matching
+# typical env-file last-wins semantics (a duplicated KEY= appended lower in
+# the file overrides an earlier one).
 proliferate_read_env() {
   local file="$1"
   local key="$2"
@@ -25,7 +25,7 @@ proliferate_read_env() {
     return 0
   fi
 
-  line="$(grep -m1 "^${key}=" "$file" || true)"
+  line="$(grep "^${key}=" "$file" | tail -n1 || true)"
   if [[ -z "$line" ]]; then
     return 0
   fi

--- a/server/deploy/ensure-secrets.sh
+++ b/server/deploy/ensure-secrets.sh
@@ -27,7 +27,7 @@ read_env_value() {
     return 0
   fi
 
-  line="$(grep -m1 "^${key}=" "$file" || true)"
+  line="$(grep "^${key}=" "$file" | tail -n1 || true)"
   if [[ -z "$line" ]]; then
     return 0
   fi

--- a/server/deploy/install-runtime.sh
+++ b/server/deploy/install-runtime.sh
@@ -14,7 +14,7 @@ read_env_value() {
   local key="$1"
   local line
 
-  line="$(grep -m1 "^${key}=" "$ENV_FILE" || true)"
+  line="$(grep "^${key}=" "$ENV_FILE" | tail -n1 || true)"
   if [[ -z "$line" ]]; then
     return 0
   fi

--- a/server/deploy/install.sh
+++ b/server/deploy/install.sh
@@ -213,7 +213,7 @@ DOWNLOAD_BASE="${PROLIFERATE_RELEASE_DOWNLOAD_BASE:-https://github.com/${REPO_SL
 read_env() {
   local file="$1" key="$2" line
   [[ -f "$file" ]] || return 0
-  line="$(grep -m1 "^${key}=" "$file" || true)"
+  line="$(grep "^${key}=" "$file" | tail -n1 || true)"
   [[ -n "$line" ]] || return 0
   printf '%s' "${line#*=}"
 }
@@ -585,7 +585,14 @@ confirm() {
 
 print_next_steps() {
   local site
-  site="$(read_env "$DEPLOY_DIR/.env.static" SITE_ADDRESS)"
+  # In --eval mode SITE_ADDRESS is blank in .env.static and only resolved (to
+  # an sslip.io host derived from the public IP) once bootstrap.sh writes
+  # .env.runtime. Prefer the resolved value; fall back to .env.static for
+  # --no-start installs that haven't bootstrapped yet.
+  site="$(read_env "$DEPLOY_DIR/.env.runtime" SITE_ADDRESS)"
+  if [[ -z "$site" ]]; then
+    site="$(read_env "$DEPLOY_DIR/.env.static" SITE_ADDRESS)"
+  fi
   local host="$site"
   host="${host#http://}"
   host="${host#https://}"

--- a/server/deploy/registry-login.sh
+++ b/server/deploy/registry-login.sh
@@ -14,7 +14,7 @@ read_env_value() {
   local key="$1"
   local line
 
-  line="$(grep -m1 "^${key}=" "$ENV_FILE" || true)"
+  line="$(grep "^${key}=" "$ENV_FILE" | tail -n1 || true)"
   if [[ -z "$line" ]]; then
     return 0
   fi

--- a/server/deploy/wait-for-health.sh
+++ b/server/deploy/wait-for-health.sh
@@ -115,7 +115,7 @@ read_env_value() {
     return 0
   fi
 
-  line="$(grep -m1 "^${key}=" "$file" || true)"
+  line="$(grep "^${key}=" "$file" | tail -n1 || true)"
   if [[ -z "$line" ]]; then
     return 0
   fi
@@ -146,6 +146,8 @@ site_url_from_address() {
 wait_for_url() {
   local target="$1"
   local url="$2"
+  local insecure="${3:-false}"
+  local insecure_flag=()
   local attempt=1
   local now
   local remaining
@@ -153,6 +155,8 @@ wait_for_url() {
   local connect_timeout
   local sleep_seconds
   local target_deadline
+
+  [[ "$insecure" == "true" ]] && insecure_flag=(-k)
 
   health_progress_marker "$target" started
   target_deadline=$(( $(date +%s) + TARGET_TIMEOUT_SECONDS ))
@@ -173,7 +177,7 @@ wait_for_url() {
     (( request_timeout > remaining )) && request_timeout="$remaining"
     (( connect_timeout > request_timeout )) && connect_timeout="$request_timeout"
 
-    if curl -fsS --connect-timeout "$connect_timeout" --max-time "$request_timeout" "$url" >/dev/null; then
+    if curl -fsS "${insecure_flag[@]}" --connect-timeout "$connect_timeout" --max-time "$request_timeout" "$url" >/dev/null 2>&1; then
       health_progress_marker "$target" completed
       return 0
     fi
@@ -273,7 +277,19 @@ fi
 wait_for_url local "$HEALTHCHECK_URL"
 
 if [[ "$SKIP_PUBLIC" == "false" && -n "$PUBLIC_HEALTHCHECK_URL" ]]; then
-  wait_for_url public "$PUBLIC_HEALTHCHECK_URL"
+  # SITE_ADDRESS=localhost (the documented "local evaluation" mode) makes
+  # Caddy serve the public hostname off its internal CA, which curl won't
+  # trust by default; the public endpoint would otherwise fail every attempt
+  # with SSL errors even though the stack is healthy. Trust that internal CA
+  # for the public check only when the target host is localhost/127.0.0.1.
+  public_insecure="false"
+  public_host="${PUBLIC_HEALTHCHECK_URL#*://}"
+  public_host="${public_host%%/*}"
+  public_host="${public_host%%:*}"
+  case "$public_host" in
+    localhost | 127.0.0.1) public_insecure="true" ;;
+  esac
+  wait_for_url public "$PUBLIC_HEALTHCHECK_URL" "$public_insecure"
 fi
 
 print_setup_instructions

--- a/server/infra/self-hosted-aws/launch-stack.sh
+++ b/server/infra/self-hosted-aws/launch-stack.sh
@@ -29,7 +29,7 @@ STACK_NAME="proliferate-self-hosted"
 VERSION=""
 SITE_ADDRESS=""
 EVAL_MODE=0
-INSTANCE_TYPE="t4g.small"
+INSTANCE_TYPE="t3.small"
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 GH_CLIENT_ID=""
 GH_CLIENT_SECRET=""
@@ -49,7 +49,7 @@ Options:
   --version X.Y.Z                Server release to launch (default: newest server-v*).
   --site-address HOST            Public hostname (required unless --eval).
   --eval                         No domain; sslip.io host from the Elastic IP.
-  --instance-type TYPE           t4g.small | t4g.medium | t4g.large (default: t4g.small).
+  --instance-type TYPE           t3.small | t3.medium | t3.large (default: t3.small).
   --region REGION                AWS region (default: from your AWS config).
   --github-oauth-client-id ID    GitHub OAuth client id (optional).
   --github-oauth-client-secret S GitHub OAuth client secret (optional).

--- a/server/infra/self-hosted-aws/template.yaml
+++ b/server/infra/self-hosted-aws/template.yaml
@@ -79,11 +79,14 @@ Parameters:
 
   InstanceType:
     Type: String
-    Default: t4g.small
+    Default: t3.small
     AllowedValues:
-      - t4g.small
-      - t4g.medium
-      - t4g.large
+      - t3.small
+      - t3.medium
+      - t3.large
+    # The published ghcr.io/proliferate-ai/proliferate-server image is a
+    # single-arch amd64 manifest (no arm64/multi-arch index), so this must
+    # stay x86_64 to match LatestAmiId and the default RuntimeBinaryUrl below.
     Description: EC2 instance type for the self-hosted control plane.
 
   PostgresPassword:
@@ -128,8 +131,8 @@ Parameters:
 
   LatestAmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64
-    Description: Amazon Linux 2023 arm64 AMI id.
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+    Description: Amazon Linux 2023 x86_64 AMI id.
 
 Rules:
   SiteAddressRequiredWithoutSslip:
@@ -460,9 +463,10 @@ Resources:
                   ResolvedRuntimeBinaryUrl: !If
                     - HasRuntimeBinaryUrlOverride
                     - !Ref RuntimeBinaryUrl
-                    # The default instance types are all Graviton (arm64), so
-                    # the default runtime asset must be the aarch64 build.
-                    - !Sub https://github.com/proliferate-ai/proliferate/releases/download/server-v${ReleaseVersion}/anyharness-aarch64-unknown-linux-musl.tar.gz
+                    # The default instance types are x86_64 (matching the
+                    # amd64-only ghcr.io server image), so the default runtime
+                    # asset must be the x86_64 build.
+                    - !Sub https://github.com/proliferate-ai/proliferate/releases/download/server-v${ReleaseVersion}/anyharness-x86_64-unknown-linux-musl.tar.gz
                   ResolvedRuntimeBinaryChecksumUrl: !If
                     - HasRuntimeBinaryChecksumUrlOverride
                     - !Ref RuntimeBinaryChecksumUrl


### PR DESCRIPTION
Overnight first-time-customer QA: installed server-v0.3.48 via every documented self-hosting method (EC2 Docker, CFN one-click, install.sh eval, localhost eval, Azure VM, E2B template build, model gateway, auth matrix, update.sh upgrade, desktop connect). Four product bugs found and fixed here; the doc-side corrections are in the companion landing PR (pablonyx/proliferate#32).

## Fixes

**1. Duplicate env keys silently break `install-runtime.sh` (F6)**
`.env.production.example` ships blank `CLOUD_*_SOURCE_BINARY_PATH=` / `RUNTIME_BINARY_URL=` keys, and e2b.mdx told operators to *append* values — the readers' `grep -m1` then returned the first (blank) copy and install-runtime.sh exited 0 without installing anything. All six deploy-script env readers now take the last occurrence.
Repro: followed e2b.mdx verbatim on EC2; update.sh "succeeded" with no binaries in /opt/proliferate/bin.

**2. `install.sh --eval` prints literal `https://<your-host>` (F2)**
The final summary read SITE_ADDRESS from `.env.static` (blank in eval mode) instead of the resolved sslip.io value in `.env.runtime`. Also silenced raw `curl: (56) Recv failure` noise during the health wait.

**3. Localhost eval mode: public health check fails 60/60 against Caddy's internal CA (F9)**
`SITE_ADDRESS=localhost` (documented "local evaluation") always ends bootstrap with "Health check failed for the public endpoint" though the stack is healthy. The public check now passes `-k` only when the target host is localhost/127.0.0.1.

**4. CFN one-click stack can never succeed: arm64 instances × amd64-only image (F4)**
Template restricted InstanceType to t4g.* (Graviton) but `ghcr.io/proliferate-ai/proliferate-server` is single-arch amd64 → migrate dies with `exec format error`, cfn-init signals FAILURE, stack rolls back after ~20 min. Every stock launch fails. Defaults flipped to t3.* + x86_64 AMI + x86_64 runtime artifact (parameter names unchanged); revert when a multi-arch image ships.
Repro: stacks proliferate-selfhost-qa / -qa2 (stock, failed) vs patched template → CREATE_COMPLETE in 9 min, claim flow verified.

Template remains 30,417 bytes (< 51,200 CFN inline limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)