### PR TITLE
fix(desktop): prevent embedded runtime artifact skew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
           node --check scripts/ci-cd/pr-metadata.mjs
           node --check scripts/ci-cd/resolve-deploy-base.mjs
           node --check scripts/ci-cd/validate-pr-metadata.mjs
+          node --check scripts/ci-cd/verify-anyharness-sdk-compat.mjs
+          node --check scripts/dev-runtime-prebuilt.mjs
           node --check scripts/agent-catalog/build-catalog.mjs
           node --check scripts/agent-catalog/check-version-discipline.mjs
           node --check scripts/agent-catalog/resolve-pins.mjs

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -213,7 +213,9 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         shell: bash
         run: |
-          cargo build --release -p anyharness --target "${{ matrix.target }}"
+          PROLIFERATE_BUILD_VERSION="$PROLIFERATE_RELEASE_VERSION" \
+          PROLIFERATE_BUILD_SHA="$(git rev-parse HEAD)" \
+            cargo build --release -p anyharness --target "${{ matrix.target }}"
           mkdir -p apps/desktop/src-tauri/binaries
           if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
             cp "target/${{ matrix.target }}/release/anyharness.exe" "apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}.exe"
@@ -221,6 +223,19 @@ jobs:
             cp "target/${{ matrix.target }}/release/anyharness" "apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}"
             chmod +x "apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}"
           fi
+
+      - name: Verify embedded AnyHarness identity and SDK compatibility
+        if: steps.filter.outputs.skip != 'true'
+        shell: bash
+        run: |
+          if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
+            anyharness_bin="apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}.exe"
+          else
+            anyharness_bin="apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}"
+          fi
+          node scripts/ci-cd/verify-anyharness-sdk-compat.mjs \
+            --binary "$anyharness_bin" \
+            --expected-version "$PROLIFERATE_RELEASE_VERSION"
 
       - name: Install seed packaging tools
         if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'macos'
@@ -372,8 +387,8 @@ jobs:
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned && 'true' || 'false' }}
         run: |
           desktop_version="$(node -p "require('./package.json').version")"
-          anyharness_version="$(grep '^version' ../../anyharness/crates/anyharness/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')"
-          short_sha="${GITHUB_SHA:0:12}"
+          anyharness_version="$PROLIFERATE_RELEASE_VERSION"
+          short_sha="$(git rev-parse --short=12 HEAD)"
 
           export VITE_PROLIFERATE_RELEASE="${VITE_PROLIFERATE_RELEASE:-proliferate-desktop@${desktop_version}+${short_sha}}"
           # Launch gate: ship with cloud compute hidden (identity/billing stay

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ PROD_DB_INSTANCE ?= proliferate-prod
 SQL ?= select version_num from alembic_version;
 LOCAL_CODEX_ACP ?= $(HOME)/codex-acp/target/debug/codex-acp
 DEV_ANYHARNESS_TARGET_DIR ?= target/runtime-local
+SHARED_DEV_RUNTIME_BIN ?= $(HOME)/.proliferate-local/dev/runtime-bin/anyharness
+SHARED_DEV_RUNTIME_TARGET_DIR ?= target/runtime-prebuilt
 CLOUD_SSH_WORKER_API_PORT ?= 8044
 CLOUD_SSH_WORKER_DB ?= proliferate_dev_ssh_worker_smoke
 DESKTOP_RELEASE_WORKFLOW ?= Release Desktop
@@ -113,7 +115,7 @@ endif
         server-litellm-up server-litellm-wait server-litellm-down db db-local db-ah server-migrate serve install git-hooks \
         check check-max-lines check-server-boundaries test test-server fmt clippy \
         dev-automation-worker \
-        sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build web-build desktop-build build-frontend build rebuild \
+        sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build refresh-dev-runtime-prebuilt web-build desktop-build build-frontend build rebuild \
         desktop-test-build release-desktop-dry-run release-desktop-draft \
         test-agent-spec test-agent-runtime-local test-agent-local-fast test-agent-local \
         test-agent-runtime-cloud-e2b \
@@ -143,6 +145,9 @@ dev-artifacts-ready:
 	elif grep -a -q "sidecar is not available\\|unsupported target placeholder" "$$runtime_bin" 2>/dev/null; then \
 		echo "AnyHarness runtime binary is a sidecar placeholder: $$runtime_bin"; \
 		missing_rust=1; \
