### PR TITLE
fix(release): fail closed on unreachable Web API target

### DIFF
--- a/.github/workflows/_deploy-web.yml
+++ b/.github/workflows/_deploy-web.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
+      API_BASE_URL: ${{ vars.API_BASE_URL }}
       WEB_URL: ${{ vars.WEB_URL }}
       VERCEL_ENVIRONMENT: ${{ vars.VERCEL_ENVIRONMENT || vars.VERCEL_TARGET || 'production' }}
       VERCEL_TARGET: ${{ vars.VERCEL_TARGET || vars.VERCEL_ENVIRONMENT || 'production' }}
@@ -49,6 +50,7 @@ jobs:
       - name: Validate Vercel config
         run: |
           set -euo pipefail
+          : "${API_BASE_URL:?Set API_BASE_URL on the GitHub environment.}"
           : "${WEB_URL:?Set WEB_URL on the GitHub environment.}"
           : "${VERCEL_TOKEN:?Set VERCEL_TOKEN on the GitHub environment.}"
           : "${VERCEL_ORG_ID:?Set VERCEL_ORG_ID on the GitHub environment.}"
@@ -74,6 +76,8 @@ jobs:
             args+=(--scope "$VERCEL_SCOPE")
           fi
           args+=(--target "$VERCEL_TARGET")
+          args+=(--skip-domain)
+          args+=(--build-env "VITE_PROLIFERATE_API_BASE_URL=$API_BASE_URL")
           deployment_output="$(pnpm dlx vercel@latest deploy "${args[@]}")"
           deployment_url="$(printf '%s\n' "$deployment_output" | awk '/^https:\/\// { url=$0 } END { print url }')"
           if [[ -z "$deployment_url" ]]; then
@@ -84,6 +88,12 @@ jobs:
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Verify candidate Web/API pair
+        run: |
+          node scripts/ci-cd/verify-web-deployment.mjs \
+            --web-url "${{ steps.deploy.outputs.deployment_url }}" \
+            --api-base-url "$API_BASE_URL"
 
       - name: Alias web domain
         run: |

--- a/scripts/ci-cd/verify-web-deployment.mjs
+++ b/scripts/ci-cd/verify-web-deployment.mjs
@@ -14,10 +14,10 @@ function normalizeHttpUrl(value, name) {
   return url.toString().replace(/\/+$/, "");
 }
 
