### PR TITLE
refactor(server): move encryption into infrastructure ownership

### DIFF
--- a/server/alembic/versions/f7a8b9c0d1e2_auth_identity_model.py
+++ b/server/alembic/versions/f7a8b9c0d1e2_auth_identity_model.py
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 
 from alembic import op
 from proliferate.config import settings
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 
 # revision identifiers, used by Alembic.
 revision: str = "f7a8b9c0d1e2"

--- a/server/alembic/versions/f8a9b0c1d2e3_auth_identity_multiple_provider_accounts.py
+++ b/server/alembic/versions/f8a9b0c1d2e3_auth_identity_multiple_provider_accounts.py
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 
 from alembic import op
 from proliferate.config import settings
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 
 # revision identifiers, used by Alembic.
 revision: str = "f8a9b0c1d2e3"

--- a/server/proliferate/auth/identity/store.py
+++ b/server/proliferate/auth/identity/store.py
@@ -27,7 +27,7 @@ from proliferate.db.models.auth import (
     ProviderGrant,
     User,
 )
-from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 
 
 @dataclass(frozen=True)

--- a/server/proliferate/constants/agent_gateway.py
+++ b/server/proliferate/constants/agent_gateway.py
@@ -134,6 +134,6 @@ AGENT_MODEL_SNAPSHOT_SCHEMA_VERSION = 2
 
 AGENT_USAGE_IMPORT_CURSOR_ID = "default"
 
-# Fernet key derivation is versioned by this identifier (see utils/crypto.py);
+# Fernet key derivation is versioned by this identifier (see lib/infra/encryption/fernet.py);
 # matches the cloud-secret convention used by other encrypted columns.
 AGENT_GATEWAY_CIPHERTEXT_KEY_ID = "cloud-secret-v1"

--- a/server/proliferate/db/models/cloud/agent_gateway.py
+++ b/server/proliferate/db/models/cloud/agent_gateway.py
@@ -64,7 +64,7 @@ class AgentApiKey(Base):
     # 'api_key' (default): value_ciphertext decrypts to one opaque secret
     # string. 'aws_bedrock' | 'azure_openai': value_ciphertext decrypts to a
     # JSON document (region+credentials / endpoint+deployment+key) — see
