### PR TITLE
fix(anyharness): re-acquire the probe-engine lock once its holder exits

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/engine_tests/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/engine_tests/lifecycle_tests.rs
@@ -375,6 +375,65 @@ async fn only_one_runtime_owns_the_probe_engine_for_a_home() {
     );
 }
 
+/// **Proof B7 (re-acquisition).** Losing the startup lock race is per-attempt,
+/// not for life. While the owner lives, the loser's forced refresh is the typed
+/// refusal and retrying never steals the lock; the moment the owner is gone
+/// (`drop` here — a killed process gets the same flock release from the OS),
+/// the loser's next trigger acquires the lock, runs the owner's orphan sweep,
+/// and probes. No restart required.
+///
+/// The wedge this pins: a sidecar orphaned by a dead desktop app held the lock,
+/// so the next app launch's runtime booted read-only and every manual refresh
+/// answered 409 ("this runtime does not hold the probe-engine lock") for the
+/// rest of its life — even after the orphan was killed and the lock was free.
+#[tokio::test]
+async fn a_read_only_engine_reacquires_the_lock_once_the_owner_exits() {
+    let home = seeded_home("engine-lock-reacquire", "opencode");
+    let (owner, _owner_runner, _owner_plan) = engine(&home, "opencode", test_config());
+    assert_eq!(owner.mode(), ProbeEngineMode::Owner);
+
+    let (second, second_runner, _second_plan) = engine(&home, "opencode", test_config());
+    assert_eq!(second.mode(), ProbeEngineMode::ReadOnly);
+
+    // The two-live-runtimes ruling is untouched: the retry loses while the
+    // owner holds the lock, and the refusal keeps its typed code.
+    let refused = second
+        .refresh_now("opencode")
+        .await
+        .expect_err("the owner is alive, so the retry must lose");
+    assert!(matches!(refused, RefreshError::NotOwner));
+    assert_eq!(second.mode(), ProbeEngineMode::ReadOnly);
+
+    // An abandoned root from a long-dead pid, so the sweep leg of late
+    // acquisition is observable (same fixture shape as the construction sweep).
+    let abandoned = home
+        .path()
+        .join("agent-auth-probe")
+        .join(format!("codex-{}-1", 999_999));
+    std::fs::create_dir_all(&abandoned).expect("create abandoned root");
+
+    drop(owner);
+
+    // The next forced refresh self-heals: acquires the lock, sweeps, probes.
+    second
+        .refresh_now("opencode")
+        .await
+        .expect("the refresh must succeed once the lock is free");
+    assert_eq!(
+        second.mode(),
+        ProbeEngineMode::Owner,
+        "ownership must follow the lock's availability"
+    );
+    assert!(
+        second_runner.count() >= 1,
+        "the once-read-only engine must actually probe"
+    );
+    assert!(
+        !abandoned.exists(),
+        "late acquisition must run the owner's orphan sweep"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Poke fan-out
 // ---------------------------------------------------------------------------

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/engine_tests/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/engine_tests/lifecycle_tests.rs
@@ -434,6 +434,33 @@ async fn a_read_only_engine_reacquires_the_lock_once_the_owner_exits() {
     );
 }
 
+/// The automatic pokes self-heal too, not just the manual refresh. The 409 was
+/// only the SYMPTOM a user could see; the common recovery paths are the
+/// event-driven pokes (auth-apply, install-completed), and a regression that
+/// re-froze only those would leave the refresh-path proof above green.
+#[tokio::test]
+async fn a_read_only_engine_reacquires_the_lock_on_an_automatic_poke() {
+    let home = seeded_home("engine-lock-reacquire-poke", "opencode");
+    let (owner, _owner_runner, _owner_plan) = engine(&home, "opencode", test_config());
+    let (second, second_runner, _second_plan) = engine(&home, "opencode", test_config());
+    assert_eq!(second.mode(), ProbeEngineMode::ReadOnly);
+
+    // While the owner lives, an automatic poke on the loser stays a no-op.
+    second
+        .clone()
+        .poke_harness("opencode", PokeReason::AuthApplied);
+    tokio::task::yield_now().await;
+    assert_eq!(second_runner.count(), 0);
+
+    drop(owner);
+
+    second
+        .clone()
+        .poke_harness("opencode", PokeReason::AuthApplied);
+    wait_until("the self-healed poke's probe", || second_runner.count() >= 1).await;
+    assert_eq!(second.mode(), ProbeEngineMode::Owner);
+}
+
 // ---------------------------------------------------------------------------
 // Poke fan-out
 // ---------------------------------------------------------------------------

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/lock.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/lock.rs
@@ -14,6 +14,12 @@
 //! nothing durable — a later poke on the owner restores it — while a runtime that
 //! WAITED for the lock would hold a startup task forever.
 //!
+//! Degrading is per-attempt, not for life: the loser retries this acquisition on
+//! every later poke and forced refresh (`ModelSnapshotService::ensure_owner`), so
+//! when the owner exits — or dies and the OS releases its flock — the surviving
+//! runtime becomes the owner on its next probe trigger instead of refusing
+//! refreshes until a restart.
+//!
 //! A crash releases the lock via the OS, which is why this is an flock and not a
 //! pid file.
 

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/mod.rs
@@ -293,7 +293,7 @@ impl ModelSnapshotService {
     /// Reclaim scratch roots abandoned by a process that died without running any
     /// guard. Owner only: a read-only runtime must never delete the owner's
     /// in-flight scratch — that is the data-loss case the lock exists for.
-    pub fn sweep_orphan_scratch(&self) {
+    pub(crate) fn sweep_orphan_scratch(&self) {
         if !self.is_owner() {
             return;
         }

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/mod.rs
@@ -161,7 +161,14 @@ impl Drop for LiveStateGuard {
 pub struct ModelSnapshotService {
     runtime_home: PathBuf,
     /// `None` ⇒ read-only mode: serve the document, never probe, never sweep.
-    engine_lock: Option<lock::ProbeEngineLock>,
+    ///
+    /// Re-acquirable, not a boot-time verdict: every poke and forced refresh
+    /// retries the lock when this is `None` (see [`Self::ensure_owner`]). A
+    /// runtime that lost the startup race to a process that later exited —
+    /// a dev sidecar quit, or a sidecar orphaned by a dead desktop app —
+    /// must not stay read-only for its whole life when the lock is free; that
+    /// wedge made every manual refresh 409 until a full app restart.
+    engine_lock: Mutex<Option<lock::ProbeEngineLock>>,
     slots: Mutex<HashMap<String, Arc<HarnessSlot>>>,
     probe_semaphore: Arc<tokio::sync::Semaphore>,
     plan_producer: Arc<dyn GatewayModelResolve>,
@@ -195,7 +202,7 @@ impl ModelSnapshotService {
         let engine_lock = lock::ProbeEngineLock::try_acquire(&runtime_home);
         let service = Self {
             runtime_home,
-            engine_lock,
+            engine_lock: Mutex::new(engine_lock),
             slots: Mutex::new(HashMap::new()),
             probe_semaphore: Arc::new(tokio::sync::Semaphore::new(
                 config.max_concurrent_probes.max(1),
@@ -229,14 +236,58 @@ impl ModelSnapshotService {
     }
 
     pub fn mode(&self) -> ProbeEngineMode {
-        match self.engine_lock {
-            Some(_) => ProbeEngineMode::Owner,
-            None => ProbeEngineMode::ReadOnly,
+        match self.is_owner() {
+            true => ProbeEngineMode::Owner,
+            false => ProbeEngineMode::ReadOnly,
         }
     }
 
     fn is_owner(&self) -> bool {
-        self.engine_lock.is_some()
+        self.engine_lock
+            .lock()
+            .expect("probe engine lock slot poisoned")
+            .is_some()
+    }
+
+    /// Own the probe engine, acquiring the lock now if this runtime does not
+    /// hold it yet.
+    ///
+    /// The startup acquisition is a race, not a verdict: the loser stays fully
+    /// functional except for probing, and the winner can exit at any time (a
+    /// dev sidecar shut down, a sidecar orphaned by a crashed desktop app and
+    /// later killed). Retrying at every probe entry point means ownership
+    /// follows the lock's actual availability instead of freezing the
+    /// boot-time outcome — the read-only runtime self-heals on its next poke
+    /// or manual refresh rather than 409ing until a restart.
+    ///
+    /// Late acquisition runs the same orphan sweep construction runs, because
+    /// the sweep is an owner duty ("at engine construction the OWNER sweeps"):
+    /// a previous owner may have died mid-probe, and its abandoned scratch —
+    /// which can hold a copy of real credential material — now has no other
+    /// process left to reclaim it. The slot mutex is released first:
+    /// `sweep_orphan_scratch` re-checks `is_owner`, which takes the same lock.
+    fn ensure_owner(&self) -> bool {
+        {
+            let mut slot = self
+                .engine_lock
+                .lock()
+                .expect("probe engine lock slot poisoned");
+            if slot.is_some() {
+                return true;
+            }
+            match lock::ProbeEngineLock::try_acquire(&self.runtime_home) {
+                Some(acquired) => {
+                    tracing::info!(
+                        path = %acquired.path().display(),
+                        "acquired the probe-engine lock after startup; this runtime now owns the probe engine"
+                    );
+                    *slot = Some(acquired);
+                }
+                None => return false,
+            }
+        }
+        self.sweep_orphan_scratch();
+        true
     }
 
     /// Reclaim scratch roots abandoned by a process that died without running any
@@ -270,7 +321,7 @@ impl ModelSnapshotService {
     /// whether to probe, because the comparison machinery cost more in complexity
     /// than the handful of background spawns it saved.
     pub fn poke_all(self: Arc<Self>, reason: PokeReason) {
-        if !self.is_owner() {
+        if !self.ensure_owner() {
             return;
         }
         for harness in self.targets.auto_harnesses() {
@@ -288,7 +339,7 @@ impl ModelSnapshotService {
     /// enumeration, so the pokes that name a harness directly bypassed it and
     /// spawned `cursor-agent` unattended.
     pub fn poke_harness(self: Arc<Self>, harness_kind: &str, reason: PokeReason) {
-        if !self.is_owner() {
+        if !self.ensure_owner() {
             return;
         }
         if !reason.is_user_initiated() && !self.targets.allows_automatic_probe(harness_kind) {
@@ -346,7 +397,7 @@ impl ModelSnapshotService {
 
     /// Poke exactly the harnesses an applied auth document names.
     pub fn poke_harnesses(self: Arc<Self>, harness_kinds: &[String], reason: PokeReason) {
-        if !self.is_owner() {
+        if !self.ensure_owner() {
             return;
         }
         for harness in harness_kinds {
@@ -404,7 +455,7 @@ impl ModelSnapshotService {
         &self,
         harness_kind: &str,
     ) -> Result<ModelSnapshotDocument, RefreshError> {
-        if !self.is_owner() {
+        if !self.ensure_owner() {
             return Err(RefreshError::NotOwner);
         }
         if !self.targets.is_installed(harness_kind) {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/probe_materialization/scratch.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/route_auth/probe_materialization/scratch.rs
@@ -98,8 +98,10 @@ fn set_private_dir_permissions(_dir: &Path) -> Result<(), RouteAuthError> {
 // ---------------------------------------------------------------------------
 
 /// Reclaim scratch roots whose owning process died without running any guard
-/// (SIGKILL, power loss). Called once at startup, and only by the runtime that
-/// holds the probe-engine lock.
+/// (SIGKILL, power loss). Called only by the runtime that holds the
+/// probe-engine lock: once at engine construction, and again whenever a
+/// runtime acquires the lock late (a boot-time loser whose owner has since
+/// exited — see `ModelSnapshotService::ensure_owner`).
 ///
 /// A root is removed only when **both** hold:
 /// (a) its embedded pid is neither ours nor live, and

--- a/specs/codebase/platforms/product/model-catalog.md
+++ b/specs/codebase/platforms/product/model-catalog.md
@@ -275,7 +275,10 @@ protect live sessions and the machine, not staleness bookkeeping:
 - **One engine per runtime home.** The engine holds an advisory exclusive
   lock; a second runtime sharing the home degrades to read-only — serves the
   document and status, neither probes nor sweeps, and refuses a forced
-  refresh rather than silently ignoring it.
+  refresh rather than silently ignoring it. Read-only is per-attempt, not
+  for life: every poke and forced refresh retries the acquisition, so once
+  the owner exits the surviving runtime takes the lock (and runs the owner's
+  orphan sweep) instead of refusing refreshes until a restart.
 - **Cursor is manual-refresh only.** Its credential lives in the macOS
   keychain, so an unattended spawn can surface an OS keychain prompt with no
   user-visible cause. Every other harness probes under the events above;

--- a/specs/codebase/platforms/product/model-catalog.md
+++ b/specs/codebase/platforms/product/model-catalog.md
@@ -270,8 +270,10 @@ protect live sessions and the machine, not staleness bookkeeping:
   not persisted across restarts
   ([model_snapshot/config.rs](../../../../anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/config.rs),
   [backoff.rs](../../../../anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/backoff.rs)).
-- **Orphan sweep.** At engine construction the owner sweeps abandoned scratch
-  roots (a SIGKILLed probe runs no guard), age-thresholded.
+- **Orphan sweep.** The owner sweeps abandoned scratch roots (a SIGKILLed
+  probe runs no guard), age-thresholded — at engine construction, and again
+  on late lock acquisition, because a dead owner's scratch has no other
+  process left to reclaim it.
 - **One engine per runtime home.** The engine holds an advisory exclusive
   lock; a second runtime sharing the home degrades to read-only — serves the
   document and status, neither probes nor sweeps, and refuses a forced


### PR DESCRIPTION
## Problem

The probe-engine lock (`model_snapshot/lock.rs`) is tried exactly once, at `ModelSnapshotService` construction. A runtime that loses that race degrades to read-only **forever**, even after the lock's holder exits.

Hit in the wild today: an `anyharness serve` sidecar orphaned by a dead desktop-app instance (parent pid 1, alive since 01:01) kept holding the flock on `~/.proliferate/anyharness/.probe-engine.lock`. The freshly launched app's sidecar booted read-only, and every manual model refresh in Settings → Agents answered 409 — the *"this runtime does not hold the probe-engine lock"* toast — with no recovery short of restarting the app after killing the orphan.

## Fix

Ownership now follows the lock's actual availability instead of freezing the boot-time outcome:

- `engine_lock` becomes a re-acquirable slot (`Mutex<Option<ProbeEngineLock>>`).
- Every probe entry point — `poke_all`/`poke_harness`/`poke_harnesses`/`refresh_now` — goes through `ensure_owner()`, which retries the non-blocking acquisition when the slot is empty.
- Late acquisition runs the same **orphan sweep** construction runs: a dead owner's abandoned scratch can hold a copy of real credential material (`~/.codex/auth.json`), and after its death no other process is left to reclaim it.

The two-live-runtimes ruling (model-catalog.md, spec bullet updated) is untouched: while another process holds the flock, the retry loses and the typed `PROBE_ENGINE_NOT_OWNER` refusal stands. The existing B7 lock proof passes unchanged.

## Tests

- New `a_read_only_engine_reacquires_the_lock_once_the_owner_exits`: refusal while the owner lives, then — after the owner drops — the next forced refresh acquires the lock, flips the mode to `owner`, probes, and sweeps a pre-planted abandoned scratch root.
- Negative control: the new test fails against the unfixed `mod.rs` (verified via stash), passes with the fix.
- Full `model_snapshot` suite: 48/48 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)