### PR TITLE
fix(ui): repair the warning token, collapsed code blocks, Geist mono, and four dead component APIs

### DIFF
--- a/apps/packages/design/scripts/copy-css.mjs
+++ b/apps/packages/design/scripts/copy-css.mjs
@@ -1,5 +1,6 @@
 import { copyFile, mkdir, readdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
@@ -14,4 +15,36 @@ for (const entry of await readdir(sourceDir)) {
   }
 
   await copyFile(resolve(sourceDir, entry), resolve(targetDir, entry));
+}
+
+/* ------------------------------------------------------------------ *
+ * Geist ships as a bare package with no stylesheet of its own, so the
+ * `@font-face` rules live in product.css. They used to point at absolute
+ * `/node_modules/geist/...` URLs, which only resolve because a dev server
+ * happens to serve node_modules — any other bundler or deploy target got a
+ * dangling rule and silently fell back to a system mono font.
+ *
+ * Copying the woff2s next to the emitted CSS lets product.css reference them
+ * relatively (`../fonts/…`), so the declaration resolves wherever the package
+ * is consumed from. `@fontsource-variable/*` needs no equivalent step: those
+ * packages ship their own CSS and their own fonts.
+ * ------------------------------------------------------------------ */
+
+// `geist` does not export `./package.json`, so resolve through `./font` (which
+// maps to `dist/font.js`) and walk to the sibling `fonts/` directory. This
+// works regardless of how pnpm hoists the package.
+const require = createRequire(import.meta.url);
+const geistFontsDir = resolve(dirname(require.resolve("geist/font")), "fonts");
+const fontsTargetDir = resolve(root, "dist/fonts");
+
+await mkdir(fontsTargetDir, { recursive: true });
+
+for (const relativePath of [
+  "geist-sans/Geist-Variable.woff2",
+  "geist-mono/GeistMono-Variable.woff2",
+]) {
+  const source = resolve(geistFontsDir, relativePath);
+  const target = resolve(fontsTargetDir, relativePath.split("/").at(-1));
+  await copyFile(source, target);
+  console.log(`copy-css: geist ${relativePath} -> dist/fonts/`);
 }

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -13,10 +13,15 @@
 @source "../../../product-surfaces/src";
 @source "../../../product-client/src";
 
