### PR TITLE
refactor(server): route checkout intents through organizations

### DIFF
--- a/server/proliferate/server/billing/team_checkout/service.py
+++ b/server/proliferate/server/billing/team_checkout/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from datetime import timedelta
+from typing import cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import UUID
 
@@ -19,13 +20,6 @@ from proliferate.db.store.billing_subjects import (
 from proliferate.db.store.organization_records import (
     CheckoutIntentRecord,
     CheckoutIntentWithOrganizationRecord,
-)
-from proliferate.db.store.organizations import (
-    acquire_membership_activation_lock,
-    bind_team_checkout_session,
-    cancel_team_checkout_intent,
-    create_pending_team_checkout_intent,
-    get_current_team_checkout_intent,
 )
 from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing.models import (
@@ -43,6 +37,7 @@ from proliferate.server.billing.team_checkout.models import (
     TeamCheckoutIntentResponse,
     TeamCheckoutResponse,
 )
+from proliferate.server.organizations import service as organization_service
 from proliferate.server.organizations.domain.profile import (
     clean_organization_name,
     derive_logo_domain_from_email,
@@ -204,7 +199,7 @@ async def _create_stripe_session_for_team_checkout_intent(
             status_code=502,
         )
     async with db.begin():
-        bound = await bind_team_checkout_session(
+        bound = await organization_service.bind_team_checkout_session(
             db,
             intent_id=intent_record.intent.id,
             stripe_checkout_session_id=checkout.id,
@@ -240,23 +235,18 @@ async def create_team_checkout_session(
     await validate_pro_subscription_price_configuration()
 
     async with db.begin():
-        await acquire_membership_activation_lock(db, user.id)
-        existing = await get_current_team_checkout_intent(db, user.id)
-        if existing is not None:
-            intent_record = existing
-        else:
-            intent_record = await create_pending_team_checkout_intent(
-                db,
-                created_by_user_id=user.id,
-                team_name=clean_name,
-                logo_domain=derive_logo_domain_from_email(user.email),
-                idempotency_key=(
-                    f"team-checkout-intent:{user.id}:"
-                    f"{_idempotency_shape_suffix(clean_name, len(normalized_invites))}"
-                ),
-                invite_emails=normalized_invites,
-                expires_at=utcnow() + timedelta(hours=24),
-            )
+        intent_record = await organization_service.ensure_pending_team_checkout_intent(
+            db,
+            cast(organization_service.OrganizationActor, user),
+            team_name=clean_name,
+            logo_domain=derive_logo_domain_from_email(user.email),
+            idempotency_key=(
+                f"team-checkout-intent:{user.id}:"
+                f"{_idempotency_shape_suffix(clean_name, len(normalized_invites))}"
+            ),
+            invite_emails=normalized_invites,
+            expires_at=utcnow() + timedelta(hours=24),
+        )
 
     return await _create_stripe_session_for_team_checkout_intent(
         db,
@@ -272,7 +262,10 @@ async def get_current_team_checkout(
     user: AuthenticatedUser,
 ) -> CurrentTeamCheckoutResponse:
     async with db.begin():
-        record = await get_current_team_checkout_intent(db, user.id)
+        record = await organization_service.get_current_team_checkout_intent(
+            db,
+            cast(organization_service.OrganizationActor, user),
+        )
     return CurrentTeamCheckoutResponse(
         intent=_team_checkout_intent_response(record) if record is not None else None,
     )
@@ -284,10 +277,10 @@ async def cancel_current_team_checkout(
     intent_id: UUID,
 ) -> CurrentTeamCheckoutResponse:
     async with db.begin():
-        record = await cancel_team_checkout_intent(
+        record = await organization_service.cancel_team_checkout_intent(
             db,
-            intent_id=intent_id,
-            created_by_user_id=user.id,
+            cast(organization_service.OrganizationActor, user),
+            intent_id,
         )
     return CurrentTeamCheckoutResponse(
         intent=_team_checkout_intent_response(record) if record is not None else None,

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Protocol
 from uuid import UUID
 
@@ -22,6 +22,8 @@ from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store import organization_member_auth_methods as member_auth_method_store
 from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.organization_records import (
+    CheckoutIntentRecord,
+    CheckoutIntentWithOrganizationRecord,
     InvitationRecord,
     MemberRecord,
     MembershipRecord,
@@ -225,6 +227,67 @@ async def list_organizations(
         user_id=actor_user.id,
         name=_default_organization_name(actor_user),
         logo_domain=derive_logo_domain_from_email(actor_user.email),
+    )
+
+
+async def ensure_pending_team_checkout_intent(
+    db: AsyncSession,
+    actor_user: OrganizationActor,
+    *,
+    team_name: str,
+    logo_domain: str | None,
+    idempotency_key: str,
+    invite_emails: list[str],
+    expires_at: datetime,
+) -> CheckoutIntentWithOrganizationRecord:
+    await organization_store.acquire_membership_activation_lock(db, actor_user.id)
+    current = await organization_store.get_current_team_checkout_intent(db, actor_user.id)
+    if current is not None:
+        return current
+    return await organization_store.create_pending_team_checkout_intent(
+        db,
+        created_by_user_id=actor_user.id,
+        team_name=team_name,
+        logo_domain=logo_domain,
+        idempotency_key=idempotency_key,
+        invite_emails=invite_emails,
+        expires_at=expires_at,
+    )
+
+
+async def get_current_team_checkout_intent(
+    db: AsyncSession,
+    actor_user: OrganizationActor,
+) -> CheckoutIntentWithOrganizationRecord | None:
+    return await organization_store.get_current_team_checkout_intent(db, actor_user.id)
+
+
+async def bind_team_checkout_session(
+    db: AsyncSession,
+    *,
+    intent_id: UUID,
+    stripe_checkout_session_id: str,
+    stripe_customer_id: str,
+    checkout_url: str,
+) -> CheckoutIntentRecord | None:
+    return await organization_store.bind_team_checkout_session(
+        db,
+        intent_id=intent_id,
+        stripe_checkout_session_id=stripe_checkout_session_id,
+        stripe_customer_id=stripe_customer_id,
+        checkout_url=checkout_url,
+    )
+
+
+async def cancel_team_checkout_intent(
+    db: AsyncSession,
+    actor_user: OrganizationActor,
+    intent_id: UUID,
+) -> CheckoutIntentWithOrganizationRecord | None:
+    return await organization_store.cancel_team_checkout_intent(
+        db,
+        intent_id=intent_id,
+        created_by_user_id=actor_user.id,
     )
 
 

--- a/server/tests/unit/test_organization_team_checkout_service.py
+++ b/server/tests/unit/test_organization_team_checkout_service.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.server.organizations import service as organization_service
+
+EXPIRES_AT = datetime(2026, 8, 6, 9, 0, tzinfo=UTC)
+
+
+def _session() -> AsyncSession:
+    return cast(AsyncSession, object())
+
+
+def _actor() -> organization_service.OrganizationActor:
+    return cast(
+        organization_service.OrganizationActor,
+        SimpleNamespace(id=uuid4(), email="owner@example.com", display_name="Owner"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_pending_team_checkout_returns_current_after_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    actor = _actor()
+    expected = object()
+    calls: list[tuple[str, object, object]] = []
+
+    async def _lock(actual_db: AsyncSession, user_id: UUID) -> None:
+        calls.append(("lock", actual_db, user_id))
+
+    async def _current(actual_db: AsyncSession, user_id: UUID) -> object:
+        calls.append(("current", actual_db, user_id))
+        return expected
+
+    async def _unexpected_create(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("an existing checkout intent must be reused")
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "acquire_membership_activation_lock",
+        _lock,
+    )
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "get_current_team_checkout_intent",
+        _current,
+    )
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "create_pending_team_checkout_intent",
+        _unexpected_create,
+    )
+
+    result = await organization_service.ensure_pending_team_checkout_intent(
+        db,
+        actor,
+        team_name="Team",
+        logo_domain="example.com",
+        idempotency_key="intent-key",
+        invite_emails=["invitee@example.com"],
+        expires_at=EXPIRES_AT,
+    )
+
+    assert result is expected
+    assert calls == [
+        ("lock", db, actor.id),
+        ("current", db, actor.id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ensure_pending_team_checkout_creates_after_lock_and_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    actor = _actor()
+    expected = object()
+    calls: list[tuple[str, object]] = []
+
+    async def _lock(actual_db: AsyncSession, user_id: UUID) -> None:
+        calls.append(("lock", (actual_db, user_id)))
+
+    async def _current(actual_db: AsyncSession, user_id: UUID) -> None:
+        calls.append(("current", (actual_db, user_id)))
+        return None
+
+    async def _create(actual_db: AsyncSession, **kwargs: object) -> object:
+        calls.append(("create", {"db": actual_db, **kwargs}))
+        return expected
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "acquire_membership_activation_lock",
+        _lock,
+    )
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "get_current_team_checkout_intent",
+        _current,
+    )
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "create_pending_team_checkout_intent",
+        _create,
+    )
+
+    result = await organization_service.ensure_pending_team_checkout_intent(
+        db,
+        actor,
+        team_name="Team",
+        logo_domain="example.com",
+        idempotency_key="intent-key",
+        invite_emails=["one@example.com", "two@example.com"],
+        expires_at=EXPIRES_AT,
+    )
+
+    assert result is expected
+    assert calls == [
+        ("lock", (db, actor.id)),
+        ("current", (db, actor.id)),
+        (
+            "create",
+            {
+                "db": db,
+                "created_by_user_id": actor.id,
+                "team_name": "Team",
+                "logo_domain": "example.com",
+                "idempotency_key": "intent-key",
+                "invite_emails": ["one@example.com", "two@example.com"],
+                "expires_at": EXPIRES_AT,
+            },
+        ),
+    ]
+
+
+@pytest.mark.parametrize("store_result", [None, object()])
+@pytest.mark.asyncio
+async def test_get_current_team_checkout_intent_forwards_actor(
+    monkeypatch: pytest.MonkeyPatch,
+    store_result: object | None,
+) -> None:
+    db = _session()
+    actor = _actor()
+    calls: list[tuple[AsyncSession, UUID]] = []
+
+    async def _current(actual_db: AsyncSession, user_id: UUID) -> object | None:
+        calls.append((actual_db, user_id))
+        return store_result
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "get_current_team_checkout_intent",
+        _current,
+    )
+
+    result = await organization_service.get_current_team_checkout_intent(db, actor)
+
+    assert result is store_result
+    assert calls == [(db, actor.id)]
+
+
+@pytest.mark.parametrize("store_result", [None, object()])
+@pytest.mark.asyncio
+async def test_bind_team_checkout_session_forwards_every_field(
+    monkeypatch: pytest.MonkeyPatch,
+    store_result: object | None,
+) -> None:
+    db = _session()
+    intent_id = uuid4()
+    calls: list[dict[str, object]] = []
+
+    async def _bind(actual_db: AsyncSession, **kwargs: object) -> object | None:
+        calls.append({"db": actual_db, **kwargs})
+        return store_result
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "bind_team_checkout_session",
+        _bind,
+    )
+
+    result = await organization_service.bind_team_checkout_session(
+        db,
+        intent_id=intent_id,
+        stripe_checkout_session_id="cs_123",
+        stripe_customer_id="cus_123",
+        checkout_url="https://checkout.example/session",
+    )
+
+    assert result is store_result
+    assert calls == [
+        {
+            "db": db,
+            "intent_id": intent_id,
+            "stripe_checkout_session_id": "cs_123",
+            "stripe_customer_id": "cus_123",
+            "checkout_url": "https://checkout.example/session",
+        }
+    ]
+
+
+@pytest.mark.parametrize("store_result", [None, object()])
+@pytest.mark.asyncio
+async def test_cancel_team_checkout_intent_forwards_actor_and_intent(
+    monkeypatch: pytest.MonkeyPatch,
+    store_result: object | None,
+) -> None:
+    db = _session()
+    actor = _actor()
+    intent_id = uuid4()
+    calls: list[dict[str, object]] = []
+
+    async def _cancel(actual_db: AsyncSession, **kwargs: object) -> object | None:
+        calls.append({"db": actual_db, **kwargs})
+        return store_result
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "cancel_team_checkout_intent",
+        _cancel,
+    )
+
+    result = await organization_service.cancel_team_checkout_intent(db, actor, intent_id)
+
+    assert result is store_result
+    assert calls == [
+        {
+            "db": db,
+            "intent_id": intent_id,
+            "created_by_user_id": actor.id,
+        }
+    ]


### PR DESCRIPTION
## Summary

- add public Organizations operations for the pending team-checkout intent lifecycle
- route Billing request-side ensure, read/expiry, Stripe-session bind, and cancel writes through that owner seam
- preserve the existing transaction phases around Stripe network calls and add exact forwarding/order characterization tests

## Proof

- 25 focused unit and Billing integration tests passed
- changed-file Ruff and format checks passed
- mypy passed for both production modules
- server boundaries, max-lines, design attribution, diff, and negative foreign-store census passed
- independent review accepted with no findings

## Scope

This repairs only the request-side intent lifecycle. Stripe webhook activation and staged invitation delivery remain unchanged for the dependent slice. No schema, API, generated source, provider behavior, or transaction collapse.