+	elif ! node scripts/ci-cd/verify-anyharness-sdk-compat.mjs --binary "$$runtime_bin" --quiet; then \
+		echo "AnyHarness runtime binary is incompatible with the checked-in SDK: $$runtime_bin"; \
+		missing_rust=1; \
 	fi; \
 	for artifact in $(DEV_FRONTEND_ARTIFACTS); do \
 		if [ ! -d "$$artifact" ]; then \
@@ -154,7 +159,11 @@ dev-artifacts-ready:
 		if [ "$$missing_rust" = "1" ] && [ "$$missing_frontend" = "1" ]; then \
 			echo "Run: make build"; \
 		elif [ "$$missing_rust" = "1" ]; then \
-			echo "Run: make build-rust"; \
+			if [ -n "$(SKIP_RUST)" ] && [ "$(SKIP_RUST)" != "0" ]; then \
+				echo "Run when no cargo/rustc build is active: make refresh-dev-runtime-prebuilt"; \
+			else \
+				echo "Run: make build-rust"; \
+			fi; \
 		else \
 			echo "Run: make build-frontend"; \
 		fi; \
@@ -1555,6 +1564,28 @@ build-rust:
 	fi
 
 runtime-build: build-rust
+
+# Build, verify, and atomically install one source/SHA-stamped AnyHarness for
+# frontend-only worktrees. The pgrep gate is intentionally fail-closed because
+# this machine cannot safely run concurrent Rust builds.
+refresh-dev-runtime-prebuilt:
+	@if pgrep -x cargo >/dev/null || pgrep -x rustc >/dev/null; then \
+		echo "Another Rust build is active; wait before refreshing the shared runtime." >&2; \
+		exit 1; \
+	fi
+	@set -e; \
+	source_sha=$$(git rev-parse HEAD); \
+	version=$$(cat VERSION); \
+	env -u CARGO_BUILD_TARGET \
+		CARGO_TARGET_DIR="$(SHARED_DEV_RUNTIME_TARGET_DIR)" \
+		PROLIFERATE_BUILD_VERSION="$$version" \
+		PROLIFERATE_BUILD_SHA="$$source_sha" \
+		$(CARGO) build --release -p anyharness; \
+	node scripts/dev-runtime-prebuilt.mjs \
+		--binary "$(SHARED_DEV_RUNTIME_TARGET_DIR)/release/anyharness" \
+		--destination "$(SHARED_DEV_RUNTIME_BIN)" \
+		--source-sha "$$source_sha" \
+		--version "$$version"
 
 desktop-build: cloud-sdk-build cloud-sdk-react-build sdk-build sdk-react-build shared-build
 	cd apps/desktop && pnpm exec tsc && pnpm exec vite build