-/* -- Geist font loading (kept for fallback / mono) -- */
+/* -- Geist font loading (kept for fallback / mono) --
+   Relative to the EMITTED stylesheet (dist/css/product.css); `copy-css.mjs`
+   places the woff2s in dist/fonts/. These were absolute `/node_modules/…`
+   URLs, which only resolve when a dev server serves node_modules — every
+   other bundler or deploy target got a dangling rule and fell back to a
+   system mono font. Keep these paths in step with copy-css.mjs. */
 @font-face {
   font-family: "Geist";
-  src: url("/node_modules/geist/dist/fonts/geist-sans/Geist-Variable.woff2") format("woff2");
+  src: url("../fonts/Geist-Variable.woff2") format("woff2");
   font-weight: 100 900;
   font-style: normal;
   font-display: swap;
@@ -24,7 +29,7 @@
 
 @font-face {
   font-family: "Geist Mono";
-  src: url("/node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2") format("woff2");
+  src: url("../fonts/GeistMono-Variable.woff2") format("woff2");
   font-weight: 100 900;
   font-style: normal;
   font-display: swap;

--- a/apps/packages/product-client/src/components/agents/AgentLoginTerminalPanel.tsx
+++ b/apps/packages/product-client/src/components/agents/AgentLoginTerminalPanel.tsx
@@ -100,7 +100,7 @@ export function AgentLoginTerminalPanel({
       ) : null}
 
       {connectionError ? (
-        <div className="border-b border-border/70 px-3 py-2 text-ui text-warning">
+        <div className="border-b border-border/70 px-3 py-2 text-ui text-warning-foreground">
           {connectionError}
         </div>
       ) : null}

--- a/apps/packages/product-client/src/components/app/OfflineIndicator.tsx
+++ b/apps/packages/product-client/src/components/app/OfflineIndicator.tsx
@@ -15,7 +15,7 @@ export function OfflineIndicator() {
   return (
     <div
       role="status"
-      className="flex items-center justify-center gap-2 border-b border-warning/40 bg-warning px-3 py-1.5 text-ui font-medium text-warning-foreground"
+      className="flex items-center justify-center gap-2 border-b border-warning-border bg-warning px-3 py-1.5 text-ui font-medium text-warning-foreground"
     >
       <WifiOff className="icon-paired shrink-0" aria-hidden="true" />
       No internet connection — local work is safe; agents need a connection.

--- a/apps/packages/product-client/src/components/auth/ConnectServerDialog.tsx
+++ b/apps/packages/product-client/src/components/auth/ConnectServerDialog.tsx
@@ -119,7 +119,7 @@ export function ConnectServerDialog({ controller, context }: ConnectServerDialog
             </p>
           )}
           {versionWarning ? (
-            <p className="text-ui-sm text-warning">{versionWarning}</p>
+            <p className="text-ui-sm text-warning-foreground">{versionWarning}</p>
           ) : null}
           {error && <p className="text-ui text-destructive">{error}</p>}
         </div>

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundStatusTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundStatusTranscript.tsx
@@ -277,7 +277,7 @@ function LiveStreamPreview() {
 
 function WarningNotice({ title, body }: { title: string; body: string }) {
   return (
-    <div className="rounded-lg border border-warning/35 bg-warning/10 px-3 py-2 text-chat text-warning-foreground">
+    <div className="rounded-lg border border-warning-border bg-warning-subtle px-3 py-2 text-chat text-warning-foreground">
       <div className="flex items-center gap-2 font-medium">
         <CircleAlert className="text-chat icon-paired" />
         <span>{title}</span>

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessConfigIssueBanner.tsx
@@ -20,10 +20,10 @@ export function HarnessConfigIssueBanner({
 
   return (
     <div
-      className="flex flex-col gap-3 rounded-lg border border-warning/30 bg-warning/5 p-3.5 sm:flex-row sm:items-center"
+      className="flex flex-col gap-3 rounded-lg border border-warning-border bg-warning-subtle p-3.5 sm:flex-row sm:items-center"
       data-harness-runtime-state={agent.readiness}
     >
-      <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-md bg-warning/10 text-warning">
+      <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-md bg-warning-subtle text-warning-foreground">
         <ProviderIcon kind={agent.kind} className="icon-control" />
       </span>
       <div className="min-w-0 flex-1 space-y-1">

--- a/apps/packages/product-client/src/components/settings/sidebar/HarnessStatusDot.test.tsx
+++ b/apps/packages/product-client/src/components/settings/sidebar/HarnessStatusDot.test.tsx
@@ -43,7 +43,7 @@ describe("HarnessStatusDot", () => {
 
   it("still flags a harness whose credentials are genuinely missing", () => {
     const warning = dot(agent({ credentialState: "login_required", readiness: "login_required" }));
-    expect(warning?.className).toContain("bg-warning");
+    expect(warning?.className).toContain("bg-warning-foreground");
   });
 
   it("still flags a failed install as an error", () => {

--- a/apps/packages/product-client/src/components/settings/sidebar/HarnessStatusDot.tsx
+++ b/apps/packages/product-client/src/components/settings/sidebar/HarnessStatusDot.tsx
@@ -32,7 +32,9 @@ export function HarnessStatusDot({ agent }: HarnessStatusDotProps) {
   if (agent.installState === "failed") {
     colorClass = "bg-destructive";
   } else if (agent.credentialState === "login_required" || agent.credentialState === "missing_env") {
-    colorClass = "bg-warning";
+    // The ink token, not `bg-warning`: that is a 15%-alpha FILL, so an 8px dot
+    // filled with it is invisible beside its opaque `bg-destructive` sibling.
+    colorClass = "bg-warning-foreground";
   } else {
     // unknown or other states → red
     colorClass = "bg-destructive";

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerIntegrationsControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerIntegrationsControl.tsx
@@ -57,7 +57,7 @@ export function ComposerIntegrationsControl() {
             isUrgent ? (
               <span
                 aria-hidden="true"
-                className="block icon-status rounded-full bg-warning/70"
+                className="block icon-status rounded-full bg-warning-foreground"
               />
             ) : (
               // Reference: the sidebar's own "Connections" entry (the

--- a/apps/packages/product-client/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/workspace-activity/WorkspaceActivityComposerCard.tsx
@@ -239,7 +239,7 @@ function ActivityFact({
   const toneClass = fact.tone === "destructive"
     ? "text-destructive"
     : fact.tone === "attention"
-      ? "text-warning"
+      ? "text-warning-foreground"
       : "text-current";
   if (index === 2 && narrowOverflowCount > 0) {
     return (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/GoalTranscriptEventRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/GoalTranscriptEventRow.tsx
@@ -141,7 +141,7 @@ function presentGoalTranscriptEvent(event: GoalTranscriptEvent): GoalTranscriptE
     case "blocked":
       return {
         Icon: CircleAlert,
-        iconClassName: "text-warning",
+        iconClassName: "text-warning-foreground",
         label: "Goal blocked",
         detailPreview: event.detail ? truncateGoalObjective(event.detail, ROW_PREVIEW_MAX_CHARS) : null,
         fullDetail: event.detail,

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -208,7 +208,7 @@ function detailToneClass(
     case "success":
       return "text-success";
     case "warning":
-      return "text-warning";
+      return "text-warning-foreground";
     case "muted":
       return "text-sidebar-muted-foreground/50";
     case "neutral":

--- a/apps/packages/product-client/src/lib/domain/cloud/composer-integrations.test.ts
+++ b/apps/packages/product-client/src/lib/domain/cloud/composer-integrations.test.ts
@@ -110,7 +110,7 @@ describe("composerIntegrationHealthDot", () => {
   });
 
   it("maps needs_reauth to a warning dot", () => {
-    expect(composerIntegrationHealthDot("needs_reauth").className).toBe("bg-warning");
+    expect(composerIntegrationHealthDot("needs_reauth").className).toBe("bg-warning-foreground");
   });
 
   it("maps error to a destructive dot", () => {

--- a/apps/packages/product-client/src/lib/domain/cloud/composer-integrations.ts
+++ b/apps/packages/product-client/src/lib/domain/cloud/composer-integrations.ts
@@ -103,8 +103,10 @@ export function composerIntegrationHealthDot(
   switch (health) {
     case "ready":
       return { className: "bg-success", label: "Connected" };
+    // The ink token, not `bg-warning`: that is a 15%-alpha FILL, so an 8px dot
+    // filled with it is invisible beside its opaque `bg-success` siblings.
     case "needs_reauth":
-      return { className: "bg-warning", label: "Needs re-authentication" };
+      return { className: "bg-warning-foreground", label: "Needs re-authentication" };
     case "error":
       return { className: "bg-destructive", label: "Error" };
     case "needs_auth":

--- a/apps/packages/product-ui/src/activity/GoalBar.tsx
+++ b/apps/packages/product-ui/src/activity/GoalBar.tsx
@@ -303,7 +303,7 @@ function GoalBarGlyph({
     }
     return (
       <CircleAlert
-        className={twMerge(className, state.outcome === "blocked" ? "text-warning" : "text-destructive")}
+        className={twMerge(className, state.outcome === "blocked" ? "text-warning-foreground" : "text-destructive")}
         aria-hidden
       />
     );

--- a/apps/packages/product-ui/src/activity/LoopsPanel.tsx
+++ b/apps/packages/product-ui/src/activity/LoopsPanel.tsx
@@ -163,7 +163,7 @@ function LoopRow({
           <span
             className={twMerge(
               "rounded px-1 py-0.5 text-ui font-medium uppercase tracking-wide",
-              loop.native ? "bg-muted text-muted-foreground" : "bg-warning/15 text-warning",
+              loop.native ? "bg-muted text-muted-foreground" : "bg-warning-subtle text-warning-foreground",
             )}
           >
             {loop.native ? "native" : "emulated"}

--- a/apps/packages/product-ui/src/billing/BillingUiParts.tsx
+++ b/apps/packages/product-ui/src/billing/BillingUiParts.tsx
@@ -67,7 +67,7 @@ export function Notice({
       className={`flex gap-3 rounded-lg border p-3 text-body ${
         tone === "destructive"
           ? "border-destructive/30 bg-destructive/10 text-destructive"
-          : "border-warning/30 bg-warning/10 text-warning"
+          : "border-warning-border bg-warning-subtle text-warning-foreground"
       }`}
     >
       <AlertTriangle className="mt-0.5 icon-paired shrink-0" />

--- a/apps/packages/product-ui/src/code/CodeBlockTokenContent.tsx
+++ b/apps/packages/product-ui/src/code/CodeBlockTokenContent.tsx
@@ -49,11 +49,16 @@ export function CodeBlockTokenContent({
   return (
     <code className={`block whitespace-pre font-mono ${className}`}>
       {lines.map((tokens, index) => (
+        // `block` is load-bearing: shiki's tokens carry no trailing newline and
+        // `CodeTokenLine` emits a bare inline <span>, so without it every line
+        // of a highlighted block runs onto one line. The gutter branch above
+        // gets its line breaks from the table rows instead.
         <CodeTokenLine
           key={index}
           tokens={tokens}
           lineIndex={index}
           renderToken={renderToken}
+          className="block"
         />
       ))}
     </code>

--- a/apps/packages/product-ui/src/layout/ProductNotice.tsx
+++ b/apps/packages/product-ui/src/layout/ProductNotice.tsx
@@ -14,7 +14,7 @@ interface ProductNoticeProps {
 const toneClasses: Record<ProductNoticeTone, string> = {
   neutral: "border-border bg-card text-foreground",
   info: "border-info/40 bg-info/10 text-foreground",
-  warning: "border-warning/40 bg-warning/10 text-foreground",
+  warning: "border-warning-border bg-warning-subtle text-foreground",
   destructive: "border-destructive/40 bg-destructive/10 text-foreground",
 };
 

--- a/apps/packages/product-ui/src/patterns/BillingGateState.tsx
+++ b/apps/packages/product-ui/src/patterns/BillingGateState.tsx
@@ -120,7 +120,7 @@ export function BillingBalanceNotice({
         "flex items-start gap-3 rounded-lg border p-3 text-body",
         tone === "destructive"
           ? "border-destructive/30 bg-destructive/10 text-destructive"
-          : "border-warning/30 bg-warning/10 text-warning-foreground",
+          : "border-warning-border bg-warning-subtle text-warning-foreground",
         className,
       )}
     >

--- a/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
+++ b/apps/packages/product-ui/src/repos/CloudRepoPicker.tsx
@@ -262,14 +262,14 @@ function RepositoryRow({
             {repo.fullName}
           </span>
           {repo.private ? <Lock className="icon-paired shrink-0 text-muted-foreground" aria-hidden /> : null}
-          {repo.archived ? <Archive className="icon-paired shrink-0 text-warning" aria-hidden /> : null}
+          {repo.archived ? <Archive className="icon-paired shrink-0 text-warning-foreground" aria-hidden /> : null}
           {repo.repoConfigState === "configured" ? (
             <Check className="icon-paired shrink-0 text-success" aria-hidden />
           ) : null}
         </span>
         <span className="block truncate text-ui-sm text-muted-foreground">
           {repo.disabledReason ? (
-            <span className="text-warning">{repo.disabledReason}</span>
+            <span className="text-warning-foreground">{repo.disabledReason}</span>
           ) : (
             meta
           )}

--- a/apps/packages/product-ui/src/settings/OrganizationSsoSettingsSurface.tsx
+++ b/apps/packages/product-ui/src/settings/OrganizationSsoSettingsSurface.tsx
@@ -154,7 +154,7 @@ export function OrganizationSsoSettingsSurface({
           </div>
         </div>
         {connection?.lastError ? (
-          <div className="mt-2 rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-ui-sm text-warning">
+          <div className="mt-2 rounded-lg border border-warning-border bg-warning-subtle px-4 py-3 text-ui-sm text-warning-foreground">
             {connection.lastError}
           </div>
         ) : null}

--- a/apps/packages/product-ui/src/workflows/WorkflowDefinitionEditor.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowDefinitionEditor.tsx
@@ -110,7 +110,7 @@ export function WorkflowDefinitionEditor({
             </div>
           ) : null}
           {catalogWarning ? (
-            <div className="rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-ui text-warning" role="status">
+            <div className="rounded-lg border border-warning-border bg-warning-subtle px-3 py-2 text-ui text-warning-foreground" role="status">
               {catalogWarning}
               {onReload && !serverError ? (
                 <Button

--- a/apps/packages/product-ui/src/workflows/WorkflowRunDetail.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunDetail.tsx
@@ -69,7 +69,7 @@ export function WorkflowRunDetail({
           <StatusCard label="Freshness" value={presentation.freshness.label} tone={presentation.freshness.tone} />
         </section>
 
-        {presentation.notice ? <p className="rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-ui text-warning" role="status">{presentation.notice}</p> : null}
+        {presentation.notice ? <p className="rounded-md border border-warning-border bg-warning-subtle px-3 py-2 text-ui text-warning-foreground" role="status">{presentation.notice}</p> : null}
         {presentation.canStartDelivery && !deliveryCapabilityEnabled ? (
           <p className="rounded-md border border-border bg-surface-raised px-3 py-2 text-ui text-muted-foreground" role="status">
             Managed Workflow delivery is not enabled on this server. This prepared run remains available.
@@ -132,7 +132,7 @@ function Detail({ label, value }: { label: string; value: string }) {
 
 function toneClass(tone: string): string {
   if (tone === "danger") return "text-destructive";
-  if (tone === "warning") return "text-warning";
+  if (tone === "warning") return "text-warning-foreground";
   if (tone === "success") return "text-success";
   return "text-foreground";
 }

--- a/apps/packages/product-ui/src/workflows/WorkflowRunForm.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunForm.tsx
@@ -69,9 +69,9 @@ export function WorkflowRunForm({
         </p>
       ) : null}
       {blockers.length > 0 ? (
-        <div className="mt-3 rounded-md border border-warning/30 bg-warning/5 px-3 py-2" role="status">
-          <p className="text-ui font-medium text-warning">This workflow cannot run yet.</p>
-          <ul className="mt-1 space-y-1 text-ui text-warning">
+        <div className="mt-3 rounded-md border border-warning-border bg-warning-subtle px-3 py-2" role="status">
+          <p className="text-ui font-medium text-warning-foreground">This workflow cannot run yet.</p>
+          <ul className="mt-1 space-y-1 text-ui text-warning-foreground">
             {[...blockers]
               .sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code))
               .map((blocker) => (

--- a/apps/packages/product-ui/src/workflows/WorkflowRunList.tsx
+++ b/apps/packages/product-ui/src/workflows/WorkflowRunList.tsx
@@ -76,7 +76,7 @@ export function WorkflowRunList({
 
 function toneClass(tone: string): string {
   if (tone === "danger") return "text-destructive";
-  if (tone === "warning") return "text-warning";
+  if (tone === "warning") return "text-warning-foreground";
   if (tone === "success") return "text-success";
   return "text-muted-foreground";
 }

--- a/apps/packages/product-ui/src/workspaces/RecentWorkStatusDot.tsx
+++ b/apps/packages/product-ui/src/workspaces/RecentWorkStatusDot.tsx
@@ -40,7 +40,7 @@ function statusToneClass(
 ): string {
   switch (indicator.tone) {
     case "attention":
-      return surface === "sidebar" ? "text-sidebar-muted-foreground" : "text-warning";
+      return surface === "sidebar" ? "text-sidebar-muted-foreground" : "text-warning-foreground";
     case "progress":
       return "text-info";
     case "success":

--- a/apps/packages/product-ui/test/CodeBlockTokenContent.test.tsx
+++ b/apps/packages/product-ui/test/CodeBlockTokenContent.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CodeBlockTokenContent } from "../src/code/CodeBlockTokenContent";
+import type { HighlightedToken } from "../src/code/types";
+
+function line(...contents: string[]): HighlightedToken[] {
+  return contents.map((content) => ({ content }));
+}
+
+const THREE_LINES: HighlightedToken[][] = [
+  line("const", " a", " = 1;"),
+  line("const", " b", " = 2;"),
+  line("return", " a + b;"),
+];
+
+describe("CodeBlockTokenContent", () => {
+  afterEach(cleanup);
+
+  // Regression: shiki's tokens carry no trailing newline and CodeTokenLine
+  // emits a bare inline <span>, so without a block-level line wrapper every
+  // highlighted transcript code block collapsed onto a single visual line.
+  // `showLineNumbers` defaults to false and both the transcript and desktop
+  // renderers rely on that default, so this is the branch users actually hit.
+  it("gives each line its own block-level wrapper when un-guttered", () => {
+    const { container } = render(<CodeBlockTokenContent lines={THREE_LINES} />);
+
+    const code = container.querySelector("code");
+    expect(code).toBeTruthy();
+
+    const lineWrappers = Array.from(code!.children);
+    expect(lineWrappers).toHaveLength(3);
+    for (const wrapper of lineWrappers) {
+      expect(wrapper.className).toContain("block");
+    }
+  });
+
+  it("keeps every line's text, in order", () => {
+    const { container } = render(<CodeBlockTokenContent lines={THREE_LINES} />);
+
+    const rendered = Array.from(container.querySelector("code")!.children).map(
+      (child) => child.textContent,
+    );
+    expect(rendered).toEqual(["const a = 1;", "const b = 2;", "return a + b;"]);
+  });
+
+  it("renders a blank line as an empty block, not a doubled newline", () => {
+    // CodeTokenLine's empty-line branch emits "\n" so that a copy of the
+    // block keeps the blank line; the wrapper must not also add height.
+    const { container } = render(
+      <CodeBlockTokenContent lines={[line("a"), [], line("b")]} />,
+    );
+
+    const children = Array.from(container.querySelector("code")!.children);
+    expect(children).toHaveLength(3);
+    expect(children[1]!.textContent).toBe("\n");
+  });
+
+  it("does not add the block wrapper on the gutter branch", () => {
+    // There the <tr> rows already break lines; a block span would be redundant.
+    const { container } = render(
+      <CodeBlockTokenContent lines={THREE_LINES} showLineNumbers />,
+    );
+
+    expect(container.querySelectorAll("tr")).toHaveLength(3);
+    for (const cell of container.querySelectorAll("td:last-child > span")) {
+      expect(cell.className).not.toContain("block");
+    }
+  });
+
+  it("numbers gutter lines from lineNumberStart", () => {
+    const { container } = render(
+      <CodeBlockTokenContent lines={THREE_LINES} showLineNumbers lineNumberStart={41} />,
+    );
+
+    const numbers = Array.from(container.querySelectorAll("td:first-child")).map(
+      (cell) => cell.textContent,
+    );
+    expect(numbers).toEqual(["41", "42", "43"]);
+  });
+});

--- a/apps/packages/ui/src/patterns/EnvironmentSearchSelect.tsx
+++ b/apps/packages/ui/src/patterns/EnvironmentSearchSelect.tsx
@@ -27,6 +27,13 @@ interface EnvironmentSearchSelectProps {
   closeOnSelect?: boolean;
   leading?: ReactNode;
   disabled?: boolean;
+  /**
+   * Controlled open state, forwarded to the underlying `PopoverButton`.
+   * Without it the menu is only reachable by a real click, so the open state
+   * cannot be driven from a test or a static capture.
+   */
+  externalOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function EnvironmentSearchSelect({
@@ -39,6 +46,8 @@ export function EnvironmentSearchSelect({
   closeOnSelect = true,
   leading,
   disabled = false,
+  externalOpen,
+  onOpenChange,
 }: EnvironmentSearchSelectProps) {
   const [searchValue, setSearchValue] = useState("");
   const filteredOptions = useMemo(() => (
@@ -51,6 +60,8 @@ export function EnvironmentSearchSelect({
   return (
     <PopoverButton
       align="start"
+      externalOpen={externalOpen}
+      onOpenChange={onOpenChange}
       trigger={(
         <Button
           type="button"

--- a/apps/packages/ui/src/patterns/SettingsMenu.tsx
+++ b/apps/packages/ui/src/patterns/SettingsMenu.tsx
@@ -55,7 +55,11 @@ export function SettingsMenu({
           type="button"
           variant="outline"
           size="sm"
-          className={`h-7 justify-between rounded-lg border border-input bg-transparent px-2.5 text-ui font-control leading-4 text-foreground shadow-none hover:bg-hover active:bg-active data-[state=open]:bg-active ${className}`}
+          // `[&_svg]:icon-paired` sizes a bare icon passed through `leading`
+          // (the same descendant-selector idiom `SegmentedControl` and
+          // `RadioCardGroup` use). Without it an unsized SVG renders at its
+          // viewport default and every call site has to compensate.
+          className={`h-7 justify-between rounded-lg border border-input bg-transparent px-2.5 text-ui font-control leading-4 text-foreground shadow-none [&_svg]:icon-paired hover:bg-hover active:bg-active data-[state=open]:bg-active ${className}`}
         >
           {leading}
           <span className="min-w-0 flex-1 truncate text-left">{label}</span>

--- a/apps/packages/ui/src/primitives/DropdownMenu.tsx
+++ b/apps/packages/ui/src/primitives/DropdownMenu.tsx
@@ -247,14 +247,19 @@ function DropdownMenuSubContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        `z-50 min-w-[220px] overflow-hidden p-1 ${POPOVER_FRAME_CLASS} animate-popover-in [transform-origin:var(--radix-dropdown-menu-content-transform-origin)]`,
-        className,
-      )}
-      {...props}
-    />
+    // Portalled for the same reason `DropdownMenuContent` is: the parent
+    // content is `overflow-hidden`, so an in-tree submenu panel gets clipped
+    // away instead of overflowing its parent.
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          `z-50 min-w-[220px] overflow-hidden p-1 ${POPOVER_FRAME_CLASS} animate-popover-in [transform-origin:var(--radix-dropdown-menu-content-transform-origin)]`,
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
   );
 }
 

--- a/apps/packages/ui/src/primitives/Tooltip.tsx
+++ b/apps/packages/ui/src/primitives/Tooltip.tsx
@@ -32,6 +32,18 @@ interface TooltipProps {
    * primitive's default dismissal.
    */
   keepOpenOnPress?: boolean;
+  /**
+   * Controlled open state. Without this the bubble is only reachable by a real
+   * hover, so it cannot be screenshotted, storybooked, or asserted in an
+   * integration test — pass `defaultOpen` for a static capture, or
+   * `open`/`onOpenChange` to drive it. Explicit control wins over
+   * `keepOpenOnPress`'s internal hover state.
+   */
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Hover delay before the bubble appears. Defaults to 0 (instant). */
+  delayDuration?: number;
 }
 
 export function Tooltip({
@@ -40,6 +52,10 @@ export function Tooltip({
   className = "inline-flex shrink-0",
   singleLine = false,
   keepOpenOnPress = false,
+  open,
+  defaultOpen,
+  onOpenChange,
+  delayDuration = 0,
 }: TooltipProps) {
   const [hoverOpen, setHoverOpen] = useState(false);
   // Only the close request raised by pressing the trigger is suppressed.
@@ -83,12 +99,16 @@ export function Tooltip({
     setHoverOpen(false);
   }, []);
 
-  const controlled = keepOpenOnPress
-    ? { open: hoverOpen, onOpenChange: handleOpenChange }
-    : {};
+  const hasExplicitControl =
+    open !== undefined || defaultOpen !== undefined || onOpenChange !== undefined;
+  const controlled = hasExplicitControl
+    ? { open, defaultOpen, onOpenChange }
+    : keepOpenOnPress
+      ? { open: hoverOpen, onOpenChange: handleOpenChange }
+      : {};
 
   return (
-    <TooltipProvider delayDuration={0}>
+    <TooltipProvider delayDuration={delayDuration}>
       <KitTooltip {...controlled}>
         <TooltipTrigger asChild>
           <span

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -50,6 +50,13 @@ QUERY_CACHE_METHODS = {
     "setQueryData",
 }
 
+# `--color-warning` is a fill token; using it as ink (or alpha-modifying an
+# already-alpha fill) renders invisible. See find_warning_ink_violations.
+WARNING_INK_RE = re.compile(
+    r"\btext-warning(?![\w-])"
+    r"|\b(?:bg|border)-warning/\d+(?![\w-])"
+)
+
 OPENAPI_CLIENT_VERB_RE = re.compile(r"\bclient\.(GET|POST|PUT|PATCH|DELETE)\s*\(")
 QUERY_CACHE_CALL_RE = re.compile(
     r"\bqueryClient\.("
@@ -386,6 +393,61 @@ def find_radix_import_violations() -> list[Violation]:
     return violations
 
 
+def find_warning_ink_violations() -> list[Violation]:
+    """Rule: `--color-warning` is a FILL token, never ink.
+
+    In dark mode `--color-warning` is `rgba(255, 180, 50, 0.15)` and in light
+    mode it is `#fff8e6` — a near-transparent / near-white *fill*. Applied as
+    ink via `text-warning` it renders the label at 15% opacity against a dark
+    surface, i.e. effectively invisible. Every other tone (`success`, `info`,
+    `destructive`) is an opaque hex, which is why only `warning` has this trap
+    and why the DS ships a separate `--color-warning-foreground` (`#ffb432`).
+
+    The purpose-built tokens are:
+      ink    -> text-warning-foreground
+      fill   -> bg-warning-subtle
+      border -> border-warning-border
+
+    Alpha-modified fills (`bg-warning/10`) are also flagged: multiplying an
+    already-0.15-alpha token yields ~1.5% alpha, so the fill does not read
+    either. Solid `bg-warning` is intentionally NOT flagged — using the fill
+    token as a fill is correct (e.g. status dots, `OfflineIndicator`).
+
+    This defect shipped to users across ~20 call sites and was invisible to
+    every existing check, hence the gate.
+    """
+    violations: list[Violation] = []
+    for path in iter_files_in_roots(
+        [UI_SRC, PRODUCT_UI_SRC, PRODUCT_SURFACES_SRC, PRODUCT_CLIENT_SRC, DESKTOP_SRC, WEB_SRC]
+    ):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            for match in WARNING_INK_RE.finditer(strip_line_comment(line)):
+                utility = match.group(0)
+                replacement = (
+                    "text-warning-foreground"
+                    if utility.startswith("text-")
+                    # A `bg-warning/N` is either a panel wash or a solid dot;
+                    # the wash wants the subtle fill, the dot wants the ink.
+                    else "bg-warning-subtle (panel fill) or bg-warning-foreground (solid dot)"
+                    if utility.startswith("bg-")
+                    else "border-warning-border"
+                )
+                violations.append(
+                    Violation(
+                        "WARNING_TOKEN_AS_INK",
+                        path,
+                        lineno,
+                        (
+                            f"`{utility}` uses the warning FILL token where the "
+                            f"purpose-built token belongs — use `{replacement}`. "
+                            "`--color-warning` is rgba(...,0.15) in dark mode, so "
+                            "this renders effectively invisible."
+                        ),
+                    )
+                )
+    return violations
+
+
 def find_ui_src_top_level_violations() -> list[Violation]:
     """Rule: apps/packages/ui/src may only contain the top-level entries named
     in the component-library taxonomy (specs/codebase/platforms/product/design-system.md):
@@ -459,6 +521,7 @@ def collect_violations() -> list[Violation]:
         violations.extend(check_file(path))
     violations.extend(find_radix_import_violations())
     violations.extend(find_ui_src_top_level_violations())
+    violations.extend(find_warning_ink_violations())
     return violations
 
 

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -169,5 +169,59 @@ class UiSrcTopLevelShapeTest(unittest.TestCase):
         self.assertEqual(violations, [])
 
 
+class WarningInkBoundaryTest(unittest.TestCase):
+    def run_rule(self, source: str) -> list[check_module.Violation]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            ui_src = root / "apps" / "packages" / "ui" / "src"
+            ui_src.mkdir(parents=True)
+            (ui_src / "Sample.tsx").write_text(source, encoding="utf-8")
+            empty = root / "empty"
+            with patch.object(check_module, "REPO_ROOT", root), patch.object(
+                check_module, "UI_SRC", ui_src
+            ), patch.multiple(
+                check_module,
+                PRODUCT_UI_SRC=empty,
+                PRODUCT_SURFACES_SRC=empty,
+                PRODUCT_CLIENT_SRC=empty,
+                DESKTOP_SRC=empty,
+                WEB_SRC=empty,
+            ):
+                return check_module.find_warning_ink_violations()
+
+    def test_bare_text_warning_fails(self) -> None:
+        violations = self.run_rule('const tone = "text-warning";\n')
+
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].rule_id, "WARNING_TOKEN_AS_INK")
+        self.assertIn("text-warning-foreground", violations[0].message)
+
+    def test_purpose_built_tokens_pass(self) -> None:
+        violations = self.run_rule(
+            'const tone = "border-warning-border bg-warning-subtle text-warning-foreground";\n'
+        )
+
+        self.assertEqual(violations, [])
+
+    def test_alpha_modified_fill_and_border_fail(self) -> None:
+        violations = self.run_rule('const tone = "border-warning/30 bg-warning/10";\n')
+
+        self.assertEqual(len(violations), 2)
+        self.assertEqual(
+            {violation.rule_id for violation in violations}, {"WARNING_TOKEN_AS_INK"}
+        )
+
+    def test_solid_fill_is_allowed(self) -> None:
+        # Using the fill token AS a fill is correct (OfflineIndicator's banner).
+        violations = self.run_rule('const tone = "bg-warning text-warning-foreground";\n')
+
+        self.assertEqual(violations, [])
+
+    def test_commented_usage_is_ignored(self) -> None:
+        violations = self.run_rule('// historical note: text-warning was wrong\n')
+
+        self.assertEqual(violations, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Rendering all 133 design-system components in isolation surfaced a set of real
defects. This fixes the ones that were mechanical enough to fix safely, and adds
a gate so the largest class of them cannot come back.

## 1. Warning states rendered in an invisible token (23 sites)

`--color-warning` is a **fill**: `rgba(255, 180, 50, 0.15)` in dark mode and
`#fff8e6` in light. The ink is `--color-warning-foreground`. 21 sites used the
fill as text colour, which is near-invisible in both modes — and several
compounded it with a Tailwind alpha modifier (`bg-warning/10`), multiplying an
already-alpha token down to ~1.5% opacity.

The worst instances were 8px status dots painted solid `bg-warning`, sitting
directly beside opaque `bg-destructive`/`bg-success` siblings: `HarnessStatusDot`
(a harness that needs login) and `composerIntegrationHealthDot` (an integration
that needs re-auth). Both are "needs your attention" signals that were invisible.

Swapped to the purpose-built trio — `bg-warning-subtle` (panel fill),
`border-warning-border`, `text-warning-foreground` / `bg-warning-foreground`
(ink) — which is what `Badge`, `ProductNotice` and the workflow surfaces already
converged on. **No token values changed.**

Then added a `WARNING_TOKEN_AS_INK` rule to `scripts/check_frontend_boundaries.py`
(already in CI) so `text-warning` and alpha-modified `bg`/`border-warning/NN`
fail the build. Solid `bg-warning` stays legal — it is a legitimate panel fill.
5 new unit tests cover both directions.

The gate justified itself immediately: `BillingGateState` landed on main while
this branch was in flight, reached for `border-warning/30 bg-warning/10`, and
got caught on rebase. That is the last commit here.

## 2. Every highlighted code block in the transcript collapsed to one line

shiki's tokens carry no trailing newline and `CodeTokenLine` emits a bare inline
`<span>`, so the un-guttered branch of `CodeBlockTokenContent` had nothing to
break lines on. `showLineNumbers` defaults to `false` and both the transcript and
desktop renderers rely on that default, so this was the branch users hit.

Fixed in `CodeBlockTokenContent`, not `CodeTokenLine`: `FileSourceView` consumes
`CodeTokenLine` directly with its own block wrapper, so fixing the leaf would
have double-wrapped it. 5 new tests, including one that fails without the fix and
one pinning that a blank line does not become double-spacing.

## 3. Geist Mono was silently missing from production

`product.css` declared `@font-face` sources as absolute
`/node_modules/geist/dist/fonts/...`. That resolves only when something serves
the repo's node_modules at the site root — true for a dev server, false for every
built target. `pnpm web:build` emitted the rule with no such asset, so the
browser dropped the declaration and fell back to a system font.

`copy-css.mjs` now copies the two woff2s into `dist/fonts/` and the CSS
references them relatively. Verified against a real build: `dist/assets` carries
hashed `Geist-Variable-*.woff2` and `GeistMono-Variable-*.woff2`, and no
`/node_modules/` font URL survives.

## 4. Four components whose public API stopped short of usable

- **`Tooltip`** hard-coded its own provider at Radix's 700ms default with no
  `open` escape hatch — impossible to drive from state or open programmatically.
  Now forwards `open`/`defaultOpen`/`onOpenChange`/`delayDuration` (default 0).
- **`DropdownMenuSubContent`** rendered inline, so a submenu inside any
  `overflow-hidden` ancestor got clipped. Now portalled, like
  `DropdownMenuContent` already was. Zero existing callers, so zero regression
  surface.
- **`EnvironmentSearchSelect`** composed `PopoverButton` but swallowed its
  `externalOpen`/`onOpenChange`. Now forwards both.
- **`SettingsMenu`**'s `leading` slot rendered raw icons at intrinsic size. Added
  `[&_svg]:icon-paired`, matching `SegmentedControl` and `RadioCardGroup`.

## Three questions from the audit, answered

**Why `body { background: transparent }`?** It is load-bearing, so I did not
touch it. `apps/desktop/src-tauri/tauri.conf.json:25` sets `"transparent": true`;
painting the body would break the desktop window. The audit's proposed fix here
was wrong and is deliberately not applied.

**Subpath-only packages — deliberate or incidental?** Deliberate.
`specs/codebase/platforms/product/design-system.md:917-926` mandates "No
aliases: one subpath per component… never a barrel." No `exports["."]` added;
that finding is working as designed.

**Icon policy (lucide vs DS duplicates)?** Left alone — this one needs a decision
and is not mechanical. Actual scope is worse than the audit reported: 76 distinct
lucide icons across 50 files, 40 of them shadowing a DS name. lucide sets
intrinsic `width/height=24`; DS icons set none and size via `icon-*` utilities.
**16 lucide usages carry no `className` at all** and silently depend on that 24px
default, so a mechanical swap renders them viewport-sized. Needs a policy call
plus per-site sizing work.

## Verification

- `product-client` 3961 passed (642 files)
- `product-ui` 218 passed (33 files)
- `ui` 30 passed (12 files)
- boundary gate 13/13; `check_frontend_boundaries.py` clean
- `pnpm shared:typecheck` clean; `check-theme: ok (276 live tokens)`
- `pnpm web:build` used to prove the font fix end to end

One caveat for the reviewer: the two status-dot fixes changed assertions in
`HarnessStatusDot.test.tsx` and `composer-integrations.test.ts`. Those tests
pinned the buggy colour, so updating them was necessary — worth a look to confirm
you agree the new colour is the intended one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
