### PR TITLE
feat(product): auto-focus the chat composer on app open and window activation

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -6,6 +6,7 @@ import { ChatComposerControlRowFrame } from "@proliferate/product-ui/chat/compos
 import { ChatComposerSurface } from "@proliferate/product-ui/chat/composer/ChatComposerSurface";
 import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
+import { focusChatInputOnActivation } from "#product/lib/domain/focus-zone";
 import { useHomeNextComposerState } from "#product/hooks/home/ui/use-home-next-composer-state";
 import {
   finishOrCancelMeasurementOperation,
@@ -136,10 +137,20 @@ export function HomeComposerForm({
     typingOperationRef.current = null;
   }, []);
 
+  // The home screen opens ready to type: focus the composer on mount, the
+  // same contract as the workspace composer's mount focus in `ChatInput`. The
+  // activation variant keeps the focus-ownership and hidden-route guards.
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      focusChatInputOnActivation();
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, []);
+
   return (
     <>
       <DebugProfiler id="home-composer">
-        <div className="relative z-10">
+        <div className="relative z-10" data-focus-zone="chat">
         <ChatComposerSurface>
           <form
             className="relative flex flex-col"

--- a/apps/packages/product-client/src/hooks/chat/lifecycle/use-composer-activation-focus.ts
+++ b/apps/packages/product-client/src/hooks/chat/lifecycle/use-composer-activation-focus.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { focusChatInputOnActivation } from "#product/lib/domain/focus-zone";
+
+/**
+ * Refocuses the visible chat composer whenever the app window becomes active
+ * again, so typing works immediately after switching back to the app. Focus
+ * ownership rules (never stealing from another surface) live in
+ * `focusChatInputOnActivation`. Mounted on Desktop only.
+ */
+export function useComposerActivationFocus(): void {
+  useEffect(() => {
+    const handleWindowFocus = () => {
+      focusChatInputOnActivation();
+    };
+    window.addEventListener("focus", handleWindowFocus);
+    return () => window.removeEventListener("focus", handleWindowFocus);
+  }, []);
+}

--- a/apps/packages/product-client/src/lib/domain/focus-zone.test.ts
+++ b/apps/packages/product-client/src/lib/domain/focus-zone.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   focusChatInput,
+  focusChatInputOnActivation,
   focusTerminal,
   getFocusZone,
   isRightPanelFocusZone,
@@ -39,6 +40,106 @@ describe("focus-zone helpers", () => {
     expect(focusChatInput()).toBe(true);
     expect(querySelector).toHaveBeenCalledWith("[data-chat-composer-editor], textarea");
     expect(focus).toHaveBeenCalledWith({ preventScroll: false });
+  });
+
+  it("focuses the chat composer on activation when nothing owns focus", () => {
+    const focus = vi.fn();
+    const querySelector = vi.fn(() => ({ focus }));
+    vi.stubGlobal("document", {
+      activeElement: null,
+      querySelector: vi.fn(() => ({ querySelector, closest: vi.fn(() => null) })),
+    });
+    vi.stubGlobal("window", {
+      getSelection: vi.fn(() => ({ isCollapsed: true })),
+    });
+
+    expect(focusChatInputOnActivation()).toBe(true);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: false });
+  });
+
+  it("restores composer focus from a non-interactive chat-zone surface", () => {
+    const focus = vi.fn();
+    const querySelector = vi.fn(() => ({ focus }));
+    const activeZone = { getAttribute: vi.fn(() => "chat") };
+    vi.stubGlobal("document", {
+      body: {},
+      activeElement: {
+        closest: vi.fn((selector: string) =>
+          (selector === "[data-focus-zone]" ? activeZone : null)),
+      },
+      querySelector: vi.fn(() => ({ querySelector, closest: vi.fn(() => null) })),
+    });
+    vi.stubGlobal("window", {
+      getSelection: vi.fn(() => ({ isCollapsed: true })),
+    });
+
+    expect(focusChatInputOnActivation()).toBe(true);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: false });
+  });
+
+  it("does not focus a composer kept mounted inside an aria-hidden route host", () => {
+    const editorQuerySelector = vi.fn();
+    vi.stubGlobal("document", {
+      activeElement: null,
+      querySelector: vi.fn(() => ({
+        querySelector: editorQuerySelector,
+        closest: vi.fn(() => ({})),
+      })),
+    });
+    vi.stubGlobal("window", {
+      getSelection: vi.fn(() => ({ isCollapsed: true })),
+    });
+
+    expect(focusChatInputOnActivation()).toBe(false);
+    expect(editorQuerySelector).not.toHaveBeenCalled();
+  });
+
+  it("does not steal activation focus from a surface outside the chat zone", () => {
+    const documentQuerySelector = vi.fn();
+    vi.stubGlobal("document", {
+      body: {},
+      activeElement: { closest: vi.fn(() => null) },
+      querySelector: documentQuerySelector,
+    });
+    vi.stubGlobal("window", {
+      getSelection: vi.fn(() => ({ isCollapsed: true })),
+    });
+
+    expect(focusChatInputOnActivation()).toBe(false);
+    expect(documentQuerySelector).not.toHaveBeenCalled();
+  });
+
+  it("does not steal activation focus from an interactive chat-zone control", () => {
+    const documentQuerySelector = vi.fn();
+    const chatZone = { getAttribute: vi.fn(() => "chat") };
+    vi.stubGlobal("document", {
+      body: {},
+      activeElement: {
+        closest: vi.fn((selector: string) =>
+          (selector === "[data-focus-zone]" ? chatZone : {})),
+      },
+      querySelector: documentQuerySelector,
+    });
+    vi.stubGlobal("window", {
+      getSelection: vi.fn(() => ({ isCollapsed: true })),
+    });
+
+    expect(focusChatInputOnActivation()).toBe(false);
+    expect(documentQuerySelector).not.toHaveBeenCalled();
+  });
+
+  it("does not collapse a live text selection on activation", () => {
+    const documentQuerySelector = vi.fn();
+    vi.stubGlobal("document", {
+      activeElement: null,
+      querySelector: documentQuerySelector,
+    });
+    vi.stubGlobal("window", {
+      getSelection: vi.fn(() => ({ isCollapsed: false })),
+    });
+
+    expect(focusChatInputOnActivation()).toBe(false);
+    expect(documentQuerySelector).not.toHaveBeenCalled();
   });
 
   it("focuses xterm's helper textarea when the terminal focus zone exists", () => {

--- a/apps/packages/product-client/src/lib/domain/focus-zone.ts
+++ b/apps/packages/product-client/src/lib/domain/focus-zone.ts
@@ -41,6 +41,53 @@ export function focusChatInput(): boolean {
   return false;
 }
 
+// Elements that keep focus ownership across an app activation even inside the
+// chat zone: interactive controls, editors, and the transcript.
+const ACTIVATION_FOCUS_OWNER_SELECTOR = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "iframe",
+  "[contenteditable='true']",
+  "[role='button']",
+  "[tabindex]:not([tabindex='-1'])",
+  "[data-chat-transcript-root='true']",
+].join(",");
+
+/**
+ * Focuses the chat composer when the app opens or its window becomes active
+ * again, without stealing focus. Focus moves only when it is unowned (resting
+ * on the document body) or on a non-interactive chat-zone surface; anything
+ * else — other zones, dialogs, menus, portaled overlays, controls, editors —
+ * keeps ownership, and a live text selection is never collapsed.
+ */
+export function focusChatInputOnActivation(): boolean {
+  const active = document.activeElement;
+  if (active && active !== document.body && active !== document.documentElement) {
+    const zone = active.closest(`[${FOCUS_ZONE_ATTR}]`);
+    if (zone?.getAttribute(FOCUS_ZONE_ATTR) !== "chat") {
+      return false;
+    }
+    if (active.closest(ACTIVATION_FOCUS_OWNER_SELECTOR)) {
+      return false;
+    }
+  }
+  const selection = window.getSelection();
+  if (selection && !selection.isCollapsed) {
+    return false;
+  }
+  // Hidden routes (settings and friends) keep the composer mounted behind an
+  // overlay inside an aria-hidden host, where it is still programmatically
+  // focusable; never focus a composer the user cannot see.
+  const chatZone = document.querySelector(`[${FOCUS_ZONE_ATTR}="chat"]`);
+  if (!chatZone || chatZone.closest('[aria-hidden="true"]')) {
+    return false;
+  }
+  return focusChatInput();
+}
+
 export function focusTerminal(): boolean {
   const terminalZone = document.querySelector(
     `[${FOCUS_ZONE_ATTR}="terminal"]:not([style*="display: none"]):not(.hidden)`,

--- a/apps/packages/product-client/src/providers/DesktopProductLifecycleRoot.tsx
+++ b/apps/packages/product-client/src/providers/DesktopProductLifecycleRoot.tsx
@@ -4,6 +4,7 @@ import type {
 } from "@proliferate/product-client/host/desktop-bridge";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 
+import { useComposerActivationFocus } from "#product/hooks/chat/lifecycle/use-composer-activation-focus";
 import { useExportRunningAgentCount } from "#product/hooks/app/lifecycle/use-export-running-agent-count";
 import { useDesktopRuntimeBootstrapLifecycle } from "#product/hooks/app/lifecycle/use-desktop-runtime-bootstrap-lifecycle";
 import { useUpdateRestartWatcher } from "#product/hooks/access/tauri/use-update-restart-watcher";
@@ -17,7 +18,8 @@ import { recordBootDiagnosticOnce } from "#product/lib/infra/measurement/measure
  * The single Desktop product-lifecycle root, mounted outside auth and route
  * gates. It reads the Desktop bridge from the host and, when present, mounts
  * local-runtime, updater, worker-enrollment, and native-UI lifecycles through
- * that bridge. On a non-Desktop host (`desktop === null`) it renders nothing.
+ * that bridge, plus Desktop-only activation UX (composer focus restore). On a
+ * non-Desktop host (`desktop === null`) it renders nothing.
  */
 export function DesktopProductLifecycleRoot() {
   const { auth, desktop } = useProductHost();
@@ -60,5 +62,6 @@ function DesktopProductLifecycles({
   useWorkspaceActivityIndicator(nativeUi.setWorkspaceActivity);
   recordBootDiagnosticOnce("app_runtime.render.after.use_workspace_activity_indicator");
   useDesktopZoomPreferenceLifecycle(nativeUi.setZoom);
+  useComposerActivationFocus();
   return null;
 }

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -134,6 +134,21 @@ Discovery follows the current caret rather than the end of the document, and a
 selection replaces only the active slash-token range while preserving text and
 formatting around it.
 
+Composer focus follows the app lifecycle. The workspace composer takes focus
+after mount and workspace switches (`ChatInput.tsx`), and the Home composer
+takes focus after mount (`HomeComposerForm.tsx`); both surfaces mark their
+region with `data-focus-zone="chat"` so `focusChatInput` can route focus. On
+Desktop, the visible composer also regains focus when the app window becomes
+active again, via `focusChatInputOnActivation`
+(`apps/packages/product-client/src/lib/domain/focus-zone.ts`, mounted through
+`DesktopProductLifecycleRoot`). Activation restore never steals focus: it
+moves focus only when focus is unowned (the document body) or resting on a
+non-interactive chat-zone surface — any other zone, dialog, menu, portaled
+overlay, control, or editor keeps ownership, and a live text selection is
+never collapsed. A composer kept mounted behind an `aria-hidden` route host
+(the settings overlay) is never focused. Hosted Web applies no activation
+restore.
+
 ## 1.1 Model Selector Semantics
 
 The composer model selector presents the model-catalog contract from


### PR DESCRIPTION
## Summary

- Focus the Home composer after mount and, on Desktop, focus the visible composer whenever the app window becomes active again.
- Centralize the activation rule in `focusChatInputOnActivation`: focus moves only when unowned or resting on a non-interactive chat-zone surface.
- Preserve focus owned by terminals, panels, browsers, dialogs, menus, portaled overlays, controls, editors, live text selections, and composers hidden behind an `aria-hidden` route host.
- Keep hosted Web activation behavior unchanged and document the lifecycle contract in the canonical composer specification.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Support and attribution

- [x] No private tracker identifiers or source data appear in this PR.
- [x] The change and interaction are described in Proliferate vocabulary.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/focus-zone.test.ts` — 10 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `python3 scripts/check_docs.py` — passed for 227 Markdown files.
- `python3 scripts/check_max_lines.py` — passed.
- `python3 scripts/report_frontend_structure.py --strict` — passed with zero violations.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- `python3 scripts/check_design_attribution.py` — passed.
- `git diff --check` — passed.
