### PR TITLE
refactor(server): move engagement sync into product ownership

### DIFF
--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -40,6 +40,19 @@ ALLOWED_WORKER_SERVICE_SQLALCHEMY_TYPE_IMPORTS = {
     "async_sessionmaker",
 }
 SERVICE_DB_METHODS = {"execute", "commit", "rollback", "add", "delete", "refresh"}
+WORKER_SERVICE_DB_METHODS = SERVICE_DB_METHODS | {
+    "add_all",
+    "connection",
+    "flush",
+    "get",
+    "get_one",
+    "merge",
+    "run_sync",
+    "scalar",
+    "scalars",
+    "stream",
+    "stream_scalars",
+}
 SERVICE_DB_SESSION_OPS_METHODS = {
     "open_async_session",
     "open_async_transaction",
@@ -165,6 +178,15 @@ def _starts_with(parts: tuple[str, ...], prefix: tuple[str, ...]) -> bool:
     return parts[: len(prefix)] == prefix
 
 
+def is_canonical_worker_service_path(path: Path) -> bool:
+    parts = logical_parts(path)
+    return (
+        len(parts) == 6
+        and _starts_with(parts, ("server", "proliferate", "server"))
+        and parts[4:] == ("worker", "service.py")
+    )
+
+
 def classify_path(path: Path) -> SourceKind:
     parts = logical_parts(path)
     is_product = _starts_with(parts, ("server", "proliferate", "server"))
@@ -182,7 +204,7 @@ def classify_path(path: Path) -> SourceKind:
         and path.suffix == ".py"
         and name not in AGENT_AUTH_SERVICE_CONCERN_EXCLUDED_FILES
     )
-    is_worker_service = is_product and name == "service.py" and path.parent.name == "worker"
+    is_worker_service = is_canonical_worker_service_path(path)
 
     return SourceKind(
         is_api=is_product and name == "api.py",
@@ -275,12 +297,10 @@ def is_allowed_single_file_worker_folder(
     source_files: list[Path],
     child_folders: list[Path],
 ) -> bool:
-    parts = logical_parts(folder)
     return (
-        _starts_with(parts, ("server", "proliferate", "server"))
-        and folder.name == "worker"
-        and len(source_files) == 1
+        len(source_files) == 1
         and source_files[0].name == "service.py"
+        and is_canonical_worker_service_path(source_files[0])
         and not child_folders
     )
 
@@ -557,9 +577,12 @@ class BoundaryChecker(ast.NodeVisitor):
                     "API_DB_METHOD_CALL",
                     f"api.py must not call session method .{func.attr}()",
                 )
+            service_db_methods = (
+                WORKER_SERVICE_DB_METHODS if self.kind.is_worker_service else SERVICE_DB_METHODS
+            )
             if (
                 (self.kind.is_service or self.kind.is_service_boundary_debt)
-                and func.attr in SERVICE_DB_METHODS
+                and func.attr in service_db_methods
                 and looks_like_db_handle(func.value)
             ):
                 self.add(

--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import ast
-from collections import Counter, defaultdict
-from dataclasses import dataclass
 import os
-from pathlib import Path
 import shutil
 import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ALLOWLIST_PATH = REPO_ROOT / "scripts" / "server_boundaries_allowlist.txt"
@@ -35,6 +35,10 @@ BANNED_JUNK_DRAWER_SUFFIXES = ("_helper.py", "_helpers.py", "_utils.py")
 ALLOWED_API_ORM_IMPORT = ("proliferate.db.models.auth", "User")
 ALLOWED_API_ENGINE_IMPORTS = {"get_async_session"}
 ALLOWED_SQLALCHEMY_TYPE_IMPORT = ("sqlalchemy.ext.asyncio", "AsyncSession")
+ALLOWED_WORKER_SERVICE_SQLALCHEMY_TYPE_IMPORTS = {
+    "AsyncSession",
+    "async_sessionmaker",
+}
 SERVICE_DB_METHODS = {"execute", "commit", "rollback", "add", "delete", "refresh"}
 SERVICE_DB_SESSION_OPS_METHODS = {
     "open_async_session",
@@ -99,6 +103,7 @@ class AllowlistEntry:
 class SourceKind:
     is_api: bool = False
     is_service: bool = False
+    is_worker_service: bool = False
     is_service_boundary_debt: bool = False
     is_domain: bool = False
     is_product_models: bool = False
@@ -177,6 +182,7 @@ def classify_path(path: Path) -> SourceKind:
         and path.suffix == ".py"
         and name not in AGENT_AUTH_SERVICE_CONCERN_EXCLUDED_FILES
     )
+    is_worker_service = is_product and name == "service.py" and path.parent.name == "worker"
 
     return SourceKind(
         is_api=is_product and name == "api.py",
@@ -188,6 +194,7 @@ def classify_path(path: Path) -> SourceKind:
                 or is_agent_auth_service_concern
             )
         ),
+        is_worker_service=is_worker_service,
         is_service_boundary_debt=relative in SERVICE_BOUNDARY_DEBT_MODULES,
         is_domain=is_product and "domain" in path.parts,
         is_product_models=is_product and name == "models.py",
@@ -227,11 +234,7 @@ def is_dunder_module(path: Path) -> bool:
 
 
 def has_single_underscore_prefix(path: Path) -> bool:
-    return (
-        path.suffix == ".py"
-        and path.name.startswith("_")
-        and not path.name.startswith("__")
-    )
+    return path.suffix == ".py" and path.name.startswith("_") and not path.name.startswith("__")
 
 
 def is_banned_junk_drawer_module(path: Path) -> bool:
@@ -264,6 +267,21 @@ def is_allowed_single_file_domain_folder(
         and len(source_files) == 1
         and not child_folders
         and is_meaningful_domain_module(source_files[0])
+    )
+
+
+def is_allowed_single_file_worker_folder(
+    folder: Path,
+    source_files: list[Path],
+    child_folders: list[Path],
+) -> bool:
+    parts = logical_parts(folder)
+    return (
+        _starts_with(parts, ("server", "proliferate", "server"))
+        and folder.name == "worker"
+        and len(source_files) == 1
+        and source_files[0].name == "service.py"
+        and not child_folders
     )
 
 
@@ -356,9 +374,12 @@ class BoundaryChecker(ast.NodeVisitor):
 
     def _check_service_import(self, node: ast.AST, module: str, names: set[str]) -> None:
         if is_module(module, "sqlalchemy"):
-            allowed = module == ALLOWED_SQLALCHEMY_TYPE_IMPORT[0] and names <= {
-                ALLOWED_SQLALCHEMY_TYPE_IMPORT[1]
-            }
+            allowed_names = (
+                ALLOWED_WORKER_SERVICE_SQLALCHEMY_TYPE_IMPORTS
+                if self.kind.is_worker_service
+                else {ALLOWED_SQLALCHEMY_TYPE_IMPORT[1]}
+            )
+            allowed = module == ALLOWED_SQLALCHEMY_TYPE_IMPORT[0] and names <= allowed_names
             if not allowed:
                 self.add(
                     node,
@@ -593,13 +614,16 @@ class BoundaryChecker(ast.NodeVisitor):
                             "Pydantic response models must not map ORM objects "
                             "with from_attributes",
                         )
-        if isinstance(func, ast.Name) and func.id == "HTTPException":
-            if self.kind.is_domain or self.kind.is_store or self.kind.is_integration:
-                self.add(
-                    node,
-                    "HTTP_EXCEPTION_FORBIDDEN",
-                    "HTTPException is banned outside HTTP boundary code",
-                )
+        if (
+            isinstance(func, ast.Name)
+            and func.id == "HTTPException"
+            and (self.kind.is_domain or self.kind.is_store or self.kind.is_integration)
+        ):
+            self.add(
+                node,
+                "HTTP_EXCEPTION_FORBIDDEN",
+                "HTTPException is banned outside HTTP boundary code",
+            )
 
 
 def parse_source(path: Path) -> ast.Module:
@@ -665,6 +689,8 @@ def check_structure(repo_root: Path = REPO_ROOT) -> list[Violation]:
             if path.is_dir() and not should_skip(path) and path.name != "__pycache__"
         ]
         if is_allowed_single_file_domain_folder(folder, source_files, child_folders):
+            continue
+        if is_allowed_single_file_worker_folder(folder, source_files, child_folders):
             continue
         if is_background_tasks_folder(folder):
             continue
@@ -758,9 +784,7 @@ def print_summary(
     violations: list[Violation],
     allowlist: dict[tuple[str, str], AllowlistEntry],
 ) -> None:
-    observed = Counter(
-        (violation.rule_id, violation.relative_path()) for violation in violations
-    )
+    observed = Counter((violation.rule_id, violation.relative_path()) for violation in violations)
     if not observed:
         return
     print("Observed server boundary debt:")
@@ -772,7 +796,7 @@ def print_summary(
 
 
 def reexec_with_python_312() -> None:
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 12):  # noqa: UP036 - bootstrap may start under older Python
         return
     python_312 = shutil.which("python3.12")
     if python_312 is None:
@@ -784,7 +808,7 @@ def reexec_with_python_312() -> None:
 
 def main() -> int:
     reexec_with_python_312()
-    if sys.version_info < (3, 12):
+    if sys.version_info < (3, 12):  # noqa: UP036 - emit a useful bootstrap failure
         print("Server boundary check requires Python 3.12+ to parse server source.")
         return 2
 

--- a/server/proliferate/background/tasks/customerio_sync.py
+++ b/server/proliferate/background/tasks/customerio_sync.py
@@ -3,126 +3,28 @@
 from __future__ import annotations
 
 import asyncio
