### PR TITLE
feat(product): make Return send chat messages and Shift+Return insert a newline

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -160,7 +160,6 @@ export function HomeComposerForm({
                 snapshot={composer.editorSnapshot}
                 onChange={handleDraftChange}
                 onKeyDown={composer.handleKeyDown}
-                submitBehavior="home"
                 canSubmit={composer.canSubmit}
                 onSubmit={() => { void composer.submit(); }}
                 placeholder={CHAT_COMPOSER_LABELS.placeholder}

--- a/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
@@ -93,7 +93,6 @@ export function PlaygroundComposerSurface({
                 setDraft(value);
                 setEditorSnapshot(snapshot);
               }}
-              submitBehavior="workspace"
               canSubmit={false}
               onSubmit={noop}
               placeholder="Type while the response renders"

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -100,7 +100,6 @@ export function ChatInputDraftArea({
                 onEditDraftChange(value);
               }}
               onKeyDown={onKeyDown}
-              submitBehavior="editing"
               canSubmit={canSubmit}
               onSubmit={onSubmit}
               placeholder={placeholder}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx
@@ -280,7 +280,6 @@ export function ComposerCommandEditor({
             onKeyDown={handleKeyDown}
             onCommandKey={handleCommandKey}
             activeDescendantId={activeDescendantId}
-            submitBehavior="workspace"
             canSubmit={canSubmit}
             onSubmit={onSubmit}
             editorRef={(editor) => { editorRef.current = editor; }}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -87,7 +87,7 @@ describe("ComposerRichTextEditor", () => {
 
   it("keeps list Enter and indentation Lexical-owned", async () => {
     const onSubmit = vi.fn();
-    const harness = renderEditor({ submitBehavior: "workspace", onSubmit });
+    const harness = renderEditor({ onSubmit });
     await harness.ready();
     act(() => resetText(harness.editor, ""));
     await typeCharacters(harness.editor, "- one");
@@ -257,23 +257,41 @@ describe("ComposerRichTextEditor", () => {
     ));
   });
 
-  it("gives each surface exactly one submit owner", async () => {
-    const workspaceSubmit = vi.fn();
-    const workspace = renderEditor({ submitBehavior: "workspace", onSubmit: workspaceSubmit });
-    await workspace.ready();
-    act(() => { workspace.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter")); });
-    expect(workspaceSubmit).toHaveBeenCalledTimes(1);
+  it("submits on plain or primary-modified Enter and inserts a newline on Shift-Enter", async () => {
+    const onSubmit = vi.fn();
+    const harness = renderEditor({ onSubmit });
+    await harness.ready();
+    act(() => resetText(harness.editor, "draft"));
+    act(() => { harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter")); });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(harness.root.querySelector("br")).toBeNull();
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+    await waitFor(() => expect(harness.root.querySelector("br")).toBeTruthy());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { metaKey: true }));
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not submit on Enter while sending is refused or composition is active", async () => {
+    const onSubmit = vi.fn();
+    const refused = renderEditor({ onSubmit, canSubmit: false });
+    await refused.ready();
+    act(() => resetText(refused.editor, ""));
+    act(() => { refused.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter")); });
+    expect(onSubmit).not.toHaveBeenCalled();
 
     cleanup();
-    const homeSubmit = vi.fn();
-    const home = renderEditor({ submitBehavior: "home", onSubmit: homeSubmit });
-    await home.ready();
-    act(() => { home.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter")); });
-    expect(homeSubmit).not.toHaveBeenCalled();
+    const composingSubmit = vi.fn();
+    const composing = renderEditor({ onSubmit: composingSubmit });
+    await composing.ready();
     act(() => {
-      home.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { metaKey: true }));
+      composing.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { isComposing: true }));
     });
-    expect(homeSubmit).toHaveBeenCalledTimes(1);
+    expect(composingSubmit).not.toHaveBeenCalled();
   });
 
   it("shows a one-pixel replacement caret only after valid geometry", async () => {
@@ -352,7 +370,6 @@ function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
   const defaults: ComposerRichTextEditorProps = {
     value: "seed",
     onChange: vi.fn(),
-    submitBehavior: "workspace",
     canSubmit: true,
     onSubmit: vi.fn(),
     placeholder: "Message",

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -55,7 +55,6 @@ export interface ComposerRichTextEditorProps {
   onCommandKey?: (event: KeyboardEvent) => boolean;
   /** Id of the highlighted row in an open inline menu, for aria-activedescendant. */
   activeDescendantId?: string;
-  submitBehavior: "workspace" | "home" | "editing";
   canSubmit: boolean;
   onSubmit: () => void;
   editorRef?: (editor: LexicalEditor) => void;
@@ -73,7 +72,6 @@ export function ComposerRichTextEditor({
   onKeyDown,
   onCommandKey,
   activeDescendantId,
-  submitBehavior,
   canSubmit,
   onSubmit,
   editorRef, rootRef, surface = "workspace",
@@ -149,7 +147,6 @@ export function ComposerRichTextEditor({
       <ListPlugin />
       <MarkdownShortcutPlugin transformers={INPUT_TRANSFORMERS} />
       <ComposerBehaviorPlugin
-        submitBehavior={submitBehavior}
         canSubmit={canSubmit}
         onSubmit={onSubmit}
         onKeyDown={onKeyDown}
@@ -267,12 +264,11 @@ function ComposerEditorBridge({
 }
 
 function ComposerBehaviorPlugin({
-  submitBehavior,
   canSubmit,
   onSubmit,
   onKeyDown,
   onCommandKey,
-}: Pick<ComposerRichTextEditorProps, "submitBehavior" | "canSubmit" | "onSubmit" | "onKeyDown" | "onCommandKey">) {
+}: Pick<ComposerRichTextEditorProps, "canSubmit" | "onSubmit" | "onKeyDown" | "onCommandKey">) {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -283,8 +279,7 @@ function ComposerBehaviorPlugin({
       const plainEnter = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
       const primaryEnter = !event.shiftKey && !event.altKey && (event.metaKey || event.ctrlKey);
       if (plainEnter && inList) return false;
-      const ownsSubmit = submitBehavior === "home" ? primaryEnter : plainEnter || primaryEnter;
-      if (!ownsSubmit) return false;
+      if (!plainEnter && !primaryEnter) return false;
       event.preventDefault();
       if (!event.repeat && canSubmit) onSubmit();
       return true;
@@ -303,7 +298,7 @@ function ComposerBehaviorPlugin({
       );
     }, COMMAND_PRIORITY_HIGH);
     return () => { unregisterEnter(); unregisterTab(); };
-  }, [canSubmit, editor, onCommandKey, onKeyDown, onSubmit, submitBehavior]);
+  }, [canSubmit, editor, onCommandKey, onKeyDown, onSubmit]);
 
   return null;
 }

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -90,15 +90,14 @@ The live editor recognizes `*`/`_` emphasis, `**`/`__` strong emphasis, and
 line-leading unordered and ordered list shortcuts. Cmd/Ctrl-B and Cmd/Ctrl-I
 toggle marks through the rich-text command layer. Enter continues or exits a
 list and Tab/Shift-Tab indent or outdent only when the selection is inside a
-list item. Outside lists, plain Enter retains workspace submission and
-Shift-Enter inserts a newline. Home retains Cmd/Ctrl-Enter submission and
-ordinary Enter editing. Queued edits retain workspace submission behavior
-outside lists and use the workspace editor's minimum height, row cap, and
+list item. Outside lists, every composer surface — workspace, Home, and queued
+edits — submits on plain Enter or Cmd/Ctrl-Enter, and Shift-Enter inserts a
+newline. Queued edits use the workspace editor's minimum height, row cap, and
 overflow scrolling.
 
 Lexical's high-priority Enter and Tab commands own this decision before native
-editor mutation. A list selection stays Lexical-owned; otherwise the workspace,
-Home, or queued-edit surface applies its own submit contract exactly once. The
+editor mutation. A list selection stays Lexical-owned; otherwise the surface
+applies the shared submit contract exactly once. The
 same native `beforeinput`, `keydown`, or `paste` event timestamp is forwarded to
 typing measurement when that event changes the document.
 


### PR DESCRIPTION
## Summary

- Use one submit contract across the Home, workspace, queued-edit, and playground composer surfaces: Return sends, Shift+Return inserts a newline, and Cmd/Ctrl+Return remains supported.
- Remove the now-redundant `submitBehavior` prop and its call sites.
- Preserve list Enter/Tab handling, active IME composition, repeat-key protection, and refused-send no-op behavior.
- Update focused editor coverage and the canonical composer contract in the same change.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Support and attribution

- [x] No private tracker identifiers or source data appear in this PR.
- [x] The change and interaction are described in Proliferate vocabulary.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx` — 15 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `python3 scripts/check_docs.py` — passed for 227 Markdown files.
- `python3 scripts/check_max_lines.py` — passed.
- `python3 scripts/report_frontend_structure.py --strict` — passed with zero violations.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- `python3 scripts/check_design_attribution.py` — passed.
- `git diff --check` — passed.
