### PR TITLE
fix(cloud): block exhausted starts before workspace provisioning

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -35,6 +35,7 @@ import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/works
 import { workspaceAvailabilityIntentForCommand } from "#product/lib/domain/workspaces/cloud/workspace-availability-intent-mapping";
 import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/sidebar/sidebar-model";
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
+import { useSelectedCloudOwner } from "#product/hooks/organizations/derived/use-selected-cloud-owner";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
 import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
@@ -78,7 +79,8 @@ export const MainSidebar = memo(function MainSidebar() {
     authStatus: cloudAuthStatus,
     cloudComputeEnabled,
   } = useCloudAvailabilityState();
-  const { data: billingPlan } = useCloudBilling();
+  const selectedCloudOwner = useSelectedCloudOwner();
+  const { data: billingPlan } = useCloudBilling(selectedCloudOwner);
   const {
     data: repoConfigs,
     isPending: isRepoConfigsPending,

--- a/apps/packages/product-client/src/hooks/app/workflows/use-app-new-workspace-command-actions.ts
+++ b/apps/packages/product-client/src/hooks/app/workflows/use-app-new-workspace-command-actions.ts
@@ -5,6 +5,7 @@ import { useRepositories } from "@proliferate/cloud-sdk-react";
 import { APP_ROUTES } from "#product/config/app-routes";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
+import { useSelectedCloudOwner } from "#product/hooks/organizations/derived/use-selected-cloud-owner";
 import { useCreateCloudWorkspace } from "#product/hooks/cloud/workflows/use-create-cloud-workspace";
 import { useHomeNextRepositorySelection } from "#product/hooks/home/derived/use-home-next-repository-selection";
 import { useHomeNextTargetSelectionSnapshot } from "#product/hooks/home/ui/use-home-next-target-selection-state";
@@ -53,7 +54,8 @@ export function useAppNewWorkspaceCommandActions(): AppNewWorkspaceCommandAction
   });
   const activeNewWorkspaceScope = useNewWorkspaceCommandScopeStore((state) => state.activeScope);
   const { cloudActive } = useCloudAvailabilityState();
