### PR TITLE
refactor(server): move redirect callback rendering into product leaves

### DIFF
--- a/server/proliferate/auth/desktop/pages.py
+++ b/server/proliferate/auth/desktop/pages.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 from fastapi.responses import HTMLResponse
 
-from proliferate.utils.redirect_callback_pages import make_redirect_callback_response
+from proliferate.lib.product.redirect_callbacks.page import render_redirect_callback_page
 
 
 def make_browser_flow_page(*, title: str, message: str) -> HTMLResponse:
-    return make_redirect_callback_response(
-        title=title,
-        status_label="Browser callback",
-        message=message,
-        tone="error",
+    return HTMLResponse(
+        render_redirect_callback_page(
+            title=title,
+            status_label="Browser callback",
+            message=message,
+            tone="error",
+        )
     )
 
 
@@ -35,21 +37,23 @@ def make_desktop_handoff_page(*, deep_link_url: str, launch_deep_link: bool) -> 
             "finish the sign-in from its recovery polling instead."
         )
     )
-    return make_redirect_callback_response(
-        title=title,
-        status_label="Desktop sign-in",
-        message=message,
-        tone="success",
-        detail=detail,
-        action_label="Open Proliferate again" if launch_deep_link else None,
-        action_href=deep_link_url if launch_deep_link else None,
-        action_visible=not launch_deep_link,
-        action_hint=(
-            "Keep this tab open if you want Proliferate's recovery polling to finish the sign-in instead."
-            if launch_deep_link
-            else None
-        ),
-        launch_url=deep_link_url if launch_deep_link else None,
-        fallback_message=fallback_message if launch_deep_link else None,
-        variant="handoff",
+    return HTMLResponse(
+        render_redirect_callback_page(
+            title=title,
+            status_label="Desktop sign-in",
+            message=message,
+            tone="success",
+            detail=detail,
+            action_label="Open Proliferate again" if launch_deep_link else None,
+            action_href=deep_link_url if launch_deep_link else None,
+            action_visible=not launch_deep_link,
+            action_hint=(
+                "Keep this tab open if you want Proliferate's recovery polling to finish the sign-in instead."
+                if launch_deep_link
+                else None
+            ),
+            launch_url=deep_link_url if launch_deep_link else None,
+            fallback_message=fallback_message if launch_deep_link else None,
+            variant="handoff",
+        )
     )

--- a/server/proliferate/lib/product/redirect_callbacks/launch.py
+++ b/server/proliferate/lib/product/redirect_callbacks/launch.py
@@ -1,0 +1,43 @@
+"""Inline browser launch behavior for redirect callback pages."""
+
+from __future__ import annotations
+
+import json
+
+
+def render_launch_script(
+    *,
+    launch_url: str | None,
+    fallback_message: str | None,
+    reveal_action_after_ms: int,
+) -> str:
+    if not launch_url:
+        return ""
+
+    fallback_json = _json_for_inline_script(fallback_message) if fallback_message else "null"
+    return f"""
+    <script>
+      window.addEventListener("load", () => {{
+        const launchUrl = {_json_for_inline_script(launch_url)};
+        const fallbackMessage = {fallback_json};
+        const recovery = document.getElementById("recovery");
+        const statusText = document.getElementById("status-text");
+
+        window.location.replace(launchUrl);
+
+        window.setTimeout(() => {{
+          if (recovery) {{
+            recovery.dataset.visible = "true";
+          }}
+          if (fallbackMessage && statusText) {{
+            statusText.textContent = fallbackMessage;
+          }}
+        }}, {reveal_action_after_ms});
+      }});
+    </script>"""
+
+
+def _json_for_inline_script(value: str) -> str:
+    return (
+        json.dumps(value).replace("<", r"\u003c").replace(">", r"\u003e").replace("&", r"\u0026")
+    )

--- a/server/proliferate/lib/product/redirect_callbacks/page.py
+++ b/server/proliferate/lib/product/redirect_callbacks/page.py
@@ -2,49 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from html import escape
 from typing import Literal
 
-from fastapi.responses import HTMLResponse
+from proliferate.lib.product.redirect_callbacks.launch import render_launch_script
 
 RedirectCallbackTone = Literal["neutral", "success", "error"]
 RedirectCallbackVariant = Literal["default", "handoff"]
-
-
-def make_redirect_callback_response(
-    *,
-    title: str,
-    status_label: str,
-    message: str,
-    tone: RedirectCallbackTone = "neutral",
-    detail: str | None = None,
-    action_label: str | None = None,
-    action_href: str | None = None,
-    action_visible: bool = True,
-    action_hint: str | None = None,
-    launch_url: str | None = None,
-    fallback_message: str | None = None,
-    reveal_action_after_ms: int = 1500,
-    variant: RedirectCallbackVariant = "default",
-) -> HTMLResponse:
-    return HTMLResponse(
-        render_redirect_callback_page(
-            title=title,
-            status_label=status_label,
-            message=message,
-            tone=tone,
-            detail=detail,
-            action_label=action_label,
-            action_href=action_href,
-            action_visible=action_visible,
-            action_hint=action_hint,
-            launch_url=launch_url,
-            fallback_message=fallback_message,
-            reveal_action_after_ms=reveal_action_after_ms,
-            variant=variant,
-        )
-    )
 
 
 def render_redirect_callback_page(
@@ -75,7 +39,7 @@ def render_redirect_callback_page(
         action_visible=action_visible,
         action_hint=action_hint,
     )
-    launch_script = _render_launch_script(
+    launch_script = render_launch_script(
         launch_url=launch_url,
         fallback_message=fallback_message,
         reveal_action_after_ms=reveal_action_after_ms,
@@ -92,7 +56,7 @@ def render_redirect_callback_page(
             action_label=action_label,
             action_href=action_href,
         )
-        handoff_launch_script = _render_launch_script(
+        handoff_launch_script = render_launch_script(
             launch_url=launch_url,
             fallback_message=None,
             reveal_action_after_ms=reveal_action_after_ms,
@@ -426,38 +390,6 @@ def _render_handoff_action_block(
       <div class="recovery" id="recovery" data-visible="true">
         <a class="action" href="{escape(action_href, quote=True)}" aria-label="{escape(action_label, quote=True)}">Click here if not redirected</a>
       </div>"""
-
-
-def _render_launch_script(
-    *,
-    launch_url: str | None,
-    fallback_message: str | None,
-    reveal_action_after_ms: int,
-) -> str:
-    if not launch_url:
-        return ""
-
-    fallback_json = json.dumps(fallback_message) if fallback_message else "null"
-    return f"""
-    <script>
-      window.addEventListener("load", () => {{
-        const launchUrl = {json.dumps(launch_url)};
-        const fallbackMessage = {fallback_json};
-        const recovery = document.getElementById("recovery");
-        const statusText = document.getElementById("status-text");
-
-        window.location.replace(launchUrl);
-
-        window.setTimeout(() => {{
-          if (recovery) {{
-            recovery.dataset.visible = "true";
-          }}
-          if (fallbackMessage && statusText) {{
-            statusText.textContent = fallbackMessage;
-          }}
-        }}, {reveal_action_after_ms});
-      }});
-    </script>"""
 
 
 _PROLIFERATE_MARK_SVG = """        <svg viewBox="300 300 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges" width="32" height="32" aria-hidden="true">

--- a/server/proliferate/server/cloud/github_app/api.py
+++ b/server/proliferate/server/cloud/github_app/api.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.lib.product.redirect_callbacks.page import render_redirect_callback_page
 from proliferate.permissions import CurrentOrgUser, current_path_org_admin, current_path_org_member
 from proliferate.server.cloud.errors import CloudApiError, raise_cloud_error
 from proliferate.server.cloud.github_app.models import (
@@ -39,7 +40,6 @@ from proliferate.server.cloud.repos.service import (
     DEFAULT_REPO_AFFILIATION,
     DEFAULT_REPO_VISIBILITY,
 )
-from proliferate.utils.redirect_callback_pages import make_redirect_callback_response
 
 _REAUTH_TRANSACTION_DEPENDENCIES = [Depends(commit_github_app_reauthorization_on_error)]
 
@@ -229,12 +229,14 @@ async def github_app_connected_page_endpoint() -> HTMLResponse:
     # return to. Served by the API itself, so it never 404s on an API-only
     # deployment. Desktop/web deployments redirect to their own settings pages
     # instead (see `_default_return_after_callback`).
-    return make_redirect_callback_response(
-        title="GitHub App connected",
-        status_label="Connected",
-        message=(
-            "The Proliferate GitHub App is connected. You can close this tab and "
-            "return to Proliferate."
-        ),
-        tone="success",
+    return HTMLResponse(
+        render_redirect_callback_page(
+            title="GitHub App connected",
+            status_label="Connected",
+            message=(
+                "The Proliferate GitHub App is connected. You can close this tab and "
+                "return to Proliferate."
+            ),
+            tone="success",
+        )
     )

--- a/server/proliferate/server/cloud/integrations/pages.py
+++ b/server/proliferate/server/cloud/integrations/pages.py
@@ -16,8 +16,8 @@ from proliferate.constants.auth import (
     DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
     DESKTOP_REDIRECT_SCHEME,
 )
+from proliferate.lib.product.redirect_callbacks.page import render_redirect_callback_page
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.utils.redirect_callback_pages import make_redirect_callback_response
 
 
 def make_integration_oauth_callback_page(
@@ -47,18 +47,20 @@ def make_integration_oauth_callback_page(
         )
     )
     fallback_message = "If Proliferate did not open automatically, use the button below."
-    return make_redirect_callback_response(
-        title=title,
-        status_label="Integrations",
-        message=message,
-        tone="success" if ok else "error",
-        detail=detail,
-        action_label="Open Proliferate",
-        action_href=deep_link_url,
-        action_visible=not DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
-        launch_url=deep_link_url if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else None,
-        fallback_message=fallback_message if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else None,
-        variant="handoff" if ok else "default",
+    return HTMLResponse(
+        render_redirect_callback_page(
+            title=title,
+            status_label="Integrations",
+            message=message,
+            tone="success" if ok else "error",
+            detail=detail,
+            action_label="Open Proliferate",
+            action_href=deep_link_url,
+            action_visible=not DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
+            launch_url=deep_link_url if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else None,
+            fallback_message=fallback_message if DESKTOP_DEEP_LINK_LAUNCH_ENABLED else None,
+            variant="handoff" if ok else "default",
+        )
     )
 
 

--- a/server/proliferate/server/organizations/landing.py
+++ b/server/proliferate/server/organizations/landing.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 from uuid import UUID
 
 from proliferate.config import settings
-from proliferate.utils.redirect_callback_pages import render_redirect_callback_page
+from proliferate.lib.product.redirect_callbacks.page import render_redirect_callback_page
 
 
 def _issuing_server_origin() -> str:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -61,7 +61,7 @@ ignore = ["B008"]
 "proliferate/utils/**" = ["ANN401"]
 # Inline HTML/SVG page renderers contain long literal lines.
 "proliferate/auth/desktop/pages.py" = ["E501"]
-"proliferate/utils/redirect_callback_pages.py" = ["E501"]
+"proliferate/lib/product/redirect_callbacks/page.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/server/tests/unit/test_github_app_callback_return.py
+++ b/server/tests/unit/test_github_app_callback_return.py
@@ -15,8 +15,28 @@ instead of failing.
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from proliferate.server.cloud.github_app import service
+from proliferate.server.cloud.github_app.api import callback_router
+
+
+def test_connected_page_is_self_host_safe_html() -> None:
+    app = FastAPI()
+    app.include_router(callback_router, prefix="/auth")
+
+    with TestClient(app) as client:
+        response = client.get("/auth/github-app/connected")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert response.text.startswith("<!doctype html>")
+    assert "<title>GitHub App connected</title>" in response.text
+    assert (
+        "The Proliferate GitHub App is connected. You can close this tab and return to "
+        "Proliferate."
+    ) in response.text
 
 
 def test_default_return_uses_frontend_when_configured(

--- a/server/tests/unit/test_redirect_callback_pages.py
+++ b/server/tests/unit/test_redirect_callback_pages.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+import re
+from itertools import product
+from typing import cast
+
+import pytest
+from fastapi.responses import HTMLResponse
+
+from proliferate.lib.product.redirect_callbacks.launch import render_launch_script
+from proliferate.lib.product.redirect_callbacks.page import (
+    RedirectCallbackTone,
+    RedirectCallbackVariant,
+    render_redirect_callback_page,
+)
+
+
+@pytest.mark.parametrize("tone", ["neutral", "success", "error"])
+def test_default_page_renders_each_tone(tone: RedirectCallbackTone) -> None:
+    page = render_redirect_callback_page(
+        title="Callback",
+        status_label="Status",
+        message="Message",
+        tone=tone,
+    )
+
+    assert f'class="status tone-{tone}"' in page
+
+
+def test_invalid_runtime_tone_and_variant_fall_back_to_default_page() -> None:
+    page = render_redirect_callback_page(
+        title="Callback",
+        status_label="Status",
+        message="Message",
+        tone=cast(RedirectCallbackTone, "warning"),
+        variant=cast(RedirectCallbackVariant, "unknown"),
+    )
+
+    assert 'class="brand"' in page
+    assert 'class="status tone-neutral"' in page
+    assert 'class="braille"' not in page
+
+
+def test_default_page_escapes_text_and_action_attribute_contexts() -> None:
+    page = render_redirect_callback_page(
+        title='<Title & "quoted">',
+        status_label='<Status & "quoted">',
+        message='<Message & "quoted">',
+        detail='<Detail & "quoted">',
+        action_label='<Open & "quoted">',
+        action_href='proliferate://callback?value=<tag>&quote="yes"',
+        action_hint='<Hint & "quoted">',
+    )
+
+    assert "<title>&lt;Title &amp; &quot;quoted&quot;&gt;</title>" in page
+    assert "&lt;Status &amp; &quot;quoted&quot;&gt;" in page
+    assert "&lt;Message &amp; &quot;quoted&quot;&gt;" in page
+    assert '<p class="detail">&lt;Detail &amp; &quot;quoted&quot;&gt;</p>' in page
+    assert "&lt;Open &amp; &quot;quoted&quot;&gt;" in page
+    assert 'href="proliferate://callback?value=&lt;tag&gt;&amp;quote=&quot;yes&quot;"' in page
+    assert '<p class="hint">&lt;Hint &amp; &quot;quoted&quot;&gt;</p>' in page
+
+
+@pytest.mark.parametrize(
+    ("has_label", "has_href", "has_hint", "action_visible"),
+    list(product([False, True], repeat=4)),
+)
+def test_default_action_block_prerequisites_and_visibility(
+    has_label: bool,
+    has_href: bool,
+    has_hint: bool,
+    action_visible: bool,
+) -> None:
+    page = render_redirect_callback_page(
+        title="Callback",
+        status_label="Status",
+        message="Message",
+        action_label="Open" if has_label else None,
+        action_href="proliferate://callback" if has_href else None,
+        action_hint="Try again" if has_hint else None,
+        action_visible=action_visible,
+    )
+    has_block = has_label or has_hint
+    has_link = has_label and has_href
+
+    assert ('id="recovery"' in page) is has_block
+    assert ('<a class="action"' in page) is has_link
+    assert ('<p class="hint">Try again</p>' in page) is has_hint
+    if has_block:
+        expected_visibility = "true" if action_visible else "false"
+        assert f'data-visible="{expected_visibility}"' in page
+
+
+@pytest.mark.parametrize("detail", [None, ""])
+def test_falsey_detail_is_omitted(detail: str | None) -> None:
+    page = render_redirect_callback_page(
+        title="Callback",
+        status_label="Status",
+        message="Message",
+        detail=detail,
+    )
+
+    assert '<p class="detail">' not in page
+
+
+def test_handoff_page_preserves_its_distinct_copy_and_ignored_fields() -> None:
+    page = render_redirect_callback_page(
+        title="Handoff",
+        status_label="Must not render",
+        message="Opening the app",
+        tone="error",
+        detail="Keep this tab open",
+        action_label='<Open & "label">',
+        action_href='proliferate://callback?value=<tag>&quote="yes"',
+        action_visible=False,
+        action_hint="Must not render either",
+        launch_url="proliferate://callback",
+        fallback_message="Ignored fallback",
+        variant="handoff",
+    )
+
+    assert 'class="braille"' in page
+    assert 'class="brand"' not in page
+    assert "Must not render" not in page
+    assert "Must not render either" not in page
+    assert "Ignored fallback" not in page
+    assert "const fallbackMessage = null;" in page
+    assert '<p class="detail">Keep this tab open</p>' in page
+    assert 'data-visible="true"' in page
+    assert "Click here if not redirected" in page
+    assert 'aria-label="&lt;Open &amp; &quot;label&quot;&gt;"' in page
+    assert 'href="proliferate://callback?value=&lt;tag&gt;&amp;quote=&quot;yes&quot;"' in page
+
+
+@pytest.mark.parametrize(
+    ("action_label", "action_href", "has_action"),
+    [
+        (None, None, False),
+        ("Open", None, False),
+        (None, "proliferate://callback", False),
+        ("Open", "proliferate://callback", True),
+    ],
+)
+def test_handoff_action_requires_both_label_and_href(
+    action_label: str | None,
+    action_href: str | None,
+    has_action: bool,
+) -> None:
+    page = render_redirect_callback_page(
+        title="Handoff",
+        status_label="Status",
+        message="Opening the app",
+        action_label=action_label,
+        action_href=action_href,
+        variant="handoff",
+    )
+
+    assert ('id="recovery"' in page) is has_action
+
+
+@pytest.mark.parametrize("launch_url", [None, ""])
+def test_falsey_launch_url_omits_script(launch_url: str | None) -> None:
+    assert (
+        render_launch_script(
+            launch_url=launch_url,
+            fallback_message="Fallback",
+            reveal_action_after_ms=1500,
+        )
+        == ""
+    )
+
+
+@pytest.mark.parametrize("fallback_message", [None, ""])
+def test_launch_script_preserves_navigation_timeout_and_falsey_fallback(
+    fallback_message: str | None,
+) -> None:
+    script = render_launch_script(
+        launch_url="proliferate://callback",
+        fallback_message=fallback_message,
+        reveal_action_after_ms=-25,
+    )
+
+    assert 'const launchUrl = "proliferate://callback";' in script
+    assert "const fallbackMessage = null;" in script
+    assert script.index("window.location.replace(launchUrl);") < script.index("window.setTimeout")
+    assert 'recovery.dataset.visible = "true";' in script
+    assert "if (fallbackMessage && statusText)" in script
+    assert "statusText.textContent = fallbackMessage;" in script
+    assert "}, -25);" in script
+
+
+def test_inline_script_json_cannot_emit_payload_closing_tag() -> None:
+    launch_url = 'proliferate://callback/"\\&<>\u2603\n</ScRiPt><script>'
+    fallback_message = 'Fallback "\\&<>\u2603\n</SCRIPT><script>'
+    script = render_launch_script(
+        launch_url=launch_url,
+        fallback_message=fallback_message,
+        reveal_action_after_ms=2750,
+    )
+    launch_match = re.search(r"const launchUrl = (.+);", script)
+    fallback_match = re.search(r"const fallbackMessage = (.+);", script)
+
+    assert launch_match is not None
+    assert fallback_match is not None
+    launch_literal = launch_match.group(1)
+    fallback_literal = fallback_match.group(1)
+    assert not {"<", ">", "&"}.intersection(launch_literal)
+    assert not {"<", ">", "&"}.intersection(fallback_literal)
+    assert json.loads(launch_literal) == launch_url
+    assert json.loads(fallback_literal) == fallback_message
+    assert len(re.findall(r"</script\s*>", script, flags=re.IGNORECASE)) == 1
+    assert "}, 2750);" in script
+
+
+def test_local_html_response_preserves_rendered_body_and_defaults() -> None:
+    page = render_redirect_callback_page(
+        title="Callback",
+        status_label="Complete",
+        message="Return to the app",
+    )
+    response = HTMLResponse(page)
+
+    assert response.status_code == 200
+    assert response.media_type == "text/html"
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.body == page.encode()


### PR DESCRIPTION
## Summary

- Move redirect callback markup/types and launch-script rendering into pure `lib/product/redirect_callbacks` leaves.
- Keep HTTP transport ownership at the three FastAPI callers while preserving the Organizations raw-string boundary.
- Remove the old utility and response wrapper without a compatibility shim or package barrel.
- Harden inline JSON against `</script>` termination by escaping literal `<`, `>`, and `&` while preserving the exact JavaScript runtime values.

## Validation

- 46 focused tests
- strict mypy
- Ruff and formatting checks
- server architecture boundaries
- max-lines and design-attribution checks
- import and production-call census

`SG08-F01` remains parked as specified: this slice intentionally uses direct leaf imports with an empty package initializer.