### PR TITLE
refactor(server): route sandbox observations through cloud

### DIFF
--- a/server/proliferate/server/billing/reconciler.py
+++ b/server/proliferate/server/billing/reconciler.py
@@ -36,11 +36,7 @@ from proliferate.db.store.billing_runtime_usage import (
     try_acquire_billing_reconciler_lock,
 )
 from proliferate.db.store.cloud_sandboxes import (
-    accept_destroyed_cloud_sandbox_provider_observation,
-    advance_cloud_sandbox_provider_observation_floor,
-    apply_cloud_sandbox_provider_observation,
     load_cloud_sandbox_by_id,
-    mark_cloud_sandbox_provider_missing,
 )
 from proliferate.integrations.sandbox import (
     ProviderSandboxState,
@@ -57,13 +53,8 @@ from proliferate.server.billing.runtime_usage import (
     converge_cloud_sandbox_provider_usage,
 )
 from proliferate.server.billing.snapshots import get_billing_snapshot_for_subject
-from proliferate.server.cloud.gateway.service import (
-    invalidate_cloud_sandbox_gateway_access_for_user,
-)
+from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandbox_service
 from proliferate.server.cloud.materialization import locks
-from proliferate.server.cloud.materialization.failures import (
-    PROVIDER_SANDBOX_MISSING_RECEIPT,
-)
 from proliferate.utils.time import utcnow
 
 logger = logging.getLogger("proliferate.billing.reconciler")
@@ -141,42 +132,25 @@ async def _mark_sandbox_environment_unavailable(
     """
     async with db_engine.async_session_factory() as db, db.begin():
         if destroyed:
-            updated = await mark_cloud_sandbox_provider_missing(
+            updated = await cloud_sandbox_service.observe_cloud_sandbox_provider_missing(
                 db,
                 sandbox_id,
                 expected_provider_sandbox_id=expected_provider_sandbox_id,
                 expected_materialization_attempt=expected_materialization_attempt,
                 observed_at=provider_observed_at,
-                last_error=PROVIDER_SANDBOX_MISSING_RECEIPT,
             )
-            if updated is not None and updated.owner_user_id is not None:
-                invalidate_cloud_sandbox_gateway_access_for_user(
-                    updated.owner_user_id,
-                )
         else:
             # Preserve a terminal materialization receipt while still ending
             # exact provider usage for an observed pause/stop.
-            updated = await apply_cloud_sandbox_provider_observation(
+            updated = await cloud_sandbox_service.observe_cloud_sandbox_provider_stopped(
                 db,
                 sandbox_id,
-                status="paused",
                 expected_provider_sandbox_id=expected_provider_sandbox_id,
                 expected_materialization_attempt=expected_materialization_attempt,
                 observed_at=provider_observed_at,
             )
         if updated is None:
-            # Explicit deletion can win after reconciliation loaded the row.
-            # Advance only the exact attempt's provider freshness floor; the
-            # product-owned destroyed state and provider binding stay intact.
-            updated = await accept_destroyed_cloud_sandbox_provider_observation(
-                db,
-                sandbox_id,
-                expected_provider_sandbox_id=expected_provider_sandbox_id,
-                expected_materialization_attempt=expected_materialization_attempt,
-                observed_at=provider_observed_at,
-            )
-            if updated is None:
-                return False
+            return False
         await converge_cloud_sandbox_provider_usage(
             db,
             sandbox_id=sandbox_id,
@@ -202,7 +176,7 @@ async def _record_running_provider_observation(
     observed_at: datetime,
 ) -> None:
     async with db_engine.async_session_factory() as db, db.begin():
-        await advance_cloud_sandbox_provider_observation_floor(
+        await cloud_sandbox_service.observe_cloud_sandbox_provider_running(
             db,
             sandbox_id,
             expected_provider_sandbox_id=expected_provider_sandbox_id,

--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -9,6 +9,7 @@ ORM stack.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Protocol
 from uuid import UUID
 
@@ -117,6 +118,91 @@ async def ensure_personal_cloud_sandbox_exists(
             e2b_template_ref="e2b",
         )
     return sandbox
+
+
+async def observe_cloud_sandbox_provider_running(
+    db: AsyncSession,
+    sandbox_id: UUID,
+    *,
+    expected_provider_sandbox_id: str,
+    expected_materialization_attempt: int,
+    observed_at: datetime,
+) -> CloudSandboxValue | None:
+    return await sandbox_store.advance_cloud_sandbox_provider_observation_floor(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id=expected_provider_sandbox_id,
+        expected_materialization_attempt=expected_materialization_attempt,
+        observed_at=observed_at,
+    )
+
+
+async def observe_cloud_sandbox_provider_stopped(
+    db: AsyncSession,
+    sandbox_id: UUID,
+    *,
+    expected_provider_sandbox_id: str,
+    expected_materialization_attempt: int,
+    observed_at: datetime,
+) -> CloudSandboxValue | None:
+    updated = await sandbox_store.apply_cloud_sandbox_provider_observation(
+        db,
+        sandbox_id,
+        status="paused",
+        expected_provider_sandbox_id=expected_provider_sandbox_id,
+        expected_materialization_attempt=expected_materialization_attempt,
+        observed_at=observed_at,
+    )
+    if updated is not None:
+        return updated
+    return await sandbox_store.accept_destroyed_cloud_sandbox_provider_observation(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id=expected_provider_sandbox_id,
+        expected_materialization_attempt=expected_materialization_attempt,
+        observed_at=observed_at,
+    )
+
+
+async def observe_cloud_sandbox_provider_missing(
+    db: AsyncSession,
+    sandbox_id: UUID,
+    *,
+    expected_provider_sandbox_id: str,
+    expected_materialization_attempt: int,
+    observed_at: datetime,
+) -> CloudSandboxValue | None:
+    # Imported lazily because materialization failures invalidate gateway
+    # access, while the gateway service imports this module.
+    from proliferate.server.cloud.materialization.failures import (
+        PROVIDER_SANDBOX_MISSING_RECEIPT,
+    )
+
+    updated = await sandbox_store.mark_cloud_sandbox_provider_missing(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id=expected_provider_sandbox_id,
+        expected_materialization_attempt=expected_materialization_attempt,
+        observed_at=observed_at,
+        last_error=PROVIDER_SANDBOX_MISSING_RECEIPT,
+    )
+    if updated is not None:
+        if updated.owner_user_id is not None:
+            # Imported lazily to avoid the gateway -> cloud-sandbox service
+            # dependency becoming a module cycle.
+            from proliferate.server.cloud.gateway.service import (
+                invalidate_cloud_sandbox_gateway_access_for_user,
+            )
+
+            invalidate_cloud_sandbox_gateway_access_for_user(updated.owner_user_id)
+        return updated
+    return await sandbox_store.accept_destroyed_cloud_sandbox_provider_observation(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id=expected_provider_sandbox_id,
+        expected_materialization_attempt=expected_materialization_attempt,
+        observed_at=observed_at,
+    )
 
 
 async def destroy_cloud_sandbox(

--- a/server/tests/unit/test_cloud_sandbox_provider_observations.py
+++ b/server/tests/unit/test_cloud_sandbox_provider_observations.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.server.cloud.cloud_sandboxes import service as cloud_sandbox_service
+from proliferate.server.cloud.gateway import service as gateway_service
+from proliferate.server.cloud.materialization.failures import (
+    PROVIDER_SANDBOX_MISSING_RECEIPT,
+)
+
+NOW = datetime(2026, 8, 5, 8, 0, tzinfo=UTC)
+
+
+def _session() -> AsyncSession:
+    return cast(AsyncSession, object())
+
+
+def _expected_call(
+    db: AsyncSession,
+    sandbox_id: UUID,
+    *,
+    include_status: bool = False,
+) -> dict[str, object]:
+    call: dict[str, object] = {
+        "db": db,
+        "sandbox_id": sandbox_id,
+        "expected_provider_sandbox_id": "provider-1",
+        "expected_materialization_attempt": 7,
+        "observed_at": NOW,
+    }
+    if include_status:
+        call["status"] = "paused"
+    return call
+
+
+@pytest.mark.asyncio
+async def test_running_observation_forwards_exact_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    sandbox_id = uuid4()
+    expected = SimpleNamespace(id=sandbox_id)
+    calls: list[dict[str, object]] = []
+
+    async def _advance(
+        actual_db: AsyncSession,
+        actual_sandbox_id: UUID,
+        **kwargs: object,
+    ) -> object:
+        calls.append({"db": actual_db, "sandbox_id": actual_sandbox_id, **kwargs})
+        return expected
+
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "advance_cloud_sandbox_provider_observation_floor",
+        _advance,
+    )
+
+    result = await cloud_sandbox_service.observe_cloud_sandbox_provider_running(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id="provider-1",
+        expected_materialization_attempt=7,
+        observed_at=NOW,
+    )
+
+    assert result is expected
+    assert calls == [_expected_call(db, sandbox_id)]
+
+
+@pytest.mark.asyncio
+async def test_stopped_observation_returns_primary_without_destroyed_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    sandbox_id = uuid4()
+    expected = SimpleNamespace(id=sandbox_id)
+    calls: list[dict[str, object]] = []
+
+    async def _apply(
+        actual_db: AsyncSession,
+        actual_sandbox_id: UUID,
+        **kwargs: object,
+    ) -> object:
+        calls.append({"db": actual_db, "sandbox_id": actual_sandbox_id, **kwargs})
+        return expected
+
+    async def _unexpected(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("primary stopped observation must not use fallback")
+
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "apply_cloud_sandbox_provider_observation",
+        _apply,
+    )
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "accept_destroyed_cloud_sandbox_provider_observation",
+        _unexpected,
+    )
+
+    result = await cloud_sandbox_service.observe_cloud_sandbox_provider_stopped(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id="provider-1",
+        expected_materialization_attempt=7,
+        observed_at=NOW,
+    )
+
+    assert result is expected
+    assert calls == [_expected_call(db, sandbox_id, include_status=True)]
+
+
+@pytest.mark.parametrize("fallback_succeeds", [True, False])
+@pytest.mark.asyncio
+async def test_stopped_observation_falls_back_only_for_destroyed_state(
+    monkeypatch: pytest.MonkeyPatch,
+    fallback_succeeds: bool,
+) -> None:
+    db = _session()
+    sandbox_id = uuid4()
+    expected = SimpleNamespace(id=sandbox_id) if fallback_succeeds else None
+    fallback_calls: list[dict[str, object]] = []
+
+    async def _reject(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def _accept(
+        actual_db: AsyncSession,
+        actual_sandbox_id: UUID,
+        **kwargs: object,
+    ) -> object | None:
+        fallback_calls.append({"db": actual_db, "sandbox_id": actual_sandbox_id, **kwargs})
+        return expected
+
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "apply_cloud_sandbox_provider_observation",
+        _reject,
+    )
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "accept_destroyed_cloud_sandbox_provider_observation",
+        _accept,
+    )
+
+    result = await cloud_sandbox_service.observe_cloud_sandbox_provider_stopped(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id="provider-1",
+        expected_materialization_attempt=7,
+        observed_at=NOW,
+    )
+
+    assert result is expected
+    assert fallback_calls == [_expected_call(db, sandbox_id)]
+
+
+@pytest.mark.asyncio
+async def test_missing_observation_invalidates_exact_returned_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    sandbox_id = uuid4()
+    owner_user_id = uuid4()
+    expected = SimpleNamespace(id=sandbox_id, owner_user_id=owner_user_id)
+    missing_calls: list[dict[str, object]] = []
+    invalidated: list[UUID] = []
+
+    async def _mark_missing(
+        actual_db: AsyncSession,
+        actual_sandbox_id: UUID,
+        **kwargs: object,
+    ) -> object:
+        missing_calls.append({"db": actual_db, "sandbox_id": actual_sandbox_id, **kwargs})
+        return expected
+
+    async def _unexpected(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("primary missing observation must not use fallback")
+
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "mark_cloud_sandbox_provider_missing",
+        _mark_missing,
+    )
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "accept_destroyed_cloud_sandbox_provider_observation",
+        _unexpected,
+    )
+    monkeypatch.setattr(
+        gateway_service,
+        "invalidate_cloud_sandbox_gateway_access_for_user",
+        invalidated.append,
+    )
+
+    result = await cloud_sandbox_service.observe_cloud_sandbox_provider_missing(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id="provider-1",
+        expected_materialization_attempt=7,
+        observed_at=NOW,
+    )
+
+    assert result is expected
+    assert missing_calls == [
+        {
+            **_expected_call(db, sandbox_id),
+            "last_error": PROVIDER_SANDBOX_MISSING_RECEIPT,
+        }
+    ]
+    assert invalidated == [owner_user_id]
+
+
+@pytest.mark.parametrize("fallback_succeeds", [True, False])
+@pytest.mark.asyncio
+async def test_missing_observation_destroyed_fallback_never_invalidates_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+    fallback_succeeds: bool,
+) -> None:
+    db = _session()
+    sandbox_id = uuid4()
+    expected = SimpleNamespace(id=sandbox_id, owner_user_id=uuid4()) if fallback_succeeds else None
+    fallback_calls: list[dict[str, object]] = []
+
+    async def _reject(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def _accept(
+        actual_db: AsyncSession,
+        actual_sandbox_id: UUID,
+        **kwargs: object,
+    ) -> object | None:
+        fallback_calls.append({"db": actual_db, "sandbox_id": actual_sandbox_id, **kwargs})
+        return expected
+
+    def _unexpected(_owner_user_id: UUID) -> None:
+        raise AssertionError("destroyed fallback must not invalidate gateway access")
+
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "mark_cloud_sandbox_provider_missing",
+        _reject,
+    )
+    monkeypatch.setattr(
+        cloud_sandbox_service.sandbox_store,
+        "accept_destroyed_cloud_sandbox_provider_observation",
+        _accept,
+    )
+    monkeypatch.setattr(
+        gateway_service,
+        "invalidate_cloud_sandbox_gateway_access_for_user",
+        _unexpected,
+    )
+
+    result = await cloud_sandbox_service.observe_cloud_sandbox_provider_missing(
+        db,
+        sandbox_id,
+        expected_provider_sandbox_id="provider-1",
+        expected_materialization_attempt=7,
+        observed_at=NOW,
+    )
+
+    assert result is expected
+    assert fallback_calls == [_expected_call(db, sandbox_id)]


### PR DESCRIPTION
## Summary

- add public Cloud-sandbox operations for running, stopped, and missing provider observations
- replace Billing reconciler foreign Cloud-store writes with those owner operations while retaining the legal direct read
- preserve destroyed-state fallback, owner gateway invalidation, exact provider fencing, and atomic Billing usage close

## Proof

- 34 focused unit and real-Postgres integration tests passed
- changed-file Ruff and format checks passed
- frozen-base mypy diagnostic parity passed with no new diagnostic
- server boundaries, max-lines, design attribution, diff, and negative AST census passed
- independent review accepted after closing SG14-B01 import-cycle repair

## Scope

Ownership only. No provider calls, sandbox states, Billing segments, locks, transaction boundaries, loop scheduling, schema, API, or generated source changed.

## Integration and landing

- After #1628 lands, rebase this branch onto updated `main`.
- Reconcile `server/proliferate/server/billing/reconciler.py` so `utcnow` remains imported from the direct `proliferate.lib.infra.time.wall_clock` leaf.
- Preserve the cycle-safe lazy provider-receipt import and do not reintroduce the stale top-level provider-receipt constant.
- Rerun the complete frozen proof after reconciliation and before landing.

