### PR TITLE
fix(tests): repair MarkdownBody link-treatment assertion broken by #1561

### DIFF
--- a/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-ui/src/chat/transcript/MarkdownBody.test.tsx
@@ -10,6 +10,7 @@ import {
   MarkdownBody,
   type MarkdownLinkRenderInput,
 } from "./MarkdownBody";
+import { CHAT_TRANSCRIPT_LINK_CLASS } from "./TranscriptLinkStyles";
 
 const COMPLETE_MARKDOWN = `# Heading one
 
@@ -124,7 +125,10 @@ describe("MarkdownBody presentation", () => {
   it("uses the shared stable-color, hover-underline treatment for web links", () => {
     const html = renderMarkdown("Open [docs](https://example.com/docs).");
 
-    expect(html).toContain("text-link-foreground no-underline hover:text-link-foreground hover:underline");
+    // The shared constant itself, not a copy: the property under test is that
+    // the anchor wears the one shared treatment, so a retune of that treatment
+    // must not fail here — only the anchor abandoning it should.
+    expect(html).toContain(CHAT_TRANSCRIPT_LINK_CLASS);
     expect(html).not.toContain("hover:text-foreground");
   });
 });


### PR DESCRIPTION
**Main is red**: `Shared frontend packages` fails on every PR since #1561 merged (last night, 00:04).

#1561 retuned `CHAT_TRANSCRIPT_LINK_CLASS` in `TranscriptLinkStyles.ts` — `hover:bg-transparent` now sits between `no-underline` and `hover:text-link-foreground` — without updating `MarkdownBody.test.tsx:127`, which asserted the old class run as one contiguous substring.

Fix: assert the shared constant itself instead of a hand-copied string. The test's own name states the property — *"uses the **shared** stable-color, hover-underline treatment"* — so importing `CHAT_TRANSCRIPT_LINK_CLASS` pins exactly that: a future retune of the treatment passes, the anchor abandoning the shared treatment fails. The `hover:text-foreground` negative guard stays.

Found while shepherding #1599 (whose frontend tree is byte-identical to main and hit the same red check); reproduced locally on main's tree, green after this change (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)