--- a/scripts/ci-cd/verify-anyharness-sdk-compat.mjs
+++ b/scripts/ci-cd/verify-anyharness-sdk-compat.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DEFAULT_SDK_OPENAPI = path.join(
+  REPO_ROOT,
+  "anyharness",
+  "sdk",
+  "generated",
+  "openapi.json",
+);
+const HTTP_METHODS = new Set(["delete", "get", "head", "options", "patch", "post", "put", "trace"]);
+
+export function openApiOperations(document) {
+  const operations = new Set();
+  for (const [route, pathItem] of Object.entries(document?.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== "object") {
+      continue;
+    }
+    for (const method of Object.keys(pathItem)) {
+      if (HTTP_METHODS.has(method.toLowerCase())) {
+        operations.add(`${method.toUpperCase()} ${route}`);
+      }
+    }
+  }
+  return operations;
+}
+
+export function assertCompatibleOpenApi(runtimeDocument, sdkDocument) {
+  const runtimeOperations = openApiOperations(runtimeDocument);
+  const sdkOperations = openApiOperations(sdkDocument);
+  const missing = [...sdkOperations]
+    .filter((operation) => !runtimeOperations.has(operation))
+    .sort();
+
+  if (missing.length > 0) {
+    throw new Error(
+      `AnyHarness binary is missing ${missing.length} SDK route(s):\n${missing
+        .map((operation) => `  - ${operation}`)
+        .join("\n")}`,
+    );
+  }
+
+  try {
+    assert.deepStrictEqual(runtimeDocument, sdkDocument);
+  } catch {
+    throw new Error(
+      "AnyHarness binary OpenAPI differs from anyharness/sdk/generated/openapi.json; "
+        + "rebuild the binary and regenerate the SDK from the same source revision.",
+    );
+  }
+}
+
+export async function verifyAnyharnessSdkCompatibility({
+  binaryPath,
+  sdkOpenApiPath = DEFAULT_SDK_OPENAPI,
+  expectedVersion,
+}) {
+  const resolvedBinary = path.resolve(binaryPath);
+  const runtimeResult = spawnSync(resolvedBinary, ["print-openapi"], {
+    encoding: "utf8",
+    env: operationalEnvironment(),
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (runtimeResult.error) {
+    throw new Error(`Could not execute ${resolvedBinary}: ${runtimeResult.error.message}`);
+  }
+  if (runtimeResult.status !== 0) {
+    throw new Error(
+      `${resolvedBinary} print-openapi exited ${runtimeResult.status}: ${runtimeResult.stderr.trim()}`,
+    );
+  }
+
+  let runtimeDocument;
+  let sdkDocument;
+  try {
+    runtimeDocument = JSON.parse(runtimeResult.stdout);
+  } catch (error) {
+    throw new Error(
+      `${resolvedBinary} print-openapi returned invalid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  try {
+    sdkDocument = JSON.parse(await readFile(path.resolve(sdkOpenApiPath), "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Could not read SDK OpenAPI at ${path.resolve(sdkOpenApiPath)}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  assertCompatibleOpenApi(runtimeDocument, sdkDocument);
+
+  let version;
+  if (expectedVersion) {
+    const versionResult = spawnSync(resolvedBinary, ["--version"], {
+      encoding: "utf8",
+      env: operationalEnvironment(),
+    });
+    if (versionResult.error || versionResult.status !== 0) {
+      throw new Error(
+        `Could not read AnyHarness version from ${resolvedBinary}: ${
+          versionResult.error?.message ?? versionResult.stderr.trim()
+        }`,
+      );
+    }
+    version = versionResult.stdout.trim().replace(/^anyharness\s+/, "");
+    if (version !== expectedVersion) {
+      throw new Error(
+        `AnyHarness binary version "${version}" does not match expected version "${expectedVersion}".`,
+      );
+    }
+  }
+
+  return {
+    binaryPath: resolvedBinary,
+    operationCount: openApiOperations(runtimeDocument).size,
+    version,
+  };
+}
+
+function operationalEnvironment(source = process.env) {
+  const result = {};
+  for (const key of [
+    "PATH",
+    "Path",
+    "SYSTEMROOT",
+    "WINDIR",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "NO_COLOR",
+  ]) {
+    if (source[key] !== undefined) {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main() {
+  const binaryPath = argValue("--binary");
+  if (!binaryPath) {
+    throw new Error(
+      "usage: verify-anyharness-sdk-compat --binary <path> "
+        + "[--sdk-openapi <path>] [--expected-version <version>] [--quiet]",
+    );
+  }
+  const proof = await verifyAnyharnessSdkCompatibility({
+    binaryPath,
+    sdkOpenApiPath: argValue("--sdk-openapi"),
+    expectedVersion: argValue("--expected-version"),
+  });
+  if (!process.argv.includes("--quiet")) {
+    const version = proof.version ? ` version=${proof.version}` : "";
+    console.log(
+      `AnyHarness/SDK compatible: ${proof.binaryPath}${version} operations=${proof.operationCount}`,
+    );
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci-cd/verify-anyharness-sdk-compat.test.mjs
+++ b/scripts/ci-cd/verify-anyharness-sdk-compat.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { installDevRuntimePrebuilt } from "../dev-runtime-prebuilt.mjs";
+import {
+  assertCompatibleOpenApi,
+  verifyAnyharnessSdkCompatibility,
+} from "./verify-anyharness-sdk-compat.mjs";
+
+const SOURCE_SHA = "a".repeat(40);
+const OPENAPI = {
+  openapi: "3.1.0",
+  info: { title: "AnyHarness API", version: "1" },
+  paths: {
+    "/health": { get: { operationId: "health" } },
+    "/v1/agents/{kind}/model-snapshot": {
+      get: { operationId: "get_model_snapshot_status" },
+    },
+    "/v1/agents/{kind}/model-snapshot/refresh": {
+      post: { operationId: "refresh_model_snapshot" },
+    },
+  },
+  components: { schemas: {} },
+};
+
+async function fakeAnyharness(dir, document = OPENAPI, version = "9.9.9") {
+  const binaryPath = path.join(dir, "anyharness");
+  await writeFile(
+    binaryPath,
+    `#!/usr/bin/env node
+const command = process.argv[2];
+if (command === "print-openapi") {
+  process.stdout.write(${JSON.stringify(JSON.stringify(document))});
+} else if (command === "--version") {
+  process.stdout.write(${JSON.stringify(`anyharness ${version}\n`)});
+} else {
+  process.exit(64);
+}
+`,
+  );
+  await chmod(binaryPath, 0o755);
+  return binaryPath;
+}
+
+test("reports SDK routes that are absent from the exact runtime binary", () => {
+  const runtime = structuredClone(OPENAPI);
+  delete runtime.paths["/v1/agents/{kind}/model-snapshot"];
+  delete runtime.paths["/v1/agents/{kind}/model-snapshot/refresh"];
+
+  assert.throws(
+    () => assertCompatibleOpenApi(runtime, OPENAPI),
+    (error) => {
+      assert.ok(error.message.includes("GET /v1/agents/{kind}/model-snapshot"));
+      assert.ok(error.message.includes("POST /v1/agents/{kind}/model-snapshot/refresh"));
+      return true;
+    },
+  );
+});
+
+test("verifies OpenAPI and stamped version from one exact executable", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "anyharness-sdk-compat-"));
+  try {
+    const binaryPath = await fakeAnyharness(dir);
+    const sdkOpenApiPath = path.join(dir, "openapi.json");
+    await writeFile(sdkOpenApiPath, JSON.stringify(OPENAPI));
+
+    const proof = await verifyAnyharnessSdkCompatibility({
+      binaryPath,
+      sdkOpenApiPath,
+      expectedVersion: "9.9.9",
+    });
+
+    assert.equal(proof.version, "9.9.9");
+    assert.equal(proof.operationCount, 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("shared dev runtime installation is verified, atomic, and receipted", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "anyharness-prebuilt-"));
+  try {
+    const binaryPath = await fakeAnyharness(dir);
+    const sdkOpenApiPath = path.join(dir, "openapi.json");
+    const destinationPath = path.join(dir, "shared", "anyharness");
+    await writeFile(sdkOpenApiPath, JSON.stringify(OPENAPI));
+
+    const installed = await installDevRuntimePrebuilt({
+      binaryPath,
+      destinationPath,
+      sourceSha: SOURCE_SHA,
+      version: "9.9.9",
+      sdkOpenApiPath,
+    });
+
+    const metadata = JSON.parse(await readFile(installed.metadataPath, "utf8"));
+    assert.equal(metadata.sourceSha, SOURCE_SHA);
+    assert.equal(metadata.version, "9.9.9");
+    assert.equal(metadata.sha256, installed.sha256);
+    assert.equal(metadata.sdkOperationCount, 3);
+    assert.equal(await readFile(destinationPath, "utf8"), await readFile(binaryPath, "utf8"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Desktop release and shared-dev entrypoints fail closed on incompatible artifacts", async () => {
+  const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+  const workflow = await readFile(
+    path.join(repoRoot, ".github", "workflows", "release-desktop.yml"),
+    "utf8",
+  );
+  const makefile = await readFile(path.join(repoRoot, "Makefile"), "utf8");
+
+  assert.match(
+    workflow,
+    /PROLIFERATE_BUILD_VERSION="\$PROLIFERATE_RELEASE_VERSION"[\s\S]*PROLIFERATE_BUILD_SHA="\$\(git rev-parse HEAD\)"[\s\S]*cargo build --release -p anyharness/,
+  );
+  assert.match(
+    workflow,
+    /Verify embedded AnyHarness identity and SDK compatibility[\s\S]*verify-anyharness-sdk-compat\.mjs[\s\S]*--expected-version "\$PROLIFERATE_RELEASE_VERSION"/,
+  );
+  assert.ok(
+    workflow.indexOf("- name: Verify embedded AnyHarness identity and SDK compatibility")
+      < workflow.indexOf("- name: Build Tauri app"),
+    "embedded runtime compatibility must be verified before Tauri packaging",
+  );
+  assert.match(
+    makefile,
+    /dev-artifacts-ready:[\s\S]*verify-anyharness-sdk-compat\.mjs --binary "\$\$runtime_bin" --quiet/,
+  );
+  assert.match(
+    makefile,
+    /refresh-dev-runtime-prebuilt:[\s\S]*pgrep -x cargo[\s\S]*pgrep -x rustc[\s\S]*dev-runtime-prebuilt\.mjs/,
+  );
+});

--- a/scripts/dev-runtime-prebuilt.mjs
+++ b/scripts/dev-runtime-prebuilt.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { verifyAnyharnessSdkCompatibility } from "./ci-cd/verify-anyharness-sdk-compat.mjs";
+
+export async function installDevRuntimePrebuilt({
+  binaryPath,
+  destinationPath,
+  sourceSha,
+  version,
+  sdkOpenApiPath,
+}) {
+  if (!/^[0-9a-f]{40}$/.test(sourceSha)) {
+    throw new Error(`--source-sha must be a lowercase 40-hex Git SHA, got "${sourceSha}"`);
+  }
+  if (!version?.trim()) {
+    throw new Error("--version must be non-empty");
+  }
+
+  const source = path.resolve(binaryPath);
+  const destination = path.resolve(destinationPath);
+  const sourceStats = await stat(source).catch(() => null);
+  if (!sourceStats?.isFile()) {
+    throw new Error(`AnyHarness build output is not a regular file: ${source}`);
+  }
+
+  const proof = await verifyAnyharnessSdkCompatibility({
+    binaryPath: source,
+    sdkOpenApiPath,
+    expectedVersion: version,
+  });
+  const sha256 = createHash("sha256").update(await readFile(source)).digest("hex");
+  const destinationDir = path.dirname(destination);
+  const binaryTemp = path.join(destinationDir, `.${path.basename(destination)}.${process.pid}.tmp`);
+  const metadataPath = `${destination}.json`;
+  const metadataTemp = `${metadataPath}.${process.pid}.tmp`;
+
+  await mkdir(destinationDir, { recursive: true, mode: 0o700 });
+  try {
+    await copyFile(source, binaryTemp);
+    await chmod(binaryTemp, 0o755);
+    await writeFile(
+      metadataTemp,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          sourceSha,
+          version,
+          sha256,
+          sdkOperationCount: proof.operationCount,
+          installedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      )}\n`,
+      { mode: 0o600 },
+    );
+    await rename(binaryTemp, destination);
+    await rename(metadataTemp, metadataPath);
+  } finally {
+    await rm(binaryTemp, { force: true }).catch(() => undefined);
+    await rm(metadataTemp, { force: true }).catch(() => undefined);
+  }
+
+  return { destination, metadataPath, sha256, version, sourceSha };
+}
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main() {
+  const binaryPath = argValue("--binary");
+  const destinationPath = argValue("--destination");
+  const sourceSha = argValue("--source-sha");
+  const version = argValue("--version");
+  if (!binaryPath || !destinationPath || !sourceSha || !version) {
+    throw new Error(
+      "usage: dev-runtime-prebuilt --binary <path> --destination <path> "
+        + "--source-sha <40-hex> --version <version> [--sdk-openapi <path>]",
+    );
+  }
+
+  const installed = await installDevRuntimePrebuilt({
+    binaryPath,
+    destinationPath,
+    sourceSha,
+    version,
+    sdkOpenApiPath: argValue("--sdk-openapi"),
+  });
+  console.log(
+    `Installed compatible AnyHarness ${installed.version} at ${installed.destination} `
+      + `(${installed.sha256.slice(0, 12)}…, source ${installed.sourceSha.slice(0, 12)}).`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/specs/codebase/structures/desktop-native/specs/anyharness-sidecar.md
+++ b/specs/codebase/structures/desktop-native/specs/anyharness-sidecar.md
@@ -30,6 +30,15 @@ desktop renderer.
 5. Packaged Tauri apps place external binaries next to the app executable. On
    macOS this means the sidecar binary is resolved from the app bundle's
    `Contents/MacOS` directory.
+6. The Desktop release workflow builds AnyHarness from the exact checked-out
+   release SHA, stamps it with the Desktop release version and source SHA,
+   copies that exact file into `binaries/`, and passes it back through
+   `ANYHARNESS_BIN` during the Tauri build.
+7. Before seed or Desktop packaging, the release workflow runs the staged
+   binary's `print-openapi` command and requires exact equality with
+   `anyharness/sdk/generated/openapi.json`. It also requires `--version` to
+   equal the Desktop release version. A renderer/SDK route that is absent from
+   the embedded binary therefore fails the release before a package is built.
 
 The Proliferate Worker binary follows the same staging/bundling model, but it
 is not the AnyHarness sidecar. It is launched on demand by desktop dispatch

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -205,6 +205,13 @@ workflows all operate on the same immutable `sha-<12>` plus rolling
 `staging`/`production` family; they are separate entrypoints, not separate
 artifact identities.
 
+The Desktop artifact includes an AnyHarness sidecar built from the same exact
+source SHA. That embedded binary carries the Desktop release version and source
+SHA, and its generated OpenAPI must exactly match the checked-in AnyHarness SDK
+OpenAPI before Tauri packaging. The standalone `runtime-v*` coordinate remains
+distinct; Desktop does not substitute a mutable installed or PATH runtime for
+its staged sidecar.
+
 Server releases publish server and LiteLLM GHCR images with version and rolling
 `stable` tags, never commit-SHA image tags. A `server-v<version>` GitHub Release
 also holds the two Linux runtime bundles, CloudFormation template, installer,

--- a/specs/developing/deploying/releases.md
+++ b/specs/developing/deploying/releases.md
@@ -78,6 +78,13 @@ job publishes signed versioned artifacts plus immutable and rolling
 Release and the live manifests. Product-side update behavior remains owned by
 [Desktop Updates](../../codebase/systems/engineering/delivery/desktop-updates.md).
 
+The embedded AnyHarness is built from the same checked-out SHA and stamped with
+the Desktop release version plus that SHA. Before seed creation or Tauri
+packaging, the workflow requires its `--version` output to match and its
+`print-openapi` document to equal the checked-in AnyHarness SDK OpenAPI
+document. A missing renderer/SDK route or an unstamped/stale sidecar fails the
+release rather than producing a Desktop package.
+
 ## Runtime And SDK
 
 Runtime releases use `runtime-v<version>`. The workflow builds AnyHarness

--- a/specs/developing/local/README.md
+++ b/specs/developing/local/README.md
@@ -57,6 +57,37 @@ Bypassing is safe for work in progress: CI runs the same
 design package's `build` re-runs the theme equality check, so a bypassed
 violation is caught before merge rather than silently landing.
 
+## Shared Prebuilt Runtime
+
+Frontend-only worktrees may use one shared AnyHarness binary without compiling
+Rust in every worktree:
+
+```bash
+SKIP_RUST=1 \
+ANYHARNESS_DEV_RUNTIME_BIN=~/.proliferate-local/dev/runtime-bin/anyharness \
+make run PROFILE=<name>
+```
+
+`dev-artifacts-ready` executes that exact binary's `print-openapi` command and
+requires its contract to equal the checked-in AnyHarness SDK OpenAPI document.
+An executable merely existing at the path is not sufficient. Contract drift,
+including a frontend/SDK route absent from the binary, fails before the profile
+starts.
+
+Refresh the shared artifact only when no `cargo` or `rustc` process is active:
+
+```bash
+make refresh-dev-runtime-prebuilt
+```
+
+The target fails closed when another Rust build is running, builds AnyHarness
+from the current worktree with the repository version and exact Git SHA,
+verifies version and SDK contract, then atomically installs the binary at
+`~/.proliferate-local/dev/runtime-bin/anyharness`. Its adjacent
+`anyharness.json` receipt records the source SHA, version, SHA-256, SDK
+operation count, and installation time. Already-running profiles keep their
+existing process; restart them explicitly to pick up the replaced artifact.
+
 ## What Starts
 
 `make run PROFILE=<name>` launches the profile's:


### PR DESCRIPTION
## Summary

- stamp the Desktop-embedded AnyHarness with the release version and exact source SHA
- fail Desktop packaging and local startup when the exact runtime OpenAPI differs from the checked-in SDK contract
- add a guarded, verified, atomic shared-dev runtime refresh path with a source/checksum receipt
- document the release and local artifact-compatibility contract

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship applies, and no private source data is included.

## Verification

- `node --test scripts/ci-cd/verify-anyharness-sdk-compat.test.mjs scripts/ci-cd/detect-deploy-surfaces.test.mjs`
- `python3 scripts/check_docs.py`
- workflow YAML parse for `.github/workflows/release-desktop.yml` and `.github/workflows/ci.yml`
- `git diff --check`
- verified the installed Desktop v0.3.50 binary matches its tagged SDK contract
- verified the stale shared runtime fails the current SDK contract, then checksum-verified and installed published `runtime-v0.3.51` with all 148 current SDK operations

No Rust build or Docker action was run because the machine was under memory pressure.