### PR TITLE
fix(billing): exclude expired grants from current balances

### DIFF
--- a/apps/packages/product-client/src/lib/domain/settings/organization-limits-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/organization-limits-presentation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { computeGrantBalance } from "./organization-limits-presentation";
+
+describe("computeGrantBalance", () => {
+  it("uses only active grants for the organization balance", () => {
+    const plan = {
+      grantAllocations: [
+        {
+          grantType: "pro_period",
+          totalSeconds: 20 * 3600,
+          consumedSeconds: 0,
+          remainingSeconds: 20 * 3600,
+          active: false,
+        },
+        {
+          grantType: "pro_period",
+          totalSeconds: 20 * 3600,
+          consumedSeconds: 20 * 3600,
+          remainingSeconds: 0,
+          active: true,
+        },
+      ],
+    } as Parameters<typeof computeGrantBalance>[0];
+
+    expect(computeGrantBalance(plan)).toEqual({
+      label: "Compute units",
+      available: "0 PCUs",
+      total: "20 PCUs purchased",
+      used: "20 PCUs used",
+      percentAvailable: 0,
+    });
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/settings/organization-limits-presentation.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/organization-limits-presentation.ts
@@ -61,9 +61,7 @@ export interface BudgetBalanceView {
 
 /** Org-wide compute balance, derived from the org billing subject's grant allocations. */
 export function computeGrantBalance(plan: BillingPlanInfo | null | undefined): BudgetBalanceView {
-  const grants = (plan?.grantAllocations ?? []).filter((grant) =>
-    grant.active || grant.consumedSeconds > 0 || grant.remainingSeconds > 0
-  );
+  const grants = (plan?.grantAllocations ?? []).filter((grant) => grant.active);
   const purchased = grants.reduce((total, grant) => total + secondsToPcus(grant.totalSeconds), 0);
   const available = grants.reduce((total, grant) => total + secondsToPcus(grant.remainingSeconds), 0);
   const used = grants.reduce((total, grant) => total + secondsToPcus(grant.consumedSeconds), 0);

--- a/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
+++ b/apps/packages/product-surfaces/src/settings/BillingSettingsSurface.test.tsx
@@ -229,6 +229,53 @@ describe("BillingSettingsSurface", () => {
     expect(screen.queryByText("Mocked")).toBeNull();
   });
 
+  it("excludes expired grant remainders from the available compute balance", () => {
+    cloudHooks.useCloudBilling.mockReturnValue({
+      data: billingPlan({
+        plan: "pro",
+        proBillingEnabled: true,
+        isPaidCloud: true,
+        includedManagedCloudHours: 20,
+        remainingManagedCloudHours: 0,
+        grantAllocations: [
+          {
+            grantType: "pro_period",
+            totalSeconds: 20 * 3600,
+            consumedSeconds: 0,
+            remainingSeconds: 20 * 3600,
+            active: false,
+          },
+          {
+            grantType: "pro_period",
+            totalSeconds: 20 * 3600,
+            consumedSeconds: 20 * 3600,
+            remainingSeconds: 0,
+            active: true,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+      refetch: cloudHooks.refetch,
+    });
+
+    render(
+      <BillingSettingsSurface
+        organization={{
+          id: "org_1",
+          name: "Team One",
+          canManageBilling: true,
+          loading: false,
+        }}
+        onOpenUrl={vi.fn()}
+        onOpenOrganizationSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/0 PCUs of 20 PCUs available/)).toBeTruthy();
+    expect(screen.queryByText(/20 PCUs of 40 PCUs available/)).toBeNull();
+  });
+
   it("renders retryable errors without inventing plan or balance data", () => {
     cloudHooks.useCloudBilling.mockReturnValue({
       data: undefined,

--- a/apps/packages/product-surfaces/src/settings/billing-settings-presentation.ts
+++ b/apps/packages/product-surfaces/src/settings/billing-settings-presentation.ts
@@ -151,19 +151,17 @@ function computeBalanceSummary(
     throw new Error("Compute balance requires billing plan data.");
   }
 
-  const visibleGrants = (plan.grantAllocations ?? []).filter((grant) =>
-    grant.active || grant.consumedSeconds > 0 || grant.remainingSeconds > 0
-  );
-  if (visibleGrants.length > 0) {
-    const purchased = visibleGrants.reduce(
+  const activeGrants = (plan.grantAllocations ?? []).filter((grant) => grant.active);
+  if (activeGrants.length > 0) {
+    const purchased = activeGrants.reduce(
       (total, grant) => total + secondsToCredits(grant.totalSeconds),
       0,
     );
-    const available = visibleGrants.reduce(
+    const available = activeGrants.reduce(
       (total, grant) => total + secondsToCredits(grant.remainingSeconds),
       0,
     );
-    const used = visibleGrants.reduce(
+    const used = activeGrants.reduce(
       (total, grant) => total + secondsToCredits(grant.consumedSeconds),
       0,
     );

--- a/apps/packages/product-ui/src/billing/billing-presentation.test.ts
+++ b/apps/packages/product-ui/src/billing/billing-presentation.test.ts
@@ -46,4 +46,33 @@ describe("proliferateCreditBalance", () => {
       })).used,
     ).toBe("0 PCUs");
   });
+
+  it("does not present an expired grant's stored remainder as available", () => {
+    expect(
+      proliferateCreditBalance(billingPlan({
+        proBillingEnabled: true,
+        isPaidCloud: true,
+        grantAllocations: [
+          {
+            grantType: "pro_period",
+            totalSeconds: 20 * 3600,
+            consumedSeconds: 0,
+            remainingSeconds: 20 * 3600,
+            active: false,
+          },
+          {
+            grantType: "pro_period",
+            totalSeconds: 20 * 3600,
+            consumedSeconds: 20 * 3600,
+            remainingSeconds: 0,
+            active: true,
+          },
+        ],
+      })),
+    ).toEqual({
+      purchased: "20 PCUs",
+      available: "0 PCUs",
+      used: "20 PCUs",
+    });
+  });
 });

--- a/apps/packages/product-ui/src/billing/billing-presentation.ts
+++ b/apps/packages/product-ui/src/billing/billing-presentation.ts
@@ -56,18 +56,18 @@ export function proliferateCreditBalance(plan: BillingPlanView): {
   available: string;
   used: string;
 } {
-  const visible = visibleGrantAllocations(plan.grantAllocations);
-  if (visible.length > 0) {
+  const current = (plan.grantAllocations ?? []).filter((grant) => grant.active);
+  if (current.length > 0) {
     return {
-      purchased: formatCredits(visible.reduce(
+      purchased: formatCredits(current.reduce(
         (total, grant) => total + secondsToHours(grant.totalSeconds),
         0,
       )),
-      available: formatCredits(visible.reduce(
+      available: formatCredits(current.reduce(
         (total, grant) => total + secondsToHours(grant.remainingSeconds),
         0,
       )),
-      used: formatCredits(visible.reduce(
+      used: formatCredits(current.reduce(
         (total, grant) => total + secondsToHours(grant.consumedSeconds),
         0,
       )),
@@ -92,12 +92,12 @@ export function proliferateCreditBalance(plan: BillingPlanView): {
 export function grantUsageSummary(
   grants: readonly BillingGrantAllocationView[] | null | undefined,
 ): { consumedHours: number } | null {
-  const visible = visibleGrantAllocations(grants);
-  if (visible.length === 0) {
+  const current = (grants ?? []).filter((grant) => grant.active);
+  if (current.length === 0) {
     return null;
   }
   return {
-    consumedHours: visible.reduce(
+    consumedHours: current.reduce(
       (total, grant) => total + secondsToHours(grant.consumedSeconds),
       0,
     ),


### PR DESCRIPTION
## Summary

- calculate current compute purchased, available, and used values from active grants only
- keep inactive grants available to the historical grant breakdown
- cover Organization Billing, Usage & limits, and the shared billing card with the expired-positive-remainder regression

## Production diagnosis

A read-only production comparison found a fully accounted active period grant at zero and an expired prior-period grant retaining unused historical seconds. The snapshot correctly reported zero current compute and a reached overage cap; only the balance presenters treated the expired remainder as spendable. No production billing rows were changed.

## Proof

- `vitest run src/billing/billing-presentation.test.ts --maxWorkers=1 --minWorkers=1` — 2 passed
- `vitest run src/lib/domain/settings/organization-limits-presentation.test.ts --maxWorkers=1 --minWorkers=1` — 1 passed
- `vitest run src/settings/BillingSettingsSurface.test.tsx --maxWorkers=1 --minWorkers=1` — 14 passed on the rebased source
- `git diff --check origin/main..HEAD`

Full builds and broad suites were intentionally not run because the incident host was under critical swap pressure; the proof stayed single-worker and file-scoped.