-import logging
-from datetime import datetime
-from typing import Any
-from uuid import UUID
 
-from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from proliferate.background.celery_app import celery_app
 from proliferate.background.config import CUSTOMERIO_ENGAGEMENT_SYNC_TASK
-from proliferate.db.engine import async_session_factory
-from proliferate.db.models.analytics import ClientDailyActivity
-from proliferate.db.models.auth import AuthIdentity, User
-from proliferate.db.models.cloud.workspaces import CloudWorkspace
-from proliferate.integrations.customerio import derive_email_type, push_user_attributes
-
-logger = logging.getLogger(__name__)
-
-PAGE_SIZE = 500
-
-
-async def _sync_page(
-    db: AsyncSession,
-    user_rows: list[tuple[UUID, str | None]],
-) -> int:
-    """Sync one page of users. Returns number of successful pushes."""
-    if not user_rows:
-        return 0
-
-    user_ids = [uid for uid, _ in user_rows]
-
-    # Workspace count per user (active, non-archived)
-    workspace_counts_result = await db.execute(
-        select(
-            CloudWorkspace.owner_user_id,
-            func.count(CloudWorkspace.id),
-        )
-        .where(
-            CloudWorkspace.owner_user_id.in_(user_ids),
-            CloudWorkspace.archived_at.is_(None),
-        )
-        .group_by(CloudWorkspace.owner_user_id)
-    )
-    workspace_counts: dict[UUID, int] = dict(workspace_counts_result.all())  # type: ignore[arg-type]
-
-    # last_active_at = GREATEST of MAX(client_daily_activity.last_seen_at)
-    # and MAX(auth_identity.last_login_at)
-    activity_result = await db.execute(
-        select(
-            ClientDailyActivity.actor_user_id,
-            func.max(ClientDailyActivity.last_seen_at),
-        )
-        .where(ClientDailyActivity.actor_user_id.in_(user_ids))
-        .group_by(ClientDailyActivity.actor_user_id)
-    )
-    activity_map: dict[UUID, datetime] = {
-        uid: last_seen for uid, last_seen in activity_result.all() if last_seen is not None
-    }
-
-    login_result = await db.execute(
-        select(
-            AuthIdentity.user_id,
-            func.max(AuthIdentity.last_login_at),
-        )
-        .where(AuthIdentity.user_id.in_(user_ids))
-        .group_by(AuthIdentity.user_id)
-    )
-    login_map: dict[UUID, datetime] = {
-        uid: last_login for uid, last_login in login_result.all() if last_login is not None
-    }
-
-    pushed = 0
-    for user_id, email in user_rows:
-        # Derive last_active_at as GREATEST of activity and login
-        candidates = [v for v in (activity_map.get(user_id), login_map.get(user_id)) if v]
-        last_active_at = max(candidates) if candidates else None
-
-        attributes: dict[str, Any] = {
-            "workspace_count": workspace_counts.get(user_id, 0),
-            "email_type": derive_email_type(email),
-        }
-        if last_active_at is not None:
-            attributes["last_active_at"] = int(last_active_at.timestamp())
-
-        ok = await push_user_attributes(user_id=str(user_id), attributes=attributes)
-        if ok:
-            pushed += 1
-
-    return pushed
+from proliferate.config import settings
+from proliferate.server.product_engagement.worker.service import (
+    run_customerio_engagement_sync,
+)
 
 
 async def _run_engagement_sync() -> None:
