### PR TITLE
feat(product): add ctrl+tab and ctrl+shift+tab shortcuts for tab switching

### DIFF
--- a/apps/packages/product-client/src/config/shortcuts/groups.ts
+++ b/apps/packages/product-client/src/config/shortcuts/groups.ts
@@ -46,8 +46,10 @@ export const SHORTCUT_GROUPS = [
     shortcutKeys: [
       "previousTab",
       "previousTabArrow",
+      "previousTabCtrlTab",
       "nextTab",
       "nextTabArrow",
+      "nextTabCtrlTab",
       "tabByIndex",
       "newSessionTab",
       "restoreTab",

--- a/apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts
+++ b/apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts
@@ -102,6 +102,16 @@ export const WORKSPACE_SHORTCUTS = {
     match: { kind: "fixed", key: "ArrowLeft", meta: true, shift: false, alt: true },
     allowInInputs: true,
   },
+  previousTabCtrlTab: {
+    id: "workspace.previous-tab",
+    label: "⌃⇧⇥",
+    nonMacLabel: "Ctrl+Shift+Tab",
+    description: "Previous tab",
+    owner: "js",
+    match: { kind: "fixed", key: "Tab", meta: false, ctrl: true, shift: true, alt: false },
+    nonMacMatch: { kind: "fixed", key: "Tab", meta: true, shift: true, alt: false },
+    allowInInputs: true,
+  },
   nextTab: {
     id: "workspace.next-tab",
     label: "⌘⇧]",
@@ -118,6 +128,16 @@ export const WORKSPACE_SHORTCUTS = {
     description: "Next tab",
     owner: "js",
     match: { kind: "fixed", key: "ArrowRight", meta: true, shift: false, alt: true },
+    allowInInputs: true,
+  },
+  nextTabCtrlTab: {
+    id: "workspace.next-tab",
+    label: "⌃⇥",
+    nonMacLabel: "Ctrl+Tab",
+    description: "Next tab",
+    owner: "js",
+    match: { kind: "fixed", key: "Tab", meta: false, ctrl: true, shift: false, alt: false },
+    nonMacMatch: { kind: "fixed", key: "Tab", meta: true, shift: false, alt: false },
     allowInInputs: true,
   },
   tabByIndex: {

--- a/apps/packages/product-client/src/lib/domain/shortcuts/ctrl-tab-keyboard-resolution.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/ctrl-tab-keyboard-resolution.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveKeyboardShortcut } from "#product/lib/domain/shortcuts/keyboard-resolution";
+
+describe("Ctrl+Tab keyboard resolution", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      platform: "Linux x86_64",
+      userAgent: "Linux",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves cycling shortcuts on mac", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "Tab",
+      code: "Tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.next-tab",
+      shortcut: expect.objectContaining({
+        id: "workspace.next-tab",
+        label: "⌃⇥",
+      }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "Tab",
+      code: "Tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.previous-tab",
+      shortcut: expect.objectContaining({
+        id: "workspace.previous-tab",
+        label: "⌃⇧⇥",
+      }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+  });
+
+  it("resolves cycling shortcuts on non-mac", () => {
+    expect(resolveKeyboardShortcut({
+      key: "Tab",
+      code: "Tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.next-tab",
+      shortcut: expect.objectContaining({ id: "workspace.next-tab" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+
+    expect(resolveKeyboardShortcut({
+      key: "Tab",
+      code: "Tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+    } as KeyboardEvent)).toEqual({
+      id: "workspace.previous-tab",
+      shortcut: expect.objectContaining({ id: "workspace.previous-tab" }),
+      trigger: expect.objectContaining({ source: "keyboard" }),
+    });
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/shortcuts/dispatch-policy.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/dispatch-policy.test.ts
@@ -490,6 +490,34 @@ describe("shortcut dispatch policy", () => {
         isContentEditable: false,
       } as unknown as EventTarget,
     } as KeyboardEvent)).toBe(true);
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.previousTabCtrlTab, {
+      key: "Tab",
+      code: "Tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      defaultPrevented: true,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
+
+    expect(shouldDispatchKeyboardShortcut(SHORTCUTS.nextTabCtrlTab, {
+      key: "Tab",
+      code: "Tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+      defaultPrevented: true,
+      target: {
+        tagName: "TEXTAREA",
+        isContentEditable: false,
+      } as unknown as EventTarget,
+    } as KeyboardEvent)).toBe(true);
   });
 
   it("allows close-other-tabs aliases through default-prevented non-input targets", () => {

--- a/apps/packages/product-client/src/lib/domain/shortcuts/shortcut-sections.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/shortcut-sections.test.ts
@@ -35,7 +35,7 @@ describe("buildShortcutSections", () => {
 
     const tabs = sections.find((section) => section.title === "Tabs");
     const currentWorkspace = sections.find((section) => section.title === "Current Workspace");
-    expect(findEntry(tabs, "Previous tab")?.labels).toEqual(["⌘⇧[", "⌘⌥←"]);
+    expect(findEntry(tabs, "Previous tab")?.labels).toEqual(["⌘⇧[", "⌘⌥←", "⌃⇧⇥"]);
     expect(findEntry(tabs, "Close other tabs")?.labels).toEqual(["⌘⌥O", "⌘⇧O"]);
     expect(findEntry(tabs, "New chat")?.labels).toEqual(["⌘T"]);
     expect(findEntry(currentWorkspace, "Open model and reasoning options")?.labels)


### PR DESCRIPTION
## Summary

- Add Ctrl+Tab (next tab) and Ctrl+Shift+Tab (previous tab) keyboard aliases for workspace tab cycling on macOS and non-macOS.
- Reuse the existing `workspace.next-tab` and `workspace.previous-tab` handlers, including tab-cycling dispatch behavior and right-panel handling.
- Merge the new labels (`⌃⇥` / `⌃⇧⇥`, `Ctrl+Tab` / `Ctrl+Shift+Tab`) into the existing Next tab / Previous tab rows in the Keyboard Shortcuts dialog.
- Keep native menu items on their existing single accelerators.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Support and attribution

- [x] No private tracker identifiers or source data appear in this PR.
- [x] The change and interaction are described in Proliferate vocabulary.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/shortcuts/ src/hooks/shortcuts/` — 13 files, 78 tests passed, including macOS and non-macOS Ctrl+Tab / Ctrl+Shift+Tab resolution and dispatch-policy coverage.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `python3 scripts/check_max_lines.py` — passed.
- `python3 scripts/report_frontend_structure.py --strict` — passed with zero violations.
- `python3 scripts/check_design_attribution.py` — passed.
- `git diff --check` — passed.
- Manually verified in the local Desktop app: Ctrl+Tab and Ctrl+Shift+Tab switch between workspace tabs.
