### PR TITLE
refactor(product): split model selector menu

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from "react";
+import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
+import { splitProviderDisplayName } from "#product/lib/domain/chat/models/model-display-name-parts";
+import { orderModelGroupsActiveFirst } from "#product/lib/domain/chat/models/order-model-groups";
+import type {
+  ModelSelectorGroup,
+  ModelSelectorProps,
+  ModelSelectorSelection,
+} from "#product/lib/domain/chat/models/model-selector-types";
+import { MODEL_UNSUPPORTED_ROW_HINT } from "#product/lib/domain/chat/models/model-support-refusals";
+import {
+  modelRowKey,
+  useModelPickerKeyboardNav,
+} from "#product/hooks/chat/ui/use-model-picker-keyboard-nav";
+import { ArrowUpRight, Check } from "@proliferate/ui/icons";
+import { ProviderIcon } from "@proliferate/ui/icons/provider-icons";
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@proliferate/ui/primitives/DropdownMenu";
+import { PopoverSearchField } from "@proliferate/ui/primitives/PopoverSearchField";
+
+export function ComposerModelOptionsSubmenu({
+  groups,
+  currentModel,
+  currentModelLabel,
+  onSelect,
+}: {
+  groups: ModelSelectorGroup[];
+  currentModel: ModelSelectorProps["currentModel"];
+  currentModelLabel: string;
+  onSelect: (selection: ModelSelectorSelection) => void;
+}) {
+  const currentKind = currentModel?.kind ?? null;
+  const orderedGroups = orderModelGroupsActiveFirst(groups, currentKind);
+  const [search, setSearch] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const filteredGroups = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return orderedGroups;
+    }
+
+    return orderedGroups
+      .map((group) => {
+        const groupMatches = group.providerDisplayName.toLowerCase().includes(query)
+          || group.kind.toLowerCase().includes(query);
+        if (groupMatches) {
+          return group;
+        }
+
+        const models = group.models.filter((model) => model.displayName.toLowerCase().includes(query));
+        return models.length > 0 ? { ...group, models } : null;
+      })
+      .filter((group): group is ModelSelectorGroup => group !== null);
+  }, [orderedGroups, search]);
+
+  const {
+    highlightedKey: effectiveHighlightedKey,
+    setHighlightedKey,
+    setRowRef,
+    handleSearchKeyDown,
+  } = useModelPickerKeyboardNav(filteredGroups, onSelect);
+
+  return (
+    <DropdownMenuSub open={open} onOpenChange={setOpen}>
+      <DropdownMenuSubTrigger
+        data-composer-model-menu
+        className="py-2 text-composer"
+        onClick={() => setOpen(true)}
+      >
+        <span className="min-w-0 flex-1">Model</span>
+        <span className="max-w-28 truncate text-muted-foreground">{currentModelLabel}</span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent
+        sideOffset={4}
+        alignOffset={-4}
+        className="flex max-h-96 w-72 flex-col overflow-hidden p-0"
+      >
+        <div className="shrink-0 border-b border-border">
+          <PopoverSearchField
+            value={search}
+            onChange={setSearch}
+            placeholder="Search models"
+            autoFocus
+            onKeyDown={(event) => {
+              event.stopPropagation();
+              handleSearchKeyDown(event);
+            }}
+          />
+        </div>
+
+        <div className="min-h-0 overflow-y-auto [scrollbar-gutter:stable] p-1">
+          {filteredGroups.map((group, index) => (
+            <ModelPickerGroup
+              key={group.kind}
+              group={group}
+              currentKind={currentKind}
+              showSeparator={index > 0}
+              onSelect={onSelect}
+              highlightedKey={effectiveHighlightedKey}
+              onHighlight={setHighlightedKey}
+              setRowRef={setRowRef}
+            />
+          ))}
+
+          {orderedGroups.length === 0 && (
+            <p className="px-3 py-4 text-center text-ui text-muted-foreground">
+              {CHAT_MODEL_SELECTOR_LABELS.noProviders}
+            </p>
+          )}
+
+          {orderedGroups.length > 0 && filteredGroups.length === 0 && (
+            <p className="px-3 py-4 text-center text-ui text-muted-foreground">
+              No models match "{search}"
+            </p>
+          )}
+        </div>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+function ModelPickerGroup({
+  group,
+  currentKind,
+  showSeparator,
+  onSelect,
+  highlightedKey,
+  onHighlight,
+  setRowRef,
+}: {
+  group: ModelSelectorGroup;
+  currentKind: string | null;
+  showSeparator: boolean;
+  onSelect: (selection: ModelSelectorSelection) => void;
+  highlightedKey: string | null;
+  onHighlight: (key: string) => void;
+  setRowRef: (key: string, element: HTMLElement | null) => void;
+}) {
+  const hasSelectedModel = group.models.some((model) => model.isSelected);
+
+  return (
+    <>
+      {/* Group anatomy: hairline between groups, then a muted harness header
+          (icon + name) above the group's model rows. */}
+      {showSeparator && (
+        <div className="mt-1 w-full px-2 py-0.5">
+          <div className="h-px w-full bg-border/60" />
+        </div>
+      )}
+      <div className="flex items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-ui-sm text-muted-foreground">
+        <ProviderIcon kind={group.kind} className="icon-compact shrink-0 [font-size:var(--text-composer)]" />
+        <span className="truncate">{group.providerDisplayName}</span>
+      </div>
+
+      {group.models.map((model) => {
+        const showNewChatIndicator =
+          model.actionKind === "open_new_chat"
+          && !model.isSelected
+          && !hasSelectedModel
+          && group.kind !== currentKind;
+
+        const nameParts = splitProviderDisplayName(model.displayName);
+        const rowKey = modelRowKey(group.kind, model.modelId);
+        const isHighlighted = highlightedKey === rowKey;
+
+        return (
+          <DropdownMenuItem
+            key={model.modelId}
+            ref={(element) => setRowRef(rowKey, element)}
+            data-model-option={model.modelId}
+            data-model-kind={group.kind}
+            data-model-selected={model.isSelected ? "true" : "false"}
+            data-model-unsupported={model.isUnsupported ? "true" : "false"}
+            // Disabled, not hidden: the row is the answer to "where did my model
+            // go", and the hint below it is what turns a dead row into an
+            // explanation. The primitive already carries the disabled styling.
+            disabled={model.isUnsupported}
+            aria-selected={isHighlighted}
+            onMouseEnter={() => onHighlight(rowKey)}
+            className={`items-start px-2.5 py-2 text-composer ${
+              !model.isUnsupported && (model.isSelected || isHighlighted) ? "bg-hover" : ""
+            }`}
+            onSelect={() => onSelect({ kind: group.kind, modelId: model.modelId })}
+          >
+            <ProviderIcon kind={group.kind} className="icon-compact mt-0.5 shrink-0 text-muted-foreground [font-size:var(--text-composer)]" />
+            <span className="flex min-w-0 flex-1 flex-col">
+              <span className="flex items-center gap-1.5">
+                <span className="min-w-0 truncate">{nameParts.leaf}</span>
+                {nameParts.badge && (
+                  <span className="shrink-0 text-ui-sm text-muted-foreground">{nameParts.badge}</span>
+                )}
+              </span>
+              {model.isUnsupported && (
+                <span className="mt-0.5 text-ui-sm text-muted-foreground">
+                  {MODEL_UNSUPPORTED_ROW_HINT}
+                </span>
+              )}
+            </span>
+            <span className="flex size-3.5 shrink-0 items-center justify-center">
+              {showNewChatIndicator ? (
+                <ArrowUpRight className="icon-paired shrink-0 text-muted-foreground/60" />
+              ) : model.isSelected ? (
+                <Check className="icon-paired shrink-0 text-foreground/60" />
+              ) : null}
+            </span>
+          </DropdownMenuItem>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { APP_ROUTES } from "#product/config/app-routes";
 import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
 import { buildSettingsHref } from "#product/lib/domain/settings/navigation";
 import { getSettingsSectionForHarnessKind } from "#product/lib/domain/settings/navigation-presentation";
 import { splitProviderDisplayName } from "#product/lib/domain/chat/models/model-display-name-parts";
-import { orderModelGroupsActiveFirst } from "#product/lib/domain/chat/models/order-model-groups";
 import { resolveReasoningEffortPresentation } from "#product/lib/domain/chat/session-controls/session-reasoning-effort-control";
 import type {
   ModelSelectorGroup,
@@ -14,8 +13,7 @@ import type {
 } from "#product/lib/domain/chat/models/model-selector-types";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 import { ComposerControlButton } from "@proliferate/ui/patterns/ComposerControlButton";
-import { PopoverSearchField } from "@proliferate/ui/primitives/PopoverSearchField";
-import { ArrowUpRight, Check, ChevronDown, Plus, Settings, Zap } from "@proliferate/ui/icons";
+import { ChevronDown, Plus, Settings, Zap } from "@proliferate/ui/icons";
 import { ProviderIcon } from "@proliferate/ui/icons/provider-icons";
 import {
   DropdownMenu,
@@ -29,14 +27,10 @@ import {
 } from "@proliferate/ui/primitives/DropdownMenu";
 import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
 import { ComposerFieldInlineError } from "#product/components/workspace/chat/input/ComposerFieldInlineError";
-import { MODEL_UNSUPPORTED_ROW_HINT } from "#product/lib/domain/chat/models/model-support-refusals";
 import { useModelSupportStore } from "#product/stores/chat/model-support-store";
-import {
-  modelRowKey,
-  useModelPickerKeyboardNav,
-} from "#product/hooks/chat/ui/use-model-picker-keyboard-nav";
 import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import { ComposerModelTuningControls } from "#product/components/workspace/chat/input/ComposerModelTuningControls";
+import { ComposerModelOptionsSubmenu } from "#product/components/workspace/chat/input/ComposerModelOptionsSubmenu";
 
 interface ComposerModelSelectorControlProps {
   modelSelectorProps: ModelSelectorProps;
@@ -234,7 +228,7 @@ function ComposerModelPickerMenu({
 }) {
   return (
     <>
-      <ModelOptionsSubmenu
+      <ComposerModelOptionsSubmenu
         groups={groups}
         currentModel={currentModel}
         currentModelLabel={currentModelLabel}
@@ -250,108 +244,6 @@ function ComposerModelPickerMenu({
         onSettings={onSettings}
       />
     </>
-  );
-}
-
-function ModelOptionsSubmenu({
-  groups,
-  currentModel,
-  currentModelLabel,
-  onSelect,
-}: {
-  groups: ModelSelectorGroup[];
-  currentModel: ModelSelectorProps["currentModel"];
-  currentModelLabel: string;
-  onSelect: (selection: ModelSelectorSelection) => void;
-}) {
-  const currentKind = currentModel?.kind ?? null;
-  const orderedGroups = orderModelGroupsActiveFirst(groups, currentKind);
-  const [search, setSearch] = useState("");
-  const [open, setOpen] = useState(false);
-
-  const filteredGroups = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) {
-      return orderedGroups;
-    }
-
-    return orderedGroups
-      .map((group) => {
-        const groupMatches = group.providerDisplayName.toLowerCase().includes(query)
-          || group.kind.toLowerCase().includes(query);
-        if (groupMatches) {
-          return group;
-        }
-
-        const models = group.models.filter((model) => model.displayName.toLowerCase().includes(query));
-        return models.length > 0 ? { ...group, models } : null;
-      })
-      .filter((group): group is ModelSelectorGroup => group !== null);
-  }, [orderedGroups, search]);
-
-  const {
-    highlightedKey: effectiveHighlightedKey,
-    setHighlightedKey,
-    setRowRef,
-    handleSearchKeyDown,
-  } = useModelPickerKeyboardNav(filteredGroups, onSelect);
-
-  return (
-    <DropdownMenuSub open={open} onOpenChange={setOpen}>
-      <DropdownMenuSubTrigger
-        data-composer-model-menu
-        className="py-2 text-composer"
-        onClick={() => setOpen(true)}
-      >
-        <span className="min-w-0 flex-1">Model</span>
-        <span className="max-w-28 truncate text-muted-foreground">{currentModelLabel}</span>
-      </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent
-        sideOffset={4}
-        alignOffset={-4}
-        className="flex max-h-96 w-72 flex-col overflow-hidden p-0"
-      >
-        <div className="shrink-0 border-b border-border">
-          <PopoverSearchField
-            value={search}
-            onChange={setSearch}
-            placeholder="Search models"
-            autoFocus
-            onKeyDown={(event) => {
-              event.stopPropagation();
-              handleSearchKeyDown(event);
-            }}
-          />
-        </div>
-
-        <div className="min-h-0 overflow-y-auto [scrollbar-gutter:stable] p-1">
-          {filteredGroups.map((group, index) => (
-            <ModelPickerGroup
-              key={group.kind}
-              group={group}
-              currentKind={currentKind}
-              showSeparator={index > 0}
-              onSelect={onSelect}
-              highlightedKey={effectiveHighlightedKey}
-              onHighlight={setHighlightedKey}
-              setRowRef={setRowRef}
-            />
-          ))}
-
-          {orderedGroups.length === 0 && (
-            <p className="px-3 py-4 text-center text-ui text-muted-foreground">
-              {CHAT_MODEL_SELECTOR_LABELS.noProviders}
-            </p>
-          )}
-
-          {orderedGroups.length > 0 && filteredGroups.length === 0 && (
-            <p className="px-3 py-4 text-center text-ui text-muted-foreground">
-              No models match "{search}"
-            </p>
-          )}
-        </div>
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
   );
 }
 
@@ -383,97 +275,6 @@ function AdvancedOptionsSubmenu({
         </DropdownMenuItem>
       </DropdownMenuSubContent>
     </DropdownMenuSub>
-  );
-}
-
-function ModelPickerGroup({
-  group,
-  currentKind,
-  showSeparator,
-  onSelect,
-  highlightedKey,
-  onHighlight,
-  setRowRef,
-}: {
-  group: ModelSelectorGroup;
-  currentKind: string | null;
-  showSeparator: boolean;
-  onSelect: (selection: ModelSelectorSelection) => void;
-  highlightedKey: string | null;
-  onHighlight: (key: string) => void;
-  setRowRef: (key: string, element: HTMLElement | null) => void;
-}) {
-  const hasSelectedModel = group.models.some((model) => model.isSelected);
-
-  return (
-    <>
-      {/* Group anatomy: hairline between groups, then a muted harness header
-          (icon + name) above the group's model rows. */}
-      {showSeparator && (
-        <div className="mt-1 w-full px-2 py-0.5">
-          <div className="h-px w-full bg-border/60" />
-        </div>
-      )}
-      <div className="flex items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-ui-sm text-muted-foreground">
-        <ProviderIcon kind={group.kind} className="icon-compact shrink-0 [font-size:var(--text-composer)]" />
-        <span className="truncate">{group.providerDisplayName}</span>
-      </div>
-
-      {group.models.map((model) => {
-        const showNewChatIndicator =
-          model.actionKind === "open_new_chat"
-          && !model.isSelected
-          && !hasSelectedModel
-          && group.kind !== currentKind;
-
-        const nameParts = splitProviderDisplayName(model.displayName);
-        const rowKey = modelRowKey(group.kind, model.modelId);
-        const isHighlighted = highlightedKey === rowKey;
-
-        return (
-          <DropdownMenuItem
-            key={model.modelId}
-            ref={(element) => setRowRef(rowKey, element)}
-            data-model-option={model.modelId}
-            data-model-kind={group.kind}
-            data-model-selected={model.isSelected ? "true" : "false"}
-            data-model-unsupported={model.isUnsupported ? "true" : "false"}
-            // Disabled, not hidden: the row is the answer to "where did my model
-            // go", and the hint below it is what turns a dead row into an
-            // explanation. The primitive already carries the disabled styling.
-            disabled={model.isUnsupported}
-            aria-selected={isHighlighted}
-            onMouseEnter={() => onHighlight(rowKey)}
-            className={`items-start px-2.5 py-2 text-composer ${
-              !model.isUnsupported && (model.isSelected || isHighlighted) ? "bg-hover" : ""
-            }`}
-            onSelect={() => onSelect({ kind: group.kind, modelId: model.modelId })}
-          >
-            <ProviderIcon kind={group.kind} className="icon-compact mt-0.5 shrink-0 text-muted-foreground [font-size:var(--text-composer)]" />
-            <span className="flex min-w-0 flex-1 flex-col">
-              <span className="flex items-center gap-1.5">
-                <span className="min-w-0 truncate">{nameParts.leaf}</span>
-                {nameParts.badge && (
-                  <span className="shrink-0 text-ui-sm text-muted-foreground">{nameParts.badge}</span>
-                )}
-              </span>
-              {model.isUnsupported && (
-                <span className="mt-0.5 text-ui-sm text-muted-foreground">
-                  {MODEL_UNSUPPORTED_ROW_HINT}
-                </span>
-              )}
-            </span>
-            <span className="flex size-3.5 shrink-0 items-center justify-center">
-              {showNewChatIndicator ? (
-                <ArrowUpRight className="icon-paired shrink-0 text-muted-foreground/60" />
-              ) : model.isSelected ? (
-                <Check className="icon-paired shrink-0 text-foreground/60" />
-              ) : null}
-            </span>
-          </DropdownMenuItem>
-        );
-      })}
-    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- Extract the searchable model-list submenu from `ComposerModelSelectorControl.tsx` into the ownership-correct sibling component `ComposerModelOptionsSubmenu.tsx`.
- Preserve the model grouping, filtering, keyboard navigation, selected/unsupported states, and rendered menu structure without changing behavior.
- Restore compliance with the frontend component-size and structure gates after #1604.

## Root cause

The model-selector update in #1604 left `ComposerModelSelectorControl.tsx` at 502 lines, above the enforced 500-line component limit. The strict repo-shape check therefore failed for every later pull request rebased onto `main`.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Support and attribution

- [x] No private tracker identifiers or source data appear in this PR.
- [x] The change is described in Proliferate vocabulary.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx src/components/workspace/chat/input/ChatInputControlRow.test.tsx` — 22 passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `python3 scripts/check_max_lines.py` — passed.
- `python3 scripts/report_frontend_structure.py --strict` — passed with zero violations.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- `python3 scripts/check_design_attribution.py` — passed.
- `git diff --check` — passed.
