### PR TITLE
chore: add riptide workspace config for workspace-mobility task development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ apps/packages/product-client/src/generated/
 
 # Local dev symlink into the root workspace node_modules (never committed)
 tests/release/node_modules
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/.humanlayer/workspace.json
+++ b/.humanlayer/workspace.json
@@ -1,0 +1,22 @@
+{
+  "disabled": false,
+  "pathTemplate": "~/.humanlayer/workspaces/{{ TASKSLUG }}/{{ REPOBASENAME }}",
+  "branchTemplate": "{{ TASKSLUG }}",
+  "sourceRef": "HEAD",
+  "setupCommand": "make install",
+  "copyGlobs": [
+    ".env",
+    ".env.local",
+    ".env.development.local",
+    "apps/*/.env.local",
+    ".claude/settings.local.json",
+    ".humanlayer/workspace.local.json"
+  ],
+  "repos": [
+    {
+      "localPath": ".",
+      "description": "Proliferate monorepo",
+      "primary": true
+    }
+  ]
+}


### PR DESCRIPTION
## Header Links

Workspace Mobility (P0) | [Artifacts](https://cloud.humanlayer.com/tasks/019fa079-a5e3-7475-a9e7-56f647b984dd/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019fa079-a5e3-7475-a9e7-56f647b984dd)

## What problems was I solving

This PR carries the repo-side scaffolding for the **Workspace Mobility (P0)** task — moving work seamlessly between local and cloud workspaces (conversation, files, Git state, and task metadata).

The task is being developed spec-first: the substantive deliverables (research, design discussion, structure outline, and the `workspace-migration-v2` delivery specification, currently at Phase 2 of 6 of its refresh) live as **cloud-synced task artifacts** under `.humanlayer/tasks/`, linked above. Two repo-side problems needed solving so that development can happen in riptide-managed worktrees without polluting git history:

1. The repo had no workspace configuration, so riptide could not provision per-task worktrees (path/branch templates, setup command, env-file propagation).
2. Cloud-synced task artifacts under `.humanlayer/tasks/` appeared as untracked files in every task worktree, inviting accidental commits of documents whose source of truth is the cloud artifact store.

## What user-facing changes did I ship

No product-facing changes. Both changes are developer-workflow configuration:

- [.humanlayer/workspace.json](https://github.com/proliferate-ai/proliferate/pull/1578/files#diff-5e97982aefc52e7bce589eef67fe247f77cde9fe40054d6ace708916bbfa64f6) - new riptide workspace configuration for the monorepo
- [.gitignore](https://github.com/proliferate-ai/proliferate/pull/1578/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) - ignore `.humanlayer/tasks/` (cloud-synced artifacts, not version controlled)

## How I implemented it

### Workspace configuration
- [.humanlayer/workspace.json](https://github.com/proliferate-ai/proliferate/pull/1578/files#diff-5e97982aefc52e7bce589eef67fe247f77cde9fe40054d6ace708916bbfa64f6) - declares the monorepo as the single primary repo and tells riptide how to provision a task workspace:
  - worktrees at `~/.humanlayer/workspaces/{{ TASKSLUG }}/{{ REPOBASENAME }}`, branched as `{{ TASKSLUG }}` off `HEAD`
  - `make install` as the setup command
  - `copyGlobs` propagating local-only files into new worktrees: root and per-app `.env*` files, `.claude/settings.local.json`, and `.humanlayer/workspace.local.json` (the local override file, which stays uncommitted)

### Git hygiene
- [.gitignore](https://github.com/proliferate-ai/proliferate/pull/1578/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) - adds `.humanlayer/tasks/` under a "Riptide artifacts (cloud-synced)" comment. `.humanlayer/workspace.json` itself is deliberately **not** ignored — it is the shared, committed config.

## Deviations from the plan

No plan file exists in the task directory; the task is still in its specification stage. The task artifacts (research questions, research, design discussion, structure outline, and the frozen `workspace-migration-v2` delivery spec being refreshed against current `main`) are the actual work product and are intentionally excluded from this diff by the `.gitignore` change in this PR.

## How to verify it

### Manual Testing
- [ ] `cat .humanlayer/workspace.json` — valid JSON, paths/templates look right for the monorepo
- [ ] From a fresh clone, confirm `git status` does not report `.humanlayer/tasks/` contents as untracked after creating files there
- [ ] Confirm `.humanlayer/workspace.json` is tracked (`git ls-files .humanlayer/`) while `.humanlayer/workspace.local.json` would remain ignored/untracked

### Automated Tests
Not applicable — configuration-only change with no code paths exercised by the test suites.

## Description for the changelog

Add riptide workspace configuration and gitignore cloud-synced task artifacts to support spec-first development of Workspace Mobility (P0).