-    """Keyset-paginate all users and push engagement attributes to Customer.io."""
-    total_users = 0
-    total_pushed = 0
-    last_id: UUID | None = None
-
-    while True:
-        async with async_session_factory() as db:
-            query = select(User.id, User.email).order_by(User.id).limit(PAGE_SIZE)
-            if last_id is not None:
-                query = query.where(User.id > last_id)
-
-            result = await db.execute(query)
-            rows = result.all()
-
-            if not rows:
-                break
-
-            total_users += len(rows)
-            user_rows = [(row[0], row[1]) for row in rows]
-            pushed = await _sync_page(db, user_rows)
-            total_pushed += pushed
-            last_id = user_rows[-1][0]
-
-    logger.info(
-        "Customer.io engagement sync complete: %d users processed, %d pushed successfully",
-        total_users,
-        total_pushed,
+    engine = create_async_engine(
+        settings.database_url,
+        pool_pre_ping=True,
+        connect_args={"statement_cache_size": 0},
     )
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        await run_customerio_engagement_sync(session_factory)
+    finally:
+        await engine.dispose()
 
 
 @celery_app.task(name=CUSTOMERIO_ENGAGEMENT_SYNC_TASK)

--- a/server/proliferate/constants/product_engagement.py
+++ b/server/proliferate/constants/product_engagement.py
@@ -1,0 +1,5 @@
+"""Product Engagement policy constants."""
+
+from typing import Final
+
+CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE: Final = 500

--- a/server/proliferate/db/store/analytics.py
+++ b/server/proliferate/db/store/analytics.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from uuid import UUID, uuid4
 
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,6 +22,39 @@ class ClientDailyActivityUpsert:
     platform: str | None
     route_or_screen: str | None
     received_at: datetime
+
+
+@dataclass(frozen=True)
+class LatestClientActivityValue:
+    actor_user_id: UUID
+    last_seen_at: datetime
+
+
+async def list_latest_client_activity(
+    db: AsyncSession,
+    *,
+    actor_user_ids: tuple[UUID, ...],
+) -> tuple[LatestClientActivityValue, ...]:
+    if not actor_user_ids:
+        return ()
+    rows = (
+        await db.execute(
+            select(
+                ClientDailyActivity.actor_user_id,
+                func.max(ClientDailyActivity.last_seen_at).label("last_seen_at"),
+            )
+            .where(ClientDailyActivity.actor_user_id.in_(actor_user_ids))
+            .group_by(ClientDailyActivity.actor_user_id)
+        )
+    ).all()
+    return tuple(
+        LatestClientActivityValue(
+            actor_user_id=row.actor_user_id,
+            last_seen_at=row.last_seen_at,
+        )
+        for row in rows
+        if row.actor_user_id is not None and row.last_seen_at is not None
+    )
 
 
 async def upsert_client_daily_activity(

--- a/server/proliferate/db/store/auth_identities.py
+++ b/server/proliferate/db/store/auth_identities.py
@@ -1,0 +1,44 @@
+"""Persistence reads for canonical external authentication identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.auth import AuthIdentity
+
+
+@dataclass(frozen=True)
+class LatestAuthLoginValue:
+    user_id: UUID
+    last_login_at: datetime | None
+
+
+async def list_latest_auth_logins(
+    db: AsyncSession,
+    *,
+    user_ids: tuple[UUID, ...],
+) -> tuple[LatestAuthLoginValue, ...]:
+    if not user_ids:
+        return ()
+    rows = (
+        await db.execute(
+            select(
+                AuthIdentity.user_id,
+                func.max(AuthIdentity.last_login_at).label("last_login_at"),
+            )
+            .where(AuthIdentity.user_id.in_(user_ids))
+            .group_by(AuthIdentity.user_id)
+        )
+    ).all()
+    return tuple(
+        LatestAuthLoginValue(
+            user_id=row.user_id,
+            last_login_at=row.last_login_at,
+        )
+        for row in rows
+    )

--- a/server/proliferate/db/store/cloud_workspaces.py
+++ b/server/proliferate/db/store/cloud_workspaces.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Literal, Protocol
 from uuid import UUID
 
-from sqlalchemy import Select, exists, or_, select, update
+from sqlalchemy import Select, exists, func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -45,6 +45,12 @@ class CloudWorkspaceValue:
     updated_at: datetime
     archived_at: datetime | None
     lost_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class ActiveWorkspaceCountValue:
+    owner_user_id: UUID
+    workspace_count: int
 
 
 class CloudWorkspaceSandboxIdentity(Protocol):
@@ -86,6 +92,35 @@ def _apply_lifecycle_filter(
     if lifecycle == "archived":
         return statement.where(CloudWorkspace.archived_at.is_not(None))
     return statement
+
+
+async def list_active_workspace_counts(
+    db: AsyncSession,
+    *,
+    owner_user_ids: tuple[UUID, ...],
+) -> tuple[ActiveWorkspaceCountValue, ...]:
+    if not owner_user_ids:
+        return ()
+    rows = (
+        await db.execute(
+            select(
+                CloudWorkspace.owner_user_id,
+                func.count(CloudWorkspace.id).label("workspace_count"),
+            )
+            .where(
+                CloudWorkspace.owner_user_id.in_(owner_user_ids),
+                CloudWorkspace.archived_at.is_(None),
+            )
+            .group_by(CloudWorkspace.owner_user_id)
+        )
+    ).all()
+    return tuple(
+        ActiveWorkspaceCountValue(
+            owner_user_id=row.owner_user_id,
+            workspace_count=int(row.workspace_count),
+        )
+        for row in rows
+    )
 
 
 async def list_cloud_workspaces(

--- a/server/proliferate/db/store/users.py
+++ b/server/proliferate/db/store/users.py
@@ -1,5 +1,6 @@
 """DB adapter for fastapi-users and user lookup store helpers."""
 
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy import func, select, update
@@ -7,6 +8,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from proliferate.db.models.auth import OAuthAccount, User
+
+
+@dataclass(frozen=True)
+class EngagementSyncUserValue:
+    id: UUID
+    email: str | None
+
+
+async def list_engagement_sync_users_page(
+    db: AsyncSession,
+    *,
+    after_id: UUID | None,
+    limit: int,
+) -> tuple[EngagementSyncUserValue, ...]:
+    statement = select(User.id, User.email).order_by(User.id).limit(limit)
+    if after_id is not None:
+        statement = statement.where(User.id > after_id)
+    rows = (await db.execute(statement)).all()
+    return tuple(EngagementSyncUserValue(id=row.id, email=row.email) for row in rows)
 
 
 async def get_user_by_id(

--- a/server/proliferate/server/product_engagement/worker/service.py
+++ b/server/proliferate/server/product_engagement/worker/service.py
@@ -1,0 +1,90 @@
+"""Worker-facing Product Engagement orchestration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from proliferate.constants.product_engagement import (
+    CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE,
+)
+from proliferate.db.store.analytics import list_latest_client_activity
+from proliferate.db.store.auth_identities import list_latest_auth_logins
+from proliferate.db.store.cloud_workspaces import list_active_workspace_counts
+from proliferate.db.store.users import list_engagement_sync_users_page
+from proliferate.integrations.customerio import derive_email_type, push_user_attributes
+
+logger = logging.getLogger(__name__)
+
+
+async def run_customerio_engagement_sync(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Keyset-paginate users and push their engagement profile attributes."""
+
+    total_users = 0
+    total_pushed = 0
+    last_id: UUID | None = None
+
+    while True:
+        async with session_factory() as db:
+            users = await list_engagement_sync_users_page(
+                db,
+                after_id=last_id,
+                limit=CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE,
+            )
+            if not users:
+                break
+
+            user_ids = tuple(user.id for user in users)
+            workspace_counts = await list_active_workspace_counts(
+                db,
+                owner_user_ids=user_ids,
+            )
+            activities = await list_latest_client_activity(
+                db,
+                actor_user_ids=user_ids,
+            )
+            logins = await list_latest_auth_logins(db, user_ids=user_ids)
+
+        workspace_count_by_user = {
+            value.owner_user_id: value.workspace_count for value in workspace_counts
+        }
+        activity_by_user = {value.actor_user_id: value.last_seen_at for value in activities}
+        login_by_user = {
+            value.user_id: value.last_login_at
+            for value in logins
+            if value.last_login_at is not None
+        }
+
+        total_users += len(users)
+        for user in users:
+            candidates = [
+                value
+                for value in (
+                    activity_by_user.get(user.id),
+                    login_by_user.get(user.id),
+                )
+                if value is not None
+            ]
+            last_active_at = max(candidates) if candidates else None
+            attributes: dict[str, Any] = {
+                "workspace_count": workspace_count_by_user.get(user.id, 0),
+                "email_type": derive_email_type(user.email),
+            }
+            if last_active_at is not None:
+                attributes["last_active_at"] = int(last_active_at.timestamp())
+
+            if await push_user_attributes(user_id=str(user.id), attributes=attributes):
+                total_pushed += 1
+
+        last_id = users[-1].id
+
+    logger.info(
+        "Customer.io engagement sync complete: %d users processed, %d pushed successfully",
+        total_users,
+        total_pushed,
+    )

--- a/server/tests/integration/test_product_engagement_store.py
+++ b/server/tests/integration/test_product_engagement_store.py
@@ -1,0 +1,220 @@
+"""Real-Postgres proof for Product Engagement resource-store reads."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import proliferate.integrations.customerio as customerio_integration
+from proliferate.db.models.analytics import ClientDailyActivity
+from proliferate.db.models.auth import AuthIdentity, User
+from proliferate.db.models.cloud.workspaces import (
+    CLOUD_WORKSPACE_SCRATCH,
+    CloudWorkspace,
+)
+from proliferate.db.store.analytics import list_latest_client_activity
+from proliferate.db.store.auth_identities import list_latest_auth_logins
+from proliferate.db.store.cloud_workspaces import list_active_workspace_counts
+from proliferate.db.store.users import list_engagement_sync_users_page
+
+
+def _user(user_id: UUID, email: str, *, is_active: bool = True) -> User:
+    return User(
+        id=user_id,
+        email=email,
+        hashed_password="unused",
+        is_active=is_active,
+        is_superuser=False,
+        is_verified=True,
+    )
+
+
+def _workspace(
+    *,
+    owner_user_id: UUID,
+    name: str,
+    archived_at: datetime | None = None,
+) -> CloudWorkspace:
+    return CloudWorkspace(
+        id=uuid4(),
+        owner_user_id=owner_user_id,
+        workspace_kind=CLOUD_WORKSPACE_SCRATCH,
+        repo_environment_id=None,
+        display_name=name,
+        git_branch="main",
+        git_base_branch=None,
+        archived_at=archived_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_engagement_stores_preserve_page_counts_maxima_and_frozen_values(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_ids = tuple(UUID(int=value) for value in range(1, 5))
+    users = tuple(
+        _user(
+            user_id,
+            f"user-{index}@example.com",
+            is_active=index != 2,
+        )
+        for index, user_id in enumerate(user_ids, start=1)
+    )
+    db_session.add_all(users)
+    await db_session.flush()
+
+    archived_at = datetime(2026, 7, 1, tzinfo=UTC)
+    db_session.add_all(
+        [
+            _workspace(owner_user_id=user_ids[0], name="active-one"),
+            _workspace(owner_user_id=user_ids[0], name="active-two"),
+            _workspace(
+                owner_user_id=user_ids[0],
+                name="archived",
+                archived_at=archived_at,
+            ),
+            _workspace(
+                owner_user_id=user_ids[1],
+                name="archived-only",
+                archived_at=archived_at,
+            ),
+            _workspace(owner_user_id=user_ids[2], name="active-three"),
+        ]
+    )
+
+    early_activity = datetime(2026, 7, 2, 8, tzinfo=UTC)
+    late_activity = datetime(2026, 7, 3, 9, tzinfo=UTC)
+    db_session.add_all(
+        [
+            ClientDailyActivity(
+                id=uuid4(),
+                activity_date=date(2026, 7, 2),
+                surface="desktop",
+                actor_user_id=user_ids[0],
+                anonymous_install_uuid=None,
+                last_seen_at=early_activity,
+            ),
+            ClientDailyActivity(
+                id=uuid4(),
+                activity_date=date(2026, 7, 3),
+                surface="web",
+                actor_user_id=user_ids[0],
+                anonymous_install_uuid=None,
+                last_seen_at=late_activity,
+            ),
+            ClientDailyActivity(
+                id=uuid4(),
+                activity_date=date(2026, 7, 4),
+                surface="mobile",
+                actor_user_id=user_ids[2],
+                anonymous_install_uuid=None,
+                last_seen_at=early_activity,
+            ),
+        ]
+    )
+
+    early_login = datetime(2026, 7, 4, 10, tzinfo=UTC)
+    late_login = datetime(2026, 7, 5, 11, tzinfo=UTC)
+    db_session.add_all(
+        [
+            AuthIdentity(
+                id=uuid4(),
+                user_id=user_ids[0],
+                provider="github",
+                provider_subject="engagement-github-user-1",
+                last_login_at=early_login,
+            ),
+            AuthIdentity(
+                id=uuid4(),
+                user_id=user_ids[0],
+                provider="google",
+                provider_subject="engagement-google-user-1",
+                last_login_at=late_login,
+            ),
+            AuthIdentity(
+                id=uuid4(),
+                user_id=user_ids[1],
+                provider="github",
+                provider_subject="engagement-github-user-2",
+                last_login_at=None,
+            ),
+            AuthIdentity(
+                id=uuid4(),
+                user_id=user_ids[2],
+                provider="github",
+                provider_subject="engagement-github-user-3",
+                last_login_at=early_login,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    provider_call = AsyncMock(side_effect=AssertionError("stores must not call provider"))
+    monkeypatch.setattr(customerio_integration, "push_user_attributes", provider_call)
+
+    first_page = await list_engagement_sync_users_page(
+        db_session,
+        after_id=None,
+        limit=2,
+    )
+    second_page = await list_engagement_sync_users_page(
+        db_session,
+        after_id=user_ids[1],
+        limit=2,
+    )
+    terminal_page = await list_engagement_sync_users_page(
+        db_session,
+        after_id=user_ids[3],
+        limit=2,
+    )
+    assert tuple(value.id for value in first_page) == user_ids[:2]
+    assert first_page[1].id == user_ids[1]  # inactive users remain in the all-user scan
+    assert tuple(value.id for value in second_page) == user_ids[2:]
+    assert terminal_page == ()
+    assert all(value.id > user_ids[1] for value in second_page)
+
+    workspace_counts = await list_active_workspace_counts(
+        db_session,
+        owner_user_ids=user_ids,
+    )
+    assert {value.owner_user_id: value.workspace_count for value in workspace_counts} == {
+        user_ids[0]: 2,
+        user_ids[2]: 1,
+    }
+
+    activities = await list_latest_client_activity(
+        db_session,
+        actor_user_ids=user_ids,
+    )
+    assert {value.actor_user_id: value.last_seen_at for value in activities} == {
+        user_ids[0]: late_activity,
+        user_ids[2]: early_activity,
+    }
+
+    logins = await list_latest_auth_logins(
+        db_session,
+        user_ids=user_ids,
+    )
+    assert {value.user_id: value.last_login_at for value in logins} == {
+        user_ids[0]: late_login,
+        user_ids[1]: None,
+        user_ids[2]: early_login,
+    }
+
+    frozen_values = (
+        (first_page[0], "email"),
+        (workspace_counts[0], "workspace_count"),
+        (activities[0], "last_seen_at"),
+        (logins[0], "last_login_at"),
+    )
+    for value, field_name in frozen_values:
+        with pytest.raises(FrozenInstanceError):
+            setattr(value, field_name, getattr(value, field_name))
+
+    provider_call.assert_not_awaited()

--- a/server/tests/unit/test_background_celery.py
+++ b/server/tests/unit/test_background_celery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from celery import Celery
+from celery.schedules import crontab
 from kombu import Queue
 
 from proliferate.background.config import (
@@ -42,6 +43,7 @@ def test_celery_app_import_registers_noop_task_without_broker_connection() -> No
     assert HEALTH_NOOP_TASK in celery_app.tasks
     assert BACKGROUND_RELAY_TASK in celery_app.tasks
     assert CLOUD_SANDBOX_ORPHAN_REAP_TASK in celery_app.tasks
+    assert CUSTOMERIO_ENGAGEMENT_SYNC_TASK in celery_app.tasks
     assert NOTIFICATIONS_SEND_SLACK_TASK in celery_app.tasks
     assert WORKFLOW_DELIVER_TASK in celery_app.tasks
     assert WORKFLOW_OBSERVE_TASK in celery_app.tasks
@@ -96,7 +98,26 @@ def test_beat_schedule_keeps_single_relay_entry_with_customerio_enabled() -> Non
         name for name, entry in schedule.items() if entry["task"] == BACKGROUND_RELAY_TASK
     ]
     assert relay_entries == [RELAY_SCHEDULE_ENTRY]
-    assert "customerio-engagement-sync" in schedule
+    entry = schedule["customerio-engagement-sync"]
+    assert entry["task"] == CUSTOMERIO_ENGAGEMENT_SYNC_TASK
+    customerio_schedule = entry["schedule"]
+    assert isinstance(customerio_schedule, crontab)
+    assert customerio_schedule.minute == {0}
+    assert customerio_schedule.hour == {9}
+    assert customerio_schedule.day_of_week == set(range(7))
+    assert customerio_schedule.day_of_month == set(range(1, 32))
+    assert customerio_schedule.month_of_year == set(range(1, 13))
+
+
+def test_beat_schedule_requires_both_customerio_credentials() -> None:
+    incomplete_settings = (
+        _test_settings(customerio_site_id="site", customerio_api_key=""),
+        _test_settings(customerio_site_id="", customerio_api_key="key"),
+        _test_settings(customerio_site_id="", customerio_api_key=""),
+    )
+
+    for config in incomplete_settings:
+        assert "customerio-engagement-sync" not in build_beat_schedule(config)
 
 
 def test_celery_config_reads_settings_without_result_backend() -> None:

--- a/server/tests/unit/test_customerio_sync.py
+++ b/server/tests/unit/test_customerio_sync.py
@@ -1,130 +1,393 @@
-"""Unit tests for the nightly Customer.io engagement sync task."""
+"""Characterization tests for the nightly Customer.io engagement sync."""
 
 from __future__ import annotations
 
-import uuid
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from uuid import UUID
 
 import pytest
 
-from proliferate.background.tasks import customerio_sync
+from proliferate.background.tasks import customerio_sync as customerio_task
+from proliferate.constants.product_engagement import (
+    CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE,
+)
+from proliferate.db.store.analytics import LatestClientActivityValue
+from proliferate.db.store.auth_identities import LatestAuthLoginValue
+from proliferate.db.store.cloud_workspaces import ActiveWorkspaceCountValue
+from proliferate.db.store.users import EngagementSyncUserValue
+from proliferate.server.product_engagement.worker import service as engagement_service
 
 
-def _uid() -> uuid.UUID:
-    return uuid.uuid4()
+def _user_id(value: int) -> UUID:
+    return UUID(int=value)
+
+
+class _SessionContext:
+    def __init__(self, factory: _SessionFactory, number: int) -> None:
+        self.factory = factory
+        self.number = number
+
+    async def __aenter__(self) -> int:
+        self.factory.open_sessions += 1
+        self.factory.events.append(("session_enter", self.number))
+        return self.number
+
+    async def __aexit__(self, *_args: Any) -> None:
+        self.factory.events.append(("session_exit", self.number))
+        self.factory.open_sessions -= 1
+
+
+class _SessionFactory:
+    def __init__(self, events: list[tuple[object, ...]]) -> None:
+        self.events = events
+        self.open_sessions = 0
+        self.created = 0
+
+    def __call__(self) -> _SessionContext:
+        self.created += 1
+        return _SessionContext(self, self.created)
 
 
 @pytest.mark.asyncio
-async def test_sync_page_pushes_attributes_for_users() -> None:
-    """Verify _sync_page computes workspace_count, last_active_at, email_type
-    and pushes them via push_user_attributes."""
-    user1_id = _uid()
-    user2_id = _uid()
-    user_rows = [
-        (user1_id, "alice@acme.com"),
-        (user2_id, "bob@gmail.com"),
+async def test_worker_preserves_pagination_query_order_profiles_and_partial_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user1 = EngagementSyncUserValue(_user_id(1), "alice@acme.com")
+    user2 = EngagementSyncUserValue(_user_id(2), "bob@gmail.com")
+    user3 = EngagementSyncUserValue(_user_id(3), None)
+    first_activity = datetime(2026, 7, 1, 12, tzinfo=UTC)
+    later_login = datetime(2026, 7, 2, 8, tzinfo=UTC)
+    second_activity = datetime(2026, 7, 3, 9, tzinfo=UTC)
+    events: list[tuple[object, ...]] = []
+    factory = _SessionFactory(events)
+
+    async def list_users(
+        db: object,
+        *,
+        after_id: UUID | None,
+        limit: int,
+    ) -> tuple[EngagementSyncUserValue, ...]:
+        events.append(("users", db, after_id, limit))
+        return {
+            None: (user1, user2),
+            user2.id: (user3,),
+            user3.id: (),
+        }[after_id]
+
+    async def workspace_counts(
+        db: object,
+        *,
+        owner_user_ids: tuple[UUID, ...],
+    ) -> tuple[ActiveWorkspaceCountValue, ...]:
+        events.append(("workspaces", db, owner_user_ids))
+        if owner_user_ids == (user1.id, user2.id):
+            return (ActiveWorkspaceCountValue(user1.id, 3),)
+        return ()
+
+    async def client_activity(
+        db: object,
+        *,
+        actor_user_ids: tuple[UUID, ...],
+    ) -> tuple[LatestClientActivityValue, ...]:
+        events.append(("activity", db, actor_user_ids))
+        if actor_user_ids == (user1.id, user2.id):
+            return (
+                LatestClientActivityValue(user1.id, first_activity),
+                LatestClientActivityValue(user2.id, second_activity),
+            )
+        return ()
+
+    async def auth_logins(
+        db: object,
+        *,
+        user_ids: tuple[UUID, ...],
+    ) -> tuple[LatestAuthLoginValue, ...]:
+        events.append(("logins", db, user_ids))
+        if user_ids == (user1.id, user2.id):
+            return (
+                LatestAuthLoginValue(user1.id, later_login),
+                LatestAuthLoginValue(user2.id, None),
+            )
+        return ()
+
+    pushes: list[tuple[str, dict[str, Any]]] = []
+    logs: list[tuple[str, tuple[object, ...]]] = []
+    push_results = (True, False, True)
+
+    async def push(*, user_id: str, attributes: dict[str, Any]) -> bool:
+        assert factory.open_sessions == 0
+        events.append(("push", user_id))
+        pushes.append((user_id, attributes))
+        return push_results[len(pushes) - 1]
+
+    monkeypatch.setattr(engagement_service, "list_engagement_sync_users_page", list_users)
+    monkeypatch.setattr(engagement_service, "list_active_workspace_counts", workspace_counts)
+    monkeypatch.setattr(engagement_service, "list_latest_client_activity", client_activity)
+    monkeypatch.setattr(engagement_service, "list_latest_auth_logins", auth_logins)
+    monkeypatch.setattr(engagement_service, "push_user_attributes", push)
+    monkeypatch.setattr(
+        engagement_service.logger,
+        "info",
+        lambda message, *args: logs.append((message, args)),
+    )
+
+    await engagement_service.run_customerio_engagement_sync(factory)  # type: ignore[arg-type]
+
+    assert events == [
+        ("session_enter", 1),
+        ("users", 1, None, CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE),
+        ("workspaces", 1, (user1.id, user2.id)),
+        ("activity", 1, (user1.id, user2.id)),
+        ("logins", 1, (user1.id, user2.id)),
+        ("session_exit", 1),
+        ("push", str(user1.id)),
+        ("push", str(user2.id)),
+        ("session_enter", 2),
+        ("users", 2, user2.id, CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE),
+        ("workspaces", 2, (user3.id,)),
+        ("activity", 2, (user3.id,)),
+        ("logins", 2, (user3.id,)),
+        ("session_exit", 2),
+        ("push", str(user3.id)),
+        ("session_enter", 3),
+        ("users", 3, user3.id, CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE),
+        ("session_exit", 3),
+    ]
+    assert pushes == [
+        (
+            str(user1.id),
+            {
+                "workspace_count": 3,
+                "email_type": "company",
+                "last_active_at": int(later_login.timestamp()),
+            },
+        ),
+        (
+            str(user2.id),
+            {
+                "workspace_count": 0,
+                "email_type": "personal",
+                "last_active_at": int(second_activity.timestamp()),
+            },
+        ),
+        (
+            str(user3.id),
+            {
+                "workspace_count": 0,
+                "email_type": "personal",
+            },
+        ),
+    ]
+    assert logs == [
+        (
+            "Customer.io engagement sync complete: %d users processed, %d pushed successfully",
+            (3, 2),
+        )
     ]
 
-    last_seen = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
-    last_login = datetime(2026, 7, 2, 8, 0, 0, tzinfo=UTC)
 
-    class _FakeResult:
-        def __init__(self, rows):
-            self._rows = rows
+@pytest.mark.asyncio
+async def test_worker_logs_zero_totals_without_running_aggregate_or_provider_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[object, ...]] = []
+    logs: list[tuple[str, tuple[object, ...]]] = []
+    factory = _SessionFactory(events)
 
-        def all(self):
-            return self._rows
+    async def no_users(
+        _db: object,
+        *,
+        after_id: UUID | None,
+        limit: int,
+    ) -> tuple[EngagementSyncUserValue, ...]:
+        assert after_id is None
+        assert limit == CUSTOMERIO_ENGAGEMENT_SYNC_PAGE_SIZE
+        return ()
 
-    call_count = 0
+    async def forbidden(*_args: object, **_kwargs: object) -> tuple[()]:
+        raise AssertionError("terminal page must not run aggregates or provider calls")
 
-    async def fake_execute(query):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            # workspace counts
-            return _FakeResult([(user1_id, 3)])
-        elif call_count == 2:
-            # activity last_seen_at
-            return _FakeResult([(user1_id, last_seen), (user2_id, last_seen)])
-        elif call_count == 3:
-            # login last_login_at
-            return _FakeResult([(user1_id, last_login)])
-        return _FakeResult([])
+    monkeypatch.setattr(engagement_service, "list_engagement_sync_users_page", no_users)
+    monkeypatch.setattr(engagement_service, "list_active_workspace_counts", forbidden)
+    monkeypatch.setattr(engagement_service, "list_latest_client_activity", forbidden)
+    monkeypatch.setattr(engagement_service, "list_latest_auth_logins", forbidden)
+    monkeypatch.setattr(engagement_service, "push_user_attributes", forbidden)
+    monkeypatch.setattr(
+        engagement_service.logger,
+        "info",
+        lambda message, *args: logs.append((message, args)),
+    )
 
-    db = AsyncMock()
-    db.execute = fake_execute
+    await engagement_service.run_customerio_engagement_sync(factory)  # type: ignore[arg-type]
 
-    push_mock = AsyncMock(return_value=True)
-    with patch.object(customerio_sync, "push_user_attributes", push_mock):
-        pushed = await customerio_sync._sync_page(db, user_rows)
-
-    assert pushed == 2
-    calls = push_mock.call_args_list
-
-    # user1: workspace_count=3, last_active_at=last_login (greater), email_type=company
-    u1_call = next(c for c in calls if c.kwargs["user_id"] == str(user1_id))
-    assert u1_call.kwargs["attributes"]["workspace_count"] == 3
-    assert u1_call.kwargs["attributes"]["last_active_at"] == int(last_login.timestamp())
-    assert u1_call.kwargs["attributes"]["email_type"] == "company"
-
-    # user2: workspace_count=0, last_active_at=last_seen, email_type=personal
-    u2_call = next(c for c in calls if c.kwargs["user_id"] == str(user2_id))
-    assert u2_call.kwargs["attributes"]["workspace_count"] == 0
-    assert u2_call.kwargs["attributes"]["last_active_at"] == int(last_seen.timestamp())
-    assert u2_call.kwargs["attributes"]["email_type"] == "personal"
+    assert events == [("session_enter", 1), ("session_exit", 1)]
+    assert logs == [
+        (
+            "Customer.io engagement sync complete: %d users processed, %d pushed successfully",
+            (0, 0),
+        )
+    ]
 
 
 @pytest.mark.asyncio
-async def test_sync_page_omits_last_active_at_when_null() -> None:
-    """last_active_at should not be in the payload when there is no activity."""
-    user_id = _uid()
-    user_rows = [(user_id, "user@company.io")]
+async def test_worker_store_failure_escapes_after_closing_session_without_success_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = EngagementSyncUserValue(_user_id(1), "user@example.com")
+    events: list[tuple[object, ...]] = []
+    logs: list[tuple[str, tuple[object, ...]]] = []
+    factory = _SessionFactory(events)
 
-    class _FakeResult:
-        def __init__(self, rows):
-            self._rows = rows
+    async def users(*_args: object, **_kwargs: object) -> tuple[EngagementSyncUserValue, ...]:
+        return (user,)
 
-        def all(self):
-            return self._rows
+    async def fail(*_args: object, **_kwargs: object) -> tuple[ActiveWorkspaceCountValue, ...]:
+        raise RuntimeError("query failed")
 
-    async def fake_execute(query):
-        return _FakeResult([])
+    async def forbidden(*_args: object, **_kwargs: object) -> tuple[()]:
+        raise AssertionError("processing must stop after the failed store")
 
-    db = AsyncMock()
-    db.execute = fake_execute
+    monkeypatch.setattr(engagement_service, "list_engagement_sync_users_page", users)
+    monkeypatch.setattr(engagement_service, "list_active_workspace_counts", fail)
+    monkeypatch.setattr(engagement_service, "list_latest_client_activity", forbidden)
+    monkeypatch.setattr(engagement_service, "list_latest_auth_logins", forbidden)
+    monkeypatch.setattr(engagement_service, "push_user_attributes", forbidden)
+    monkeypatch.setattr(
+        engagement_service.logger,
+        "info",
+        lambda message, *args: logs.append((message, args)),
+    )
 
-    push_mock = AsyncMock(return_value=True)
-    with patch.object(customerio_sync, "push_user_attributes", push_mock):
-        await customerio_sync._sync_page(db, user_rows)
+    with pytest.raises(RuntimeError, match="query failed"):
+        await engagement_service.run_customerio_engagement_sync(factory)  # type: ignore[arg-type]
 
-    attrs = push_mock.call_args.kwargs["attributes"]
-    assert "last_active_at" not in attrs
-    assert attrs["workspace_count"] == 0
-    assert attrs["email_type"] == "company"
+    assert events == [("session_enter", 1), ("session_exit", 1)]
+    assert logs == []
 
 
 @pytest.mark.asyncio
-async def test_sync_page_counts_failures() -> None:
-    """When push_user_attributes returns False, it shouldn't count as pushed."""
-    user_id = _uid()
-    user_rows = [(user_id, "x@gmail.com")]
+async def test_worker_unexpected_integration_failure_escapes_after_session_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = EngagementSyncUserValue(_user_id(1), "user@example.com")
+    events: list[tuple[object, ...]] = []
+    logs: list[tuple[str, tuple[object, ...]]] = []
+    factory = _SessionFactory(events)
 
-    class _FakeResult:
-        def __init__(self, rows):
-            self._rows = rows
+    async def users(*_args: object, **_kwargs: object) -> tuple[EngagementSyncUserValue, ...]:
+        return (user,)
 
-        def all(self):
-            return self._rows
+    async def empty(*_args: object, **_kwargs: object) -> tuple[()]:
+        return ()
 
-    async def fake_execute(query):
-        return _FakeResult([])
+    async def fail_push(*_args: object, **_kwargs: object) -> bool:
+        assert factory.open_sessions == 0
+        events.append(("push", str(user.id)))
+        raise RuntimeError("unexpected adapter failure")
 
-    db = AsyncMock()
-    db.execute = fake_execute
+    monkeypatch.setattr(engagement_service, "list_engagement_sync_users_page", users)
+    monkeypatch.setattr(engagement_service, "list_active_workspace_counts", empty)
+    monkeypatch.setattr(engagement_service, "list_latest_client_activity", empty)
+    monkeypatch.setattr(engagement_service, "list_latest_auth_logins", empty)
+    monkeypatch.setattr(engagement_service, "push_user_attributes", fail_push)
+    monkeypatch.setattr(
+        engagement_service.logger,
+        "info",
+        lambda message, *args: logs.append((message, args)),
+    )
 
-    push_mock = AsyncMock(return_value=False)
-    with patch.object(customerio_sync, "push_user_attributes", push_mock):
-        pushed = await customerio_sync._sync_page(db, user_rows)
+    with pytest.raises(RuntimeError, match="unexpected adapter failure"):
+        await engagement_service.run_customerio_engagement_sync(factory)  # type: ignore[arg-type]
 
-    assert pushed == 0
+    assert events == [
+        ("session_enter", 1),
+        ("session_exit", 1),
+        ("push", str(user.id)),
+    ]
+    assert logs == []
+
+
+def test_task_uses_distinct_task_local_engines_and_returns_ok_only_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(customerio_task.settings, "customerio_site_id", "")
+    monkeypatch.setattr(customerio_task.settings, "customerio_api_key", "")
+
+    class _Engine:
+        def __init__(self, number: int) -> None:
+            self.number = number
+
+        async def dispose(self) -> None:
+            calls.append(("dispose", self.number))
+
+    def create_engine(database_url: str, **kwargs: object) -> _Engine:
+        number = 1 + sum(call[0] == "engine" for call in calls)
+        calls.append(("engine", number, database_url, kwargs))
+        return _Engine(number)
+
+    def sessionmaker(engine: _Engine, **kwargs: object) -> tuple[str, int]:
+        calls.append(("sessionmaker", engine.number, kwargs))
+        return ("factory", engine.number)
+
+    async def run(factory: tuple[str, int]) -> None:
+        calls.append(("run", factory))
+
+    monkeypatch.setattr(customerio_task, "create_async_engine", create_engine)
+    monkeypatch.setattr(customerio_task, "async_sessionmaker", sessionmaker)
+    monkeypatch.setattr(customerio_task, "run_customerio_engagement_sync", run)
+
+    assert customerio_task.customerio_engagement_sync() == "ok"
+    assert customerio_task.customerio_engagement_sync() == "ok"
+    assert calls == [
+        (
+            "engine",
+            1,
+            customerio_task.settings.database_url,
+            {"pool_pre_ping": True, "connect_args": {"statement_cache_size": 0}},
+        ),
+        ("sessionmaker", 1, {"expire_on_commit": False}),
+        ("run", ("factory", 1)),
+        ("dispose", 1),
+        (
+            "engine",
+            2,
+            customerio_task.settings.database_url,
+            {"pool_pre_ping": True, "connect_args": {"statement_cache_size": 0}},
+        ),
+        ("sessionmaker", 2, {"expire_on_commit": False}),
+        ("run", ("factory", 2)),
+        ("dispose", 2),
+    ]
+
+
+def test_task_disposes_engine_and_propagates_worker_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class _Engine:
+        async def dispose(self) -> None:
+            calls.append("dispose")
+
+    def create_engine(*_args: object, **_kwargs: object) -> _Engine:
+        calls.append("engine")
+        return _Engine()
+
+    def sessionmaker(*_args: object, **_kwargs: object) -> object:
+        calls.append("sessionmaker")
+        return object()
+
+    async def fail(_factory: object) -> None:
+        calls.append("run")
+        raise RuntimeError("worker failed")
+
+    monkeypatch.setattr(customerio_task, "create_async_engine", create_engine)
+    monkeypatch.setattr(customerio_task, "async_sessionmaker", sessionmaker)
+    monkeypatch.setattr(customerio_task, "run_customerio_engagement_sync", fail)
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        customerio_task.customerio_engagement_sync()
+
+    assert calls == ["engine", "sessionmaker", "run", "dispose"]

--- a/server/tests/unit/test_server_boundary_checker.py
+++ b/server/tests/unit/test_server_boundary_checker.py
@@ -16,6 +16,15 @@ def _load_checker_module():
     return module
 
 
+def _configure_structure_root(module, tmp_path: Path) -> Path:  # type: ignore[no-untyped-def]
+    root = tmp_path / "server" / "proliferate" / "server"
+    root.mkdir(parents=True)
+    module.REPO_ROOT = tmp_path
+    module.CHECK_ROOTS = [root]
+    module.STRUCTURE_ROOTS = [root]
+    return root
+
+
 def test_api_allows_auth_user_import_only(tmp_path: Path) -> None:
     module = _load_checker_module()
     path = tmp_path / "server" / "proliferate" / "server" / "example" / "api.py"
@@ -83,6 +92,92 @@ def test_service_allows_async_session_type_only(tmp_path: Path) -> None:
 
     violations = module.check_paths([path])
     assert violations == []
+
+
+def test_worker_service_allows_task_created_session_factory_type(tmp_path: Path) -> None:
+    module = _load_checker_module()
+    path = tmp_path / "server" / "proliferate" / "server" / "example" / "worker" / "service.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker\n"
+        "async def run(factory: async_sessionmaker[AsyncSession]) -> None:\n"
+        "    async with factory() as db:\n"
+        "        await read_store(db)\n"
+    )
+
+    violations = module.check_paths([path])
+
+    assert violations == []
+
+
+def test_ordinary_service_rejects_session_factory_type(tmp_path: Path) -> None:
+    module = _load_checker_module()
+    path = tmp_path / "server" / "proliferate" / "server" / "example" / "service.py"
+    path.parent.mkdir(parents=True)
+    path.write_text("from sqlalchemy.ext.asyncio import async_sessionmaker\n")
+
+    violations = module.check_paths([path])
+
+    assert any(item.rule_id == "SERVICE_SQLALCHEMY_IMPORT" for item in violations)
+
+
+def test_worker_service_still_rejects_queries_engines_models_and_session_methods(
+    tmp_path: Path,
+) -> None:
+    module = _load_checker_module()
+    path = tmp_path / "server" / "proliferate" / "server" / "example" / "worker" / "service.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "from sqlalchemy import select\n"
+        "from sqlalchemy.ext.asyncio import (\n"
+        "    AsyncSession, async_sessionmaker, create_async_engine,\n"
+        ")\n"
+        "from proliferate.db.engine import async_session_factory\n"
+        "from proliferate.db.models.auth import User\n"
+        "async def run(db) -> None:\n"
+        "    await db.execute(select(User))\n"
+        "    await db.commit()\n"
+        "    await db.rollback()\n"
+    )
+
+    violations = module.check_paths([path])
+
+    assert sum(item.rule_id == "SERVICE_SQLALCHEMY_IMPORT" for item in violations) == 2
+    assert any(item.rule_id == "SERVICE_DB_ENGINE_IMPORT" for item in violations)
+    assert any(item.rule_id == "SERVICE_ORM_IMPORT" for item in violations)
+    assert sum(item.rule_id == "SERVICE_DB_METHOD_CALL" for item in violations) == 3
+
+
+def test_canonical_single_file_worker_service_folder_is_allowed(tmp_path: Path) -> None:
+    module = _load_checker_module()
+    root = _configure_structure_root(module, tmp_path)
+    worker = root / "example" / "worker"
+    worker.mkdir(parents=True)
+    (worker / "__init__.py").write_text("")
+    (worker / "service.py").write_text("async def run() -> None:\n    return None\n")
+
+    violations = module.check_structure(tmp_path)
+
+    assert not any(item.path == worker for item in violations)
+
+
+def test_noncanonical_worker_and_arbitrary_single_file_folders_remain_rejected(
+    tmp_path: Path,
+) -> None:
+    module = _load_checker_module()
+    root = _configure_structure_root(module, tmp_path)
+    worker = root / "example" / "worker"
+    worker.mkdir(parents=True)
+    (worker / "jobs.py").write_text("def run() -> None:\n    return None\n")
+    arbitrary = root / "example" / "reports"
+    arbitrary.mkdir()
+    (arbitrary / "snapshot.py").write_text("def read() -> None:\n    return None\n")
+
+    violations = module.check_structure(tmp_path)
+
+    rejected = {item.path for item in violations if item.rule_id == "SINGLE_FILE_FOLDER"}
+    assert worker in rejected
+    assert arbitrary in rejected
 
 
 def test_service_rejects_query_builder_import(tmp_path: Path) -> None:

--- a/server/tests/unit/test_server_boundary_checker.py
+++ b/server/tests/unit/test_server_boundary_checker.py
@@ -4,6 +4,8 @@ import importlib.util
 from pathlib import Path
 import sys
 
+import pytest
+
 
 def _load_checker_module():
     script_path = Path(__file__).resolve().parents[3] / "scripts" / "check_server_boundaries.py"
@@ -148,6 +150,36 @@ def test_worker_service_still_rejects_queries_engines_models_and_session_methods
     assert sum(item.rule_id == "SERVICE_DB_METHOD_CALL" for item in violations) == 3
 
 
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "scalar",
+        "scalars",
+        "stream",
+        "stream_scalars",
+        "get",
+        "get_one",
+        "add_all",
+        "merge",
+        "flush",
+        "connection",
+        "run_sync",
+    ],
+)
+def test_worker_service_rejects_direct_session_escape_methods(
+    tmp_path: Path,
+    method_name: str,
+) -> None:
+    module = _load_checker_module()
+    path = tmp_path / "server" / "proliferate" / "server" / "example" / "worker" / "service.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(f"async def run(db) -> None:\n    db.{method_name}(value)\n")
+
+    violations = module.check_paths([path])
+
+    assert any(item.rule_id == "SERVICE_DB_METHOD_CALL" for item in violations)
+
+
 def test_canonical_single_file_worker_service_folder_is_allowed(tmp_path: Path) -> None:
     module = _load_checker_module()
     root = _configure_structure_root(module, tmp_path)
@@ -159,6 +191,33 @@ def test_canonical_single_file_worker_service_folder_is_allowed(tmp_path: Path) 
     violations = module.check_structure(tmp_path)
 
     assert not any(item.path == worker for item in violations)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        Path("worker/service.py"),
+        Path("example/subdomain/worker/service.py"),
+    ],
+)
+def test_worker_service_exemption_requires_exact_domain_depth(
+    tmp_path: Path,
+    relative_path: Path,
+) -> None:
+    module = _load_checker_module()
+    root = _configure_structure_root(module, tmp_path)
+    path = root / relative_path
+    path.parent.mkdir(parents=True)
+    path.write_text("from sqlalchemy.ext.asyncio import async_sessionmaker\n")
+
+    path_violations = module.check_paths([path])
+    structure_violations = module.check_structure(tmp_path)
+
+    assert any(item.rule_id == "SERVICE_SQLALCHEMY_IMPORT" for item in path_violations)
+    assert any(
+        item.rule_id == "SINGLE_FILE_FOLDER" and item.path == path.parent
+        for item in structure_violations
+    )
 
 
 def test_noncanonical_worker_and_arbitrary_single_file_folders_remain_rejected(

--- a/specs/codebase/structures/server/README.md
+++ b/specs/codebase/structures/server/README.md
@@ -141,9 +141,14 @@ Persistence rule:
 - `api.py` is transport only. It may receive FastAPI deps and pass the request
   session to services; it must not import stores, SQLAlchemy, or run auth
   checks inline.
-- `service.py` owns orchestration and receives `db: AsyncSession` from its
-  caller. It must not open sessions, commit, import SQLAlchemy, or execute
-  queries directly.
+- `service.py` owns orchestration and normally receives `db: AsyncSession` from
+  its caller. It must not commit, import SQLAlchemy query APIs, or execute
+  queries directly. A `worker/service.py` that alternates bounded database
+  phases with foreign I/O may instead receive a task-created
+  `async_sessionmaker[AsyncSession]`, open sessions only around store calls,
+  and release each session before foreign I/O. The task owns current-event-loop
+  engine creation and disposal; the worker service cannot import settings or
+  global engine helpers, construct an engine, or call session database methods.
 - All database access lives in `db/store/**`. Stores take `db: AsyncSession`,
   construct queries, return frozen dataclasses, and never commit or open
   sessions.
@@ -192,7 +197,8 @@ Persistence rule:
   `domain/`, a promoted subdomain, an integration, or the owning service. There
   is no `utils/` bucket.
 - Single-file folders are forbidden, except `server/**/domain/` may contain
-  one meaningful pure-domain module.
+  one meaningful pure-domain module and a canonical `worker/` may contain only
+  `service.py`.
 - A parent folder is either flat or organized into subfolders consistently.
   Mixed shapes are forbidden.
 - Cross-domain reads go through stores. Cross-domain writes go through the

--- a/specs/codebase/structures/server/architecture.md
+++ b/specs/codebase/structures/server/architecture.md
@@ -52,7 +52,7 @@ server/proliferate/
 | Layer | Owns | Never |
 | --- | --- | --- |
 | `api.py` | parse → call service → return | `db/store` import, `AsyncSession` methods, SQLAlchemy, business logic, inline auth, try/except around the handler |
-| `service.py` | business logic, orchestration, invariants, validation | open sessions, SQLAlchemy, `select/insert/db.execute`, `commit`, inline auth |
+| `service.py` | business logic, orchestration, invariants, validation | open sessions except the bounded worker-service exception below, SQLAlchemy query APIs, `select/insert/db.execute`, `commit`, inline auth |
 | `domain/**` | pure rules: validators, state machines, calculators, mappings, **planners** | `async def`, DB/ORM, FastAPI, integrations, I/O — *returns data* |
 | `db/store/**` | query construction + execution; returns **frozen dataclasses** | commit, open sessions; ORM never leaves here |
 | `db/models/**` | ORM table definitions only | imports nothing (leaf) |
@@ -77,8 +77,12 @@ ORM (db/models)  ──store returns──►  @dataclass(frozen=True)  ──mo
   while a transaction is open. They are different things.
 - **Stores take `db: AsyncSession`, never commit, never open sessions.**
 - **HTTP:** the `get_async_session` dep owns the transaction (commit on success,
-  rollback on exception). **Workers:** open a session at the entry point
-  (`async with session_factory() as db: async with db.begin(): …`).
+  rollback on exception). **Workers:** the task normally opens a session at the
+  entry point (`async with session_factory() as db: async with db.begin(): …`).
+  A worker service that must alternate bounded database phases with foreign I/O
+  may receive the task-created session factory and open a fresh session around
+  each store-only phase. The task still owns current-event-loop engine creation
+  and disposal.
 - **Never hold a connection across foreign I/O.** Short transactions only; for
   vendor-interleaving flows, commit → release → call → fresh short transaction.
   This is why the **outbox** exists (commit intent in one txn, do the side effect
@@ -92,7 +96,8 @@ api → service → store → models → SQLAlchemy        (nothing else imports
 service → integrations / domain / other domains' public services (writes) or stores (reads)
 domain → pure (no FastAPI/SQLAlchemy/store/integrations/HTTP)
 auth/** → importable by every layer
-workers → call services, not stores; own the transaction at the entry
+workers → call services, not stores; tasks own the engine/factory lifetime and
+          either open the session or pass the factory for bounded worker phases
 ```
 
 ---
@@ -148,8 +153,12 @@ outbox row and let a worker do the call.
 ### `server/<domain>/service.py`
 - Business logic, orchestration, invariants. Takes `db`, threads it to stores,
   calls integrations + `domain/`, raises domain errors.
-- **Never:** open sessions, import SQLAlchemy, run `select/insert/db.execute`,
+- **Never:** open sessions outside the bounded `worker/service.py` exception,
+  import SQLAlchemy query APIs, run `select/insert/db.execute`,
   `commit/rollback`, inline auth, or call another service's private helpers.
+  The exception accepts only a task-created session factory, surrounds store
+  calls with short session scopes, and releases them before foreign I/O; it
+  never owns an engine or global session entry point.
 
 ### `server/<domain>/models.py`
 - Pydantic request/response schemas; constructor functions take **dataclasses**.
@@ -209,9 +218,12 @@ outbox row and let a worker do the call.
   `celery_app.py`, `config.py`, `beat_schedule.py`, `relay.py`, thin `tasks/`;
   the work a task performs lives in the domain's `worker/service.py` (or
   `service.py`), same layer law (call services/stores, no ORM, no vendor client).
-  The task opens the session at its boundary. There are no per-domain `worker.py`,
-  `reconciler.py`, or `scheduler.py` process or loop files. Request-driven
-  external-process claim/heartbeat/report surfaces are APIs, not background work.
+  The task owns the database engine/session-factory lifetime. It normally opens
+  the session itself, but may pass its task-local factory to a worker service
+  that needs bounded store phases separated from foreign I/O. There are no
+  per-domain `worker.py`, `reconciler.py`, or `scheduler.py` process or loop
+  files. Request-driven external-process claim/heartbeat/report surfaces are
+  APIs, not background work.
 
 ### `lib/**`
 - Reusable cross-domain logic owned by no single domain: `infra/` (generic, no
@@ -232,8 +244,8 @@ outbox row and let a worker do the call.
 
 **Cross-cutting hygiene:** canonical files never prefixed/suffixed; no junk-drawer
 modules (`helpers.py`/`utils.py`/`misc.py`); no single-file folders (except
-`domain/`); a folder is all-subfolders or all-flat; never `datetime.utcnow()`
-(use `datetime.now(timezone.utc)`). Size thresholds are CI-enforced
+`domain/` and canonical `worker/service.py`); a folder is all-subfolders or
+all-flat; never `datetime.utcnow()` (use `datetime.now(timezone.utc)`). Size thresholds are CI-enforced
 (`check_max_lines.py`); boundaries by `check_server_boundaries.py`.
 
 ---

--- a/specs/codebase/structures/server/guides/background.md
+++ b/specs/codebase/structures/server/guides/background.md
@@ -40,15 +40,18 @@ Two homes, split by a single boundary: substrate versus product logic.
 
 `background/**` is plumbing. It knows how to run a task, when to fire periodic
 ones, and how to turn a committed outbox row into a dispatched task. It owns no
-business logic. A task module is a thin wrapper: it opens a database session at
-the task boundary, calls the owning domain's public service, and maps failures
-to retries.
+business logic. A task module is a thin wrapper: it owns the database
+engine/session boundary, calls the owning domain's public service, and maps
+failures to retries.
 
 `server/<domain>/**` owns the work itself. A task for a domain calls that
-domain's service exactly as an HTTP handler would. The service follows the same
-layer law as API-facing code: it takes `db: AsyncSession`, never commits, never
-imports SQLAlchemy or constructs vendor clients, and calls store functions for
-data and integrations through their public API.
+domain's service. The service follows the same layer law as API-facing code:
+it never commits, imports SQLAlchemy query APIs, or constructs vendor clients,
+and it calls store functions for data and integrations through their public
+API. It normally takes `db: AsyncSession`. A worker service that alternates
+bounded database phases with foreign I/O may instead take a task-created
+session factory, open sessions only around store calls, and release them before
+the external call.
 
 ## Axes
 
@@ -63,7 +66,7 @@ fires because a committed state change needs follow-up   -> outbox relay task
 And place the work it runs:
 
 ```text
-the task wrapper itself (open session, call service)    -> background/tasks/<area>.py
+the task wrapper itself (own DB boundary, call service) -> background/tasks/<area>.py
 worker-facing orchestration (pick due, dispatch, record) -> server/<domain>/worker/service.py
 pure computation shared with HTTP paths                  -> server/<domain>/domain/
 ```
@@ -81,7 +84,7 @@ server/proliferate/background/
   beat_schedule.py     # periodic registry: every X -> task Y (redbeat entries)
   relay.py             # outbox -> Celery: read committed rows, dispatch, mark relayed
   tasks/
-    <area>.py          # thin @app.task wrappers; open session; call domain service
+    <area>.py          # thin @app.task wrappers; own DB boundary; call domain service
 
 server/<domain>/
   service.py           # API-facing and, when modest, worker-facing orchestration
@@ -176,23 +179,29 @@ metrics contain only the fixed operation and a bounded safe code.
 
 Thin task wrappers — the boundary between the broker and a domain.
 
-- Owns: the `@app.task` function, the database session opened at the task
-  boundary, the call into the owning domain's public service, and the mapping of
-  failures to retries.
-- Imports: `celery_app`, the owning domain's service, the session factory.
+- Owns: the `@app.task` function, the database engine/session boundary, the call
+  into the owning domain's public service, and the mapping of failures to
+  retries. A synchronous task using `asyncio.run()` creates and disposes its
+  engine inside that event-loop lifecycle rather than reusing a module-global
+  async engine across firings.
+- Imports: `celery_app`, the owning domain's service, and the session machinery.
 - Never holds: business logic, SQLAlchemy queries or ORM imports, or raw vendor
   clients. A task that grows logic has put it in the wrong layer — push it into
   the domain's service or `domain/`.
 
 ```python
-# background/tasks/automations.py
-@app.task(bind=True, max_retries=5)
-def execute_automation_run(self, run_id: str) -> None:
-    async def _run() -> None:
-        async with async_session_factory() as db:
-            async with db.begin():
-                await automations_worker_service.execute_run(db, run_id=UUID(run_id))
-    asyncio.run(_run())
+# background/tasks/customerio_sync.py
+async def _run_engagement_sync() -> None:
+    engine = create_async_engine(
+        settings.database_url,
+        pool_pre_ping=True,
+        connect_args={"statement_cache_size": 0},
+    )
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        await run_customerio_engagement_sync(session_factory)
+    finally:
+        await engine.dispose()
 ```
 
 ## `server/<domain>/worker/service.py`
@@ -203,9 +212,14 @@ substantial and distinct from the API-facing service.
 - Owns: picking due work, dispatching to the right execution, recording results,
   and handling failures, as ordinary service functions.
 - Imports: `db/store`, `domain/`, `integrations` through their public API.
-- Same layer law as any service: takes `db: AsyncSession`, never commits (the
-  task owns the transaction boundary), never imports SQLAlchemy, never
-  constructs vendor clients.
+- Same layer law as any service: normally takes `db: AsyncSession`, never
+  commits, never imports SQLAlchemy query APIs, and never constructs vendor
+  clients. When foreign I/O must alternate with multiple bounded database
+  phases, it may take the task-created `async_sessionmaker[AsyncSession]`, open
+  sessions only around direct store calls, and release each before foreign I/O.
+  The task creates and disposes the engine; the service cannot import settings
+  or global engine helpers, construct an engine, issue SQL, or call session
+  query/commit/rollback methods.
 
 When the worker-facing surface is modest, these functions live in the domain's
 ordinary `service.py` and there is no `worker/` subfolder. Two `service.py`
@@ -231,8 +245,10 @@ share `domain/` and the stores.
 - `background/**` imports no domain service except through a task module, and
   only `relay.py` touches stores (outbox writes plus read-only bounded
   operational snapshots).
-- No task module imports ORM or constructs vendor clients; it opens a session at
-  the boundary and threads `db` through the normal service/store layers.
+- No task module imports ORM or constructs vendor clients. It owns the
+  current-event-loop engine/session-factory lifetime and either opens the
+  session itself or passes the factory to the narrow bounded worker-service
+  pattern.
 
 ## Smells
 

--- a/specs/codebase/structures/server/guides/database.md
+++ b/specs/codebase/structures/server/guides/database.md
@@ -326,6 +326,15 @@ async def run_billing_reconcile_pass() -> None:
         # commits on context exit, rolls back on exception
 ```
 
+A worker service that must alternate repeated read-only database phases with
+foreign I/O may instead receive an `async_sessionmaker[AsyncSession]` created by
+the task. The task creates and disposes the engine within the current
+`asyncio.run()` lifecycle. The worker service opens one bounded session around
+direct store calls, materializes frozen values, closes the session, and only
+then performs foreign I/O. This exception does not permit the service to import
+settings or global engine helpers, construct an engine, issue SQL, call session
+query methods, commit, or roll back.
+
 ### Narrower atomicity within a request
 
 When a service needs an inner transaction smaller than the request, use

--- a/specs/codebase/structures/server/guides/domains.md
+++ b/specs/codebase/structures/server/guides/domains.md
@@ -102,6 +102,10 @@ Allowed:
 
 - `db: AsyncSession` as a parameter (passed by the handler or the worker
   entry point). Service functions take this and thread it to stores.
+- In `worker/service.py` only, a task-created
+  `async_sessionmaker[AsyncSession]` when the orchestration must alternate
+  bounded store-only phases with foreign I/O. Each session closes before the
+  external call.
 - Composing multiple store function calls within a single transaction
   (the request session by default; `db.begin_nested()` for narrower
   atomicity).
@@ -113,9 +117,12 @@ Allowed:
 
 Banned:
 
-- `async_session_factory` imports. Services don't open sessions; they
-  receive them.
-- SQLAlchemy direct imports (`from sqlalchemy import ...`).
+- Global `async_session_factory` and engine-helper imports. Ordinary services
+  don't open sessions. The narrow worker exception receives a factory from its
+  task but cannot import settings, create an engine, or reach a global factory.
+- SQLAlchemy query/building imports. The narrow worker exception may import
+  only the `AsyncSession` and `async_sessionmaker` types from
+  `sqlalchemy.ext.asyncio`.
 - `select()`, `insert()`, `update()`, `delete()`, `db.execute()`. All DB
   access goes through stores.
 - `db.commit()` or `db.rollback()`. Transactions are owned by the caller
@@ -292,8 +299,10 @@ uses it."
 
 `worker/service.py` for background work a Celery task calls. See
 [background.md](background.md). Same layer law: no ORM imports, calls service or
-store functions. The task itself is substrate in `background/**`, not a file in
-the domain.
+store functions. It normally receives `db`; when foreign I/O separates bounded
+database phases, it may receive a task-created session factory and must close
+each store-only session before the external call. The task itself is substrate
+in `background/**`, not a file in the domain.
 
 ### Forbidden
 
@@ -408,13 +417,16 @@ an outside process claims, heartbeats, or reports against a Postgres lease — a
 APIs, not worker code, and stay near `api.py`/`service.py`. See
 [background.md](background.md) for the full background-work organization.
 
+A `worker/` folder containing only its canonical `service.py` is the narrow
+worker exception to the single-file-folder rule.
+
 ## Patterns
 
 - A domain folder either has subfolder children consistently or is flat.
   Mixed shapes (some subfolders, some flat sibling files belonging to a
-  subdomain) are forbidden. `domain/` is the narrow exception to the
-  single-file-folder rule: one meaningful pure-domain file is allowed when
-  the domain only has one extracted rule module.
+  subdomain) are forbidden. `domain/` may contain one meaningful pure-domain
+  file, and `worker/` may contain only its canonical `service.py`; these are the
+  narrow exceptions to the single-file-folder rule.
 - Service composes; domain decides; store persists. If you find a service
   computing a complex rule inline, the rule belongs in `domain/`. If you find
   a domain function calling a store, it's not domain.

--- a/specs/codebase/systems/product/engagement/README.md
+++ b/specs/codebase/systems/product/engagement/README.md
@@ -71,7 +71,10 @@ Each nonempty page performs exactly:
 ```
 
 The three aggregates are set-based for all user ids on the page, not one query
-per user. For each profile the task writes:
+per user. The task-local engine is created inside the Celery firing's event-loop
+lifecycle. Product Engagement opens one read-only session per page, materializes
+the four store results, closes that session, and only then writes profiles
+sequentially. For each profile the worker service writes:
 
 - `workspace_count`: count of owned `cloud_workspace` rows whose
   `archived_at` is null, defaulting to zero
@@ -90,6 +93,12 @@ Current owners:
 - `server/proliferate/background/beat_schedule.py`
 - `server/proliferate/background/config.py`
 - `server/proliferate/background/tasks/customerio_sync.py`
+- `server/proliferate/server/product_engagement/worker/service.py`
+- `server/proliferate/db/store/users.py`
+- `server/proliferate/db/store/cloud_workspaces.py`
+- `server/proliferate/db/store/analytics.py`
+- `server/proliferate/db/store/auth_identities.py`
+- `server/proliferate/integrations/customerio.py`
 
 ## Provider Boundary
 
@@ -119,7 +128,9 @@ Code-level coverage lives in:
 
 - `server/tests/unit/test_customerio.py`
 - `server/tests/unit/test_customerio_sync.py`
+- `server/tests/unit/test_background_celery.py`
 - `server/tests/unit/auth/test_desktop_customerio.py`
+- `server/tests/integration/test_product_engagement_store.py`
 - `server/tests/integration/test_desktop_auth_customerio.py`
 
 Use the [Customer.io operating procedure](../../../../developing/operating/analytics/customerio.md)


### PR DESCRIPTION
## Summary

- thin the nightly Customer.io Celery task into runtime substrate with a task-local async engine/session factory that is safe across repeated `asyncio.run()` lifecycles
- move keyset pagination, profile assembly, sequential best-effort delivery, totals, and logging into a Product Engagement worker service
- move the four SQL reads to users, cloud-workspaces, analytics, and auth-identity stores with frozen return values, closing each page session before provider I/O
- document and enforce the narrow canonical `server/<domain>/worker/service.py` session-factory pattern without permitting queries, engines, ORM access, direct session methods, or noncanonical path depths
- add exact schedule, multi-page, failure, engine-lifecycle, checker, and real-Postgres store characterization

## Readiness

- [ ] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- frozen seven-file unit/integration surface in the pinned Python 3.12 dev environment — 75 passed
- changed-path Ruff check/format
- `python3 scripts/check_server_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_migration_heads.py`
- `python3 scripts/check_docs.py`
- design-attribution check and `git diff --check`
- adversarial checker coverage for every direct-session escape plus missing-domain and nested-subdomain worker paths
- independently reviewed and accepted after closing `SG05-B001` and `SG05-B002`; no remaining findings

No task name, queue, 09:00 UTC schedule, two-credential Beat gate, user selection, query cadence, cursor, provider ordering, partial-failure, or retry behavior changes.
