### PR TITLE
chore(product): describe our UI in our own vocabulary

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/loops/wire.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/wire.rs
@@ -1,5 +1,5 @@
 //! LoopPort wire contract v1 (pinned 2026-07-02, tagged-chunk vocabulary per
-//! `codex/session-activity-architecture.md`): the normalized shapes the
+//! the session-activity architecture): the normalized shapes the
 //! sidecars speak — `LoopWire` payloads on tagged notification chunks and
 //! (once the loop runtime PR lands) `_anyharness/loop/*` ext-method
 //! responses. Status/schedule vocabulary arrives already normalized by the

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -534,7 +534,7 @@ body {
   color: var(--diffs-fg);
 }
 
-mark.codex-thread-find-match {
+mark.content-find-match {
   background-color: var(--color-terminal-yellow);
   color: var(--color-background);
   border-radius: calc(var(--radius) / 4);
@@ -548,7 +548,7 @@ mark.codex-thread-find-match {
   vertical-align: baseline;
 }
 
-mark.codex-thread-find-active {
+mark.content-find-active {
   background-color: hsl(30 95% 65%);
 }
 

--- a/apps/packages/product-client/src/components/content/ui/DiffViewer.test.tsx
+++ b/apps/packages/product-client/src/components/content/ui/DiffViewer.test.tsx
@@ -48,7 +48,7 @@ describe("DiffViewer chat variant", () => {
     expect(sharedSurfaceRule).toContain("background-color: var(--color-diff-code-surface);");
   });
 
-  it("renders Codex-style data attributes and dynamic gutter width", () => {
+  it("renders diff data attributes and dynamic gutter width", () => {
     const html = renderToStaticMarkup(
       createElement(DiffViewer, {
         patch: PATCH,
@@ -145,7 +145,7 @@ describe("DiffViewer chat variant", () => {
     expect(splitHtml).toContain("overscroll-behavior-y:none");
   });
 
-  it("renders split diffs with Codex-style paired code columns", () => {
+  it("renders split diffs with paired code columns", () => {
     const html = renderToStaticMarkup(
       createElement(DiffViewer, {
         patch: PATCH,

--- a/apps/packages/product-client/src/components/content/ui/FileChangeStats.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FileChangeStats.tsx
@@ -4,7 +4,7 @@ interface FileChangeStatsProps {
   className?: string;
   /** Keep activity-row counts neutral until their parent row is hovered/focused. */
   tone?: "semantic" | "activity";
-  /** Match Codex completion cards by rolling changed digits between values. */
+  /** Rolls changed digits between values, as the completion cards do. */
   rolling?: boolean;
 }
 

--- a/apps/packages/product-client/src/components/content/ui/FileDiffCard.test.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FileDiffCard.test.tsx
@@ -45,7 +45,7 @@ describe("FileChangesCard and FileDiffCard", () => {
     expect(html).not.toContain("thread-diff-virtualized");
     expect(html).toContain("--diff-view-surface:var(--diff-view-surface-override, var(--color-diff-panel-surface))");
     expect(html).toContain("data-diff-surface=\"sidebar\"");
-    expect(html).toContain("codex-review-diff-card");
+    expect(html).toContain("review-diff-card");
     expect(html).toContain("--diff-view-header-surface:var(--color-diff-sidebar-file-header-surface)");
     expect(html).toContain("--diff-view-separator-surface:var(--color-diff-sidebar-file-header-hover-surface)");
     expect(html).toContain("sticky top-0 bg-[color-mix(in_srgb,var(--diff-view-header-surface)_97%,transparent)]");

--- a/apps/packages/product-client/src/components/content/ui/FileDiffCard.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FileDiffCard.tsx
@@ -67,7 +67,7 @@ export function FileDiffCard({
     ? "text-sidebar-muted-foreground hover:bg-hover active:bg-active hover:text-sidebar-foreground focus-visible:ring-sidebar-ring"
     : "text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-border";
   const cardClass = isSidebar
-    ? "codex-review-diff-card rounded-md"
+    ? "review-diff-card rounded-md"
     : embedded ? "" : "rounded-lg";
   const cardStyle = {
     "--diff-view-surface":

--- a/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
@@ -18,7 +18,7 @@ interface FilePathLinkProps {
  *  - Click -> open the file in the workspace right-sidebar viewer.
  *  - Context menu -> external open targets, copy path, reveal in Finder.
  *
- * Style: Codex-style local file/doc link in `text-link-foreground`, no pill,
+ * Style: local file/doc link in `text-link-foreground`, no pill,
  * no border, underline on hover only.
  */
 export const FilePathLink = memo(function FilePathLink({

--- a/apps/packages/product-client/src/components/content/ui/search/ContentSearchMarks.tsx
+++ b/apps/packages/product-client/src/components/content/ui/search/ContentSearchMarks.tsx
@@ -36,8 +36,8 @@ export function renderContentSearchMarkedText({
     nodes.push(
       <mark
         key={matchId}
-        className={`codex-thread-find-match ${
-          matchId === activeMatchId ? "codex-thread-find-active" : ""
+        className={`content-find-match ${
+          matchId === activeMatchId ? "content-find-active" : ""
         }`}
         data-content-search-match-id={matchId}
       >
@@ -89,8 +89,8 @@ export function renderContentSearchMarkedToken({
     nodes.push(
       <mark
         key={`${matchId}:${segment.start}:${segment.end}`}
-        className={`codex-thread-find-match ${
-          matchId === activeMatchId ? "codex-thread-find-active" : ""
+        className={`content-find-match ${
+          matchId === activeMatchId ? "content-find-active" : ""
         }`}
         data-content-search-match-id={matchId}
       >

--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -193,7 +193,7 @@ export function HomeComposerForm({
       </DebugProfiler>
 
       <DebugProfiler id="home-target-picker">
-        {/* Codex home footer: a tray tucked under the composer (rounded-b,
+        {/* Home footer: a tray tucked under the composer (rounded-b,
             sidebar bg) so the selectors read as attached, not floating. */}
         <div className="relative z-0 -mx-px -mt-[18px] flex min-w-0 flex-wrap items-center justify-start gap-1 overflow-hidden rounded-b-2xl bg-sidebar px-2 pb-2 pt-[25px]">
           {targetPickerSlot}

--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPickerParts.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPickerParts.tsx
@@ -102,7 +102,7 @@ interface HomeTargetRowItemProps
 }
 
 /**
- * Codex home footer item (UX spec §1.3, anchor `_externalFooterItem`):
+ * Home footer item (UX spec §1.3, anchor `_externalFooterItem`):
  * inline "value ▾" trigger — 13px text, value weight 400 truncated,
  * 12px `--faint` chevron, pill hover fill.
  */

--- a/apps/packages/product-client/src/components/playground/PlaygroundSidebarGitDiff.test.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundSidebarGitDiff.test.tsx
@@ -26,7 +26,7 @@ describe("PlaygroundSidebarGitDiff", () => {
     expect(html).toContain("data-thread-find-target=\"review\"");
     expect(html).toContain("data-app-action-review-metrics-probe=\"\"");
     expect(html).toContain("data-review-path=");
-    expect(html).toContain("codex-review-diff-card");
+    expect(html).toContain("review-diff-card");
     expect(html).toContain("px-2 pb-3");
     expect(html).toContain("pt-2");
     expect(html).not.toContain("px-2 py-2");

--- a/apps/packages/product-client/src/components/playground/loading/PlaygroundThinkingTimingControls.tsx
+++ b/apps/packages/product-client/src/components/playground/loading/PlaygroundThinkingTimingControls.tsx
@@ -15,7 +15,7 @@ import { RangeSlider } from "@proliferate/ui/primitives/RangeSlider";
 // The controls below write those vars onto the preview labels, so what
 // animates here is byte-for-byte the shipping mechanism; copy the summary
 // line into product.css to change the product defaults. The steps() preset
-// exists to compare codex's cadenced feel (steps(48, end)) against the
+// exists to compare a cadenced feel (steps(48, end)) against the
 // smooth sweep we ship.
 
 type EasingKind = "linear" | "steps" | "ease-in-out";

--- a/apps/packages/product-client/src/components/playground/subagents-ux/identity-receipts/SubagentCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/playground/subagents-ux/identity-receipts/SubagentCreationReceipt.tsx
@@ -41,7 +41,7 @@ export function SubagentCreationReceipt({
       aria-label={`${model.title} subagent created`}
       className="flex min-w-0 flex-col items-start"
     >
-      {/* Codex-style inline chip row: pill with glyph + authored task label,
+      {/* Inline chip row: pill with glyph + authored task label,
           then a quiet verb. The chip itself is the disclosure trigger. */}
       <div className={`flex min-w-0 max-w-full items-center ${compact ? "gap-1.5" : "gap-2"}`}>
         <Button

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -289,7 +289,7 @@ interface MethodCardProps {
 }
 
 /**
- * One auth-method choice as a Conductor-style card (design-handoff v2): 32px
+ * One auth-method choice as a method card (design-handoff v2): 32px
  * icon tile pinned top, label + one-line rationale bottom, check icon top-right
  * when selected. The cards are a radio by behavior, not by markup:
  * `handleSingleSourceSelect` drops the other sources on every pick

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.tsx
@@ -251,7 +251,7 @@ function HarnessRuntimeStatusRow({
 }
 
 /**
- * The v2 pane anatomy (reference/design-handoff): identity → Authentication
+ * The v2 pane anatomy (design-handoff v2): identity → Authentication
  * (method cards with the ONE status badge merged into the header, detail area
  * below the cards) → harness settings → Models. There is no separate Status
  * section — the state is said exactly once, in the section header. OpenCode

--- a/apps/packages/product-client/src/components/workspace/activity/SessionActivityBar.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/SessionActivityBar.tsx
@@ -45,8 +45,8 @@ export function SessionActivityBar() {
   }), [activity.loops, activity.processes, activity.agents]);
 
   // TODO(activity-integration): the ⑂ agents chip's `onOpen` is the remaining
-  // documented integration seam — see
-  // codex/session-activity-architecture.md "Product UI". It should route into
+  // documented integration seam ("Product UI" section of the session-activity
+  // architecture notes). It should route into
   // the existing delegated-work surfaces (features/delegated-work.md) once this
   // roster is merged into DelegatedWorkComposerViewModel as a new `subagent`
   // source. Until then the chip's popover is a fully-functional, self-contained

--- a/apps/packages/product-client/src/components/workspace/chat/input/ApprovalCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ApprovalCard.tsx
@@ -17,7 +17,7 @@ import type { PermissionOptionAction } from "#product/lib/domain/chat/composer/c
 // MCP tool call) renders as a wrapping mono snippet in the body instead of a
 // truncating one-line title, so long commands stay fully readable.
 //
-// Options follow the codex popover-row anatomy (ComposerOptionRow): rounded
+// Options follow the canonical popover-row anatomy (ComposerOptionRow): rounded
 // hover rows without hairlines, leading number-key badges, 1–9 selects. The
 // harness-provided options and the fallback Allow/Deny path render through the
 // exact same rows so the two paths are visually identical; destructive kinds

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -253,9 +253,8 @@ function ModelPickerGroup({
 
   return (
     <>
-      {/* Conductor-style group anatomy (reference/conductor/input/models.html):
-          hairline between groups, then a muted harness header (icon + name)
-          above the group's model rows. */}
+      {/* Group anatomy: hairline between groups, then a muted harness header
+          (icon + name) above the group's model rows. */}
       {showSeparator && (
         <div className="mt-1 w-full px-2 py-0.5">
           <div className="h-px w-full bg-border/60" />

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerOptionRow.tsx
@@ -3,7 +3,7 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { twMerge } from "@proliferate/ui/utils/tw-merge";
 
 /**
- * Codex popover-row anatomy for composer option lists: full-width rows with
+ * Canonical popover-row anatomy for composer option lists: full-width rows with
  * a rounded-lg hover fill and NO hairline separators (spacing does the
  * separation, so the hover pill never overlaps a border), leading number-key
  * badge (mono text-ui-sm on control bg, 4px radius), text-ui labels that

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -11,7 +11,7 @@ import { Tooltip } from "@proliferate/ui/primitives/Tooltip";
 import { LevelBarsButton } from "@proliferate/ui/patterns/LevelBarsButton";
 
 // Tier-label tint ladder for ultra-capable ladders. Ultra keeps the
-// codex-convention purple (same hue as --color-pr-merged); max keeps the app
+// established purple (same hue as --color-pr-merged); max keeps the app
 // special blue. Tinted tiers pin their color through hover (the control
 // button's base `hover:text-current` would otherwise wash the tint back to
 // plain ink); gray tiers keep the standard muted→full hover promotion.
@@ -61,8 +61,9 @@ export function ComposerReasoningEffortBars({
   ) + ". Click to step.";
 
   const tierTone = resolveReasoningEffortTierTone(currentOption?.value ?? null);
-  // Codex frontier ladders (GPT Sol) trade the purple ultra tint for the
-  // active chip while the icon itself keeps the semantic tier color.
+  // The codex harness's frontier ladders (GPT Sol) trade the purple ultra
+  // tint for the active chip while the icon itself keeps the semantic tier
+  // color.
   const isUltraTier = isUltraLadder && tierTone === "ultra";
   // Ultra "on" reads like the fast-mode zap when enabled: a filled purple
   // chip behind the bars. Pinned through hover so it doesn't wash back.

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -145,12 +145,12 @@ export function ComposerRichTextEditor({
             />
           )}
           placeholder={(
-            // ui-foundation-escalation: [CHAT-03] wants Codex's placeholder ink,
-            // but neither Codex reading is expressible in the ruled vocabulary.
-            // Codex's prose target is its tertiary/description role (~49.8%
-            // white) while its actual ProseMirror implementation is a separate
-            // `--color-token-input-placeholder-foreground` further multiplied by
-            // `opacity: .5` (~25-35% effective) —
+            // ui-foundation-escalation: [CHAT-03] wants a placeholder ink
+            // target that isn't expressible in the ruled vocabulary — the
+            // two candidate readings of the reference split apart. Its prose
+            // target is a tertiary/description role (~49.8% white) while its
+            // actual implementation is a separate placeholder token further
+            // multiplied by `opacity: .5` (~25-35% effective) —
             // ui-foundation-chat-addendum.md [CHAT-03] flags exactly this split.
             // `text-foreground-tertiary` (--color-foreground-tertiary, 50%) is
             // the closest legal role and the addendum's recommendation; it

--- a/apps/packages/product-client/src/components/workspace/chat/input/UserInputCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/UserInputCard.tsx
@@ -20,7 +20,7 @@ import {
 
 // Agent question wizard on the shared interaction-card anatomy: header/type
 // grammar from ComposerAttachedPanel (text-ui title + text-ui-sm progress
-// context), codex-style option rows with number-key badges (1–9 selects), an
+// context), canonical option rows with number-key badges (1–9 selects), an
 // inset free-text row on --control with an inset ring, and the shared
 // ComposerCardFooter (secondary chips left, primary chip right).
 //

--- a/apps/packages/product-client/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.tsx
@@ -134,7 +134,7 @@ export function WorkspaceActivityComposerCard({
                 title="Source control"
                 flush
               >
-                {/* Changes is the codex-style summary row: the change count
+                {/* Changes is the canonical summary row: the change count
                     with +adds −dels trailing, and the row itself opens the
                     review panel (no separate "Review changes" entry). */}
                 <ActivityActionRow

--- a/apps/packages/product-client/src/components/workspace/chat/input/workspace-status/StatusCardPrimitives.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/workspace-status/StatusCardPrimitives.tsx
@@ -9,9 +9,9 @@ import {
 } from "@proliferate/ui/primitives/tooltip-primitive";
 
 /**
- * The codex card anatomy (reference/codex/status/card.html), extracted from
- * the workspace-status card so every composer ambient surface — status card,
- * environment popover — shares one section/row recipe.
+ * The status card anatomy, extracted from the workspace-status card so
+ * every composer ambient surface — status card, environment popover —
+ * shares one section/row recipe.
  */
 
 export type WorkspaceStatusDetailState =
@@ -29,8 +29,8 @@ export interface WorkspaceStatusDetailItem {
   meta?: string;
 }
 
-/* Codex section anatomy (card.html): hairline via ::after inset-x-4,
-   sticky h-7 header in card background, rows in a gap-0.5 px-4 column. */
+/* Section anatomy: hairline via ::after inset-x-4, sticky h-7 header in
+   card background, rows in a gap-0.5 px-4 column. */
 export function StatusSection({
   title,
   detail,
@@ -51,9 +51,8 @@ export function StatusSection({
   );
 }
 
-/* Codex row recipe (group/summary-panel-row): h-7, icon in a fixed slot,
-   truncating label, trailing meta, full-row hover paint via ::before that
-   outsets 8px past the row box. */
+/* Row recipe: h-7, icon in a fixed slot, truncating label, trailing meta,
+   full-row hover paint via ::before that outsets 8px past the row box. */
 const STATUS_ROW_CLASS =
   "group/status-row relative isolate flex h-7 w-full min-w-0 items-center gap-2 rounded-md py-1 text-left text-ui text-foreground before:absolute before:inset-y-0 before:-inset-x-2 before:-z-10 before:rounded-md before:content-['']";
 
@@ -69,14 +68,14 @@ export function StatusRow({
   title,
 }: {
   icon?: ReactNode;
-  /** Replaces the fixed-width icon slot — for codex avatar-group clusters. */
+  /** Replaces the fixed-width icon slot — for avatar-group clusters. */
   leading?: ReactNode;
   label: string;
   meta?: string;
   trailing?: ReactNode;
   hoverItems?: WorkspaceStatusDetailItem[];
   onSelect?: () => void;
-  /** Codex cmdk disabled recipe: dimmed, no hover paint, no action. */
+  /** Disabled recipe: dimmed, no hover paint, no action. */
   disabled?: boolean;
   title?: string;
 }) {
@@ -120,10 +119,10 @@ export function StatusRow({
     return row;
   }
 
-  /* Leaf detail on hover, codex tooltip recipe (tooltip1.html): rounded-xl,
-     translucent popover bg, 0.5px ring, backdrop blur; radix-portaled so the
-     card's scroll container can't clip it; opens leftward over the
-     transcript — the free side next to a right-anchored card. */
+  /* Leaf detail on hover, tooltip recipe: rounded-xl, translucent popover bg,
+     0.5px ring, backdrop blur; radix-portaled so the card's scroll container
+     can't clip it; opens leftward over the transcript — the free side next to
+     a right-anchored card. */
   return (
     <TooltipProvider delayDuration={150}>
       <KitTooltip>

--- a/apps/packages/product-client/src/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl.tsx
@@ -29,10 +29,10 @@ import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/sess
 
 /**
  * Workspace status: the single ambient-state surface for a session.
- * One icon-only trigger in the composer's trailing cluster opens a
- * codex-anatomy card (reference/codex/status/card.html):
+ * One icon-only trigger in the composer's trailing cluster opens the
+ * status card anatomy:
  *   - Source control first (review / commit-push / compare / checks)
- *   - Subagents (ours), codex-format: pixel sprite + name rows
+ *   - Subagents (ours): pixel sprite + name rows
  *   - Native agents & terminals as count rows with hover detail cards
  *   - Resources (worktrees summary → searchable modal, cloud CPU/RAM/disk)
  *   - Advanced session config (absorbed from the removed "..." overflow)
@@ -79,7 +79,7 @@ export interface WorkspaceStatusModel {
       items: WorkspaceStatusDetailItem[];
     } | null;
   } | null;
-  /** Codex format: one row per state group — sprite cluster + "N working". */
+  /** One row per state group — sprite cluster + "N working". */
   subagents: {
     working: WorkspaceStatusSubagentRow[];
     done: WorkspaceStatusSubagentRow[];
@@ -168,7 +168,7 @@ export function WorkspaceStatusCard({
   };
 
   return (
-    // Codex card surface: 300px, 20px radius (their rounded-3xl base is
+    // Status card surface: 300px, 20px radius (rounded-3xl base is
     // 1.25rem), solid dropdown background, elevation-prominent = 0.5px
     // stroke painted in the shadow stack + two soft shadows — no ring.
     <ComposerPopoverSurface
@@ -286,7 +286,7 @@ export function WorkspaceStatusCard({
   );
 }
 
-/* One state group of our agents, codex-format: sprite cluster + "N working".
+/* One state group of our agents: sprite cluster + "N working".
    Clicking focuses the group's first agent session (tab activation) — the
    hover card lists every member. */
 function SubagentGroupRow({
@@ -324,8 +324,8 @@ function SubagentGroupRow({
   );
 }
 
-/* Codex avatar-group (thread-summary-panel-item-avatar-group): the group's
-   sprites sit side by side ahead of the "N working" label, capped at four. */
+/* Avatar-group cluster: the group's sprites sit side by side ahead of the
+   "N working" label, capped at four. */
 function SubagentSpriteCluster({ rows }: { rows: WorkspaceStatusSubagentRow[] }) {
   return (
     <span className="flex shrink-0 items-center gap-0.5">

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -218,7 +218,7 @@ describe("CollapsedActions", () => {
     expect(liveButton.querySelector("path")?.getAttribute("d")).toContain("7.33057 1.98535");
   });
 
-  it("uses Codex's dominant completed icon instead of last-command priority", () => {
+  it("uses the dominant completed icon instead of last-command priority", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       command: terminalItem("command", "turn-1", 1, "pnpm test", "completed"),
@@ -329,7 +329,7 @@ describe("CollapsedActions", () => {
     expect(html).toContain("flex flex-col gap-1");
   });
 
-  it("starts expanded non-edit ledgers at the top with Codex edge fading", () => {
+  it("starts expanded non-edit ledgers at the top with edge fading", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       read: toolItem("read", "turn-1", 1, "file_read"),
@@ -391,7 +391,7 @@ describe("CollapsedActions", () => {
     expect(ledger.scrollTop).toBe(24);
   });
 
-  it("uses the same Codex ink for command and plain ledger rows", () => {
+  it("uses the same ink for command and plain ledger rows", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       read: toolItem("read", "turn-1", 1, "file_read"),

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ModeTransitionDivider.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ModeTransitionDivider.tsx
@@ -1,7 +1,7 @@
 import { SlidersHorizontal } from "@proliferate/ui/icons";
 
 /**
- * Phase-divider row for a harness mode transition (codex turn-header recipe):
+ * Phase-divider row for a harness mode transition (turn-header recipe):
  * a leading mode label ("Plan mode → Default") followed by a full-width
  * hairline rule. Replaces the old cryptic "Mode change / switch_mode" tool
  * row for exact known mode tools; the chip-enter entrance is compositor-only

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.test.tsx
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 describe("TurnDocumentReferenceCard", () => {
-  it("renders a Codex-style document result and opens its preview", () => {
+  it("renders a document result and opens its preview", () => {
     render(
       <TurnDocumentReferenceCard
         resource={{

--- a/apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx
@@ -449,10 +449,10 @@ describe("FileEditorView", () => {
       target: { value: "ok" },
     });
 
-    expect(container.querySelector("mark.codex-thread-find-match")).toBeTruthy();
+    expect(container.querySelector("mark.content-find-match")).toBeTruthy();
 
     fireEvent.click(screen.getByLabelText("Close find"));
-    expect(container.querySelector("mark.codex-thread-find-match")).toBeNull();
+    expect(container.querySelector("mark.content-find-match")).toBeNull();
   });
 
   it("switches rendered files back to source before opening file find", () => {

--- a/apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx
@@ -148,7 +148,7 @@ describe("GitPanel", () => {
     expect(html).toContain("Git review options");
     // Flat document sections replace the card grid; no section headers.
     expect(html).toContain("data-review-file-section");
-    expect(html).not.toContain("codex-review-diff-card");
+    expect(html).not.toContain("review-diff-card");
     expect(html).toContain("data-review-path=\"apps/desktop/src/components/workspace/git/GitPanel.tsx\"");
     expect(html).toContain("data-git-review-document=\"\"");
     expect(html).toContain("id=\"review-diffs-collapsed\"");

--- a/apps/packages/product-client/src/components/workspace/git/PublishDialog.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/PublishDialog.test.tsx
@@ -188,7 +188,7 @@ describe("PublishDialog", () => {
       />,
     );
 
-    // Codex anatomy has no Cancel button — Escape closes and clears drafts.
+    // The git-modal anatomy has no Cancel button — Escape closes and clears drafts.
     fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
     expect(mocks.workflow?.resetDrafts).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/apps/packages/product-client/src/components/workspace/git/PublishDialog.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/PublishDialog.tsx
@@ -12,10 +12,10 @@ import { ArrowUp, GitCommit, GitHub, GitPullRequest, Spinner } from "@proliferat
 import { useWorkspacePublishWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-publish-workflow";
 import type { PublishIntent } from "#product/lib/domain/workspaces/creation/publish-workflow-model";
 
-/* Codex git-modal anatomy (reference/codex/git_modal/git_modal.html): no
- * intent tabs and no Cancel/Submit footer — the bottom of the card is a
- * command list. The row for the current intent is the primary action and
- * carries the ⌘⏎ hint; clicking another row switches intent. */
+/* Git-modal anatomy: no intent tabs and no Cancel/Submit footer — the
+ * bottom of the card is a command list. The row for the current intent is
+ * the primary action and carries the ⌘⏎ hint; clicking another row
+ * switches intent. */
 const PUBLISH_INTENTS: ReadonlyArray<{
   id: PublishIntent;
   label: string;
@@ -228,7 +228,7 @@ export function PublishDialog({
                 placeholder="Commit message (leave blank to generate)…"
                 disabled={isSubmitting}
                 variant="flush"
-                // Codex git-modal field: bare textarea, no focus ring — the
+                // Git-modal field: bare textarea, no focus ring — the
                 // section hairlines already frame it.
                 className="h-20 focus:ring-0"
               />
@@ -317,7 +317,7 @@ export function PublishDialog({
   );
 }
 
-/* Codex cmdk-item recipe: rounded-lg row, icon slot + truncating label,
+/* Command-list row recipe: rounded-lg row, icon slot + truncating label,
  * hover paint on the selected/primary row, disabled rows dimmed, and
  * the primary row carries the ⌘⏎ hint. */
 function PublishActionRow({

--- a/apps/packages/product-client/src/components/workspace/open-target/OpenTargetMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/open-target/OpenTargetMenu.tsx
@@ -52,9 +52,9 @@ interface OpenTargetMenuProps {
 }
 
 /**
- * Compact "open in <app>" dropdown (codex popover recipe: 220px, icon+label
- * rows). Built on the canonical Radix PopoverButton so it portals, handles
- * collision/dismiss, and matches every other menu's chrome.
+ * Compact "open in <app>" dropdown (canonical popover recipe: 220px,
+ * icon+label rows). Built on the canonical Radix PopoverButton so it
+ * portals, handles collision/dismiss, and matches every other menu's chrome.
  */
 export function OpenTargetMenu({ targets, onTargetClick, trigger, align = "start" }: OpenTargetMenuProps) {
   return (

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarUpdatePill.tsx
@@ -24,7 +24,7 @@ const VARIANT_LABELS: Record<PillVariant, string> = {
 };
 
 // Per-variant caps sized to each label; the .3s max-width transition is what
-// morphs the pill between states (codex recipe).
+// morphs the pill between states.
 const VARIANT_MAX_WIDTH: Record<PillVariant, string> = {
   available: "max-w-36",
   downloading: "max-w-32",

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
@@ -9,7 +9,7 @@ interface SidebarWorkspaceGitGlyphProps {
 }
 
 /**
- * Compact git/PR glyph for the sidebar detail cluster, codex-style: three
+ * Compact git/PR glyph for the sidebar detail cluster: three
  * visual states only. Merged gets its own purple merge glyph; a PR with a
  * problem (failing checks, closed, conflicts) is the muted branch glyph with
  * a red dot baked into the SVG; every other real PR is the plain muted

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -81,7 +81,7 @@ interface WorkspaceItemProps {
    * PR omit the glyph, so missing git data degrades gracefully.
    */
   gitStatus?: WorkspaceGitStatus | null;
-  /** Renders the trailing unseen-activity dot (§3.4, codex pattern). */
+  /** Renders the trailing unseen-activity dot (§3.4). */
   needsReview?: boolean;
   onSelect?: () => void;
   /** Opens the PR URL externally; enables the "Open pull request" menu item. */
@@ -238,7 +238,7 @@ export function WorkspaceItem({
   ) : null;
 
   // Git/PR state lives in the right-side detail cluster, matching the compact
-  // Codex row treatment and keeping the left edge free of stacked glyphs.
+  // sidebar row treatment and keeping the left edge free of stacked glyphs.
   // Activity indicators live in the row's RIGHT slot (trailingStatus).
   // Relative timestamp (trailingLabel) is also in the RIGHT slot, with lower
   // precedence than trailingStatus and unreadDot.

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -157,7 +157,7 @@ describe("playground scenarios", () => {
     expect(html).not.toContain("data-jank-canary=\"braille\"");
   });
 
-  it("includes Codex-style diff scenarios for visual iteration", () => {
+  it("includes diff scenarios for visual iteration", () => {
     expect(Object.keys(SCENARIOS)).toEqual(expect.arrayContaining(DIFF_PLAYGROUND_SCENARIOS));
   });
 

--- a/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/git-diff-fixtures.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/git-diff-fixtures.ts
@@ -5,7 +5,7 @@ export const PLAYGROUND_PATCH_README = [
   "@@ -1,4 +1,5 @@",
   " Proliferate",
   "-Old transcript rows",
-  "+Codex-style transcript rows",
+  "+Shared transcript rows",
   "+Shared diff cards",
   " Runtime orchestration",
 ].join("\n");
@@ -197,7 +197,7 @@ export const PLAYGROUND_END_TURN_DIFF_TRANSCRIPT: TranscriptState = {
       lastUpdatedSeq: 1,
       completedSeq: 1,
       completedAt: "2026-04-29T12:00:00Z",
-      text: "I updated the chat and git diff surfaces to share the Codex-style contract. The implementation notes are in [tool-call-blocks.md](docs/tool-call-blocks.md).",
+      text: "I updated the chat and git diff surfaces to share the same transcript contract. The implementation notes are in [tool-call-blocks.md](docs/tool-call-blocks.md).",
       isStreaming: false,
     },
     ...Object.fromEntries(PLAYGROUND_END_TURN_FILE_CHANGES.map((file) => [

--- a/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/panel-todo-fixtures.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/panel-todo-fixtures.ts
@@ -16,7 +16,7 @@ export const TODOS_MID: PlanEntry[] = [
 
 export const TODOS_LONG: PlanEntry[] = [
   { content: "Audit the existing plan panel implementation for dead branches", status: "completed" },
-  { content: "Read the Codex HTML reference for todo tracker + plan approval", status: "completed" },
+  { content: "Read the HTML reference for todo tracker + plan approval", status: "completed" },
   { content: "Confirm toolKind is preserved on pending approval interactions", status: "completed" },
   { content: "Delete PlanBlock, InlinePermissionPrompt embeddedInComposer, merge booleans", status: "completed" },
   { content: "Create TodoTrackerPanel with fade mask and line-through", status: "completed" },

--- a/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/workspace-status-fixtures.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/workspace-status-fixtures.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceStatusModel } from "#product/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl";
 
 /** Every section populated so the card's full anatomy is judgeable at once:
- * codex-ordered source control (review / commit-push / compare / checks with
+ * ordered source control (review / commit-push / compare / checks with
  * hover detail), pixel-sprite subagents, and native count rows whose hover
  * cards list the individual agents/terminals/loops. */
 export function createPlaygroundWorkspaceStatusModel(): WorkspaceStatusModel {

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
@@ -23,7 +23,7 @@ export type ReasoningEffortTierTone =
 
 // Tint ladder for the tier-label chip (ultra-capable ladders show the tier
 // by name instead of bars): quiet grays through the working range, the app
-// special blue at max, and the codex-convention purple for ultra.
+// special blue at max, and the established purple for ultra.
 const TIER_TONES: Readonly<Record<string, ReasoningEffortTierTone>> = {
   minimal: "muted",
   low: "muted",

--- a/apps/packages/product-client/src/lib/domain/content-search/chat-row-match-jump.test.ts
+++ b/apps/packages/product-client/src/lib/domain/content-search/chat-row-match-jump.test.ts
@@ -38,7 +38,7 @@ describe("scrollActiveChatRowMatchIntoView", () => {
     const container = document.createElement("div");
     for (let index = 0; index < count; index += 1) {
       const mark = document.createElement("mark");
-      mark.className = "codex-thread-find-match";
+      mark.className = "content-find-match";
       mark.setAttribute("data-content-search-row", rowUnitId);
       mark.scrollIntoView = () => {};
       container.append(mark);
@@ -51,12 +51,12 @@ describe("scrollActiveChatRowMatchIntoView", () => {
     const rowUnitId = "chatrow:turn:abc:block:content";
     const container = seedMarks(rowUnitId, 3);
     const marks = container.querySelectorAll("mark");
-    marks[0].classList.add("codex-thread-find-active");
+    marks[0].classList.add("content-find-active");
 
     expect(scrollActiveChatRowMatchIntoView({ rowUnitId, ordinal: 2 })).toBe(true);
 
-    expect(marks[0].classList.contains("codex-thread-find-active")).toBe(false);
-    expect(marks[2].classList.contains("codex-thread-find-active")).toBe(true);
+    expect(marks[0].classList.contains("content-find-active")).toBe(false);
+    expect(marks[2].classList.contains("content-find-active")).toBe(true);
   });
 
   it("clamps to the last painted mark when fewer are painted than counted", () => {
@@ -65,7 +65,7 @@ describe("scrollActiveChatRowMatchIntoView", () => {
     const marks = container.querySelectorAll("mark");
 
     expect(scrollActiveChatRowMatchIntoView({ rowUnitId, ordinal: 5 })).toBe(true);
-    expect(marks[1].classList.contains("codex-thread-find-active")).toBe(true);
+    expect(marks[1].classList.contains("content-find-active")).toBe(true);
   });
 
   it("returns false when the row has no painted marks yet", () => {

--- a/apps/packages/product-client/src/lib/domain/content-search/chat-row-match-jump.ts
+++ b/apps/packages/product-client/src/lib/domain/content-search/chat-row-match-jump.ts
@@ -48,14 +48,14 @@ export function scrollActiveChatRowMatchIntoView(target: ChatRowMatchTarget): bo
   }
 
   for (const active of document.querySelectorAll<HTMLElement>(
-    "mark[data-content-search-row].codex-thread-find-active",
+    "mark[data-content-search-row].content-find-active",
   )) {
-    active.classList.remove("codex-thread-find-active");
+    active.classList.remove("content-find-active");
   }
 
   const index = Math.min(target.ordinal, marks.length - 1);
   const mark = marks[index];
-  mark.classList.add("codex-thread-find-active");
+  mark.classList.add("content-find-active");
   mark.scrollIntoView({ block: "center", inline: "nearest" });
   return true;
 }

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts
@@ -2,7 +2,7 @@
 // card is a step lighter, which rendered the header as a visibly lighter haze
 // band against the opaque chat surface on every theme.
 //
-// Both chrome modes use 46px (codex --height-toolbar, UX_SPEC §7) so the
+// Both chrome modes use 46px (UX_SPEC §7's --height-toolbar) so the
 // header always lines up with the right panel's --tab-system-height in
 // apps/packages/design/src/css/product.css — the main header aligns down to
 // the right pane, not the other way around (owner ruling 2026-07-10).

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/chrome-layout.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/chrome-layout.ts
@@ -1,7 +1,7 @@
 export const CHROME_TAB_MIN_WIDTH = 136;
 export const CHROME_TAB_COMPACT_WIDTH = 60;
 export const CHROME_TAB_SMALL_WIDTH = 84;
-// 156px = codex tab chrome max-width (UX_SPEC §7).
+// 156px = tab chrome max-width (UX_SPEC §7).
 export const CHROME_TAB_MAX_WIDTH = 156;
 export const CHROME_DELEGATED_TAB_MAX_WIDTH = CHROME_TAB_SMALL_WIDTH;
 export const CHROME_TAB_GAP = 3;

--- a/apps/packages/product-client/src/pages/WorkspacesPage.tsx
+++ b/apps/packages/product-client/src/pages/WorkspacesPage.tsx
@@ -25,7 +25,7 @@ import type { SidebarGroupState, SidebarWorkspaceItemState } from "#product/lib/
 const PR_STATUS_UNAVAILABLE_LABEL = "PR status unavailable — gh not signed in";
 
 /**
- * Conductor-style Workspaces page (UX spec §3): cmdk filter-list with
+ * Workspaces page (UX spec §3): cmdk filter-list with
  * recency-grouped rows. Reuses the sidebar's workspace selectors (same data
  * wiring as the main sidebar) — this surface is presentation only. Git/PR
  * state comes from `useWorkspaceGitStatuses`, keyed by the same logical

--- a/apps/packages/product-domain/src/activity/goal-transcript-events.ts
+++ b/apps/packages/product-domain/src/activity/goal-transcript-events.ts
@@ -2,10 +2,10 @@
  * Goal lifecycle transcript rows — client-side composition only.
  *
  * The runtime deliberately keeps goal_updated/goal_met/goal_cleared chunks
- * out of stored transcript content (see `codex/session-activity-architecture
- * .md` §Locked decisions #5): they're session-level mirror events, not
- * transcript items. This module derives the quiet, compact system-style rows
- * the transcript interleaves *client-side* from the raw session event
+ * out of stored transcript content (session-activity locked decision #5):
+ * they're session-level mirror events, not transcript items. This module
+ * derives the quiet, compact system-style rows the transcript interleaves
+ * *client-side* from the raw session event
  * stream — the same envelopes the goal bar's mirror reads, replayed here to
  * recover the lifecycle history (set → edited → paused/resumed → met/
  * cleared) instead of just the latest value.
@@ -61,7 +61,7 @@ export interface DeriveGoalTranscriptEventsOptions {
   /**
    * Whether to emit a standalone `met` row. False for the transcript row
    * model, where the "goal met" outcome is surfaced inline in the final
-   * completed message's action footer (a codex-style "✓ Goal achieved in
+   * completed message's action footer (an inline "✓ Goal achieved in
    * Xs" marker) instead of a standalone system row. Failed/blocked/cleared
    * always keep their standalone rows. Defaults to true so non-transcript
    * callers (playground fixtures, tests) still see the met row.

--- a/apps/packages/product-domain/src/activity/goal.ts
+++ b/apps/packages/product-domain/src/activity/goal.ts
@@ -306,7 +306,7 @@ export function humanizeGoalDurationSeconds(totalSeconds: number): string {
 
 /**
  * Inline "goal met" marker label for the final completed message's action
- * footer (codex-style "✓ Goal achieved in 40s"). Appends the elapsed time
+ * footer (e.g. "✓ Goal achieved in 40s"). Appends the elapsed time
  * when the met goal reported `timeUsedSeconds`; otherwise just the base
  * "Goal achieved" — never a bare "in" with no duration.
  */

--- a/apps/packages/product-domain/src/activity/subagent.ts
+++ b/apps/packages/product-domain/src/activity/subagent.ts
@@ -1,9 +1,8 @@
 /**
  * Activity subagent — pure mirror of `anyharness-contract v1::ActivitySubagent`.
  * A harness-native subagent (Claude Task agent, Codex collab child thread,
- * Cursor `cursor/task`). Read-only roster element; per
- * `codex/session-activity-architecture.md` the ⑂ chip routes to the existing
- * delegated-work surfaces — harness-native subagents become a new
+ * Cursor `cursor/task`). Read-only roster element; the ⑂ chip routes to
+ * the existing delegated-work surfaces — harness-native subagents become a new
  * delegated-work *source* feeding `kind: "subagent"` items, so this module
  * also owns the pure status/field mapping into that shape (identity
  * synthesis — generated name/color — stays desktop-owned, same as the

--- a/apps/packages/product-domain/src/chats/transcript/transcript-collapsed-actions.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-collapsed-actions.ts
@@ -170,8 +170,8 @@ export function formatCollapsedActionsSummary(
 ): string {
   const fragments: string[] = [];
 
-  // Match Codex's calm completed-activity voice. The expanded ledger owns
-  // exact counts. One representative exploration phrase summarizes the whole
+  // Keep a calm, understated completed-activity voice. The expanded ledger
+  // owns exact counts. One representative exploration phrase summarizes the whole
   // read/search/list/fetch family (copy priority: read > search > list > fetch)
   // so the collapsed row stays short even when the ledger is heterogeneous.
   if (summary.edits > 0) {
@@ -204,9 +204,10 @@ export function formatCollapsedActionsSummary(
 }
 
 /**
- * Resolve the dominant completed-work glyph. Codex intentionally uses search
- * for mixed search/read groups even while its concise copy says "Read files".
- * Keep this shared so desktop and cloud cannot derive different icons.
+ * Resolve the dominant completed-work glyph. Mixed search/read groups use
+ * the search glyph even though the concise copy says "Read files" — the
+ * icon favors the broader action. Keep this shared so desktop and cloud
+ * cannot derive different icons.
  */
 export function resolveCollapsedActionsLeadingKind(
   summary: CollapsedActionSummary,

--- a/apps/packages/product-domain/src/chats/transcript/transcript-work-duration.test.ts
+++ b/apps/packages/product-domain/src/chats/transcript/transcript-work-duration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { formatWorkedForDuration } from "./transcript-work-duration";
 
 describe("formatWorkedForDuration", () => {
-  it("formats completed turn time like the Codex work disclosure", () => {
+  it("formats completed turn time for the work disclosure", () => {
     expect(formatWorkedForDuration(
       "2026-07-10T12:00:00.000Z",
       "2026-07-10T12:13:25.000Z",

--- a/apps/packages/product-domain/src/chats/transcript/turn-stopped-presentation.ts
+++ b/apps/packages/product-domain/src/chats/transcript/turn-stopped-presentation.ts
@@ -1,7 +1,7 @@
 import type { TurnRecord } from "@anyharness/sdk";
 
 /**
- * Codex-style stopped-turn notice: a muted "You stopped after Ns" line with a
+ * Stopped-turn notice: a muted "You stopped after Ns" line with a
  * hairline divider, shown when the user cancelled the turn. Not an error —
  * error items keep their own presentation.
  */

--- a/apps/packages/product-ui/src/activity/GoalBar.tsx
+++ b/apps/packages/product-ui/src/activity/GoalBar.tsx
@@ -113,8 +113,8 @@ export function GoalBar({
   }
 
   // Editing/composing swaps the fixed single-row layout for a tall,
-  // auto-growing textarea (Conductor reference): the glyph aligns with the
-  // textarea's first line instead of a fixed-height row.
+  // auto-growing textarea: the glyph aligns with the textarea's first line
+  // instead of a fixed-height row.
   const isEditingLayout = goalVisible && (composing || (state.kind === "live" && editing));
   // Chips are suppressed while the multi-line editor is showing — its
   // absolute-positioned commit/cancel icons already crowd that row.

--- a/apps/packages/product-ui/src/activity/GoalBarObjectiveEditor.tsx
+++ b/apps/packages/product-ui/src/activity/GoalBarObjectiveEditor.tsx
@@ -10,9 +10,9 @@ interface GoalBarObjectiveEditorProps {
   onCancel: () => void;
 }
 
-// Conductor reference: a tall auto-growing textarea (≈3 rows minimum, grows
-// with content up to a cap before it scrolls internally) with ✓/✗ icon
-// buttons pinned to the top-right corner.
+// A tall auto-growing textarea (≈3 rows minimum, grows with content up to a
+// cap before it scrolls internally) with ✓/✗ icon buttons pinned to the
+// top-right corner.
 const MIN_ROWS = 3;
 const MAX_HEIGHT_PX = 240;
 

--- a/apps/packages/product-ui/src/activity/SubagentRosterRow.tsx
+++ b/apps/packages/product-ui/src/activity/SubagentRosterRow.tsx
@@ -25,8 +25,7 @@ export interface SubagentRosterRowProps {
 
 /**
  * A read-only roster row for a harness-native subagent (Claude Task agent,
- * Codex collab child thread, Cursor `cursor/task`). Per
- * `codex/session-activity-architecture.md` this roster feeds a new
+ * Codex collab child thread, Cursor `cursor/task`). This roster feeds a new
  * delegated-work *source* (see `activitySubagentToDelegatedWorkFields` in
  * product-domain) — this row is the interim standalone rendering until a
  * follow-up pass merges it into the existing delegated-work surfaces

--- a/apps/packages/product-ui/src/chat/transcript/CopyMessageButton.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CopyMessageButton.test.tsx
@@ -11,11 +11,11 @@ describe("CopyMessageButton", () => {
     expect(html).toContain("!size-icon-button-sm !p-0");
   });
 
-  it("sizes the glyph to the reference's 16px/13px (icon-paired) ratio, not icon-control", () => {
-    // Reference: pages/thread's "Copy message" button renders a 16px glyph
-    // against --codex-chat-font-size: 13px — 1.230769em, which is
-    // --icon-paired. --icon-control (1.333333em) is visibly larger and was
-    // the round-2 regression this guards against.
+  it("sizes the glyph to our 16px/13px (icon-paired) ratio, not icon-control", () => {
+    // The "Copy message" button renders a 16px glyph against our chat font
+    // size of 13px — 1.230769em, which is --icon-paired. --icon-control
+    // (1.333333em) is visibly larger and was the round-2 regression this
+    // guards against.
     const html = renderToStaticMarkup(
       <CopyMessageButton content="Answer" visibilityClassName="opacity-100" />,
     );

--- a/apps/packages/product-ui/src/chat/transcript/CopyMessageButton.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/CopyMessageButton.tsx
@@ -45,20 +45,20 @@ export function CopyMessageButton({
       size="xs"
       onClick={handleCopy}
       title={copied ? "Copied" : "Copy message"}
-      // Reference: the "Copy message" button is text-token-text-tertiary at
-      // rest (our --color-foreground-tertiary, the same dim tone the
-      // adjacent date already uses) — not the brighter muted-foreground.
+      // The "Copy message" button is --color-foreground-tertiary at
+      // rest (the same dim tone the adjacent date already uses) — not the
+      // brighter muted-foreground.
       className="!size-icon-button-sm !p-0 rounded-full !text-foreground-tertiary hover:!text-foreground"
     >
       {/*
-       * Reference: pages/thread's "Copy message" button renders a 16px glyph
-       * (icon-xs) against --codex-chat-font-size: 13px — a 1.230769em ratio,
-       * which is exactly --icon-paired (already used for every other small
-       * inline glyph in the transcript), not --icon-control (1.333333em,
-       * ~17px at this base — visibly larger than the reference). Pin the em
-       * base to --text-chat explicitly since this button sits in the
-       * text-chat-meta (11px) row, same pattern as the pending-interaction
-       * and goal-met glyphs elsewhere in the transcript.
+       * The "Copy message" button renders a 16px glyph (icon-xs) against our
+       * chat font size of 13px — a 1.230769em ratio, which is exactly
+       * --icon-paired (already used for every other small inline glyph in
+       * the transcript), not --icon-control (1.333333em, ~17px at this
+       * base — visibly larger). Pin the em base to --text-chat explicitly
+       * since this button sits in the text-chat-meta (11px) row, same
+       * pattern as the pending-interaction and goal-met glyphs elsewhere in
+       * the transcript.
        */}
       {copied
         ? <Check className="icon-paired [font-size:var(--text-chat)]" />

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
@@ -111,7 +111,7 @@ describe("MarkdownBody presentation", () => {
       </ChatContentSearchQueryContext.Provider>,
     );
 
-    expect(html).toContain('class="codex-thread-find-match"');
+    expect(html).toContain('class="content-find-match"');
     expect(html).toContain('data-content-search-row="assistant-1"');
   });
 

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownCodeBlock.tsx
@@ -3,7 +3,7 @@ import { Button } from "@proliferate/ui/primitives/Button";
 import { Check, Copy } from "@proliferate/ui/icons";
 
 /**
- * Codex-style code block card: bordered rounded shell with a header carrying
+ * Our code block card: bordered rounded shell with a header carrying
  * the language label and an always-visible copy icon button. `children`
  * overrides the rendered code content (e.g. app-injected highlighted HTML);
  * `code` remains the copy payload and the plain-text fallback.

--- a/apps/packages/product-ui/src/chat/transcript/MarkdownContentSearchMarks.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownContentSearchMarks.tsx
@@ -2,7 +2,7 @@ import { Fragment, type ReactNode } from "react";
 
 /**
  * Wraps content-search query matches inside a markdown text node with
- * `<mark class="codex-thread-find-match">` (the same class the diff/file
+ * `<mark class="content-find-match">` (the same class the diff/file
  * highlighters use, so styling is shared). Marks carry only the row unit id —
  * no per-match id — because the active match is resolved by DOM ordinal at
  * jump time, not encoded at render (see the desktop jump-to-match effect).
@@ -48,7 +48,7 @@ function markString(text: string, query: string, rowUnitId: string): ReactNode {
     nodes.push(
       <mark
         key={`m-${index}`}
-        className="codex-thread-find-match"
+        className="content-find-match"
         data-content-search-row={rowUnitId}
       >
         {text.slice(range.start, range.end)}

--- a/apps/packages/product-ui/src/chat/transcript/PlanMarkdownBody.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/PlanMarkdownBody.tsx
@@ -53,7 +53,7 @@ const PROPOSED_PLAN_MARKDOWN_CLASSNAME = [
   "[&_ol]:mb-4 [&_ol]:mt-1 [&_ol]:list-decimal [&_ol]:pl-5",
   "[&_ul]:mb-4 [&_ul]:mt-1 [&_ul]:list-disc [&_ul]:pl-5",
   "[&_li]:mb-0.5 [&_li]:text-chat [&_li::marker]:text-muted-foreground",
-  // Codex task-list treatment: no markers/indent (the grid columns come from
+  // Task-list treatment: no markers/indent (the grid columns come from
   // MarkdownBody's grid task-list items) and 0.5rem gaps between items.
   "[&_ul.contains-task-list]:pl-0",
   "[&_li.task-list-item+li.task-list-item]:mt-2",

--- a/apps/packages/product-ui/src/patterns/PrStatusBadge.tsx
+++ b/apps/packages/product-ui/src/patterns/PrStatusBadge.tsx
@@ -1,12 +1,12 @@
 /**
- * PR status rendered as a codex-style dot (UX spec §2/§3).
+ * PR status rendered as a small status dot (UX spec §2/§3).
  *
  * The dot is 6px, colored per PR state, and carries a tooltip with the PR
  * number + state. Two render modes:
  *  - `PrStatusDot` — standalone dot (workspaces page rows, after branch name)
  *  - `PrStatusIconOverlay` — wraps a row icon and anchors the dot on its
  *    bottom-right corner (web sidebar rows; the desktop sidebar renders
- *    PR state via SidebarWorkspaceGitGlyph instead), mirroring codex's
+ *    PR state via SidebarWorkspaceGitGlyph instead), using our
  *    `--pr-status-dot-color` circle-on-icon pattern.
  *
  * Tone rules (spec §3.3): every dot tone is an OPAQUE color — no alpha
@@ -97,7 +97,7 @@ export function PrStatusDot({
 }
 
 /**
- * Anchors the PR dot on the bottom-right of a row icon (codex dot-on-icon).
+ * Anchors the PR dot on the bottom-right of a row icon (dot-on-icon overlay).
  * Renders children unchanged when no status is present. The dot sits fully
  * off the 14px glyph's strokes as a bare opaque dot — no ring halo, which
  * reads wrong on hovered/active alpha-overlay rows.

--- a/apps/packages/product-ui/src/sidebar/ProductSidebarNavigation.tsx
+++ b/apps/packages/product-ui/src/sidebar/ProductSidebarNavigation.tsx
@@ -51,7 +51,8 @@ export function ProductSidebarNavRow({
       shortcutLabel={item.shortcutLabel}
       shortcutRevealVisible={shortcutRevealVisible}
       onPress={() => onSelect(item.id)}
-      // Codex primary-nav tier; the row's em-based icon well scales with it.
+      // The sidebar's primary-nav tier; the row's em-based icon well scales
+      // with it.
       className="text-sidebar-nav leading-(--text-sidebar-nav--line-height)"
       {...props}
     />

--- a/apps/packages/product-ui/src/workspaces/WorkspacesCommandList.tsx
+++ b/apps/packages/product-ui/src/workspaces/WorkspacesCommandList.tsx
@@ -1,5 +1,5 @@
 /**
- * Conductor-style workspaces list (UX spec §3): a cmdk filter-list, not a
+ * The workspaces filter-list (UX spec §3): a cmdk filter-list, not a
  * table. Filter input row on top (border-b, search icon, 13px input), then a
  * scrolling list of recency-grouped rows:
  *

--- a/apps/packages/ui/src/icons/core.tsx
+++ b/apps/packages/ui/src/icons/core.tsx
@@ -8,7 +8,7 @@ export function ChevronRight({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled disclosure chevron matching Codex transcript activities. */
+/** Filled disclosure chevron for transcript activity rows. */
 export function ChevronRightActivity({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -104,7 +104,7 @@ export function Search({ className, ...props }: IconProps) {
   );
 }
 
-/** Compact filled search glyph matching Codex transcript activities. */
+/** Compact filled search glyph for transcript activity rows. */
 export function SearchActivity({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="currentColor" {...props}>

--- a/apps/packages/ui/src/icons/product.tsx
+++ b/apps/packages/ui/src/icons/product.tsx
@@ -1,8 +1,8 @@
 import type { IconProps } from "./types";
 
-/* Codex-style pixel agent sprite (reference/codex/status/card.html): a
-   deterministic symmetric grid of 4px cells on the -2 -1 24 24 viewBox with
-   crisp edges. Color comes from currentColor so callers pick the agent tint. */
+/* Pixel agent sprite: a deterministic symmetric grid of 4px cells on the
+   -2 -1 24 24 viewBox with crisp edges. Color comes from currentColor so
+   callers pick the agent tint. */
 export function PixelAgentSprite({ seed, className, ...props }: IconProps & { seed: string }) {
   let hash = 2166136261;
   for (let i = 0; i < seed.length; i += 1) {

--- a/apps/packages/ui/src/icons/workspace.tsx
+++ b/apps/packages/ui/src/icons/workspace.tsx
@@ -51,7 +51,7 @@ export function SquareTerminal({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled command-window glyph matching Codex transcript activities. */
+/** Filled command-window glyph for transcript command activities. */
 export function CommandWindow({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -62,7 +62,7 @@ export function CommandWindow({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled open-book glyph matching Codex file-reading activities. */
+/** Filled open-book glyph for file-reading activities. */
 export function ReadBook({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -133,7 +133,7 @@ export function FilePen({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled plus/minus file glyph used by Codex's completed diff summary. */
+/** Filled plus/minus file glyph for completed diff summaries. */
 export function FileDiff({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 20" fill="currentColor" {...props}>
@@ -147,7 +147,7 @@ export function FileDiff({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled pen glyph matching Codex transcript edit activities. */
+/** Filled pen glyph for transcript edit activities. */
 export function FilePenActivity({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 20 21" fill="currentColor" {...props}>
@@ -240,7 +240,7 @@ export function FolderOpen({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled closed folder matching Codex's sidebar project folders */
+/** Filled closed folder for sidebar project folders */
 export function FolderClosedFilled({ className, ...props }: IconProps) {
   return (
     <svg className={className} xmlns="http://www.w3.org/2000/svg" width="var(--icon-paired)" height="var(--icon-paired)" fill="currentColor" viewBox="0 0 20 20" {...props}>
@@ -249,7 +249,7 @@ export function FolderClosedFilled({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled folder-plus icon matching Codex's "Add new project" button */
+/** Filled folder-plus icon for the "Add new project" button */
 export function FolderPlusFilled({ className, ...props }: IconProps) {
   return (
     <svg className={className} xmlns="http://www.w3.org/2000/svg" width="var(--icon-control)" height="var(--icon-control)" fill="currentColor" viewBox="0 0 20 20" {...props}>
@@ -258,7 +258,7 @@ export function FolderPlusFilled({ className, ...props }: IconProps) {
   );
 }
 
-/** Filled folder icon matching Codex's sidebar project folders */
+/** Filled folder icon for sidebar project folders */
 export function FolderFilled({ className, ...props }: IconProps) {
   return (
     <svg className={className} xmlns="http://www.w3.org/2000/svg" width="var(--icon-paired)" height="var(--icon-paired)" fill="currentColor" viewBox="0 0 20 20" {...props}>
@@ -276,7 +276,7 @@ export function Filter({ className, ...props }: IconProps) {
   );
 }
 
-/** Collapse-all icon matching Codex's sidebar collapse button */
+/** Collapse-all icon for the sidebar collapse button */
 export function CollapseAll({ className, ...props }: IconProps) {
   return (
     <svg className={className} xmlns="http://www.w3.org/2000/svg" width="var(--icon-control)" height="var(--icon-control)" fill="currentColor" viewBox="0 0 20 20" {...props}>
@@ -330,7 +330,7 @@ export function GitBranchIcon({ className, ...props }: IconProps) {
   );
 }
 
-/** Codex-style spiral-bound notebook — the "project" glyph (16 viewBox, filled). */
+/** Spiral-bound notebook — the "project" glyph (16 viewBox, filled). */
 export function ProjectNotebook({ className, ...props }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
@@ -352,7 +352,7 @@ export function ProjectNotebook({ className, ...props }: IconProps) {
   );
 }
 
-/** Codex's remote-project folder: the globe is fused into the folder's
+/** Remote-project folder: the globe is fused into the folder's
  * corner as one glyph — never a separate badge overlay. */
 export function FolderRemote({ className, ...props }: IconProps) {
   return (
@@ -363,7 +363,7 @@ export function FolderRemote({ className, ...props }: IconProps) {
   );
 }
 
-/** Codex's thread-row PR glyph: muted branch pipe + inbound arrow; the
+/** Thread-row PR glyph: muted branch pipe + inbound arrow; the
  * status dot is part of the SVG and colored via --pr-status-dot-color
  * (rendered only when `dot` is set). */
 export function PrBranchGlyph({ className, dot = false, ...props }: IconProps & { dot?: boolean }) {
@@ -380,7 +380,7 @@ export function PrBranchGlyph({ className, dot = false, ...props }: IconProps & 
   );
 }
 
-/** Codex's merged-PR glyph: merge topology, tinted at the callsite. */
+/** Merged-PR glyph: merge topology, tinted at the callsite. */
 export function PrMergedGlyph({ className, ...props }: IconProps) {
   return (
     <svg className={className} width="var(--icon-paired)" height="var(--icon-paired)" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>

--- a/apps/packages/ui/src/patterns/ComposerControlButton.tsx
+++ b/apps/packages/ui/src/patterns/ComposerControlButton.tsx
@@ -37,11 +37,11 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
       ? "text-composer-control-active-foreground"
       : "text-composer-control-foreground";
     // [CHAT-02]: hover is 7.8% (--color-hover) and the press is 5.2%
-    // (--color-active). Codex's literal
-    // control press is bg-token-foreground/15, but D-V2-4 ruled the ledger
-    // vocabulary wins over that one value — see ui-foundation-chat-addendum.md
-    // [CHAT-02], flagged item 4. Press was previously absent entirely, so the
-    // control had no down-state at all.
+    // (--color-active). The escalation's reference target was a literal 15%
+    // foreground press, but D-V2-4 ruled the ledger vocabulary wins over that
+    // one value — see ui-foundation-chat-addendum.md [CHAT-02], flagged item 4.
+    // Press was previously absent entirely, so the control had no down-state
+    // at all.
     const baseClassName = `cursor-pointer disabled:cursor-default gap-1 rounded-full border border-transparent bg-transparent transition-colors hover:bg-hover hover:text-current active:bg-active focus:outline-none data-[state=open]:bg-hover ${classes}`;
     const buttonClassName = iconOnly
       ? `h-7 w-7 shrink-0 !justify-center px-0 ${baseClassName} ${className}`

--- a/apps/packages/ui/src/patterns/ComposerTextarea.tsx
+++ b/apps/packages/ui/src/patterns/ComposerTextarea.tsx
@@ -4,7 +4,7 @@ import { Textarea } from "../primitives/Textarea";
 type ComposerTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 // UX_SPEC §5 + owner rev 2026-07-01: the input reads LARGER than the 13px
-// composer controls (codex hierarchy: input > controls), with codex's font+8
+// composer controls (our type hierarchy: input > controls), with a font+8
 // leading.
 //
 // ui-foundation-escalation: [CHAT-03] rules composer placeholders onto the
@@ -12,8 +12,8 @@ type ComposerTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 // `--color-foreground-tertiary` (50%) instead of the old
 // `text-muted-foreground/55` (70% x 55% = 38.5% effective). That is a small step
 // UP in contrast, chosen because the ruled vocabulary has no
-// placeholder-specific role and 50% is the closest legal match to Codex's stated
-// ~49.8% tertiary target — Codex's own compounded placeholder mechanism
+// placeholder-specific role and 50% is the closest legal match to our
+// ~49.8% tertiary target — the compounded placeholder mechanism
 // (placeholder-foreground x opacity .5, ~25-35%) is not expressible here. See
 // ui-foundation-chat-addendum.md [CHAT-03]. It still sits well below typed text
 // (`text-foreground`) in both mono dark and light.

--- a/apps/packages/ui/src/primitives/PopoverMenuItem.tsx
+++ b/apps/packages/ui/src/primitives/PopoverMenuItem.tsx
@@ -32,8 +32,8 @@ export function PopoverMenuItem({
 }: PopoverMenuItemProps) {
   const hoverClassName = "hover:bg-hover focus:bg-hover";
   const hasDescription = children !== undefined && children !== null && children !== false;
-  // Codex menu-row recipe (reference/codex main_chat_view + popover dumps):
-  // 12px rows (text-ui-sm) in full row foreground, 11px muted hints
+  // Canonical menu-row recipe: 12px rows (text-ui-sm) in full row
+  // foreground, 11px muted hints
   // (text-ui-sm), 16px icons promoting muted → prominent on hover; spacing
   // stays fixed (px 10 / py 5 at default density).
   //

--- a/apps/packages/ui/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/ui/src/primitives/PopoverSearchField.tsx
@@ -17,7 +17,7 @@ export interface PopoverSearchFieldProps {
 }
 
 /**
- * Inline search row for popovers/pickers (codex popover.html recipe): a muted
+ * Inline search row for popovers/pickers (our popover chrome recipe): a muted
  * magnifier icon + a borderless, transparent input sitting directly in the
  * popover — NO boxed field — with a hairline divider below. Single source of
  * truth for every picker search; do not hand-roll a boxed `bg-surface-control`

--- a/apps/packages/ui/src/primitives/Skeleton.tsx
+++ b/apps/packages/ui/src/primitives/Skeleton.tsx
@@ -12,7 +12,7 @@ export interface SkeletonBlockProps {
 
 /**
  * Loading placeholder block. Motion comes from the shared `.skeleton-shimmer`
- * class (design css): a codex-style gradient band sweeping via transform —
+ * class (design css): a gradient band sweeping via transform —
  * compositor-only, same motion family as the thinking-text indicator. Under
  * `prefers-reduced-motion` the sweep is replaced by a calm opacity fade.
  */

--- a/apps/packages/ui/src/primitives/popover-surface.ts
+++ b/apps/packages/ui/src/primitives/popover-surface.ts
@@ -1,4 +1,4 @@
-// Canonical popover chrome (codex dropdown recipe): 90%-alpha popover fill,
+// Canonical popover chrome recipe: 90%-alpha popover fill,
 // 8px blur, 0.5px hairline ring, 12px radius, hairline-spread shadow. Lives in
 // a dependency-free leaf so its primitives/ siblings can compose it without
 // an import cycle (Popover.tsx, PopoverButton.tsx, and DropdownMenu.tsx all

--- a/server/alembic/versions/c9b8a7d6e5f4_agent_auth_selection_rebuild.py
+++ b/server/alembic/versions/c9b8a7d6e5f4_agent_auth_selection_rebuild.py
@@ -1,6 +1,6 @@
 """agent auth selection rebuild
 
-Destructive P1 auth-model rebuild (codex/p1-auth-contract.md §1). Replaces the
+Destructive P1 auth-model rebuild (agent-auth selection model). Replaces the
 route-selection wiring with ``agent_auth_selection`` (source_kind gateway|api_key,
 no native, no slot) and re-shapes ``agent_api_key`` into a titled, provider-less
 vault. No users exist, so there is no data migration.

--- a/server/alembic/versions/d2e3f4a5b6c8_agent_catalog_runtime_mirror_source.py
+++ b/server/alembic/versions/d2e3f4a5b6c8_agent_catalog_runtime_mirror_source.py
@@ -1,6 +1,6 @@
 """agent catalog runtime mirror source
 
-P3 runtime catalog (codex/p3-catalog-contract.md §4): the runtime mirror
+P3 runtime catalog (agent-catalog update runbook): the runtime mirror
 endpoint stores probe snapshots with ``source="runtime-mirror"``. Widen the
 ``agent_catalog_snapshot.source`` check constraint to admit that value
 alongside the existing probe/seed/override sources.

--- a/server/proliferate/db/models/cloud/agent_gateway.py
+++ b/server/proliferate/db/models/cloud/agent_gateway.py
@@ -1,6 +1,6 @@
 """Agent LLM gateway ORM models (LiteLLM-era agent auth).
 
-The auth model (P1 rebuild, see codex/p1-auth-contract.md §1): a titled
+The auth model (P1 rebuild, see the agent-auth selection model): a titled
 personal API key vault (``agent_api_key``) plus per-(user, harness, surface)
 wiring rows (``agent_auth_selection``). Each selection row is either the
 gateway or a single direct api_key; there is no native source (native == the

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -1,6 +1,6 @@
 """Agent gateway auth services: key vault, auth selections, capabilities.
 
-The P1 auth model (contract ``codex/p1-auth-contract.md`` §5): a titled,
+The P1 auth model (the agent-auth API surface): a titled,
 provider-less key vault plus per-(user, harness, surface) selection sources
 written as full desired state. Store legality errors surface as typed
 :class:`CloudApiError` values so the API layer maps them uniformly. Key and

--- a/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
+++ b/server/proliferate/server/cloud/materialization/materialize/agent_auth.py
@@ -1,7 +1,7 @@
 """Agent-auth state materialization into cloud sandboxes (state.json v2).
 
 Writes the declarative AUTH-ONLY contract file that AnyHarness renders into
-per-harness launch profiles (contract ``codex/p1-auth-contract.md`` §3). The
+per-harness launch profiles (the agent-auth state.json delivery contract). The
 file lives at ``<anyharness home>/agent-auth/state.json`` (mode 0600):
 
 .. code-block:: json

--- a/specs/codebase/features/content-search.md
+++ b/specs/codebase/features/content-search.md
@@ -56,7 +56,7 @@ truth.
   `apps/packages/product-ui/src/chat/transcript/ChatContentSearchContext.tsx`).
   `MarkdownBody` (assistant prose, opted in via `enableContentSearch`) and the
   desktop `FileLinkedText` (user prose) wrap query matches in
-  `<mark class="codex-thread-find-match" data-content-search-row={rowUnitId}>` —
+  `<mark class="content-find-match" data-content-search-row={rowUnitId}>` —
   no per-match id at render time. Everything is inert when the query context is
   null; secondary chrome (tool detail bodies, plan cards) reuses `MarkdownBody`
   without `enableContentSearch` and shadows the query context to null so its

--- a/specs/codebase/systems/product/clients/web-desktop-unification/move-ledger.md
+++ b/specs/codebase/systems/product/clients/web-desktop-unification/move-ledger.md
@@ -2395,7 +2395,7 @@ hooks/access/tauri/workspace-scratch/query-keys.ts	move	pure host.desktop.scratc
 hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad-mutations.ts	move	pure host.desktop.scratch consumer (F3 relocation); retain was a stale bucket default
 hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.test.tsx	move	test of the relocated scratch hook; runs in the package vitest lane
 hooks/access/tauri/workspace-scratch/use-workspace-scratch-pad.ts	move	pure host.desktop.scratch consumer (F3 relocation); retain was a stale bucket default
-components/workspace/git/GitReviewFileTree.tsx	delete	main merge (post-merge reconciliation): deleted on origin/main by the git-review-v2 PR #1214 (flat Codex-style review document replaces the tree/stage/badge components); source gone from apps/desktop/src, no product target
+components/workspace/git/GitReviewFileTree.tsx	delete	main merge (post-merge reconciliation): deleted on origin/main by the git-review-v2 PR #1214 (flat review document replaces the tree/stage/badge components); source gone from apps/desktop/src, no product target
 components/workspace/git/GitReviewStageAction.tsx	delete	main merge: deleted on origin/main by git-review-v2 PR #1214; replaced by the flat review document
 components/workspace/git/GitReviewStatusBadge.tsx	delete	main merge: deleted on origin/main by git-review-v2 PR #1214; replaced by the flat review document
 hooks/chat/ui/use-composer-ultra-emphasis.ts	delete	main merge: deleted on origin/main by the workspace-status-card PR #1210 (composer ultra-emphasis removed)


### PR DESCRIPTION
## What

Rewrites code comments that credited competitor products (Codex, Conductor) as the source of our UI/UX design, and drops dead citations to untracked local design captures.

Comments-only, plus one CSS class rename. **Every technical detail is preserved verbatim** — pixel values, radii, ratios, timing functions, CSS mechanics, spec anchors, and escalation tags.

## Changes

- `Codex-style` / `codex recipe` / `Codex anatomy` / `matching Codex's sidebar…` and all six `Conductor-style` / `Conductor reference` comments now describe the design in our own terms.
- Deletes `reference/codex/...` and `reference/conductor/...` path citations plus competitor DOM class names (`thread-summary-panel-item-avatar-group`). That directory is untracked local UI captures, so the citations were dead pointers *and* traced our design to their markup.
- Repoints `codex/*.md` contract citations (untracked scratch dir, 5 server files + 1 Rust) at the agent-auth / agent-catalog contracts by name.
- Renames CSS classes `codex-thread-find-match` / `-active` → `content-find-match` / `-active` across all 20 references in 8 files (CSS, components, tests, spec doc). **This is the only functional change.**
- Neutralizes test names and two playground fixture display strings carrying "Codex-style".

## Deliberately kept

Every reference to Codex, Cursor, OpenCode, Windsurf and Zed as **harnesses/editors we integrate with** — harness kind strings, `CODEX_HOME`, `CURSOR_API_KEY`, `CodexConfigRecipe` config rendering, provider-icon maps, catalog-probe rules, the README harness list, and comments describing how those harnesses behave (e.g. "codex emits accounting-only goal_updated ticks"). That is real product functionality, not design attribution.

## Verification

- product-client **3961 tests pass**, product-ui **195**, product-domain **633**
- `ruff format --check` + `ruff check` clean on the 5 changed Python files
- `tsc --noEmit` on product-domain shows only errors that reproduce identically on clean `origin/main` (pre-existing, in files this PR does not touch)
- No cargo build needed — the single Rust change is one doc-comment line
- Full-repo sweep: zero attribution hits remain; surviving `codex recipe` hits refer to the real `CodexConfigRecipe` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)