### PR TITLE
refactor(server): route SSO invitation acceptance through organizations

### DIFF
--- a/server/proliferate/auth/sso/user_resolution.py
+++ b/server/proliferate/auth/sso/user_resolution.py
@@ -164,6 +164,9 @@ async def _resolve_organization_sso_user(
     if membership is not None:
         return user
     if has_pending_invitation:
+        # Invitation acceptance mutates Organization-owned records, so Auth calls
+        # its public service: it owns locking, membership, billing, and enrollment.
+        # The dependency remains Auth -> Organizations; the owner never imports this resolver.
         accepted = await organization_service.try_accept_invitation(
             db,
             user,

--- a/server/proliferate/auth/sso/user_resolution.py
+++ b/server/proliferate/auth/sso/user_resolution.py
@@ -33,6 +33,7 @@ from proliferate.server.billing.seat_reconciliation import (
     maybe_create_organization_seat_adjustment,
 )
 from proliferate.server.cloud.agent_gateway import signup_hook
+from proliferate.server.organizations import service as organization_service
 from proliferate.server.organizations.admin_emails import ensure_admin_email_role
 from proliferate.server.organizations.membership_policy import (
     ensure_instance_membership_not_removed,
@@ -60,6 +61,7 @@ async def _resolve_sso_user(
     verified: VerifiedSsoIdentity,
 ) -> User:
     _require_verified_allowed_email(connection=connection, verified=verified)
+    assert verified.email is not None
     existing_identity = await sso_store.get_sso_identity_by_connection_subject(
         db,
         connection_key=connection.connection_key,
@@ -162,21 +164,13 @@ async def _resolve_organization_sso_user(
     if membership is not None:
         return user
     if has_pending_invitation:
-        accepted, _error = await invitation_store.accept_pending_invitation_for_organization_email(
+        accepted = await organization_service.try_accept_invitation(
             db,
+            user,
             organization_id=connection.organization_id,
-            authenticated_user_id=user.id,
             authenticated_email=verified.email or "",
         )
         if accepted is not None:
-            await maybe_create_organization_seat_adjustment(
-                db,
-                organization_id=accepted.organization.id,
-                membership_id=accepted.membership.id,
-            )
-            signup_hook.schedule_agent_gateway_org_enrollment(
-                accepted.organization.id, user.id, db=db
-            )
             return user
     if connection.jit_policy != SsoJitPolicy.CREATE_MEMBER:
         raise HTTPException(status_code=403, detail="SSO user is not a team member.")

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -536,31 +536,67 @@ async def create_organization_join_landing(
     return build_join_landing_html(organization.name, organization.id)
 
 
-async def accept_invitation(
+async def _accept_invitation_for_organization(
     db: AsyncSession,
     actor_user: OrganizationActor,
     *,
     organization_id: UUID,
-) -> OrganizationWithMembershipRecord:
+    authenticated_email: str,
+) -> tuple[OrganizationWithMembershipRecord | None, str | None]:
     accepted, error = await invitation_store.accept_pending_invitation_for_organization_email(
         db,
         organization_id=organization_id,
         authenticated_user_id=actor_user.id,
-        authenticated_email=actor_user.email,
+        authenticated_email=authenticated_email,
     )
     if accepted is None:
-        accept_error = _build_invitation_accept_error(error)
-        raise accept_error
+        return None, error
     await maybe_create_organization_seat_adjustment(
         db,
         organization_id=accepted.organization.id,
         membership_id=accepted.membership.id,
     )
     schedule_agent_gateway_org_enrollment(accepted.organization.id, actor_user.id, db=db)
-    return OrganizationWithMembershipRecord(
-        organization=accepted.organization,
-        membership=accepted.membership,
+    return (
+        OrganizationWithMembershipRecord(
+            organization=accepted.organization,
+            membership=accepted.membership,
+        ),
+        error,
     )
+
+
+async def try_accept_invitation(
+    db: AsyncSession,
+    actor_user: OrganizationActor,
+    *,
+    organization_id: UUID,
+    authenticated_email: str,
+) -> OrganizationWithMembershipRecord | None:
+    accepted, _error = await _accept_invitation_for_organization(
+        db,
+        actor_user,
+        organization_id=organization_id,
+        authenticated_email=authenticated_email,
+    )
+    return accepted
+
+
+async def accept_invitation(
+    db: AsyncSession,
+    actor_user: OrganizationActor,
+    *,
+    organization_id: UUID,
+) -> OrganizationWithMembershipRecord:
+    accepted, error = await _accept_invitation_for_organization(
+        db,
+        actor_user,
+        organization_id=organization_id,
+        authenticated_email=actor_user.email,
+    )
+    if accepted is None:
+        raise _build_invitation_accept_error(error)
+    return accepted
 
 
 def _build_invitation_accept_error(

--- a/server/tests/unit/auth/test_sso_service_security.py
+++ b/server/tests/unit/auth/test_sso_service_security.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -23,7 +24,7 @@ from proliferate.auth.sso.types import (
     VerifiedSsoIdentity,
 )
 from proliferate.db.models.auth import User
-from proliferate.db.store.auth_sso_records import SsoConnectionRecord, SsoIdentityRecord
+from proliferate.db.store.auth_sso_records import SsoConnectionRecord
 
 
 @pytest.mark.asyncio
@@ -105,82 +106,81 @@ async def test_discover_sso_finds_org_connection_with_explicit_org_context(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("verified_email", "has_pending_invitation"),
+    [
+        ("person@example.com", False),
+        ("new-person@example.com", True),
+    ],
+)
 async def test_resolve_sso_user_rechecks_org_membership_for_existing_identity(
     monkeypatch: pytest.MonkeyPatch,
+    verified_email: str,
+    has_pending_invitation: bool,
 ) -> None:
     target_organization_id = uuid4()
     connection_id = uuid4()
     user_id = uuid4()
-    now = datetime.now(UTC)
-    attach_called = False
-
-    async def fake_get_sso_identity_by_connection_subject(
-        *_args: object,
-        **_kwargs: object,
-    ) -> SsoIdentityRecord:
-        return SsoIdentityRecord(
-            id=uuid4(),
-            user_id=user_id,
-            organization_id=target_organization_id,
-            connection_id=connection_id,
-            connection_key=f"organization:{connection_id}",
-            protocol=SsoProtocol.OIDC.value,
-            provider_subject="subject-1",
-            email="person@example.com",
-            email_verified=True,
-            display_name="Person Example",
-            linked_at=now,
-            last_login_at=now,
-        )
-
-    async def fake_get_user_by_id(_db: AsyncSession, _user_id: object) -> User:
-        return _user(user_id=user_id, email="person@example.com")
-
-    async def fake_get_active_membership(*_args: object, **_kwargs: object) -> None:
-        return None
-
-    async def fake_attach_sso_identity(*_args: object, **_kwargs: object) -> None:
-        nonlocal attach_called
-        attach_called = True
+    user = _user(user_id=user_id, email="person@example.com")
+    db = cast(AsyncSession, object())
+    try_accept = AsyncMock(return_value=SimpleNamespace() if has_pending_invitation else None)
+    attach_identity = AsyncMock()
 
     monkeypatch.setattr(
         sso_service.sso_store,
         "get_sso_identity_by_connection_subject",
-        fake_get_sso_identity_by_connection_subject,
+        AsyncMock(return_value=SimpleNamespace(user_id=user_id)),
     )
-    monkeypatch.setattr(sso_user_resolution, "get_user_by_id", fake_get_user_by_id)
+    monkeypatch.setattr(sso_user_resolution, "get_user_by_id", AsyncMock(return_value=user))
     monkeypatch.setattr(
         sso_user_resolution.organization_store,
         "get_active_membership",
-        fake_get_active_membership,
+        AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
         sso_user_resolution.invitation_store,
         "has_live_pending_invitation_for_organization_email",
-        _false_pending_invitation,
+        AsyncMock(return_value=has_pending_invitation),
     )
-    monkeypatch.setattr(sso_user_resolution, "_attach_sso_identity", fake_attach_sso_identity)
+    monkeypatch.setattr(
+        sso_user_resolution.organization_service,
+        "try_accept_invitation",
+        try_accept,
+    )
+    monkeypatch.setattr(sso_user_resolution, "_attach_sso_identity", attach_identity)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await sso_service.resolve_sso_user(
-            cast(AsyncSession, object()),
-            connection=_organization_connection(
-                connection_id=connection_id,
-                organization_id=target_organization_id,
-                jit_policy=SsoJitPolicy.EXISTING_USER,
-            ),
-            verified=VerifiedSsoIdentity(
-                provider_subject="subject-1",
-                email="person@example.com",
-                email_verified=True,
-                display_name="Person Example",
-                avatar_url=None,
-                claims={},
-            ),
-        )
+    resolution = sso_service.resolve_sso_user(
+        db,
+        connection=_organization_connection(
+            connection_id=connection_id,
+            organization_id=target_organization_id,
+            jit_policy=SsoJitPolicy.EXISTING_USER,
+        ),
+        verified=VerifiedSsoIdentity(
+            provider_subject="subject-1",
+            email=verified_email,
+            email_verified=True,
+            display_name="Person Example",
+            avatar_url=None,
+            claims={},
+        ),
+    )
 
-    assert exc_info.value.status_code == 403
-    assert attach_called is False
+    if not has_pending_invitation:
+        with pytest.raises(HTTPException) as exc_info:
+            await resolution
+        assert exc_info.value.status_code == 403
+        attach_identity.assert_not_awaited()
+        return
+
+    assert await resolution is user
+    try_accept.assert_awaited_once_with(
+        db,
+        user,
+        organization_id=target_organization_id,
+        authenticated_email=verified_email,
+    )
+    attach_identity.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -307,21 +307,12 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
 ) -> None:
     target_organization_id = uuid4()
     connection_id = uuid4()
-    membership_id = uuid4()
     user = _user(user_id=uuid4(), email="person@example.com")
-    ensured_user_ids: list[object] = []
-    seat_adjustments: list[tuple[object, object]] = []
-
-    async def fake_get_sso_identity_by_connection_subject(
-        *_args: object,
-        **_kwargs: object,
-    ) -> None:
-        return None
-
-    async def fake_get_user_by_email(*_args: object, **_kwargs: object) -> None:
-        return None
+    db = cast(AsyncSession, object())
+    events: list[str] = []
 
     async def fake_create_auth_user(*_args: object, **_kwargs: object) -> User:
+        events.append("create_user")
         return user
 
     async def fake_place_new_identity(
@@ -330,7 +321,10 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
         *,
         default_role: str | None = None,
     ) -> None:
-        ensured_user_ids.append(ensured_user.id)
+        assert _db is db
+        assert ensured_user is user
+        assert default_role == "member"
+        events.append("place_user")
 
     async def fake_has_pending_invitation(
         _db: AsyncSession,
@@ -342,35 +336,27 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
         assert email == "person@example.com"
         return True
 
-    async def fake_get_active_membership(*_args: object, **_kwargs: object) -> None:
-        return None
-
-    async def fake_accept_pending_invitation(*_args: object, **_kwargs: object):
-        return (
-            SimpleNamespace(
-                organization=SimpleNamespace(id=target_organization_id),
-                membership=SimpleNamespace(id=membership_id),
-            ),
-            None,
-        )
-
-    async def fake_maybe_create_organization_seat_adjustment(
-        _db: AsyncSession,
+    async def fake_try_accept_invitation(
+        call_db: AsyncSession,
+        actor_user: User,
         *,
         organization_id: object,
-        membership_id: object,
-    ) -> None:
-        seat_adjustments.append((organization_id, membership_id))
-
-    async def fake_attach_sso_identity(*_args: object, **_kwargs: object) -> None:
-        return None
+        authenticated_email: str,
+    ) -> SimpleNamespace:
+        assert call_db is db
+        assert actor_user is user
+        assert organization_id == target_organization_id
+        assert authenticated_email == "person@example.com"
+        assert events == ["create_user", "place_user"]
+        events.append("accept_invitation")
+        return SimpleNamespace()
 
     monkeypatch.setattr(
         sso_service.sso_store,
         "get_sso_identity_by_connection_subject",
-        fake_get_sso_identity_by_connection_subject,
+        AsyncMock(return_value=None),
     )
-    monkeypatch.setattr(sso_user_resolution, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(sso_user_resolution, "get_user_by_email", AsyncMock(return_value=None))
     monkeypatch.setattr(sso_user_resolution, "create_auth_user", fake_create_auth_user)
     monkeypatch.setattr(
         sso_user_resolution,
@@ -385,22 +371,17 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
     monkeypatch.setattr(
         sso_user_resolution.organization_store,
         "get_active_membership",
-        fake_get_active_membership,
+        AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        sso_user_resolution.invitation_store,
-        "accept_pending_invitation_for_organization_email",
-        fake_accept_pending_invitation,
+        sso_user_resolution.organization_service,
+        "try_accept_invitation",
+        fake_try_accept_invitation,
     )
-    monkeypatch.setattr(
-        sso_user_resolution,
-        "maybe_create_organization_seat_adjustment",
-        fake_maybe_create_organization_seat_adjustment,
-    )
-    monkeypatch.setattr(sso_user_resolution, "_attach_sso_identity", fake_attach_sso_identity)
+    monkeypatch.setattr(sso_user_resolution, "_attach_sso_identity", AsyncMock())
 
     resolved = await sso_service.resolve_sso_user(
-        cast(AsyncSession, object()),
+        db,
         connection=_organization_connection(
             connection_id=connection_id,
             organization_id=target_organization_id,
@@ -417,8 +398,93 @@ async def test_resolve_sso_user_accepts_pending_org_invitation_when_jit_disabled
     )
 
     assert resolved is user
-    assert ensured_user_ids == [user.id]
-    assert seat_adjustments == [(target_organization_id, membership_id)]
+    assert events == ["create_user", "place_user", "accept_invitation"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_sso_user_falls_back_to_jit_after_invitation_acceptance_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_organization_id = uuid4()
+    connection_id = uuid4()
+    user = _user(user_id=uuid4(), email="person@example.com")
+    db = cast(AsyncSession, object())
+    try_accept = AsyncMock(return_value=None)
+    ensure_membership = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+
+    monkeypatch.setattr(
+        sso_service.sso_store,
+        "get_sso_identity_by_connection_subject",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(sso_user_resolution, "get_user_by_email", AsyncMock(return_value=user))
+    monkeypatch.setattr(
+        sso_user_resolution.invitation_store,
+        "has_live_pending_invitation_for_organization_email",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        sso_user_resolution.organization_store,
+        "get_active_membership",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        sso_user_resolution.organization_service,
+        "try_accept_invitation",
+        try_accept,
+    )
+    monkeypatch.setattr(
+        sso_user_resolution,
+        "ensure_instance_membership_not_removed",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        sso_user_resolution.sso_store,
+        "ensure_sso_organization_membership",
+        ensure_membership,
+    )
+    monkeypatch.setattr(
+        sso_user_resolution,
+        "maybe_create_organization_seat_adjustment",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        sso_user_resolution.signup_hook,
+        "schedule_agent_gateway_org_enrollment",
+        Mock(),
+    )
+    monkeypatch.setattr(sso_user_resolution, "_attach_sso_identity", AsyncMock())
+
+    resolved = await sso_service.resolve_sso_user(
+        db,
+        connection=_organization_connection(
+            connection_id=connection_id,
+            organization_id=target_organization_id,
+            jit_policy=SsoJitPolicy.CREATE_MEMBER,
+        ),
+        verified=VerifiedSsoIdentity(
+            provider_subject="subject-1",
+            email=user.email,
+            email_verified=True,
+            display_name="Person Example",
+            avatar_url=None,
+            claims={},
+        ),
+    )
+
+    assert resolved is user
+    try_accept.assert_awaited_once_with(
+        db,
+        user,
+        organization_id=target_organization_id,
+        authenticated_email=user.email,
+    )
+    ensure_membership.assert_awaited_once_with(
+        db,
+        organization_id=target_organization_id,
+        user_id=user.id,
+        role="member",
+    )
 
 
 async def _false_pending_invitation(*_args: object, **_kwargs: object) -> bool:

--- a/server/tests/unit/test_organization_invitation_service.py
+++ b/server/tests/unit/test_organization_invitation_service.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.organization_records import (
+    InvitationAcceptRecord,
+    MembershipRecord,
+    OrganizationRecord,
+    OrganizationWithMembershipRecord,
+)
+from proliferate.server.organizations import service as organization_service
+from proliferate.server.organizations.errors import OrganizationServiceError
+
+
+def _accepted_record(
+    *,
+    organization_id: UUID,
+    membership_id: UUID,
+    user_id: UUID,
+) -> InvitationAcceptRecord:
+    now = datetime.now(UTC)
+    return InvitationAcceptRecord(
+        organization=OrganizationRecord(
+            id=organization_id,
+            name="Acme",
+            slug="acme",
+            logo_domain=None,
+            logo_image=None,
+            status="active",
+            is_instance=False,
+            created_at=now,
+            updated_at=now,
+        ),
+        membership=MembershipRecord(
+            id=membership_id,
+            organization_id=organization_id,
+            user_id=user_id,
+            role="member",
+            status="active",
+            joined_at=now,
+            removed_at=None,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_try_accept_invitation_runs_owner_followups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = cast(AsyncSession, object())
+    organization_id = uuid4()
+    user_id = uuid4()
+    membership_id = uuid4()
+    actor_user = SimpleNamespace(
+        id=user_id,
+        email="old-person@example.com",
+        display_name="Person Example",
+    )
+    authenticated_email = "New-Person@Example.com"
+    accepted = _accepted_record(
+        organization_id=organization_id,
+        membership_id=membership_id,
+        user_id=user_id,
+    )
+    events: list[str] = []
+
+    async def fake_accept_pending_invitation(
+        call_db: AsyncSession,
+        *,
+        organization_id: UUID,
+        authenticated_user_id: UUID,
+        authenticated_email: str,
+    ) -> tuple[InvitationAcceptRecord, None]:
+        assert call_db is db
+        assert organization_id == accepted.organization.id
+        assert authenticated_user_id == actor_user.id
+        assert authenticated_email == expected_authenticated_email
+        events.append("accept")
+        return accepted, None
+
+    async def fake_maybe_create_organization_seat_adjustment(
+        call_db: AsyncSession,
+        *,
+        organization_id: UUID,
+        membership_id: UUID,
+    ) -> None:
+        assert call_db is db
+        assert organization_id == accepted.organization.id
+        assert membership_id == accepted.membership.id
+        events.append("seat")
+
+    def fake_schedule_agent_gateway_org_enrollment(
+        scheduled_organization_id: UUID,
+        scheduled_user_id: UUID,
+        *,
+        db: AsyncSession,
+    ) -> None:
+        assert scheduled_organization_id == accepted.organization.id
+        assert scheduled_user_id == actor_user.id
+        assert db is expected_db
+        events.append("enrollment")
+
+    expected_db = db
+    expected_authenticated_email = authenticated_email
+    monkeypatch.setattr(
+        organization_service.invitation_store,
+        "accept_pending_invitation_for_organization_email",
+        fake_accept_pending_invitation,
+    )
+    monkeypatch.setattr(
+        organization_service,
+        "maybe_create_organization_seat_adjustment",
+        fake_maybe_create_organization_seat_adjustment,
+    )
+    monkeypatch.setattr(
+        organization_service,
+        "schedule_agent_gateway_org_enrollment",
+        fake_schedule_agent_gateway_org_enrollment,
+    )
+
+    result = await organization_service.try_accept_invitation(
+        db,
+        actor_user,
+        organization_id=organization_id,
+        authenticated_email=authenticated_email,
+    )
+
+    assert result == OrganizationWithMembershipRecord(
+        organization=accepted.organization,
+        membership=accepted.membership,
+    )
+    assert events == ["accept", "seat", "enrollment"]
+
+
+@pytest.mark.asyncio
+async def test_try_accept_invitation_returns_none_without_followups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = cast(AsyncSession, object())
+    organization_id = uuid4()
+    user_id = uuid4()
+    actor_user = SimpleNamespace(id=user_id, email="person@example.com", display_name=None)
+    authenticated_email = "verified-person@example.com"
+    store_calls = 0
+
+    async def fake_accept_pending_invitation(
+        call_db: AsyncSession,
+        *,
+        organization_id: UUID,
+        authenticated_user_id: UUID,
+        authenticated_email: str,
+    ) -> tuple[None, str]:
+        nonlocal store_calls
+        assert call_db is db
+        assert organization_id == expected_organization_id
+        assert authenticated_user_id == actor_user.id
+        assert authenticated_email == expected_authenticated_email
+        store_calls += 1
+        return None, "invalid_invitation"
+
+    async def fail_seat_adjustment(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("seat adjustment must not run after rejection")
+
+    def fail_enrollment(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("enrollment must not run after rejection")
+
+    expected_organization_id = organization_id
+    expected_authenticated_email = authenticated_email
+    monkeypatch.setattr(
+        organization_service.invitation_store,
+        "accept_pending_invitation_for_organization_email",
+        fake_accept_pending_invitation,
+    )
+    monkeypatch.setattr(
+        organization_service,
+        "maybe_create_organization_seat_adjustment",
+        fail_seat_adjustment,
+    )
+    monkeypatch.setattr(
+        organization_service,
+        "schedule_agent_gateway_org_enrollment",
+        fail_enrollment,
+    )
+
+    result = await organization_service.try_accept_invitation(
+        db,
+        actor_user,
+        organization_id=organization_id,
+        authenticated_email=authenticated_email,
+    )
+
+    assert result is None
+    assert store_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_translates_store_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = cast(AsyncSession, object())
+    organization_id = uuid4()
+    actor_user = SimpleNamespace(
+        id=uuid4(),
+        email="person@example.com",
+        display_name=None,
+    )
+
+    async def fake_accept_pending_invitation(
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[None, str]:
+        return None, "invitation_email_mismatch"
+
+    monkeypatch.setattr(
+        organization_service.invitation_store,
+        "accept_pending_invitation_for_organization_email",
+        fake_accept_pending_invitation,
+    )
+
+    with pytest.raises(OrganizationServiceError) as exc_info:
+        await organization_service.accept_invitation(
+            db,
+            actor_user,
+            organization_id=organization_id,
+        )
+
+    assert exc_info.value.code == "invitation_email_mismatch"
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.message == "This invitation was sent to a different email address."
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_uses_shared_owner_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = cast(AsyncSession, object())
+    organization_id = uuid4()
+    user_id = uuid4()
+    actor_user = SimpleNamespace(id=user_id, email="person@example.com", display_name=None)
+    accepted = _accepted_record(
+        organization_id=organization_id,
+        membership_id=uuid4(),
+        user_id=user_id,
+    )
+    expected = OrganizationWithMembershipRecord(
+        organization=accepted.organization,
+        membership=accepted.membership,
+    )
+    calls = 0
+
+    async def fake_shared_owner_path(
+        call_db: AsyncSession,
+        call_actor_user: object,
+        *,
+        organization_id: UUID,
+        authenticated_email: str,
+    ) -> tuple[OrganizationWithMembershipRecord, None]:
+        nonlocal calls
+        assert call_db is db
+        assert call_actor_user is actor_user
+        assert organization_id == expected.organization.id
+        assert authenticated_email == actor_user.email
+        calls += 1
+        return expected, None
+
+    monkeypatch.setattr(
+        organization_service,
+        "_accept_invitation_for_organization",
+        fake_shared_owner_path,
+    )
+
+    result = await organization_service.accept_invitation(
+        db,
+        actor_user,
+        organization_id=organization_id,
+    )
+
+    assert result is expected
+    assert calls == 1


### PR DESCRIPTION
## Summary

- add a public Organizations operation for conditional invitation acceptance and its owned seat/enrollment followups
- remove the direct invitation-store write from SSO resolution while preserving the separate JIT membership path
- pass the verified identity-provider email through the acceptance seam so linked identities remain correct when the local account email differs

## Proof

- 22 focused SSO, Organizations, and invitation tests passed
- changed-file Ruff and format checks passed
- mypy passed for both production modules
- server boundaries, max-lines, design attribution, diff, and negative foreign-write census passed
- independent review accepted with no findings

## Scope

Ownership only. No SSO verification, JIT membership, Billing-seat, gateway-enrollment, transaction, API, schema, or generated-source behavior changed.

## Review repair update (2026-08-05)

- Frozen specification: Server Grid 13 revision 4, SHA256 `b65eca75526e0881a076970d6006fea24cab2c8833f4d3156e1d71397ca07037`.
- Repair head: `94756a4eb3a3a3247bad749c962c7cd57624a0d3`.
- The accepted ownership note is now at the call boundary: Auth calls Organizations because that owner holds the invitation mutation, locking, seat adjustment, and enrollment follow-up, and Organizations does not import the resolver.
- Disclosure: the added `assert verified.email is not None` narrows the pre-existing optional email type after `_require_verified_allowed_email` rejects missing email. It resolves the existing-identity and create-user base type errors without changing runtime control flow and follows the repository's existing assertion-narrowing pattern. Mypy is not a required gate for this slice.
- The remaining cosmetic/process observations required no source change.
- Changed-file Ruff, format, compilation, and diff checks passed. This remains a draft. Independent re-review: ACCEPT with no findings. GitHub CI for the repair head is terminal green.