-  const { data: billingPlan } = useCloudBilling();
+  const selectedCloudOwner = useSelectedCloudOwner();
+  const { data: billingPlan } = useCloudBilling(selectedCloudOwner);
   const {
     data: repoConfigs,
     isPending: isRepoConfigsPending,

--- a/apps/packages/product-client/src/hooks/cloud/workflows/use-cloud-workspace-start-preflight.ts
+++ b/apps/packages/product-client/src/hooks/cloud/workflows/use-cloud-workspace-start-preflight.ts
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+import { useCloudBillingQuery } from "#product/hooks/access/cloud/use-cloud-billing";
+import { useAppCapabilities } from "#product/hooks/capabilities/derived/use-app-capabilities";
+import { useSelectedCloudOwner } from "#product/hooks/organizations/derived/use-selected-cloud-owner";
+import {
+  resolveCloudWorkspaceStartPreflight,
+  type CloudWorkspaceStartPreflight,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
+import { descriptionForStartBlockReason } from "#product/lib/domain/workspaces/cloud/cloud-workspace-status-presentation";
+
+const BILLING_PREFLIGHT_UNAVAILABLE =
+  "Billing state could not be read. Please retry before starting Cloud work.";
+
+/**
+ * Fresh owner-scoped billing gate for every managed-Cloud start.
+ *
+ * The check deliberately runs on the user action, before any optimistic
+ * workspace or session state is created. The create endpoint still owns the
+ * authoritative gate; this preflight prevents a known block from becoming a
+ * dead client-only workspace while preserving the server's typed denial.
+ */
+export function useCloudWorkspaceStartPreflight() {
+  const { billingEnabled } = useAppCapabilities();
+  const selectedOwner = useSelectedCloudOwner();
+  const billingQuery = useCloudBillingQuery(selectedOwner, { enabled: false });
+
+  const preflightCloudWorkspaceStart = useCallback(
+    async (): Promise<CloudWorkspaceStartPreflight> => {
+      if (!billingEnabled) {
+        return { status: "allowed" };
+      }
+
+      try {
+        const result = await billingQuery.refetch({ throwOnError: true });
+        if (!result.data) {
+          return {
+            status: "unavailable",
+            message: BILLING_PREFLIGHT_UNAVAILABLE,
+          };
+        }
+        return resolveCloudWorkspaceStartPreflight(
+          result.data,
+          descriptionForStartBlockReason,
+        );
+      } catch {
+        return {
+          status: "unavailable",
+          message: BILLING_PREFLIGHT_UNAVAILABLE,
+        };
+      }
+    },
+    [billingEnabled, billingQuery.refetch],
+  );
+
+  return { preflightCloudWorkspaceStart };
+}

--- a/apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
+++ b/apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts
@@ -8,6 +8,7 @@ import {
   buildNextCloudWorkspaceAttempt,
   collectKnownCloudBranchNames,
   buildCloudWorkspaceAttemptFromRequest,
+  type CloudWorkspaceStartPreflight,
   type CloudWorkspaceRepoTarget,
   isCloudWorkspaceBranchConflictError,
   resolveCloudWorkspaceCreateFailureMessage,
@@ -36,6 +37,7 @@ import {
   logLatency,
   startLatencyTimer,
 } from "#product/lib/infra/measurement/measurement-port";
+import { useCloudWorkspaceStartPreflight } from "#product/hooks/cloud/workflows/use-cloud-workspace-start-preflight";
 
 const MAX_CLOUD_CREATE_ATTEMPTS = 3;
 
@@ -43,6 +45,7 @@ interface CreateCloudWorkspaceAndEnterOptions {
   repoGroupKeyToExpand?: string | null;
   latencyFlowId?: string | null;
   initialSession?: PendingWorkspaceInitialSession | null;
+  startPreflight?: CloudWorkspaceStartPreflight;
 }
 
 export type CloudWorkspaceEntryResult =
@@ -84,6 +87,7 @@ function buildRepoTargetFromRequest(
 
 export function useCreateCloudWorkspace() {
   const telemetry = useProductTelemetry();
+  const { preflightCloudWorkspaceStart } = useCloudWorkspaceStartPreflight();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const setPendingWorkspaceEntry = useSessionSelectionStore((state) => state.setPendingWorkspaceEntry);
   const branchPrefixType = useUserPreferencesStore((state) => state.branchPrefixType);
@@ -138,7 +142,17 @@ export function useCreateCloudWorkspace() {
     repoGroupKeyToExpand?: string | null;
     latencyFlowId?: string | null;
     initialSession?: PendingWorkspaceInitialSession | null;
+    startPreflight?: CloudWorkspaceStartPreflight;
   }): Promise<CloudWorkspaceEntryResult> => {
+    const startPreflight =
+      args.startPreflight ?? await preflightCloudWorkspaceStart();
+    if (startPreflight.status !== "allowed") {
+      return {
+        status: "interrupted",
+        failureMessage: startPreflight.message,
+      };
+    }
+
     const startedAt = startLatencyTimer();
     const repoLabel = `${args.target.gitOwner}/${args.target.gitRepoName}`;
     const attemptId = createPendingWorkspaceAttemptId();
@@ -321,6 +335,7 @@ export function useCreateCloudWorkspace() {
     failPendingEntry,
     finalizeSelection,
     getWorkspaceCollections,
+    preflightCloudWorkspaceStart,
     selectWorkspace,
     setPendingWorkspaceEntry,
     telemetry,
@@ -336,6 +351,7 @@ export function useCreateCloudWorkspace() {
       repoGroupKeyToExpand: options?.repoGroupKeyToExpand,
       latencyFlowId: options?.latencyFlowId,
       initialSession: options?.initialSession,
+      startPreflight: options?.startPreflight,
     });
   }, [runCloudWorkspaceCreateFlow]);
 
@@ -349,6 +365,7 @@ export function useCreateCloudWorkspace() {
       repoGroupKeyToExpand: options?.repoGroupKeyToExpand,
       latencyFlowId: options?.latencyFlowId,
       initialSession: options?.initialSession,
+      startPreflight: options?.startPreflight,
     });
   }, [runCloudWorkspaceCreateFlow]);
 

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => {
     createThreadFromSelection,
     createWorktreeAndEnterWithResult: vi.fn(),
     navigate: vi.fn(),
+    preflightCloudWorkspaceStart: vi.fn(),
     productHost: { desktop: {} as object | null },
     selectWorkspace: vi.fn(),
     showToast: vi.fn(),
@@ -61,6 +62,12 @@ vi.mock("#product/stores/toast/toast-store", () => ({
 vi.mock("#product/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
   useCreateCloudWorkspace: () => ({
     createCloudWorkspaceAndEnterWithResult: mocks.createCloudWorkspaceAndEnterWithResult,
+  }),
+}));
+
+vi.mock("#product/hooks/cloud/workflows/use-cloud-workspace-start-preflight", () => ({
+  useCloudWorkspaceStartPreflight: () => ({
+    preflightCloudWorkspaceStart: mocks.preflightCloudWorkspaceStart,
   }),
 }));
 
@@ -118,6 +125,7 @@ function renderHomeNextLaunch() {
 describe("useHomeNextLaunch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.preflightCloudWorkspaceStart.mockResolvedValue({ status: "allowed" });
     mocks.productHost.desktop = {};
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
@@ -312,8 +320,54 @@ describe("useHomeNextLaunch", () => {
     });
 
     expect(mocks.useCoworkThreadWorkflow).not.toHaveBeenCalled();
+    expect(mocks.preflightCloudWorkspaceStart).toHaveBeenCalledTimes(1);
     expect(mocks.createCloudWorkspaceAndEnterWithResult).toHaveBeenCalledTimes(1);
+    expect(mocks.createCloudWorkspaceAndEnterWithResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gitOwner: "proliferate-ai",
+        gitRepoName: "proliferate",
+      }),
+      expect.objectContaining({
+        startPreflight: { status: "allowed" },
+      }),
+    );
     expect(mocks.createLocalWorkspaceAndEnterWithResult).not.toHaveBeenCalled();
     expect(mocks.createWorktreeAndEnterWithResult).not.toHaveBeenCalled();
+  });
+
+  it("rejects an exhausted Cloud start before creating a visible draft or workspace", async () => {
+    mocks.productHost.desktop = null;
+    mocks.preflightCloudWorkspaceStart.mockResolvedValue({
+      status: "blocked",
+      startBlockReason: "cap_exhausted",
+      message: "Cloud usage is paused because the managed cloud overage cap is exhausted.",
+    });
+    const { result } = renderHomeNextLaunch();
+
+    let succeeded = true;
+    await act(async () => {
+      succeeded = await result.current.launch({
+        text: "do not create a dead chat",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: {
+          kind: "cloud",
+          gitOwner: "proliferate-ai",
+          gitRepoName: "proliferate",
+          baseBranch: "main",
+        },
+      });
+    });
+
+    expect(succeeded).toBe(false);
+    expect(useChatLaunchIntentStore.getState().activeIntent).toBeNull();
+    expect(useSessionSelectionStore.getState().pendingWorkspaceEntry).toBeNull();
+    expect(useSessionDirectoryStore.getState().entriesById).toEqual({});
+    expect(mocks.createCloudWorkspaceAndEnterWithResult).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      "Failed to start work: Cloud usage is paused because the managed cloud overage cap is exhausted.",
+    );
   });
 });

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
@@ -21,6 +21,8 @@ import {
   markHomeLaunchIntentMaterializedFromPendingWorkspace,
   newHomeNextLaunchId,
 } from "#product/hooks/home/workflows/home-next-launch-intent";
