### PR TITLE
refactor(server): route checkout activation through organizations

### DIFF
--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -345,6 +345,14 @@ async def get_active_membership(
     return membership_record(membership) if membership is not None else None
 
 
+def _checkout_intent_with_organization_record(
+    intent: OrganizationCheckoutIntent, organization: Organization
+) -> CheckoutIntentWithOrganizationRecord:
+    return CheckoutIntentWithOrganizationRecord(
+        checkout_intent_record(intent), organization_record(organization)
+    )
+
+
 async def create_pending_team_checkout_intent(
     db: AsyncSession,
     *,
@@ -393,10 +401,7 @@ async def create_pending_team_checkout_intent(
     )
     db.add(intent)
     await db.flush()
-    return CheckoutIntentWithOrganizationRecord(
-        intent=checkout_intent_record(intent),
-        organization=organization_record(organization),
-    )
+    return _checkout_intent_with_organization_record(intent, organization)
 
 
 async def get_current_team_checkout_intent(
@@ -421,19 +426,14 @@ async def get_current_team_checkout_intent(
     intent, organization = row
     now = utcnow()
     if intent.status == ORGANIZATION_CHECKOUT_INTENT_STATUS_PENDING and intent.expires_at <= now:
-        intent.status = ORGANIZATION_CHECKOUT_INTENT_STATUS_EXPIRED
-        intent.updated_at = now
-        organization.status = ORGANIZATION_STATUS_ARCHIVED
-        organization.updated_at = now
+        intent.status, intent.updated_at = ORGANIZATION_CHECKOUT_INTENT_STATUS_EXPIRED, now
+        organization.status, organization.updated_at = ORGANIZATION_STATUS_ARCHIVED, now
         await db.flush()
         return None
-    return CheckoutIntentWithOrganizationRecord(
-        intent=checkout_intent_record(intent),
-        organization=organization_record(organization),
-    )
+    return _checkout_intent_with_organization_record(intent, organization)
 
 
-async def load_team_checkout_intent_for_update(
+async def _load_team_checkout_intent_for_update(
     db: AsyncSession,
     intent_id: UUID,
 ) -> tuple[OrganizationCheckoutIntent, Organization] | None:
@@ -445,10 +445,15 @@ async def load_team_checkout_intent_for_update(
             .with_for_update(of=(OrganizationCheckoutIntent, Organization))
         )
     ).one_or_none()
-    if row is None:
-        return None
-    intent, organization = row
-    return intent, organization
+    return (row[0], row[1]) if row is not None else None
+
+
+async def load_team_checkout_activation_for_update(
+    db: AsyncSession,
+    intent_id: UUID,
+) -> CheckoutIntentWithOrganizationRecord | None:
+    row = await _load_team_checkout_intent_for_update(db, intent_id)
+    return _checkout_intent_with_organization_record(*row) if row is not None else None
 
 
 async def bind_team_checkout_session(
@@ -476,7 +481,7 @@ async def cancel_team_checkout_intent(
     intent_id: UUID,
     created_by_user_id: UUID,
 ) -> CheckoutIntentWithOrganizationRecord | None:
-    row = await load_team_checkout_intent_for_update(db, intent_id)
+    row = await _load_team_checkout_intent_for_update(db, intent_id)
     if row is None:
         return None
     intent, organization = row
@@ -485,63 +490,61 @@ async def cancel_team_checkout_intent(
     if intent.status == ORGANIZATION_CHECKOUT_INTENT_STATUS_PENDING:
         now = utcnow()
         intent.status = ORGANIZATION_CHECKOUT_INTENT_STATUS_CANCELLED
-        intent.cancelled_at = now
-        intent.updated_at = now
-        organization.status = ORGANIZATION_STATUS_ARCHIVED
-        organization.updated_at = now
+        intent.cancelled_at = intent.updated_at = now
+        organization.status, organization.updated_at = ORGANIZATION_STATUS_ARCHIVED, now
         await db.flush()
-    return CheckoutIntentWithOrganizationRecord(
-        intent=checkout_intent_record(intent),
-        organization=organization_record(organization),
-    )
+    return _checkout_intent_with_organization_record(intent, organization)
 
 
-async def mark_team_checkout_activating(
+async def mark_team_checkout_activating_by_id(
     db: AsyncSession,
-    intent: OrganizationCheckoutIntent,
     *,
-    stripe_subscription_id: str | None,
+    intent_id: UUID,
+    stripe_subscription_id: str,
 ) -> None:
+    intent = await db.get(OrganizationCheckoutIntent, intent_id)
+    assert intent is not None, "Checkout intent disappeared during activation."
     intent.activation_status = ORGANIZATION_CHECKOUT_ACTIVATION_ACTIVATING
-    if stripe_subscription_id:
-        intent.stripe_subscription_id = stripe_subscription_id
+    intent.stripe_subscription_id = stripe_subscription_id
     intent.updated_at = utcnow()
     await db.flush()
 
 
-async def mark_team_checkout_failed(
+async def mark_team_checkout_failed_by_id(
     db: AsyncSession,
-    intent: OrganizationCheckoutIntent,
     *,
+    intent_id: UUID,
     activation_status: str,
     error_code: str,
     error_message: str,
     webhook_event_id: str | None,
-) -> CheckoutIntentRecord:
+) -> CheckoutIntentRecord | None:
+    if (row := await _load_team_checkout_intent_for_update(db, intent_id)) is None:
+        return None
+    intent, _ = row
     now = utcnow()
     intent.status = ORGANIZATION_CHECKOUT_INTENT_STATUS_FAILED
     intent.activation_status = activation_status
-    intent.activation_error_code = error_code
-    intent.activation_error_message = error_message
+    intent.activation_error_code, intent.activation_error_message = error_code, error_message
     intent.last_webhook_event_id = webhook_event_id
-    intent.failed_at = now
-    intent.updated_at = now
+    intent.failed_at = intent.updated_at = now
     await db.flush()
     return checkout_intent_record(intent)
 
 
-async def complete_team_checkout_activation(
+async def complete_team_checkout_activation_by_id(
     db: AsyncSession,
     *,
-    intent: OrganizationCheckoutIntent,
-    organization: Organization,
+    intent_id: UUID,
     stripe_subscription_id: str,
     stripe_customer_id: str,
     webhook_event_id: str | None,
 ) -> OrganizationWithMembershipRecord:
+    row = await _load_team_checkout_intent_for_update(db, intent_id)
+    assert row is not None, "Checkout intent disappeared during activation."
+    intent, organization = row
     now = utcnow()
-    organization.status = ORGANIZATION_STATUS_ACTIVE
-    organization.updated_at = now
+    organization.status, organization.updated_at = ORGANIZATION_STATUS_ACTIVE, now
     result = await db.execute(
         pg_insert(OrganizationMembership)
         .values(
@@ -572,14 +575,11 @@ async def complete_team_checkout_activation(
     intent.status = ORGANIZATION_CHECKOUT_INTENT_STATUS_COMPLETED
     intent.activation_status = ORGANIZATION_CHECKOUT_ACTIVATION_ACTIVATED
     intent.stripe_subscription_id = stripe_subscription_id
-    intent.stripe_customer_id = stripe_customer_id
-    intent.last_webhook_event_id = webhook_event_id
-    intent.completed_at = now
-    intent.updated_at = now
+    intent.stripe_customer_id, intent.last_webhook_event_id = stripe_customer_id, webhook_event_id
+    intent.completed_at = intent.updated_at = now
     await db.flush()
     return OrganizationWithMembershipRecord(
-        organization=organization_record(organization),
-        membership=membership_record(membership),
+        organization_record(organization), membership_record(membership)
     )
 
 

--- a/server/proliferate/server/billing/team_checkout/activation.py
+++ b/server/proliferate/server/billing/team_checkout/activation.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import logging
-from datetime import timedelta
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,23 +10,12 @@ from proliferate.constants.organizations import (
     ORGANIZATION_CHECKOUT_ACTIVATION_FAILED_BILLING_STATE,
     ORGANIZATION_CHECKOUT_ACTIVATION_FAILED_BUSINESS_STATE,
     ORGANIZATION_CHECKOUT_INTENT_STATUS_PENDING,
-    ORGANIZATION_INVITE_EXPIRES_DAYS,
-    ORGANIZATION_ROLE_MEMBER,
     ORGANIZATION_STATUS_PENDING_CHECKOUT,
 )
 from proliferate.db import session_ops as db_session
 from proliferate.db.models.billing import BillingSubscription
 from proliferate.db.store import billing_subscriptions
-from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store import users as user_store
-from proliferate.db.store.organizations import (
-    acquire_membership_activation_lock,
-    complete_team_checkout_activation,
-    load_team_checkout_intent_for_update,
-    mark_team_checkout_activating,
-    mark_team_checkout_failed,
-)
-from proliferate.integrations import resend
 from proliferate.integrations import stripe as stripe_billing
 from proliferate.server.billing.domain.pricing import (
     monthly_subscription_price_ids,
@@ -45,119 +31,16 @@ from proliferate.server.billing.domain.webhooks import (
 from proliferate.server.billing.domain.webhooks import (
     subscription_period as _stripe_subscription_period,
 )
-from proliferate.server.billing.models import BillingServiceError, coerce_utc, utcnow
+from proliferate.server.billing.models import BillingServiceError, coerce_utc
 from proliferate.server.billing.pricing import billing_price_ids_from_settings
 from proliferate.server.cloud.agent_gateway.signup_hook import (
     schedule_agent_gateway_org_enrollment,
 )
-from proliferate.server.organizations.join_links import organization_join_url
-
-logger = logging.getLogger("proliferate.billing.team_checkout.activation")
+from proliferate.server.organizations import service as organization_service
 
 
 def _map_stripe_error(error: stripe_billing.StripeBillingError) -> BillingServiceError:
     return BillingServiceError(error.code, error.message, status_code=error.status_code)
-
-
-async def _send_staged_team_checkout_invitation(
-    *,
-    organization_id: UUID,
-    organization_name: str,
-    invited_by_user_id: UUID,
-    inviter_email: str,
-    email: str,
-) -> None:
-    async with db_session.open_async_transaction() as db:
-        record = await invitation_store.create_or_rotate_organization_invitation(
-            db,
-            organization_id=organization_id,
-            email=email,
-            role=ORGANIZATION_ROLE_MEMBER,
-            invited_by_user_id=invited_by_user_id,
-            expires_at=utcnow() + timedelta(days=ORGANIZATION_INVITE_EXPIRES_DAYS),
-        )
-    if record is None:
-        logger.warning(
-            "Skipping staged team checkout invitation because organization was not found",
-            extra={"organization_id": str(organization_id), "email": email},
-        )
-        return
-    try:
-        result = await resend.send_organization_invitation_email(
-            to_email=record.invitation.email,
-            organization_name=organization_name,
-            inviter_email=inviter_email,
-            invite_url=organization_join_url(organization_id),
-        )
-    except resend.ResendEmailError as error:
-        async with db_session.open_async_transaction() as db:
-            await invitation_store.mark_invitation_delivery(
-                db,
-                invitation_id=record.invitation.id,
-                sent=False,
-                skipped=False,
-                error=error.message,
-            )
-        logger.warning(
-            "Failed to deliver staged team checkout invitation",
-            extra={
-                "organization_id": str(organization_id),
-                "invitation_id": str(record.invitation.id),
-                "email": record.invitation.email,
-                "error_code": error.code,
-            },
-        )
-        return
-    async with db_session.open_async_transaction() as db:
-        await invitation_store.mark_invitation_delivery(
-            db,
-            invitation_id=record.invitation.id,
-            sent=not result.skipped,
-            skipped=result.skipped,
-        )
-
-
-async def _send_staged_team_checkout_invitations(
-    *,
-    organization_id: UUID,
-    organization_name: str,
-    invited_by_user_id: UUID,
-    inviter_email: str,
-    invite_emails_json: str | None,
-) -> None:
-    if not invite_emails_json:
-        return
-    try:
-        raw_invites = json.loads(invite_emails_json)
-    except ValueError:
-        logger.warning(
-            "Skipping staged team checkout invitations because invite JSON is invalid",
-            extra={"organization_id": str(organization_id)},
-        )
-        return
-    if not isinstance(raw_invites, list):
-        return
-    invite_emails = sorted(
-        {
-            email.strip().lower()
-            for email in raw_invites
-            if isinstance(email, str) and email.strip()
-        }
-    )
-    for email in invite_emails:
-        try:
-            await _send_staged_team_checkout_invitation(
-                organization_id=organization_id,
-                organization_name=organization_name,
-                invited_by_user_id=invited_by_user_id,
-                inviter_email=inviter_email,
-                email=email,
-            )
-        except Exception:
-            logger.exception(
-                "Unexpected failure while creating staged team checkout invitation",
-                extra={"organization_id": str(organization_id), "email": email},
-            )
 
 
 async def _upsert_team_subscription_from_stripe(
@@ -275,29 +158,30 @@ async def activate_team_checkout_from_stripe_session(
     status = subscription.get("status")
     if status not in {"active", "trialing"}:
         async with db_session.open_async_transaction() as db:
-            row = await load_team_checkout_intent_for_update(db, intent_id)
-            if row is not None:
-                intent, _organization = row
-                await mark_team_checkout_failed(
-                    db,
-                    intent,
-                    activation_status=ORGANIZATION_CHECKOUT_ACTIVATION_FAILED_BILLING_STATE,
-                    error_code="subscription_not_active",
-                    error_message="Team subscription is not active or trialing.",
-                    webhook_event_id=webhook_event_id,
-                )
+            await organization_service.fail_team_checkout_activation(
+                db,
+                intent_id=intent_id,
+                activation_status=ORGANIZATION_CHECKOUT_ACTIVATION_FAILED_BILLING_STATE,
+                error_code="subscription_not_active",
+                error_message="Team subscription is not active or trialing.",
+                webhook_event_id=webhook_event_id,
+            )
         return
 
     staged_invites: tuple[UUID, str, UUID, str, str | None] | None = None
     async with db_session.open_async_transaction() as db:
-        row = await load_team_checkout_intent_for_update(db, intent_id)
-        if row is None:
+        activation = await organization_service.load_team_checkout_activation(
+            db,
+            intent_id=intent_id,
+        )
+        if activation is None:
             raise BillingServiceError(
                 "team_checkout_intent_not_found",
                 "Team checkout intent was not found.",
                 status_code=404,
             )
-        intent, organization = row
+        intent = activation.intent
+        organization = activation.organization
         if (
             intent.organization_id != organization_id
             or intent.created_by_user_id != created_by_user_id
@@ -312,9 +196,9 @@ async def activate_team_checkout_from_stripe_session(
         if intent.status != ORGANIZATION_CHECKOUT_INTENT_STATUS_PENDING:
             return
         if organization.status != ORGANIZATION_STATUS_PENDING_CHECKOUT:
-            await mark_team_checkout_failed(
+            await organization_service.fail_team_checkout_activation(
                 db,
-                intent,
+                intent_id=intent_id,
                 activation_status=ORGANIZATION_CHECKOUT_ACTIVATION_FAILED_BUSINESS_STATE,
                 error_code="organization_not_pending_checkout",
                 error_message="Team checkout organization is not pending checkout.",
@@ -323,26 +207,29 @@ async def activate_team_checkout_from_stripe_session(
             return
         creator = await user_store.get_user_by_id(db, created_by_user_id)
         if creator is None:
-            await mark_team_checkout_failed(
+            await organization_service.fail_team_checkout_activation(
                 db,
-                intent,
+                intent_id=intent_id,
                 activation_status=ORGANIZATION_CHECKOUT_ACTIVATION_FAILED_BUSINESS_STATE,
                 error_code="checkout_creator_not_found",
                 error_message="Checkout creator account was not found.",
                 webhook_event_id=webhook_event_id,
             )
             return
-        await acquire_membership_activation_lock(db, created_by_user_id)
-        await mark_team_checkout_activating(db, intent, stripe_subscription_id=subscription_id)
+        await organization_service.begin_team_checkout_activation(
+            db,
+            intent_id=intent_id,
+            created_by_user_id=created_by_user_id,
+            stripe_subscription_id=subscription_id,
+        )
         await _upsert_team_subscription_from_stripe(
             db,
             subscription=subscription,
             billing_subject_id=billing_subject_id,
         )
-        activated = await complete_team_checkout_activation(
+        activated = await organization_service.complete_team_checkout_activation(
             db,
-            intent=intent,
-            organization=organization,
+            intent_id=intent_id,
             stripe_subscription_id=subscription_id,
             stripe_customer_id=customer_id,
             webhook_event_id=webhook_event_id,
@@ -365,7 +252,7 @@ async def activate_team_checkout_from_stripe_session(
         schedule_agent_gateway_org_enrollment(
             activated_organization_id, activated_created_by_user_id
         )
-        await _send_staged_team_checkout_invitations(
+        await organization_service.send_staged_team_checkout_invitations(
             organization_id=activated_organization_id,
             organization_name=activated_organization_name,
             invited_by_user_id=activated_created_by_user_id,

--- a/server/proliferate/server/organizations/invitation_delivery.py
+++ b/server/proliferate/server/organizations/invitation_delivery.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from proliferate.config import settings
+from proliferate.constants.organizations import (
+    ORGANIZATION_INVITE_EXPIRES_DAYS,
+    ORGANIZATION_ROLE_MEMBER,
+)
 from proliferate.db import engine as db_engine
+from proliferate.db import session_ops as db_session
 from proliferate.db.store import organization_invitations as invitation_store
 from proliferate.db.store.organization_records import InvitationRecord
 from proliferate.integrations import resend
@@ -15,6 +22,9 @@ from proliferate.server.organizations.join_links import (
     invitation_registration_url,
     organization_join_url,
 )
+from proliferate.utils.time import utcnow
+
+team_checkout_logger = logging.getLogger("proliferate.billing.team_checkout.activation")
 
 
 @dataclass(frozen=True)
@@ -139,3 +149,104 @@ async def rotate_and_send_invitation(
         organization_name=record.organization.name,
         inviter_email=inviter_email,
     )
+
+
+async def _send_staged_team_checkout_invitation(
+    *,
+    organization_id: UUID,
+    organization_name: str,
+    invited_by_user_id: UUID,
+    inviter_email: str,
+    email: str,
+) -> None:
+    async with db_session.open_async_transaction() as db:
+        record = await invitation_store.create_or_rotate_organization_invitation(
+            db,
+            organization_id=organization_id,
+            email=email,
+            role=ORGANIZATION_ROLE_MEMBER,
+            invited_by_user_id=invited_by_user_id,
+            expires_at=utcnow() + timedelta(days=ORGANIZATION_INVITE_EXPIRES_DAYS),
+        )
+    if record is None:
+        team_checkout_logger.warning(
+            "Skipping staged team checkout invitation because organization was not found",
+            extra={"organization_id": str(organization_id), "email": email},
+        )
+        return
+    try:
+        result = await resend.send_organization_invitation_email(
+            to_email=record.invitation.email,
+            organization_name=organization_name,
+            inviter_email=inviter_email,
+            invite_url=organization_join_url(organization_id),
+        )
+    except resend.ResendEmailError as error:
+        async with db_session.open_async_transaction() as db:
+            await invitation_store.mark_invitation_delivery(
+                db,
+                invitation_id=record.invitation.id,
+                sent=False,
+                skipped=False,
+                error=error.message,
+            )
+        team_checkout_logger.warning(
+            "Failed to deliver staged team checkout invitation",
+            extra={
+                "organization_id": str(organization_id),
+                "invitation_id": str(record.invitation.id),
+                "email": record.invitation.email,
+                "error_code": error.code,
+            },
+        )
+        return
+    async with db_session.open_async_transaction() as db:
+        await invitation_store.mark_invitation_delivery(
+            db,
+            invitation_id=record.invitation.id,
+            sent=not result.skipped,
+            skipped=result.skipped,
+        )
+
+
+async def send_staged_team_checkout_invitations(
+    *,
+    organization_id: UUID,
+    organization_name: str,
+    invited_by_user_id: UUID,
+    inviter_email: str,
+    invite_emails_json: str | None,
+) -> None:
+    if not invite_emails_json:
+        return
+    try:
+        raw_invites = json.loads(invite_emails_json)
+    except ValueError:
+        team_checkout_logger.warning(
+            "Skipping staged team checkout invitations because invite JSON is invalid",
+            extra={"organization_id": str(organization_id)},
+        )
+        return
+    if not isinstance(raw_invites, list):
+        return
+    invite_emails = sorted(
+        {
+            email.strip().lower()
+            for email in raw_invites
+            if isinstance(email, str) and email.strip()
+        }
+    )
+    for email in invite_emails:
+        try:
+            await _send_staged_team_checkout_invitation(
+                organization_id=organization_id,
+                organization_name=organization_name,
+                invited_by_user_id=invited_by_user_id,
+                inviter_email=inviter_email,
+                email=email,
+            )
+        except Exception:
+            team_checkout_logger.exception(
+                "Unexpected failure while creating staged team checkout invitation",
+                extra={"organization_id": str(organization_id), "email": email},
+            )

--- a/server/proliferate/server/organizations/service.py
+++ b/server/proliferate/server/organizations/service.py
@@ -291,6 +291,82 @@ async def cancel_team_checkout_intent(
     )
 
 
+async def load_team_checkout_activation(
+    db: AsyncSession,
+    *,
+    intent_id: UUID,
+) -> CheckoutIntentWithOrganizationRecord | None:
+    return await organization_store.load_team_checkout_activation_for_update(db, intent_id)
+
+
+async def fail_team_checkout_activation(
+    db: AsyncSession,
+    *,
+    intent_id: UUID,
+    activation_status: str,
+    error_code: str,
+    error_message: str,
+    webhook_event_id: str | None,
+) -> CheckoutIntentRecord | None:
+    return await organization_store.mark_team_checkout_failed_by_id(
+        db,
+        intent_id=intent_id,
+        activation_status=activation_status,
+        error_code=error_code,
+        error_message=error_message,
+        webhook_event_id=webhook_event_id,
+    )
+
+
+async def begin_team_checkout_activation(
+    db: AsyncSession,
+    *,
+    intent_id: UUID,
+    created_by_user_id: UUID,
+    stripe_subscription_id: str,
+) -> None:
+    await organization_store.acquire_membership_activation_lock(db, created_by_user_id)
+    await organization_store.mark_team_checkout_activating_by_id(
+        db,
+        intent_id=intent_id,
+        stripe_subscription_id=stripe_subscription_id,
+    )
+
+
+async def complete_team_checkout_activation(
+    db: AsyncSession,
+    *,
+    intent_id: UUID,
+    stripe_subscription_id: str,
+    stripe_customer_id: str,
+    webhook_event_id: str | None,
+) -> OrganizationWithMembershipRecord:
+    return await organization_store.complete_team_checkout_activation_by_id(
+        db,
+        intent_id=intent_id,
+        stripe_subscription_id=stripe_subscription_id,
+        stripe_customer_id=stripe_customer_id,
+        webhook_event_id=webhook_event_id,
+    )
+
+
+async def send_staged_team_checkout_invitations(
+    *,
+    organization_id: UUID,
+    organization_name: str,
+    invited_by_user_id: UUID,
+    inviter_email: str,
+    invite_emails_json: str | None,
+) -> None:
+    await invitation_delivery.send_staged_team_checkout_invitations(
+        organization_id=organization_id,
+        organization_name=organization_name,
+        invited_by_user_id=invited_by_user_id,
+        inviter_email=inviter_email,
+        invite_emails_json=invite_emails_json,
+    )
+
+
 async def get_organization(
     db: AsyncSession,
     org_user: CurrentOrgUser,

--- a/server/tests/unit/test_billing_team_checkout_activation.py
+++ b/server/tests/unit/test_billing_team_checkout_activation.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.organization_records import (
+    CheckoutIntentRecord,
+    CheckoutIntentWithOrganizationRecord,
+    MembershipRecord,
+    OrganizationRecord,
+    OrganizationWithMembershipRecord,
+)
+from proliferate.integrations import stripe as stripe_billing
+from proliferate.server.billing.models import BillingServiceError
+from proliferate.server.billing.team_checkout import activation
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+
+
+def _metadata() -> dict[str, str]:
+    return {
+        "purpose": "team_subscription",
+        "organization_checkout_intent_id": str(uuid4()),
+        "organization_id": str(uuid4()),
+        "created_by_user_id": str(uuid4()),
+        "billing_subject_id": str(uuid4()),
+    }
+
+
+def _session(
+    metadata: dict[str, str],
+    *,
+    subscription: object = "sub_team",
+    customer: object = "cus_team",
+) -> dict[str, object]:
+    return {
+        "id": "cs_team",
+        "metadata": metadata,
+        "subscription": subscription,
+        "customer": customer,
+    }
+
+
+def _subscription(metadata: dict[str, str], *, status: str = "active") -> dict[str, object]:
+    return {
+        "id": "sub_team",
+        "customer": "cus_team",
+        "status": status,
+        "metadata": dict(metadata),
+    }
+
+
+def _activation_record(metadata: dict[str, str]) -> CheckoutIntentWithOrganizationRecord:
+    organization_id = UUID(metadata["organization_id"])
+    creator_id = UUID(metadata["created_by_user_id"])
+    intent = CheckoutIntentRecord(
+        id=UUID(metadata["organization_checkout_intent_id"]),
+        organization_id=organization_id,
+        created_by_user_id=creator_id,
+        billing_subject_id=UUID(metadata["billing_subject_id"]),
+        team_name="Activation Team",
+        status="pending",
+        activation_status="not_started",
+        activation_error_code=None,
+        activation_error_message=None,
+        last_webhook_event_id=None,
+        stripe_checkout_session_id="cs_team",
+        stripe_customer_id="cus_team",
+        stripe_subscription_id=None,
+        idempotency_key="checkout-key",
+        invite_emails_json='["member@example.com"]',
+        checkout_url="https://checkout.example/session",
+        expires_at=NOW,
+        completed_at=None,
+        failed_at=None,
+        cancelled_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    return CheckoutIntentWithOrganizationRecord(
+        intent=intent,
+        organization=OrganizationRecord(
+            id=organization_id,
+            name="Activation Team",
+            slug="activation-team",
+            logo_domain="example.com",
+            logo_image=None,
+            status="pending_checkout",
+            is_instance=False,
+            created_at=NOW,
+            updated_at=NOW,
+        ),
+    )
+
+
+def _activated_record(
+    locked: CheckoutIntentWithOrganizationRecord,
+) -> OrganizationWithMembershipRecord:
+    return OrganizationWithMembershipRecord(
+        organization=replace(locked.organization, name="Activated Team", status="active"),
+        membership=MembershipRecord(
+            id=uuid4(),
+            organization_id=locked.organization.id,
+            user_id=locked.intent.created_by_user_id,
+            role="owner",
+            status="active",
+            joined_at=NOW,
+            removed_at=None,
+        ),
+    )
+
+
+def _error_tuple(error: BillingServiceError) -> tuple[str, str, int]:
+    return error.code, error.message, error.status_code
+
+
+def _forbid_transaction() -> None:
+    raise AssertionError("this branch must not open a database transaction")
+
+
+class _ActivationHarness:
+    def __init__(
+        self,
+        metadata: dict[str, str],
+        *,
+        subscription_status: str = "active",
+        activation_result: CheckoutIntentWithOrganizationRecord | None,
+        creator_email: str | None = "owner@example.com",
+        failure_result: CheckoutIntentRecord | None = None,
+        raise_at: str | None = None,
+    ) -> None:
+        self.metadata = metadata
+        self.subscription = _subscription(metadata, status=subscription_status)
+        self.activation_result = activation_result
+        self.creator_email = creator_email
+        self.failure_result = failure_result
+        self.raise_at = raise_at
+        self.db = cast(AsyncSession, object())
+        self.active_transactions = 0
+        self.transaction_count = 0
+        self.trace: list[str] = []
+        self.load_calls: list[dict[str, object]] = []
+        self.failure_calls: list[dict[str, object]] = []
+        self.creator_calls: list[tuple[AsyncSession, UUID]] = []
+        self.begin_calls: list[dict[str, object]] = []
+        self.upsert_calls: list[dict[str, object]] = []
+        self.complete_calls: list[dict[str, object]] = []
+        self.enrollment_calls: list[tuple[UUID, UUID]] = []
+        self.staged_calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def open_transaction(self) -> AsyncIterator[AsyncSession]:
+        self.transaction_count += 1
+        assert self.active_transactions == 0
+        self.active_transactions += 1
+        self.trace.append("transaction_enter")
+        try:
+            yield self.db
+        finally:
+            self.trace.append("transaction_exit")
+            self.active_transactions -= 1
+
+    async def retrieve(self, subscription_id: str) -> dict[str, object]:
+        assert subscription_id == "sub_team"
+        assert self.active_transactions == 0
+        self.trace.append("stripe")
+        return self.subscription
+
+    async def load(self, actual_db: AsyncSession, **kwargs: object) -> object:
+        self.trace.append("load")
+        self.load_calls.append({"db": actual_db, **kwargs})
+        return self.activation_result
+
+    async def fail(self, actual_db: AsyncSession, **kwargs: object) -> object:
+        self.trace.append("fail")
+        self.failure_calls.append({"db": actual_db, **kwargs})
+        return self.failure_result
+
+    async def creator(self, actual_db: AsyncSession, user_id: UUID) -> object | None:
+        self.trace.append("creator")
+        self.creator_calls.append((actual_db, user_id))
+        if self.creator_email is None:
+            return None
+        return SimpleNamespace(email=self.creator_email)
+
+    async def begin(self, actual_db: AsyncSession, **kwargs: object) -> None:
+        self.trace.append("begin")
+        self.begin_calls.append({"db": actual_db, **kwargs})
+
+    async def upsert(self, actual_db: AsyncSession, **kwargs: object) -> object:
+        self.trace.append("upsert")
+        self.upsert_calls.append({"db": actual_db, **kwargs})
+        if self.raise_at == "upsert":
+            raise RuntimeError("upsert failed")
+        return object()
+
+    async def complete(self, actual_db: AsyncSession, **kwargs: object) -> object:
+        self.trace.append("complete")
+        self.complete_calls.append({"db": actual_db, **kwargs})
+        if self.raise_at == "complete":
+            raise RuntimeError("complete failed")
+        assert self.activation_result is not None
+        return _activated_record(self.activation_result)
+
+    def schedule_enrollment(self, organization_id: UUID, user_id: UUID) -> None:
+        assert self.active_transactions == 0
+        self.trace.append("enrollment")
+        self.enrollment_calls.append((organization_id, user_id))
+
+    async def send_staged(self, **kwargs: object) -> None:
+        assert self.active_transactions == 0
+        self.trace.append("staged")
+        self.staged_calls.append(kwargs)
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(activation.db_session, "open_async_transaction", self.open_transaction)
+        monkeypatch.setattr(activation.stripe_billing, "retrieve_subscription", self.retrieve)
+        for name, replacement in (
+            ("load_team_checkout_activation", self.load),
+            ("fail_team_checkout_activation", self.fail),
+            ("begin_team_checkout_activation", self.begin),
+            ("complete_team_checkout_activation", self.complete),
+            ("send_staged_team_checkout_invitations", self.send_staged),
+        ):
+            monkeypatch.setattr(activation.organization_service, name, replacement)
+        monkeypatch.setattr(activation.user_store, "get_user_by_id", self.creator)
+        monkeypatch.setattr(activation, "_upsert_team_subscription_from_stripe", self.upsert)
+        monkeypatch.setattr(
+            activation,
+            "schedule_agent_gateway_org_enrollment",
+            self.schedule_enrollment,
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_team_session_returns_before_stripe_or_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _forbid_stripe(_subscription_id: str) -> None:
+        raise AssertionError("non-team sessions must not retrieve a subscription")
+
+    monkeypatch.setattr(activation.stripe_billing, "retrieve_subscription", _forbid_stripe)
+    monkeypatch.setattr(activation.db_session, "open_async_transaction", _forbid_transaction)
+
+    await activation.activate_team_checkout_from_stripe_session(
+        session={"metadata": {"purpose": "refill"}},
+    )
+
+
+@pytest.mark.parametrize("case", ["missing", "invalid", "subscription", "customer"])
+@pytest.mark.asyncio
+async def test_pre_stripe_validation_errors_are_exact_and_open_no_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    metadata = _metadata()
+    subscription: object = "sub_team"
+    customer: object = "cus_team"
+    if case == "missing":
+        metadata.pop("organization_id")
+        expected = ("team_checkout_metadata_missing", "Team checkout metadata is incomplete.", 400)
+    elif case == "invalid":
+        metadata["organization_id"] = "not-a-uuid"
+        expected = ("team_checkout_metadata_invalid", "Team checkout metadata is invalid.", 400)
+    else:
+        if case == "subscription":
+            subscription = None
+        else:
+            customer = None
+        expected = (
+            "team_checkout_subscription_missing",
+            "Team checkout session is missing its subscription.",
+            400,
+        )
+
+    async def _forbid_stripe(_subscription_id: str) -> None:
+        raise AssertionError("validation failures must precede Stripe retrieval")
+
+    monkeypatch.setattr(activation.stripe_billing, "retrieve_subscription", _forbid_stripe)
+    monkeypatch.setattr(activation.db_session, "open_async_transaction", _forbid_transaction)
+
+    with pytest.raises(BillingServiceError) as raised:
+        await activation.activate_team_checkout_from_stripe_session(
+            session=_session(metadata, subscription=subscription, customer=customer),
+        )
+
+    assert _error_tuple(raised.value) == expected
+
+
+@pytest.mark.asyncio
+async def test_stripe_error_is_mapped_before_database_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _metadata()
+
+    async def _raise_stripe(_subscription_id: str) -> None:
+        raise stripe_billing.StripeBillingError(
+            "stripe_unavailable",
+            "Stripe is unavailable.",
+            status_code=503,
+        )
+
+    monkeypatch.setattr(activation.stripe_billing, "retrieve_subscription", _raise_stripe)
+    monkeypatch.setattr(activation.db_session, "open_async_transaction", _forbid_transaction)
+
+    with pytest.raises(BillingServiceError) as raised:
+        await activation.activate_team_checkout_from_stripe_session(session=_session(metadata))
+
+    assert _error_tuple(raised.value) == (
+        "stripe_unavailable",
+        "Stripe is unavailable.",
+        503,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subscription_metadata_mismatch_precedes_database_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _metadata()
+    subscription = _subscription(metadata)
+    cast(dict[str, str], subscription["metadata"])["organization_id"] = str(uuid4())
+
+    async def _retrieve(_subscription_id: str) -> dict[str, object]:
+        return subscription
+
+    monkeypatch.setattr(activation.stripe_billing, "retrieve_subscription", _retrieve)
+    monkeypatch.setattr(activation.db_session, "open_async_transaction", _forbid_transaction)
+
+    with pytest.raises(BillingServiceError) as raised:
+        await activation.activate_team_checkout_from_stripe_session(session=_session(metadata))
+
+    assert _error_tuple(raised.value) == (
+        "team_checkout_subscription_metadata_mismatch",
+        "Team checkout subscription metadata does not match the checkout session.",
+        409,
+    )
+
+
+@pytest.mark.parametrize("failure_present", [True, False])
+@pytest.mark.asyncio
+async def test_inactive_subscription_uses_only_owner_failure_command(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_present: bool,
+) -> None:
+    metadata = _metadata()
+    locked = _activation_record(metadata)
+    harness = _ActivationHarness(
+        metadata,
+        subscription_status="past_due",
+        activation_result=locked,
+        failure_result=locked.intent if failure_present else None,
+    )
+    harness.install(monkeypatch)
+
+    await activation.activate_team_checkout_from_stripe_session(
+        session=_session(metadata),
+        webhook_event_id="evt_inactive",
+    )
+
+    assert harness.trace == ["stripe", "transaction_enter", "fail", "transaction_exit"]
+    assert harness.transaction_count == 1
+    assert harness.failure_calls == [
+        {
+            "db": harness.db,
+            "intent_id": locked.intent.id,
+            "activation_status": "failed_billing_state",
+            "error_code": "subscription_not_active",
+            "error_message": "Team subscription is not active or trialing.",
+            "webhook_event_id": "evt_inactive",
+        }
+    ]
+    assert harness.active_transactions == 0
+
+
+@pytest.mark.parametrize("case", ["missing", "mismatch"])
+@pytest.mark.asyncio
+async def test_active_load_errors_are_exact(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    metadata = _metadata()
+    locked = _activation_record(metadata)
+    if case == "missing":
+        activation_result = None
+        expected = (
+            "team_checkout_intent_not_found",
+            "Team checkout intent was not found.",
+            404,
+        )
+    else:
+        activation_result = replace(
+            locked,
+            intent=replace(locked.intent, organization_id=uuid4()),
+        )
+        expected = (
+            "team_checkout_intent_mismatch",
+            "Team checkout intent does not match Stripe metadata.",
+            409,
+        )
+    harness = _ActivationHarness(metadata, activation_result=activation_result)
+    harness.install(monkeypatch)
+
+    with pytest.raises(BillingServiceError) as raised:
+        await activation.activate_team_checkout_from_stripe_session(session=_session(metadata))
+
+    assert _error_tuple(raised.value) == expected
+    assert harness.trace == ["stripe", "transaction_enter", "load", "transaction_exit"]
+
+
+@pytest.mark.asyncio
+async def test_non_pending_intent_is_a_noop_after_locked_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _metadata()
+    locked = _activation_record(metadata)
+    completed = replace(locked, intent=replace(locked.intent, status="completed"))
+    harness = _ActivationHarness(metadata, activation_result=completed)
+    harness.install(monkeypatch)
+
+    await activation.activate_team_checkout_from_stripe_session(session=_session(metadata))
+
+    assert harness.trace == ["stripe", "transaction_enter", "load", "transaction_exit"]
+
+
+@pytest.mark.parametrize("case", ["organization", "creator"])
+@pytest.mark.asyncio
+async def test_active_business_failures_are_exact(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    metadata = _metadata()
+    locked = _activation_record(metadata)
+    if case == "organization":
+        activation_result = replace(
+            locked,
+            organization=replace(locked.organization, status="active"),
+        )
+        creator_email = "owner@example.com"
+        event_id = "evt_org_invalid"
+        error_code = "organization_not_pending_checkout"
+        error_message = "Team checkout organization is not pending checkout."
+        middle_trace: list[str] = []
+    else:
+        activation_result = locked
+        creator_email = None
+        event_id = "evt_creator_missing"
+        error_code = "checkout_creator_not_found"
+        error_message = "Checkout creator account was not found."
+        middle_trace = ["creator"]
+    harness = _ActivationHarness(
+        metadata,
+        activation_result=activation_result,
+        creator_email=creator_email,
+    )
+    harness.install(monkeypatch)
+
+    await activation.activate_team_checkout_from_stripe_session(
+        session=_session(metadata),
+        webhook_event_id=event_id,
+    )
+
+    assert harness.trace == [
+        "stripe",
+        "transaction_enter",
+        "load",
+        *middle_trace,
+        "fail",
+        "transaction_exit",
+    ]
+    assert harness.failure_calls == [
+        {
+            "db": harness.db,
+            "intent_id": locked.intent.id,
+            "activation_status": "failed_business_state",
+            "error_code": error_code,
+            "error_message": error_message,
+            "webhook_event_id": event_id,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_happy_path_preserves_transaction_and_post_commit_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _metadata()
+    locked = _activation_record(metadata)
+    harness = _ActivationHarness(metadata, activation_result=locked)
+    harness.install(monkeypatch)
+
+    await activation.activate_team_checkout_from_stripe_session(
+        session=_session(metadata),
+        webhook_event_id="evt_happy",
+    )
+
+    assert harness.trace == [
+        "stripe",
+        "transaction_enter",
+        "load",
+        "creator",
+        "begin",
+        "upsert",
+        "complete",
+        "transaction_exit",
+        "enrollment",
+        "staged",
+    ]
+    primary_calls = [
+        harness.load_calls[0],
+        {"db": harness.creator_calls[0][0]},
+        harness.begin_calls[0],
+        harness.upsert_calls[0],
+        harness.complete_calls[0],
+    ]
+    assert all(call["db"] is harness.db for call in primary_calls)
+    assert harness.creator_calls[0][1] == locked.intent.created_by_user_id
+    assert harness.begin_calls[0] == {
+        "db": harness.db,
+        "intent_id": locked.intent.id,
+        "created_by_user_id": locked.intent.created_by_user_id,
+        "stripe_subscription_id": "sub_team",
+    }
+    assert harness.upsert_calls[0] == {
+        "db": harness.db,
+        "subscription": harness.subscription,
+        "billing_subject_id": locked.intent.billing_subject_id,
+    }
+    assert harness.complete_calls[0] == {
+        "db": harness.db,
+        "intent_id": locked.intent.id,
+        "stripe_subscription_id": "sub_team",
+        "stripe_customer_id": "cus_team",
+        "webhook_event_id": "evt_happy",
+    }
+    assert harness.enrollment_calls == [(locked.organization.id, locked.intent.created_by_user_id)]
+    assert harness.staged_calls == [
+        {
+            "organization_id": locked.organization.id,
+            "organization_name": "Activated Team",
+            "invited_by_user_id": locked.intent.created_by_user_id,
+            "inviter_email": "owner@example.com",
+            "invite_emails_json": locked.intent.invite_emails_json,
+        }
+    ]
+    assert harness.active_transactions == 0
+
+
+@pytest.mark.parametrize("raise_at", ["upsert", "complete"])
+@pytest.mark.asyncio
+async def test_primary_failure_prevents_both_post_commit_effects(
+    monkeypatch: pytest.MonkeyPatch,
+    raise_at: str,
+) -> None:
+    metadata = _metadata()
+    locked = _activation_record(metadata)
+    harness = _ActivationHarness(metadata, activation_result=locked, raise_at=raise_at)
+    harness.install(monkeypatch)
+
+    with pytest.raises(RuntimeError, match=f"{raise_at} failed"):
+        await activation.activate_team_checkout_from_stripe_session(session=_session(metadata))
+
+    assert harness.enrollment_calls == []
+    assert harness.staged_calls == []
+    assert harness.trace[-1] == "transaction_exit"
+    assert harness.active_transactions == 0
+    if raise_at == "upsert":
+        assert harness.complete_calls == []
+    else:
+        assert len(harness.complete_calls) == 1
+
+
+def test_billing_activation_has_no_organization_store_imports() -> None:
+    assert not hasattr(activation, "organization_store")
+    assert not hasattr(activation, "invitation_store")

--- a/server/tests/unit/test_organization_team_checkout_activation_service.py
+++ b/server/tests/unit/test_organization_team_checkout_activation_service.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast, get_type_hints
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.organization_records import (
+    CheckoutIntentRecord,
+    CheckoutIntentWithOrganizationRecord,
+    MembershipRecord,
+    OrganizationRecord,
+    OrganizationWithMembershipRecord,
+)
+from proliferate.server.organizations import service as organization_service
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+
+
+class _TransactionForbiddenSession:
+    def begin(self) -> None:
+        raise AssertionError("organization activation services must not open transactions")
+
+    async def commit(self) -> None:
+        raise AssertionError("organization activation services must not commit")
+
+    async def rollback(self) -> None:
+        raise AssertionError("organization activation services must not roll back")
+
+    async def close(self) -> None:
+        raise AssertionError("organization activation services must not close the caller session")
+
+
+def _session() -> AsyncSession:
+    return cast(AsyncSession, _TransactionForbiddenSession())
+
+
+def _intent_record() -> CheckoutIntentRecord:
+    return CheckoutIntentRecord(
+        id=uuid4(),
+        organization_id=uuid4(),
+        created_by_user_id=uuid4(),
+        billing_subject_id=uuid4(),
+        team_name="Activation Team",
+        status="pending",
+        activation_status="not_started",
+        activation_error_code=None,
+        activation_error_message=None,
+        last_webhook_event_id=None,
+        stripe_checkout_session_id="cs_team",
+        stripe_customer_id="cus_team",
+        stripe_subscription_id=None,
+        idempotency_key="checkout-key",
+        invite_emails_json='["member@example.com"]',
+        checkout_url="https://checkout.example/session",
+        expires_at=NOW,
+        completed_at=None,
+        failed_at=None,
+        cancelled_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _organization_record(organization_id: UUID) -> OrganizationRecord:
+    return OrganizationRecord(
+        id=organization_id,
+        name="Activation Team",
+        slug="activation-team",
+        logo_domain="example.com",
+        logo_image=None,
+        status="pending_checkout",
+        is_instance=False,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _activation_record() -> CheckoutIntentWithOrganizationRecord:
+    intent = _intent_record()
+    return CheckoutIntentWithOrganizationRecord(
+        intent=intent,
+        organization=_organization_record(intent.organization_id),
+    )
+
+
+def _activated_record(
+    activation: CheckoutIntentWithOrganizationRecord,
+) -> OrganizationWithMembershipRecord:
+    return OrganizationWithMembershipRecord(
+        organization=_organization_record(activation.organization.id),
+        membership=MembershipRecord(
+            id=uuid4(),
+            organization_id=activation.organization.id,
+            user_id=activation.intent.created_by_user_id,
+            role="owner",
+            status="active",
+            joined_at=NOW,
+            removed_at=None,
+        ),
+    )
+
+
+@pytest.mark.parametrize("store_result", [_activation_record(), None])
+@pytest.mark.asyncio
+async def test_load_team_checkout_activation_forwards_session_and_result(
+    monkeypatch: pytest.MonkeyPatch,
+    store_result: CheckoutIntentWithOrganizationRecord | None,
+) -> None:
+    db = _session()
+    intent_id = uuid4()
+    calls: list[tuple[AsyncSession, UUID]] = []
+
+    async def _load(actual_db: AsyncSession, actual_intent_id: UUID) -> object:
+        calls.append((actual_db, actual_intent_id))
+        return store_result
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "load_team_checkout_activation_for_update",
+        _load,
+    )
+
+    result = await organization_service.load_team_checkout_activation(
+        db,
+        intent_id=intent_id,
+    )
+
+    assert result is store_result
+    assert calls == [(db, intent_id)]
+
+
+@pytest.mark.parametrize("store_result", [_intent_record(), None])
+@pytest.mark.asyncio
+async def test_fail_team_checkout_activation_forwards_every_field(
+    monkeypatch: pytest.MonkeyPatch,
+    store_result: CheckoutIntentRecord | None,
+) -> None:
+    db = _session()
+    intent_id = uuid4()
+    calls: list[dict[str, object]] = []
+
+    async def _fail(actual_db: AsyncSession, **kwargs: object) -> object:
+        calls.append({"db": actual_db, **kwargs})
+        return store_result
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "mark_team_checkout_failed_by_id",
+        _fail,
+    )
+
+    result = await organization_service.fail_team_checkout_activation(
+        db,
+        intent_id=intent_id,
+        activation_status="failed_billing_state",
+        error_code="subscription_not_active",
+        error_message="Team subscription is not active or trialing.",
+        webhook_event_id="evt_failure",
+    )
+
+    assert result is store_result
+    assert calls == [
+        {
+            "db": db,
+            "intent_id": intent_id,
+            "activation_status": "failed_billing_state",
+            "error_code": "subscription_not_active",
+            "error_message": "Team subscription is not active or trialing.",
+            "webhook_event_id": "evt_failure",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_begin_team_checkout_activation_locks_before_marking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    intent_id = uuid4()
+    creator_id = uuid4()
+    calls: list[tuple[str, object]] = []
+
+    async def _lock(actual_db: AsyncSession, user_id: UUID) -> None:
+        calls.append(("lock", (actual_db, user_id)))
+
+    async def _mark(actual_db: AsyncSession, **kwargs: object) -> None:
+        calls.append(("mark", {"db": actual_db, **kwargs}))
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "acquire_membership_activation_lock",
+        _lock,
+    )
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "mark_team_checkout_activating_by_id",
+        _mark,
+    )
+
+    await organization_service.begin_team_checkout_activation(
+        db,
+        intent_id=intent_id,
+        created_by_user_id=creator_id,
+        stripe_subscription_id="sub_team",
+    )
+
+    assert calls == [
+        ("lock", (db, creator_id)),
+        (
+            "mark",
+            {
+                "db": db,
+                "intent_id": intent_id,
+                "stripe_subscription_id": "sub_team",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_begin_team_checkout_activation_propagates_mark_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    calls: list[str] = []
+
+    async def _lock(_db: AsyncSession, _user_id: UUID) -> None:
+        calls.append("lock")
+
+    async def _mark(_db: AsyncSession, **_kwargs: object) -> None:
+        calls.append("mark")
+        raise RuntimeError("mark failed")
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "acquire_membership_activation_lock",
+        _lock,
+    )
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "mark_team_checkout_activating_by_id",
+        _mark,
+    )
+
+    with pytest.raises(RuntimeError, match="mark failed"):
+        await organization_service.begin_team_checkout_activation(
+            db,
+            intent_id=uuid4(),
+            created_by_user_id=uuid4(),
+            stripe_subscription_id="sub_team",
+        )
+
+    assert calls == ["lock", "mark"]
+
+
+@pytest.mark.asyncio
+async def test_complete_team_checkout_activation_forwards_every_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = _session()
+    activation = _activation_record()
+    expected = _activated_record(activation)
+    calls: list[dict[str, object]] = []
+
+    async def _complete(actual_db: AsyncSession, **kwargs: object) -> object:
+        calls.append({"db": actual_db, **kwargs})
+        return expected
+
+    monkeypatch.setattr(
+        organization_service.organization_store,
+        "complete_team_checkout_activation_by_id",
+        _complete,
+    )
+
+    result = await organization_service.complete_team_checkout_activation(
+        db,
+        intent_id=activation.intent.id,
+        stripe_subscription_id="sub_team",
+        stripe_customer_id="cus_team",
+        webhook_event_id="evt_team",
+    )
+
+    assert result is expected
+    assert calls == [
+        {
+            "db": db,
+            "intent_id": activation.intent.id,
+            "stripe_subscription_id": "sub_team",
+            "stripe_customer_id": "cus_team",
+            "webhook_event_id": "evt_team",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_staged_delivery_forwards_every_value_and_awaits_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization_id = uuid4()
+    creator_id = uuid4()
+    calls: list[dict[str, object]] = []
+    completed = False
+
+    async def _send(**kwargs: object) -> None:
+        nonlocal completed
+        calls.append(kwargs)
+        completed = True
+
+    monkeypatch.setattr(
+        organization_service.invitation_delivery,
+        "send_staged_team_checkout_invitations",
+        _send,
+    )
+
+    await organization_service.send_staged_team_checkout_invitations(
+        organization_id=organization_id,
+        organization_name="Activation Team",
+        invited_by_user_id=creator_id,
+        inviter_email="owner@example.com",
+        invite_emails_json='["member@example.com"]',
+    )
+
+    assert completed is True
+    assert calls == [
+        {
+            "organization_id": organization_id,
+            "organization_name": "Activation Team",
+            "invited_by_user_id": creator_id,
+            "inviter_email": "owner@example.com",
+            "invite_emails_json": '["member@example.com"]',
+        }
+    ]
+
+
+def test_activation_service_public_types_do_not_expose_organization_orm() -> None:
+    functions = (
+        organization_service.load_team_checkout_activation,
+        organization_service.fail_team_checkout_activation,
+        organization_service.begin_team_checkout_activation,
+        organization_service.complete_team_checkout_activation,
+    )
+
+    for function in functions:
+        for annotation in get_type_hints(function).values():
+            assert "proliferate.db.models.organizations" not in repr(annotation)

--- a/server/tests/unit/test_team_checkout_invitation_delivery.py
+++ b/server/tests/unit/test_team_checkout_invitation_delivery.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from proliferate.db.store.organization_records import (
+    InvitationCreateRecord,
+    InvitationRecord,
+    OrganizationRecord,
+)
+from proliferate.integrations import resend
+from proliferate.server.organizations import invitation_delivery
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+LOGGER_NAME = "proliferate.billing.team_checkout.activation"
+
+
+@pytest.fixture
+def _capture_team_checkout_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(invitation_delivery.team_checkout_logger, "disabled", False)
+    monkeypatch.setattr(invitation_delivery.team_checkout_logger, "propagate", True)
+
+
+def _organization(organization_id: UUID) -> OrganizationRecord:
+    return OrganizationRecord(
+        id=organization_id,
+        name="Activation Team",
+        slug="activation-team",
+        logo_domain="example.com",
+        logo_image=None,
+        status="active",
+        is_instance=False,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _invitation(
+    *,
+    organization_id: UUID,
+    invited_by_user_id: UUID,
+    email: str,
+    expires_at: datetime,
+) -> InvitationRecord:
+    return InvitationRecord(
+        id=uuid4(),
+        organization_id=organization_id,
+        organization_name="Activation Team",
+        email=email,
+        role="member",
+        status="pending",
+        delivery_status="pending",
+        delivery_error=None,
+        expires_at=expires_at,
+        delivered_at=None,
+        invited_by_user_id=invited_by_user_id,
+        accepted_by_user_id=None,
+        accepted_at=None,
+        revoked_at=None,
+        expired_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+class _DeliveryHarness:
+    def __init__(self, organization_id: UUID, invited_by_user_id: UUID) -> None:
+        self.organization_id = organization_id
+        self.invited_by_user_id = invited_by_user_id
+        self.active_transactions = 0
+        self.transaction_count = 0
+        self.trace: list[tuple[str, object]] = []
+        self.create_calls: list[dict[str, object]] = []
+        self.provider_calls: list[dict[str, str]] = []
+        self.mark_calls: list[dict[str, object]] = []
+        self.join_calls: list[UUID] = []
+        self.invitations: dict[str, InvitationRecord] = {}
+        self.missing_emails: set[str] = set()
+        self.create_errors: dict[str, Exception] = {}
+        self.provider_results: dict[str, resend.ResendEmailResult | Exception] = {}
+
+    @asynccontextmanager
+    async def open_transaction(self) -> AsyncIterator[object]:
+        self.transaction_count += 1
+        transaction_id = self.transaction_count
+        assert self.active_transactions == 0
+        self.active_transactions += 1
+        self.trace.append(("transaction_enter", transaction_id))
+        try:
+            yield SimpleNamespace(transaction_id=transaction_id)
+        finally:
+            self.trace.append(("transaction_exit", transaction_id))
+            self.active_transactions -= 1
+
+    async def create(self, db: object, **kwargs: object) -> InvitationCreateRecord | None:
+        assert self.active_transactions == 1
+        email = kwargs["email"]
+        assert isinstance(email, str)
+        transaction_id = db.transaction_id  # type: ignore[attr-defined]
+        self.trace.append(("create", (email, transaction_id)))
+        self.create_calls.append({"db": db, **kwargs})
+        if error := self.create_errors.get(email):
+            raise error
+        if email in self.missing_emails:
+            return None
+        expires_at = kwargs["expires_at"]
+        assert isinstance(expires_at, datetime)
+        invitation = _invitation(
+            organization_id=self.organization_id,
+            invited_by_user_id=self.invited_by_user_id,
+            email=email,
+            expires_at=expires_at,
+        )
+        self.invitations[email] = invitation
+        return InvitationCreateRecord(
+            invitation=invitation,
+            organization=_organization(self.organization_id),
+        )
+
+    async def send(self, **kwargs: str) -> resend.ResendEmailResult:
+        assert self.active_transactions == 0
+        email = kwargs["to_email"]
+        self.trace.append(("provider", email))
+        self.provider_calls.append(dict(kwargs))
+        result = self.provider_results.get(email)
+        if isinstance(result, Exception):
+            raise result
+        return result or resend.ResendEmailResult(provider_message_id="email-id")
+
+    async def mark(self, db: object, **kwargs: object) -> InvitationRecord:
+        assert self.active_transactions == 1
+        invitation_id = kwargs["invitation_id"]
+        invitation = next(
+            invitation
+            for invitation in self.invitations.values()
+            if invitation.id == invitation_id
+        )
+        transaction_id = db.transaction_id  # type: ignore[attr-defined]
+        self.trace.append(("mark", (invitation.email, transaction_id)))
+        self.mark_calls.append({"db": db, **kwargs})
+        return invitation
+
+    def join_url(self, organization_id: UUID) -> str:
+        self.join_calls.append(organization_id)
+        return f"https://hosted.example/join/{organization_id}"
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            invitation_delivery.db_session,
+            "open_async_transaction",
+            self.open_transaction,
+        )
+        monkeypatch.setattr(
+            invitation_delivery.invitation_store,
+            "create_or_rotate_organization_invitation",
+            self.create,
+        )
+        monkeypatch.setattr(
+            invitation_delivery.invitation_store,
+            "mark_invitation_delivery",
+            self.mark,
+        )
+        monkeypatch.setattr(
+            invitation_delivery.resend,
+            "send_organization_invitation_email",
+            self.send,
+        )
+        monkeypatch.setattr(invitation_delivery, "organization_join_url", self.join_url)
+        monkeypatch.setattr(invitation_delivery, "utcnow", lambda: NOW)
+
+
+@pytest.mark.parametrize("payload", [None, "", "{}", '"email@example.com"'])
+@pytest.mark.asyncio
+async def test_falsey_and_non_list_staged_invites_are_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _capture_team_checkout_logs: None,
+    payload: str | None,
+) -> None:
+    def _forbidden_transaction() -> None:
+        raise AssertionError("ignored staged invite input must not open a transaction")
+
+    monkeypatch.setattr(
+        invitation_delivery.db_session,
+        "open_async_transaction",
+        _forbidden_transaction,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        await invitation_delivery.send_staged_team_checkout_invitations(
+            organization_id=uuid4(),
+            organization_name="Activation Team",
+            invited_by_user_id=uuid4(),
+            inviter_email="owner@example.com",
+            invite_emails_json=payload,
+        )
+
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_staged_invite_json_logs_exact_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _capture_team_checkout_logs: None,
+) -> None:
+    organization_id = uuid4()
+
+    def _forbidden_transaction() -> None:
+        raise AssertionError("invalid staged invite JSON must not open a transaction")
+
+    monkeypatch.setattr(
+        invitation_delivery.db_session,
+        "open_async_transaction",
+        _forbidden_transaction,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        await invitation_delivery.send_staged_team_checkout_invitations(
+            organization_id=organization_id,
+            organization_name="Activation Team",
+            invited_by_user_id=uuid4(),
+            inviter_email="owner@example.com",
+            invite_emails_json="{invalid",
+        )
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.name == LOGGER_NAME
+    assert record.levelno == logging.WARNING
+    assert record.getMessage() == (
+        "Skipping staged team checkout invitations because invite JSON is invalid"
+    )
+    assert record.organization_id == str(organization_id)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_staged_invites_are_normalized_serial_and_outside_transactions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    organization_id = uuid4()
+    creator_id = uuid4()
+    harness = _DeliveryHarness(organization_id, creator_id)
+    harness.provider_results["b@example.com"] = resend.ResendEmailResult(
+        provider_message_id=None,
+        skipped=True,
+    )
+    harness.install(monkeypatch)
+    monkeypatch.setattr(invitation_delivery.settings, "single_org_mode_override", True)
+
+    await invitation_delivery.send_staged_team_checkout_invitations(
+        organization_id=organization_id,
+        organization_name="Activation Team",
+        invited_by_user_id=creator_id,
+        inviter_email="owner@example.com",
+        invite_emails_json=(
+            '[" B@example.com ", 7, "", "a@example.com", "b@example.com", "A@example.com"]'
+        ),
+    )
+
+    assert [call["email"] for call in harness.create_calls] == [
+        "a@example.com",
+        "b@example.com",
+    ]
+    assert all(call["role"] == "member" for call in harness.create_calls)
+    assert all(call["organization_id"] == organization_id for call in harness.create_calls)
+    assert all(call["invited_by_user_id"] == creator_id for call in harness.create_calls)
+    assert all(
+        call["expires_at"]
+        == NOW + timedelta(days=invitation_delivery.ORGANIZATION_INVITE_EXPIRES_DAYS)
+        for call in harness.create_calls
+    )
+    assert [call["to_email"] for call in harness.provider_calls] == [
+        "a@example.com",
+        "b@example.com",
+    ]
+    assert [call["invite_url"] for call in harness.provider_calls] == [
+        f"https://hosted.example/join/{organization_id}",
+        f"https://hosted.example/join/{organization_id}",
+    ]
+    assert harness.join_calls == [organization_id, organization_id]
+    assert [(call["sent"], call["skipped"], call.get("error")) for call in harness.mark_calls] == [
+        (True, False, None),
+        (False, True, None),
+    ]
+    create_transactions = [
+        call["db"].transaction_id
+        for call in harness.create_calls  # type: ignore[attr-defined]
+    ]
+    mark_transactions = [
+        call["db"].transaction_id
+        for call in harness.mark_calls  # type: ignore[attr-defined]
+    ]
+    assert create_transactions == [1, 3]
+    assert mark_transactions == [2, 4]
+    assert harness.trace == [
+        ("transaction_enter", 1),
+        ("create", ("a@example.com", 1)),
+        ("transaction_exit", 1),
+        ("provider", "a@example.com"),
+        ("transaction_enter", 2),
+        ("mark", ("a@example.com", 2)),
+        ("transaction_exit", 2),
+        ("transaction_enter", 3),
+        ("create", ("b@example.com", 3)),
+        ("transaction_exit", 3),
+        ("provider", "b@example.com"),
+        ("transaction_enter", 4),
+        ("mark", ("b@example.com", 4)),
+        ("transaction_exit", 4),
+    ]
+    assert harness.active_transactions == 0
+
+
+@pytest.mark.asyncio
+async def test_resend_failure_marks_failed_and_logs_exact_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _capture_team_checkout_logs: None,
+) -> None:
+    organization_id = uuid4()
+    creator_id = uuid4()
+    harness = _DeliveryHarness(organization_id, creator_id)
+    harness.provider_results["failed@example.com"] = resend.ResendEmailError(
+        "resend_unavailable",
+        "Resend is unavailable.",
+    )
+    harness.install(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        await invitation_delivery.send_staged_team_checkout_invitations(
+            organization_id=organization_id,
+            organization_name="Activation Team",
+            invited_by_user_id=creator_id,
+            inviter_email="owner@example.com",
+            invite_emails_json='["failed@example.com"]',
+        )
+
+    assert len(harness.mark_calls) == 1
+    mark = harness.mark_calls[0]
+    assert (mark["sent"], mark["skipped"], mark["error"]) == (
+        False,
+        False,
+        "Resend is unavailable.",
+    )
+    assert mark["db"].transaction_id == 2  # type: ignore[attr-defined]
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    invitation = harness.invitations["failed@example.com"]
+    assert record.name == LOGGER_NAME
+    assert record.getMessage() == "Failed to deliver staged team checkout invitation"
+    assert record.organization_id == str(organization_id)  # type: ignore[attr-defined]
+    assert record.invitation_id == str(invitation.id)  # type: ignore[attr-defined]
+    assert record.email == "failed@example.com"  # type: ignore[attr-defined]
+    assert record.error_code == "resend_unavailable"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_missing_organization_skips_provider_and_logs_exact_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _capture_team_checkout_logs: None,
+) -> None:
+    organization_id = uuid4()
+    creator_id = uuid4()
+    harness = _DeliveryHarness(organization_id, creator_id)
+    harness.missing_emails.add("missing@example.com")
+    harness.install(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        await invitation_delivery.send_staged_team_checkout_invitations(
+            organization_id=organization_id,
+            organization_name="Activation Team",
+            invited_by_user_id=creator_id,
+            inviter_email="owner@example.com",
+            invite_emails_json='["missing@example.com"]',
+        )
+
+    assert harness.provider_calls == []
+    assert harness.mark_calls == []
+    assert harness.transaction_count == 1
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.name == LOGGER_NAME
+    assert record.getMessage() == (
+        "Skipping staged team checkout invitation because organization was not found"
+    )
+    assert record.organization_id == str(organization_id)  # type: ignore[attr-defined]
+    assert record.email == "missing@example.com"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_failure_logs_exception_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _capture_team_checkout_logs: None,
+) -> None:
+    organization_id = uuid4()
+    creator_id = uuid4()
+    harness = _DeliveryHarness(organization_id, creator_id)
+    harness.create_errors["a@example.com"] = RuntimeError("unexpected create failure")
+    harness.install(monkeypatch)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+        await invitation_delivery.send_staged_team_checkout_invitations(
+            organization_id=organization_id,
+            organization_name="Activation Team",
+            invited_by_user_id=creator_id,
+            inviter_email="owner@example.com",
+            invite_emails_json='["b@example.com", "a@example.com"]',
+        )
+
+    assert [call["email"] for call in harness.create_calls] == [
+        "a@example.com",
+        "b@example.com",
+    ]
+    assert [call["to_email"] for call in harness.provider_calls] == ["b@example.com"]
+    assert len(harness.mark_calls) == 1
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.name == LOGGER_NAME
+    assert record.getMessage() == (
+        "Unexpected failure while creating staged team checkout invitation"
+    )
+    assert record.organization_id == str(organization_id)  # type: ignore[attr-defined]
+    assert record.email == "a@example.com"  # type: ignore[attr-defined]
+    assert record.exc_info is not None
+    assert harness.active_transactions == 0


### PR DESCRIPTION
## Summary

- route team-checkout activation persistence through the Organizations owner service
- replace public raw-ORM store seams with frozen record/id-based operations
- move staged invitation delivery into Organizations while preserving transaction and provider ordering
- add focused characterization coverage for service, delivery, and Billing orchestration

## Stack

- depends on draft PR #1621
- base branch: codex/team-checkout-intent-write-ownership
- reviewed against frozen Server Grid 17 Rev6 at exact head ed9c93017dee61e5c5d1c96da55396ebc04b841e
- independent verdict: ACCEPT; no findings

## Proof

- 53 focused unit/integration tests passed
- Ruff check and format passed for all seven changed paths
- frozen-base mypy diagnostic parity passed with no new diagnostics
- server boundaries, max-lines, and design-attribution checks passed
- Organizations store remains exactly 725 lines; max-lines allowlist unchanged
- negative import/helper censuses and static ORM/transaction checks passed

Draft only. Do not merge until the dependency stack is reviewed.

## Integration and landing

- Required landing order is #1611 → #1628, with #1613 landed, and #1621 → this PR. Do not land this PR until #1628, #1613, and #1621 are all on `main`.
- After those prerequisites land, rebase this implementation onto their landed `main` revision, retarget this PR to `main`, and rerun the complete frozen proof.
- In the reconciled activation code, import `BillingServiceError` from `billing.errors` and `coerce_utc` from `billing.models`; `team_checkout/activation.py` must not import `utcnow`.
- Update `server/tests/unit/test_billing_team_checkout_activation.py` to import `BillingServiceError` from `proliferate.server.billing.errors`; #1613 removes that symbol from `billing.models`.
- Update `server/proliferate/server/organizations/invitation_delivery.py` to import `utcnow` from `proliferate.lib.infra.time.wall_clock`; #1628 removes `proliferate.utils.time`.