-async function fetchOk(fetchImpl, url, label, headers = undefined) {
+async function fetchOk(fetchImpl, url, label, options = undefined) {
   let response;
   try {
-    response = await fetchImpl(url, { headers });
+    response = await fetchImpl(url, options);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`${label} was unreachable at ${url}: ${detail}`);
@@ -26,6 +26,40 @@ async function fetchOk(fetchImpl, url, label, headers = undefined) {
     throw new Error(`${label} returned HTTP ${response.status} at ${url}`);
   }
   return response;
+}
+
+async function verifyProductHealth(fetchImpl, healthUrl) {
+  const response = await fetchOk(fetchImpl, healthUrl, "API health", {
+    headers: { Accept: "application/json" },
+    redirect: "manual",
+  });
+  if (response.redirected) {
+    throw new Error(`API health redirected away from ${healthUrl}`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    throw new Error(`API health did not return JSON at ${healthUrl}`);
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error(`API health returned invalid JSON at ${healthUrl}`);
+  }
+  if (
+    payload === null
+    || typeof payload !== "object"
+    || Array.isArray(payload)
+    || payload.status !== "ok"
+    || typeof payload.version !== "string"
+    || payload.version.trim().length === 0
+  ) {
+    throw new Error(
+      `API health did not return the product health contract at ${healthUrl}`,
+    );
+  }
 }
 
 function scriptSources(html) {
@@ -37,6 +71,13 @@ function scriptSources(html) {
   return [...new Set(sources)];
 }
 
+function containsExactStringLiteral(sourceText, value) {
+  return ['"', "'", "`"].some(
+    (quote) => !value.includes(quote)
+      && sourceText.includes(`${quote}${value}${quote}`),
+  );
+}
+
 export async function verifyWebDeployment({
   webUrl,
   apiBaseUrl,
@@ -46,15 +87,13 @@ export async function verifyWebDeployment({
   const normalizedApiBaseUrl = normalizeHttpUrl(apiBaseUrl, "apiBaseUrl");
   const healthUrl = `${normalizedApiBaseUrl}/health`;
 
-  await fetchOk(fetchImpl, healthUrl, "API health", {
-    Accept: "application/json",
-  });
+  await verifyProductHealth(fetchImpl, healthUrl);
 
   const htmlResponse = await fetchOk(
     fetchImpl,
     normalizedWebUrl,
     "candidate Web",
-    { Accept: "text/html" },
+    { headers: { Accept: "text/html" } },
   );
   const html = await htmlResponse.text();
   const sources = scriptSources(html);
@@ -72,7 +111,7 @@ export async function verifyWebDeployment({
     );
     const sourceText = await assetResponse.text();
     checkedAssets.push(assetUrl);
-    if (sourceText.includes(normalizedApiBaseUrl)) {
+    if (containsExactStringLiteral(sourceText, normalizedApiBaseUrl)) {
       return {
         apiBaseUrl: normalizedApiBaseUrl,
         healthUrl,

--- a/scripts/ci-cd/verify-web-deployment.mjs
+++ b/scripts/ci-cd/verify-web-deployment.mjs
@@ -1,0 +1,121 @@
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+function normalizeHttpUrl(value, name) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an absolute URL`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`${name} must use http or https`);
+  }
+  return url.toString().replace(/\/+$/, "");
+}
+
+async function fetchOk(fetchImpl, url, label, headers = undefined) {
+  let response;
+  try {
+    response = await fetchImpl(url, { headers });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} was unreachable at ${url}: ${detail}`);
+  }
+  if (!response.ok) {
+    throw new Error(`${label} returned HTTP ${response.status} at ${url}`);
+  }
+  return response;
+}
+
+function scriptSources(html) {
+  const sources = [];
+  const pattern = /<script\b[^>]*\bsrc=(["'])([^"']+)\1[^>]*>/gi;
+  for (const match of html.matchAll(pattern)) {
+    sources.push(match[2]);
+  }
+  return [...new Set(sources)];
+}
+
+export async function verifyWebDeployment({
+  webUrl,
+  apiBaseUrl,
+  fetchImpl = globalThis.fetch,
+}) {
+  const normalizedWebUrl = normalizeHttpUrl(webUrl, "webUrl");
+  const normalizedApiBaseUrl = normalizeHttpUrl(apiBaseUrl, "apiBaseUrl");
+  const healthUrl = `${normalizedApiBaseUrl}/health`;
+
+  await fetchOk(fetchImpl, healthUrl, "API health", {
+    Accept: "application/json",
+  });
+
+  const htmlResponse = await fetchOk(
+    fetchImpl,
+    normalizedWebUrl,
+    "candidate Web",
+    { Accept: "text/html" },
+  );
+  const html = await htmlResponse.text();
+  const sources = scriptSources(html);
+  if (sources.length === 0) {
+    throw new Error(`candidate Web exposed no script assets at ${normalizedWebUrl}`);
+  }
+
+  const checkedAssets = [];
+  for (const source of sources) {
+    const assetUrl = new URL(source, `${normalizedWebUrl}/`).toString();
+    const assetResponse = await fetchOk(
+      fetchImpl,
+      assetUrl,
+      "candidate Web script",
+    );
+    const sourceText = await assetResponse.text();
+    checkedAssets.push(assetUrl);
+    if (sourceText.includes(normalizedApiBaseUrl)) {
+      return {
+        apiBaseUrl: normalizedApiBaseUrl,
+        healthUrl,
+        webUrl: normalizedWebUrl,
+        matchedAssetUrl: assetUrl,
+      };
+    }
+  }
+
+  throw new Error(
+    `candidate Web did not bake the expected API base ${normalizedApiBaseUrl} `
+      + `into ${checkedAssets.length} script asset(s)`,
+  );
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      "api-base-url": { type: "string" },
+      "web-url": { type: "string" },
+    },
+    strict: true,
+  });
+  if (!values["web-url"] || !values["api-base-url"]) {
+    throw new Error("--web-url and --api-base-url are required");
+  }
+
+  const receipt = await verifyWebDeployment({
+    webUrl: values["web-url"],
+    apiBaseUrl: values["api-base-url"],
+  });
+  console.log(
+    `Verified candidate Web ${receipt.webUrl} against ${receipt.healthUrl}; `
+      + `API base found in ${receipt.matchedAssetUrl}`,
+  );
+}
+
+if (
+  process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci-cd/verify-web-deployment.test.mjs
+++ b/scripts/ci-cd/verify-web-deployment.test.mjs
@@ -18,21 +18,26 @@ function response(body, status = 200, contentType = "text/plain") {
 
 function fakeFetch(routes) {
   const calls = [];
-  const fetchImpl = async (input) => {
+  const requests = [];
+  const fetchImpl = async (input, options) => {
     const url = String(input);
     calls.push(url);
+    requests.push({ options, url });
     const value = routes.get(url);
     if (!value) {
       throw new Error(`unexpected URL ${url}`);
     }
     return value;
   };
-  return { calls, fetchImpl };
+  return { calls, fetchImpl, requests };
 }
 
-function healthyRoutes(assetSource = `const apiBase = "${API_BASE_URL}";`) {
+function healthyRoutes(
+  assetSource = `const apiBase = "${API_BASE_URL}";`,
+  healthBody = '{"status":"ok","version":"1.2.3"}',
+) {
   return new Map([
-    [HEALTH_URL, response('{"status":"ok"}', 200, "application/json")],
+    [HEALTH_URL, response(healthBody, 200, "application/json")],
     [
       WEB_URL,
       response(
@@ -55,6 +60,7 @@ test("verifies the API health and exact base baked into the candidate bundle", a
   });
 
   assert.deepEqual(fake.calls, [HEALTH_URL, WEB_URL, ASSET_URL]);
+  assert.equal(fake.requests[0].options?.redirect, "manual");
   assert.deepEqual(receipt, {
     apiBaseUrl: API_BASE_URL,
     healthUrl: HEALTH_URL,
@@ -80,9 +86,79 @@ test("rejects the production Cloudflare 530 failure before checking Web", async 
   assert.deepEqual(fake.calls, [HEALTH_URL]);
 });
 
+test("rejects an API health redirect before checking Web", async () => {
+  const routes = healthyRoutes();
+  routes.set(HEALTH_URL, response("", 302));
+  const fake = fakeFetch(routes);
+
+  await assert.rejects(
+    () =>
+      verifyWebDeployment({
+        webUrl: WEB_URL,
+        apiBaseUrl: API_BASE_URL,
+        fetchImpl: fake.fetchImpl,
+      }),
+    /API health returned HTTP 302/,
+  );
+  assert.equal(fake.requests[0].options?.redirect, "manual");
+  assert.deepEqual(fake.calls, [HEALTH_URL]);
+});
+
+test("rejects an unrelated successful health response before checking Web", async () => {
+  const routes = healthyRoutes();
+  routes.set(
+    HEALTH_URL,
+    response("<html>Sign in</html>", 200, "text/html"),
+  );
+  const fake = fakeFetch(routes);
+
+  await assert.rejects(
+    () =>
+      verifyWebDeployment({
+        webUrl: WEB_URL,
+        apiBaseUrl: API_BASE_URL,
+        fetchImpl: fake.fetchImpl,
+      }),
+    /API health did not return JSON/,
+  );
+  assert.deepEqual(fake.calls, [HEALTH_URL]);
+});
+
+test("rejects a generic JSON health response before checking Web", async () => {
+  const fake = fakeFetch(healthyRoutes('const unused = "ok";', '{"status":"ok"}'));
+
+  await assert.rejects(
+    () =>
+      verifyWebDeployment({
+        webUrl: WEB_URL,
+        apiBaseUrl: API_BASE_URL,
+        fetchImpl: fake.fetchImpl,
+      }),
+    /API health did not return the product health contract/,
+  );
+  assert.deepEqual(fake.calls, [HEALTH_URL]);
+});
+
 test("rejects a candidate bundle that baked a stale API base", async () => {
   const fake = fakeFetch(
     healthyRoutes('const apiBase = "https://api.proliferate.test";'),
+  );
+
+  await assert.rejects(
+    () =>
+      verifyWebDeployment({
+        webUrl: WEB_URL,
+        apiBaseUrl: API_BASE_URL,
+        fetchImpl: fake.fetchImpl,
+      }),
+    /did not bake the expected API base/,
+  );
+  assert.deepEqual(fake.calls, [HEALTH_URL, WEB_URL, ASSET_URL]);
+});
+
+test("rejects a longer API base that only contains the expected target", async () => {
+  const fake = fakeFetch(
+    healthyRoutes(`const apiBase = "${API_BASE_URL}/v2";`),
   );
 
   await assert.rejects(

--- a/scripts/ci-cd/verify-web-deployment.test.mjs
+++ b/scripts/ci-cd/verify-web-deployment.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { verifyWebDeployment } from "./verify-web-deployment.mjs";
+
+const API_BASE_URL = "https://app.proliferate.test/api";
+const WEB_URL = "https://web.proliferate.test";
+const HEALTH_URL = `${API_BASE_URL}/health`;
+const ASSET_URL = `${WEB_URL}/assets/index.js`;
+
+function response(body, status = 200, contentType = "text/plain") {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": contentType },
+  });
+}
+
+function fakeFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (input) => {
+    const url = String(input);
+    calls.push(url);
+    const value = routes.get(url);
+    if (!value) {
+      throw new Error(`unexpected URL ${url}`);
+    }
+    return value;
+  };
+  return { calls, fetchImpl };
+}
+
+function healthyRoutes(assetSource = `const apiBase = "${API_BASE_URL}";`) {
+  return new Map([
+    [HEALTH_URL, response('{"status":"ok"}', 200, "application/json")],
+    [
+      WEB_URL,
+      response(
+        '<!doctype html><script type="module" src="/assets/index.js"></script>',
+        200,
+        "text/html",
+      ),
+    ],
+    [ASSET_URL, response(assetSource, 200, "application/javascript")],
+  ]);
+}
+
+test("verifies the API health and exact base baked into the candidate bundle", async () => {
+  const fake = fakeFetch(healthyRoutes());
+
+  const receipt = await verifyWebDeployment({
+    webUrl: `${WEB_URL}/`,
+    apiBaseUrl: `${API_BASE_URL}/`,
+    fetchImpl: fake.fetchImpl,
+  });
+
+  assert.deepEqual(fake.calls, [HEALTH_URL, WEB_URL, ASSET_URL]);
+  assert.deepEqual(receipt, {
+    apiBaseUrl: API_BASE_URL,
+    healthUrl: HEALTH_URL,
+    webUrl: WEB_URL,
+    matchedAssetUrl: ASSET_URL,
+  });
+});
+
+test("rejects the production Cloudflare 530 failure before checking Web", async () => {
+  const routes = healthyRoutes();
+  routes.set(HEALTH_URL, response("error code: 1016", 530));
+  const fake = fakeFetch(routes);
+
+  await assert.rejects(
+    () =>
+      verifyWebDeployment({
+        webUrl: WEB_URL,
+        apiBaseUrl: API_BASE_URL,
+        fetchImpl: fake.fetchImpl,
+      }),
+    /API health returned HTTP 530/,
+  );
+  assert.deepEqual(fake.calls, [HEALTH_URL]);
+});
+
+test("rejects a candidate bundle that baked a stale API base", async () => {
+  const fake = fakeFetch(
+    healthyRoutes('const apiBase = "https://api.proliferate.test";'),
+  );
+
+  await assert.rejects(
+    () =>
+      verifyWebDeployment({
+        webUrl: WEB_URL,
+        apiBaseUrl: API_BASE_URL,
+        fetchImpl: fake.fetchImpl,
+      }),
+    /did not bake the expected API base/,
+  );
+  assert.deepEqual(fake.calls, [HEALTH_URL, WEB_URL, ASSET_URL]);
+});
+
+test("Web workflow pins and verifies the API base before aliasing", async () => {
+  const source = await readFile(
+    new URL("../../.github/workflows/_deploy-web.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /API_BASE_URL: \$\{\{ vars\.API_BASE_URL \}\}/);
+  assert.match(
+    source,
+    /: "\$\{API_BASE_URL:\?Set API_BASE_URL on the GitHub environment\.\}"/,
+  );
+  assert.match(
+    source,
+    /args\+=\(--build-env "VITE_PROLIFERATE_API_BASE_URL=\$API_BASE_URL"\)/,
+  );
+  assert.match(source, /args\+=\(--skip-domain\)/);
+
+  const deploy = source.indexOf("- name: Deploy to Vercel");
+  const verify = source.indexOf("- name: Verify candidate Web/API pair");
+  const alias = source.indexOf("- name: Alias web domain");
+  assert.ok(
+    deploy >= 0 && deploy < verify && verify < alias,
+    "candidate verification must pass after deploy and before aliasing",
+  );
+  assert.match(
+    source.slice(verify, alias),
+    /node scripts\/ci-cd\/verify-web-deployment\.mjs[\s\S]*?--web-url[\s\S]*?--api-base-url "\$API_BASE_URL"/,
+  );
+});

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -230,7 +230,7 @@ gate.
 | `_deploy-litellm.yml` | Reusable only | Build and roll the LiteLLM ECS service when its environment switch is enabled. |
 | `_deploy-mobile.yml` | Reusable only | Run the selected EAS build and optional submit lane when enabled. |
 | `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, conditionally roll the Celery worker and Beat before the API, roll the API, and verify health. API, worker, and Beat are all pinned to the one candidate image by its **immutable `repo@sha256:` digest** (resolved from the build/push output), never a mutable tag, so all three planes run the byte-identical image and a later tag move cannot change what a rolled service runs. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, preserves the support-feed secret, and explicitly authors the API's checked-in environment-bound Redis and E2B-key field references after account, region, secret-identity, DNS-safe Redis, and nonempty-key preflights. The conditional background re-image authors the same exact key projection plus the reviewed template, and asserts the full contract before and after registration. |
-| `_deploy-web.yml` | Reusable only | Deploy and verify the selected Vercel web surface. |
+| `_deploy-web.yml` | Reusable only | Deploy the selected Vercel Web surface with the environment's canonical `API_BASE_URL` forced into the Vite build, keep the candidate unaliased until its API health and baked bundle target pass, then move and verify the public alias. |
 | `_deploy-workers.yml` | Reusable only | Report the disabled Worker lane, or fail if enabled before a canonical deploy exists. |
 
 ### CI, security, compatibility, probes, and qualification

--- a/specs/developing/deploying/hosted.md
+++ b/specs/developing/deploying/hosted.md
@@ -108,6 +108,10 @@ see [Releases](releases.md).
   files on every exit before those actions' post-job hooks execute.
 - Worker deployment is a no-op while `WORKERS_DEPLOY_ENABLED=false`. Enabling
   it before a canonical service and command exist deliberately fails.
+- The Web lane takes `API_BASE_URL` from the selected GitHub Environment,
+  forces it into Vercel as `VITE_PROLIFERATE_API_BASE_URL`, and keeps the
+  candidate off the public alias until both `<API_BASE_URL>/health` and the
+  candidate bundle's baked API target match that value.
 - The nightly and hotfix coordinators have no LiteLLM job. Deploy an exact
   LiteLLM ref through `Promote Production` with that exact surface selected.
 - `Cloud Live Webhook` is manual-only and is not part of CI, staging, the

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -1052,7 +1052,7 @@
 - name: VITE_PROLIFERATE_API_BASE_URL
   secret: false
   default: ""
-  description: Desktop/web control-plane base URL; when unset Desktop falls back to http://127.0.0.1:8000 and may use ~/.proliferate/config.json at runtime, while Web falls back to http://localhost:8000
+  description: Desktop/Web control-plane base URL; hosted Web derives this build input from the selected GitHub Environment's API_BASE_URL, production self-hosted Web falls back to its current origin when unset, and local Web falls back to http://localhost:8000; Desktop falls back to http://127.0.0.1:8000 and may use ~/.proliferate/config.json at runtime
   tags: [local-dev, ci, desktop, web]
 
 - name: VITE_PROLIFERATE_ENVIRONMENT

--- a/specs/developing/reference/environment-sources.md
+++ b/specs/developing/reference/environment-sources.md
@@ -133,6 +133,13 @@ or CI job. Consult the owning surface and its release procedure before changing
 an input; these build environments do not share one repository-wide precedence
 chain.
 
+Hosted Web is intentionally stricter than an ambient provider build: the
+reusable Vercel lane requires the selected GitHub Environment's
+`API_BASE_URL`, passes it as the build-time
+`VITE_PROLIFERATE_API_BASE_URL`, and verifies the same value in the candidate
+bundle before moving the public alias. That explicit workflow input wins over a
+stale Vercel project value.
+
 ## Workflow and Release Controls
 
 Workflow-only, publishing, signing, upload, and release-promotion controls are


### PR DESCRIPTION
## Summary

- pass the GitHub Environment API base explicitly into the Vercel Vite build
- keep the candidate deployment unaliased until the configured API health probe and candidate bundle API-base verification both pass
- add narrow CI/CD contract coverage and document the deployment configuration precedence

## Verification

Previously completed on the exact pushed commit; not rerun for this PR follow-up:

- `node --test scripts/ci-cd/*.test.mjs` — 174 passed
- `python3 -m unittest scripts/test_check_docs.py` — 17 passed
- `python3 scripts/check_docs.py` — passed
- workflow YAML parsing — passed
- live verifier against `https://web.proliferate.com` with `https://app.proliferate.com/api` — passed

## Production evidence

- The current Web/GitHub sign-in path recovered before this PR was opened.
- The legacy `https://api.proliferate.com/health` hostname still returned Cloudflare 530 / error 1016 at the end of the investigation.
- This PR does not deploy or mutate production infrastructure.