### PR TITLE
docs(testing): clarify session revocation scenario

### DIFF
--- a/specs/developing/testing/scenarios.md
+++ b/specs/developing/testing/scenarios.md
@@ -31,8 +31,8 @@ post-login the app shell renders with the seeded user.
 Negatives: wrong password rejected; second claim attempt rejected.
 
 ### T2-AUTH-2: session revocation
-Steps: log in in context A; revoke the session (settings UI or API); context A
-performs any authenticated call.
+Steps: sign in from context A; revoke that session (settings UI or API); make
+any authenticated call from context A.
 Assert: the call fails and the UI returns to signed-out state.
 
 ### T2-AUTH-3: SSO OIDC round-trip (mock IdP)


### PR DESCRIPTION
## Summary

- clarify the Tier 2 session-revocation steps
- consistently identify the browser context and revoked session

## Why

The previous wording repeated “in” and switched between an implicit session and context A, making the sequence harder to scan.

## Impact

Documentation only. The scenario's intended behavior is unchanged.

## Validation

- `python3 scripts/check_docs.py`
- `python3 scripts/check_design_attribution.py`
- `git diff --check`