+import { useCloudWorkspaceStartPreflight } from "#product/hooks/cloud/workflows/use-cloud-workspace-start-preflight";
+import type { CloudWorkspaceStartPreflight } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
 
 interface HomeNextLaunchInput {
   text: string;
@@ -54,6 +56,7 @@ export function useHomeNextLaunch() {
     createWorktreeAndEnterWithResult,
   } = useWorkspaceEntryActions();
   const { createCloudWorkspaceAndEnterWithResult } = useCreateCloudWorkspace();
+  const { preflightCloudWorkspaceStart } = useCloudWorkspaceStartPreflight();
   const { selectWorkspace } = useWorkspaceSelection();
 
   const launch = useCallback(async ({
@@ -77,6 +80,16 @@ export function useHomeNextLaunch() {
 
     inFlightRef.current = true;
     setIsLaunching(true);
+    let cloudStartPreflight: CloudWorkspaceStartPreflight | null = null;
+    if (target.kind === "cloud") {
+      cloudStartPreflight = await preflightCloudWorkspaceStart();
+      if (cloudStartPreflight.status !== "allowed") {
+        showToast(`Failed to start work: ${cloudStartPreflight.message}`);
+        inFlightRef.current = false;
+        setIsLaunching(false);
+        return false;
+      }
+    }
     const launchIntentId = newHomeNextLaunchId();
     const promptId = newHomeNextLaunchId();
     const resolvedLaunchControlValues = buildResolvedHomeLaunchControlValues({
@@ -275,6 +288,7 @@ export function useHomeNextLaunch() {
           {
             latencyFlowId,
             initialSession,
+            startPreflight: cloudStartPreflight ?? undefined,
           },
         );
       const queuedProjectedSessionId = await promptProjectedPendingWorkspaceSession({
@@ -390,6 +404,7 @@ export function useHomeNextLaunch() {
     markLaunchIntentMaterialized,
     navigate,
     promptExistingSession,
+    preflightCloudWorkspaceStart,
     selectWorkspace,
     showToast,
   ]);

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts
@@ -10,6 +10,7 @@ import {
   isCloudWorkspaceBranchConflictError,
   isCreateCloudWorkspaceRequest,
   resolveCloudRepoActionState,
+  resolveCloudWorkspaceStartPreflight,
   resolveCloudWorkspaceCreateFailureMessage,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-creation";
 
@@ -267,6 +268,29 @@ describe("cloud workspace creation helpers", () => {
       cloudError("nope", "github_branch_not_found"),
     )).toBe(false);
     expect(isCloudWorkspaceBillingBlockError(new Error("no code"))).toBe(false);
+  });
+
+  it("types an exhausted-cap preflight before optimistic workspace creation", () => {
+    expect(resolveCloudWorkspaceStartPreflight(
+      {
+        billingMode: "enforce",
+        startBlocked: true,
+        startBlockReason: "cap_exhausted",
+      },
+      (reason) => `blocked:${reason}`,
+    )).toEqual({
+      status: "blocked",
+      startBlockReason: "cap_exhausted",
+      message: "blocked:cap_exhausted",
+    });
+    expect(resolveCloudWorkspaceStartPreflight(
+      {
+        billingMode: "enforce",
+        startBlocked: false,
+        startBlockReason: null,
+      },
+      () => "unused",
+    )).toEqual({ status: "allowed" });
   });
 
   it("surfaces the server billing message with an upgrade pointer when exhausted", () => {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-creation.ts
@@ -19,6 +19,37 @@ export interface CloudWorkspaceRepoTarget {
   baseBranch?: string | null;
 }
 
+export type CloudWorkspaceStartPreflight =
+  | { status: "allowed" }
+  | {
+    status: "blocked";
+    startBlockReason: string | null;
+    message: string;
+  }
+  | {
+    status: "unavailable";
+    message: string;
+  };
+
+export function resolveCloudWorkspaceStartPreflight(
+  billingPlan: {
+    billingMode: string;
+    startBlocked: boolean;
+    startBlockReason?: string | null;
+  },
+  messageForReason: (reason: string | null | undefined) => string,
+): CloudWorkspaceStartPreflight {
+  if (billingPlan.billingMode !== "enforce" || !billingPlan.startBlocked) {
+    return { status: "allowed" };
+  }
+  const startBlockReason = billingPlan.startBlockReason ?? null;
+  return {
+    status: "blocked",
+    startBlockReason,
+    message: messageForReason(startBlockReason),
+  };
+}
+
 export type CloudWorkspaceCreateInput =
   | CloudWorkspaceRepoTarget
   | CreateCloudWorkspaceRequest;

--- a/server/proliferate/server/cloud/workspaces/service.py
+++ b/server/proliferate/server/cloud/workspaces/service.py
@@ -34,6 +34,9 @@ from proliferate.integrations.anyharness.workspaces import (
     retire_runtime_workspace,
 )
 from proliferate.lib.product.workspace_naming import resolve_generated_branch_name
+from proliferate.server.billing.authorization import (
+    assert_cloud_sandbox_resume_allowed_for_owner,
+)
 from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandboxes_service
 from proliferate.server.cloud.cloud_sandboxes.transactions import run_after_commit
 from proliferate.server.cloud.errors import CloudApiError
@@ -207,6 +210,15 @@ async def create_cloud_workspace_for_user(
             "Branch name is required.",
             status_code=400,
         )
+
+    # Workspace creation is itself a managed-compute start. Gate it before
+    # repository lookup, provider materialization, or optimistic product-row
+    # writes so an exhausted owner receives the existing typed 402 without
+    # entering provisioning.
+    await assert_cloud_sandbox_resume_allowed_for_owner(
+        db,
+        owner_user_id=user.id,
+    )
 
     repo_environment = await repositories_store.get_cloud_repo_environment(
         db,

--- a/server/tests/integration/test_billing_start_block_paging.py
+++ b/server/tests/integration/test_billing_start_block_paging.py
@@ -8,6 +8,8 @@ the quota denial. These tests pin:
 
 * the credits-exhausted denial surfaces the stable ``billing_credits_exhausted``
   code with a machine-readable reason + remaining_seconds on the 402 body, and
+* cloud workspace create denies an exhausted owner before provisioning or
+  repository materialization starts, and
 * the materialization runner logs (does not page) on a billing block, while
   still paging on genuinely unexpected failures.
 """
@@ -28,6 +30,7 @@ from proliferate.constants.billing import (
     WORKSPACE_ACTION_BLOCK_KIND_CREDITS_EXHAUSTED,
 )
 from proliferate.db.models.auth import User
+from proliferate.db.store import cloud_workspaces as cloud_workspace_store
 from proliferate.db.store.billing_subjects import (
     ensure_free_included_grant,
     ensure_personal_billing_subject,
@@ -38,6 +41,8 @@ from proliferate.server.billing.authorization import (
 )
 from proliferate.server.cloud.cloud_sandboxes.service import ensure_cloud_sandbox_ready
 from proliferate.server.cloud.materialization import runner as runner_module
+from proliferate.server.cloud.workspaces import service as workspaces_service
+from proliferate.server.cloud.workspaces.models import CreateCloudWorkspaceRequest
 from tests.integration.billing_accounting_helpers import seed_usage_segment
 
 
@@ -92,6 +97,61 @@ async def test_credits_exhausted_uses_stable_402_code(
     assert "remaining_seconds" in error.extra_detail
     assert error.billing_subject_id is not None
     assert error.owner_user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_workspace_create_denies_exhausted_owner_before_materialization(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create request reuses the billing 402 before provisioning can start."""
+    monkeypatch.setattr(settings, "cloud_billing_mode", BILLING_MODE_ENFORCE)
+    monkeypatch.setattr(settings, "pro_billing_enabled", False)
+    monkeypatch.setattr(settings, "cloud_free_sandbox_hours", 1.0)
+    monkeypatch.setattr(
+        workspaces_service.cloud_sandboxes_service,
+        "require_cloud_provisioning_configured",
+        lambda: None,
+    )
+    materialization_calls: list[object] = []
+    provisioning_calls: list[object] = []
+
+    async def _materialize(*args: object, **kwargs: object) -> None:
+        materialization_calls.append((args, kwargs))
+
+    @contextlib.asynccontextmanager
+    async def _provisioning_phase(**kwargs: object):
+        provisioning_calls.append(kwargs)
+        yield
+
+    monkeypatch.setattr(
+        workspaces_service.materialization_service,
+        "materialize_repo_environment",
+        _materialize,
+    )
+    monkeypatch.setattr(
+        workspaces_service,
+        "provisioning_phase",
+        _provisioning_phase,
+    )
+    user_id = await _seed_credits_exhausted_user(db_session)
+
+    with pytest.raises(CloudSandboxResumeBlockedError) as excinfo:
+        await workspaces_service.create_cloud_workspace_for_user(
+            db_session,
+            SimpleNamespace(id=user_id),
+            CreateCloudWorkspaceRequest(
+                gitOwner="owner",
+                gitRepoName="repo",
+                branchName="blocked-start",
+            ),
+        )
+
+    assert excinfo.value.status_code == 402
+    assert provisioning_calls == []
+    assert materialization_calls == []
+    await db_session.rollback()
+    assert await cloud_workspace_store.list_cloud_workspaces(db_session, user_id) == []
 
 
 @contextlib.asynccontextmanager

--- a/specs/codebase/platforms/product/billing.md
+++ b/specs/codebase/platforms/product/billing.md
@@ -280,11 +280,11 @@ pass so per-seat grants land before that pass's usage is walked.
 provider I/O.** In enforce mode, `assert_cloud_sandbox_resume_allowed`/
 `_for_owner`
 ([`authorization.py`](../../../../server/proliferate/server/billing/authorization.py))
-runs at the top of `connect_ready_sandbox`
+runs at the top of Cloud workspace creation, `connect_ready_sandbox`
 ([`connect.py`](../../../../server/proliferate/server/cloud/materialization/sandbox_io/connect.py))
 and `ensure_cloud_sandbox_ready`
 ([`cloud_sandboxes/service.py`](../../../../server/proliferate/server/cloud/cloud_sandboxes/service.py)),
-before either stages a provider call or a new-row INSERT, and raises
+before any repository materialization, provider call, or new-row INSERT, and raises
 `CloudSandboxResumeBlockedError` (HTTP 402) on an active spend hold or
 over-cap compute budget, committing its own audit `BillingDecisionEvent`
 first (the caller rolls back its session on exception).
@@ -449,6 +449,7 @@ Stripe integration unit tests
 - **E1** Exhausted subject → ensure/resume → 402 with decision detail; zero
   provider calls.
   [`test_credits_exhausted_uses_stable_402_code`](../../../../server/tests/integration/test_billing_start_block_paging.py),
+  [`test_workspace_create_denies_exhausted_owner_before_materialization`](../../../../server/tests/integration/test_billing_start_block_paging.py),
   [`test_ensure_denied_when_exhausted`](../../../../server/tests/integration/test_cloud_sandbox_ensure_billing_gate.py).
 - **E2** Reconciler pauses an open over-limit segment, closes as quota
   enforcement.

--- a/specs/codebase/platforms/product/workspace-provisioning.md
+++ b/specs/codebase/platforms/product/workspace-provisioning.md
@@ -18,6 +18,7 @@ save cloud repository environment
   -> schedule best-effort materialization after commit
 
 create cloud workspace
+  -> reject a billing-blocked start before provisioning
   -> validate GitHub repository and branch authority
   -> synchronously materialize the repository environment
   -> insert cloud_workspace
@@ -180,21 +181,23 @@ surfaces converge on server truth.
 performs the current synchronous flow:
 
 1. require cloud provisioning configuration;
-2. load the user's cloud `repo_environment`;
-3. verify GitHub App authority and fetch the repository's branches;
-4. validate or generate the new branch name;
-5. synchronously rematerialize the repository environment, which creates or
+2. apply the authoritative owner-scoped billing start gate before repository
+   materialization or any product-row write;
+3. load the user's cloud `repo_environment`;
+4. verify GitHub App authority and fetch the repository's branches;
+5. validate or generate the new branch name;
+6. synchronously rematerialize the repository environment, which creates or
    resumes E2B and launches or reconnects AnyHarness as needed;
-6. insert and flush `cloud_workspace` with no AnyHarness workspace id inside
+7. insert and flush `cloud_workspace` with no AnyHarness workspace id inside
    the request transaction;
-7. load ready runtime access from `cloud_sandbox`;
-8. resolve the repository root through AnyHarness;
-9. call AnyHarness directly to create the worktree; and
-10. write the returned `anyharness_workspace_id` and managed materialization;
-11. when this is an exact-ref Desktop source flow, require the local descriptor
+8. load ready runtime access from `cloud_sandbox`;
+9. resolve the repository root through AnyHarness;
+10. call AnyHarness directly to create the worktree; and
+11. write the returned `anyharness_workspace_id` and managed materialization;
+12. when this is an exact-ref Desktop source flow, require the local descriptor
     to match the independently verified HEAD and record the owned local
     association (a conflict fails the request rather than reporting success);
-12. commit the final request transaction after the handler returns successfully
+13. commit the final request transaction after the handler returns successfully
     and before the HTTP response starts.
 
 The create route uses a function-scoped request session for that last boundary.
@@ -297,6 +300,7 @@ Use these focused tests as the code-level proof:
 - `server/tests/unit/test_cloud_sandbox_gateway_access.py`
 - `server/tests/integration/test_cloud_workspace_backing_kind.py`
 - `server/tests/integration/test_cloud_workspace_backing_kind_migration.py`
+- `server/tests/integration/test_billing_start_block_paging.py`
 - `server/tests/integration/test_cloud_workspace_identity_payload.py`
 - `server/tests/integration/test_cloud_workspace_materialization_service.py`
 - `apps/packages/product-client/src/lib/domain/workspaces/cloud/open-on-mac-orchestration.test.ts`

--- a/specs/codebase/systems/product/workspaces/cloud-workspace.md
+++ b/specs/codebase/systems/product/workspaces/cloud-workspace.md
@@ -31,19 +31,25 @@ dialogs ([MainSidebar.tsx](../../../../../apps/packages/product-client/src/compo
 All converge on one flow
 ([use-create-cloud-workspace.ts](../../../../../apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts)):
 
-1. **The workspace appears before the network answers.** A pending entry
+1. **A fresh typed billing preflight runs before client state is staged.** A
+   billing-blocked or unreadable owner stays on the current screen with the
+   reason; no pending workspace, projected session, or prompt draft is created.
+   The create endpoint independently repeats the authoritative gate before
+   repository materialization.
+2. **For an allowed start, the workspace appears before the create request
+   answers.** A pending entry
    seeds the sidebar (stage `submitting`) before the create request is
    sent — this is the product face of the optimistic `cloud_workspace` row
    (content spec, "One workspace, two records"): the row commits first, so
    the product can show the workspace tied to its target immediately.
-2. Branch-name conflicts retry silently (3 attempts, server-generated
+3. Branch-name conflicts retry silently (3 attempts, server-generated
    names); the user never sees a naming collision.
-3. If the response is already `ready`, the user enters chat directly. If
+4. If the response is already `ready`, the user enters chat directly. If
    it is still `pending`/`materializing`, the workspace opens onto the
    status panel (below) at stage `awaiting-cloud-ready` and auto-advances
    when materialization completes. A prompt typed while waiting is queued:
    "Queued prompt will send when this cloud workspace is ready."
-4. Hard failure fails the pending entry with a specific message; the row
+5. Hard failure fails the pending entry with a specific message; the row
    survives and renders in the error state with a retry action.
 
 ## The status panel
@@ -127,6 +133,7 @@ is the one resource surface, for local and cloud targets alike:
 ```text
 apps/packages/product-client/src/
 ├── hooks/cloud/workflows/
+│   ├── use-cloud-workspace-start-preflight.ts billing gate before client staging
 │   ├── use-create-cloud-workspace.ts        create flow, optimistic pending entry
 │   └── use-cloud-workspace-actions.ts       archive/delete/unarchive + cache clears
 ├── lib/domain/workspaces/cloud/


### PR DESCRIPTION
## Summary

- run a fresh owner-scoped billing preflight before any optimistic Cloud launch intent, pending workspace, projected session, or prompt draft is created
- preserve allowed Cloud starts and align sidebar/command billing reads with the selected Cloud owner
- reuse the server's existing typed 402 billing gate before repository lookup, provisioning observability, materialization, or workspace-row writes

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

No support relationship is attached to this PR.

## Verification

- `(cd apps/packages/product-client && node_modules/.bin/vitest run src/lib/domain/workspaces/cloud/cloud-workspace-creation.test.ts --maxWorkers=1 --minWorkers=1 -t 'types an exhausted-cap preflight')`
- `(cd apps/packages/product-client && node_modules/.bin/vitest run src/hooks/home/workflows/use-home-next-launch.test.tsx --maxWorkers=1 --minWorkers=1 -t 'still invokes the Cloud workflow from Web Home|rejects an exhausted Cloud start')`
- `(cd server && DEBUG=true PYTHONPATH=. pytest -q tests/integration/test_billing_start_block_paging.py::test_workspace_create_denies_exhausted_owner_before_materialization -p no:randomly)`
- `python3 scripts/check_docs.py`
- `git diff --check origin/main...HEAD`

Focused verification only: broad builds, typechecks, and suites were intentionally not run under the machine's active swap-pressure constraint.
