### PR TITLE
chore(product): enforce ProductClient boundaries

### DIFF
--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -458,104 +458,61 @@ def check_file(path: Path) -> list[Violation]:
 
 
 def statement_identifiers(statement: ImportStatement) -> set[str]:
-    return set(statement.imported_names) | {
-        token.value
-        for token in tokenize_typescript(statement.statement)
-        if token.kind == "identifier"
-    }
+    """Return the module's exported names, not their local aliases.
+
+    Identifier-sensitive rules describe external capabilities.  A local alias
+    with the same spelling as a forbidden export is not that capability, while
+    renaming the real export must not hide it.  The shared import parser owns
+    that distinction for static, re-export, and dynamic forms.
+    """
+
+    return set(statement.imported_names)
 
 
 def imported_bindings(statement: ImportStatement) -> set[str]:
-    tokens = tokenize_typescript(statement.statement)
-    bindings = set(statement.local_bindings)
-    if not tokens or tokens[0].value != "import":
-        return bindings
-    try:
-        from_index = next(
-            index
-            for index, token in enumerate(tokens[:-1])
-            if token.value == "from" and tokens[index + 1].kind == "string"
-        )
-    except StopIteration:
-        return bindings
-
-    clause = tokens[1:from_index]
-    if clause and clause[0].value == "type":
-        clause = clause[1:]
-    if clause and clause[0].kind == "identifier":
-        bindings.add(clause[0].value)
-
-    for index, token in enumerate(clause):
-        if token.value == "*" and index + 2 < len(clause) and clause[index + 1].value == "as":
-            bindings.add(clause[index + 2].value)
-
-    try:
-        open_index = next(index for index, token in enumerate(clause) if token.value == "{")
-        close_index = max(index for index, token in enumerate(clause) if token.value == "}")
-    except (StopIteration, ValueError):
-        return bindings
-
-    current: list = []
-    entries: list[list] = []
-    for token in clause[open_index + 1 : close_index]:
-        if token.value == ",":
-            if current:
-                entries.append(current)
-            current = []
-        else:
-            current.append(token)
-    if current:
-        entries.append(current)
-
-    for entry in entries:
-        if entry and entry[0].value == "type":
-            entry = entry[1:]
-        if not entry:
-            continue
-        alias_index = next(
-            (index for index, token in enumerate(entry) if token.value == "as"),
-            None,
-        )
-        if alias_index is not None and alias_index + 1 < len(entry):
-            bindings.add(entry[alias_index + 1].value)
-        elif entry[0].kind == "identifier":
-            bindings.add(entry[0].value)
-    return bindings
+    return set(statement.local_bindings)
 
 
 def namespace_bindings(statement: ImportStatement) -> set[str]:
-    bindings = set(statement.namespace_bindings)
-    tokens = tokenize_typescript(statement.statement)
-    for index, token in enumerate(tokens):
-        if (
-            token.value == "*"
-            and index + 2 < len(tokens)
-            and tokens[index + 1].value == "as"
-            and tokens[index + 2].kind == "identifier"
-        ):
-            bindings.add(tokens[index + 2].value)
-    return bindings
+    return set(statement.namespace_bindings)
 
 
 def namespace_member_identifiers(
-    text: str, bindings: set[str], *, jsx: bool
+    text: str,
+    bindings: set[str],
+    *,
+    jsx: bool,
+    tracked_import_starts: dict[str, set[int]] | None = None,
 ) -> set[str]:
     if not bindings:
         return set()
     tokens = tokenize_typescript(text, jsx=jsx)
+    _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
+    _, closing_parens = _matching_token_pairs(tokens, "(", ")")
+    shadow_ranges = _function_shadow_ranges(tokens, bindings)
     members: set[str] = set()
-    for index, token in enumerate(tokens[:-2]):
+    for index, token in enumerate(tokens):
         if token.kind != "identifier" or token.value not in bindings:
             continue