-    # proliferate.utils.crypto.{encrypt_json,decrypt_json}.
+    # proliferate.lib.infra.encryption.json.{encrypt_json,decrypt_json}.
     kind: Mapped[str] = mapped_column(
         Text,
         default="api_key",

--- a/server/proliferate/db/store/agent_gateway/api_keys.py
+++ b/server/proliferate/db/store/agent_gateway/api_keys.py
@@ -18,7 +18,8 @@ from proliferate.constants.agent_gateway import (
 from proliferate.db.models.cloud.agent_gateway import AgentApiKey
 from proliferate.db.store.agent_gateway.mappers import api_key_record
 from proliferate.db.store.agent_gateway.records import AgentApiKeyRecord
-from proliferate.utils.crypto import decrypt_json, decrypt_text, encrypt_json, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.json import decrypt_json, encrypt_json
 from proliferate.utils.time import utcnow
 
 

--- a/server/proliferate/db/store/agent_gateway/enrollment_keys.py
+++ b/server/proliferate/db/store/agent_gateway/enrollment_keys.py
@@ -18,7 +18,7 @@ from proliferate.constants.agent_gateway import AGENT_GATEWAY_CIPHERTEXT_KEY_ID
 from proliferate.db.models.cloud.agent_gateway import AgentGatewayEnrollmentKey
 from proliferate.db.store.agent_gateway.mappers import enrollment_key_record
 from proliferate.db.store.agent_gateway.records import AgentGatewayEnrollmentKeyRecord
-from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 from proliferate.utils.time import utcnow
 
 

--- a/server/proliferate/db/store/agent_gateway/enrollments.py
+++ b/server/proliferate/db/store/agent_gateway/enrollments.py
@@ -23,7 +23,7 @@ from proliferate.db.models.organizations import OrganizationMembership
 from proliferate.db.store.agent_gateway.enrollment_keys import revoke_enrollment_keys
 from proliferate.db.store.agent_gateway.mappers import enrollment_record
 from proliferate.db.store.agent_gateway.records import AgentGatewayEnrollmentRecord
-from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 from proliferate.utils.time import utcnow
 
 # The per-(org, member) LiteLLM user id prefix. A pre-migration row whose

--- a/server/proliferate/db/store/auth_sso.py
+++ b/server/proliferate/db/store/auth_sso.py
@@ -22,7 +22,7 @@ from proliferate.db.store.auth_sso_records import (
     sso_identity_record,
 )
 from proliferate.db.store.organization_records import MembershipRecord, membership_record
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 
 
 def _now() -> datetime:

--- a/server/proliferate/db/store/auth_sso_records.py
+++ b/server/proliferate/db/store/auth_sso_records.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from proliferate.config import settings
 from proliferate.db.models.auth import SsoChallenge, SsoConnection, SsoIdentity
-from proliferate.utils.crypto import decrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text
 
 
 @dataclass(frozen=True)

--- a/server/proliferate/db/store/cloud_secrets.py
+++ b/server/proliferate/db/store/cloud_secrets.py
@@ -17,7 +17,7 @@ from proliferate.db.models.cloud.secrets import (
     CloudSecretFile,
     CloudSecretSet,
 )
-from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 from proliferate.utils.time import utcnow
 
 

--- a/server/proliferate/db/store/github_app.py
+++ b/server/proliferate/db/store/github_app.py
@@ -18,7 +18,7 @@ from proliferate.db.models.cloud.github_app import (
     GitHubAppInstallation,
     GitHubAppInstallationRepository,
 )
-from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 from proliferate.utils.time import utcnow
 
 _CACHE_FRESHNESS_SECONDS = 600

--- a/server/proliferate/lib/infra/encryption/fernet.py
+++ b/server/proliferate/lib/infra/encryption/fernet.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+
+
+def _fernet(*, secret: str) -> Fernet:
+    secret_bytes = secret.encode("utf-8")
+    key = base64.urlsafe_b64encode(hashlib.sha256(secret_bytes).digest())
+    return Fernet(key)
+
+
+def encrypt_text(value: str, *, secret: str) -> str:
+    return _fernet(secret=secret).encrypt(value.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_text(ciphertext: str, *, secret: str) -> str:
+    return _fernet(secret=secret).decrypt(ciphertext.encode("utf-8")).decode("utf-8")

--- a/server/proliferate/lib/infra/encryption/json.py
+++ b/server/proliferate/lib/infra/encryption/json.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-import base64
-import hashlib
 import json
 from typing import Any
 
-from cryptography.fernet import Fernet
-
-
-def _fernet(*, secret: str) -> Fernet:
-    secret_bytes = secret.encode("utf-8")
-    key = base64.urlsafe_b64encode(hashlib.sha256(secret_bytes).digest())
-    return Fernet(key)
+from proliferate.lib.infra.encryption.fernet import _fernet
 
 
 def encrypt_json(payload: dict[str, Any], *, secret: str) -> str:
@@ -25,11 +17,3 @@ def decrypt_json(ciphertext: str, *, secret: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("encrypted payload did not contain an object")
     return value
-
-
-def encrypt_text(value: str, *, secret: str) -> str:
-    return _fernet(secret=secret).encrypt(value.encode("utf-8")).decode("utf-8")
-
-
-def decrypt_text(ciphertext: str, *, secret: str) -> str:
-    return _fernet(secret=secret).decrypt(ciphertext.encode("utf-8")).decode("utf-8")

--- a/server/proliferate/lib/infra/encryption/json.py
+++ b/server/proliferate/lib/infra/encryption/json.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from proliferate.lib.infra.encryption.fernet import _fernet
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 
 
 def encrypt_json(payload: dict[str, Any], *, secret: str) -> str:
-    plaintext = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
-    return _fernet(secret=secret).encrypt(plaintext).decode("utf-8")
+    plaintext = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return encrypt_text(plaintext, secret=secret)
 
 
 def decrypt_json(ciphertext: str, *, secret: str) -> dict[str, Any]:
-    plaintext = _fernet(secret=secret).decrypt(ciphertext.encode("utf-8"))
-    value = json.loads(plaintext.decode("utf-8"))
+    value = json.loads(decrypt_text(ciphertext, secret=secret))
     if not isinstance(value, dict):
         raise ValueError("encrypted payload did not contain an object")
     return value

--- a/server/proliferate/server/cloud/cloud_sandboxes/service.py
+++ b/server/proliferate/server/cloud/cloud_sandboxes/service.py
@@ -21,6 +21,7 @@ from proliferate.db.store import cloud_workspaces as cloud_workspace_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_sandboxes import CloudSandboxValue
 from proliferate.integrations.sandbox import get_sandbox_provider
+from proliferate.lib.infra.encryption.fernet import decrypt_text
 from proliferate.server.billing.authorization import (
     assert_cloud_sandbox_resume_allowed_for_owner,
 )
@@ -30,7 +31,6 @@ from proliferate.server.cloud.cloud_sandboxes.transactions import (
 )
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.provisioning_observability import provisioning_phase
-from proliferate.utils.crypto import decrypt_text
 
 logger = logging.getLogger("proliferate.cloud.cloud_sandboxes")
 

--- a/server/proliferate/server/cloud/integrations/access.py
+++ b/server/proliferate/server/cloud/integrations/access.py
@@ -6,7 +6,7 @@ the provider's MCP endpoint, refreshing an OAuth access token in place when it
 is missing or about to expire. :func:`resolve_launch` additionally renders the
 endpoint URL so callers get a launch-ready ``(url, headers, query)`` triple.
 
-Credential bundles (see ``proliferate.utils.crypto``):
+Credential bundles (see ``proliferate.lib.infra.encryption.json``):
   - ``secret-fields-v1`` -> ``{"secretFields": {"<id>": "<value>", ...}}``
   - ``oauth-bundle-v1``  -> ``{issuer, resource, clientId, accessToken,
     refreshToken, expiresAt, scopes, tokenEndpoint, redirectUri}``
@@ -27,6 +27,8 @@ from proliferate.db import session_ops
 from proliferate.db.store.integrations.accounts import set_account_credentials
 from proliferate.db.store.integrations.oauth_clients import get_oauth_client
 from proliferate.integrations.integration_oauth.tokens import refresh_token
+from proliferate.lib.infra.encryption.fernet import decrypt_text
+from proliferate.lib.infra.encryption.json import decrypt_json, encrypt_json
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integrations.config import (
     HeaderTemplate,
@@ -41,7 +43,6 @@ from proliferate.server.cloud.integrations.oauth.scope_policy import (
     resolve_refreshed_oauth_scopes,
     validate_stored_oauth_scopes,
 )
-from proliferate.utils.crypto import decrypt_json, decrypt_text, encrypt_json
 from proliferate.utils.time import utcnow
 
 if TYPE_CHECKING:

--- a/server/proliferate/server/cloud/integrations/oauth/clients.py
+++ b/server/proliferate/server/cloud/integrations/oauth/clients.py
@@ -25,7 +25,7 @@ from proliferate.integrations.integration_oauth import (
     discover_authorization_server_metadata,
     register_client,
 )
-from proliferate.utils.crypto import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 
 # Static-client auth methods this deployment can drive.
 # Static-client auth methods this deployment can drive.

--- a/server/proliferate/server/cloud/integrations/oauth/service.py
+++ b/server/proliferate/server/cloud/integrations/oauth/service.py
@@ -54,6 +54,8 @@ from proliferate.integrations.integration_oauth import (
     normalize_resource_url,
     random_urlsafe,
 )
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.json import encrypt_json
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integrations.config import parse_definition_config, render_mcp_url
 from proliferate.server.cloud.integrations.oauth.clients import resolve_oauth_client
@@ -64,7 +66,6 @@ from proliferate.server.cloud.integrations.oauth.scope_policy import (
 from proliferate.server.cloud.integrations.oauth.scope_policy import (
     resolve_requested_oauth_scope as resolve_scope_policy,
 )
-from proliferate.utils.crypto import decrypt_text, encrypt_json, encrypt_text
 
 # Callback path appended to the API base URL for the shared OAuth callback.
 OAUTH_CALLBACK_PATH = "/v1/cloud/integrations/oauth/callback"

--- a/server/proliferate/server/cloud/integrations/service.py
+++ b/server/proliferate/server/cloud/integrations/service.py
@@ -41,6 +41,7 @@ from proliferate.integrations.integration_oauth.discovery import (
     discover_protected_resource_metadata,
 )
 from proliferate.integrations.integration_oauth.errors import IntegrationOAuthProviderError
+from proliferate.lib.infra.encryption.json import encrypt_json
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integrations.config import (
     HeaderTemplate,
@@ -69,7 +70,6 @@ from proliferate.server.cloud.integrations.oauth import (
     start_oauth_flow,
 )
 from proliferate.server.organizations.domain.policy import organization_admin_roles
-from proliferate.utils.crypto import encrypt_json
 
 _DEFAULT_SECRET_FIELD_ID = "api_key"
 

--- a/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
+++ b/server/proliferate/server/cloud/materialization/sandbox_io/connect.py
@@ -25,6 +25,7 @@ from proliferate.integrations.sandbox import (
     SandboxProviderUnavailableError,
     get_sandbox_provider,
 )
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 from proliferate.server.billing.authorization import assert_cloud_sandbox_resume_allowed
 from proliferate.server.billing.runtime_usage import (
     converge_cloud_sandbox_provider_usage,
@@ -52,7 +53,6 @@ from proliferate.server.cloud.runtime.liveness_health import (
     verify_runtime_auth_enforced,
     wait_for_runtime_health,
 )
-from proliferate.utils.crypto import decrypt_text, encrypt_text
 from proliferate.utils.time import utcnow
 
 logger = logging.getLogger("proliferate.cloud.materialization.connect")

--- a/server/proliferate/server/cloud/runtime_workers/service.py
+++ b/server/proliferate/server/cloud/runtime_workers/service.py
@@ -33,6 +33,7 @@ from proliferate.integrations.sandbox import (
     SandboxRuntimeContext,
     get_sandbox_provider,
 )
+from proliferate.lib.infra.encryption.fernet import decrypt_text
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime.bootstrap import (
     build_runtime_env,
@@ -57,7 +58,6 @@ from proliferate.server.cloud.runtime_workers.models import (
 from proliferate.server.organizations.domain.policy import organization_admin_roles
 from proliferate.server.version import runtime_version_pin as pinned_runtime_version
 from proliferate.server.version import worker_version_pin as pinned_worker_version
-from proliferate.utils.crypto import decrypt_text
 from proliferate.utils.time import utcnow
 
 _TOKEN_BYTES = 48

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -57,8 +57,9 @@ ignore = ["B008"]
 "proliferate/integrations/**" = ["ANN401"]
 # runtime/ operates on untyped E2B sandbox objects
 "proliferate/server/cloud/runtime/**" = ["ANN401"]
-# utils/ contains generic helpers where Any is unavoidable at public boundaries
-"proliferate/utils/**" = ["ANN401"]
+# Recursive JSON encryption and telemetry scrubbing require Any at their data boundaries.
+"proliferate/lib/infra/encryption/json.py" = ["ANN401"]
+"proliferate/utils/telemetry_scrub.py" = ["ANN401"]
 # Inline HTML/SVG page renderers contain long literal lines.
 "proliferate/auth/desktop/pages.py" = ["E501"]
 "proliferate/utils/redirect_callback_pages.py" = ["E501"]
@@ -82,11 +83,12 @@ warn_return_any = false
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-# cloud/runtime operates on untyped E2B sandbox objects; utils contains generic
-# helpers (JSON crypto, telemetry scrubbing, time) where Any is unavoidable.
+# cloud/runtime operates on untyped E2B sandbox objects; recursive JSON encryption
+# and telemetry scrubbing require Any at their data boundaries.
 module = [
     "proliferate.server.cloud.runtime.*",
-    "proliferate.utils.*",
+    "proliferate.lib.infra.encryption.json",
+    "proliferate.utils.telemetry_scrub",
 ]
 disallow_any_explicit = false
 warn_return_any = false

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -57,8 +57,7 @@ ignore = ["B008"]
 "proliferate/integrations/**" = ["ANN401"]
 # runtime/ operates on untyped E2B sandbox objects
 "proliferate/server/cloud/runtime/**" = ["ANN401"]
-# Recursive JSON encryption and telemetry scrubbing require Any at their data boundaries.
-"proliferate/lib/infra/encryption/json.py" = ["ANN401"]
+# Telemetry scrubbing requires Any at its recursive data boundary.
 "proliferate/utils/telemetry_scrub.py" = ["ANN401"]
 # Inline HTML/SVG page renderers contain long literal lines.
 "proliferate/auth/desktop/pages.py" = ["E501"]
@@ -83,10 +82,15 @@ warn_return_any = false
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-# cloud/runtime operates on untyped E2B sandbox objects; recursive JSON encryption
-# and telemetry scrubbing require Any at their data boundaries.
+# cloud/runtime operates on untyped E2B sandbox objects.
+module = ["proliferate.server.cloud.runtime.*"]
+disallow_any_explicit = false
+warn_return_any = false
+
+[[tool.mypy.overrides]]
+# Recursive JSON encryption and telemetry scrubbing accept untyped JSON values
+# at their data boundaries.
 module = [
-    "proliferate.server.cloud.runtime.*",
     "proliferate.lib.infra.encryption.json",
     "proliferate.utils.telemetry_scrub",
 ]

--- a/server/tests/e2e/cloud/helpers/webhooks.py
+++ b/server/tests/e2e/cloud/helpers/webhooks.py
@@ -66,7 +66,7 @@ async def create_seeded_workspace_and_sandbox(
     runtime_url = "https://example-runtime.invalid" if with_runtime_metadata else None
     anyharness_workspace_id = "workspace-123" if with_runtime_metadata else None
 
-    from proliferate.utils.crypto import encrypt_text
+    from proliferate.lib.infra.encryption.fernet import encrypt_text
 
     user_uuid = uuid.UUID(user_id)
     await ensure_personal_billing_subject(db_session, user_uuid)

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -22,7 +22,7 @@ from proliferate.config import settings
 from proliferate.constants.auth import DESKTOP_GITHUB_CSRF_COOKIE, REFRESH_TOKEN_LIFETIME_SECONDS
 from proliferate.db.models.auth import AuthIdentity, ProviderGrant, User
 from proliferate.integrations.github import GitHubUserProfile
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 from tests.helpers.desktop_auth import make_pkce_pair as _make_pkce_pair
 from tests.integration.cloud_api_helpers import configure_github_app
 

--- a/server/tests/integration/test_auth_viewer_api.py
+++ b/server/tests/integration/test_auth_viewer_api.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.identity.store import get_account_readiness
 from proliferate.db.models.auth import AuthIdentity, OAuthAccount, ProviderGrant, SsoIdentity, User
 from proliferate.config import settings
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 from tests.helpers.desktop_auth import mint_desktop_token_payload
 
 

--- a/server/tests/integration/test_cloud_integration_action_approvals_api.py
+++ b/server/tests/integration/test_cloud_integration_action_approvals_api.py
@@ -33,7 +33,7 @@ from proliferate.server.cloud.integrations.action_approvals.domain.actions impor
 from proliferate.server.cloud.integrations.action_approvals.transactions import (
     consume_action_for_execution_committed,
 )
-from proliferate.utils.crypto import encrypt_json
+from proliferate.lib.infra.encryption.json import encrypt_json
 from tests.integration.test_cloud_integration_gateway_api import (
     GATEWAY_URL,
     _authed_user,

--- a/server/tests/integration/test_cloud_integration_gateway_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_api.py
@@ -17,7 +17,7 @@ from proliferate.db.models.organizations import Organization, OrganizationMember
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
-from proliferate.utils.crypto import encrypt_json
+from proliferate.lib.infra.encryption.json import encrypt_json
 from proliferate.config import settings
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account

--- a/server/tests/integration/test_cloud_integration_gateway_policy_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_policy_api.py
@@ -12,7 +12,7 @@ from proliferate.config import settings
 from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.db.store.integrations import policies as policies_store
-from proliferate.utils.crypto import encrypt_json
+from proliferate.lib.infra.encryption.json import encrypt_json
 from tests.integration.test_cloud_integration_gateway_api import (
     _authed_user,
     _create_org_with_member,

--- a/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
+++ b/server/tests/integration/test_cloud_integration_gateway_tool_policy_api.py
@@ -18,7 +18,7 @@ from proliferate.server.cloud.integration_gateway.domain.tool_policy import (
     SLACK_MUTATING_TOOL_NAMES,
 )
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
-from proliferate.utils.crypto import encrypt_json
+from proliferate.lib.infra.encryption.json import encrypt_json
 from tests.integration.test_cloud_integration_gateway_api import (
     GATEWAY_URL,
     _authed_user,

--- a/server/tests/integration/test_cloud_integration_health_api.py
+++ b/server/tests/integration/test_cloud_integration_health_api.py
@@ -10,7 +10,7 @@ from proliferate.db.store.integrations import accounts as accounts_store
 from proliferate.db.store.integrations import definitions as definitions_store
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
 from proliferate.config import settings
-from proliferate.utils.crypto import encrypt_json
+from proliferate.lib.infra.encryption.json import encrypt_json
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
 

--- a/server/tests/integration/test_cloud_integrations_api.py
+++ b/server/tests/integration/test_cloud_integrations_api.py
@@ -38,7 +38,7 @@ from proliferate.server.cloud.integrations.oauth import clients as oauth_clients
 from proliferate.server.cloud.integrations.oauth import service as oauth_service
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
 from proliferate.config import settings
-from proliferate.utils.crypto import decrypt_json
+from proliferate.lib.infra.encryption.json import decrypt_json
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
 

--- a/server/tests/integration/test_cloud_sandbox_cold_access_repair.py
+++ b/server/tests/integration/test_cloud_sandbox_cold_access_repair.py
@@ -36,7 +36,7 @@ from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.gateway import service as gateway_service
 from proliferate.server.cloud.materialization import operation, runner
 from proliferate.server.cloud.materialization import service as materialization_service
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 from proliferate.utils.time import utcnow
 
 

--- a/server/tests/integration/test_cloud_sandbox_desired_versions.py
+++ b/server/tests/integration/test_cloud_sandbox_desired_versions.py
@@ -31,7 +31,7 @@ from proliferate.db.store import instance_organizations as instance_organization
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.runtime_workers import service
 from proliferate.server.cloud.runtime_workers.service import create_cloud_sandbox_enrollment
-from proliferate.utils.crypto import encrypt_text
+from proliferate.lib.infra.encryption.fernet import encrypt_text
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 
 

--- a/server/tests/integration/test_integration_oauth_scope_policy.py
+++ b/server/tests/integration/test_integration_oauth_scope_policy.py
@@ -20,7 +20,7 @@ from proliferate.server.cloud.integrations.oauth import clients as oauth_clients
 from proliferate.server.cloud.integrations.oauth import service as oauth_service
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
 from proliferate.config import settings
-from proliferate.utils.crypto import decrypt_json
+from proliferate.lib.infra.encryption.json import decrypt_json
 from tests.e2e.cloud.helpers.auth import create_user_and_login
 from tests.e2e.cloud.helpers.github import seed_linked_github_account
 from tests.e2e.cloud.helpers.shared import AuthSession

--- a/server/tests/integration/test_integration_provider_access.py
+++ b/server/tests/integration/test_integration_provider_access.py
@@ -24,7 +24,7 @@ from proliferate.server.cloud.integrations.config import (
 )
 from proliferate.server.cloud.integrations.seeds import sync_seed_definitions
 from proliferate.config import settings
-from proliferate.utils.crypto import decrypt_json, encrypt_json
+from proliferate.lib.infra.encryption.json import decrypt_json, encrypt_json
 
 SLACK_SCOPES = (
     "search:read.public",

--- a/server/tests/unit/test_encryption.py
+++ b/server/tests/unit/test_encryption.py
@@ -11,7 +11,8 @@ from types import ModuleType
 import pytest
 from cryptography.fernet import Fernet, InvalidToken
 
-from proliferate.utils.crypto import decrypt_json, decrypt_text, encrypt_json, encrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
+from proliferate.lib.infra.encryption.json import decrypt_json, encrypt_json
 
 _LEGACY_SECRET = "legacy-test-secret"
 _LEGACY_TEXT_CIPHERTEXT = (

--- a/tests/release/scripts/github_app_seed.py
+++ b/tests/release/scripts/github_app_seed.py
@@ -97,7 +97,7 @@ from proliferate.server.cloud.github_app.service import (  # noqa: E402
 from proliferate.server.cloud.materialization.materialize.sandbox import (  # noqa: E402
     materialize_sandbox,
 )
-from proliferate.utils.crypto import decrypt_text  # noqa: E402
+from proliferate.lib.infra.encryption.fernet import decrypt_text  # noqa: E402
 from proliferate.utils.time import utcnow  # noqa: E402
 
 _DEFAULT_STATE_PATH = (

--- a/tests/release/scripts/prov1_fallback.py
+++ b/tests/release/scripts/prov1_fallback.py
@@ -47,7 +47,7 @@ from proliferate.server.cloud.materialization.materialize.sandbox import (  # no
     materialize_sandbox,
 )
 from proliferate.config import settings  # noqa: E402
-from proliferate.utils.crypto import decrypt_text  # noqa: E402
+from proliferate.lib.infra.encryption.fernet import decrypt_text  # noqa: E402
 
 
 async def main(email: str, poll_timeout_seconds: int) -> dict:

--- a/tests/release/src/scenarios/cloud-provision-1.ts
+++ b/tests/release/src/scenarios/cloud-provision-1.ts
@@ -417,15 +417,15 @@ export interface CloudProvision1Driver {
  * Mirrors `connect.py`'s `_runtime_token`: decrypts
  * `cloud_sandbox.runtime_token_ciphertext` (the `CloudSandboxValue` field the
  * product calls `anyharness_bearer_token_ciphertext`) with the exact same
- * `proliferate.utils.crypto.decrypt_text` helper. Never prints the token
- * itself — only a `{"token": ...}` JSON line the caller parses.
+ * `proliferate.lib.infra.encryption.fernet.decrypt_text` helper. Never prints
+ * the token itself — only a `{"token": ...}` JSON line the caller parses.
  */
 const DECRYPT_RUNTIME_TOKEN_PY = `import asyncio, json, os
 from uuid import UUID
 from proliferate.config import settings
 from proliferate.db.engine import async_session_factory
 from proliferate.db.store.cloud_sandboxes import load_cloud_sandbox_by_id
-from proliferate.utils.crypto import decrypt_text
+from proliferate.lib.infra.encryption.fernet import decrypt_text
 
 CLOUD_SANDBOX_ID = UUID(os.environ["CLOUD_SANDBOX_ID"])
 


### PR DESCRIPTION
## Summary

- move Fernet helpers from the legacy utility path into direct infrastructure leaves
- split generic Fernet mechanics from JSON envelope serialization without changing helper bodies or explicit-secret calls
- migrate every Python, migration, test, and embedded release consumer atomically; delete the old module with no shim or re-export

## Proof

- 179 focused tests and 2,248 full server tests passed
- leaf mypy, full-server Ruff, and 882-file format check passed
- release TypeScript check, server boundaries, max-lines, migration heads, design attribution, and diff checks passed
- exact 34-file / 38-import and 95-call censuses passed with zero old references
- independent review accepted with no findings

## Stack

This draft targets PR #1619 branch `codex/encryption-secret-dependency-inversion`, whose explicit-secret API is the required parent. Retarget to the eventual merge revision after that draft lands.

## Scope

Ownership move only. No encryption format, key derivation, secret selection, schema, migration graph, generated source, or public API behavior changed.

## Integration and landing

- PR #1619 is the required parent.
- After #1619 lands, rebase onto the landed revision and reconcile the already-landed ownership moves from #1615 and #1617.
- After #1628 lands, rebase onto updated `main` and reconcile its atomic time ownership in the same integration replay.
- In the ten shared consumers, retain both the direct `proliferate.lib.infra.encryption.*` leaf imports and the direct `proliferate.lib.infra.time.*` leaf imports; neither ownership move may overwrite the other.
- The reconciled `pyproject.toml` must retain leaf overrides for `lib/infra/encryption/json.py`, `lib/product/telemetry/scrubbing.py`, and `lib/product/redirect_callbacks/page.py`, together with the encryption and telemetry mypy leaves.
- Rerun the complete frozen proof after reconciliation and before landing.

## Review repair update (2026-08-05)

- Frozen specification: Server Grid 11 revision 4, SHA256 `c87f6b5a97526b2df5f390d2139f47df375327f2e8842628c0b03cd33bd1ce1f`.
- Rebased repair head: `1ebfe96e2aa14921e494f8822e563c008f581955`, on repaired parent #1619 at `8df7d24dd771f933db76115e7a2e048565403780`.
- Accepted findings closed: the JSON leaf now composes public text primitives rather than a private Fernet helper; the dead JSON Ruff exemption was removed; and the JSON and telemetry mypy boundaries are stated accurately.
- The proposed package-level re-exports were not added. Repository architecture requires concrete direct imports and forbids convenience barrels; the verified whole-tree contract remains 34 files and 38 direct leaf-import statements with empty package markers.
- Integrated repair proof: 20 encryption tests plus scoped Ruff, format, mypy, compilation, and diff checks passed.
- This remains a draft. Independent re-review: ACCEPT with no findings. GitHub CI for the rewritten head is terminal green.
