### PR TITLE
fix(server-tests): drop dangling legacy-launch flag pins left by the merge train

### DIFF
--- a/server/tests/integration/test_cloud_sandbox_reconnect_self_heal.py
+++ b/server/tests/integration/test_cloud_sandbox_reconnect_self_heal.py
@@ -170,9 +170,6 @@ async def test_stale_runtime_is_killed_before_relaunch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The legacy NULL-token row relaunches, and the stale runtime is killed first."""
-    # This test asserts the legacy direct-AnyHarness launch path specifically;
-    # pin the flag explicitly now that supervisor-owned is the default.
-    monkeypatch.setattr(runtime_launch_module.settings, "supervisor_owned_runtime", False)
     provider = _FakeProvider(db_session)
     _install_stubs(monkeypatch, provider)
     sandbox = await _seed_sandbox(
@@ -214,9 +211,6 @@ async def test_fresh_token_persisted_when_url_unchanged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A NULL-token row whose URL already matches still persists the minted token."""
-    # This test asserts token persistence on the legacy relaunch path;
-    # pin the flag explicitly now that supervisor-owned is the default.
-    monkeypatch.setattr(runtime_launch_module.settings, "supervisor_owned_runtime", False)
     provider = _FakeProvider(db_session)
     _install_stubs(monkeypatch, provider)
     # The row already carries the URL the provider resolves to, but no token.


### PR DESCRIPTION
## What

Deletes two `monkeypatch.setattr(runtime_launch_module.settings, "supervisor_owned_runtime", False)` lines from `server/tests/integration/test_cloud_sandbox_reconnect_self_heal.py`.

## Why

The sandbox fix-stack merge train (#1502 … #1534) squash-merged 12 PRs. S5-A (#1531) added those pins while the legacy launch path still read the flag; S5-B (#1534) then deleted the legacy path and `runtime_launch`'s `settings` import entirely. In the validated combined tree the pins were gone, but they survived the train's conflict resolution of this file, so on `main` they now raise `AttributeError: module 'proliferate.server.cloud.materialization.sandbox_io.runtime_launch' has no attribute 'settings'`.

This restores the file byte-for-byte to the validated tree's state (`train-14-S5B`).

## Verification

- `python3 scripts/check_max_lines.py` and `python3 scripts/check_docs.py` pass
- File now diffs empty against the validated stack tag
- `runtime_launch_module` is still used (7 other references), so no unused import

🤖 Generated with [Claude Code](https://claude.com/claude-code)