-        cursor = index + 1
-        if tokens[cursor].value == "?" and cursor + 1 < len(tokens):
-            cursor += 1
-        if (
-            cursor + 1 < len(tokens)
-            and tokens[cursor].value == "."
-            and tokens[cursor + 1].kind == "identifier"
+        if not _is_imported_binding_occurrence(
+            tokens,
+            index,
+            shadow_ranges,
+            brace_reverse,
+            (tracked_import_starts or {}).get(token.value, set()),
         ):
-            members.add(tokens[cursor + 1].value)
+            continue
+        member_cursor = _transparent_receiver_end(
+            tokens, index + 1, index, closing_parens
+        )
+        member = (
+            _member_name_after(tokens, member_cursor)
+            if member_cursor is not None
+            else None
+        )
+        if member is not None:
+            members.add(member[0])
+        members.update(_namespace_destructure_names(tokens, index))
     return members
 
 
@@ -575,6 +532,38 @@ def _matching_token_pairs(
             forward[open_index] = index
             reverse[index] = open_index
     return forward, reverse
+
+
+def _top_level_token_index(tokens: list[Token], value: str) -> int | None:
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for index, token in enumerate(tokens):
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+        elif not nesting and token.value == value:
+            return index
+    return None
+
+
+def _split_top_level_tokens(tokens: list[Token], delimiter: str) -> list[list[Token]]:
+    entries: list[list[Token]] = []
+    current: list[Token] = []
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for token in tokens:
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+        if token.value == delimiter and not nesting:
+            entries.append(current)
+            current = []
+        else:
+            current.append(token)
+    entries.append(current)
+    return entries
 
 
 def _binding_names_in_pattern(tokens: list[Token], bindings: set[str]) -> set[str]:
@@ -601,20 +590,34 @@ def _binding_names_in_pattern(tokens: list[Token], bindings: set[str]) -> set[st
     opener = first.value
     closer = "}" if opener == "{" else "]"
     depth = 1
-    end = cursor + 1
-    rebound: set[str] = set()
-    while end < len(tokens) and depth:
-        token = tokens[end]
+    close_index = cursor + 1
+    while close_index < len(tokens) and depth:
+        token = tokens[close_index]
         if token.value == opener:
             depth += 1
         elif token.value == closer:
             depth -= 1
-        elif token.kind == "identifier" and token.value in bindings:
-            next_value = tokens[end + 1].value if end + 1 < len(tokens) else None
-            # `{ sourceName: localName }` does not bind the property key.
-            if not (opener == "{" and next_value == ":"):
-                rebound.add(token.value)
-        end += 1
+        close_index += 1
+    if depth:
+        return set()
+
+    entries = _split_top_level_tokens(tokens[cursor + 1 : close_index - 1], ",")
+    rebound: set[str] = set()
+    for entry in entries:
+        while entry and entry[0].value == ".":
+            entry = entry[1:]
+        if not entry:
+            continue
+
+        equals_index = _top_level_token_index(entry, "=")
+        binding_part = entry[:equals_index] if equals_index is not None else entry
+        if opener == "{":
+            colon_index = _top_level_token_index(binding_part, ":")
+            if colon_index is not None:
+                # Object property keys—including computed keys—are reads, not
+                # bindings.  Only the pattern to the right of `:` can shadow.
+                binding_part = binding_part[colon_index + 1 :]
+        rebound.update(_binding_names_in_pattern(binding_part, bindings))
     return rebound
 
 
@@ -982,87 +985,274 @@ def _declares_binding_in_scope(
     return False
 
 
+def _is_property_identifier(tokens: list[Token], index: int) -> bool:
+    return (index > 0 and tokens[index - 1].value == ".") or (
+        index > 1
+        and tokens[index - 2].value == "?"
+        and tokens[index - 1].value == "."
+    )
+
+
+def _is_imported_binding_occurrence(
+    tokens: list[Token],
+    index: int,
+    shadow_ranges: list[tuple[int, int, set[str]]],
+    brace_reverse: dict[int, int],
+    tracked_import_starts: set[int],
+) -> bool:
+    token = tokens[index]
+    if token.kind != "identifier" or _is_property_identifier(tokens, index):
+        return False
+    if any(
+        start <= index < end and token.value in rebound
+        for start, end, rebound in shadow_ranges
+    ):
+        return False
+    return not _declares_binding_in_scope(
+        tokens,
+        token.value,
+        index,
+        brace_reverse,
+        tracked_import_starts,
+    )
+
+
+def _member_name_after(
+    tokens: list[Token], cursor: int
+) -> tuple[str, int] | None:
+    """Return a statically named member and the token after its access."""
+
+    if cursor < len(tokens) and tokens[cursor].value == "!":
+        cursor += 1
+    optional = (
+        cursor + 1 < len(tokens)
+        and tokens[cursor].value == "?"
+        and tokens[cursor + 1].value == "."
+    )
+    if optional:
+        cursor += 2
+    elif cursor < len(tokens) and tokens[cursor].value == ".":
+        cursor += 1
+
+    if cursor < len(tokens) and tokens[cursor].kind == "identifier":
+        # An identifier member requires a preceding dot/optional-chain dot.
+        if optional or (cursor > 0 and tokens[cursor - 1].value == "."):
+            return tokens[cursor].value, cursor + 1
+        return None
+    if cursor + 1 < len(tokens) and tokens[cursor].value == "[":
+        name = tokens[cursor + 1]
+        if (
+            name.kind == "string"
+            and cursor + 2 < len(tokens)
+            and tokens[cursor + 2].value == "]"
+        ):
+            return name.value, cursor + 3
+    return None
+
+
+def _namespace_destructure_names(tokens: list[Token], index: int) -> set[str]:
+    """Return exports selected from an imported namespace at this occurrence."""
+
+    after = index + 1
+    while after < len(tokens) and tokens[after].value in {"!", ")"}:
+        after += 1
+    if after < len(tokens) and tokens[after].value != ";":
+        # `const { useMutation } = Query.options` destructures a property value,
+        # not the imported namespace itself.
+        return set()
+
+    cursor = index - 1
+    while cursor >= 0 and tokens[cursor].value == "(":
+        cursor -= 1
+    if cursor < 1 or tokens[cursor].value != "=" or tokens[cursor - 1].value != "}":
+        return set()
+
+    _, reverse = _matching_token_pairs(tokens, "{", "}")
+    close_index = cursor - 1
+    open_index = reverse.get(close_index)
+    if open_index is None:
+        return set()
+
+    names: set[str] = set()
+    for entry in _split_top_level_tokens(tokens[open_index + 1 : close_index], ","):
+        while entry and entry[0].value == ".":
+            entry = entry[1:]
+        if not entry:
+            continue
+        equals_index = _top_level_token_index(entry, "=")
+        binding_part = entry[:equals_index] if equals_index is not None else entry
+        colon_index = _top_level_token_index(binding_part, ":")
+        key = binding_part[:colon_index] if colon_index is not None else binding_part
+        if key and key[0].kind in {"identifier", "string"}:
+            names.add(key[0].value)
+        elif (
+            len(key) == 3
+            and key[0].value == "["
+            and key[1].kind == "string"
+            and key[2].value == "]"
+        ):
+            names.add(key[1].value)
+    return names
+
+
+def _parenthesis_is_grouping(tokens: list[Token], open_index: int) -> bool:
+    if open_index == 0:
+        return True
+    previous = tokens[open_index - 1]
+    if previous.kind == "identifier":
+        return previous.value in {
+            "await",
+            "case",
+            "delete",
+            "do",
+            "else",
+            "return",
+            "throw",
+            "typeof",
+            "void",
+            "yield",
+        }
+    return previous.value not in {")", "]", "}", "."}
+
+
+def _skip_type_assertion(
+    tokens: list[Token],
+    cursor: int,
+    receiver_index: int,
+    closing_parens: dict[int, int],
+) -> int | None:
+    """Skip an `as`/`satisfies` type up to its receiver's grouping close."""
+
+    if cursor >= len(tokens) or tokens[cursor].value not in {"as", "satisfies"}:
+        return cursor
+    cursor += 1
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    saw_conditional_extends = False
+    while cursor < len(tokens):
+        value = tokens[cursor].value
+        if value == ")" and not nesting:
+            open_index = closing_parens.get(cursor)
+            if open_index is not None and open_index < receiver_index:
+                return cursor
+            return None
+        if value in {",", ";"} and not nesting:
+            return None
+        if not nesting:
+            if value == "extends":
+                saw_conditional_extends = True
+            elif value in {"instanceof", "in", "+", "-", "*", "/", "%", "^"}:
+                return None
+            elif value in {"?", ":"} and not saw_conditional_extends:
+                return None
+            elif (
+                value in {"&", "|"}
+                and cursor + 1 < len(tokens)
+                and tokens[cursor + 1].value == value
+            ):
+                return None
+            elif value == "=" and (
+                cursor + 1 >= len(tokens) or tokens[cursor + 1].value != ">"
+            ):
+                return None
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        cursor += 1
+    return None
+
+
+def _transparent_receiver_end(
+    tokens: list[Token],
+    cursor: int,
+    receiver_index: int,
+    closing_parens: dict[int, int],
+) -> int | None:
+    """Consume wrappers that preserve the value of a binding expression."""
+
+    while cursor < len(tokens):
+        while cursor < len(tokens) and tokens[cursor].value == "!":
+            cursor += 1
+        if cursor < len(tokens) and tokens[cursor].value in {"as", "satisfies"}:
+            cursor = _skip_type_assertion(
+                tokens, cursor, receiver_index, closing_parens
+            )
+            if cursor is None:
+                return None
+            continue
+        if cursor < len(tokens) and tokens[cursor].value == ")":
+            open_index = closing_parens.get(cursor)
+            if open_index is None or not _parenthesis_is_grouping(tokens, open_index):
+                return None
+            cursor += 1
+            continue
+        break
+    return cursor
+
+
+def _member_call_after(
+    tokens: list[Token], cursor: int, member: str
+) -> bool:
+    access = _member_name_after(tokens, cursor)
+    if access is None or access[0] != member:
+        return False
+    call_cursor = access[1]
+    while call_cursor < len(tokens) and tokens[call_cursor].value == "!":
+        call_cursor += 1
+    if (
+        call_cursor + 1 < len(tokens)
+        and tokens[call_cursor].value == "?"
+        and tokens[call_cursor + 1].value == "."
+    ):
+        call_cursor += 2
+    return call_cursor < len(tokens) and tokens[call_cursor].value == "("
+
+
 def member_call_lines(
     text: str,
     bindings: set[str],
     member: str,
     *,
     jsx: bool,
+    namespace_bindings: set[str] | None = None,
     tracked_import_starts: dict[str, set[int]] | None = None,
 ) -> list[int]:
     if not bindings:
         return []
     tokens = tokenize_typescript(text, jsx=jsx)
     _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
+    _, closing_parens = _matching_token_pairs(tokens, "(", ")")
     shadow_ranges = _function_shadow_ranges(tokens, bindings)
     lines: list[int] = []
     for index, token in enumerate(tokens):
         if token.kind != "identifier" or token.value not in bindings:
             continue
-        # `fixture.store.setState()` and `fixture?.store.setState()` are calls
-        # on a property, not on the imported binding with the same spelling.
-        if index > 0 and tokens[index - 1].value == ".":
-            continue
-        if index > 1 and tokens[index - 2].value == "?" and tokens[index - 1].value == ".":
-            continue
-
-        # Parentheses and optional/non-null chaining do not change the receiver
-        # binding: `(store).setState`, `store?.setState`, and
-        # `(store)!.setState` all still target the imported store.
-        preceding_parens = 0
-        cursor = index - 1
-        while cursor >= 0 and tokens[cursor].value == "(":
-            preceding_parens += 1
-            cursor -= 1
-        if (
-            preceding_parens
-            and cursor >= 0
-            and (
-                tokens[cursor].kind == "identifier"
-                or tokens[cursor].value in {")", "]"}
-            )
-        ):
-            continue
-        cursor = index + 1
-        closed_parens = 0
-        while cursor < len(tokens) and tokens[cursor].value == ")":
-            closed_parens += 1
-            cursor += 1
-        if closed_parens != preceding_parens:
-            continue
-        if cursor < len(tokens) and tokens[cursor].value == "!":
-            cursor += 1
-        if cursor < len(tokens) and tokens[cursor].value == "?":
-            cursor += 1
-        if (
-            cursor + 2 >= len(tokens)
-            or tokens[cursor].value != "."
-            or tokens[cursor + 1].value != member
-        ):
-            continue
-        call_cursor = cursor + 2
-        if (
-            call_cursor + 1 < len(tokens)
-            and tokens[call_cursor].value == "?"
-            and tokens[call_cursor + 1].value == "."
-        ):
-            call_cursor += 2
-        if call_cursor >= len(tokens) or tokens[call_cursor].value != "(":
-            continue
-        if any(
-            start <= index < end and token.value in rebound
-            for start, end, rebound in shadow_ranges
-        ):
-            continue
-        if _declares_binding_in_scope(
+        if not _is_imported_binding_occurrence(
             tokens,
-            token.value,
             index,
+            shadow_ranges,
             brace_reverse,
             (tracked_import_starts or {}).get(token.value, set()),
         ):
             continue
-        lines.append(token.lineno)
+        cursor = _transparent_receiver_end(
+            tokens, index + 1, index, closing_parens
+        )
+        if cursor is not None and _member_call_after(tokens, cursor, member):
+            lines.append(token.lineno)
+            continue
+
+        if token.value not in (namespace_bindings or set()):
+            continue
+        namespace_member = _member_name_after(tokens, index + 1)
+        if namespace_member is None:
+            continue
+        cursor = _transparent_receiver_end(
+            tokens, namespace_member[1], index, closing_parens
+        )
+        if cursor is not None and _member_call_after(tokens, cursor, member):
+            lines.append(token.lineno)
     return lines
 
 
@@ -1111,7 +1301,13 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         else None
     )
     imported_store_bindings: set[str] = set()
+    imported_store_namespace_bindings: set[str] = set()
     imported_store_binding_starts: dict[str, set[int]] = defaultdict(set)
+    namespace_binding_starts: dict[str, set[int]] = defaultdict(set)
+
+    for statement in statements:
+        for binding in namespace_bindings(statement):
+            namespace_binding_starts[binding].add(statement.start)
 
     for statement in statements:
         identifiers = statement_identifiers(statement)
@@ -1120,6 +1316,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 text,
                 namespace_bindings(statement),
                 jsx=jsx,
+                tracked_import_starts=namespace_binding_starts,
             )
         )
         if is_product_client_forbidden_import(path, statement.source):
@@ -1155,6 +1352,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         if target_layer == "stores":
             statement_bindings = imported_bindings(statement)
             imported_store_bindings.update(statement_bindings)
+            imported_store_namespace_bindings.update(namespace_bindings(statement))
             if statement.local_bindings:
                 for binding in statement_bindings:
                     imported_store_binding_starts[binding].add(statement.start)
@@ -1268,6 +1466,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         imported_store_bindings,
         "setState",
         jsx=jsx,
+        namespace_bindings=imported_store_namespace_bindings,
         tracked_import_starts=imported_store_binding_starts,
     ):
         violations.append(

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -458,7 +458,7 @@ def check_file(path: Path) -> list[Violation]:
 
 
 def statement_identifiers(statement: ImportStatement) -> set[str]:
-    return {
+    return set(statement.imported_names) | {
         token.value
         for token in tokenize_typescript(statement.statement)
         if token.kind == "identifier"
@@ -467,18 +467,21 @@ def statement_identifiers(statement: ImportStatement) -> set[str]:
 
 def imported_bindings(statement: ImportStatement) -> set[str]:
     tokens = tokenize_typescript(statement.statement)
+    bindings = set(statement.local_bindings)
     if not tokens or tokens[0].value != "import":
-        return set()
+        return bindings
     try:
-        from_index = next(index for index, token in enumerate(tokens) if token.value == "from")
+        from_index = next(
+            index
+            for index, token in enumerate(tokens[:-1])
+            if token.value == "from" and tokens[index + 1].kind == "string"
+        )
     except StopIteration:
-        return set()
+        return bindings
 
     clause = tokens[1:from_index]
     if clause and clause[0].value == "type":
         clause = clause[1:]
-    bindings: set[str] = set()
-
     if clause and clause[0].kind == "identifier":
         bindings.add(clause[0].value)
 
@@ -518,6 +521,42 @@ def imported_bindings(statement: ImportStatement) -> set[str]:
         elif entry[0].kind == "identifier":
             bindings.add(entry[0].value)
     return bindings
+
+
+def namespace_bindings(statement: ImportStatement) -> set[str]:
+    bindings = set(statement.namespace_bindings)
+    tokens = tokenize_typescript(statement.statement)
+    for index, token in enumerate(tokens):
+        if (
+            token.value == "*"
+            and index + 2 < len(tokens)
+            and tokens[index + 1].value == "as"
+            and tokens[index + 2].kind == "identifier"
+        ):
+            bindings.add(tokens[index + 2].value)
+    return bindings
+
+
+def namespace_member_identifiers(
+    text: str, bindings: set[str], *, jsx: bool
+) -> set[str]:
+    if not bindings:
+        return set()
+    tokens = tokenize_typescript(text, jsx=jsx)
+    members: set[str] = set()
+    for index, token in enumerate(tokens[:-2]):
+        if token.kind != "identifier" or token.value not in bindings:
+            continue
+        cursor = index + 1
+        if tokens[cursor].value == "?" and cursor + 1 < len(tokens):
+            cursor += 1
+        if (
+            cursor + 1 < len(tokens)
+            and tokens[cursor].value == "."
+            and tokens[cursor + 1].kind == "identifier"
+        ):
+            members.add(tokens[cursor + 1].value)
+    return members
 
 
 def _matching_token_pairs(
@@ -622,15 +661,32 @@ def _is_named_expression(tokens: list[Token], keyword_index: int) -> bool:
         return True
     return tokens[cursor].value in {
         "(",
+        "!",
+        "%",
+        "&",
+        "*",
+        "+",
         ",",
+        "-",
+        "/",
         ":",
+        "<",
         "=",
+        ">",
         "[",
         "?",
+        "^",
         "await",
+        "delete",
+        "extends",
+        "in",
+        "instanceof",
         "new",
         "return",
+        "void",
         "yield",
+        "|",
+        "~",
     }
 
 
@@ -788,6 +844,56 @@ def _function_shadow_ranges(
             continue
         add_range(open_index + 1, close_index, body_open + 1, braces[body_open])
 
+    # `let`/`const` bindings declared by a for-loop are scoped to its body and
+    # must not hide the imported binding after the loop completes.
+    for for_index, token in enumerate(tokens):
+        if token.value != "for":
+            continue
+        open_index = for_index + 1
+        while open_index < len(tokens) and tokens[open_index].value != "(":
+            if tokens[open_index].value in {"{", ";"}:
+                break
+            open_index += 1
+        close_index = parens.get(open_index)
+        if close_index is None:
+            continue
+        initializer_end = close_index
+        nesting: list[str] = []
+        matching = {")": "(", "]": "[", "}": "{"}
+        for cursor in range(open_index + 1, close_index):
+            value = tokens[cursor].value
+            if value in {"(", "[", "{"}:
+                nesting.append(value)
+            elif value in matching and nesting and nesting[-1] == matching[value]:
+                nesting.pop()
+            elif value == ";" and not nesting:
+                initializer_end = cursor
+                break
+
+        declaration_index = open_index + 1
+        if (
+            declaration_index >= initializer_end
+            or tokens[declaration_index].value not in {"const", "let"}
+        ):
+            declaration_index = None
+        rebound = (
+            _binding_names_in_parameter_tokens(
+                tokens[declaration_index + 1 : initializer_end], bindings
+            )
+            if declaration_index is not None
+            else set()
+        )
+        if not rebound or close_index + 1 >= len(tokens):
+            continue
+        body_start = close_index + 1
+        if tokens[body_start].value == "{" and body_start in braces:
+            ranges.append((body_start + 1, braces[body_start], rebound))
+            continue
+        body_end = body_start
+        while body_end < len(tokens) and tokens[body_end].value != ";":
+            body_end += 1
+        ranges.append((body_start, body_end, rebound))
+
     return ranges
 
 
@@ -796,6 +902,7 @@ def _declares_binding_in_scope(
     binding: str,
     candidate_index: int,
     brace_reverse: dict[int, int],
+    tracked_import_starts: set[int],
 ) -> bool:
     """Whether a local declaration shadows an imported binding at a call."""
 
@@ -806,10 +913,20 @@ def _declares_binding_in_scope(
         for close_index, open_index in brace_reverse.items()
         if open_index < candidate_index < close_index
     }
+    paren_forward, _ = _matching_token_pairs(tokens, "(", ")")
 
     for index in range(len(tokens)):
         if tokens[index].value not in {"const", "let", "var", "class", "function"}:
             continue
+        if tokens[index].value in {"const", "let"}:
+            in_for_header = any(
+                open_index < index < close_index
+                and open_index > 0
+                and tokens[open_index - 1].value in {"for", "await"}
+                for open_index, close_index in paren_forward.items()
+            )
+            if in_for_header:
+                continue
         # The declaration itself must begin inside one of the candidate's
         # enclosing blocks, not a completed sibling/nested block.
         declaration_containers = [
@@ -852,10 +969,13 @@ def _declares_binding_in_scope(
                 if not nesting and value in {",", ";"}:
                     break
                 cursor += 1
-            if binding in _binding_names_in_pattern(
-                tokens[declarator_start:cursor], {binding}
-            ):
-                return True
+            declarator = tokens[declarator_start:cursor]
+            if binding in _binding_names_in_pattern(declarator, {binding}):
+                if not any(
+                    token.value == "import" and token.start in tracked_import_starts
+                    for token in declarator
+                ):
+                    return True
             if cursor >= len(tokens) or tokens[cursor].value == ";":
                 break
             cursor += 1
@@ -863,7 +983,12 @@ def _declares_binding_in_scope(
 
 
 def member_call_lines(
-    text: str, bindings: set[str], member: str, *, jsx: bool
+    text: str,
+    bindings: set[str],
+    member: str,
+    *,
+    jsx: bool,
+    tracked_import_starts: dict[str, set[int]] | None = None,
 ) -> list[int]:
     if not bindings:
         return []
@@ -871,15 +996,8 @@ def member_call_lines(
     _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
     shadow_ranges = _function_shadow_ranges(tokens, bindings)
     lines: list[int] = []
-    for index in range(len(tokens) - 3):
-        token = tokens[index]
-        if (
-            token.kind != "identifier"
-            or token.value not in bindings
-            or tokens[index + 1].value != "."
-            or tokens[index + 2].value != member
-            or tokens[index + 3].value != "("
-        ):
+    for index, token in enumerate(tokens):
+        if token.kind != "identifier" or token.value not in bindings:
             continue
         # `fixture.store.setState()` and `fixture?.store.setState()` are calls
         # on a property, not on the imported binding with the same spelling.
@@ -887,12 +1005,62 @@ def member_call_lines(
             continue
         if index > 1 and tokens[index - 2].value == "?" and tokens[index - 1].value == ".":
             continue
+
+        # Parentheses and optional/non-null chaining do not change the receiver
+        # binding: `(store).setState`, `store?.setState`, and
+        # `(store)!.setState` all still target the imported store.
+        preceding_parens = 0
+        cursor = index - 1
+        while cursor >= 0 and tokens[cursor].value == "(":
+            preceding_parens += 1
+            cursor -= 1
+        if (
+            preceding_parens
+            and cursor >= 0
+            and (
+                tokens[cursor].kind == "identifier"
+                or tokens[cursor].value in {")", "]"}
+            )
+        ):
+            continue
+        cursor = index + 1
+        closed_parens = 0
+        while cursor < len(tokens) and tokens[cursor].value == ")":
+            closed_parens += 1
+            cursor += 1
+        if closed_parens != preceding_parens:
+            continue
+        if cursor < len(tokens) and tokens[cursor].value == "!":
+            cursor += 1
+        if cursor < len(tokens) and tokens[cursor].value == "?":
+            cursor += 1
+        if (
+            cursor + 2 >= len(tokens)
+            or tokens[cursor].value != "."
+            or tokens[cursor + 1].value != member
+        ):
+            continue
+        call_cursor = cursor + 2
+        if (
+            call_cursor + 1 < len(tokens)
+            and tokens[call_cursor].value == "?"
+            and tokens[call_cursor + 1].value == "."
+        ):
+            call_cursor += 2
+        if call_cursor >= len(tokens) or tokens[call_cursor].value != "(":
+            continue
         if any(
             start <= index < end and token.value in rebound
             for start, end, rebound in shadow_ranges
         ):
             continue
-        if _declares_binding_in_scope(tokens, token.value, index, brace_reverse):
+        if _declares_binding_in_scope(
+            tokens,
+            token.value,
+            index,
+            brace_reverse,
+            (tracked_import_starts or {}).get(token.value, set()),
+        ):
             continue
         lines.append(token.lineno)
     return lines
@@ -935,6 +1103,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
     violations: list[Violation] = []
     text = path.read_text()
     statements = collect_imports(path, text)
+    jsx = path.suffix == ".tsx"
     source_layer = product_client_layer(product_client_relative(path))
     lib_area = (
         product_client_relative(path).split("/", 2)[1]
@@ -942,9 +1111,17 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         else None
     )
     imported_store_bindings: set[str] = set()
+    imported_store_binding_starts: dict[str, set[int]] = defaultdict(set)
 
     for statement in statements:
         identifiers = statement_identifiers(statement)
+        identifiers.update(
+            namespace_member_identifiers(
+                text,
+                namespace_bindings(statement),
+                jsx=jsx,
+            )
+        )
         if is_product_client_forbidden_import(path, statement.source):
             violations.append(
                 Violation(
@@ -976,7 +1153,11 @@ def find_product_client_violations(path: Path) -> list[Violation]:
             )
 
         if target_layer == "stores":
-            imported_store_bindings.update(imported_bindings(statement))
+            statement_bindings = imported_bindings(statement)
+            imported_store_bindings.update(statement_bindings)
+            if statement.local_bindings:
+                for binding in statement_bindings:
+                    imported_store_binding_starts[binding].add(statement.start)
 
         query_hook_has_specific_owner = source_layer == "stores" or (
             source_layer == "lib" and lib_area in {"domain", "workflows"}
@@ -1082,9 +1263,12 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                     )
                 )
 
-    jsx = path.suffix == ".tsx"
     for lineno in member_call_lines(
-        text, imported_store_bindings, "setState", jsx=jsx
+        text,
+        imported_store_bindings,
+        "setState",
+        jsx=jsx,
+        tracked_import_starts=imported_store_binding_starts,
     ):
         violations.append(
             Violation(

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -1609,6 +1609,25 @@ def _simple_alias_declaration(
     while cursor >= 0 and tokens[cursor].value == "(":
         receiver_groups += 1
         cursor -= 1
+    if cursor >= 0 and tokens[cursor].value == ",":
+        parens, _ = _matching_token_pairs(tokens, "(", ")")
+        comma_groups = [
+            (open_index, close_index)
+            for open_index, close_index in parens.items()
+            if open_index < cursor < receiver_index < close_index
+        ]
+        if not comma_groups:
+            return None
+        declaration_open, _ = max(comma_groups)
+        receiver_groups += 1
+        while (
+            declaration_open > 0
+            and tokens[declaration_open - 1].value == "("
+        ):
+            declaration_open -= 1
+            receiver_groups += 1
+        cursor = declaration_open - 1
+
     if cursor < 1 or tokens[cursor].value != "=":
         return None
     binding = tokens[cursor - 1]

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+import posixpath
 import re
 import sys
+
+try:
+    from scripts.frontend_imports import ImportStatement, collect_imports, tokenize_typescript
+except ModuleNotFoundError:  # Direct `python3 scripts/...` execution.
+    from frontend_imports import ImportStatement, collect_imports, tokenize_typescript
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DESKTOP_SRC = REPO_ROOT / "apps" / "desktop" / "src"
@@ -66,6 +72,28 @@ QUERY_CACHE_CALL_RE = re.compile(
 REACT_IMPORT_RE = re.compile(
     r"^\s*import(?:\s+type)?(?:\s+[^;]*\s+from)?\s+['\"]react['\"]"
 )
+QUERY_HOOK_NAMES = {
+    "useInfiniteQuery",
+    "useMutation",
+    "useQueries",
+    "useQuery",
+    "useSuspenseQuery",
+}
+RAW_CLIENT_BINDINGS = {
+    "createCloudClient",
+    "getAnyHarnessClient",
+    "getCloudClient",
+}
+PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES = {
+    ("hooks", "components"),
+    ("lib", "components"),
+    ("lib", "hooks"),
+    ("lib", "providers"),
+    ("lib", "stores"),
+    ("stores", "components"),
+    ("stores", "hooks"),
+    ("stores", "providers"),
+}
 
 
 @dataclass(frozen=True)
@@ -156,6 +184,74 @@ def is_under(relative_path: str, prefix: str) -> bool:
     return relative_path.startswith(prefix)
 
 
+def is_product_client_path(path: Path, prefix: str = "") -> bool:
+    try:
+        product_relative = path.relative_to(PRODUCT_CLIENT_SRC).as_posix()
+    except ValueError:
+        return False
+    return not prefix or product_relative.startswith(prefix)
+
+
+def product_client_relative(path: Path) -> str:
+    return path.relative_to(PRODUCT_CLIENT_SRC).as_posix()
+
+
+def resolve_product_client_import(path: Path, source: str) -> str | None:
+    if source.startswith("#product/"):
+        target = source.removeprefix("#product/")
+    elif source.startswith("@proliferate/product-client/internal/"):
+        target = source.removeprefix("@proliferate/product-client/internal/")
+    elif source.startswith("@proliferate/product-client/host/"):
+        target = f"host/{source.removeprefix('@proliferate/product-client/host/')}"
+    elif source == "@proliferate/product-client/infra/measurement":
+        target = "lib/infra/measurement/measurement-port"
+    elif source == "@proliferate/product-client/infra/cloud-gateway":
+        target = "lib/access/cloud/sandbox-gateway-access"
+    elif source == "@proliferate/product-client/ProductClient":
+        target = "ProductClient"
+    elif source.startswith("."):
+        target = posixpath.normpath(
+            posixpath.join(product_client_relative(path.parent), source)
+        )
+    else:
+        return None
+
+    target = target.split("?", 1)[0]
+    normalized = posixpath.normpath(target)
+    if normalized == ".." or normalized.startswith("../"):
+        return None
+    return normalized
+
+
+def product_client_layer(path_or_target: str) -> str:
+    return path_or_target.split("/", 1)[0]
+
+
+def is_product_client_query_owner(path: Path) -> bool:
+    target = product_client_relative(path)
+    return (
+        target.startswith("hooks/access/")
+        or target.startswith("lib/infra/query/")
+        or (target.startswith("hooks/") and "/cache/" in f"/{target}")
+    )
+
+
+def is_product_client_query_hook_owner(path: Path) -> bool:
+    target = product_client_relative(path)
+    return target.startswith("hooks/access/") or (
+        target.startswith("hooks/") and "/cache/" in f"/{target}"
+    )
+
+
+def code_only_text(text: str) -> str:
+    masked = ["\n" if char == "\n" else " " for char in text]
+    for token in tokenize_typescript(text):
+        if token.kind == "string":
+            continue
+        masked[token.start : token.end] = text[token.start : token.end]
+    return "".join(masked)
+
+
 def is_tauri_access_path(relative_path: str) -> bool:
     return is_under(relative_path, "apps/desktop/src/lib/access/tauri/")
 
@@ -164,11 +260,15 @@ def is_anyharness_client_path(relative_path: str) -> bool:
     return (
         is_under(relative_path, "apps/desktop/src/lib/access/anyharness/")
         or is_under(relative_path, "apps/desktop/src/hooks/access/anyharness/")
+        or is_under(relative_path, "apps/packages/product-client/src/lib/access/anyharness/")
+        or is_under(relative_path, "apps/packages/product-client/src/hooks/access/anyharness/")
     )
 
 
 def is_cloud_access_path(relative_path: str) -> bool:
-    return is_under(relative_path, "apps/desktop/src/lib/access/cloud/")
+    return is_under(relative_path, "apps/desktop/src/lib/access/cloud/") or is_under(
+        relative_path, "apps/packages/product-client/src/lib/access/cloud/"
+    )
 
 
 def is_ui_component_library_path(relative_path: str) -> bool:
@@ -183,6 +283,12 @@ def is_query_cache_owner_path(relative_path: str) -> bool:
         or is_under(relative_path, "apps/desktop/src/lib/infra/query/")
         or (
             is_under(relative_path, "apps/desktop/src/hooks/")
+            and "/cache/" in relative_path
+        )
+        or is_under(relative_path, "apps/packages/product-client/src/hooks/access/")
+        or is_under(relative_path, "apps/packages/product-client/src/lib/infra/query/")
+        or (
+            is_under(relative_path, "apps/packages/product-client/src/hooks/")
             and "/cache/" in relative_path
         )
     )
@@ -209,8 +315,14 @@ def check_file(path: Path) -> list[Violation]:
     in_stores = is_under(rel, "apps/desktop/src/stores/")
     in_desktop = is_under(rel, "apps/desktop/src/")
     in_product_client = is_under(rel, "apps/packages/product-client/src/")
+    text = path.read_text()
+    scan_lines = (
+        code_only_text(text).splitlines()
+        if in_product_client
+        else text.splitlines()
+    )
 
-    for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
+    for lineno, raw_line in enumerate(scan_lines, start=1):
         line = strip_line_comment(raw_line)
         if not line.strip():
             continue
@@ -247,7 +359,7 @@ def check_file(path: Path) -> list[Violation]:
         )
         add_if(
             violations,
-            in_desktop
+            (in_desktop or in_product_client)
             and contains_openapi_client_verb
             and not is_cloud_access_path(rel),
             "CLOUD_OPENAPI_CLIENT_OUTSIDE_ACCESS",
@@ -257,7 +369,7 @@ def check_file(path: Path) -> list[Violation]:
         )
         add_if(
             violations,
-            in_desktop
+            (in_desktop or in_product_client)
             and (contains_use_query_client or contains_query_cache_call)
             and not is_query_cache_owner_path(rel),
             "QUERY_CLIENT_OUTSIDE_CACHE_OWNER",
@@ -273,25 +385,6 @@ def check_file(path: Path) -> list[Violation]:
             lineno,
             "legacy cloud/AnyHarness/Tauri access paths are not allowed",
         )
-
-        if in_product_client:
-            add_if(
-                violations,
-                contains_tauri_api
-                or "@tauri-apps/" in line
-                or "__TAURI" in line
-                or "apps/desktop/" in line
-                or "apps/web/" in line
-                or "@/" in line,
-                "PRODUCT_CLIENT_FORBIDDEN_IMPORT",
-                path,
-                lineno,
-                (
-                    "product-client must not import either host (apps/desktop, "
-                    "apps/web), Tauri package or raw Tauri globals (__TAURI*), "
-                    "or Desktop-relative @/ aliases"
-                ),
-            )
 
         if in_domain:
             add_if(
@@ -334,13 +427,11 @@ def check_file(path: Path) -> list[Violation]:
                     "@/lib/access/" in line
                     or contains_tauri_api
                     or contains_anyharness_client
-                    or contains_use_query_client
-                    or contains_query_cache_call
                 ),
                 "COMPONENT_FORBIDDEN_ACCESS",
                 path,
                 lineno,
-                "components must not own raw access or React Query cache shape",
+                "components must not own raw access",
             )
 
         if in_stores:
@@ -356,6 +447,288 @@ def check_file(path: Path) -> list[Violation]:
                 path,
                 lineno,
                 "stores must not import raw access, Tauri, TanStack Query, or AnyHarness clients",
+            )
+
+    return violations
+
+
+def statement_identifiers(statement: ImportStatement) -> set[str]:
+    return {
+        token.value
+        for token in tokenize_typescript(statement.statement)
+        if token.kind == "identifier"
+    }
+
+
+def imported_bindings(statement: ImportStatement) -> set[str]:
+    tokens = tokenize_typescript(statement.statement)
+    if not tokens or tokens[0].value != "import":
+        return set()
+    try:
+        from_index = next(index for index, token in enumerate(tokens) if token.value == "from")
+    except StopIteration:
+        return set()
+
+    clause = tokens[1:from_index]
+    if clause and clause[0].value == "type":
+        clause = clause[1:]
+    bindings: set[str] = set()
+
+    if clause and clause[0].kind == "identifier":
+        bindings.add(clause[0].value)
+
+    for index, token in enumerate(clause):
+        if token.value == "*" and index + 2 < len(clause) and clause[index + 1].value == "as":
+            bindings.add(clause[index + 2].value)
+
+    try:
+        open_index = next(index for index, token in enumerate(clause) if token.value == "{")
+        close_index = max(index for index, token in enumerate(clause) if token.value == "}")
+    except (StopIteration, ValueError):
+        return bindings
+
+    current: list = []
+    entries: list[list] = []
+    for token in clause[open_index + 1 : close_index]:
+        if token.value == ",":
+            if current:
+                entries.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        entries.append(current)
+
+    for entry in entries:
+        if entry and entry[0].value == "type":
+            entry = entry[1:]
+        if not entry:
+            continue
+        alias_index = next(
+            (index for index, token in enumerate(entry) if token.value == "as"),
+            None,
+        )
+        if alias_index is not None and alias_index + 1 < len(entry):
+            bindings.add(entry[alias_index + 1].value)
+        elif entry[0].kind == "identifier":
+            bindings.add(entry[0].value)
+    return bindings
+
+
+def member_call_lines(text: str, bindings: set[str], member: str) -> list[int]:
+    if not bindings:
+        return []
+    tokens = tokenize_typescript(text)
+    return [
+        tokens[index].lineno
+        for index in range(len(tokens) - 3)
+        if tokens[index].kind == "identifier"
+        and tokens[index].value in bindings
+        and tokens[index + 1].value == "."
+        and tokens[index + 2].value == member
+        and tokens[index + 3].value == "("
+    ]
+
+
+def direct_call_lines(text: str, binding: str) -> list[int]:
+    tokens = tokenize_typescript(text)
+    return [
+        token.lineno
+        for index, token in enumerate(tokens[:-1])
+        if token.kind == "identifier"
+        and token.value == binding
+        and tokens[index + 1].value == "("
+        and (index == 0 or tokens[index - 1].value != ".")
+    ]
+
+
+def is_product_client_forbidden_import(path: Path, source: str) -> bool:
+    if (
+        source.startswith("@tauri-apps/")
+        or source.startswith("@/")
+        or source.startswith("apps/desktop/")
+        or source.startswith("apps/web/")
+    ):
+        return True
+    if not source.startswith("."):
+        return False
+    clean_source = source.split("?", 1)[0]
+    resolved = (path.parent / clean_source).resolve()
+    return any(
+        is_under(resolved.as_posix(), root.resolve().as_posix() + "/")
+        for root in (REPO_ROOT / "apps" / "desktop", REPO_ROOT / "apps" / "web")
+    )
+
+
+def find_product_client_violations(path: Path) -> list[Violation]:
+    if not is_product_client_path(path):
+        return []
+
+    violations: list[Violation] = []
+    text = path.read_text()
+    statements = collect_imports(path, text)
+    source_layer = product_client_layer(product_client_relative(path))
+    imported_store_bindings: set[str] = set()
+
+    for statement in statements:
+        identifiers = statement_identifiers(statement)
+        if is_product_client_forbidden_import(path, statement.source):
+            violations.append(
+                Violation(
+                    "PRODUCT_CLIENT_FORBIDDEN_IMPORT",
+                    path,
+                    statement.lineno,
+                    (
+                        "product-client must use its typed host boundary instead of "
+                        f"importing {statement.source!r}"
+                    ),
+                )
+            )
+            continue
+
+        target = resolve_product_client_import(path, statement.source)
+        target_layer = product_client_layer(target) if target is not None else None
+        if target_layer is not None and (source_layer, target_layer) in PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES:
+            edge_kind = "type-only" if statement.type_only else "runtime"
+            violations.append(
+                Violation(
+                    "PRODUCT_CLIENT_LAYER_DIRECTION",
+                    path,
+                    statement.lineno,
+                    (
+                        f"{edge_kind} {source_layer} -> {target_layer} import is upward; "
+                        "move the dependency or its owned type to the lower layer"
+                    ),
+                )
+            )
+
+        if target_layer == "stores":
+            imported_store_bindings.update(imported_bindings(statement))
+
+        if (
+            source_layer not in {"lib", "stores"}
+            and statement.source == "@tanstack/react-query"
+            and identifiers.intersection(QUERY_HOOK_NAMES)
+            and not is_product_client_query_hook_owner(path)
+        ):
+            violations.append(
+                Violation(
+                    "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE",
+                    path,
+                    statement.lineno,
+                    (
+                        "React Query query/mutation hooks belong under hooks/access/** "
+                        "or a product hooks/**/cache/** owner"
+                    ),
+                )
+            )
+
+        if (
+            "getAnyHarnessClient" in identifiers
+            and not is_anyharness_client_path(relative(path))
+        ):
+            violations.append(
+                Violation(
+                    "ANYHARNESS_CLIENT_OUTSIDE_ACCESS",
+                    path,
+                    statement.lineno,
+                    "getAnyHarnessClient must stay behind AnyHarness access boundaries",
+                )
+            )
+
+        if source_layer == "components" and target is not None and target.startswith("lib/access/"):
+            violations.append(
+                Violation(
+                    "COMPONENT_FORBIDDEN_ACCESS",
+                    path,
+                    statement.lineno,
+                    "components must call hooks instead of importing lib/access directly",
+                )
+            )
+
+        if source_layer == "stores" and target is not None and target.startswith("lib/access/"):
+            violations.append(
+                Violation(
+                    "STORE_FORBIDDEN_ACCESS",
+                    path,
+                    statement.lineno,
+                    "stores must receive access-owned values instead of importing lib/access",
+                )
+            )
+
+        runtime_access_import = (
+            not statement.type_only
+            and source_layer == "stores"
+            and (
+                statement.source == "@tanstack/react-query"
+                or statement.source.startswith("@proliferate/cloud-sdk-react")
+                or statement.source.startswith("@anyharness/sdk-react")
+                or bool(identifiers.intersection(RAW_CLIENT_BINDINGS))
+            )
+        )
+        if runtime_access_import:
+            violations.append(
+                Violation(
+                    "STORE_RUNTIME_ACCESS",
+                    path,
+                    statement.lineno,
+                    "stores must not import query/React SDK clients or raw client constructors",
+                )
+            )
+
+        if source_layer == "lib":
+            lib_area = product_client_relative(path).split("/", 2)[1]
+            rule_id = (
+                "DOMAIN_FORBIDDEN_IMPORT"
+                if lib_area == "domain"
+                else "WORKFLOW_FORBIDDEN_IMPORT"
+                if lib_area == "workflows"
+                else None
+            )
+            forbidden_lib_import = (
+                statement.source in {"react", "react-dom", "@tanstack/react-query"}
+                or (target is not None and target.startswith("lib/access/"))
+            )
+            if rule_id is not None and forbidden_lib_import:
+                violations.append(
+                    Violation(
+                        rule_id,
+                        path,
+                        statement.lineno,
+                        f"lib/{lib_area} must remain non-React and free of query/raw access imports",
+                    )
+                )
+
+    for lineno in member_call_lines(text, imported_store_bindings, "setState"):
+        violations.append(
+            Violation(
+                "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER",
+                path,
+                lineno,
+                "call an action owned by the store instead of mutating imported store state directly",
+            )
+        )
+
+    if source_layer == "stores":
+        for lineno in direct_call_lines(text, "fetch"):
+            violations.append(
+                Violation(
+                    "STORE_RUNTIME_ACCESS",
+                    path,
+                    lineno,
+                    "stores must receive fetched values through actions instead of calling fetch directly",
+                )
+            )
+
+    for token in tokenize_typescript(text):
+        if token.kind == "identifier" and token.value.startswith("__TAURI"):
+            violations.append(
+                Violation(
+                    "PRODUCT_CLIENT_FORBIDDEN_IMPORT",
+                    path,
+                    token.lineno,
+                    "product-client must use its typed host boundary instead of raw __TAURI* globals",
+                )
             )
 
     return violations
@@ -519,6 +892,7 @@ def collect_violations() -> list[Violation]:
     violations: list[Violation] = []
     for path in iter_frontend_files():
         violations.extend(check_file(path))
+        violations.extend(find_product_client_violations(path))
     violations.extend(find_radix_import_violations())
     violations.extend(find_ui_src_top_level_violations())
     violations.extend(find_warning_ink_violations())

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -117,6 +117,15 @@ class Violation:
 
 
 @dataclass(frozen=True)
+class ScopedLocalBinding:
+    name: str
+    start: int
+    end: int
+    namespace: bool = False
+    tracked_import_start: int | None = None
+
+
+@dataclass(frozen=True)
 class AllowlistEntry:
     rule_id: str
     relative_path: str
@@ -477,6 +486,22 @@ def namespace_bindings(statement: ImportStatement) -> set[str]:
     return set(statement.namespace_bindings)
 
 
+def scoped_import_bindings(statement: ImportStatement) -> list[ScopedLocalBinding]:
+    return [
+        ScopedLocalBinding(
+            name=binding.name,
+            start=binding.start,
+            end=binding.end,
+            namespace=binding.namespace,
+        )
+        for binding in statement.scoped_bindings
+    ]
+
+
+def is_package_source(source: str, package: str) -> bool:
+    return source == package or source.startswith(f"{package}/")
+
+
 def namespace_member_identifiers(
     text: str,
     bindings: set[str],
@@ -532,6 +557,56 @@ def _matching_token_pairs(
             forward[open_index] = index
             reverse[index] = open_index
     return forward, reverse
+
+
+def _statement_binding_scope(
+    text: str,
+    tokens: list[Token],
+    statement: ImportStatement,
+) -> tuple[int, int]:
+    import_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if token.start == statement.start and token.value == "import"
+        ),
+        None,
+    )
+    if (
+        import_index is None
+        or import_index + 1 >= len(tokens)
+        or tokens[import_index + 1].value != "("
+    ):
+        return 0, len(text)
+
+    braces, _ = _matching_token_pairs(tokens, "{", "}")
+    containers = [
+        (open_index, close_index)
+        for open_index, close_index in braces.items()
+        if open_index < import_index < close_index
+    ]
+    if not containers:
+        return 0, len(text)
+    open_index, close_index = max(containers)
+    return tokens[open_index].end, tokens[close_index].start
+
+
+def _is_dynamic_import_statement(
+    tokens: list[Token], statement: ImportStatement
+) -> bool:
+    import_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if token.start == statement.start and token.value == "import"
+        ),
+        None,
+    )
+    return (
+        import_index is not None
+        and import_index + 1 < len(tokens)
+        and tokens[import_index + 1].value == "("
+    )
 
 
 def _top_level_token_index(tokens: list[Token], value: str) -> int | None:
@@ -1050,28 +1125,73 @@ def _member_name_after(
     return None
 
 
-def _namespace_destructure_names(tokens: list[Token], index: int) -> set[str]:
-    """Return exports selected from an imported namespace at this occurrence."""
-
+def _namespace_destructure_pattern(
+    tokens: list[Token], index: int
+) -> tuple[int, int, int] | None:
     after = index + 1
     while after < len(tokens) and tokens[after].value in {"!", ")"}:
         after += 1
     if after < len(tokens) and tokens[after].value != ";":
-        # `const { useMutation } = Query.options` destructures a property value,
-        # not the imported namespace itself.
-        return set()
+        next_token = tokens[after]
+        previous_token = tokens[after - 1]
+        continuation_starters = {
+            ".",
+            "?",
+            "[",
+            "(",
+            "`",
+            ",",
+            ":",
+            "+",
+            "-",
+            "*",
+            "/",
+            "%",
+            "&",
+            "|",
+            "^",
+            "<",
+            ">",
+            "=",
+            "as",
+            "satisfies",
+            "instanceof",
+            "in",
+        }
+        has_asi_boundary = (
+            next_token.value == "}"
+            or (
+                next_token.lineno > previous_token.lineno
+                and next_token.value not in continuation_starters
+            )
+        )
+        if not has_asi_boundary:
+            # `const { useMutation } = Query.options` destructures a property
+            # value, not the imported namespace itself. A line continuation
+            # such as `Query\n.options` is likewise still the same expression.
+            return None
 
     cursor = index - 1
     while cursor >= 0 and tokens[cursor].value == "(":
         cursor -= 1
     if cursor < 1 or tokens[cursor].value != "=" or tokens[cursor - 1].value != "}":
-        return set()
+        return None
 
     _, reverse = _matching_token_pairs(tokens, "{", "}")
     close_index = cursor - 1
     open_index = reverse.get(close_index)
     if open_index is None:
+        return None
+    return open_index, close_index, after
+
+
+def _namespace_destructure_names(tokens: list[Token], index: int) -> set[str]:
+    """Return exports selected from an imported namespace at this occurrence."""
+
+    pattern = _namespace_destructure_pattern(tokens, index)
+    if pattern is None:
         return set()
+    open_index, close_index, _ = pattern
 
     names: set[str] = set()
     for entry in _split_top_level_tokens(tokens[open_index + 1 : close_index], ","):
@@ -1093,6 +1213,91 @@ def _namespace_destructure_names(tokens: list[Token], index: int) -> set[str]:
         ):
             names.add(key[1].value)
     return names
+
+
+def _namespace_destructure_local_bindings(
+    tokens: list[Token], open_index: int, close_index: int
+) -> set[tuple[str, bool]]:
+    bindings: set[tuple[str, bool]] = set()
+    for entry in _split_top_level_tokens(tokens[open_index + 1 : close_index], ","):
+        if not entry:
+            continue
+        is_namespace = len(entry) >= 3 and all(
+            token.value == "." for token in entry[:3]
+        )
+        if is_namespace:
+            binding_part = entry[3:]
+        else:
+            equals_index = _top_level_token_index(entry, "=")
+            binding_part = entry[:equals_index] if equals_index is not None else entry
+            colon_index = _top_level_token_index(binding_part, ":")
+            if colon_index is not None:
+                binding_part = binding_part[colon_index + 1 :]
+        candidates = {
+            token.value for token in binding_part if token.kind == "identifier"
+        }
+        for name in _binding_names_in_pattern(binding_part, candidates):
+            bindings.add((name, is_namespace))
+    return bindings
+
+
+def namespace_destructured_bindings(
+    text: str,
+    bindings: set[str],
+    *,
+    jsx: bool,
+    tracked_import_starts: dict[str, set[int]] | None = None,
+) -> list[ScopedLocalBinding]:
+    if not bindings:
+        return []
+    tokens = tokenize_typescript(text, jsx=jsx)
+    _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
+    shadow_ranges = _function_shadow_ranges(tokens, bindings)
+    derived: set[ScopedLocalBinding] = set()
+    for index, token in enumerate(tokens):
+        if token.kind != "identifier" or token.value not in bindings:
+            continue
+        if not _is_imported_binding_occurrence(
+            tokens,
+            index,
+            shadow_ranges,
+            brace_reverse,
+            (tracked_import_starts or {}).get(token.value, set()),
+        ):
+            continue
+        pattern = _namespace_destructure_pattern(tokens, index)
+        if pattern is None:
+            continue
+        open_index, close_index, after_index = pattern
+        range_start = (
+            tokens[after_index].end
+            if after_index < len(tokens) and tokens[after_index].value == ";"
+            else token.end
+        )
+        containers = [
+            (brace_open, brace_close)
+            for brace_close, brace_open in brace_reverse.items()
+            if brace_open < index < brace_close
+        ]
+        range_end = (
+            tokens[max(containers)[1]].start if containers else len(text)
+        )
+        if range_start >= range_end:
+            continue
+        for name, namespace in _namespace_destructure_local_bindings(
+            tokens, open_index, close_index
+        ):
+            derived.add(
+                ScopedLocalBinding(
+                    name=name,
+                    start=range_start,
+                    end=range_end,
+                    namespace=namespace,
+                )
+            )
+    return sorted(
+        derived, key=lambda binding: (binding.start, binding.end, binding.name)
+    )
 
 
 def _parenthesis_is_grouping(tokens: list[Token], open_index: int) -> bool:
@@ -1256,6 +1461,40 @@ def member_call_lines(
     return lines
 
 
+def scoped_member_call_lines(
+    text: str,
+    binding: ScopedLocalBinding,
+    member: str,
+    *,
+    jsx: bool,
+) -> list[int]:
+    start = max(0, min(len(text), binding.start))
+    end = max(start, min(len(text), binding.end))
+    segment = text[start:end]
+    line_offset = text.count("\n", 0, start)
+    tracked_import_starts = (
+        {
+            binding.name: {
+                binding.tracked_import_start - start,
+            }
+        }
+        if binding.tracked_import_start is not None
+        and start <= binding.tracked_import_start < end
+        else None
+    )
+    return [
+        line_offset + lineno
+        for lineno in member_call_lines(
+            segment,
+            {binding.name},
+            member,
+            jsx=jsx,
+            namespace_bindings={binding.name} if binding.namespace else set(),
+            tracked_import_starts=tracked_import_starts,
+        )
+    ]
+
+
 def direct_call_lines(text: str, binding: str, *, jsx: bool) -> list[int]:
     tokens = tokenize_typescript(text, jsx=jsx)
     return [
@@ -1294,6 +1533,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
     text = path.read_text()
     statements = collect_imports(path, text)
     jsx = path.suffix == ".tsx"
+    source_tokens = tokenize_typescript(text, jsx=jsx)
     source_layer = product_client_layer(product_client_relative(path))
     lib_area = (
         product_client_relative(path).split("/", 2)[1]
@@ -1303,22 +1543,73 @@ def find_product_client_violations(path: Path) -> list[Violation]:
     imported_store_bindings: set[str] = set()
     imported_store_namespace_bindings: set[str] = set()
     imported_store_binding_starts: dict[str, set[int]] = defaultdict(set)
-    namespace_binding_starts: dict[str, set[int]] = defaultdict(set)
-
-    for statement in statements:
-        for binding in namespace_bindings(statement):
-            namespace_binding_starts[binding].add(statement.start)
+    scoped_store_bindings: set[ScopedLocalBinding] = set()
 
     for statement in statements:
         identifiers = statement_identifiers(statement)
-        identifiers.update(
-            namespace_member_identifiers(
-                text,
-                namespace_bindings(statement),
-                jsx=jsx,
-                tracked_import_starts=namespace_binding_starts,
-            )
+        statement_is_dynamic = _is_dynamic_import_statement(
+            source_tokens, statement
         )
+        statement_namespaces = namespace_bindings(statement)
+        statement_namespace_aliases: list[ScopedLocalBinding] = []
+        if statement_namespaces:
+            scope_start, scope_end = _statement_binding_scope(
+                text, source_tokens, statement
+            )
+            scope_text = text[scope_start:scope_end]
+            relative_import_start = statement.start - scope_start
+            tracked_starts = {
+                binding: {relative_import_start} for binding in statement_namespaces
+            }
+            identifiers.update(
+                namespace_member_identifiers(
+                    scope_text,
+                    statement_namespaces,
+                    jsx=jsx,
+                    tracked_import_starts=tracked_starts,
+                )
+            )
+            statement_namespace_aliases = [
+                ScopedLocalBinding(
+                    name=binding.name,
+                    start=scope_start + binding.start,
+                    end=scope_start + binding.end,
+                    namespace=binding.namespace,
+                )
+                for binding in namespace_destructured_bindings(
+                    scope_text,
+                    statement_namespaces,
+                    jsx=jsx,
+                    tracked_import_starts=tracked_starts,
+                )
+            ]
+
+        statement_scoped_bindings = scoped_import_bindings(statement)
+        scoped_namespace_aliases: list[ScopedLocalBinding] = []
+        for binding in statement_scoped_bindings:
+            if not binding.namespace:
+                continue
+            scoped_text = text[binding.start : binding.end]
+            identifiers.update(
+                namespace_member_identifiers(
+                    scoped_text,
+                    {binding.name},
+                    jsx=jsx,
+                )
+            )
+            scoped_namespace_aliases.extend(
+                ScopedLocalBinding(
+                    name=alias.name,
+                    start=binding.start + alias.start,
+                    end=binding.start + alias.end,
+                    namespace=alias.namespace,
+                )
+                for alias in namespace_destructured_bindings(
+                    scoped_text,
+                    {binding.name},
+                    jsx=jsx,
+                )
+            )
         if is_product_client_forbidden_import(path, statement.source):
             violations.append(
                 Violation(
@@ -1351,9 +1642,27 @@ def find_product_client_violations(path: Path) -> list[Violation]:
 
         if target_layer == "stores":
             statement_bindings = imported_bindings(statement)
-            imported_store_bindings.update(statement_bindings)
-            imported_store_namespace_bindings.update(namespace_bindings(statement))
-            if statement.local_bindings:
+            if statement_is_dynamic:
+                scope_start, scope_end = _statement_binding_scope(
+                    text, source_tokens, statement
+                )
+                scoped_store_bindings.update(
+                    ScopedLocalBinding(
+                        name=binding,
+                        start=scope_start,
+                        end=scope_end,
+                        namespace=binding in statement_namespaces,
+                        tracked_import_start=statement.start,
+                    )
+                    for binding in statement_bindings
+                )
+            else:
+                imported_store_bindings.update(statement_bindings)
+                imported_store_namespace_bindings.update(statement_namespaces)
+            scoped_store_bindings.update(statement_scoped_bindings)
+            scoped_store_bindings.update(statement_namespace_aliases)
+            scoped_store_bindings.update(scoped_namespace_aliases)
+            if statement.local_bindings and not statement_is_dynamic:
                 for binding in statement_bindings:
                     imported_store_binding_starts[binding].add(statement.start)
 
@@ -1362,7 +1671,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         )
         if (
             not query_hook_has_specific_owner
-            and statement.source == "@tanstack/react-query"
+            and is_package_source(statement.source, "@tanstack/react-query")
             and identifiers.intersection(QUERY_HOOK_NAMES)
             and not is_product_client_query_hook_owner(path)
         ):
@@ -1423,9 +1732,11 @@ def find_product_client_violations(path: Path) -> list[Violation]:
             and source_layer == "stores"
             and not internal_store_access
             and (
-                statement.source == "@tanstack/react-query"
-                or statement.source.startswith("@proliferate/cloud-sdk-react")
-                or statement.source.startswith("@anyharness/sdk-react")
+                is_package_source(statement.source, "@tanstack/react-query")
+                or is_package_source(
+                    statement.source, "@proliferate/cloud-sdk-react"
+                )
+                or is_package_source(statement.source, "@anyharness/sdk-react")
                 or bool(identifiers.intersection(RAW_CLIENT_BINDINGS))
             )
         )
@@ -1448,7 +1759,10 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 else None
             )
             forbidden_lib_import = (
-                statement.source in {"react", "react-dom", "@tanstack/react-query"}
+                any(
+                    is_package_source(statement.source, package)
+                    for package in {"react", "react-dom", "@tanstack/react-query"}
+                )
                 or (target is not None and target.startswith("lib/access/"))
             )
             if rule_id is not None and forbidden_lib_import:
@@ -1477,6 +1791,31 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 "call an action owned by the store instead of mutating imported store state directly",
             )
         )
+
+    for binding in sorted(
+        scoped_store_bindings,
+        key=lambda item: (
+            item.start,
+            item.end,
+            item.name,
+            item.namespace,
+            item.tracked_import_start if item.tracked_import_start is not None else -1,
+        ),
+    ):
+        for lineno in scoped_member_call_lines(
+            text,
+            binding,
+            "setState",
+            jsx=jsx,
+        ):
+            violations.append(
+                Violation(
+                    "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER",
+                    path,
+                    lineno,
+                    "call an action owned by the store instead of mutating imported store state directly",
+                )
+            )
 
     if source_layer == "stores":
         for lineno in direct_call_lines(text, "fetch", jsx=jsx):

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -10,9 +10,14 @@ import re
 import sys
 
 try:
-    from scripts.frontend_imports import ImportStatement, collect_imports, tokenize_typescript
+    from scripts.frontend_imports import (
+        ImportStatement,
+        Token,
+        collect_imports,
+        tokenize_typescript,
+    )
 except ModuleNotFoundError:  # Direct `python3 scripts/...` execution.
-    from frontend_imports import ImportStatement, collect_imports, tokenize_typescript
+    from frontend_imports import ImportStatement, Token, collect_imports, tokenize_typescript
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DESKTOP_SRC = REPO_ROOT / "apps" / "desktop" / "src"
@@ -515,19 +520,305 @@ def imported_bindings(statement: ImportStatement) -> set[str]:
     return bindings
 
 
+def _matching_token_pairs(
+    tokens: list[Token],
+    opener: str,
+    closer: str,
+) -> tuple[dict[int, int], dict[int, int]]:
+    opens: list[int] = []
+    forward: dict[int, int] = {}
+    reverse: dict[int, int] = {}
+    for index, token in enumerate(tokens):
+        if token.value == opener:
+            opens.append(index)
+        elif token.value == closer and opens:
+            open_index = opens.pop()
+            forward[open_index] = index
+            reverse[index] = open_index
+    return forward, reverse
+
+
+def _binding_names_in_pattern(tokens: list[Token], bindings: set[str]) -> set[str]:
+    """Return imported names rebound by one parameter/declaration pattern."""
+
+    cursor = 0
+    while cursor < len(tokens) and tokens[cursor].value in {
+        ".",
+        "override",
+        "private",
+        "protected",
+        "public",
+        "readonly",
+    }:
+        cursor += 1
+    if cursor >= len(tokens):
+        return set()
+    first = tokens[cursor]
+    if first.kind == "identifier":
+        return {first.value} & bindings
+    if first.value not in {"{", "["}:
+        return set()
+
+    opener = first.value
+    closer = "}" if opener == "{" else "]"
+    depth = 1
+    end = cursor + 1
+    rebound: set[str] = set()
+    while end < len(tokens) and depth:
+        token = tokens[end]
+        if token.value == opener:
+            depth += 1
+        elif token.value == closer:
+            depth -= 1
+        elif token.kind == "identifier" and token.value in bindings:
+            next_value = tokens[end + 1].value if end + 1 < len(tokens) else None
+            # `{ sourceName: localName }` does not bind the property key.
+            if not (opener == "{" and next_value == ":"):
+                rebound.add(token.value)
+        end += 1
+    return rebound
+
+
+def _binding_names_in_parameter_tokens(
+    tokens: list[Token], bindings: set[str]
+) -> set[str]:
+    """Return imported names rebound by a function-like parameter list."""
+
+    entries: list[list[Token]] = []
+    current: list[Token] = []
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for token in tokens:
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+        if token.value == "," and not nesting:
+            entries.append(current)
+            current = []
+        else:
+            current.append(token)
+    entries.append(current)
+
+    rebound: set[str] = set()
+    for entry in entries:
+        rebound.update(_binding_names_in_pattern(entry, bindings))
+    return rebound
+
+
+def _function_shadow_ranges(
+    tokens: list[Token], bindings: set[str]
+) -> list[tuple[int, int, set[str]]]:
+    parens, closing_parens = _matching_token_pairs(tokens, "(", ")")
+    braces, _ = _matching_token_pairs(tokens, "{", "}")
+    ranges: list[tuple[int, int, set[str]]] = []
+
+    def add_range(param_start: int, param_end: int, body_start: int, body_end: int) -> None:
+        rebound = _binding_names_in_parameter_tokens(
+            tokens[param_start:param_end], bindings
+        )
+        if rebound:
+            ranges.append((body_start, body_end, rebound))
+
+    # Function declarations/expressions and catch clauses.
+    for index, token in enumerate(tokens):
+        if token.value not in {"function", "catch"}:
+            continue
+        open_index = index + 1
+        while open_index < len(tokens) and tokens[open_index].value != "(":
+            if tokens[open_index].value in {"{", ";"}:
+                break
+            open_index += 1
+        close_index = parens.get(open_index)
+        if close_index is None or close_index + 1 >= len(tokens):
+            continue
+        body_open = close_index + 1
+        if tokens[body_open].value != "{" or body_open not in braces:
+            continue
+        add_range(open_index + 1, close_index, body_open + 1, braces[body_open])
+
+    # Arrow functions, including a single bare parameter.
+    for arrow_index, token in enumerate(tokens):
+        is_combined_arrow = token.value == "=>"
+        is_split_arrow = (
+            token.value == "="
+            and arrow_index + 1 < len(tokens)
+            and tokens[arrow_index + 1].value == ">"
+        )
+        if (
+            not (is_combined_arrow or is_split_arrow)
+            or arrow_index == 0
+            or arrow_index + (2 if is_split_arrow else 1) >= len(tokens)
+        ):
+            continue
+        before = arrow_index - 1
+        if tokens[before].value == ")" and before in closing_parens:
+            open_index = closing_parens[before]
+            param_start, param_end = open_index + 1, before
+        elif tokens[before].kind == "identifier":
+            param_start, param_end = before, arrow_index
+        else:
+            continue
+
+        body_start = arrow_index + (2 if is_split_arrow else 1)
+        if tokens[body_start].value == "{" and body_start in braces:
+            body_end = braces[body_start]
+            add_range(param_start, param_end, body_start + 1, body_end)
+            continue
+
+        # An expression body ends at the first delimiter in its containing
+        # expression. This is deliberately conservative: skipping a false
+        # positive is preferable to attributing an unrelated object's call to
+        # an imported Zustand binding.
+        body_end = len(tokens)
+        depth = 0
+        for cursor in range(body_start, len(tokens)):
+            value = tokens[cursor].value
+            if value in {"(", "[", "{"}:
+                depth += 1
+            elif value in {
+                ")",
+                "]",
+                "}",
+            }:
+                if depth == 0:
+                    body_end = cursor
+                    break
+                depth -= 1
+            elif depth == 0 and value in {",", ";"}:
+                body_end = cursor
+                break
+        add_range(param_start, param_end, body_start, body_end)
+
+    # Object/class methods have the same parameter/body spelling but no
+    # `function` keyword. Limit this to a closing parameter list immediately
+    # followed by a body; control-flow constructs contain no imported binding
+    # parameter and therefore do not add a range.
+    for open_index, close_index in parens.items():
+        if open_index == 0:
+            continue
+        owner = tokens[open_index - 1]
+        if owner.kind != "identifier" or owner.value in {
+            "catch",
+            "for",
+            "if",
+            "switch",
+            "while",
+            "with",
+        }:
+            continue
+        if close_index + 1 >= len(tokens) or tokens[close_index + 1].value != "{":
+            continue
+        body_open = close_index + 1
+        if body_open not in braces:
+            continue
+        add_range(open_index + 1, close_index, body_open + 1, braces[body_open])
+
+    return ranges
+
+
+def _declares_binding_in_scope(
+    tokens: list[Token],
+    binding: str,
+    candidate_index: int,
+    brace_reverse: dict[int, int],
+) -> bool:
+    """Whether a local declaration shadows an imported binding at a call."""
+
+    # Lexical declarations shadow the import for their whole scope, including
+    # before initialization (where JavaScript's temporal dead zone applies).
+    enclosing_starts = {0} | {
+        open_index + 1
+        for close_index, open_index in brace_reverse.items()
+        if open_index < candidate_index < close_index
+    }
+
+    for index in range(len(tokens)):
+        if tokens[index].value not in {"const", "let", "var", "class", "function"}:
+            continue
+        # The declaration itself must begin inside one of the candidate's
+        # enclosing blocks, not a completed sibling/nested block.
+        declaration_containers = [
+            (open_index, close_index)
+            for close_index, open_index in brace_reverse.items()
+            if open_index < index < close_index
+        ]
+        declaration_scope = 0
+        if declaration_containers:
+            open_index, close_index = max(declaration_containers)
+            if not (open_index < candidate_index < close_index):
+                continue
+            declaration_scope = open_index + 1
+        if declaration_scope not in enclosing_starts:
+            continue
+
+        if tokens[index].value in {"class", "function"}:
+            if (
+                index + 1 < len(tokens)
+                and tokens[index + 1].kind == "identifier"
+                and tokens[index + 1].value == binding
+            ):
+                return True
+            continue
+
+        # Walk every declarator in `const a = 1, b = 2;`, but inspect only its
+        # binding pattern—not type annotations or initializer expressions.
+        cursor = index + 1
+        while cursor < len(tokens):
+            declarator_start = cursor
+            nesting: list[str] = []
+            matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+            while cursor < len(tokens):
+                value = tokens[cursor].value
+                if value in {"(", "[", "{", "<"}:
+                    nesting.append(value)
+                elif value in matching and nesting and nesting[-1] == matching[value]:
+                    nesting.pop()
+                if not nesting and value in {",", ";"}:
+                    break
+                cursor += 1
+            if binding in _binding_names_in_pattern(
+                tokens[declarator_start:cursor], {binding}
+            ):
+                return True
+            if cursor >= len(tokens) or tokens[cursor].value == ";":
+                break
+            cursor += 1
+    return False
+
+
 def member_call_lines(text: str, bindings: set[str], member: str) -> list[int]:
     if not bindings:
         return []
     tokens = tokenize_typescript(text)
-    return [
-        tokens[index].lineno
-        for index in range(len(tokens) - 3)
-        if tokens[index].kind == "identifier"
-        and tokens[index].value in bindings
-        and tokens[index + 1].value == "."
-        and tokens[index + 2].value == member
-        and tokens[index + 3].value == "("
-    ]
+    _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
+    shadow_ranges = _function_shadow_ranges(tokens, bindings)
+    lines: list[int] = []
+    for index in range(len(tokens) - 3):
+        token = tokens[index]
+        if (
+            token.kind != "identifier"
+            or token.value not in bindings
+            or tokens[index + 1].value != "."
+            or tokens[index + 2].value != member
+            or tokens[index + 3].value != "("
+        ):
+            continue
+        # `fixture.store.setState()` and `fixture?.store.setState()` are calls
+        # on a property, not on the imported binding with the same spelling.
+        if index > 0 and tokens[index - 1].value == ".":
+            continue
+        if index > 1 and tokens[index - 2].value == "?" and tokens[index - 1].value == ".":
+            continue
+        if any(
+            start <= index < end and token.value in rebound
+            for start, end, rebound in shadow_ranges
+        ):
+            continue
+        if _declares_binding_in_scope(tokens, token.value, index, brace_reverse):
+            continue
+        lines.append(token.lineno)
+    return lines
 
 
 def direct_call_lines(text: str, binding: str) -> list[int]:
@@ -568,6 +859,11 @@ def find_product_client_violations(path: Path) -> list[Violation]:
     text = path.read_text()
     statements = collect_imports(path, text)
     source_layer = product_client_layer(product_client_relative(path))
+    lib_area = (
+        product_client_relative(path).split("/", 2)[1]
+        if source_layer == "lib"
+        else None
+    )
     imported_store_bindings: set[str] = set()
 
     for statement in statements:
@@ -605,8 +901,11 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         if target_layer == "stores":
             imported_store_bindings.update(imported_bindings(statement))
 
+        query_hook_has_specific_owner = source_layer == "stores" or (
+            source_layer == "lib" and lib_area in {"domain", "workflows"}
+        )
         if (
-            source_layer not in {"lib", "stores"}
+            not query_hook_has_specific_owner
             and statement.source == "@tanstack/react-query"
             and identifiers.intersection(QUERY_HOOK_NAMES)
             and not is_product_client_query_hook_owner(path)
@@ -623,8 +922,15 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 )
             )
 
+        internal_store_access = (
+            source_layer == "stores"
+            and target is not None
+            and target.startswith("lib/access/")
+        )
+
         if (
             "getAnyHarnessClient" in identifiers
+            and not internal_store_access
             and not is_anyharness_client_path(relative(path))
         ):
             violations.append(
@@ -646,7 +952,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 )
             )
 
-        if source_layer == "stores" and target is not None and target.startswith("lib/access/"):
+        if internal_store_access:
             violations.append(
                 Violation(
                     "STORE_FORBIDDEN_ACCESS",
@@ -659,6 +965,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         runtime_access_import = (
             not statement.type_only
             and source_layer == "stores"
+            and not internal_store_access
             and (
                 statement.source == "@tanstack/react-query"
                 or statement.source.startswith("@proliferate/cloud-sdk-react")
@@ -677,7 +984,6 @@ def find_product_client_violations(path: Path) -> list[Violation]:
             )
 
         if source_layer == "lib":
-            lib_area = product_client_relative(path).split("/", 2)[1]
             rule_id = (
                 "DOMAIN_FORBIDDEN_IMPORT"
                 if lib_area == "domain"

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -85,9 +85,10 @@ QUERY_HOOK_NAMES = {
     "useSuspenseQuery",
 }
 RAW_CLIENT_BINDINGS = {
-    "createCloudClient",
+    "AnyHarnessClient",
+    "createProliferateClient",
     "getAnyHarnessClient",
-    "getCloudClient",
+    "getProliferateClient",
 }
 PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES = {
     ("hooks", "components"),
@@ -559,12 +560,10 @@ def _matching_token_pairs(
     return forward, reverse
 
 
-def _statement_binding_scope(
-    text: str,
-    tokens: list[Token],
-    statement: ImportStatement,
-) -> tuple[int, int]:
-    import_index = next(
+def _statement_import_index(
+    tokens: list[Token], statement: ImportStatement
+) -> int | None:
+    return next(
         (
             index
             for index, token in enumerate(tokens)
@@ -572,6 +571,268 @@ def _statement_binding_scope(
         ),
         None,
     )
+
+
+def _function_body_ranges(tokens: list[Token]) -> list[tuple[int, int]]:
+    parens, _ = _matching_token_pairs(tokens, "(", ")")
+    braces, _ = _matching_token_pairs(tokens, "{", "}")
+    body_opens: set[int] = set()
+
+    for index, token in enumerate(tokens):
+        if token.value != "function":
+            continue
+        open_index = index + 1
+        while open_index < len(tokens) and tokens[open_index].value != "(":
+            if tokens[open_index].value in {"{", ";"}:
+                break
+            open_index += 1
+        close_index = parens.get(open_index)
+        if (
+            close_index is not None
+            and close_index + 1 < len(tokens)
+            and tokens[close_index + 1].value == "{"
+        ):
+            body_opens.add(close_index + 1)
+
+    for arrow_index, token in enumerate(tokens):
+        is_combined_arrow = token.value == "=>"
+        is_split_arrow = (
+            token.value == "="
+            and arrow_index + 1 < len(tokens)
+            and tokens[arrow_index + 1].value == ">"
+        )
+        if not (is_combined_arrow or is_split_arrow):
+            continue
+        body_open = arrow_index + (2 if is_split_arrow else 1)
+        if body_open < len(tokens) and tokens[body_open].value == "{":
+            body_opens.add(body_open)
+
+    control_owners = {"await", "catch", "for", "if", "switch", "while", "with"}
+    for open_index, close_index in parens.items():
+        if close_index + 1 >= len(tokens) or tokens[close_index + 1].value != "{":
+            continue
+        owner = tokens[open_index - 1] if open_index else None
+        if owner is None or (
+            owner.kind == "identifier" and owner.value in control_owners
+        ):
+            continue
+        if owner.kind == "identifier" or owner.value in {"]", ">"}:
+            body_opens.add(close_index + 1)
+
+    return sorted(
+        (body_open + 1, braces[body_open])
+        for body_open in body_opens
+        if body_open in braces
+    )
+
+
+def _static_block_ranges(tokens: list[Token]) -> list[tuple[int, int]]:
+    braces, _ = _matching_token_pairs(tokens, "{", "}")
+    return sorted(
+        (open_index + 1, close_index)
+        for open_index, close_index in braces.items()
+        if open_index > 0 and tokens[open_index - 1].value == "static"
+    )
+
+
+def _var_scope_token_range(
+    tokens: list[Token], index: int
+) -> tuple[int, int] | None:
+    ranges = [
+        scope
+        for scope in _function_body_ranges(tokens) + _static_block_ranges(tokens)
+        if scope[0] <= index < scope[1]
+    ]
+    return max(ranges) if ranges else None
+
+
+def _enclosing_for_header(
+    tokens: list[Token], index: int
+) -> tuple[int, int] | None:
+    parens, _ = _matching_token_pairs(tokens, "(", ")")
+    headers = []
+    for open_index, close_index in parens.items():
+        if not (open_index < index < close_index) or open_index == 0:
+            continue
+        owner = tokens[open_index - 1].value
+        if owner == "for" or (
+            owner == "await"
+            and open_index > 1
+            and tokens[open_index - 2].value == "for"
+        ):
+            headers.append((open_index, close_index))
+    return max(headers) if headers else None
+
+
+def _controlled_statement_end(
+    tokens: list[Token], start: int
+) -> int:
+    if start >= len(tokens):
+        return len(tokens)
+    parens, _ = _matching_token_pairs(tokens, "(", ")")
+    braces, _ = _matching_token_pairs(tokens, "{", "}")
+    if tokens[start].value == "{" and start in braces:
+        return braces[start] + 1
+
+    if tokens[start].value == "if":
+        condition_open = start + 1
+        while condition_open < len(tokens) and tokens[condition_open].value != "(":
+            condition_open += 1
+        condition_close = parens.get(condition_open)
+        if condition_close is not None:
+            then_end = _controlled_statement_end(tokens, condition_close + 1)
+            if then_end < len(tokens) and tokens[then_end].value == "else":
+                return _controlled_statement_end(tokens, then_end + 1)
+            return then_end
+
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{"}
+    cursor = start
+    while cursor < len(tokens):
+        if (
+            cursor > start
+            and not nesting
+            and _line_starts_new_statement(tokens, cursor)
+        ):
+            return cursor
+        value = tokens[cursor].value
+        if value in {"(", "[", "{"}:
+            nesting.append(value)
+        elif value in matching:
+            if nesting and nesting[-1] == matching[value]:
+                nesting.pop()
+            elif not nesting:
+                return cursor
+        if value == ";" and not nesting:
+            return cursor + 1
+        cursor += 1
+    return len(tokens)
+
+
+def _line_starts_new_statement(tokens: list[Token], index: int) -> bool:
+    if index <= 0 or tokens[index].lineno <= tokens[index - 1].lineno:
+        return False
+    continuation_tokens = {
+        ".",
+        "?",
+        "[",
+        "(",
+        "`",
+        ",",
+        ":",
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "&",
+        "|",
+        "^",
+        "<",
+        ">",
+        "=",
+        "as",
+        "satisfies",
+        "instanceof",
+        "in",
+    }
+    return (
+        tokens[index].value not in continuation_tokens
+        and tokens[index - 1].value not in continuation_tokens
+    )
+
+
+def _declaration_keyword_before(
+    tokens: list[Token], binding_start: int
+) -> tuple[str, int] | None:
+    if binding_start == 0:
+        return None
+    cursor = binding_start - 1
+    if tokens[cursor].value in {"const", "let", "var"}:
+        return tokens[cursor].value, cursor
+    if tokens[cursor].value != ",":
+        return None
+
+    nesting: list[str] = []
+    matching = {"(": ")", "[": "]", "{": "}"}
+    cursor -= 1
+    while cursor >= 0:
+        value = tokens[cursor].value
+        if value in {")", "]", "}"}:
+            nesting.append(value)
+        elif value in matching:
+            if nesting and nesting[-1] == matching[value]:
+                nesting.pop()
+            elif not nesting:
+                return None
+        elif not nesting and value in {"const", "let", "var"}:
+            return value, cursor
+        elif not nesting and value in {";", "{"}:
+            return None
+        cursor -= 1
+    return None
+
+
+def _dynamic_import_declaration(
+    tokens: list[Token], import_index: int
+) -> tuple[str, int] | None:
+    _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
+    _, bracket_reverse = _matching_token_pairs(tokens, "[", "]")
+    cursor = import_index - 1
+    while cursor >= 0:
+        value = tokens[cursor].value
+        if value in {";", "{"}:
+            return None
+        if value == "=" and not (
+            cursor + 1 < len(tokens) and tokens[cursor + 1].value == ">"
+        ):
+            binding_end = cursor - 1
+            if binding_end < 0:
+                return None
+            if tokens[binding_end].kind == "identifier":
+                binding_start = binding_end
+            elif tokens[binding_end].value == "}":
+                binding_start = brace_reverse.get(binding_end, -1)
+            elif tokens[binding_end].value == "]":
+                binding_start = bracket_reverse.get(binding_end, -1)
+            else:
+                return None
+            return _declaration_keyword_before(tokens, binding_start)
+        cursor -= 1
+    return None
+
+
+def _declaration_scope_end(
+    text: str,
+    tokens: list[Token],
+    declaration: tuple[str, int] | None,
+    origin_index: int,
+) -> int:
+    kind, declaration_index = declaration or ("", -1)
+    if kind == "var":
+        scope = _var_scope_token_range(tokens, declaration_index)
+        return tokens[scope[1]].start if scope is not None else len(text)
+    if kind in {"const", "let"}:
+        header = _enclosing_for_header(tokens, declaration_index)
+        if header is not None:
+            body_end = _controlled_statement_end(tokens, header[1] + 1)
+            return tokens[body_end - 1].end if body_end else len(text)
+
+    braces, _ = _matching_token_pairs(tokens, "{", "}")
+    containers = [
+        (open_index, close_index)
+        for open_index, close_index in braces.items()
+        if open_index < origin_index < close_index
+    ]
+    return tokens[max(containers)[1]].start if containers else len(text)
+
+
+def _statement_binding_scope(
+    text: str,
+    tokens: list[Token],
+    statement: ImportStatement,
+) -> tuple[int, int]:
+    import_index = _statement_import_index(tokens, statement)
     if (
         import_index is None
         or import_index + 1 >= len(tokens)
@@ -579,29 +840,16 @@ def _statement_binding_scope(
     ):
         return 0, len(text)
 
-    braces, _ = _matching_token_pairs(tokens, "{", "}")
-    containers = [
-        (open_index, close_index)
-        for open_index, close_index in braces.items()
-        if open_index < import_index < close_index
-    ]
-    if not containers:
-        return 0, len(text)
-    open_index, close_index = max(containers)
-    return tokens[open_index].end, tokens[close_index].start
+    declaration = _dynamic_import_declaration(tokens, import_index)
+    return statement.start, _declaration_scope_end(
+        text, tokens, declaration, import_index
+    )
 
 
 def _is_dynamic_import_statement(
     tokens: list[Token], statement: ImportStatement
 ) -> bool:
-    import_index = next(
-        (
-            index
-            for index, token in enumerate(tokens)
-            if token.start == statement.start and token.value == "import"
-        ),
-        None,
-    )
+    import_index = _statement_import_index(tokens, statement)
     return (
         import_index is not None
         and import_index + 1 < len(tokens)
@@ -1005,21 +1253,31 @@ def _declares_binding_in_scope(
             )
             if in_for_header:
                 continue
-        # The declaration itself must begin inside one of the candidate's
-        # enclosing blocks, not a completed sibling/nested block.
-        declaration_containers = [
-            (open_index, close_index)
-            for close_index, open_index in brace_reverse.items()
-            if open_index < index < close_index
-        ]
-        declaration_scope = 0
-        if declaration_containers:
-            open_index, close_index = max(declaration_containers)
-            if not (open_index < candidate_index < close_index):
+        if tokens[index].value == "var":
+            # `var` belongs to its containing function/static block, not the
+            # nearest ordinary block. Descendant closures see it; sibling
+            # functions and module code outside that owner do not.
+            var_scope = _var_scope_token_range(tokens, index)
+            if var_scope is not None and not (
+                var_scope[0] <= candidate_index < var_scope[1]
+            ):
                 continue
-            declaration_scope = open_index + 1
-        if declaration_scope not in enclosing_starts:
-            continue
+        else:
+            # The declaration itself must begin inside one of the candidate's
+            # enclosing blocks, not a completed sibling/nested block.
+            declaration_containers = [
+                (open_index, close_index)
+                for close_index, open_index in brace_reverse.items()
+                if open_index < index < close_index
+            ]
+            declaration_scope = 0
+            if declaration_containers:
+                open_index, close_index = max(declaration_containers)
+                if not (open_index < candidate_index < close_index):
+                    continue
+                declaration_scope = open_index + 1
+            if declaration_scope not in enclosing_starts:
+                continue
 
         if tokens[index].value in {"class", "function"}:
             if (
@@ -1128,9 +1386,36 @@ def _member_name_after(
 def _namespace_destructure_pattern(
     tokens: list[Token], index: int
 ) -> tuple[int, int, int] | None:
+    cursor = index - 1
+    receiver_groups = 0
+    while cursor >= 0 and tokens[cursor].value == "(":
+        receiver_groups += 1
+        cursor -= 1
+    if cursor < 1 or tokens[cursor].value != "=" or tokens[cursor - 1].value != "}":
+        return None
+
+    _, reverse = _matching_token_pairs(tokens, "{", "}")
+    close_index = cursor - 1
+    open_index = reverse.get(close_index)
+    if open_index is None:
+        return None
+    declaration = _declaration_keyword_before(tokens, open_index)
+
     after = index + 1
-    while after < len(tokens) and tokens[after].value in {"!", ")"}:
-        after += 1
+    while after < len(tokens):
+        while after < len(tokens) and tokens[after].value == "!":
+            after += 1
+        if after < len(tokens) and tokens[after].value in {"as", "satisfies"}:
+            after = _namespace_assertion_end(tokens, after)
+            continue
+        if receiver_groups and tokens[after].value == ")":
+            receiver_groups -= 1
+            after += 1
+            continue
+        break
+    if receiver_groups:
+        return None
+
     if after < len(tokens) and tokens[after].value != ";":
         next_token = tokens[after]
         previous_token = tokens[after - 1]
@@ -1158,8 +1443,10 @@ def _namespace_destructure_pattern(
             "instanceof",
             "in",
         }
+        declarator_boundary = next_token.value == "," and declaration is not None
         has_asi_boundary = (
-            next_token.value == "}"
+            declarator_boundary
+            or next_token.value == "}"
             or (
                 next_token.lineno > previous_token.lineno
                 and next_token.value not in continuation_starters
@@ -1170,19 +1457,29 @@ def _namespace_destructure_pattern(
             # value, not the imported namespace itself. A line continuation
             # such as `Query\n.options` is likewise still the same expression.
             return None
-
-    cursor = index - 1
-    while cursor >= 0 and tokens[cursor].value == "(":
-        cursor -= 1
-    if cursor < 1 or tokens[cursor].value != "=" or tokens[cursor - 1].value != "}":
-        return None
-
-    _, reverse = _matching_token_pairs(tokens, "{", "}")
-    close_index = cursor - 1
-    open_index = reverse.get(close_index)
-    if open_index is None:
-        return None
     return open_index, close_index, after
+
+
+def _namespace_assertion_end(tokens: list[Token], assertion_index: int) -> int:
+    cursor = assertion_index + 1
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    while cursor < len(tokens):
+        value = tokens[cursor].value
+        if (
+            cursor > assertion_index + 1
+            and not nesting
+            and _line_starts_new_statement(tokens, cursor)
+        ):
+            return cursor
+        if not nesting and value in {",", ";", ")", "}"}:
+            return cursor
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        cursor += 1
+    return cursor
 
 
 def _namespace_destructure_names(tokens: list[Token], index: int) -> set[str]:
@@ -1233,11 +1530,8 @@ def _namespace_destructure_local_bindings(
             colon_index = _top_level_token_index(binding_part, ":")
             if colon_index is not None:
                 binding_part = binding_part[colon_index + 1 :]
-        candidates = {
-            token.value for token in binding_part if token.kind == "identifier"
-        }
-        for name in _binding_names_in_pattern(binding_part, candidates):
-            bindings.add((name, is_namespace))
+        if len(binding_part) == 1 and binding_part[0].kind == "identifier":
+            bindings.add((binding_part[0].value, is_namespace))
     return bindings
 
 
@@ -1269,19 +1563,26 @@ def namespace_destructured_bindings(
         if pattern is None:
             continue
         open_index, close_index, after_index = pattern
-        range_start = (
-            tokens[after_index].end
-            if after_index < len(tokens) and tokens[after_index].value == ";"
-            else token.end
-        )
-        containers = [
-            (brace_open, brace_close)
-            for brace_close, brace_open in brace_reverse.items()
-            if brace_open < index < brace_close
-        ]
-        range_end = (
-            tokens[max(containers)[1]].start if containers else len(text)
-        )
+        if after_index < len(tokens) and tokens[after_index].value in {",", ";"}:
+            range_start = tokens[after_index].end
+        elif after_index < len(tokens):
+            range_start = tokens[after_index].start
+        else:
+            range_start = token.end
+        declaration = _declaration_keyword_before(tokens, open_index)
+        if declaration is not None:
+            range_end = _declaration_scope_end(
+                text, tokens, declaration, open_index
+            )
+        else:
+            containers = [
+                (brace_open, brace_close)
+                for brace_close, brace_open in brace_reverse.items()
+                if brace_open < index < brace_close
+            ]
+            range_end = (
+                tokens[max(containers)[1]].start if containers else len(text)
+            )
         if range_start >= range_end:
             continue
         for name, namespace in _namespace_destructure_local_bindings(
@@ -1298,6 +1599,190 @@ def namespace_destructured_bindings(
     return sorted(
         derived, key=lambda binding: (binding.start, binding.end, binding.name)
     )
+
+
+def _simple_alias_declaration(
+    tokens: list[Token], receiver_index: int
+) -> tuple[str, tuple[str, int], int] | None:
+    cursor = receiver_index - 1
+    receiver_groups = 0
+    while cursor >= 0 and tokens[cursor].value == "(":
+        receiver_groups += 1
+        cursor -= 1
+    if cursor < 1 or tokens[cursor].value != "=":
+        return None
+    binding = tokens[cursor - 1]
+    if binding.kind != "identifier":
+        return None
+    declaration = _declaration_keyword_before(tokens, cursor - 1)
+    if declaration is None:
+        return None
+    return binding.value, declaration, receiver_groups
+
+
+def _simple_alias_receiver_end(
+    tokens: list[Token], cursor: int, receiver_groups: int
+) -> int | None:
+    while cursor < len(tokens):
+        while cursor < len(tokens) and tokens[cursor].value == "!":
+            cursor += 1
+        if cursor < len(tokens) and tokens[cursor].value in {"as", "satisfies"}:
+            cursor = _namespace_assertion_end(tokens, cursor)
+            continue
+        if receiver_groups and tokens[cursor].value == ")":
+            receiver_groups -= 1
+            cursor += 1
+            continue
+        break
+    return cursor if not receiver_groups else None
+
+
+def _alias_range_start(
+    tokens: list[Token], receiver_end: int
+) -> int | None:
+    if receiver_end >= len(tokens):
+        return tokens[-1].end if tokens else 0
+    token = tokens[receiver_end]
+    if token.value in {",", ";"}:
+        return token.end
+    previous = tokens[receiver_end - 1]
+    continuation_starters = {
+        ".",
+        "?",
+        "[",
+        "(",
+        "`",
+        ":",
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "&",
+        "|",
+        "^",
+        "<",
+        ">",
+        "=",
+        "as",
+        "satisfies",
+        "instanceof",
+        "in",
+    }
+    if token.value == "}" or (
+        token.lineno > previous.lineno
+        and token.value not in continuation_starters
+    ):
+        return token.start
+    return None
+
+
+def simple_store_value_aliases(
+    text: str,
+    bindings: set[str],
+    *,
+    jsx: bool,
+    namespace_bindings: set[str] | None = None,
+    tracked_import_starts: dict[str, set[int]] | None = None,
+) -> list[ScopedLocalBinding]:
+    if not bindings:
+        return []
+    tokens = tokenize_typescript(text, jsx=jsx)
+    _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
+    shadow_ranges = _function_shadow_ranges(tokens, bindings)
+    aliases: set[ScopedLocalBinding] = set()
+    for index, token in enumerate(tokens):
+        if token.kind != "identifier" or token.value not in bindings:
+            continue
+        if not _is_imported_binding_occurrence(
+            tokens,
+            index,
+            shadow_ranges,
+            brace_reverse,
+            (tracked_import_starts or {}).get(token.value, set()),
+        ):
+            continue
+        alias_declaration = _simple_alias_declaration(tokens, index)
+        if alias_declaration is None:
+            continue
+
+        alias_name, declaration, receiver_groups = alias_declaration
+        candidates: list[tuple[int | None, bool]] = []
+        direct_end = _simple_alias_receiver_end(
+            tokens, index + 1, receiver_groups
+        )
+        candidates.append(
+            (direct_end, token.value in (namespace_bindings or set()))
+        )
+        if token.value in (namespace_bindings or set()):
+            member = _member_name_after(tokens, index + 1)
+            if member is not None:
+                member_end = _simple_alias_receiver_end(
+                    tokens, member[1], receiver_groups
+                )
+                candidates.append((member_end, False))
+
+        for receiver_end, alias_is_namespace in candidates:
+            if receiver_end is None:
+                continue
+            range_start = _alias_range_start(tokens, receiver_end)
+            if range_start is None:
+                continue
+            range_end = _declaration_scope_end(
+                text, tokens, declaration, index
+            )
+            if range_start < range_end:
+                aliases.add(
+                    ScopedLocalBinding(
+                        name=alias_name,
+                        start=range_start,
+                        end=range_end,
+                        namespace=alias_is_namespace,
+                    )
+                )
+            break
+    return sorted(
+        aliases, key=lambda binding: (binding.start, binding.end, binding.name)
+    )
+
+
+def expanded_store_value_aliases(
+    text: str,
+    seeds: set[ScopedLocalBinding],
+    *,
+    jsx: bool,
+) -> set[ScopedLocalBinding]:
+    aliases: set[ScopedLocalBinding] = set()
+    queue = list(seeds)
+    while queue:
+        source = queue.pop()
+        start = max(0, min(len(text), source.start))
+        end = max(start, min(len(text), source.end))
+        segment = text[start:end]
+        tracked_starts = (
+            {source.name: {source.tracked_import_start - start}}
+            if source.tracked_import_start is not None
+            and start <= source.tracked_import_start < end
+            else None
+        )
+        for derived in simple_store_value_aliases(
+            segment,
+            {source.name},
+            jsx=jsx,
+            namespace_bindings={source.name} if source.namespace else set(),
+            tracked_import_starts=tracked_starts,
+        ):
+            absolute = ScopedLocalBinding(
+                name=derived.name,
+                start=start + derived.start,
+                end=min(end, start + derived.end),
+                namespace=derived.namespace,
+            )
+            if absolute in seeds or absolute in aliases:
+                continue
+            aliases.add(absolute)
+            queue.append(absolute)
+    return aliases
 
 
 def _parenthesis_is_grouping(tokens: list[Token], open_index: int) -> bool:
@@ -1544,6 +2029,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
     imported_store_namespace_bindings: set[str] = set()
     imported_store_binding_starts: dict[str, set[int]] = defaultdict(set)
     scoped_store_bindings: set[ScopedLocalBinding] = set()
+    store_value_seeds: set[ScopedLocalBinding] = set()
 
     for statement in statements:
         identifiers = statement_identifiers(statement)
@@ -1646,7 +2132,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 scope_start, scope_end = _statement_binding_scope(
                     text, source_tokens, statement
                 )
-                scoped_store_bindings.update(
+                dynamic_bindings = {
                     ScopedLocalBinding(
                         name=binding,
                         start=scope_start,
@@ -1655,13 +2141,28 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                         tracked_import_start=statement.start,
                     )
                     for binding in statement_bindings
-                )
+                }
+                scoped_store_bindings.update(dynamic_bindings)
+                store_value_seeds.update(dynamic_bindings)
             else:
                 imported_store_bindings.update(statement_bindings)
                 imported_store_namespace_bindings.update(statement_namespaces)
+                store_value_seeds.update(
+                    ScopedLocalBinding(
+                        name=binding,
+                        start=0,
+                        end=len(text),
+                        namespace=binding in statement_namespaces,
+                        tracked_import_start=statement.start,
+                    )
+                    for binding in statement_bindings
+                )
             scoped_store_bindings.update(statement_scoped_bindings)
             scoped_store_bindings.update(statement_namespace_aliases)
             scoped_store_bindings.update(scoped_namespace_aliases)
+            store_value_seeds.update(statement_scoped_bindings)
+            store_value_seeds.update(statement_namespace_aliases)
+            store_value_seeds.update(scoped_namespace_aliases)
             if statement.local_bindings and not statement_is_dynamic:
                 for binding in statement_bindings:
                     imported_store_binding_starts[binding].add(statement.start)
@@ -1774,6 +2275,10 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                         f"lib/{lib_area} must remain non-React and free of query/raw access imports",
                     )
                 )
+
+    scoped_store_bindings.update(
+        expanded_store_value_aliases(text, store_value_seeds, jsx=jsx)
+    )
 
     for lineno in member_call_lines(
         text,

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -248,9 +248,9 @@ def is_product_client_query_hook_owner(path: Path) -> bool:
     )
 
 
-def code_only_text(text: str) -> str:
+def code_only_text(text: str, *, jsx: bool) -> str:
     masked = ["\n" if char == "\n" else " " for char in text]
-    for token in tokenize_typescript(text):
+    for token in tokenize_typescript(text, jsx=jsx):
         if token.kind == "string":
             continue
         masked[token.start : token.end] = text[token.start : token.end]
@@ -322,7 +322,7 @@ def check_file(path: Path) -> list[Violation]:
     in_product_client = is_under(rel, "apps/packages/product-client/src/")
     text = path.read_text()
     scan_lines = (
-        code_only_text(text).splitlines()
+        code_only_text(text, jsx=path.suffix == ".tsx").splitlines()
         if in_product_client
         else text.splitlines()
     )
@@ -606,6 +606,34 @@ def _binding_names_in_parameter_tokens(
     return rebound
 
 
+def _is_named_expression(tokens: list[Token], keyword_index: int) -> bool:
+    """Whether `function`/`class Name` introduces an inner-only name."""
+
+    cursor = keyword_index - 1
+    if cursor >= 0 and tokens[cursor].value == "async":
+        cursor -= 1
+    if cursor < 0:
+        return False
+    if (
+        tokens[cursor].value == ">"
+        and cursor > 0
+        and tokens[cursor - 1].value == "="
+    ):
+        return True
+    return tokens[cursor].value in {
+        "(",
+        ",",
+        ":",
+        "=",
+        "[",
+        "?",
+        "await",
+        "new",
+        "return",
+        "yield",
+    }
+
+
 def _function_shadow_ranges(
     tokens: list[Token], bindings: set[str]
 ) -> list[tuple[int, int, set[str]]]:
@@ -613,10 +641,17 @@ def _function_shadow_ranges(
     braces, _ = _matching_token_pairs(tokens, "{", "}")
     ranges: list[tuple[int, int, set[str]]] = []
 
-    def add_range(param_start: int, param_end: int, body_start: int, body_end: int) -> None:
+    def add_range(
+        param_start: int,
+        param_end: int,
+        body_start: int,
+        body_end: int,
+        extra_rebound: set[str] | None = None,
+    ) -> None:
         rebound = _binding_names_in_parameter_tokens(
             tokens[param_start:param_end], bindings
         )
+        rebound.update(extra_rebound or set())
         if rebound:
             ranges.append((body_start, body_end, rebound))
 
@@ -635,7 +670,46 @@ def _function_shadow_ranges(
         body_open = close_index + 1
         if tokens[body_open].value != "{" or body_open not in braces:
             continue
-        add_range(open_index + 1, close_index, body_open + 1, braces[body_open])
+        inner_name = (
+            tokens[index + 1].value
+            if token.value == "function"
+            and index + 1 < open_index
+            and tokens[index + 1].kind == "identifier"
+            and tokens[index + 1].value in bindings
+            and _is_named_expression(tokens, index)
+            else None
+        )
+        add_range(
+            open_index + 1,
+            close_index,
+            body_open + 1,
+            braces[body_open],
+            {inner_name} if inner_name is not None else None,
+        )
+
+    # A named class expression binds its name only inside the class body.
+    for index, token in enumerate(tokens):
+        if (
+            token.value != "class"
+            or index + 1 >= len(tokens)
+            or tokens[index + 1].kind != "identifier"
+            or tokens[index + 1].value not in bindings
+            or not _is_named_expression(tokens, index)
+        ):
+            continue
+        body_open = index + 2
+        while body_open < len(tokens) and tokens[body_open].value != "{":
+            if tokens[body_open].value == ";":
+                break
+            body_open += 1
+        if body_open in braces:
+            ranges.append(
+                (
+                    body_open + 1,
+                    braces[body_open],
+                    {tokens[index + 1].value},
+                )
+            )
 
     # Arrow functions, including a single bare parameter.
     for arrow_index, token in enumerate(tokens):
@@ -757,6 +831,7 @@ def _declares_binding_in_scope(
                 index + 1 < len(tokens)
                 and tokens[index + 1].kind == "identifier"
                 and tokens[index + 1].value == binding
+                and not _is_named_expression(tokens, index)
             ):
                 return True
             continue
@@ -787,10 +862,12 @@ def _declares_binding_in_scope(
     return False
 
 
-def member_call_lines(text: str, bindings: set[str], member: str) -> list[int]:
+def member_call_lines(
+    text: str, bindings: set[str], member: str, *, jsx: bool
+) -> list[int]:
     if not bindings:
         return []
-    tokens = tokenize_typescript(text)
+    tokens = tokenize_typescript(text, jsx=jsx)
     _, brace_reverse = _matching_token_pairs(tokens, "{", "}")
     shadow_ranges = _function_shadow_ranges(tokens, bindings)
     lines: list[int] = []
@@ -821,8 +898,8 @@ def member_call_lines(text: str, bindings: set[str], member: str) -> list[int]:
     return lines
 
 
-def direct_call_lines(text: str, binding: str) -> list[int]:
-    tokens = tokenize_typescript(text)
+def direct_call_lines(text: str, binding: str, *, jsx: bool) -> list[int]:
+    tokens = tokenize_typescript(text, jsx=jsx)
     return [
         token.lineno
         for index, token in enumerate(tokens[:-1])
@@ -1005,7 +1082,10 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                     )
                 )
 
-    for lineno in member_call_lines(text, imported_store_bindings, "setState"):
+    jsx = path.suffix == ".tsx"
+    for lineno in member_call_lines(
+        text, imported_store_bindings, "setState", jsx=jsx
+    ):
         violations.append(
             Violation(
                 "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER",
@@ -1016,7 +1096,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
         )
 
     if source_layer == "stores":
-        for lineno in direct_call_lines(text, "fetch"):
+        for lineno in direct_call_lines(text, "fetch", jsx=jsx):
             violations.append(
                 Violation(
                     "STORE_RUNTIME_ACCESS",
@@ -1026,7 +1106,7 @@ def find_product_client_violations(path: Path) -> list[Violation]:
                 )
             )
 
-    for token in tokenize_typescript(text):
+    for token in tokenize_typescript(text, jsx=jsx):
         if token.kind == "identifier" and token.value.startswith("__TAURI"):
             violations.append(
                 Violation(

--- a/scripts/frontend_boundaries_allowlist.txt
+++ b/scripts/frontend_boundaries_allowlist.txt
@@ -3,14 +3,44 @@
 # Format:
 # RULE_ID path count reason
 
-# WDU slice 04: sample diff/tool-call DISPLAY-PATH strings inside playground
-# fixtures and dev-only playground components. These are string-literal example
-# paths rendered in the diff viewer, NOT import specifiers — the text-based
-# boundary scanner matches the literal "apps/desktop/" substring. Several are
-# asserted verbatim by diff-display tests, so they are pinned here rather than
-# rewritten. Retire when the playground fixtures are refreshed post-move.
-PRODUCT_CLIENT_FORBIDDEN_IMPORT apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/git-diff-fixtures.ts 4 sample diff display-path strings, not imports
-PRODUCT_CLIENT_FORBIDDEN_IMPORT apps/packages/product-client/src/components/playground/transcript/PlaygroundToolTranscript.tsx 4 sample tool-call path strings in a dev playground, not imports
-PRODUCT_CLIENT_FORBIDDEN_IMPORT apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/plan-transcript-fixtures.ts 3 sample display-path strings, not imports
-PRODUCT_CLIENT_FORBIDDEN_IMPORT apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/subagent-tool-transcript-fixtures.ts 2 sample display-path strings, not imports
-PRODUCT_CLIENT_FORBIDDEN_IMPORT apps/packages/product-client/src/components/playground/composer-slots/PlaygroundPanelSlotFixtures.tsx 1 sample edit-title path string in a dev playground, not an import
+# ProductClient's existing internal upward edges. These are import-statement
+# counts, including type-only edges; move the dependency/type down and shrink
+# the matching entry whenever a site is repaired.
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.ts 1 hook imports component-owned reveal type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/hooks/chat/ui/use-composer-dock-slots.tsx 11 JSX-returning hook imports connected components
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/hooks/ui/diff/use-gap-expansion.ts 1 hook imports component-owned expansion type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/hooks/workspaces/ui/tabs/use-header-tabs-group-editor.ts 1 hook imports component-owned anchor type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/hooks/workspaces/ui/use-repo-group-native-context-menu.ts 1 hook imports component-owned environment type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/access/anyharness/runtime-bootstrap.ts 1 access module imports connection store
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/access/anyharness/session-runtime.ts 4 access module imports session stores
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/access/cloud/owner-context-headers.ts 1 access module imports organization store
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/domain/workspaces/cloud/workspace-availability-intent-mapping.ts 1 domain module imports store-owned intent type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/workflows/sessions/hot-session-ingest-manager.ts 1 workflow imports ingest store
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/workspace-status-fixtures.ts 1 domain fixture imports component-owned status type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/domain/workspaces/status/workspace-status-model.ts 1 domain module imports component-owned status type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/infra/chat/assistant-reveal-progress.ts 1 infra module imports component-owned reveal type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/infra/debug/dev-assistant-reveal-log.ts 1 infra module imports component-owned reveal type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/environment-fixtures.ts 1 domain fixture imports hook-owned pressure type
+PRODUCT_CLIENT_LAYER_DIRECTION apps/packages/product-client/src/stores/toast/toast-store.ts 1 store imports component toast implementation
+
+# React Query wrapper/cache ownership debt.
+QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE apps/packages/product-client/src/hooks/cloud/workflows/use-cloud-workspace-actions.ts 1 workflow owns useMutation wrapper
+QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE apps/packages/product-client/src/hooks/cloud/workflows/use-create-cloud-workspace.ts 1 workflow owns useMutation wrapper
+QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE apps/packages/product-client/src/hooks/workspaces/facade/use-worktree-settings-targets.ts 1 facade owns useQueries wrapper
+QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-actions.ts 1 workflow owns useMutation wrapper
+QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-display-name-actions.ts 1 workflow owns useMutation wrapper
+QUERY_CLIENT_OUTSIDE_CACHE_OWNER apps/packages/product-client/src/components/playground/PlaygroundAttachmentFixtures.tsx 5 playground component owns query cache shape
+QUERY_CLIENT_OUTSIDE_CACHE_OWNER apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx 4 connected component owns query invalidation
+QUERY_CLIENT_OUTSIDE_CACHE_OWNER apps/packages/product-client/src/hooks/agents/lifecycle/use-local-auth-state-sync.ts 5 lifecycle hook owns query invalidation
+
+# Direct raw-access ownership debt.
+COMPONENT_FORBIDDEN_ACCESS apps/packages/product-client/src/components/settings/panes/AccountPane.tsx 1 component imports raw auth probe
+STORE_FORBIDDEN_ACCESS apps/packages/product-client/src/stores/workspaces/cloud-workspace-billing-block-store.ts 1 store imports access-owned billing type
+ANYHARNESS_CLIENT_OUTSIDE_ACCESS apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts 1 workflow imports raw AnyHarness client
+ANYHARNESS_CLIENT_OUTSIDE_ACCESS apps/packages/product-client/src/hooks/workspaces/workflows/use-materialization-health-pass.ts 1 workflow imports raw AnyHarness client
+ANYHARNESS_CLIENT_OUTSIDE_ACCESS apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-availability-actions.ts 1 workflow imports raw AnyHarness client
+ANYHARNESS_CLIENT_OUTSIDE_ACCESS apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-git-reconciliation-actions.ts 1 workflow imports raw AnyHarness client
+
+# Zustand stores must expose owned actions rather than external raw writes.
+PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER apps/packages/product-client/src/lib/access/anyharness/runtime-bootstrap.ts 10 runtime bootstrap mutates imported connection store
+PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER apps/packages/product-client/src/hooks/workspaces/lifecycle/use-workspace-header-tabs-preference-effects.ts 1 lifecycle hook mutates imported workspace UI store

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -85,9 +85,10 @@ def _decode_javascript_string(raw: str) -> str:
 
 
 class _TypeScriptLexer:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, *, jsx: bool) -> None:
         self.text = text
         self.length = len(text)
+        self.jsx = jsx
         self.tokens: list[Token] = []
 
     def scan(self) -> list[Token]:
@@ -145,16 +146,39 @@ class _TypeScriptLexer:
             "throw",
             "case",
             "delete",
+            "do",
+            "else",
             "void",
             "yield",
             "await",
         }:
             return True
-        return (
+        if (
             len(self.tokens) >= 2
             and self.tokens[-2].value == "="
             and previous == ">"
-        )
+        ):
+            return True
+        if previous != ")":
+            return False
+
+        # A regex may begin the statement controlled by `if (...)`, `while
+        # (...)`, and similar constructs. A close parenthesis in an ordinary
+        # expression still leaves `/` as division.
+        depth = 0
+        for cursor in range(len(self.tokens) - 1, segment_token_start - 1, -1):
+            value = self.tokens[cursor].value
+            if value == ")":
+                depth += 1
+            elif value == "(":
+                depth -= 1
+                if depth == 0:
+                    return (
+                        cursor > segment_token_start
+                        and self.tokens[cursor - 1].value
+                        in {"for", "if", "switch", "while", "with"}
+                    )
+        return False
 
     def _scan_regex(self, index: int, lineno: int) -> tuple[int, int]:
         index += 1
@@ -376,7 +400,7 @@ class _TypeScriptLexer:
             if char == "/" and self._expression_can_start(segment_token_start):
                 index, lineno = self._scan_regex(index, lineno)
                 continue
-            if char == "<" and self._looks_like_jsx(index, segment_token_start):
+            if self.jsx and char == "<" and self._looks_like_jsx(index, segment_token_start):
                 index, lineno = self._scan_jsx(index, lineno)
                 continue
 
@@ -402,14 +426,14 @@ class _TypeScriptLexer:
         return index, lineno
 
 
-def tokenize_typescript(text: str) -> list[Token]:
+def tokenize_typescript(text: str, *, jsx: bool = True) -> list[Token]:
     """Return executable TypeScript tokens plus cooked string literals.
 
     Comments, regular-expression bodies, JSX display text, and template prose
     are skipped. Executable JSX and template interpolations are scanned.
     """
 
-    return _TypeScriptLexer(text).scan()
+    return _TypeScriptLexer(text, jsx=jsx).scan()
 
 
 def _statement_end(text: str, tokens: list[Token], source_index: int) -> int:
@@ -478,8 +502,72 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
         equals_index = next(index for index, token in enumerate(prefix) if token.value == "=")
     except StopIteration:
         return False
+
+    # Type aliases may omit their semicolon. At top level, a newline ends the
+    # alias once the preceding type is complete; only explicit type-continuation
+    # syntax or an open delimiter carries the alias onto the next line.
+    continuation_after = {
+        "(",
+        "[",
+        "{",
+        "<",
+        "&",
+        "|",
+        "=",
+        ",",
+        ":",
+        "?",
+        "extends",
+        "infer",
+        "keyof",
+        "new",
+        "readonly",
+        "typeof",
+    }
+    continuation_before = {".", "[", "&", "|", ":", "?", "extends"}
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    alias_tokens = prefix[equals_index + 1 :]
+    for index, token in enumerate(alias_tokens):
+        if index:
+            previous = alias_tokens[index - 1]
+            if (
+                token.lineno > previous.lineno
+                and not nesting
+                and previous.value not in continuation_after
+                and token.value not in continuation_before
+            ):
+                return False
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+
+    if alias_tokens:
+        previous = alias_tokens[-1]
+        import_token = tokens[import_index]
+        if (
+            import_token.lineno > previous.lineno
+            and not nesting
+            and previous.value not in continuation_after
+            and import_token.value not in continuation_before
+        ):
+            return False
     return not any(
-        token.value in {"class", "const", "enum", "function", "interface", "let", "var"}
+        token.value
+        in {
+            "class",
+            "const",
+            "default",
+            "enum",
+            "export",
+            "function",
+            "interface",
+            "let",
+            "return",
+            "throw",
+            "var",
+        }
         for token in prefix[equals_index + 1 :]
     )
 
@@ -487,8 +575,7 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
 def collect_imports(path: Path, text: str) -> list[ImportStatement]:
     """Collect static imports, re-exports, and quoted dynamic imports."""
 
-    del path  # Kept in the API because callers naturally have the source path.
-    tokens = tokenize_typescript(text)
+    tokens = tokenize_typescript(text, jsx=path.suffix == ".tsx")
     imports: list[ImportStatement] = []
     index = 0
 

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -136,7 +136,43 @@ class _TypeScriptLexer:
     def _expression_can_start(self, segment_token_start: int) -> bool:
         if len(self.tokens) == segment_token_start:
             return True
+        previous_index = len(self.tokens) - 1
         previous = self.tokens[-1].value
+
+        # TypeScript's postfix non-null assertion leaves `/` as division,
+        # while prefix logical negation still permits a regular expression.
+        if previous == "!":
+            return not self._is_postfix_non_null(
+                previous_index, segment_token_start
+            )
+
+        # The lexer stores punctuation one character at a time. Reconstitute
+        # an adjacent postfix increment/decrement here so its trailing slash
+        # is not mistaken for a regex. Spaced unary operators remain separate.
+        if (
+            previous in {"+", "-"}
+            and previous_index > segment_token_start
+            and self.tokens[previous_index - 1].value == previous
+            and self.tokens[previous_index - 1].end
+            == self.tokens[previous_index].start
+            and self._token_ends_expression(
+                previous_index - 2, segment_token_start
+            )
+            and self.tokens[previous_index - 2].lineno
+            == self.tokens[previous_index - 1].lineno
+        ):
+            return False
+
+        # `in` and `instanceof` are binary operators and `typeof` is unary,
+        # so each can be followed by a regex operand. The same spellings used
+        # as property names still end an ordinary member expression.
+        if previous in {"in", "instanceof", "typeof"}:
+            return not self._is_property_name(previous_index)
+        if previous == "of" and self._is_contextual_for_of(
+            previous_index, segment_token_start
+        ):
+            return True
+
         if previous in {
             "(",
             "[",
@@ -145,7 +181,6 @@ class _TypeScriptLexer:
             ";",
             ":",
             "=",
-            "!",
             "?",
             "~",
             "+",
@@ -196,6 +231,83 @@ class _TypeScriptLexer:
                         in {"for", "if", "switch", "while", "with"}
                     )
         return False
+
+    def _is_property_name(self, index: int) -> bool:
+        return index > 0 and self.tokens[index - 1].value == "."
+
+    def _token_ends_expression(
+        self, index: int, segment_token_start: int
+    ) -> bool:
+        if index < segment_token_start:
+            return False
+        token = self.tokens[index]
+        if token.kind == "string" or token.value in {")", "]", "}"}:
+            return True
+        if token.value == "!":
+            return self._is_postfix_non_null(index, segment_token_start)
+        if token.kind != "identifier":
+            return token.value.isdigit()
+        return token.value not in {
+            "await",
+            "case",
+            "delete",
+            "do",
+            "else",
+            "in",
+            "instanceof",
+            "new",
+            "return",
+            "throw",
+            "typeof",
+            "void",
+            "yield",
+        }
+
+    def _is_postfix_non_null(
+        self, index: int, segment_token_start: int
+    ) -> bool:
+        return index > segment_token_start and self._token_ends_expression(
+            index - 1, segment_token_start
+        )
+
+    def _is_contextual_for_of(
+        self, of_index: int, segment_token_start: int
+    ) -> bool:
+        if self._is_property_name(of_index):
+            return False
+
+        # Find the still-open parenthesis containing this token. `of` is the
+        # for-of delimiter only at the top level of a `for (...)` header and
+        # only after a left-hand binding/expression.
+        depth = 0
+        open_index: int | None = None
+        for cursor in range(of_index - 1, segment_token_start - 1, -1):
+            value = self.tokens[cursor].value
+            if value == ")":
+                depth += 1
+            elif value == "(":
+                if depth:
+                    depth -= 1
+                else:
+                    open_index = cursor
+                    break
+        if open_index is None or of_index <= open_index + 1:
+            return False
+        owner_index = open_index - 1
+        if owner_index >= 0 and self.tokens[owner_index].value == "await":
+            owner_index -= 1
+        if owner_index < 0 or self.tokens[owner_index].value != "for":
+            return False
+
+        nesting = 0
+        for token in self.tokens[open_index + 1 : of_index]:
+            if token.value in {"(", "[", "{"}:
+                nesting += 1
+            elif token.value in {")", "]", "}"} and nesting:
+                nesting -= 1
+            elif token.value == ";" and not nesting:
+                return False
+        return True
 
     def _closing_brace_ends_block(self, segment_token_start: int) -> bool:
         depth = 0
@@ -656,14 +768,15 @@ def _statement_end(
         end = tokens[cursor].end
         cursor += 1
 
-    if cursor < len(tokens) and tokens[cursor].value in {"assert", "with"}:
-        end = tokens[cursor].end
-        cursor += 1
-        if cursor < len(tokens) and tokens[cursor].value == "{":
-            attribute_close = _matching_pairs(tokens, "{", "}").get(cursor)
-            if attribute_close is not None:
-                end = tokens[attribute_close].end
-                cursor = attribute_close + 1
+    if (
+        cursor + 1 < len(tokens)
+        and tokens[cursor].value in {"assert", "with"}
+        and tokens[cursor + 1].value == "{"
+    ):
+        attribute_close = _matching_pairs(tokens, "{", "}").get(cursor + 1)
+        if attribute_close is not None:
+            end = tokens[attribute_close].end
+            cursor = attribute_close + 1
 
     if cursor < len(tokens) and tokens[cursor].value == ";":
         return tokens[cursor].end
@@ -1267,6 +1380,48 @@ def _declaration_annotation_contains_import(
     )
 
 
+def _generic_call_import_is_type(
+    tokens: list[Token],
+    generic_open: int,
+    generic_close: int,
+    import_index: int,
+) -> bool:
+    """Whether an import has type grammar inside a generic call span."""
+
+    import_open = import_index + 1
+    import_close = _matching_pairs(tokens, "(", ")").get(import_open)
+    if import_close is None or import_close >= generic_close:
+        return False
+
+    # Import types require their literal/options grammar. An asserted module
+    # expression remains a runtime dynamic import even when the literal under
+    # the assertion is statically discoverable.
+    if any(
+        token.value in {"as", "satisfies"}
+        for token in tokens[import_open + 1 : import_close]
+    ):
+        return False
+
+    # A direct `.Name` is an import-type qualifier. Once grouping has closed
+    # around the import, `.Name` is instead a runtime property read and makes
+    # TypeScript fall back to relational-expression parsing. Indexed access
+    # remains legal on a parenthesized type.
+    closed_group = False
+    for cursor in range(import_close + 1, generic_close):
+        value = tokens[cursor].value
+        if value in {"as", "satisfies", "await"}:
+            return False
+        if value == ")":
+            closed_group = True
+        elif value == "." and closed_group:
+            return False
+        elif value == "(":
+            # Calls such as `import("pkg").then(load)` are runtime values,
+            # not type arguments.
+            return False
+    return True
+
+
 def _generic_argument_contains_import(
     tokens: list[Token], import_index: int
 ) -> bool:
@@ -1299,7 +1454,20 @@ def _generic_argument_contains_import(
         header_values = {
             token.value for token in tokens[header_start + 1 : open_index]
         }
-        if header_values & {"as", "implements", "interface", "satisfies", "type"}:
+        if header_values & {"implements", "interface", "type"}:
+            return True
+        type_operator_index = next(
+            (
+                cursor
+                for cursor in range(open_index - 1, header_start, -1)
+                if tokens[cursor].value in {"as", "satisfies"}
+            ),
+            None,
+        )
+        if type_operator_index is not None and not any(
+            token.value in {")", "]", "}"}
+            for token in tokens[type_operator_index + 1 : open_index]
+        ):
             return True
         if "class" in header_values and "extends" in header_values:
             return True
@@ -1335,36 +1503,17 @@ def _generic_argument_contains_import(
         if owner_value in assertion_prefixes:
             return True
 
-        # Optional generic calls are syntactically unambiguous. Ordinary
-        # `value < import("pkg") > (other)` remains a relational expression;
-        # require a qualified/nested import type before treating that spelling
-        # as a generic call.
+        # TypeScript parses a valid type argument followed by `(...)` as a
+        # generic call regardless of whitespace around `<` and `>`. Reject
+        # runtime grouping/assertion shapes rather than relying on adjacency.
         if after == "(":
             optional_call = (
                 open_index >= 2
                 and tokens[open_index - 1].value == "."
                 and tokens[open_index - 2].value == "?"
             )
-            import_type_tail = tokens[import_index + 3 : close_index]
-            runtime_member_call = any(
-                token.value == "(" for token in import_type_tail
-            )
-            qualified_import_type = any(
-                token.value == "."
-                and index + 1 < len(import_type_tail)
-                and import_type_tail[index + 1].kind == "identifier"
-                and import_type_tail[index + 1].value
-                not in {"catch", "default", "finally", "then"}
-                for index, token in enumerate(import_type_tail)
-            )
-            adjacent_owner = (
-                owner is not None
-                and tokens[open_index].start == owner.end
-            )
-            if not runtime_member_call and (
-                optional_call
-                or qualified_import_type
-                or adjacent_owner
+            if optional_call or _generic_call_import_is_type(
+                tokens, open_index, close_index, import_index
             ):
                 return True
             continue
@@ -1649,6 +1798,24 @@ def _destructuring_import_facts(
     return imported, local, namespaces
 
 
+def _call_open_after_member(tokens: list[Token], member_index: int) -> int | None:
+    """Return a direct or generic member call's opening parenthesis."""
+
+    cursor = member_index + 1
+    if cursor < len(tokens) and tokens[cursor].value == "(":
+        return cursor
+    if cursor >= len(tokens) or tokens[cursor].value != "<":
+        return None
+    generic_close = _matching_pairs(tokens, "<", ">").get(cursor)
+    if (
+        generic_close is None
+        or generic_close + 1 >= len(tokens)
+        or tokens[generic_close + 1].value != "("
+    ):
+        return None
+    return generic_close + 1
+
+
 def _member_name_after(tokens: list[Token], close_index: int) -> str | None:
     cursor = close_index + 1
     while cursor < len(tokens) and tokens[cursor].value == ")":
@@ -1662,8 +1829,7 @@ def _member_name_after(tokens: list[Token], close_index: int) -> str | None:
     ):
         if (
             tokens[cursor + 1].value in {"catch", "finally", "then"}
-            and cursor + 2 < len(tokens)
-            and tokens[cursor + 2].value == "("
+            and _call_open_after_member(tokens, cursor + 1) is not None
         ):
             return None
         return tokens[cursor + 1].value
@@ -1732,14 +1898,15 @@ def _then_callback_import_facts(
         cursor += 1
         grouping_count -= 1
     if (
-        cursor + 2 >= len(tokens)
+        cursor + 1 >= len(tokens)
         or tokens[cursor].value != "."
         or tokens[cursor + 1].value != "then"
-        or tokens[cursor + 2].value != "("
     ):
         return set(), ()
 
-    then_open = cursor + 2
+    then_open = _call_open_after_member(tokens, cursor + 1)
+    if then_open is None:
+        return set(), ()
     then_close = _matching_pairs(tokens, "(", ")").get(then_open)
     if then_close is None:
         return set(), ()
@@ -1967,17 +2134,75 @@ def _literal_dynamic_import_source(
         elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
             nesting.pop()
 
+    return _literal_asserted_expression_source(first_argument)
+
+
+def _literal_asserted_expression_source(tokens: list[Token]) -> Token | None:
+    """Return the literal underneath grouping and TS-only assertions."""
+
     while (
-        len(first_argument) >= 2
-        and first_argument[0].value == "("
-        and first_argument[-1].value == ")"
-        and _matching_pairs(first_argument, "(", ")").get(0)
-        == len(first_argument) - 1
+        len(tokens) >= 2
+        and tokens[0].value == "("
+        and tokens[-1].value == ")"
+        and _matching_pairs(tokens, "(", ")").get(0) == len(tokens) - 1
     ):
-        first_argument = first_argument[1:-1]
-    if len(first_argument) == 1 and first_argument[0].kind == "string":
-        return first_argument[0]
+        tokens = tokens[1:-1]
+    if len(tokens) == 1 and tokens[0].kind == "string":
+        return tokens[0]
+
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for index, token in enumerate(tokens):
+        value = token.value
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        elif not nesting and value in {"as", "satisfies"}:
+            source = _literal_asserted_expression_source(tokens[:index])
+            if source is not None and _looks_like_assertion_type(tokens[index + 1 :]):
+                return source
+            return None
     return None
+
+
+def _looks_like_assertion_type(tokens: list[Token]) -> bool:
+    """Reject runtime continuations after an otherwise transparent assertion."""
+
+    if not tokens:
+        return False
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    saw_extends = False
+    for index, token in enumerate(tokens):
+        value = token.value
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+            continue
+        if value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+            continue
+        if nesting:
+            continue
+        if value == "extends":
+            saw_extends = True
+        elif value in {",", ";", "+", "-", "*", "/", "%", "instanceof"}:
+            return False
+        elif value == "=" and not (
+            index + 1 < len(tokens) and tokens[index + 1].value == ">"
+        ):
+            return False
+        elif value in {"&", "|", "?"}:
+            if (
+                index + 1 < len(tokens)
+                and tokens[index + 1].value == value
+            ):
+                return False
+            if value == "?" and not saw_extends:
+                return False
+        elif value in {"in", "await", "delete", "throw", "yield"}:
+            return False
+    return not nesting
 
 
 def collect_imports(path: Path, text: str) -> list[ImportStatement]:

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -29,101 +29,387 @@ def _is_identifier_part(char: str) -> bool:
     return char.isalnum() or char in {"_", "$"}
 
 
-def tokenize_typescript(text: str) -> list[Token]:
-    """Return the code tokens needed by the frontend boundary checks.
+def _decode_javascript_string(raw: str) -> str:
+    """Cook a JavaScript string without changing its source span."""
 
-    Comments and template-literal contents are skipped. Quoted strings remain
-    tokens so import specifiers can be read without treating arbitrary prose as
-    code.
-    """
-
-    tokens: list[Token] = []
+    simple_escapes = {
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        "0": "\0",
+    }
+    cooked: list[str] = []
     index = 0
-    lineno = 1
-    length = len(text)
-
-    while index < length:
-        char = text[index]
-        if char.isspace():
-            if char == "\n":
-                lineno += 1
+    while index < len(raw):
+        if raw[index] != "\\" or index + 1 >= len(raw):
+            cooked.append(raw[index])
             index += 1
             continue
 
-        if char == "/" and index + 1 < length and text[index + 1] == "/":
+        escaped = raw[index + 1]
+        if escaped == "\n":
             index += 2
-            while index < length and text[index] != "\n":
-                index += 1
             continue
+        if escaped == "\r":
+            index += 3 if index + 2 < len(raw) and raw[index + 2] == "\n" else 2
+            continue
+        if escaped == "x" and index + 3 < len(raw):
+            digits = raw[index + 2 : index + 4]
+            if all(char in "0123456789abcdefABCDEF" for char in digits):
+                cooked.append(chr(int(digits, 16)))
+                index += 4
+                continue
+        if escaped == "u":
+            if index + 2 < len(raw) and raw[index + 2] == "{":
+                close = raw.find("}", index + 3)
+                digits = raw[index + 3 : close] if close >= 0 else ""
+                if digits and all(char in "0123456789abcdefABCDEF" for char in digits):
+                    value = int(digits, 16)
+                    if value <= 0x10FFFF:
+                        cooked.append(chr(value))
+                        index = close + 1
+                        continue
+            elif index + 5 < len(raw):
+                digits = raw[index + 2 : index + 6]
+                if all(char in "0123456789abcdefABCDEF" for char in digits):
+                    cooked.append(chr(int(digits, 16)))
+                    index += 6
+                    continue
 
-        if char == "/" and index + 1 < length and text[index + 1] == "*":
-            index += 2
-            while index < length:
-                if text[index] == "\n":
+        cooked.append(simple_escapes.get(escaped, escaped))
+        index += 2
+    return "".join(cooked)
+
+
+class _TypeScriptLexer:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.length = len(text)
+        self.tokens: list[Token] = []
+
+    def scan(self) -> list[Token]:
+        self._scan_code(0, 1, stop_on_closing_brace=False)
+        return self.tokens
+
+    def _scan_quoted(self, index: int, lineno: int) -> tuple[str, int, int]:
+        quote = self.text[index]
+        index += 1
+        raw: list[str] = []
+        while index < self.length:
+            current = self.text[index]
+            if current == "\\" and index + 1 < self.length:
+                raw.extend((current, self.text[index + 1]))
+                if self.text[index + 1] == "\n":
                     lineno += 1
-                if index + 1 < length and text[index : index + 2] == "*/":
-                    index += 2
-                    break
-                index += 1
-            continue
-
-        if char in {"'", '"'}:
-            quote = char
-            start = index
-            start_line = lineno
+                elif self.text[index + 1] == "\r":
+                    if index + 2 < self.length and self.text[index + 2] == "\n":
+                        raw.append("\n")
+                        index += 1
+                    lineno += 1
+                index += 2
+                continue
+            if current == quote:
+                return "".join(raw), index + 1, lineno
+            if current == "\n":
+                lineno += 1
+            raw.append(current)
             index += 1
-            value: list[str] = []
-            while index < length:
-                current = text[index]
-                if current == "\\" and index + 1 < length:
-                    value.append(current)
-                    value.append(text[index + 1])
-                    if text[index + 1] == "\n":
-                        lineno += 1
-                    index += 2
+        return "".join(raw), index, lineno
+
+    def _expression_can_start(self, segment_token_start: int) -> bool:
+        if len(self.tokens) == segment_token_start:
+            return True
+        previous = self.tokens[-1].value
+        if previous in {
+            "(",
+            "[",
+            "{",
+            ",",
+            ";",
+            ":",
+            "=",
+            "!",
+            "?",
+            "~",
+            "+",
+            "-",
+            "*",
+            "%",
+            "&",
+            "|",
+            "^",
+            "return",
+            "throw",
+            "case",
+            "delete",
+            "void",
+            "yield",
+            "await",
+        }:
+            return True
+        return (
+            len(self.tokens) >= 2
+            and self.tokens[-2].value == "="
+            and previous == ">"
+        )
+
+    def _scan_regex(self, index: int, lineno: int) -> tuple[int, int]:
+        index += 1
+        in_character_class = False
+        while index < self.length:
+            current = self.text[index]
+            if current == "\\" and index + 1 < self.length:
+                index += 2
+                continue
+            if current == "\n":
+                return index, lineno
+            if current == "[":
+                in_character_class = True
+            elif current == "]":
+                in_character_class = False
+            elif current == "/" and not in_character_class:
+                index += 1
+                while index < self.length and self.text[index].isalpha():
+                    index += 1
+                return index, lineno
+            index += 1
+        return index, lineno
+
+    def _jsx_tag_end(self, index: int) -> int | None:
+        cursor = index + 1
+        brace_depth = 0
+        quote: str | None = None
+        while cursor < self.length:
+            current = self.text[cursor]
+            if quote is not None:
+                if current == "\\" and cursor + 1 < self.length:
+                    cursor += 2
                     continue
                 if current == quote:
-                    index += 1
-                    break
-                if current == "\n":
-                    lineno += 1
-                value.append(current)
-                index += 1
-            tokens.append(Token("string", "".join(value), start_line, start, index))
-            continue
+                    quote = None
+                cursor += 1
+                continue
+            if current in {"'", '"'}:
+                quote = current
+            elif current == "{":
+                brace_depth += 1
+            elif current == "}" and brace_depth:
+                brace_depth -= 1
+            elif current == ">" and not brace_depth:
+                return cursor
+            cursor += 1
+        return None
 
-        if char == "`":
-            # Imports are required to use static quoted specifiers. Skipping the
-            # full template keeps fixture prose and display paths non-code.
+    def _looks_like_jsx(self, index: int, segment_token_start: int) -> bool:
+        if not self._expression_can_start(segment_token_start) or index + 1 >= self.length:
+            return False
+        next_char = self.text[index + 1]
+        if next_char == ">":
+            return True
+        if not _is_identifier_start(next_char):
+            return False
+
+        cursor = index + 2
+        while cursor < self.length and (
+            _is_identifier_part(self.text[cursor]) or self.text[cursor] in {".", ":", "-"}
+        ):
+            cursor += 1
+        tag_name = self.text[index + 1 : cursor]
+        tag_end = self._jsx_tag_end(index)
+        if tag_end is None:
+            return False
+        after = tag_end + 1
+        while after < self.length and self.text[after].isspace():
+            after += 1
+        if after < self.length and self.text[after] == "(":
+            return False
+        if self.text[index:tag_end].rstrip().endswith("/"):
+            return True
+        if tag_name[0].islower() or any(char in tag_name for char in ".:-"):
+            return True
+        if f"</{tag_name}" in self.text[tag_end + 1 :]:
+            return True
+        return bool(self.text[cursor:tag_end].strip())
+
+    def _scan_jsx_tag(
+        self, index: int, lineno: int
+    ) -> tuple[int, int, bool, bool]:
+        closing = self.text.startswith("</", index)
+        cursor = index + (2 if closing else 1)
+        last_nonspace = ""
+        while cursor < self.length:
+            current = self.text[cursor]
+            if current in {"'", '"'}:
+                _, cursor, lineno = self._scan_quoted(cursor, lineno)
+                last_nonspace = "quoted"
+                continue
+            if current == "{" and not closing:
+                cursor, lineno = self._scan_code(
+                    cursor + 1, lineno, stop_on_closing_brace=True
+                )
+                last_nonspace = "expression"
+                continue
+            if current == ">":
+                return cursor + 1, lineno, closing, last_nonspace == "/"
+            if current == "\n":
+                lineno += 1
+            if not current.isspace():
+                last_nonspace = current
+            cursor += 1
+        return cursor, lineno, closing, False
+
+    def _scan_jsx(self, index: int, lineno: int) -> tuple[int, int]:
+        index, lineno, closing, self_closing = self._scan_jsx_tag(index, lineno)
+        if closing or self_closing:
+            return index, lineno
+        depth = 1
+        while index < self.length and depth:
+            current = self.text[index]
+            if current == "{":
+                index, lineno = self._scan_code(
+                    index + 1, lineno, stop_on_closing_brace=True
+                )
+                continue
+            if current == "<" and index + 1 < self.length and (
+                self.text[index + 1] in {"/", ">"}
+                or _is_identifier_start(self.text[index + 1])
+            ):
+                index, lineno, closing, self_closing = self._scan_jsx_tag(index, lineno)
+                if closing:
+                    depth -= 1
+                elif not self_closing:
+                    depth += 1
+                continue
+            if current == "\n":
+                lineno += 1
             index += 1
-            while index < length:
-                current = text[index]
-                if current == "\\" and index + 1 < length:
-                    if text[index + 1] == "\n":
-                        lineno += 1
-                    index += 2
-                    continue
-                if current == "`":
-                    index += 1
-                    break
-                if current == "\n":
-                    lineno += 1
-                index += 1
-            continue
+        return index, lineno
 
-        if _is_identifier_start(char):
-            start = index
-            start_line = lineno
-            index += 1
-            while index < length and _is_identifier_part(text[index]):
-                index += 1
-            tokens.append(Token("identifier", text[start:index], start_line, start, index))
-            continue
-
-        tokens.append(Token("punctuation", char, lineno, index, index + 1))
+    def _scan_template(self, index: int, lineno: int) -> tuple[int, int]:
+        start = index
+        start_line = lineno
         index += 1
+        raw: list[str] = []
+        interpolated = False
+        while index < self.length:
+            current = self.text[index]
+            if current == "\\" and index + 1 < self.length:
+                raw.extend((current, self.text[index + 1]))
+                if self.text[index + 1] == "\n":
+                    lineno += 1
+                index += 2
+                continue
+            if current == "`":
+                index += 1
+                if not interpolated:
+                    self.tokens.append(
+                        Token(
+                            "string",
+                            _decode_javascript_string("".join(raw)),
+                            start_line,
+                            start,
+                            index,
+                        )
+                    )
+                return index, lineno
+            if current == "$" and index + 1 < self.length and self.text[index + 1] == "{":
+                interpolated = True
+                index, lineno = self._scan_code(
+                    index + 2, lineno, stop_on_closing_brace=True
+                )
+                continue
+            if current == "\n":
+                lineno += 1
+            raw.append(current)
+            index += 1
+        return index, lineno
 
-    return tokens
+    def _scan_code(
+        self, index: int, lineno: int, *, stop_on_closing_brace: bool
+    ) -> tuple[int, int]:
+        brace_depth = 0
+        segment_token_start = len(self.tokens)
+        while index < self.length:
+            char = self.text[index]
+            if char.isspace():
+                if char == "\n":
+                    lineno += 1
+                index += 1
+                continue
+
+            if char == "/" and index + 1 < self.length and self.text[index + 1] == "/":
+                index += 2
+                while index < self.length and self.text[index] != "\n":
+                    index += 1
+                continue
+            if char == "/" and index + 1 < self.length and self.text[index + 1] == "*":
+                index += 2
+                while index < self.length:
+                    if self.text[index] == "\n":
+                        lineno += 1
+                    if index + 1 < self.length and self.text[index : index + 2] == "*/":
+                        index += 2
+                        break
+                    index += 1
+                continue
+
+            if char in {"'", '"'}:
+                start = index
+                start_line = lineno
+                raw, index, lineno = self._scan_quoted(index, lineno)
+                self.tokens.append(
+                    Token(
+                        "string",
+                        _decode_javascript_string(raw),
+                        start_line,
+                        start,
+                        index,
+                    )
+                )
+                continue
+            if char == "`":
+                index, lineno = self._scan_template(index, lineno)
+                continue
+            if char == "/" and self._expression_can_start(segment_token_start):
+                index, lineno = self._scan_regex(index, lineno)
+                continue
+            if char == "<" and self._looks_like_jsx(index, segment_token_start):
+                index, lineno = self._scan_jsx(index, lineno)
+                continue
+
+            if _is_identifier_start(char):
+                start = index
+                start_line = lineno
+                index += 1
+                while index < self.length and _is_identifier_part(self.text[index]):
+                    index += 1
+                self.tokens.append(
+                    Token("identifier", self.text[start:index], start_line, start, index)
+                )
+                continue
+
+            if char == "{" and stop_on_closing_brace:
+                brace_depth += 1
+            elif char == "}" and stop_on_closing_brace:
+                if brace_depth == 0:
+                    return index + 1, lineno
+                brace_depth -= 1
+            self.tokens.append(Token("punctuation", char, lineno, index, index + 1))
+            index += 1
+        return index, lineno
+
+
+def tokenize_typescript(text: str) -> list[Token]:
+    """Return executable TypeScript tokens plus cooked string literals.
+
+    Comments, regular-expression bodies, JSX display text, and template prose
+    are skipped. Executable JSX and template interpolations are scanned.
+    """
+
+    return _TypeScriptLexer(text).scan()
 
 
 def _statement_end(text: str, tokens: list[Token], source_index: int) -> int:
@@ -142,6 +428,11 @@ def _all_named_bindings_are_types(tokens: list[Token]) -> bool:
     except (StopIteration, ValueError):
         return False
 
+    # A default or namespace binding makes the statement a runtime import even
+    # when every binding inside the named clause uses a `type` modifier.
+    if tokens[1:open_index]:
+        return False
+
     entries: list[list[Token]] = []
     current: list[Token] = []
     for token in tokens[open_index + 1 : close_index]:
@@ -153,13 +444,44 @@ def _all_named_bindings_are_types(tokens: list[Token]) -> bool:
             current.append(token)
     if current:
         entries.append(current)
-    return bool(entries) and all(entry[0].value == "type" for entry in entries)
+    return bool(entries) and all(
+        len(entry) >= 2
+        and entry[0].value == "type"
+        and entry[1].value != "as"
+        for entry in entries
+    )
 
 
 def _is_type_only_tokens(tokens: list[Token], keyword: str) -> bool:
-    if len(tokens) >= 2 and tokens[0].value == keyword and tokens[1].value == "type":
+    if (
+        len(tokens) >= 3
+        and tokens[0].value == keyword
+        and tokens[1].value == "type"
+        and tokens[2].value != "from"
+    ):
         return True
     return _all_named_bindings_are_types(tokens)
+
+
+def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
+    """Recognize a dynamic-import-shaped node in a definite type alias."""
+
+    statement_start = import_index
+    while statement_start > 0 and tokens[statement_start - 1].value != ";":
+        statement_start -= 1
+    prefix = tokens[statement_start:import_index]
+    while prefix and prefix[0].value in {"declare", "export"}:
+        prefix = prefix[1:]
+    if not prefix or prefix[0].value != "type":
+        return False
+    try:
+        equals_index = next(index for index, token in enumerate(prefix) if token.value == "=")
+    except StopIteration:
+        return False
+    return not any(
+        token.value in {"class", "const", "enum", "function", "interface", "let", "var"}
+        for token in prefix[equals_index + 1 :]
+    )
 
 
 def collect_imports(path: Path, text: str) -> list[ImportStatement]:
@@ -196,10 +518,33 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
                         source=source_token.value,
                         statement=text[token.start:end],
                         lineno=token.lineno,
-                        type_only=False,
+                        type_only=_is_import_type_expression(tokens, index),
                     )
                 )
                 index = close_index + 1
+                continue
+            # The module source is computed, so there is no stable target to
+            # report. Continue walking its executable expression so a nested
+            # literal import is still discovered independently.
+            index += 1
+            continue
+
+        # `import.meta` is an expression, and declaration exports (`export
+        # const`, `export function`, and friends) cannot contain a re-export
+        # source. Restrict the static-source search to actual grammar prefixes
+        # so a later function call named `from(...)` cannot become an import.
+        if keyword == "import" and index + 1 < len(tokens) and tokens[index + 1].value == ".":
+            index += 1
+            continue
+        if keyword == "export":
+            export_clause = index + 1
+            if export_clause < len(tokens) and tokens[export_clause].value == "type":
+                export_clause += 1
+            if (
+                export_clause >= len(tokens)
+                or tokens[export_clause].value not in {"{", "*"}
+            ):
+                index += 1
                 continue
 
         source_index: int | None = None

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -1187,7 +1187,6 @@ def _type_annotation_prefix_reaches_import(
         "&",
         "|",
         "=",
-        ">",
         "(",
         "[",
         "{",
@@ -1207,6 +1206,11 @@ def _type_annotation_prefix_reaches_import(
                 and not nesting
                 and saw_complete_type
                 and tokens[cursor - 1].value not in type_literal_prefixes
+                and not (
+                    tokens[cursor - 1].value == ">"
+                    and cursor >= 2
+                    and tokens[cursor - 2].value == "="
+                )
             ):
                 return False
             nesting.append(value)

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -202,6 +202,34 @@ class _TypeScriptLexer:
                     break
         if open_index is None or open_index == segment_token_start:
             return open_index == segment_token_start
+        class_index = next(
+            (
+                cursor
+                for cursor in range(open_index - 1, segment_token_start - 1, -1)
+                if self.tokens[cursor].value == "class"
+            ),
+            None,
+        )
+        if (
+            class_index is not None
+            and self._is_class_body_open(class_index, open_index)
+            and self._keyword_starts_declaration(class_index, segment_token_start)
+        ):
+            return True
+        function_index = next(
+            (
+                cursor
+                for cursor in range(open_index - 1, segment_token_start - 1, -1)
+                if self.tokens[cursor].value == "function"
+            ),
+            None,
+        )
+        if (
+            function_index is not None
+            and self._is_function_body_open(function_index, open_index)
+            and self._keyword_starts_declaration(function_index, segment_token_start)
+        ):
+            return True
         previous = self.tokens[open_index - 1].value
         if previous in {"do", "else", "finally", "try"}:
             return True
@@ -216,12 +244,141 @@ class _TypeScriptLexer:
             elif value == "(":
                 paren_depth -= 1
                 if paren_depth == 0:
+                    if cursor <= segment_token_start:
+                        return False
+                    owner = self.tokens[cursor - 1].value
+                    if owner in {
+                        "catch",
+                        "for",
+                        "if",
+                        "switch",
+                        "while",
+                        "with",
+                    }:
+                        return True
+                    function_index = next(
+                        (
+                            candidate
+                            for candidate in range(
+                                cursor - 1, segment_token_start - 1, -1
+                            )
+                            if self.tokens[candidate].value == "function"
+                        ),
+                        None,
+                    )
                     return (
-                        cursor > segment_token_start
-                        and self.tokens[cursor - 1].value
-                        in {"for", "if", "switch", "while", "with"}
+                        function_index is not None
+                        and self._keyword_starts_declaration(
+                            function_index, segment_token_start
+                        )
                     )
         return False
+
+    def _is_class_body_open(self, class_index: int, open_index: int) -> bool:
+        nesting: list[str] = []
+        matching = {")": "(", "]": "[", ">": "<"}
+        for cursor in range(class_index + 1, open_index):
+            value = self.tokens[cursor].value
+            if value in {"(", "[", "<"}:
+                nesting.append(value)
+            elif value in matching and nesting and nesting[-1] == matching[value]:
+                nesting.pop()
+            elif value == "{" and not nesting:
+                return False
+        return True
+
+    def _is_function_body_open(
+        self, function_index: int, candidate_open: int
+    ) -> bool:
+        parameter_open: int | None = None
+        angle_depth = 0
+        for cursor in range(function_index + 1, candidate_open):
+            value = self.tokens[cursor].value
+            if value == "<":
+                angle_depth += 1
+            elif value == ">" and angle_depth:
+                angle_depth -= 1
+            elif value == "(" and angle_depth == 0:
+                parameter_open = cursor
+                break
+        if parameter_open is None:
+            return False
+
+        depth = 0
+        parameter_close: int | None = None
+        for cursor in range(parameter_open, candidate_open):
+            value = self.tokens[cursor].value
+            if value == "(":
+                depth += 1
+            elif value == ")":
+                depth -= 1
+                if depth == 0:
+                    parameter_close = cursor
+                    break
+        if parameter_close is None:
+            return False
+        if parameter_close + 1 == candidate_open:
+            return True
+        if self.tokens[parameter_close + 1].value != ":":
+            return False
+
+        nesting: list[str] = []
+        matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+        saw_complete_type = False
+        type_literal_prefixes = {
+            "&",
+            "|",
+            "=",
+            ">",
+            "(",
+            "[",
+            "{",
+            ",",
+            ":",
+            "?",
+            "extends",
+            "keyof",
+            "readonly",
+            "typeof",
+        }
+        for cursor in range(parameter_close + 2, candidate_open + 1):
+            value = self.tokens[cursor].value
+            if value in {"(", "[", "{", "<"}:
+                if value == "{" and not nesting:
+                    is_type_literal = (
+                        not saw_complete_type
+                        or self.tokens[cursor - 1].value in type_literal_prefixes
+                    )
+                    if cursor == candidate_open:
+                        return not is_type_literal
+                    if not is_type_literal:
+                        return False
+                nesting.append(value)
+                saw_complete_type = True
+            elif value in matching and nesting and nesting[-1] == matching[value]:
+                nesting.pop()
+                saw_complete_type = True
+            elif not nesting and value not in {"&", "|", ":", "?", "extends"}:
+                saw_complete_type = True
+        return False
+
+    def _keyword_starts_declaration(
+        self, keyword_index: int, segment_token_start: int
+    ) -> bool:
+        cursor = keyword_index - 1
+        while cursor >= segment_token_start and self.tokens[cursor].value in {
+            "abstract",
+            "async",
+            "declare",
+            "default",
+            "export",
+        }:
+            cursor -= 1
+        return cursor < segment_token_start or self.tokens[cursor].value in {
+            ";",
+            "{",
+            "}",
+        }
 
     def _scan_regex(self, index: int, lineno: int) -> tuple[int, int]:
         index += 1
@@ -524,7 +681,7 @@ def _is_type_only_tokens(tokens: list[Token], keyword: str) -> bool:
         len(tokens) >= 3
         and tokens[0].value == keyword
         and tokens[1].value == "type"
-        and tokens[2].value != "from"
+        and tokens[2].value not in {",", "=", "from"}
     ):
         return True
     return _all_named_bindings_are_types(tokens)
@@ -573,11 +730,21 @@ def _type_sequence_reaches_import(
     for index, token in enumerate(sequence):
         if index:
             previous = sequence[index - 1]
+            previous_continues = previous.value in continuation_after or (
+                previous.value == ">"
+                and index >= 2
+                and sequence[index - 2].value == "="
+            )
+            token_continues = token.value in continuation_before or (
+                token.value == "="
+                and index + 1 < len(sequence)
+                and sequence[index + 1].value == ">"
+            )
             if (
                 token.lineno > previous.lineno
                 and not nesting
-                and previous.value not in continuation_after
-                and token.value not in continuation_before
+                and not previous_continues
+                and not token_continues
             ):
                 return False
         if token.value in {"(", "[", "{", "<"}:
@@ -588,10 +755,15 @@ def _type_sequence_reaches_import(
     if sequence:
         previous = sequence[-1]
         import_token = tokens[import_index]
+        previous_continues = previous.value in continuation_after or (
+            previous.value == ">"
+            and len(sequence) >= 2
+            and sequence[-2].value == "="
+        )
         if (
             import_token.lineno > previous.lineno
             and not nesting
-            and previous.value not in continuation_after
+            and not previous_continues
             and import_token.value not in continuation_before
         ):
             return False
@@ -688,9 +860,45 @@ def _is_function_parameter_list(
     matching = {")": "(", "]": "[", "}": "{", ">": "<"}
     while cursor < len(tokens):
         value = tokens[cursor].value
+        if cursor >= close_index + 1 and not nesting:
+            previous_token = tokens[cursor - 1]
+            if (
+                tokens[cursor].lineno > previous_token.lineno
+                and previous_token.value not in {
+                    "(",
+                    "[",
+                    "{",
+                    "<",
+                    "&",
+                    "|",
+                    "=",
+                    ",",
+                    ":",
+                    "?",
+                    "extends",
+                }
+                and value not in {".", "[", "&", "|", ":", "?", "=", "{"}
+            ):
+                return False
         if value in {"(", "[", "{", "<"}:
             if value == "{" and not nesting:
-                return tokens[owner_index].kind == "identifier"
+                previous_value = tokens[cursor - 1].value
+                if cursor == close_index + 1 or previous_value not in {
+                    "&",
+                    "|",
+                    "=",
+                    "(",
+                    "[",
+                    "{",
+                    ",",
+                    ":",
+                    "?",
+                    "extends",
+                    "keyof",
+                    "readonly",
+                    "typeof",
+                }:
+                    return tokens[owner_index].kind == "identifier"
             nesting.append(value)
         elif value in matching and nesting and nesting[-1] == matching[value]:
             nesting.pop()
@@ -742,6 +950,11 @@ def _top_level_annotation_colon(
             nesting.pop()
         elif not nesting:
             if value == "=":
+                if (
+                    cursor + 1 < import_index
+                    and tokens[cursor + 1].value == ">"
+                ):
+                    continue
                 return None
             if value == ":" and colon_index is None:
                 colon_index = cursor
@@ -790,39 +1003,157 @@ def _function_return_annotation_contains_import(
     tokens: list[Token], import_index: int
 ) -> bool:
     parens = _matching_pairs(tokens, "(", ")")
-    closing_parens = {close: open_index for open_index, close in parens.items()}
-    for colon_index in range(import_index - 1, -1, -1):
-        if tokens[colon_index].value in {";", "{", "}"}:
-            return False
-        if tokens[colon_index].value != ":" or colon_index == 0:
+    for open_index, close_index in parens.items():
+        colon_index = close_index + 1
+        if (
+            colon_index >= import_index
+            or colon_index >= len(tokens)
+            or tokens[colon_index].value != ":"
+        ):
             continue
-        close_index = colon_index - 1
-        open_index = closing_parens.get(close_index)
-        if open_index is None:
+        if not _is_function_parameter_list(tokens, open_index, close_index):
             continue
-        if _is_function_parameter_list(tokens, open_index, close_index):
-            if not _type_sequence_reaches_import(
-                tokens, colon_index + 1, import_index
+        if not _type_annotation_prefix_reaches_import(
+            tokens, colon_index + 1, import_index
+        ):
+            continue
+
+        # A top-level arrow can either be part of a function return type or be
+        # the outer arrow that begins a runtime expression. Function
+        # declarations/methods have no outer arrow. For arrow functions, a
+        # later arrow after the candidate means the earlier one belonged to
+        # the declared return type.
+        top_level_arrows = _top_level_arrow_indices(
+            tokens, colon_index + 1, import_index
+        )
+        if top_level_arrows and not _parameter_list_has_declaration_owner(
+            tokens, open_index
+        ):
+            if not _has_later_arrow_before_statement_end(tokens, import_index):
+                continue
+        return True
+    return False
+
+
+def _type_annotation_prefix_reaches_import(
+    tokens: list[Token], start_index: int, import_index: int
+) -> bool:
+    """Keep a type annotation live until its initializer/body boundary."""
+
+    if not _type_sequence_reaches_import(tokens, start_index, import_index):
+        return False
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    saw_complete_type = False
+    type_literal_prefixes = {
+        "&",
+        "|",
+        "=",
+        ">",
+        "(",
+        "[",
+        "{",
+        ",",
+        ":",
+        "?",
+        "extends",
+        "keyof",
+        "readonly",
+        "typeof",
+    }
+    for cursor in range(start_index, import_index):
+        value = tokens[cursor].value
+        if value in {"(", "[", "{", "<"}:
+            if (
+                value == "{"
+                and not nesting
+                and saw_complete_type
+                and tokens[cursor - 1].value not in type_literal_prefixes
             ):
                 return False
+            nesting.append(value)
+            saw_complete_type = True
+        elif value in matching:
+            if (
+                value == ">"
+                and cursor > start_index
+                and tokens[cursor - 1].value == "="
+            ):
+                saw_complete_type = True
+                continue
+            if not nesting or nesting[-1] != matching[value]:
+                return False
+            nesting.pop()
+            saw_complete_type = True
+        elif not nesting:
+            if value == ";":
+                return False
+            if value == "=" and not (
+                cursor + 1 < import_index and tokens[cursor + 1].value == ">"
+            ):
+                return False
+            if value not in {"&", "|", ":", "?", "extends"}:
+                saw_complete_type = True
+    return True
 
-            # An outer arrow before the candidate starts the runtime body.
-            # Arrows nested in parentheses/brackets/braces belong to the type.
-            nesting: list[str] = []
-            matching = {")": "(", "]": "[", "}": "{", ">": "<"}
-            for cursor in range(colon_index + 1, import_index):
-                value = tokens[cursor].value
-                if value in {"(", "[", "{", "<"}:
-                    nesting.append(value)
-                elif value in matching and nesting and nesting[-1] == matching[value]:
-                    nesting.pop()
-                elif (
-                    not nesting
-                    and value == "="
-                    and cursor + 1 < import_index
-                    and tokens[cursor + 1].value == ">"
-                ):
-                    return False
+
+def _top_level_arrow_indices(
+    tokens: list[Token], start_index: int, end_index: int
+) -> list[int]:
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    arrows: list[int] = []
+    for cursor in range(start_index, end_index):
+        value = tokens[cursor].value
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        elif (
+            not nesting
+            and value == "="
+            and cursor + 1 < end_index
+            and tokens[cursor + 1].value == ">"
+        ):
+            arrows.append(cursor)
+    return arrows
+
+
+def _parameter_list_has_declaration_owner(
+    tokens: list[Token], open_index: int
+) -> bool:
+    for cursor in range(open_index - 1, -1, -1):
+        if tokens[cursor].value in {";", "{", "}"}:
+            break
+        if tokens[cursor].value == "function":
+            return True
+    containing_braces = [
+        (brace_open, brace_close)
+        for brace_open, brace_close in _matching_pairs(tokens, "{", "}").items()
+        if brace_open < open_index < brace_close
+    ]
+    if not containing_braces:
+        return False
+    brace_open, _ = max(containing_braces)
+    header_start = brace_open - 1
+    while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
+        header_start -= 1
+    return any(
+        token.value in {"class", "interface"}
+        for token in tokens[header_start + 1 : brace_open]
+    )
+
+
+def _has_later_arrow_before_statement_end(
+    tokens: list[Token], import_index: int
+) -> bool:
+    # Dynamic import's own parentheses are balanced before any relevant outer
+    # arrow. Looking to the next semicolon is sufficient to distinguish a
+    # function-valued return annotation from the arrow's runtime body.
+    for cursor in range(import_index + 1, len(tokens) - 1):
+        if tokens[cursor].value == ";":
+            return False
+        if tokens[cursor].value == "=" and tokens[cursor + 1].value == ">":
             return True
     return False
 
@@ -937,11 +1268,6 @@ def _generic_argument_contains_import(
             owner_index -= 2
         owner = tokens[owner_index] if owner_index >= 0 else None
 
-        # Generic calls and generic declarations immediately followed by their
-        # parameter list are definite type-argument contexts.
-        if close_index + 1 < len(tokens) and tokens[close_index + 1].value == "(":
-            return True
-
         header_start = open_index - 1
         while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
             header_start -= 1
@@ -949,6 +1275,8 @@ def _generic_argument_contains_import(
             token.value for token in tokens[header_start + 1 : open_index]
         }
         if header_values & {"as", "implements", "interface", "satisfies", "type"}:
+            return True
+        if "class" in header_values and "extends" in header_values:
             return True
 
         # Type parameters on class/function/arrow declarations use constraints
@@ -980,6 +1308,52 @@ def _generic_argument_contains_import(
         }
         owner_value = owner.value if owner is not None else None
         if owner_value in assertion_prefixes:
+            return True
+
+        # Optional generic calls are syntactically unambiguous. Ordinary
+        # `value < import("pkg") > (other)` remains a relational expression;
+        # require a qualified/nested import type before treating that spelling
+        # as a generic call.
+        if after == "(":
+            optional_call = (
+                open_index >= 2
+                and tokens[open_index - 1].value == "."
+                and tokens[open_index - 2].value == "?"
+            )
+            import_type_tail = tokens[import_index + 3 : close_index]
+            runtime_member_call = any(
+                token.value == "(" for token in import_type_tail
+            )
+            qualified_import_type = any(
+                token.value == "."
+                and index + 1 < len(import_type_tail)
+                and import_type_tail[index + 1].kind == "identifier"
+                and import_type_tail[index + 1].value
+                not in {"catch", "default", "finally", "then"}
+                for index, token in enumerate(import_type_tail)
+            )
+            nested_type_owner = any(
+                token.kind == "identifier"
+                for token in tokens[open_index + 1 : import_index]
+            )
+            adjacent_owner = (
+                owner is not None
+                and tokens[open_index].start == owner.end
+            )
+            if not runtime_member_call and (
+                optional_call
+                or qualified_import_type
+                or nested_type_owner
+                or adjacent_owner
+            ):
+                return True
+            continue
+
+        if (
+            close_index + 1 < len(tokens)
+            and tokens[close_index + 1].kind == "string"
+            and tokens[close_index + 1].start == tokens[close_index].end
+        ):
             return True
 
         # Instantiation expressions (`const C = Factory<Type>`) and generic
@@ -1014,9 +1388,49 @@ def _type_operator_reaches_import(
             return False
         if value not in {"as", "implements", "satisfies"}:
             continue
-        return _type_sequence_reaches_import(
+        if operator_index + 1 > import_index:
+            continue
+        previous = tokens[operator_index - 1].value if operator_index else None
+        following = tokens[operator_index + 1].value
+        if previous in {".", "?"} or following in {":", "=", "("}:
+            continue
+        if value == "implements" and not any(
+            token.value == "class" for token in tokens[:operator_index]
+        ):
+            continue
+        if not _type_sequence_reaches_import(
             tokens, operator_index + 1, import_index
-        )
+        ):
+            continue
+
+        nesting: list[str] = []
+        matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+        saw_conditional_extends = False
+        for cursor in range(operator_index + 1, import_index):
+            token_value = tokens[cursor].value
+            if token_value in {"(", "[", "{", "<"}:
+                nesting.append(token_value)
+            elif token_value in matching:
+                if not nesting or nesting[-1] != matching[token_value]:
+                    break
+                nesting.pop()
+            elif not nesting:
+                if token_value == "extends":
+                    saw_conditional_extends = True
+                elif token_value in {",", ";", "="}:
+                    break
+                elif token_value in {"+", "-", "*", "/", "%", "^"}:
+                    break
+                elif token_value in {"?", ":"} and not saw_conditional_extends:
+                    break
+                elif (
+                    token_value in {"&", "|"}
+                    and cursor + 1 < import_index
+                    and tokens[cursor + 1].value == token_value
+                ):
+                    break
+        else:
+            return True
     return False
 
 
@@ -1049,78 +1463,364 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
 def _dynamic_import_binding_facts(
     tokens: list[Token], import_index: int
 ) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
-    """Return imported names, local names, and namespace names for assignments."""
+    """Return original export names, locals, and namespace locals."""
 
-    cursor = import_index - 1
-    while cursor >= 0 and tokens[cursor].value in {"await", "("}:
-        cursor -= 1
-    if cursor < 1 or tokens[cursor].value != "=":
+    parens = _matching_pairs(tokens, "(", ")")
+    close_index = parens.get(import_index + 1)
+    if close_index is None:
         return frozenset(), frozenset(), frozenset()
 
-    pattern_end = cursor - 1
-    if tokens[pattern_end].kind == "identifier":
-        if pattern_end > 0 and tokens[pattern_end - 1].value in {".", "?"}:
-            return frozenset(), frozenset(), frozenset()
-        binding = tokens[pattern_end].value
-        return frozenset(), frozenset({binding}), frozenset({binding})
-    if tokens[pattern_end].value != "}":
-        return frozenset(), frozenset(), frozenset()
+    imported: set[str] = set()
+    local: set[str] = set()
+    namespaces: set[str] = set()
 
-    depth = 0
-    pattern_start: int | None = None
-    for index in range(pattern_end, -1, -1):
-        value = tokens[index].value
-        if value == "}":
-            depth += 1
-        elif value == "{":
-            depth -= 1
-            if depth == 0:
-                pattern_start = index
-                break
-    if pattern_start is None:
-        return frozenset(), frozenset(), frozenset()
+    member_name = _member_name_after(tokens, close_index)
+    if member_name is not None:
+        imported.add(member_name)
 
+    equals_index = _direct_dynamic_assignment(tokens, import_index)
+    if equals_index is not None:
+        pattern = _assignment_pattern(tokens, equals_index)
+        if pattern:
+            if pattern[0].value == "{":
+                pattern_imported, pattern_local, pattern_namespaces = (
+                    _destructuring_import_facts(pattern)
+                )
+                imported.update(pattern_imported)
+                local.update(pattern_local)
+                namespaces.update(pattern_namespaces)
+            else:
+                binding_names = _binding_names_from_pattern(pattern)
+                local.update(binding_names)
+                if member_name is None:
+                    imported.add("*")
+                    namespaces.update(binding_names)
+
+    # Promise-style dynamic imports expose callback destructuring just as an
+    # awaited destructure does. These names are deliberately not added to the
+    # global local-binding set because their scope is only the callback.
+    then_imported = _then_callback_imported_names(tokens, close_index)
+    imported.update(then_imported)
+    return frozenset(imported), frozenset(local), frozenset(namespaces)
+
+
+def _split_top_level_entries(tokens: list[Token]) -> list[list[Token]]:
     entries: list[list[Token]] = []
     current: list[Token] = []
-    nesting = 0
-    for token in tokens[pattern_start + 1 : pattern_end]:
-        if token.value in {"{", "[", "("}:
-            nesting += 1
-        elif token.value in {"}", "]", ")"}:
-            nesting -= 1
-        if token.value == "," and nesting == 0:
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for token in tokens:
+        value = token.value
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        if value == "," and not nesting:
             entries.append(current)
             current = []
         else:
             current.append(token)
-    entries.append(current)
+    if current:
+        entries.append(current)
+    return entries
 
+
+def _top_level_token_index(tokens: list[Token], value: str) -> int | None:
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for index, token in enumerate(tokens):
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+        elif token.value == value and not nesting:
+            return index
+    return None
+
+
+def _binding_names_from_pattern(tokens: list[Token]) -> set[str]:
+    while tokens and tokens[0].value in {".", "readonly"}:
+        tokens = tokens[1:]
+    if not tokens:
+        return set()
+    if tokens[0].kind == "identifier":
+        return {tokens[0].value}
+    if tokens[0].value not in {"{", "["}:
+        return set()
+
+    closer = "}" if tokens[0].value == "{" else "]"
+    inner = tokens[1:]
+    if inner and inner[-1].value == closer:
+        inner = inner[:-1]
+    bindings: set[str] = set()
+    for entry in _split_top_level_entries(inner):
+        if not entry:
+            continue
+        while entry and entry[0].value == ".":
+            entry = entry[1:]
+        colon_index = _top_level_token_index(entry, ":")
+        equals_index = _top_level_token_index(entry, "=")
+        if colon_index is not None:
+            end = equals_index if equals_index is not None else len(entry)
+            bindings.update(
+                _binding_names_from_pattern(entry[colon_index + 1 : end])
+            )
+        elif entry and entry[0].kind == "identifier":
+            bindings.add(entry[0].value)
+    return bindings
+
+
+def _destructuring_import_facts(
+    pattern: list[Token],
+) -> tuple[set[str], set[str], set[str]]:
+    inner = pattern[1:-1] if pattern[-1].value == "}" else pattern[1:]
     imported: set[str] = set()
     local: set[str] = set()
-    for entry in entries:
-        identifiers = [token.value for token in entry if token.kind == "identifier"]
-        if not identifiers:
+    namespaces: set[str] = set()
+    for entry in _split_top_level_entries(inner):
+        if not entry:
             continue
-        imported_name = identifiers[0]
+        if len(entry) >= 4 and all(token.value == "." for token in entry[:3]):
+            rest = next(
+                (token.value for token in entry[3:] if token.kind == "identifier"),
+                None,
+            )
+            if rest is not None:
+                imported.add("*")
+                local.add(rest)
+                namespaces.add(rest)
+            continue
+
+        colon_index = _top_level_token_index(entry, ":")
+        equals_index = _top_level_token_index(entry, "=")
+        imported_name: str | None = None
+        if entry[0].value == "[":
+            close_bracket = next(
+                (index for index, token in enumerate(entry) if token.value == "]"),
+                None,
+            )
+            if close_bracket == 2 and entry[1].kind == "string":
+                imported_name = entry[1].value
+        elif entry[0].kind in {"identifier", "string"}:
+            imported_name = entry[0].value
+        if imported_name is None:
+            continue
         imported.add(imported_name)
-        colon = next(
-            (index for index, token in enumerate(entry) if token.value == ":"),
+
+        if colon_index is not None:
+            end = equals_index if equals_index is not None else len(entry)
+            local.update(
+                _binding_names_from_pattern(entry[colon_index + 1 : end])
+            )
+        elif entry[0].kind == "identifier":
+            local.add(entry[0].value)
+    return imported, local, namespaces
+
+
+def _member_name_after(tokens: list[Token], close_index: int) -> str | None:
+    cursor = close_index + 1
+    while cursor < len(tokens) and tokens[cursor].value == ")":
+        cursor += 1
+    if cursor < len(tokens) and tokens[cursor].value == "?":
+        cursor += 1
+    if (
+        cursor + 1 < len(tokens)
+        and tokens[cursor].value == "."
+        and tokens[cursor + 1].kind == "identifier"
+    ):
+        if (
+            tokens[cursor + 1].value in {"catch", "finally", "then"}
+            and cursor + 2 < len(tokens)
+            and tokens[cursor + 2].value == "("
+        ):
+            return None
+        return tokens[cursor + 1].value
+    if (
+        cursor + 2 < len(tokens)
+        and tokens[cursor].value == "["
+        and tokens[cursor + 1].kind == "string"
+        and tokens[cursor + 2].value == "]"
+    ):
+        return tokens[cursor + 1].value
+    return None
+
+
+def _direct_dynamic_assignment(tokens: list[Token], import_index: int) -> int | None:
+    cursor = import_index - 1
+    while cursor >= 0 and tokens[cursor].value in {"(", "await"}:
+        cursor -= 1
+    if cursor >= 0 and tokens[cursor].value == "=":
+        return cursor
+    return None
+
+
+def _assignment_pattern(tokens: list[Token], equals_index: int) -> list[Token]:
+    declaration_index: int | None = None
+    for cursor in range(equals_index - 1, -1, -1):
+        if tokens[cursor].value == ";":
+            break
+        if tokens[cursor].value in {"const", "let", "var"}:
+            declaration_index = cursor
+            break
+    start = declaration_index + 1 if declaration_index is not None else 0
+    pattern = tokens[start:equals_index]
+    declarators = _split_top_level_entries(pattern)
+    if declarators:
+        pattern = declarators[-1]
+    colon_index = _top_level_token_index(pattern, ":")
+    if colon_index is not None:
+        pattern = pattern[:colon_index]
+    return pattern
+
+
+def _then_callback_imported_names(
+    tokens: list[Token], import_close_index: int
+) -> set[str]:
+    cursor = import_close_index + 1
+    if (
+        cursor + 2 >= len(tokens)
+        or tokens[cursor].value != "."
+        or tokens[cursor + 1].value != "then"
+        or tokens[cursor + 2].value != "("
+    ):
+        return set()
+    cursor += 3
+    while cursor < len(tokens) and tokens[cursor].value == "(":
+        cursor += 1
+    if cursor >= len(tokens) or tokens[cursor].value != "{":
+        return set()
+    brace_close = _matching_pairs(tokens, "{", "}").get(cursor)
+    if brace_close is None:
+        return set()
+    imported, _, _ = _destructuring_import_facts(tokens[cursor : brace_close + 1])
+    return imported
+
+
+def _static_import_facts(
+    tokens: list[Token], keyword: str, source_index: int, *, import_equals: bool
+) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
+    imported: set[str] = set()
+    local: set[str] = set()
+    namespaces: set[str] = set()
+    clause = tokens[1:source_index]
+
+    if import_equals:
+        if clause and clause[0].value == "type":
+            clause = clause[1:]
+        binding = next(
+            (token.value for token in clause if token.kind == "identifier"),
             None,
         )
-        local_name = (
-            next(
-                (
-                    token.value
-                    for token in entry[colon + 1 :]
-                    if token.kind == "identifier"
-                ),
-                imported_name,
-            )
-            if colon is not None
-            else imported_name
+        if binding is not None:
+            imported.add("*")
+            local.add(binding)
+            namespaces.add(binding)
+        return frozenset(imported), frozenset(local), frozenset(namespaces)
+
+    if clause and clause[-1].value == "from":
+        clause = clause[:-1]
+    declaration_type_only = _is_type_only_tokens(tokens[: source_index + 1], keyword)
+    if declaration_type_only and clause and clause[0].value == "type":
+        clause = clause[1:]
+
+    if keyword == "export":
+        if clause and clause[0].value == "type":
+            clause = clause[1:]
+        if clause and clause[0].value == "*":
+            imported.add("*")
+        named_open = next(
+            (index for index, token in enumerate(clause) if token.value == "{"),
+            None,
         )
-        local.add(local_name)
-    return frozenset(imported), frozenset(local), frozenset()
+        if named_open is not None:
+            named_close = max(
+                index for index, token in enumerate(clause) if token.value == "}"
+            )
+            for entry in _split_top_level_entries(
+                clause[named_open + 1 : named_close]
+            ):
+                if entry and entry[0].value == "type" and (
+                    len(entry) < 2 or entry[1].value != "as"
+                ):
+                    entry = entry[1:]
+                if entry and entry[0].kind in {"identifier", "string"}:
+                    imported.add(entry[0].value)
+        return frozenset(imported), frozenset(), frozenset()
+
+    named_open = next(
+        (index for index, token in enumerate(clause) if token.value == "{"),
+        None,
+    )
+    prefix_end = named_open if named_open is not None else len(clause)
+    prefix = [token for token in clause[:prefix_end] if token.value != ","]
+    if prefix and prefix[0].value != "*" and prefix[0].kind == "identifier":
+        imported.add("default")
+        local.add(prefix[0].value)
+    for index, token in enumerate(clause):
+        if (
+            token.value == "*"
+            and index + 2 < len(clause)
+            and clause[index + 1].value == "as"
+            and clause[index + 2].kind == "identifier"
+        ):
+            imported.add("*")
+            local.add(clause[index + 2].value)
+            namespaces.add(clause[index + 2].value)
+
+    if named_open is not None:
+        named_close = max(
+            index for index, token in enumerate(clause) if token.value == "}"
+        )
+        for entry in _split_top_level_entries(clause[named_open + 1 : named_close]):
+            if entry and entry[0].value == "type" and (
+                len(entry) < 2 or entry[1].value != "as"
+            ):
+                entry = entry[1:]
+            if not entry or entry[0].kind not in {"identifier", "string"}:
+                continue
+            imported.add(entry[0].value)
+            as_index = next(
+                (
+                    index
+                    for index, token in enumerate(entry[1:], start=1)
+                    if token.value == "as"
+                ),
+                None,
+            )
+            if as_index is not None and as_index + 1 < len(entry):
+                if entry[as_index + 1].kind == "identifier":
+                    local.add(entry[as_index + 1].value)
+            elif entry[0].kind == "identifier":
+                local.add(entry[0].value)
+    return frozenset(imported), frozenset(local), frozenset(namespaces)
+
+
+def _literal_dynamic_import_source(
+    tokens: list[Token], open_index: int, close_index: int
+) -> Token | None:
+    first_argument: list[Token] = []
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for token in tokens[open_index + 1 : close_index]:
+        if token.value == "," and not nesting:
+            break
+        first_argument.append(token)
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+
+    while (
+        len(first_argument) >= 2
+        and first_argument[0].value == "("
+        and first_argument[-1].value == ")"
+        and _matching_pairs(first_argument, "(", ")").get(0)
+        == len(first_argument) - 1
+    ):
+        first_argument = first_argument[1:-1]
+    if len(first_argument) == 1 and first_argument[0].kind == "string":
+        return first_argument[0]
+    return None
 
 
 def collect_imports(path: Path, text: str) -> list[ImportStatement]:
@@ -1140,33 +1840,37 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
             continue
 
         keyword = token.value
-        if keyword == "import" and index + 2 < len(tokens) and tokens[index + 1].value == "(":
-            source_token = tokens[index + 2]
-            if source_token.kind == "string":
+        if keyword == "import" and index + 1 < len(tokens) and tokens[index + 1].value == "(":
+            close_index = _matching_pairs(tokens, "(", ")").get(index + 1)
+            source_token = (
+                _literal_dynamic_import_source(tokens, index + 1, close_index)
+                if close_index is not None
+                else None
+            )
+            if source_token is not None and close_index is not None:
+                type_only = _is_import_type_expression(tokens, index)
                 imported_names, local_bindings, namespace_bindings = (
                     _dynamic_import_binding_facts(tokens, index)
                 )
-                close_index = index + 3
-                while close_index < len(tokens) and tokens[close_index].value != ")":
-                    close_index += 1
-                end = (
-                    tokens[close_index].end
-                    if close_index < len(tokens)
-                    else source_token.end
-                )
+                if type_only:
+                    local_bindings = frozenset()
+                    namespace_bindings = frozenset()
+                end = tokens[close_index].end
                 imports.append(
                     ImportStatement(
                         source=source_token.value,
                         statement=text[token.start:end],
                         lineno=token.lineno,
-                        type_only=_is_import_type_expression(tokens, index),
+                        type_only=type_only,
                         imported_names=imported_names,
                         local_bindings=local_bindings,
                         namespace_bindings=namespace_bindings,
                         start=token.start,
                     )
                 )
-                index = close_index + 1
+                # Keep walking the argument/options tokens: nested literal
+                # imports are independent dependencies and must also report.
+                index += 1
                 continue
             # The module source is computed, so there is no stable target to
             # report. Continue walking its executable expression so a nested
@@ -1193,11 +1897,29 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
                 continue
 
         source_index: int | None = None
+        import_equals = False
         if keyword == "import" and index + 1 < len(tokens) and tokens[index + 1].kind == "string":
             source_index = index + 1
         else:
+            if keyword == "import":
+                equals_cursor = index + 1
+                if (
+                    equals_cursor < len(tokens)
+                    and tokens[equals_cursor].value == "type"
+                ):
+                    equals_cursor += 1
+                if (
+                    equals_cursor + 4 < len(tokens)
+                    and tokens[equals_cursor].kind == "identifier"
+                    and tokens[equals_cursor + 1].value == "="
+                    and tokens[equals_cursor + 2].value == "require"
+                    and tokens[equals_cursor + 3].value == "("
+                    and tokens[equals_cursor + 4].kind == "string"
+                ):
+                    source_index = equals_cursor + 4
+                    import_equals = True
             cursor = index + 1
-            while cursor < len(tokens):
+            while source_index is None and cursor < len(tokens):
                 current = tokens[cursor]
                 if current.value == ";":
                     break
@@ -1214,12 +1936,21 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
 
         end = _statement_end(text, tokens, source_index)
         statement_tokens = tokens[index : source_index + 1]
+        imported_names, local_bindings, namespace_bindings = _static_import_facts(
+            statement_tokens,
+            keyword,
+            source_index - index,
+            import_equals=import_equals,
+        )
         imports.append(
             ImportStatement(
                 source=tokens[source_index].value,
                 statement=text[token.start:end],
                 lineno=token.lineno,
                 type_only=_is_type_only_tokens(statement_tokens, keyword),
+                imported_names=imported_names,
+                local_bindings=local_bindings,
+                namespace_bindings=namespace_bindings,
                 start=token.start,
             )
         )

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -22,7 +22,16 @@ class ImportStatement:
     imported_names: frozenset[str] = frozenset()
     local_bindings: frozenset[str] = frozenset()
     namespace_bindings: frozenset[str] = frozenset()
+    scoped_bindings: tuple[ScopedBinding, ...] = ()
     start: int = -1
+
+
+@dataclass(frozen=True)
+class ScopedBinding:
+    name: str
+    start: int
+    end: int
+    namespace: bool = False
 
 
 def _is_identifier_start(char: str) -> bool:
@@ -636,13 +645,29 @@ def tokenize_typescript(text: str, *, jsx: bool = True) -> list[Token]:
     return _TypeScriptLexer(text, jsx=jsx).scan()
 
 
-def _statement_end(text: str, tokens: list[Token], source_index: int) -> int:
-    for token in tokens[source_index + 1 :]:
-        if token.value == ";":
-            return token.end
-        if token.lineno > tokens[source_index].lineno and token.value in {"import", "export"}:
-            break
-    return tokens[source_index].end
+def _statement_end(
+    tokens: list[Token], source_index: int, *, import_equals: bool
+) -> int:
+    """Return the grammar end of one static import/re-export statement."""
+
+    cursor = source_index + 1
+    end = tokens[source_index].end
+    if import_equals and cursor < len(tokens) and tokens[cursor].value == ")":
+        end = tokens[cursor].end
+        cursor += 1
+
+    if cursor < len(tokens) and tokens[cursor].value in {"assert", "with"}:
+        end = tokens[cursor].end
+        cursor += 1
+        if cursor < len(tokens) and tokens[cursor].value == "{":
+            attribute_close = _matching_pairs(tokens, "{", "}").get(cursor)
+            if attribute_close is not None:
+                end = tokens[attribute_close].end
+                cursor = attribute_close + 1
+
+    if cursor < len(tokens) and tokens[cursor].value == ";":
+        return tokens[cursor].end
+    return end
 
 
 def _all_named_bindings_are_types(tokens: list[Token]) -> bool:
@@ -1332,10 +1357,6 @@ def _generic_argument_contains_import(
                 not in {"catch", "default", "finally", "then"}
                 for index, token in enumerate(import_type_tail)
             )
-            nested_type_owner = any(
-                token.kind == "identifier"
-                for token in tokens[open_index + 1 : import_index]
-            )
             adjacent_owner = (
                 owner is not None
                 and tokens[open_index].start == owner.end
@@ -1343,7 +1364,6 @@ def _generic_argument_contains_import(
             if not runtime_member_call and (
                 optional_call
                 or qualified_import_type
-                or nested_type_owner
                 or adjacent_owner
             ):
                 return True
@@ -1462,13 +1482,18 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
 
 def _dynamic_import_binding_facts(
     tokens: list[Token], import_index: int
-) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
+) -> tuple[
+    frozenset[str],
+    frozenset[str],
+    frozenset[str],
+    tuple[ScopedBinding, ...],
+]:
     """Return original export names, locals, and namespace locals."""
 
     parens = _matching_pairs(tokens, "(", ")")
     close_index = parens.get(import_index + 1)
     if close_index is None:
-        return frozenset(), frozenset(), frozenset()
+        return frozenset(), frozenset(), frozenset(), ()
 
     imported: set[str] = set()
     local: set[str] = set()
@@ -1499,9 +1524,16 @@ def _dynamic_import_binding_facts(
     # Promise-style dynamic imports expose callback destructuring just as an
     # awaited destructure does. These names are deliberately not added to the
     # global local-binding set because their scope is only the callback.
-    then_imported = _then_callback_imported_names(tokens, close_index)
+    then_imported, scoped_bindings = _then_callback_import_facts(
+        tokens, import_index, close_index
+    )
     imported.update(then_imported)
-    return frozenset(imported), frozenset(local), frozenset(namespaces)
+    return (
+        frozenset(imported),
+        frozenset(local),
+        frozenset(namespaces),
+        scoped_bindings,
+    )
 
 
 def _split_top_level_entries(tokens: list[Token]) -> list[list[Token]]:
@@ -1673,27 +1705,152 @@ def _assignment_pattern(tokens: list[Token], equals_index: int) -> list[Token]:
     return pattern
 
 
-def _then_callback_imported_names(
-    tokens: list[Token], import_close_index: int
-) -> set[str]:
+def _then_callback_import_facts(
+    tokens: list[Token], import_index: int, import_close_index: int
+) -> tuple[set[str], tuple[ScopedBinding, ...]]:
     cursor = import_close_index + 1
+    grouping_count = 0
+    prefix = import_index - 1
+    if prefix >= 0 and tokens[prefix].value == "await":
+        prefix -= 1
+    while prefix >= 0 and tokens[prefix].value == "(":
+        previous = tokens[prefix - 1] if prefix else None
+        if previous is not None and previous.kind == "identifier" and previous.value not in {
+            "await",
+            "case",
+            "delete",
+            "return",
+            "throw",
+            "typeof",
+            "void",
+            "yield",
+        }:
+            break
+        grouping_count += 1
+        prefix -= 1
+    while grouping_count and cursor < len(tokens) and tokens[cursor].value == ")":
+        cursor += 1
+        grouping_count -= 1
     if (
         cursor + 2 >= len(tokens)
         or tokens[cursor].value != "."
         or tokens[cursor + 1].value != "then"
         or tokens[cursor + 2].value != "("
     ):
-        return set()
-    cursor += 3
-    while cursor < len(tokens) and tokens[cursor].value == "(":
+        return set(), ()
+
+    then_open = cursor + 2
+    then_close = _matching_pairs(tokens, "(", ")").get(then_open)
+    if then_close is None:
+        return set(), ()
+    cursor = then_open + 1
+    if cursor < then_close and tokens[cursor].value == "async":
         cursor += 1
-    if cursor >= len(tokens) or tokens[cursor].value != "{":
-        return set()
-    brace_close = _matching_pairs(tokens, "{", "}").get(cursor)
-    if brace_close is None:
-        return set()
-    imported, _, _ = _destructuring_import_facts(tokens[cursor : brace_close + 1])
-    return imported
+
+    function_callback = cursor < then_close and tokens[cursor].value == "function"
+    if function_callback:
+        cursor += 1
+        if cursor < then_close and tokens[cursor].kind == "identifier":
+            cursor += 1
+
+    parameter_tokens: list[Token]
+    if cursor < then_close and tokens[cursor].value == "(":
+        parameter_close = _matching_pairs(tokens, "(", ")").get(cursor)
+        if parameter_close is None or parameter_close >= then_close:
+            return set(), ()
+        parameter_tokens = tokens[cursor + 1 : parameter_close]
+        cursor = parameter_close + 1
+    elif cursor < then_close and tokens[cursor].kind == "identifier":
+        parameter_tokens = [tokens[cursor]]
+        cursor += 1
+    else:
+        return set(), ()
+
+    if function_callback:
+        while cursor < then_close and tokens[cursor].value != "{":
+            cursor += 1
+        if cursor >= then_close:
+            return set(), ()
+        body_close = _matching_pairs(tokens, "{", "}").get(cursor)
+        if body_close is None:
+            return set(), ()
+        scope_start = tokens[cursor].end
+        scope_end = tokens[body_close].start
+    else:
+        nesting: list[str] = []
+        matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+        arrow_index: int | None = None
+        while cursor + 1 < then_close:
+            value = tokens[cursor].value
+            if value in {"(", "[", "{", "<"}:
+                nesting.append(value)
+            elif value in matching and nesting and nesting[-1] == matching[value]:
+                nesting.pop()
+            elif (
+                not nesting
+                and value == "="
+                and tokens[cursor + 1].value == ">"
+            ):
+                arrow_index = cursor
+                break
+            cursor += 1
+        if arrow_index is None or arrow_index + 2 >= then_close:
+            return set(), ()
+        body_start = arrow_index + 2
+        if tokens[body_start].value == "{":
+            body_close = _matching_pairs(tokens, "{", "}").get(body_start)
+            if body_close is None:
+                return set(), ()
+            scope_start = tokens[body_start].end
+            scope_end = tokens[body_close].start
+        else:
+            scope_start = tokens[body_start].start
+            scope_end = tokens[then_close].start
+            expression_nesting: list[str] = []
+            matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+            for expression_token in tokens[body_start:then_close]:
+                if expression_token.value in {"(", "[", "{", "<"}:
+                    expression_nesting.append(expression_token.value)
+                elif (
+                    expression_token.value in matching
+                    and expression_nesting
+                    and expression_nesting[-1]
+                    == matching[expression_token.value]
+                ):
+                    expression_nesting.pop()
+                elif expression_token.value == "," and not expression_nesting:
+                    scope_end = expression_token.start
+                    break
+
+    parameters = _split_top_level_entries(parameter_tokens)
+    if not parameters:
+        return set(), ()
+    first_parameter = parameters[0]
+    imported: set[str] = set()
+    local: set[str] = set()
+    namespaces: set[str] = set()
+    if first_parameter and first_parameter[0].value == "{":
+        close_brace = _matching_pairs(first_parameter, "{", "}").get(0)
+        if close_brace is None:
+            return set(), ()
+        imported, local, namespaces = _destructuring_import_facts(
+            first_parameter[: close_brace + 1]
+        )
+    elif first_parameter and first_parameter[0].kind == "identifier":
+        local.add(first_parameter[0].value)
+        namespaces.add(first_parameter[0].value)
+        imported.add("*")
+
+    scoped = tuple(
+        ScopedBinding(
+            name=name,
+            start=scope_start,
+            end=scope_end,
+            namespace=name in namespaces,
+        )
+        for name in sorted(local)
+    )
+    return imported, scoped
 
 
 def _static_import_facts(
@@ -1849,7 +2006,12 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
             )
             if source_token is not None and close_index is not None:
                 type_only = _is_import_type_expression(tokens, index)
-                imported_names, local_bindings, namespace_bindings = (
+                (
+                    imported_names,
+                    local_bindings,
+                    namespace_bindings,
+                    scoped_bindings,
+                ) = (
                     _dynamic_import_binding_facts(tokens, index)
                 )
                 if type_only:
@@ -1865,6 +2027,7 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
                         imported_names=imported_names,
                         local_bindings=local_bindings,
                         namespace_bindings=namespace_bindings,
+                        scoped_bindings=scoped_bindings,
                         start=token.start,
                     )
                 )
@@ -1934,7 +2097,9 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
             index += 1
             continue
 
-        end = _statement_end(text, tokens, source_index)
+        end = _statement_end(
+            tokens, source_index, import_equals=import_equals
+        )
         statement_tokens = tokens[index : source_index + 1]
         imported_names, local_bindings, namespace_bindings = _static_import_facts(
             statement_tokens,

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -19,6 +19,10 @@ class ImportStatement:
     statement: str
     lineno: int
     type_only: bool
+    imported_names: frozenset[str] = frozenset()
+    local_bindings: frozenset[str] = frozenset()
+    namespace_bindings: frozenset[str] = frozenset()
+    start: int = -1
 
 
 def _is_identifier_start(char: str) -> bool:
@@ -139,6 +143,8 @@ class _TypeScriptLexer:
             "-",
             "*",
             "%",
+            "<",
+            ">",
             "&",
             "|",
             "^",
@@ -160,7 +166,9 @@ class _TypeScriptLexer:
         ):
             return True
         if previous != ")":
-            return False
+            return previous == "}" and self._closing_brace_ends_block(
+                segment_token_start
+            )
 
         # A regex may begin the statement controlled by `if (...)`, `while
         # (...)`, and similar constructs. A close parenthesis in an ordinary
@@ -173,6 +181,41 @@ class _TypeScriptLexer:
             elif value == "(":
                 depth -= 1
                 if depth == 0:
+                    return (
+                        cursor > segment_token_start
+                        and self.tokens[cursor - 1].value
+                        in {"for", "if", "switch", "while", "with"}
+                    )
+        return False
+
+    def _closing_brace_ends_block(self, segment_token_start: int) -> bool:
+        depth = 0
+        open_index: int | None = None
+        for cursor in range(len(self.tokens) - 1, segment_token_start - 1, -1):
+            value = self.tokens[cursor].value
+            if value == "}":
+                depth += 1
+            elif value == "{":
+                depth -= 1
+                if depth == 0:
+                    open_index = cursor
+                    break
+        if open_index is None or open_index == segment_token_start:
+            return open_index == segment_token_start
+        previous = self.tokens[open_index - 1].value
+        if previous in {"do", "else", "finally", "try"}:
+            return True
+        if previous != ")":
+            return False
+
+        paren_depth = 0
+        for cursor in range(open_index - 1, segment_token_start - 1, -1):
+            value = self.tokens[cursor].value
+            if value == ")":
+                paren_depth += 1
+            elif value == "(":
+                paren_depth -= 1
+                if paren_depth == 0:
                     return (
                         cursor > segment_token_start
                         and self.tokens[cursor - 1].value
@@ -487,25 +530,24 @@ def _is_type_only_tokens(tokens: list[Token], keyword: str) -> bool:
     return _all_named_bindings_are_types(tokens)
 
 
-def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
-    """Recognize a dynamic-import-shaped node in a definite type alias."""
+def _matching_pairs(
+    tokens: list[Token], opener: str, closer: str
+) -> dict[int, int]:
+    stack: list[int] = []
+    pairs: dict[int, int] = {}
+    for index, token in enumerate(tokens):
+        if token.value == opener:
+            stack.append(index)
+        elif token.value == closer and stack:
+            pairs[stack.pop()] = index
+    return pairs
 
-    statement_start = import_index
-    while statement_start > 0 and tokens[statement_start - 1].value != ";":
-        statement_start -= 1
-    prefix = tokens[statement_start:import_index]
-    while prefix and prefix[0].value in {"declare", "export"}:
-        prefix = prefix[1:]
-    if not prefix or prefix[0].value != "type":
-        return False
-    try:
-        equals_index = next(index for index, token in enumerate(prefix) if token.value == "=")
-    except StopIteration:
-        return False
 
-    # Type aliases may omit their semicolon. At top level, a newline ends the
-    # alias once the preceding type is complete; only explicit type-continuation
-    # syntax or an open delimiter carries the alias onto the next line.
+def _type_sequence_reaches_import(
+    tokens: list[Token], start_index: int, import_index: int
+) -> bool:
+    """Whether a multiline type sequence still owns the candidate import."""
+
     continuation_after = {
         "(",
         "[",
@@ -527,10 +569,10 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
     continuation_before = {".", "[", "&", "|", ":", "?", "extends"}
     nesting: list[str] = []
     matching = {")": "(", "]": "[", "}": "{", ">": "<"}
-    alias_tokens = prefix[equals_index + 1 :]
-    for index, token in enumerate(alias_tokens):
+    sequence = tokens[start_index:import_index]
+    for index, token in enumerate(sequence):
         if index:
-            previous = alias_tokens[index - 1]
+            previous = sequence[index - 1]
             if (
                 token.lineno > previous.lineno
                 and not nesting
@@ -543,8 +585,8 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
         elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
             nesting.pop()
 
-    if alias_tokens:
-        previous = alias_tokens[-1]
+    if sequence:
+        previous = sequence[-1]
         import_token = tokens[import_index]
         if (
             import_token.lineno > previous.lineno
@@ -553,23 +595,532 @@ def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
             and import_token.value not in continuation_before
         ):
             return False
-    return not any(
-        token.value
-        in {
-            "class",
-            "const",
-            "default",
-            "enum",
-            "export",
-            "function",
-            "interface",
-            "let",
-            "return",
-            "throw",
-            "var",
+    return True
+
+
+def _type_alias_reaches_import(
+    tokens: list[Token], type_index: int, import_index: int
+) -> bool:
+    if (
+        type_index + 1 >= import_index
+        or tokens[type_index + 1].kind != "identifier"
+    ):
+        return False
+
+    # The import may occur in a type-parameter default/constraint before the
+    # alias's own assignment: `type Box<T = import("pkg").T> = T`.
+    if type_index + 2 < import_index and tokens[type_index + 2].value == "<":
+        close_index = _matching_pairs(tokens, "<", ">").get(type_index + 2)
+        if close_index is not None and import_index < close_index:
+            cursor = close_index + 1
+            while cursor < len(tokens) and tokens[cursor].value in {"?", "readonly"}:
+                cursor += 1
+            if cursor < len(tokens) and tokens[cursor].value == "=":
+                return True
+
+    # Find the alias assignment, ignoring defaults inside `<...>` type
+    # parameters. `from` or a string before `=` identifies an import clause,
+    # not a type-alias declaration.
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    equals_index: int | None = None
+    for cursor in range(type_index + 2, import_index):
+        token = tokens[cursor]
+        if token.value == ";" or token.value == "from" or token.kind == "string":
+            return False
+        if token.value in {"(", "[", "{", "<"}:
+            nesting.append(token.value)
+        elif token.value in matching and nesting and nesting[-1] == matching[token.value]:
+            nesting.pop()
+        elif token.value == "=" and not nesting:
+            equals_index = cursor
+            break
+    if equals_index is None:
+        return False
+
+    return _type_sequence_reaches_import(tokens, equals_index + 1, import_index)
+
+
+def _is_function_parameter_list(
+    tokens: list[Token], open_index: int, close_index: int
+) -> bool:
+    owner_index = open_index - 1
+    if owner_index < 0:
+        return False
+    owner = tokens[owner_index].value
+    if owner in {"for", "if", "switch", "while", "with"}:
+        return False
+
+    # A `function` keyword in this header is unambiguous. Stop at the nearest
+    # body/statement boundary so a call inside a function body cannot inherit
+    # the outer function's keyword.
+    for cursor in range(open_index - 1, -1, -1):
+        value = tokens[cursor].value
+        if value in {";", "{", "}"}:
+            break
+        if value == "function":
+            return True
+
+    # Direct class/interface members are method or call signatures. A call in
+    # a method body has that body (rather than the class body) as its nearest
+    # containing brace and therefore does not take this path.
+    containing_braces = [
+        (brace_open, brace_close)
+        for brace_open, brace_close in _matching_pairs(tokens, "{", "}").items()
+        if brace_open < open_index < brace_close
+    ]
+    if containing_braces:
+        brace_open, _ = max(containing_braces)
+        header_start = brace_open - 1
+        while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
+            header_start -= 1
+        header_values = {
+            token.value for token in tokens[header_start + 1 : brace_open]
         }
-        for token in prefix[equals_index + 1 :]
+        if header_values & {"class", "interface"}:
+            return True
+
+    # Arrow functions and object methods may declare a return type between
+    # `)` and their arrow/body. Importantly, a bare `:` is not enough: it may
+    # be the false branch of `condition ? call() : import(...)`.
+    cursor = close_index + 1
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    while cursor < len(tokens):
+        value = tokens[cursor].value
+        if value in {"(", "[", "{", "<"}:
+            if value == "{" and not nesting:
+                return tokens[owner_index].kind == "identifier"
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        elif not nesting:
+            if value in {";", "}"}:
+                return False
+            if (
+                value == "="
+                and cursor + 1 < len(tokens)
+                and tokens[cursor + 1].value == ">"
+            ):
+                return True
+        cursor += 1
+    return False
+
+
+def _top_level_segment_start(
+    tokens: list[Token], start_index: int, end_index: int
+) -> int:
+    """Return the start of the comma-delimited segment owning end_index."""
+
+    segment_start = start_index
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for cursor in range(start_index, end_index):
+        value = tokens[cursor].value
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        elif value == "," and not nesting:
+            segment_start = cursor + 1
+    return segment_start
+
+
+def _top_level_annotation_colon(
+    tokens: list[Token], start_index: int, import_index: int
+) -> int | None:
+    """Find a live annotation colon before import, excluding initializers."""
+
+    colon_index: int | None = None
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    for cursor in range(start_index, import_index):
+        value = tokens[cursor].value
+        if value in {"(", "[", "{", "<"}:
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        elif not nesting:
+            if value == "=":
+                return None
+            if value == ":" and colon_index is None:
+                colon_index = cursor
+    if colon_index is None:
+        return None
+    if not _type_sequence_reaches_import(tokens, colon_index + 1, import_index):
+        return None
+    return colon_index
+
+
+def _parameter_annotation_contains_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    for open_index, close_index in _matching_pairs(tokens, "(", ")").items():
+        if not (open_index < import_index < close_index):
+            continue
+        if not _is_function_parameter_list(tokens, open_index, close_index):
+            continue
+        segment_start = _top_level_segment_start(
+            tokens, open_index + 1, import_index
+        )
+        if _top_level_annotation_colon(tokens, segment_start, import_index) is not None:
+            return True
+    return False
+
+
+def _interface_property_contains_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    # Every executable-looking import inside an interface body is necessarily
+    # part of a type member/signature. Use the declared interface body rather
+    # than the innermost brace so nested object types remain covered.
+    for open_index, close_index in _matching_pairs(tokens, "{", "}").items():
+        if not (open_index < import_index < close_index):
+            continue
+        header_start = open_index - 1
+        while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
+            header_start -= 1
+        header = tokens[header_start + 1 : open_index]
+        if any(token.value == "interface" for token in header):
+            return True
+    return False
+
+
+def _function_return_annotation_contains_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    parens = _matching_pairs(tokens, "(", ")")
+    closing_parens = {close: open_index for open_index, close in parens.items()}
+    for colon_index in range(import_index - 1, -1, -1):
+        if tokens[colon_index].value in {";", "{", "}"}:
+            return False
+        if tokens[colon_index].value != ":" or colon_index == 0:
+            continue
+        close_index = colon_index - 1
+        open_index = closing_parens.get(close_index)
+        if open_index is None:
+            continue
+        if _is_function_parameter_list(tokens, open_index, close_index):
+            if not _type_sequence_reaches_import(
+                tokens, colon_index + 1, import_index
+            ):
+                return False
+
+            # An outer arrow before the candidate starts the runtime body.
+            # Arrows nested in parentheses/brackets/braces belong to the type.
+            nesting: list[str] = []
+            matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+            for cursor in range(colon_index + 1, import_index):
+                value = tokens[cursor].value
+                if value in {"(", "[", "{", "<"}:
+                    nesting.append(value)
+                elif value in matching and nesting and nesting[-1] == matching[value]:
+                    nesting.pop()
+                elif (
+                    not nesting
+                    and value == "="
+                    and cursor + 1 < import_index
+                    and tokens[cursor + 1].value == ">"
+                ):
+                    return False
+            return True
+    return False
+
+
+def _class_property_contains_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    containing_class_bodies: list[tuple[int, int]] = []
+    for open_index, close_index in _matching_pairs(tokens, "{", "}").items():
+        if not (open_index < import_index < close_index):
+            continue
+        header_start = open_index - 1
+        while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
+            header_start -= 1
+        if any(
+            token.value == "class"
+            for token in tokens[header_start + 1 : open_index]
+        ):
+            containing_class_bodies.append((open_index, close_index))
+    if not containing_class_bodies:
+        return False
+
+    class_open, _ = max(containing_class_bodies)
+    member_start = class_open + 1
+    nesting: list[str] = []
+    matching = {")": "(", "]": "[", "}": "{", ">": "<"}
+    colon_index: int | None = None
+    for cursor in range(member_start, import_index):
+        value = tokens[cursor].value
+        if value in {"(", "[", "{", "<"}:
+            if value == "{" and not nesting:
+                # A brace after an initializer or a completed method return
+                # type is a runtime body. A brace immediately starting (or
+                # extending) the annotation is a type literal.
+                if colon_index is None:
+                    return False
+                prefix = tokens[colon_index + 1 : cursor]
+                if prefix and prefix[-1].value not in {
+                    "&",
+                    "|",
+                    "=",
+                    "(",
+                    "[",
+                    "{",
+                    ",",
+                    ":",
+                    "?",
+                    "extends",
+                }:
+                    return False
+            nesting.append(value)
+        elif value in matching and nesting and nesting[-1] == matching[value]:
+            nesting.pop()
+        elif not nesting:
+            if value == ";":
+                member_start = cursor + 1
+                colon_index = None
+            elif value == "=":
+                return False
+            elif value == ":" and colon_index is None:
+                colon_index = cursor
+
+    return colon_index is not None and _type_sequence_reaches_import(
+        tokens, colon_index + 1, import_index
     )
+
+
+def _declaration_annotation_contains_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    declaration_index: int | None = None
+    for cursor in range(import_index - 1, -1, -1):
+        if tokens[cursor].value == ";":
+            break
+        if tokens[cursor].value in {"const", "let", "var"}:
+            declaration_index = cursor
+            break
+    if declaration_index is None:
+        return False
+    declarator_start = _top_level_segment_start(
+        tokens, declaration_index + 1, import_index
+    )
+    return (
+        _top_level_annotation_colon(tokens, declarator_start, import_index)
+        is not None
+    )
+
+
+def _generic_argument_contains_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    for open_index, close_index in _matching_pairs(tokens, "<", ">").items():
+        if not (open_index < import_index < close_index):
+            continue
+
+        # `await import()` cannot occur in a TypeScript type argument. This
+        # also disambiguates comparisons such as
+        # `left < (await import("pkg")).default > (right)`.
+        if any(
+            token.value in {"await", "delete", "throw", "yield"}
+            for token in tokens[open_index + 1 : import_index]
+        ):
+            continue
+
+        after = tokens[close_index + 1].value if close_index + 1 < len(tokens) else None
+        owner_index = open_index - 1
+        if (
+            owner_index >= 2
+            and tokens[owner_index].value == "."
+            and tokens[owner_index - 1].value == "?"
+        ):
+            owner_index -= 2
+        owner = tokens[owner_index] if owner_index >= 0 else None
+
+        # Generic calls and generic declarations immediately followed by their
+        # parameter list are definite type-argument contexts.
+        if close_index + 1 < len(tokens) and tokens[close_index + 1].value == "(":
+            return True
+
+        header_start = open_index - 1
+        while header_start >= 0 and tokens[header_start].value not in {";", "{", "}"}:
+            header_start -= 1
+        header_values = {
+            token.value for token in tokens[header_start + 1 : open_index]
+        }
+        if header_values & {"as", "implements", "interface", "satisfies", "type"}:
+            return True
+
+        # Type parameters on class/function/arrow declarations use constraints
+        # or defaults before an import type.
+        inner_prefix = {
+            token.value for token in tokens[open_index + 1 : import_index]
+        }
+        if inner_prefix & {"extends", "="} and (
+            header_values & {"class", "function", "interface", "type"}
+            or owner is None
+            or (owner is not None and owner.value in {"=", "("})
+        ):
+            return True
+
+        # Angle-bracket assertions begin where an expression may begin and do
+        # not have a value owner immediately to their left.
+        assertion_prefixes = {
+            None,
+            "(",
+            "[",
+            "{",
+            ",",
+            ":",
+            "=",
+            "?",
+            "=>",
+            "return",
+            "yield",
+        }
+        owner_value = owner.value if owner is not None else None
+        if owner_value in assertion_prefixes:
+            return True
+
+        # Instantiation expressions (`const C = Factory<Type>`) and generic
+        # type references end at a delimiter/member operator. A comparison has
+        # a right-hand value after `>` and is deliberately not accepted here.
+        if owner is not None and owner.kind == "identifier" and after in {
+            None,
+            ";",
+            ",",
+            ")",
+            "]",
+            "}",
+            ".",
+            "?",
+            "!",
+            "[",
+            "as",
+            "satisfies",
+        }:
+            return True
+    return False
+
+
+def _type_operator_reaches_import(
+    tokens: list[Token], import_index: int
+) -> bool:
+    """Recognize nested types owned by `as`, `satisfies`, or `implements`."""
+
+    for operator_index in range(import_index - 1, -1, -1):
+        value = tokens[operator_index].value
+        if value == ";":
+            return False
+        if value not in {"as", "implements", "satisfies"}:
+            continue
+        return _type_sequence_reaches_import(
+            tokens, operator_index + 1, import_index
+        )
+    return False
+
+
+def _is_import_type_expression(tokens: list[Token], import_index: int) -> bool:
+    """Recognize dynamic-import syntax used as a TypeScript import type."""
+
+    statement_floor = import_index
+    while statement_floor > 0 and tokens[statement_floor - 1].value != ";":
+        statement_floor -= 1
+    for type_index in range(import_index - 1, statement_floor - 1, -1):
+        if tokens[type_index].value == "type" and _type_alias_reaches_import(
+            tokens, type_index, import_index
+        ):
+            return True
+    if _parameter_annotation_contains_import(tokens, import_index):
+        return True
+    if _interface_property_contains_import(tokens, import_index):
+        return True
+    if _function_return_annotation_contains_import(tokens, import_index):
+        return True
+    if _class_property_contains_import(tokens, import_index):
+        return True
+    if _declaration_annotation_contains_import(tokens, import_index):
+        return True
+    if _generic_argument_contains_import(tokens, import_index):
+        return True
+    return _type_operator_reaches_import(tokens, import_index)
+
+
+def _dynamic_import_binding_facts(
+    tokens: list[Token], import_index: int
+) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
+    """Return imported names, local names, and namespace names for assignments."""
+
+    cursor = import_index - 1
+    while cursor >= 0 and tokens[cursor].value in {"await", "("}:
+        cursor -= 1
+    if cursor < 1 or tokens[cursor].value != "=":
+        return frozenset(), frozenset(), frozenset()
+
+    pattern_end = cursor - 1
+    if tokens[pattern_end].kind == "identifier":
+        if pattern_end > 0 and tokens[pattern_end - 1].value in {".", "?"}:
+            return frozenset(), frozenset(), frozenset()
+        binding = tokens[pattern_end].value
+        return frozenset(), frozenset({binding}), frozenset({binding})
+    if tokens[pattern_end].value != "}":
+        return frozenset(), frozenset(), frozenset()
+
+    depth = 0
+    pattern_start: int | None = None
+    for index in range(pattern_end, -1, -1):
+        value = tokens[index].value
+        if value == "}":
+            depth += 1
+        elif value == "{":
+            depth -= 1
+            if depth == 0:
+                pattern_start = index
+                break
+    if pattern_start is None:
+        return frozenset(), frozenset(), frozenset()
+
+    entries: list[list[Token]] = []
+    current: list[Token] = []
+    nesting = 0
+    for token in tokens[pattern_start + 1 : pattern_end]:
+        if token.value in {"{", "[", "("}:
+            nesting += 1
+        elif token.value in {"}", "]", ")"}:
+            nesting -= 1
+        if token.value == "," and nesting == 0:
+            entries.append(current)
+            current = []
+        else:
+            current.append(token)
+    entries.append(current)
+
+    imported: set[str] = set()
+    local: set[str] = set()
+    for entry in entries:
+        identifiers = [token.value for token in entry if token.kind == "identifier"]
+        if not identifiers:
+            continue
+        imported_name = identifiers[0]
+        imported.add(imported_name)
+        colon = next(
+            (index for index, token in enumerate(entry) if token.value == ":"),
+            None,
+        )
+        local_name = (
+            next(
+                (
+                    token.value
+                    for token in entry[colon + 1 :]
+                    if token.kind == "identifier"
+                ),
+                imported_name,
+            )
+            if colon is not None
+            else imported_name
+        )
+        local.add(local_name)
+    return frozenset(imported), frozenset(local), frozenset()
 
 
 def collect_imports(path: Path, text: str) -> list[ImportStatement]:
@@ -592,6 +1143,9 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
         if keyword == "import" and index + 2 < len(tokens) and tokens[index + 1].value == "(":
             source_token = tokens[index + 2]
             if source_token.kind == "string":
+                imported_names, local_bindings, namespace_bindings = (
+                    _dynamic_import_binding_facts(tokens, index)
+                )
                 close_index = index + 3
                 while close_index < len(tokens) and tokens[close_index].value != ")":
                     close_index += 1
@@ -606,6 +1160,10 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
                         statement=text[token.start:end],
                         lineno=token.lineno,
                         type_only=_is_import_type_expression(tokens, index),
+                        imported_names=imported_names,
+                        local_bindings=local_bindings,
+                        namespace_bindings=namespace_bindings,
+                        start=token.start,
                     )
                 )
                 index = close_index + 1
@@ -647,7 +1205,7 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
                     candidate = tokens[cursor + 1]
                     if candidate.kind == "string":
                         source_index = cursor + 1
-                    break
+                        break
                 cursor += 1
 
         if source_index is None:
@@ -662,6 +1220,7 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
                 statement=text[token.start:end],
                 lineno=token.lineno,
                 type_only=_is_type_only_tokens(statement_tokens, keyword),
+                start=token.start,
             )
         )
         index = source_index + 1

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: str
+    value: str
+    lineno: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ImportStatement:
+    source: str
+    statement: str
+    lineno: int
+    type_only: bool
+
+
+def _is_identifier_start(char: str) -> bool:
+    return char.isalpha() or char in {"_", "$"}
+
+
+def _is_identifier_part(char: str) -> bool:
+    return char.isalnum() or char in {"_", "$"}
+
+
+def tokenize_typescript(text: str) -> list[Token]:
+    """Return the code tokens needed by the frontend boundary checks.
+
+    Comments and template-literal contents are skipped. Quoted strings remain
+    tokens so import specifiers can be read without treating arbitrary prose as
+    code.
+    """
+
+    tokens: list[Token] = []
+    index = 0
+    lineno = 1
+    length = len(text)
+
+    while index < length:
+        char = text[index]
+        if char.isspace():
+            if char == "\n":
+                lineno += 1
+            index += 1
+            continue
+
+        if char == "/" and index + 1 < length and text[index + 1] == "/":
+            index += 2
+            while index < length and text[index] != "\n":
+                index += 1
+            continue
+
+        if char == "/" and index + 1 < length and text[index + 1] == "*":
+            index += 2
+            while index < length:
+                if text[index] == "\n":
+                    lineno += 1
+                if index + 1 < length and text[index : index + 2] == "*/":
+                    index += 2
+                    break
+                index += 1
+            continue
+
+        if char in {"'", '"'}:
+            quote = char
+            start = index
+            start_line = lineno
+            index += 1
+            value: list[str] = []
+            while index < length:
+                current = text[index]
+                if current == "\\" and index + 1 < length:
+                    value.append(current)
+                    value.append(text[index + 1])
+                    if text[index + 1] == "\n":
+                        lineno += 1
+                    index += 2
+                    continue
+                if current == quote:
+                    index += 1
+                    break
+                if current == "\n":
+                    lineno += 1
+                value.append(current)
+                index += 1
+            tokens.append(Token("string", "".join(value), start_line, start, index))
+            continue
+
+        if char == "`":
+            # Imports are required to use static quoted specifiers. Skipping the
+            # full template keeps fixture prose and display paths non-code.
+            index += 1
+            while index < length:
+                current = text[index]
+                if current == "\\" and index + 1 < length:
+                    if text[index + 1] == "\n":
+                        lineno += 1
+                    index += 2
+                    continue
+                if current == "`":
+                    index += 1
+                    break
+                if current == "\n":
+                    lineno += 1
+                index += 1
+            continue
+
+        if _is_identifier_start(char):
+            start = index
+            start_line = lineno
+            index += 1
+            while index < length and _is_identifier_part(text[index]):
+                index += 1
+            tokens.append(Token("identifier", text[start:index], start_line, start, index))
+            continue
+
+        tokens.append(Token("punctuation", char, lineno, index, index + 1))
+        index += 1
+
+    return tokens
+
+
+def _statement_end(text: str, tokens: list[Token], source_index: int) -> int:
+    for token in tokens[source_index + 1 :]:
+        if token.value == ";":
+            return token.end
+        if token.lineno > tokens[source_index].lineno and token.value in {"import", "export"}:
+            break
+    return tokens[source_index].end
+
+
+def _all_named_bindings_are_types(tokens: list[Token]) -> bool:
+    try:
+        open_index = next(index for index, token in enumerate(tokens) if token.value == "{")
+        close_index = max(index for index, token in enumerate(tokens) if token.value == "}")
+    except (StopIteration, ValueError):
+        return False
+
+    entries: list[list[Token]] = []
+    current: list[Token] = []
+    for token in tokens[open_index + 1 : close_index]:
+        if token.value == ",":
+            if current:
+                entries.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        entries.append(current)
+    return bool(entries) and all(entry[0].value == "type" for entry in entries)
+
+
+def _is_type_only_tokens(tokens: list[Token], keyword: str) -> bool:
+    if len(tokens) >= 2 and tokens[0].value == keyword and tokens[1].value == "type":
+        return True
+    return _all_named_bindings_are_types(tokens)
+
+
+def collect_imports(path: Path, text: str) -> list[ImportStatement]:
+    """Collect static imports, re-exports, and quoted dynamic imports."""
+
+    del path  # Kept in the API because callers naturally have the source path.
+    tokens = tokenize_typescript(text)
+    imports: list[ImportStatement] = []
+    index = 0
+
+    while index < len(tokens):
+        token = tokens[index]
+        if token.kind != "identifier" or token.value not in {"import", "export"}:
+            index += 1
+            continue
+        if index > 0 and tokens[index - 1].value == ".":
+            index += 1
+            continue
+
+        keyword = token.value
+        if keyword == "import" and index + 2 < len(tokens) and tokens[index + 1].value == "(":
+            source_token = tokens[index + 2]
+            if source_token.kind == "string":
+                close_index = index + 3
+                while close_index < len(tokens) and tokens[close_index].value != ")":
+                    close_index += 1
+                end = (
+                    tokens[close_index].end
+                    if close_index < len(tokens)
+                    else source_token.end
+                )
+                imports.append(
+                    ImportStatement(
+                        source=source_token.value,
+                        statement=text[token.start:end],
+                        lineno=token.lineno,
+                        type_only=False,
+                    )
+                )
+                index = close_index + 1
+                continue
+
+        source_index: int | None = None
+        if keyword == "import" and index + 1 < len(tokens) and tokens[index + 1].kind == "string":
+            source_index = index + 1
+        else:
+            cursor = index + 1
+            while cursor < len(tokens):
+                current = tokens[cursor]
+                if current.value == ";":
+                    break
+                if current.value == "from" and cursor + 1 < len(tokens):
+                    candidate = tokens[cursor + 1]
+                    if candidate.kind == "string":
+                        source_index = cursor + 1
+                    break
+                cursor += 1
+
+        if source_index is None:
+            index += 1
+            continue
+
+        end = _statement_end(text, tokens, source_index)
+        statement_tokens = tokens[index : source_index + 1]
+        imports.append(
+            ImportStatement(
+                source=tokens[source_index].value,
+                statement=text[token.start:end],
+                lineno=token.lineno,
+                type_only=_is_type_only_tokens(statement_tokens, keyword),
+            )
+        )
+        index = source_index + 1
+
+    return imports
+
+
+def is_type_only_import(statement: str) -> bool:
+    tokens = tokenize_typescript(statement)
+    if not tokens or tokens[0].value not in {"import", "export"}:
+        return False
+    return _is_type_only_tokens(tokens, tokens[0].value)

--- a/scripts/report_frontend_structure.py
+++ b/scripts/report_frontend_structure.py
@@ -10,9 +10,15 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+try:
+    from scripts.frontend_imports import ImportStatement, collect_imports
+except ModuleNotFoundError:  # Direct `python3 scripts/...` execution.
+    from frontend_imports import ImportStatement, collect_imports
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MAX_LINES_ALLOWLIST_PATH = REPO_ROOT / "scripts" / "max_lines_allowlist.txt"
 FRONTEND_STRUCTURE_ALLOWLIST_PATH = REPO_ROOT / "scripts" / "frontend_structure_allowlist.txt"
+PRODUCT_CLIENT_SRC = REPO_ROOT / "apps" / "packages" / "product-client" / "src"
 
 FRONTEND_ROOTS = [
     REPO_ROOT / "apps" / "desktop" / "src",
@@ -23,7 +29,7 @@ FRONTEND_ROOTS = [
     REPO_ROOT / "apps" / "packages" / "product-domain" / "src",
     REPO_ROOT / "apps" / "packages" / "product-ui" / "src",
     REPO_ROOT / "apps" / "packages" / "product-surfaces" / "src",
-    REPO_ROOT / "apps" / "packages" / "product-client" / "src",
+    PRODUCT_CLIENT_SRC,
 ]
 
 APP_ROOTS = [
@@ -32,7 +38,7 @@ APP_ROOTS = [
     REPO_ROOT / "apps" / "mobile" / "src",
     # product-client is app-shaped (components/, hooks/, stores/), so the
     # component-.tsx-only and hook-responsibility-folder rules apply to it too.
-    REPO_ROOT / "apps" / "packages" / "product-client" / "src",
+    PRODUCT_CLIENT_SRC,
 ]
 
 DOM_APP_AND_PACKAGE_ROOTS = [
@@ -40,7 +46,7 @@ DOM_APP_AND_PACKAGE_ROOTS = [
     REPO_ROOT / "apps" / "web" / "src",
     REPO_ROOT / "apps" / "packages" / "product-ui" / "src",
     REPO_ROOT / "apps" / "packages" / "product-surfaces" / "src",
-    REPO_ROOT / "apps" / "packages" / "product-client" / "src",
+    PRODUCT_CLIENT_SRC,
 ]
 
 PACKAGE_ROOTS = {
@@ -49,18 +55,12 @@ PACKAGE_ROOTS = {
     "product-domain": REPO_ROOT / "apps" / "packages" / "product-domain" / "src",
     "product-ui": REPO_ROOT / "apps" / "packages" / "product-ui" / "src",
     "product-surfaces": REPO_ROOT / "apps" / "packages" / "product-surfaces" / "src",
-    "product-client": REPO_ROOT / "apps" / "packages" / "product-client" / "src",
+    "product-client": PRODUCT_CLIENT_SRC,
 }
 
 EXTENSIONS = {".ts", ".tsx"}
 RAW_DOM_TAGS = ("button", "input", "label", "select", "textarea")
 RAW_DOM_TAG_RE = re.compile(r"<\s*(" + "|".join(RAW_DOM_TAGS) + r")\b")
-
-IMPORT_START_RE = re.compile(r"^\s*(?:import\b|export\b(?:\s+type)?\s*(?:\{|\*))")
-IMPORT_SOURCE_RE = re.compile(
-    r"\bfrom\s+['\"]([^'\"]+)['\"]|^\s*import\s+['\"]([^'\"]+)['\"]",
-    re.MULTILINE,
-)
 
 COMPONENT_DEFINITION_RES = [
     re.compile(r"\b(?:export\s+)?function\s+([A-Z][A-Za-z0-9_]*)\b"),
@@ -140,6 +140,20 @@ SPECIAL_HOOK_ROOTS = {"access", "ui"}
 
 LINE_SOFT_THRESHOLD = 400
 LINE_STRONG_REASON_THRESHOLD = 600
+JUNK_DRAWER_BASENAMES = {
+    "common.ts",
+    "common.tsx",
+    "helper.ts",
+    "helper.tsx",
+    "helpers.ts",
+    "helpers.tsx",
+    "misc.ts",
+    "misc.tsx",
+    "util.ts",
+    "util.tsx",
+    "utils.ts",
+    "utils.tsx",
+}
 
 RULE_ORDER = [
     "RAW_DOM_CONTROL",
@@ -147,6 +161,7 @@ RULE_ORDER = [
     "COMPONENT_TS_FILE",
     "PRODUCT_HOOK_DIRECT_FILE",
     "NONSTANDARD_HOOK_FOLDER",
+    "FRONTEND_JUNK_DRAWER_FILENAME",
     "FORBIDDEN_SHARED_PACKAGE_IMPORT",
     "LARGE_FRONTEND_FILE",
 ]
@@ -157,6 +172,7 @@ RULE_TITLES = {
     "COMPONENT_TS_FILE": ".ts files under components/**",
     "PRODUCT_HOOK_DIRECT_FILE": "Product hooks directly under hooks/<domain>/",
     "NONSTANDARD_HOOK_FOLDER": "Nonstandard product hook responsibility folders",
+    "FRONTEND_JUNK_DRAWER_FILENAME": "Generic frontend junk-drawer filenames",
     "FORBIDDEN_SHARED_PACKAGE_IMPORT": "Forbidden shared-package imports",
     "LARGE_FRONTEND_FILE": "Large frontend files over documented thresholds",
 }
@@ -175,13 +191,6 @@ class Violation:
 
     def format(self) -> str:
         return f"{self.relative_path}:{self.lineno}: {self.message}"
-
-
-@dataclass(frozen=True)
-class ImportStatement:
-    source: str
-    statement: str
-    lineno: int
 
 
 def relative(path: Path) -> str:
@@ -281,51 +290,6 @@ def load_large_file_allowlist() -> dict[str, LargeFileAllowlistEntry]:
 def line_is_comment(line: str) -> bool:
     stripped = line.strip()
     return stripped.startswith("//") or stripped.startswith("*") or stripped.startswith("/*")
-
-
-def collect_imports(path: Path, text: str) -> list[ImportStatement]:
-    imports: list[ImportStatement] = []
-    active: list[str] = []
-    start_line = 0
-
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        if not active and not IMPORT_START_RE.match(line):
-            continue
-        if not active:
-            start_line = lineno
-        active.append(line)
-        if ";" not in line:
-            continue
-        statement = "\n".join(active)
-        active = []
-        match = IMPORT_SOURCE_RE.search(statement)
-        if match:
-            imports.append(
-                ImportStatement(
-                    source=match.group(1) or match.group(2),
-                    statement=statement,
-                    lineno=start_line,
-                )
-            )
-
-    if active:
-        statement = "\n".join(active)
-        match = IMPORT_SOURCE_RE.search(statement)
-        if match:
-            imports.append(
-                ImportStatement(
-                    source=match.group(1) or match.group(2),
-                    statement=statement,
-                    lineno=start_line,
-                )
-            )
-
-    return imports
-
-
-def is_type_only_import(statement: str) -> bool:
-    stripped = statement.strip()
-    return stripped.startswith("import type ")
 
 
 def is_primitive_like_name(name: str) -> bool:
@@ -491,6 +455,19 @@ def find_hook_shape_violations() -> list[Violation]:
     return violations
 
 
+def find_junk_drawer_filename_violations(files: Iterable[Path]) -> list[Violation]:
+    return [
+        Violation(
+            "FRONTEND_JUNK_DRAWER_FILENAME",
+            path,
+            1,
+            "name the owned concept instead of using a generic junk-drawer filename",
+        )
+        for path in files
+        if is_under(path, PRODUCT_CLIENT_SRC) and path.name in JUNK_DRAWER_BASENAMES
+    ]
+
+
 def resolved_relative_import_leaves_package(path: Path, package_root: Path, source: str) -> bool:
     if not source.startswith("."):
         return False
@@ -504,7 +481,7 @@ def resolved_relative_import_leaves_package(path: Path, package_root: Path, sour
 
 def forbidden_import_reason(package_name: str, statement: ImportStatement) -> str | None:
     source = statement.source
-    type_only = is_type_only_import(statement.statement)
+    type_only = statement.type_only
 
     if source.startswith("@/"):
         return "shared packages must not import app-root aliases"
@@ -714,6 +691,7 @@ def collect_violations() -> list[Violation]:
     violations.extend(find_primitive_definitions(files))
     violations.extend(find_component_ts_files(files))
     violations.extend(find_hook_shape_violations())
+    violations.extend(find_junk_drawer_filename_violations(files))
     violations.extend(find_forbidden_shared_package_imports(files))
     violations.extend(find_large_frontend_files(files))
     return sorted(

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -1427,6 +1427,29 @@ class ProductClientBoundaryTest(unittest.TestCase):
             },
         )
 
+    def test_store_alias_tracking_distinguishes_calls_from_comma_expressions(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/call-result.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const chat = selectStore(value, useChatStore);\n"
+                "chat.setState({ unrelated: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/comma-result.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const chat = (value, useChatStore);\n"
+                "chat.setState({ ready: true });\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            (violation.path.name, violation.lineno)
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(set_state, [("comma-result.ts", 3)])
+
     def test_domain_and_workflow_purity_covers_react_package_subpaths(self) -> None:
         files = {
             "apps/packages/product-client/src/lib/domain/chat/react.ts": (

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
 from scripts import check_frontend_boundaries as check_module
+from scripts import report_frontend_structure as structure_module
+from scripts.frontend_imports import collect_imports
 
 
 class RadixImportBoundaryTest(unittest.TestCase):
@@ -221,6 +225,305 @@ class WarningInkBoundaryTest(unittest.TestCase):
         violations = self.run_rule('// historical note: text-warning was wrong\n')
 
         self.assertEqual(violations, [])
+
+
+class ProductClientBoundaryTest(unittest.TestCase):
+    def write_files(self, root: Path, files: dict[str, str]) -> list[Path]:
+        paths: list[Path] = []
+        for relative_path, content in files.items():
+            path = root / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+            paths.append(path)
+        return paths
+
+    def run_product_rules(
+        self,
+        root: Path,
+        files: dict[str, str],
+    ) -> list[check_module.Violation]:
+        paths = self.write_files(root, files)
+        product_src = root / "apps" / "packages" / "product-client" / "src"
+        with patch.multiple(
+            check_module,
+            REPO_ROOT=root,
+            PRODUCT_CLIENT_SRC=product_src,
+        ):
+            return [
+                violation
+                for path in paths
+                for violation in check_module.find_product_client_violations(path)
+            ]
+
+    def test_shared_parser_retains_multiline_type_mixed_and_dynamic_facts(self) -> None:
+        source = (
+            "// import('apps/desktop/src/not-code')\n"
+            "import type {\n"
+            "  First,\n"
+            "} from '#product/components/First';\n"
+            "import { value, type Shape } from '#product/components/Mixed';\n"
+            "const load = () => import('#product/components/Lazy');\n"
+            "export type { PublicShape } from '#product/components/Public';\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual([statement.lineno for statement in statements], [2, 5, 6, 7])
+        self.assertEqual(
+            [statement.type_only for statement in statements],
+            [True, False, False, True],
+        )
+        self.assertEqual(
+            [statement.source for statement in statements],
+            [
+                "#product/components/First",
+                "#product/components/Mixed",
+                "#product/components/Lazy",
+                "#product/components/Public",
+            ],
+        )
+        self.assertTrue(statements[0].statement.startswith("import type"))
+
+    def test_every_forbidden_layer_pair_fails_for_alias_and_relative_imports(self) -> None:
+        forbidden_pairs = sorted(check_module.PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES)
+        files: dict[str, str] = {}
+        for index, (source_layer, target_layer) in enumerate(forbidden_pairs):
+            files[f"apps/packages/product-client/src/{source_layer}/alias-{index}/Sample.ts"] = (
+                f'import {{ Value }} from "#product/{target_layer}/Value";\n'
+            )
+            files[f"apps/packages/product-client/src/{source_layer}/relative-{index}/Sample.ts"] = (
+                f'import {{ Value }} from "../../{target_layer}/Value";\n'
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        layer_violations = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_LAYER_DIRECTION"
+        ]
+        self.assertEqual(len(layer_violations), 2 * len(forbidden_pairs))
+
+    def test_reverse_same_layer_and_lower_store_imports_pass(self) -> None:
+        files = {
+            "apps/packages/product-client/src/components/chat/Sample.ts": (
+                'import { useThing } from "#product/hooks/chat/use-thing";\n'
+            ),
+            "apps/packages/product-client/src/hooks/chat/Sample.ts": (
+                'import { useThing } from "#product/hooks/workspaces/use-thing";\n'
+            ),
+            "apps/packages/product-client/src/stores/chat/Sample.ts": (
+                'import { model } from "#product/lib/domain/chat/model";\n'
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        self.assertNotIn(
+            "PRODUCT_CLIENT_LAYER_DIRECTION",
+            {violation.rule_id for violation in violations},
+        )
+
+    def test_type_only_multiline_edge_and_dynamic_edge_report_start_lines(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/typed.ts": (
+                "\nimport type {\n  Props,\n} from '#product/components/chat/View';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/lazy.ts": (
+                "\n\nconst load = () => import('#product/components/chat/View');\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        layer_violations = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_LAYER_DIRECTION"
+        ]
+        self.assertEqual([violation.lineno for violation in layer_violations], [2, 3])
+        self.assertIn("type-only", layer_violations[0].message)
+        self.assertIn("runtime", layer_violations[1].message)
+
+    def test_fixture_host_text_passes_but_real_host_import_and_tauri_global_fail(self) -> None:
+        files = {
+            "apps/packages/product-client/src/lib/domain/chat/fixture.ts": (
+                'const sample = "apps/desktop/src/App.tsx __TAURI_INTERNALS__";\n'
+                "// import '@/host-only'\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/host-import.ts": (
+                "import thing from 'apps/desktop/src/thing';\n"
+                "const tauri = window.__TAURI_INTERNALS__;\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            violations = self.run_product_rules(root, files)
+
+        forbidden = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_FORBIDDEN_IMPORT"
+        ]
+        self.assertEqual(len(forbidden), 2)
+        self.assertTrue(all(violation.path.name == "host-import.ts" for violation in forbidden))
+
+    def test_imported_store_alias_set_state_fails_but_react_and_owner_calls_pass(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/external.ts": (
+                "import { useChatStore as chatState } from '#product/stores/chat/chat-store';\n"
+                "chatState.setState({ ready: true });\n"
+                "this.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/chat-store.ts": (
+                "const useChatStore = { setState(_value: unknown) {} };\n"
+                "useChatStore.setState({ ready: true });\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(len(set_state), 1)
+        self.assertEqual(set_state[0].lineno, 2)
+
+    def test_query_hooks_pass_in_access_and_cache_but_fail_in_workflow_and_facade(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/access/cloud/query.ts": (
+                "import { useQuery } from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/cache/query.ts": (
+                "import { useQueries } from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/action.ts": (
+                "import { useMutation } from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/facade/model.ts": (
+                "import { useSuspenseQuery } from '@tanstack/react-query';\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        query_violations = [
+            violation
+            for violation in violations
+            if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
+        ]
+        self.assertEqual(len(query_violations), 2)
+        self.assertEqual(
+            {violation.path.name for violation in query_violations},
+            {"action.ts", "model.ts"},
+        )
+
+    def test_store_runtime_access_fails_but_contract_types_and_pure_sdk_helpers_pass(self) -> None:
+        files = {
+            "apps/packages/product-client/src/stores/chat/legal.ts": (
+                "import type { TranscriptState } from '@anyharness/sdk';\n"
+                "import { createTranscriptState } from '@anyharness/sdk';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/react-sdk.ts": (
+                "import { useCloudThing } from '@proliferate/cloud-sdk-react';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/raw-client.ts": (
+                "import { getAnyHarnessClient } from '@anyharness/sdk';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/fetch.ts": (
+                "export const load = () => fetch('/state');\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        runtime_access = [
+            violation
+            for violation in violations
+            if violation.rule_id == "STORE_RUNTIME_ACCESS"
+        ]
+        self.assertEqual(len(runtime_access), 3)
+
+    def test_product_client_generalizes_existing_access_and_lib_purity_rules(self) -> None:
+        files = {
+            "apps/packages/product-client/src/components/chat/Raw.tsx": (
+                "import { probe } from '#product/lib/access/cloud/probe';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/state.ts": (
+                "import type { Snapshot } from '#product/lib/access/cloud/snapshot';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/raw-client.ts": (
+                "import { getAnyHarnessClient } from '@anyharness/sdk-react';\n"
+            ),
+            "apps/packages/product-client/src/lib/domain/chat/model.ts": (
+                "import React from 'react';\n"
+                "import type { Raw } from '#product/lib/access/cloud/raw';\n"
+            ),
+            "apps/packages/product-client/src/lib/workflows/chat/run.ts": (
+                "import type { QueryClient } from '@tanstack/react-query';\n"
+                "import { raw } from '#product/lib/access/cloud/raw';\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        counts: dict[str, int] = {}
+        for violation in violations:
+            counts[violation.rule_id] = counts.get(violation.rule_id, 0) + 1
+        self.assertEqual(counts.get("COMPONENT_FORBIDDEN_ACCESS"), 1)
+        self.assertEqual(counts.get("STORE_FORBIDDEN_ACCESS"), 1)
+        self.assertEqual(counts.get("ANYHARNESS_CLIENT_OUTSIDE_ACCESS"), 1)
+        self.assertEqual(counts.get("DOMAIN_FORBIDDEN_IMPORT"), 2)
+        self.assertEqual(counts.get("WORKFLOW_FORBIDDEN_IMPORT"), 2)
+
+    def test_exact_junk_drawer_names_fail_but_descriptive_helpers_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            files = self.write_files(
+                root,
+                {
+                    "apps/packages/product-client/src/lib/domain/chat/utils.ts": "export {};\n",
+                    "apps/packages/product-client/src/lib/domain/chat/session-runtime-helpers.ts": "export {};\n",
+                    "apps/packages/ui/src/lib/utils.ts": "export {};\n",
+                },
+            )
+            with patch.multiple(
+                structure_module,
+                REPO_ROOT=root,
+                PRODUCT_CLIENT_SRC=root / "apps/packages/product-client/src",
+            ):
+                violations = structure_module.find_junk_drawer_filename_violations(files)
+
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].path.name, "utils.ts")
+
+    def test_allowlist_overage_and_stale_count_both_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            path = root / "apps/packages/product-client/src/hooks/chat/sample.ts"
+            path.parent.mkdir(parents=True)
+            path.write_text("export {};\n", encoding="utf-8")
+            entry = check_module.AllowlistEntry("RULE", path.relative_to(root).as_posix(), 1, "debt")
+            with patch.multiple(
+                check_module,
+                REPO_ROOT=root,
+                load_allowlist=lambda: {("RULE", entry.relative_path): entry},
+                collect_violations=lambda: [
+                    check_module.Violation("RULE", path, 1, "old"),
+                    check_module.Violation("RULE", path, 2, "new"),
+                ],
+            ), redirect_stdout(StringIO()):
+                self.assertEqual(check_module.main(), 1)
+            with patch.multiple(
+                check_module,
+                REPO_ROOT=root,
+                load_allowlist=lambda: {("RULE", entry.relative_path): entry},
+                collect_violations=lambda: [],
+            ), redirect_stdout(StringIO()):
+                self.assertEqual(check_module.main(), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -467,7 +467,11 @@ class ProductClientBoundaryTest(unittest.TestCase):
             'const x = { as: import("pkg") }',
             'const x = { satisfies: import("pkg") }',
             'object.as(import("pkg"))',
-            'left < import("pkg") > (right)',
+            (
+                'const ok = (left as any) < '
+                '(import("pkg") as any).Thing > (right as any)'
+            ),
+            'left < (import("pkg")).Thing > (right)',
             'left < import("pkg").then(load) > (right)',
             (
                 'left < (ready ? import("pkg") : fallback).default '
@@ -500,6 +504,8 @@ class ProductClientBoundaryTest(unittest.TestCase):
             'tag<import("pkg").Thing>`value`',
             'type Fn = (value: string)\n=> import("pkg").Thing',
             'type Fn = (value: string) =>\nimport("pkg").Thing',
+            'left < import("pkg") > (right)',
+            'select < typeof import("pkg") > (input)',
         ]
         for type_source in type_expressions:
             with self.subTest(type_source=type_source):
@@ -654,6 +660,61 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 'import { value } from "pkg-a"',
                 'import data from "pkg-b" with { type: "json" }',
                 'import Equals = require("pkg-c")',
+            ],
+        )
+
+    def test_shared_parser_handles_asserted_dynamic_literals_and_following_assert_calls(self) -> None:
+        source = (
+            'const first = import("pkg-a" as const);\n'
+            'const second = import(("pkg-b" satisfies string));\n'
+            'const computed = import(source satisfies string);\n'
+            'import value from "pkg-c"\n'
+            'assert(value)\n'
+            'import data from "pkg-d" assert { type: "json" }\n'
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            ["pkg-a", "pkg-b", "pkg-c", "pkg-d"],
+        )
+        self.assertEqual(statements[2].statement, 'import value from "pkg-c"')
+        self.assertEqual(
+            statements[3].statement,
+            'import data from "pkg-d" assert { type: "json" }',
+        )
+
+    def test_shared_parser_distinguishes_regex_contexts_from_postfix_division(self) -> None:
+        source = (
+            "for (const item of /import('apps\\/desktop\\/src\\/of')/ as any) {}\n"
+            "const contains = 'x' in /import('apps\\/desktop\\/src\\/in')/;\n"
+            "const instance = value instanceof "
+            "/import('apps\\/desktop\\/src\\/instanceof')/;\n"
+            "const kind = typeof /import('apps\\/desktop\\/src\\/typeof')/;\n"
+            "async function ratios(value: number) {\n"
+            "  const asserted = value! / "
+            "(await import('#product/components/Asserted')).default;\n"
+            "  const incremented = value++ / "
+            "(await import('#product/components/Incremented')).default;\n"
+            "  const property = fixture.of / "
+            "(await import('#product/components/PropertyOf')).default;\n"
+            "  const of = value ?? 1;\n"
+            "  const named = of / "
+            "(await import('#product/components/NamedOf')).default;\n"
+            "  return asserted + incremented + property + named;\n"
+            "}\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            [
+                "#product/components/Asserted",
+                "#product/components/Incremented",
+                "#product/components/PropertyOf",
+                "#product/components/NamedOf",
             ],
         )
 
@@ -1033,6 +1094,14 @@ class ProductClientBoundaryTest(unittest.TestCase):
             "apps/packages/product-client/src/stores/chat/raw-client.ts": (
                 "import { getAnyHarnessClient } from '@anyharness/sdk';\n"
             ),
+            "apps/packages/product-client/src/stores/chat/cloud-constructor.ts": (
+                "import { createProliferateClient } from '@proliferate/cloud-sdk';\n"
+                "export const client = createProliferateClient({});\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/runtime-constructor.ts": (
+                "import { AnyHarnessClient } from '@anyharness/sdk';\n"
+                "export const client = new AnyHarnessClient({ baseUrl });\n"
+            ),
             "apps/packages/product-client/src/stores/chat/fetch.ts": (
                 "export const load = () => fetch('/state');\n"
             ),
@@ -1045,7 +1114,16 @@ class ProductClientBoundaryTest(unittest.TestCase):
             for violation in violations
             if violation.rule_id == "STORE_RUNTIME_ACCESS"
         ]
-        self.assertEqual(len(runtime_access), 3)
+        self.assertEqual(
+            {violation.path.name for violation in runtime_access},
+            {
+                "react-sdk.ts",
+                "raw-client.ts",
+                "cloud-constructor.ts",
+                "runtime-constructor.ts",
+                "fetch.ts",
+            },
+        )
 
     def test_store_import_type_expressions_and_mixed_runtime_imports_are_distinguished(self) -> None:
         files = {
@@ -1215,6 +1293,10 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 "import('@tanstack/react-query').then("
                 "Query => Query.useInfiniteQuery());\n"
             ),
+            "apps/packages/product-client/src/hooks/chat/workflows/generic-namespace-query.ts": (
+                "import('@tanstack/react-query').then<void>("
+                "Query => void Query.useMutation());\n"
+            ),
             "apps/packages/product-client/src/hooks/chat/workflows/sibling-safe.ts": (
                 "import('@tanstack/react-query').then("
                 "Query => void Query.QueryClient, "
@@ -1241,7 +1323,10 @@ class ProductClientBoundaryTest(unittest.TestCase):
             for violation in violations
             if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
         }
-        self.assertEqual(query_paths, {"async-query.ts", "namespace-query.ts"})
+        self.assertEqual(
+            query_paths,
+            {"async-query.ts", "namespace-query.ts", "generic-namespace-query.ts"},
+        )
 
     def test_dynamic_and_static_namespace_store_aliases_cannot_mutate_state(self) -> None:
         files = {
@@ -1257,8 +1342,43 @@ class ProductClientBoundaryTest(unittest.TestCase):
             ),
             "apps/packages/product-client/src/hooks/chat/workflows/static-namespace.ts": (
                 "import * as Stores from '#product/stores/chat/chat-store';\n"
-                "const { useChatStore: chat } = Stores\n"
+                "const { useChatStore: chat } = Stores, marker = 1;\n"
                 "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/asserted-namespace.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "const { useChatStore: chat } = Stores satisfies typeof Stores;\n"
+                "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/direct-alias.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const chat = useChatStore;\n"
+                "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/member-alias.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "const chat = Stores.useChatStore;\n"
+                "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/asserted-direct-alias.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const chat = useChatStore as StoreApi<State>;\n"
+                "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/comma-alias-safe.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const chat = (useChatStore, fixture.store);\n"
+                "chat.setState({ unrelated: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/member-comma-alias-safe.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "const chat = (Stores.useChatStore, fixture.store);\n"
+                "chat.setState({ unrelated: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/member-target-safe.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "({ useChatStore: target.store } = Stores);\n"
+                "target.setState({ unrelated: true });\n"
             ),
             "apps/packages/product-client/src/hooks/chat/workflows/block-sibling-safe.ts": (
                 "async function inspect() {\n"
@@ -1284,7 +1404,15 @@ class ProductClientBoundaryTest(unittest.TestCase):
         }
         self.assertEqual(
             set_state_paths,
-            {"dynamic-destructure.ts", "dynamic-namespace.ts", "static-namespace.ts"},
+            {
+                "dynamic-destructure.ts",
+                "dynamic-namespace.ts",
+                "static-namespace.ts",
+                "asserted-namespace.ts",
+                "direct-alias.ts",
+                "member-alias.ts",
+                "asserted-direct-alias.ts",
+            },
         )
 
     def test_domain_and_workflow_purity_covers_react_package_subpaths(self) -> None:
@@ -1317,6 +1445,57 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 "WORKFLOW_FORBIDDEN_IMPORT",
             ],
         )
+
+    def test_for_initializer_imports_and_function_scoped_var_shadows_are_distinguished(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/for-query.ts": (
+                "async function inspect() {\n"
+                "  for (const Query = await import('@tanstack/react-query'); ready;) {\n"
+                "    Query.useMutation();\n"
+                "    break;\n"
+                "  }\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/for-store.ts": (
+                "async function update() {\n"
+                "  for (const Stores = await "
+                "import('#product/stores/chat/chat-store'); ready;) {\n"
+                "    Stores.useChatStore.setState({ ready: true });\n"
+                "    break;\n"
+                "  }\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/var-store.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "function local() {\n"
+                "  if (ready) { var useChatStore = fixture.store; }\n"
+                "  useChatStore.setState({ local: true });\n"
+                "}\n"
+                "useChatStore.setState({ imported: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/var-query-safe.ts": (
+                "import * as Query from '@tanstack/react-query';\n"
+                "function local() {\n"
+                "  if (ready) { var Query = fixture.query; }\n"
+                "  Query.useQuery();\n"
+                "}\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        query_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
+        }
+        self.assertEqual(query_paths, {"for-query.ts"})
+        set_state = [
+            (violation.path.name, violation.lineno)
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(set_state, [("for-store.ts", 3), ("var-store.ts", 6)])
 
     def test_executable_template_and_jsx_code_is_checked_but_display_text_and_regex_pass(self) -> None:
         files = {

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -469,6 +469,10 @@ class ProductClientBoundaryTest(unittest.TestCase):
             'object.as(import("pkg"))',
             'left < import("pkg") > (right)',
             'left < import("pkg").then(load) > (right)',
+            (
+                'left < (ready ? import("pkg") : fallback).default '
+                '> (right)'
+            ),
             'import type, { Value } from "pkg"',
         ]
         for runtime_source in runtime_expressions:
@@ -516,7 +520,9 @@ class ProductClientBoundaryTest(unittest.TestCase):
             'await import("pkg-f");\n'
             'const dynamicNamespace: Module = await import("pkg-g");\n'
             'const client = (await import("pkg-h")).getAnyHarnessClient;\n'
-            'import("pkg-i").then(({ useInfiniteQuery: query }) => query());\n'
+            'import("pkg-i").then(async '
+            '({ useInfiniteQuery: query }) => query());\n'
+            'import("pkg-j").then((Query) => Query.useQuery());\n'
         )
 
         statements = {
@@ -580,6 +586,21 @@ class ProductClientBoundaryTest(unittest.TestCase):
             statements["pkg-i"].imported_names,
             frozenset({"useInfiniteQuery"}),
         )
+        self.assertEqual(
+            [
+                (binding.name, binding.namespace)
+                for binding in statements["pkg-i"].scoped_bindings
+            ],
+            [("query", False)],
+        )
+        self.assertEqual(statements["pkg-j"].imported_names, frozenset({"*"}))
+        self.assertEqual(
+            [
+                (binding.name, binding.namespace)
+                for binding in statements["pkg-j"].scoped_bindings
+            ],
+            [("Query", True)],
+        )
 
     def test_shared_parser_skips_regex_after_declaration_and_catch_blocks(self) -> None:
         source = (
@@ -613,6 +634,27 @@ class ProductClientBoundaryTest(unittest.TestCase):
         self.assertEqual(
             [statement.source for statement in statements],
             ["outer-a", "inner-a", "outer-b", "inner-b", "grouped"],
+        )
+
+    def test_shared_parser_ends_semicolonless_static_statements_at_their_grammar_end(self) -> None:
+        source = (
+            'import { value } from "pkg-a"\n'
+            "const unrelatedA = 1;\n"
+            'import data from "pkg-b" with { type: "json" }\n'
+            "const unrelatedB = 2;\n"
+            'import Equals = require("pkg-c")\n'
+            "const unrelatedC = 3;\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.statement for statement in statements],
+            [
+                'import { value } from "pkg-a"',
+                'import data from "pkg-b" with { type: "json" }',
+                'import Equals = require("pkg-c")',
+            ],
         )
 
     def test_every_forbidden_layer_pair_fails_for_alias_and_relative_imports(self) -> None:
@@ -1161,6 +1203,119 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 ("raw-dynamic-member.ts", "ANYHARNESS_CLIENT_OUTSIDE_ACCESS"),
                 ("raw-dynamic-member.ts", "STORE_RUNTIME_ACCESS"),
             },
+        )
+
+    def test_dynamic_then_bindings_are_checked_only_inside_their_callbacks(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/async-query.ts": (
+                "import('@tanstack/react-query').then(async "
+                "({ useQuery: query }) => query());\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/namespace-query.ts": (
+                "import('@tanstack/react-query').then("
+                "Query => Query.useInfiniteQuery());\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/sibling-safe.ts": (
+                "import('@tanstack/react-query').then("
+                "Query => void Query.QueryClient, "
+                "Query => Query.useMutation());\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/block-sibling-safe.ts": (
+                "async function inspect() {\n"
+                "  if (ready) {\n"
+                "    const Query = await import('@tanstack/react-query');\n"
+                "    void Query.QueryClient;\n"
+                "  }\n"
+                "  if (other) {\n"
+                "    const Query = fixture.query;\n"
+                "    Query.useQuery();\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        query_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
+        }
+        self.assertEqual(query_paths, {"async-query.ts", "namespace-query.ts"})
+
+    def test_dynamic_and_static_namespace_store_aliases_cannot_mutate_state(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/dynamic-destructure.ts": (
+                "import('#product/stores/chat/chat-store').then("
+                "({ useChatStore: chat }) => chat.setState({ ready: true }));\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/dynamic-namespace.ts": (
+                "import('#product/stores/chat/chat-store').then(Stores => {\n"
+                "  const { useChatStore: chat } = Stores\n"
+                "  chat.setState({ ready: true });\n"
+                "});\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/static-namespace.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "const { useChatStore: chat } = Stores\n"
+                "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/block-sibling-safe.ts": (
+                "async function inspect() {\n"
+                "  if (ready) {\n"
+                "    const Stores = await "
+                "import('#product/stores/chat/chat-store');\n"
+                "    void Stores.useChatStore;\n"
+                "  }\n"
+                "  if (other) {\n"
+                "    const Stores = fixture.stores;\n"
+                "    Stores.useChatStore.setState({ local: true });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        }
+        self.assertEqual(
+            set_state_paths,
+            {"dynamic-destructure.ts", "dynamic-namespace.ts", "static-namespace.ts"},
+        )
+
+    def test_domain_and_workflow_purity_covers_react_package_subpaths(self) -> None:
+        files = {
+            "apps/packages/product-client/src/lib/domain/chat/react.ts": (
+                "import { jsx } from 'react/jsx-runtime';\n"
+                "import type { UseQueryResult } "
+                "from '@tanstack/react-query/build/legacy';\n"
+            ),
+            "apps/packages/product-client/src/lib/workflows/chat/react.ts": (
+                "import { createRoot } from 'react-dom/client';\n"
+                "import { useQuery } from '@tanstack/react-query/experimental';\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        purity_rules = [
+            violation.rule_id
+            for violation in violations
+            if violation.rule_id
+            in {"DOMAIN_FORBIDDEN_IMPORT", "WORKFLOW_FORBIDDEN_IMPORT"}
+        ]
+        self.assertEqual(
+            purity_rules,
+            [
+                "DOMAIN_FORBIDDEN_IMPORT",
+                "DOMAIN_FORBIDDEN_IMPORT",
+                "WORKFLOW_FORBIDDEN_IMPORT",
+                "WORKFLOW_FORBIDDEN_IMPORT",
+            ],
         )
 
     def test_executable_template_and_jsx_code_is_checked_but_display_text_and_regex_pass(self) -> None:

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -322,6 +322,61 @@ class ProductClientBoundaryTest(unittest.TestCase):
             [False, False, True, False, False, False, False],
         )
 
+    def test_shared_parser_distinguishes_control_flow_regex_from_division(self) -> None:
+        source = (
+            "if (ready) /import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            "while (ready) /import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            "for (; ready;) /import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            "do /import('apps\\/desktop\\/src\\/not-code')/.test(value); while (ready);\n"
+            "const divided = total / import('#product/components/Divided').default;\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [(statement.source, statement.lineno) for statement in statements],
+            [("#product/components/Divided", 5)],
+        )
+
+    def test_shared_parser_keeps_ts_assertions_and_semicolonless_runtime_imports(self) -> None:
+        source = (
+            "const lazy = <unknown>import('#product/components/Lazy');\n"
+            "type TypeOnly =\n"
+            "  import('@proliferate/cloud-sdk-react').UseHook\n"
+            "type Previous = unknown\n"
+            "export default import('@proliferate/cloud-sdk-react')\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            [
+                "#product/components/Lazy",
+                "@proliferate/cloud-sdk-react",
+                "@proliferate/cloud-sdk-react",
+            ],
+        )
+        self.assertEqual(
+            [statement.type_only for statement in statements],
+            [False, True, False],
+        )
+
+        runtime_expressions = [
+            "consume(import('@proliferate/cloud-sdk-react'))",
+            "runtime = import('@proliferate/cloud-sdk-react')",
+            "void [import('@proliferate/cloud-sdk-react')]",
+            "ready ? import('@proliferate/cloud-sdk-react') : fallback",
+        ]
+        for expression in runtime_expressions:
+            with self.subTest(expression=expression):
+                statements = collect_imports(
+                    Path("Sample.ts"),
+                    f"type Previous = unknown\n{expression}\n",
+                )
+                self.assertEqual(len(statements), 1)
+                self.assertFalse(statements[0].type_only)
+
     def test_every_forbidden_layer_pair_fails_for_alias_and_relative_imports(self) -> None:
         forbidden_pairs = sorted(check_module.PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES)
         files: dict[str, str] = {}
@@ -482,6 +537,32 @@ class ProductClientBoundaryTest(unittest.TestCase):
             [violation.lineno for violation in set_state],
             [2, 18, 21, 24, 29],
         )
+
+    def test_named_function_and_class_expressions_do_not_shadow_the_outer_import(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/expressions.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const functionExpression = function useChatStore() {\n"
+                "  useChatStore.setState({ innerFunctionName: true });\n"
+                "};\n"
+                "useChatStore.setState({ afterFunctionExpression: true });\n"
+                "const classExpression = class useChatStore {\n"
+                "  static update() {\n"
+                "    useChatStore.setState({ innerClassName: true });\n"
+                "  }\n"
+                "};\n"
+                "useChatStore.setState({ afterClassExpression: true });\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual([violation.lineno for violation in set_state], [5, 11])
 
     def test_query_hooks_pass_in_access_and_cache_but_fail_in_workflow_and_facade(self) -> None:
         files = {

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -284,6 +284,44 @@ class ProductClientBoundaryTest(unittest.TestCase):
         )
         self.assertTrue(statements[0].statement.startswith("import type"))
 
+    def test_shared_parser_handles_types_templates_jsx_regex_and_escaped_sources(self) -> None:
+        source = (
+            "import runtimeHook, { type HookOptions } "
+            "from '@proliferate/cloud-sdk-react';\n"
+            "import { type as runtimeBinding } from '@anyharness/sdk-react';\n"
+            "type Hook = import('@proliferate/cloud-sdk-react').UseHook;\n"
+            "const direct = import(`#product/components/Direct`);\n"
+            "const nested = `${import('#product/components/Nested')}`;\n"
+            "const computed = import(`#product/${from('@tauri-apps/api')}`);\n"
+            "const nestedSpecifier = "
+            "import(`${import('#product/components/SpecifierInner')}`);\n"
+            "const prose = <code>import('apps/desktop/src/not-code')</code>;\n"
+            "const regex = /import('apps\\/desktop\\/src\\/not-code')/;\n"
+            "export const Demo = () => <>from '@tauri-apps/api'</>;\n"
+            "export const prose = () => from('@tauri-apps/api');\n"
+            "const metadata = import.meta;\n"
+            "const escaped = import('@tauri\\u002dapps/api');\n"
+        )
+
+        statements = collect_imports(Path("Sample.tsx"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            [
+                "@proliferate/cloud-sdk-react",
+                "@anyharness/sdk-react",
+                "@proliferate/cloud-sdk-react",
+                "#product/components/Direct",
+                "#product/components/Nested",
+                "#product/components/SpecifierInner",
+                "@tauri-apps/api",
+            ],
+        )
+        self.assertEqual(
+            [statement.type_only for statement in statements],
+            [False, False, True, False, False, False, False],
+        )
+
     def test_every_forbidden_layer_pair_fails_for_alias_and_relative_imports(self) -> None:
         forbidden_pairs = sorted(check_module.PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES)
         files: dict[str, str] = {}
@@ -392,6 +430,59 @@ class ProductClientBoundaryTest(unittest.TestCase):
         self.assertEqual(len(set_state), 1)
         self.assertEqual(set_state[0].lineno, 2)
 
+    def test_imported_store_set_state_respects_lexical_and_property_shadowing(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/external.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "useChatStore.setState({ top: true });\n"
+                "function parameter(useChatStore: OtherObject) {\n"
+                "  useChatStore.setState({ parameter: true });\n"
+                "}\n"
+                "const arrow = (useChatStore: OtherObject) => "
+                "useChatStore.setState({ arrow: true });\n"
+                "function local() {\n"
+                "  const useChatStore = fixture.store;\n"
+                "  useChatStore.setState({ local: true });\n"
+                "}\n"
+                "function destructured() {\n"
+                "  const { useChatStore } = fixture;\n"
+                "  useChatStore.setState({ destructured: true });\n"
+                "}\n"
+                "fixture.useChatStore.setState({ property: true });\n"
+                "fixture?.useChatStore.setState({ optional: true });\n"
+                "function unshadowed() {\n"
+                "  useChatStore.setState({ nested: true });\n"
+                "}\n"
+                "function typed(other: ReturnType<typeof useChatStore>) {\n"
+                "  useChatStore.setState({ typed: true });\n"
+                "}\n"
+                "function propertyParameter({ useChatStore: local }: Fixture) {\n"
+                "  useChatStore.setState({ propertyParameter: true });\n"
+                "  local.setState({ local: true });\n"
+                "}\n"
+                "function propertyDestructure() {\n"
+                "  const { useChatStore: local } = fixture;\n"
+                "  useChatStore.setState({ propertyDestructure: true });\n"
+                "}\n"
+                "function temporalDeadZone() {\n"
+                "  useChatStore.setState({ localBeforeDeclaration: true });\n"
+                "  const useChatStore = fixture.store;\n"
+                "}\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(
+            [violation.lineno for violation in set_state],
+            [2, 18, 21, 24, 29],
+        )
+
     def test_query_hooks_pass_in_access_and_cache_but_fail_in_workflow_and_facade(self) -> None:
         files = {
             "apps/packages/product-client/src/hooks/access/cloud/query.ts": (
@@ -421,6 +512,40 @@ class ProductClientBoundaryTest(unittest.TestCase):
             {"action.ts", "model.ts"},
         )
 
+    def test_query_hooks_fail_in_non_owner_lib_areas_without_duplicate_domain_rules(self) -> None:
+        files = {
+            "apps/packages/product-client/src/lib/access/cloud/query.ts": (
+                "import { useQuery } from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/lib/infra/query.ts": (
+                "import { useMutation } from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/lib/domain/chat/query.ts": (
+                "import { useQueries } from '@tanstack/react-query';\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        query_paths = {
+            violation.path.as_posix().split("/src/", 1)[1]
+            for violation in violations
+            if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
+        }
+        self.assertEqual(
+            query_paths,
+            {
+                "lib/access/cloud/query.ts",
+                "lib/infra/query.ts",
+            },
+        )
+        domain_rules = [
+            violation.rule_id
+            for violation in violations
+            if violation.path.as_posix().endswith("lib/domain/chat/query.ts")
+        ]
+        self.assertEqual(domain_rules, ["DOMAIN_FORBIDDEN_IMPORT"])
+
     def test_store_runtime_access_fails_but_contract_types_and_pure_sdk_helpers_pass(self) -> None:
         files = {
             "apps/packages/product-client/src/stores/chat/legal.ts": (
@@ -446,6 +571,76 @@ class ProductClientBoundaryTest(unittest.TestCase):
             if violation.rule_id == "STORE_RUNTIME_ACCESS"
         ]
         self.assertEqual(len(runtime_access), 3)
+
+    def test_store_import_type_expressions_and_mixed_runtime_imports_are_distinguished(self) -> None:
+        files = {
+            "apps/packages/product-client/src/stores/chat/type-expression.ts": (
+                "type Hook = import('@proliferate/cloud-sdk-react').UseHook;\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/mixed.ts": (
+                "import runtimeHook, { type HookOptions } "
+                "from '@proliferate/cloud-sdk-react';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/type-named-runtime.ts": (
+                "import { type as runtimeBinding } from '@anyharness/sdk-react';\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        runtime_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "STORE_RUNTIME_ACCESS"
+        }
+        self.assertEqual(runtime_paths, {"mixed.ts", "type-named-runtime.ts"})
+
+    def test_internal_store_access_has_exactly_one_rule_owner(self) -> None:
+        files = {
+            "apps/packages/product-client/src/stores/chat/internal-access.ts": (
+                "import { getAnyHarnessClient } "
+                "from '#product/lib/access/anyharness/client';\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        self.assertEqual(
+            [violation.rule_id for violation in violations],
+            ["STORE_FORBIDDEN_ACCESS"],
+        )
+
+    def test_executable_template_and_jsx_code_is_checked_but_display_text_and_regex_pass(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/template.ts": (
+                "const direct = import(`#product/components/Direct`);\n"
+                "const nested = `${import('#product/components/Nested')}`;\n"
+                "const tauri = `${window.__TAURI_INTERNALS__}`;\n"
+                "const divided = numerator / import('#product/components/Divided');\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/display.tsx": (
+                "export const Demo = () => (\n"
+                "  <code>import('apps/desktop/src/not-code') "
+                "from '@tauri-apps/api' __TAURI_INTERNALS__</code>\n"
+                ");\n"
+                "const pattern = /import('apps\\/desktop\\/src\\/not-code')/;\n"
+                "const executable = <code>{import('#product/components/InExpression')}</code>;\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        relevant = [
+            violation
+            for violation in violations
+            if violation.rule_id
+            in {"PRODUCT_CLIENT_LAYER_DIRECTION", "PRODUCT_CLIENT_FORBIDDEN_IMPORT"}
+        ]
+        self.assertEqual(len(relevant), 5)
+        self.assertEqual(
+            [violation.lineno for violation in relevant],
+            [1, 2, 4, 3, 5],
+        )
 
     def test_product_client_generalizes_existing_access_and_lib_purity_rules(self) -> None:
         files = {

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -513,6 +513,52 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 self.assertEqual(len(statements), 1)
                 self.assertTrue(statements[0].type_only)
 
+    def test_shared_parser_stops_generic_return_types_at_runtime_bodies(self) -> None:
+        runtime_sources = [
+            'async function load(): Promise<unknown> { return import("function") }',
+            (
+                'class Loader { load(): Record<string, unknown> '
+                '{ return import("class-method") } }'
+            ),
+            (
+                'const loader = { load(): Promise<Result<Value>> '
+                '{ return import("object-method") } };'
+            ),
+            'const load = (): Promise<unknown> => import("arrow")',
+        ]
+        for runtime_source in runtime_sources:
+            with self.subTest(runtime_source=runtime_source):
+                statements = collect_imports(Path("Sample.ts"), runtime_source)
+                self.assertEqual(len(statements), 1)
+                self.assertFalse(statements[0].type_only)
+
+        paired_source = (
+            'function load(): Promise<Result<Array<import("contract").Shape>>> {\n'
+            '  return import("runtime");\n'
+            '}\n'
+        )
+        paired = collect_imports(Path("Sample.ts"), paired_source)
+        self.assertEqual(
+            [(statement.source, statement.type_only) for statement in paired],
+            [("contract", True), ("runtime", False)],
+        )
+
+        function_type_sources = [
+            (
+                'function read(): () => { value: import("function-type").Thing } '
+                '{ throw failure }'
+            ),
+            (
+                'const read = (): () => { value: import("arrow-type").Thing } '
+                '=> value;'
+            ),
+        ]
+        for type_source in function_type_sources:
+            with self.subTest(type_source=type_source):
+                statements = collect_imports(Path("Sample.ts"), type_source)
+                self.assertEqual(len(statements), 1)
+                self.assertTrue(statements[0].type_only)
+
     def test_shared_parser_preserves_semantic_static_and_dynamic_import_facts(self) -> None:
         source = (
             'import defaultName, { useQuery as query, type Shape, '
@@ -1148,6 +1194,47 @@ class ProductClientBoundaryTest(unittest.TestCase):
         }
         self.assertEqual(runtime_paths, {"mixed.ts", "type-named-runtime.ts"})
 
+    def test_generic_return_types_do_not_hide_store_runtime_imports(self) -> None:
+        files = {
+            "apps/packages/product-client/src/stores/chat/function.ts": (
+                "export async function load(): Promise<unknown> {\n"
+                "  return import('@tanstack/react-query');\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/class-method.ts": (
+                "class Loader {\n"
+                "  load(): Record<string, unknown> {\n"
+                "    return import('@proliferate/cloud-sdk-react');\n"
+                "  }\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/object-method.ts": (
+                "const loader = {\n"
+                "  load(): Promise<Result<Value>> {\n"
+                "    return import('@anyharness/sdk-react');\n"
+                "  },\n"
+                "};\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/type-only.ts": (
+                "export function contract(): "
+                "Promise<import('@proliferate/cloud-sdk-react').UseHook> {\n"
+                "  throw new Error('not implemented');\n"
+                "}\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        runtime_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "STORE_RUNTIME_ACCESS"
+        }
+        self.assertEqual(
+            runtime_paths,
+            {"function.ts", "class-method.ts", "object-method.ts"},
+        )
+
     def test_internal_store_access_has_exactly_one_rule_owner(self) -> None:
         files = {
             "apps/packages/product-client/src/stores/chat/internal-access.ts": (
@@ -1616,6 +1703,44 @@ class ProductClientBoundaryTest(unittest.TestCase):
 
         self.assertEqual(len(violations), 1)
         self.assertEqual(violations[0].path.name, "utils.ts")
+
+    def test_generic_return_types_do_not_hide_domain_runtime_imports(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            paths = self.write_files(
+                root,
+                {
+                    "apps/packages/product-domain/src/runtime.ts": (
+                        "export async function load(): Promise<void> {\n"
+                        "  const { createProliferateClient } = "
+                        "await import('@proliferate/cloud-sdk');\n"
+                        "  return createProliferateClient({});\n"
+                        "}\n"
+                    ),
+                    "apps/packages/product-domain/src/type-only.ts": (
+                        "export function contract(): "
+                        "Promise<Result<Array<"
+                        "import('@proliferate/cloud-sdk').CloudWorkspace>>> {\n"
+                        "  throw new Error('not implemented');\n"
+                        "}\n"
+                    ),
+                },
+            )
+            package_root = root / "apps/packages/product-domain/src"
+            with patch.multiple(
+                structure_module,
+                REPO_ROOT=root,
+                PACKAGE_ROOTS={"product-domain": package_root},
+            ):
+                violations = structure_module.find_forbidden_shared_package_imports(paths)
+
+        self.assertEqual(
+            [
+                (violation.path.name, violation.rule_id, violation.lineno)
+                for violation in violations
+            ],
+            [("runtime.ts", "FORBIDDEN_SHARED_PACKAGE_IMPORT", 2)],
+        )
 
     def test_allowlist_overage_and_stale_count_both_fail(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -460,6 +460,16 @@ class ProductClientBoundaryTest(unittest.TestCase):
             'left < (await import("pkg")).default > (right)',
             'function f(): Result { return import("pkg") }',
             'const f = (): Result => import("pkg")',
+            'consume(ready ? current : import("pkg"))\nconst later = () => value',
+            'consume(ready ? current : import("pkg"))\nfunction later() {}',
+            'const x = (value as Shape) ? current : import("pkg")',
+            'const x = value satisfies Shape ? current : import("pkg")',
+            'const x = { as: import("pkg") }',
+            'const x = { satisfies: import("pkg") }',
+            'object.as(import("pkg"))',
+            'left < import("pkg") > (right)',
+            'left < import("pkg").then(load) > (right)',
+            'import type, { Value } from "pkg"',
         ]
         for runtime_source in runtime_expressions:
             with self.subTest(runtime_source=runtime_source):
@@ -479,12 +489,131 @@ class ProductClientBoundaryTest(unittest.TestCase):
             'const a = 1, b: import("pkg").Thing = value',
             'const value = source satisfies Readonly<import("pkg").Thing>',
             'const value = source as { load: import("pkg").Thing }',
+            'function read(): { value: import("pkg").Thing } {}',
+            'const read = (): { value: import("pkg").Thing } => value',
+            'function read(cb: (value: string) => import("pkg").Thing) {}',
+            'class Child extends Base<import("pkg").Thing> {}',
+            'tag<import("pkg").Thing>`value`',
+            'type Fn = (value: string)\n=> import("pkg").Thing',
+            'type Fn = (value: string) =>\nimport("pkg").Thing',
         ]
         for type_source in type_expressions:
             with self.subTest(type_source=type_source):
                 statements = collect_imports(Path("Sample.ts"), type_source)
                 self.assertEqual(len(statements), 1)
                 self.assertTrue(statements[0].type_only)
+
+    def test_shared_parser_preserves_semantic_static_and_dynamic_import_facts(self) -> None:
+        source = (
+            'import defaultName, { useQuery as query, type Shape, '
+            'mutationOptions as useMutation, "getAnyHarnessClient" as make } '
+            'from "pkg-a";\n'
+            'import * as Namespace from "pkg-b";\n'
+            'export { useMutation as mutation } from "pkg-c";\n'
+            'export * from "pkg-d";\n'
+            'import Equals = require("pkg-e");\n'
+            'const { useQuery: dynamicQuery, other = fallback, ...rest } = '
+            'await import("pkg-f");\n'
+            'const dynamicNamespace: Module = await import("pkg-g");\n'
+            'const client = (await import("pkg-h")).getAnyHarnessClient;\n'
+            'import("pkg-i").then(({ useInfiniteQuery: query }) => query());\n'
+        )
+
+        statements = {
+            statement.source: statement
+            for statement in collect_imports(Path("Sample.ts"), source)
+        }
+
+        self.assertEqual(
+            statements["pkg-a"].imported_names,
+            frozenset(
+                {
+                    "default",
+                    "useQuery",
+                    "Shape",
+                    "mutationOptions",
+                    "getAnyHarnessClient",
+                }
+            ),
+        )
+        self.assertEqual(
+            statements["pkg-a"].local_bindings,
+            frozenset({"defaultName", "query", "Shape", "useMutation", "make"}),
+        )
+        self.assertEqual(statements["pkg-b"].imported_names, frozenset({"*"}))
+        self.assertEqual(
+            statements["pkg-b"].namespace_bindings,
+            frozenset({"Namespace"}),
+        )
+        self.assertEqual(statements["pkg-c"].imported_names, frozenset({"useMutation"}))
+        self.assertFalse(statements["pkg-c"].local_bindings)
+        self.assertEqual(statements["pkg-d"].imported_names, frozenset({"*"}))
+        self.assertEqual(
+            statements["pkg-e"].namespace_bindings,
+            frozenset({"Equals"}),
+        )
+        self.assertEqual(
+            statements["pkg-f"].imported_names,
+            frozenset({"*", "useQuery", "other"}),
+        )
+        self.assertEqual(
+            statements["pkg-f"].local_bindings,
+            frozenset({"dynamicQuery", "other", "rest"}),
+        )
+        self.assertEqual(
+            statements["pkg-f"].namespace_bindings,
+            frozenset({"rest"}),
+        )
+        self.assertEqual(
+            statements["pkg-g"].namespace_bindings,
+            frozenset({"dynamicNamespace"}),
+        )
+        self.assertEqual(
+            statements["pkg-h"].imported_names,
+            frozenset({"getAnyHarnessClient"}),
+        )
+        self.assertEqual(
+            statements["pkg-h"].local_bindings,
+            frozenset({"client"}),
+        )
+        self.assertEqual(
+            statements["pkg-i"].imported_names,
+            frozenset({"useInfiniteQuery"}),
+        )
+
+    def test_shared_parser_skips_regex_after_declaration_and_catch_blocks(self) -> None:
+        source = (
+            "function read(): Result {}\n"
+            "/import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            "class Reader extends mixin(Base) {}\n"
+            "/import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            "try {} catch (error) {}\n"
+            "/import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            'const functionValue = function() {} / import("pkg-function");\n'
+            'const classValue = class {} / import("pkg-class");\n'
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            ["pkg-function", "pkg-class"],
+        )
+
+    def test_shared_parser_recurses_dynamic_options_and_requires_a_literal_argument(self) -> None:
+        source = (
+            'import("outer-a", import("inner-a"));\n'
+            'import("outer-b", { with: make(import("inner-b")) });\n'
+            'import((("grouped")));\n'
+            'import("prefix/" + name);\n'
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            ["outer-a", "inner-a", "outer-b", "inner-b", "grouped"],
+        )
 
     def test_every_forbidden_layer_pair_fails_for_alias_and_relative_imports(self) -> None:
         forbidden_pairs = sorted(check_module.PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES)
@@ -742,6 +871,51 @@ class ProductClientBoundaryTest(unittest.TestCase):
             [2, 3, 7, 11, 15],
         )
 
+    def test_store_set_state_tracks_assertions_brackets_commas_and_namespaces(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/direct.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "(useChatStore as StoreApi<State>).setState({ asserted: true });\n"
+                "(<StoreApi<State>>useChatStore).setState({ angled: true });\n"
+                "useChatStore['setState']({ bracketed: true });\n"
+                "(0, useChatStore).setState({ comma: true });\n"
+                "factory(useChatStore).setState({ callResult: true });\n"
+                "fixture.useChatStore.setState({ property: true });\n"
+                "function shadowed(useChatStore: Other) { useChatStore.setState({}); }\n"
+                "function defaultRead({ other = useChatStore }: Other) {\n"
+                "  useChatStore.setState({ imported: true });\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/static-namespace.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "Stores.useChatStore.setState({ staticNamespace: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/dynamic-namespace.ts": (
+                "const Stores = await import('#product/stores/chat/chat-store');\n"
+                "Stores['useChatStore'].setState({ dynamicNamespace: true });\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            (violation.path.name, violation.lineno)
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(
+            set_state,
+            [
+                ("direct.ts", 2),
+                ("direct.ts", 3),
+                ("direct.ts", 4),
+                ("direct.ts", 5),
+                ("direct.ts", 10),
+                ("static-namespace.ts", 2),
+                ("dynamic-namespace.ts", 2),
+            ],
+        )
+
     def test_query_hooks_pass_in_access_and_cache_but_fail_in_workflow_and_facade(self) -> None:
         files = {
             "apps/packages/product-client/src/hooks/access/cloud/query.ts": (
@@ -924,6 +1098,69 @@ class ProductClientBoundaryTest(unittest.TestCase):
         self.assertIn(
             "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER",
             dynamic_store_rules,
+        )
+
+    def test_identifier_sensitive_rules_preserve_export_identity_and_namespace_scope(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/alias-safe.ts": (
+                "import { mutationOptions as useMutation } "
+                "from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/alias-real.ts": (
+                "import { useMutation as mutate } from '@tanstack/react-query';\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/namespace-shadow.ts": (
+                "import * as Query from '@tanstack/react-query';\n"
+                "function local(Query: Other) { Query.useQuery(); }\n"
+                "fixture.Query.useMutation();\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/namespace-used.ts": (
+                "import * as Query from '@tanstack/react-query';\n"
+                "Query['useInfiniteQuery']();\n"
+                "const { useMutation: mutate } = Query;\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/dynamic-then.ts": (
+                "import('@tanstack/react-query').then("
+                "({ useQuery: query }) => query());\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/raw-alias-safe.ts": (
+                "import { createTranscriptState as getAnyHarnessClient } "
+                "from '@anyharness/sdk';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/raw-string-name.ts": (
+                "import { 'getAnyHarnessClient' as makeClient } "
+                "from '@anyharness/sdk';\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/raw-dynamic-member.ts": (
+                "const makeClient = (await import('@anyharness/sdk'))"
+                ".getAnyHarnessClient;\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        query_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
+        }
+        self.assertEqual(
+            query_paths,
+            {"alias-real.ts", "namespace-used.ts", "dynamic-then.ts"},
+        )
+        raw_rules = {
+            (violation.path.name, violation.rule_id)
+            for violation in violations
+            if violation.path.name.startswith("raw-")
+        }
+        self.assertEqual(
+            raw_rules,
+            {
+                ("raw-string-name.ts", "ANYHARNESS_CLIENT_OUTSIDE_ACCESS"),
+                ("raw-string-name.ts", "STORE_RUNTIME_ACCESS"),
+                ("raw-dynamic-member.ts", "ANYHARNESS_CLIENT_OUTSIDE_ACCESS"),
+                ("raw-dynamic-member.ts", "STORE_RUNTIME_ACCESS"),
+            },
         )
 
     def test_executable_template_and_jsx_code_is_checked_but_display_text_and_regex_pass(self) -> None:

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -328,14 +328,34 @@ class ProductClientBoundaryTest(unittest.TestCase):
             "while (ready) /import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
             "for (; ready;) /import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
             "do /import('apps\\/desktop\\/src\\/not-code')/.test(value); while (ready);\n"
+            "if (ready) {}\n"
+            "/import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
+            "const compared = value > /import('apps\\/desktop\\/src\\/not-code')/.test(value);\n"
             "const divided = total / import('#product/components/Divided').default;\n"
+            "const objectDivided = {} / import('#product/components/ObjectDivided').default;\n"
         )
 
         statements = collect_imports(Path("Sample.ts"), source)
 
         self.assertEqual(
             [(statement.source, statement.lineno) for statement in statements],
-            [("#product/components/Divided", 5)],
+            [
+                ("#product/components/Divided", 8),
+                ("#product/components/ObjectDivided", 9),
+            ],
+        )
+
+    def test_shared_parser_accepts_from_as_a_contextual_import_name(self) -> None:
+        source = (
+            "import { from } from '#product/components/Imported';\n"
+            "export { from } from '#product/components/Exported';\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.source for statement in statements],
+            ["#product/components/Imported", "#product/components/Exported"],
         )
 
     def test_shared_parser_keeps_ts_assertions_and_semicolonless_runtime_imports(self) -> None:
@@ -367,6 +387,7 @@ class ProductClientBoundaryTest(unittest.TestCase):
             "runtime = import('@proliferate/cloud-sdk-react')",
             "void [import('@proliferate/cloud-sdk-react')]",
             "ready ? import('@proliferate/cloud-sdk-react') : fallback",
+            "const choice = ready ? value : import('@proliferate/cloud-sdk-react')",
         ]
         for expression in runtime_expressions:
             with self.subTest(expression=expression):
@@ -376,6 +397,94 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 )
                 self.assertEqual(len(statements), 1)
                 self.assertFalse(statements[0].type_only)
+
+    def test_shared_parser_recognizes_import_types_in_standard_type_positions(self) -> None:
+        source = (
+            "type First = import('@proliferate/cloud-sdk-react').First\n"
+            "type Second = import('@proliferate/cloud-sdk-react').Second\n"
+            "function take(\n"
+            "  value: import('@proliferate/cloud-sdk-react').Thing,\n"
+            "): void {}\n"
+            "interface Shape {\n"
+            "  value: import('@proliferate/cloud-sdk-react').Thing;\n"
+            "}\n"
+            "const ref = useRef<import('@proliferate/cloud-sdk-react').Thing>();\n"
+            "const annotated: import('@proliferate/cloud-sdk-react').Thing = value;\n"
+            "const runtimeDefault = (\n"
+            "  value: unknown = import('@proliferate/cloud-sdk-react')\n"
+            ") => value;\n"
+            "const runtimeObject = {\n"
+            "  value: import('@proliferate/cloud-sdk-react'),\n"
+            "};\n"
+        )
+
+        statements = collect_imports(Path("Sample.ts"), source)
+
+        self.assertEqual(
+            [statement.lineno for statement in statements],
+            [1, 2, 4, 7, 9, 10, 12, 15],
+        )
+        self.assertEqual(
+            [statement.type_only for statement in statements],
+            [True, True, True, True, True, True, False, False],
+        )
+
+        additional_type_positions = [
+            "function read(): import('@proliferate/cloud-sdk-react').Thing {}",
+            "const read = (): import('@proliferate/cloud-sdk-react').Thing => value;",
+            (
+                "interface Reader { "
+                "read(value: import('@proliferate/cloud-sdk-react').Thing): "
+                "import('@proliferate/cloud-sdk-react').Thing }"
+            ),
+            "class Holder { value: import('@proliferate/cloud-sdk-react').Thing; }",
+            "const asserted = value as import('@proliferate/cloud-sdk-react').Thing;",
+            (
+                "interface Extended extends "
+                "Wrapper<import('@proliferate/cloud-sdk-react').Thing> {}"
+            ),
+        ]
+        for type_source in additional_type_positions:
+            with self.subTest(type_source=type_source):
+                statements = collect_imports(Path("Sample.ts"), type_source)
+                self.assertTrue(statements)
+                self.assertTrue(all(statement.type_only for statement in statements))
+
+    def test_shared_parser_distinguishes_advanced_type_positions_from_runtime(self) -> None:
+        runtime_expressions = [
+            'function f(value = { load: import("pkg") }) {}',
+            'function f(value = ready ? current : import("pkg")) {}',
+            'const x = ready ? current() : import("pkg")',
+            'class X { value = ready ? current : import("pkg") }',
+            'let value: string\nimport("pkg")',
+            'left < (await import("pkg")).default > (right)',
+            'function f(): Result { return import("pkg") }',
+            'const f = (): Result => import("pkg")',
+        ]
+        for runtime_source in runtime_expressions:
+            with self.subTest(runtime_source=runtime_source):
+                statements = collect_imports(Path("Sample.ts"), runtime_source)
+                self.assertEqual(len(statements), 1)
+                self.assertFalse(statements[0].type_only)
+
+        type_expressions = [
+            'type Box<T = import("pkg").Thing> = T',
+            'type Box<T extends import("pkg").Thing> = T',
+            'const fn = <T extends import("pkg").Thing>(x: T) => x',
+            'class Box<T extends import("pkg").Thing> {}',
+            'fn?.<import("pkg").Thing>()',
+            'const C = Factory<import("pkg").Thing>',
+            'const x = <import("pkg").Thing>value',
+            'const { x }: import("pkg").Thing = value',
+            'const a = 1, b: import("pkg").Thing = value',
+            'const value = source satisfies Readonly<import("pkg").Thing>',
+            'const value = source as { load: import("pkg").Thing }',
+        ]
+        for type_source in type_expressions:
+            with self.subTest(type_source=type_source):
+                statements = collect_imports(Path("Sample.ts"), type_source)
+                self.assertEqual(len(statements), 1)
+                self.assertTrue(statements[0].type_only)
 
     def test_every_forbidden_layer_pair_fails_for_alias_and_relative_imports(self) -> None:
         forbidden_pairs = sorted(check_module.PRODUCT_CLIENT_FORBIDDEN_LAYER_EDGES)
@@ -564,6 +673,75 @@ class ProductClientBoundaryTest(unittest.TestCase):
         ]
         self.assertEqual([violation.lineno for violation in set_state], [5, 11])
 
+    def test_store_set_state_handles_unary_loop_parenthesized_and_optional_contexts(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/contexts.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "void function useChatStore() {\n"
+                "  useChatStore.setState({ innerFunctionName: true });\n"
+                "}();\n"
+                "useChatStore.setState({ afterFunction: true });\n"
+                "void class useChatStore {\n"
+                "  static update() {\n"
+                "    useChatStore.setState({ innerClassName: true });\n"
+                "  }\n"
+                "};\n"
+                "useChatStore.setState({ afterClass: true });\n"
+                "for (const useChatStore of stores) {\n"
+                "  useChatStore.setState({ loopLocal: true });\n"
+                "}\n"
+                "useChatStore.setState({ afterLoop: true });\n"
+                "(useChatStore).setState({ parenthesized: true });\n"
+                "useChatStore?.setState({ optional: true });\n"
+                "factory(useChatStore).setState({ returnedObject: true });\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(
+            [violation.lineno for violation in set_state],
+            [5, 11, 15, 16, 17],
+        )
+
+    def test_store_set_state_handles_optional_calls_operators_and_later_loop_bindings(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/contexts.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "useChatStore.setState?.({ optionalCall: true });\n"
+                "useChatStore?.setState?.({ optionalReceiverAndCall: true });\n"
+                "const ClassExpression = ready && class useChatStore {\n"
+                "  static update() { useChatStore.setState({ innerClass: true }); }\n"
+                "};\n"
+                "useChatStore.setState({ afterClass: true });\n"
+                "const FunctionExpression = ready || function useChatStore() {\n"
+                "  useChatStore.setState({ innerFunction: true });\n"
+                "};\n"
+                "useChatStore.setState({ afterFunction: true });\n"
+                "for (let index = 0, useChatStore = stores[index]; index < 1; index++) {\n"
+                "  useChatStore.setState({ loopLocal: true });\n"
+                "}\n"
+                "useChatStore.setState({ afterLoop: true });\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        set_state = [
+            violation
+            for violation in violations
+            if violation.rule_id == "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER"
+        ]
+        self.assertEqual(
+            [violation.lineno for violation in set_state],
+            [2, 3, 7, 11, 15],
+        )
+
     def test_query_hooks_pass_in_access_and_cache_but_fail_in_workflow_and_facade(self) -> None:
         files = {
             "apps/packages/product-client/src/hooks/access/cloud/query.ts": (
@@ -689,6 +867,63 @@ class ProductClientBoundaryTest(unittest.TestCase):
         self.assertEqual(
             [violation.rule_id for violation in violations],
             ["STORE_FORBIDDEN_ACCESS"],
+        )
+
+    def test_dynamic_and_namespace_imports_preserve_identifier_sensitive_rules(self) -> None:
+        files = {
+            "apps/packages/product-client/src/hooks/chat/workflows/dynamic-query.ts": (
+                "export async function load() {\n"
+                "  const { useMutation } = await import('@tanstack/react-query');\n"
+                "  return useMutation;\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/namespace-query.ts": (
+                "import * as Query from '@tanstack/react-query';\n"
+                "export const mutation = Query.useMutation;\n"
+            ),
+            "apps/packages/product-client/src/stores/chat/dynamic-client.ts": (
+                "export async function load() {\n"
+                "  const { getAnyHarnessClient } = await import('@anyharness/sdk');\n"
+                "  return getAnyHarnessClient();\n"
+                "}\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/dynamic-store.ts": (
+                "export async function update() {\n"
+                "  const { useChatStore } = "
+                "await import('#product/stores/chat/chat-store');\n"
+                "  useChatStore.setState({ ready: true });\n"
+                "}\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            violations = self.run_product_rules(Path(directory).resolve(), files)
+
+        query_paths = {
+            violation.path.name
+            for violation in violations
+            if violation.rule_id == "QUERY_HOOK_OUTSIDE_ACCESS_OR_CACHE"
+        }
+        self.assertEqual(
+            query_paths,
+            {"dynamic-query.ts", "namespace-query.ts"},
+        )
+        dynamic_client_rules = {
+            violation.rule_id
+            for violation in violations
+            if violation.path.name == "dynamic-client.ts"
+        }
+        self.assertTrue(
+            {"ANYHARNESS_CLIENT_OUTSIDE_ACCESS", "STORE_RUNTIME_ACCESS"}
+            <= dynamic_client_rules
+        )
+        dynamic_store_rules = [
+            violation.rule_id
+            for violation in violations
+            if violation.path.name == "dynamic-store.ts"
+        ]
+        self.assertIn(
+            "PRODUCT_CLIENT_STORE_SET_STATE_OUTSIDE_OWNER",
+            dynamic_store_rules,
         )
 
     def test_executable_template_and_jsx_code_is_checked_but_display_text_and_regex_pass(self) -> None:

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -1375,6 +1375,16 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 "const chat = (Stores.useChatStore, fixture.store);\n"
                 "chat.setState({ unrelated: true });\n"
             ),
+            "apps/packages/product-client/src/hooks/chat/workflows/comma-last-alias.ts": (
+                "import { useChatStore } from '#product/stores/chat/chat-store';\n"
+                "const chat = (fixture.store, useChatStore);\n"
+                "chat.setState({ ready: true });\n"
+            ),
+            "apps/packages/product-client/src/hooks/chat/workflows/member-comma-last-alias.ts": (
+                "import * as Stores from '#product/stores/chat/chat-store';\n"
+                "const chat = (fixture.store, Stores.useChatStore);\n"
+                "chat.setState({ ready: true });\n"
+            ),
             "apps/packages/product-client/src/hooks/chat/workflows/member-target-safe.ts": (
                 "import * as Stores from '#product/stores/chat/chat-store';\n"
                 "({ useChatStore: target.store } = Stores);\n"
@@ -1412,6 +1422,8 @@ class ProductClientBoundaryTest(unittest.TestCase):
                 "direct-alias.ts",
                 "member-alias.ts",
                 "asserted-direct-alias.ts",
+                "comma-last-alias.ts",
+                "member-comma-last-alias.ts",
             },
         )
 


### PR DESCRIPTION
## Summary

- make ProductClient a first-class app-shaped root in the frontend boundary checker
- share import-aware TypeScript parsing across boundary and structure checks
- enforce exact layer, query/cache, raw-access, and external store-mutation debt ratchets without slack
- reject new ProductClient junk-drawer filenames while excluding comments, fixtures, display strings, and regex literals from import facts

This is Slice 1 of the stacked frontend package-consolidation program. It changes enforcement only; no product source or runtime behavior changes.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- `python3 -m unittest scripts/test_check_frontend_boundaries.py` (51 test methods)
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only` (2,261 files, 0 violations)
- `python3 scripts/check_docs.py` (227 Markdown files)
- `python3 -m py_compile scripts/frontend_imports.py scripts/check_frontend_boundaries.py scripts/report_frontend_structure.py scripts/test_check_frontend_boundaries.py`
- `git diff --check`
- two independent frozen-spec reviews accepted exact head `77c63a7c9eda26186f56dbba5c178ce2f3c7e501`
