### PR TITLE
chore(server): enforce named cross-domain writes

### DIFF
--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import ast
-from collections import Counter, defaultdict
-from dataclasses import dataclass
 import os
-from pathlib import Path
 import shutil
 import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ALLOWLIST_PATH = REPO_ROOT / "scripts" / "server_boundaries_allowlist.txt"
@@ -71,6 +71,98 @@ SERVICE_BOUNDARY_DEBT_MODULES = {
 
 
 @dataclass(frozen=True)
+class NamedStoreBoundary:
+    store_module: str
+    protected_symbols: frozenset[str]
+    owner_label: str
+    product_owner_prefix: tuple[str, ...]
+    persistence_owner_paths: frozenset[str]
+    owner_service_hint: str
+
+
+NAMED_STORE_BOUNDARIES: dict[str, NamedStoreBoundary] = {
+    "proliferate.db.store.organizations": NamedStoreBoundary(
+        store_module="proliferate.db.store.organizations",
+        protected_symbols=frozenset(
+            {
+                "acquire_membership_activation_lock",
+                "bind_team_checkout_session",
+                "cancel_team_checkout_intent",
+                "complete_team_checkout_activation",
+                "complete_team_checkout_activation_by_id",
+                "create_pending_team_checkout_intent",
+                "get_current_team_checkout_intent",
+                "load_team_checkout_activation_for_update",
+                "load_team_checkout_intent_for_update",
+                "mark_team_checkout_activating",
+                "mark_team_checkout_activating_by_id",
+                "mark_team_checkout_failed",
+                "mark_team_checkout_failed_by_id",
+            }
+        ),
+        owner_label="Organization",
+        product_owner_prefix=(
+            "server",
+            "proliferate",
+            "server",
+            "organizations",
+        ),
+        persistence_owner_paths=frozenset(
+            {
+                "server/proliferate/db/store/organization_invitations.py",
+                "server/proliferate/db/store/organizations.py",
+            }
+        ),
+        owner_service_hint="proliferate.server.organizations.service",
+    ),
+    "proliferate.db.store.organization_invitations": NamedStoreBoundary(
+        store_module="proliferate.db.store.organization_invitations",
+        protected_symbols=frozenset(
+            {
+                "accept_pending_invitation_for_organization_email",
+                "create_or_rotate_organization_invitation",
+                "mark_invitation_delivery",
+            }
+        ),
+        owner_label="Organization",
+        product_owner_prefix=(
+            "server",
+            "proliferate",
+            "server",
+            "organizations",
+        ),
+        persistence_owner_paths=frozenset(
+            {
+                "server/proliferate/db/store/organization_invitations.py",
+                "server/proliferate/db/store/organizations.py",
+            }
+        ),
+        owner_service_hint="proliferate.server.organizations.service",
+    ),
+    "proliferate.db.store.cloud_sandboxes": NamedStoreBoundary(
+        store_module="proliferate.db.store.cloud_sandboxes",
+        protected_symbols=frozenset(
+            {
+                "accept_destroyed_cloud_sandbox_provider_observation",
+                "advance_cloud_sandbox_provider_observation_floor",
+                "apply_cloud_sandbox_provider_observation",
+                "mark_cloud_sandbox_provider_missing",
+            }
+        ),
+        owner_label="Cloud sandbox",
+        product_owner_prefix=(
+            "server",
+            "proliferate",
+            "server",
+            "cloud",
+        ),
+        persistence_owner_paths=frozenset({"server/proliferate/db/store/cloud_sandboxes.py"}),
+        owner_service_hint="proliferate.server.cloud.cloud_sandboxes.service",
+    ),
+}
+
+
+@dataclass(frozen=True)
 class Violation:
     rule_id: str
     path: Path
@@ -122,6 +214,13 @@ def iter_target_files(repo_root: Path) -> list[Path]:
                 continue
             files.append(path)
     return files
+
+
+def iter_named_write_target_files(repo_root: Path) -> list[Path]:
+    root = repo_root / "server" / "proliferate"
+    if not root.is_dir():
+        return []
+    return [path for path in sorted(root.rglob("*.py")) if not should_skip(path)]
 
 
 def iter_structure_folders(repo_root: Path) -> list[Path]:
@@ -227,11 +326,7 @@ def is_dunder_module(path: Path) -> bool:
 
 
 def has_single_underscore_prefix(path: Path) -> bool:
-    return (
-        path.suffix == ".py"
-        and path.name.startswith("_")
-        and not path.name.startswith("__")
-    )
+    return path.suffix == ".py" and path.name.startswith("_") and not path.name.startswith("__")
 
 
 def is_banned_junk_drawer_module(path: Path) -> bool:
@@ -593,13 +688,118 @@ class BoundaryChecker(ast.NodeVisitor):
                             "Pydantic response models must not map ORM objects "
                             "with from_attributes",
                         )
-        if isinstance(func, ast.Name) and func.id == "HTTPException":
+        if isinstance(func, ast.Name) and func.id == "HTTPException":  # noqa: SIM102
             if self.kind.is_domain or self.kind.is_store or self.kind.is_integration:
                 self.add(
                     node,
                     "HTTP_EXCEPTION_FORBIDDEN",
                     "HTTPException is banned outside HTTP boundary code",
                 )
+
+
+def _dotted_name(node: ast.AST) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        if prefix is not None:
+            return (*prefix, node.attr)
+    return None
+
+
+class NamedCrossDomainWriteChecker(ast.NodeVisitor):
+    def __init__(self, path: Path, repo_root: Path) -> None:
+        self.path = path
+        self.repo_root = repo_root
+        self.module_aliases: dict[str, set[str]] = defaultdict(set)
+        self.imported_modules: set[str] = set()
+        self.violations: list[Violation] = []
+
+    def check(self, tree: ast.Module) -> list[Violation]:
+        self._collect_import_bindings(tree)
+        self.visit(tree)
+        return self.violations
+
+    def _collect_import_bindings(self, tree: ast.Module) -> None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                self._collect_import_from(node)
+            elif isinstance(node, ast.Import):
+                self._collect_import(node)
+
+    def _collect_import_from(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        boundary = NAMED_STORE_BOUNDARIES.get(module)
+        if boundary is not None:
+            for alias in node.names:
+                if alias.name == "*":
+                    for symbol in sorted(boundary.protected_symbols):
+                        self._add(node, boundary, symbol)
+                elif alias.name in boundary.protected_symbols:
+                    self._add(node, boundary, alias.name)
+
+        for alias in node.names:
+            imported_module = f"{module}.{alias.name}" if module else alias.name
+            if imported_module in NAMED_STORE_BOUNDARIES:
+                local_name = alias.asname or alias.name
+                self.module_aliases[local_name].add(imported_module)
+
+    def _collect_import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.name not in NAMED_STORE_BOUNDARIES:
+                continue
+            if alias.asname is not None:
+                self.module_aliases[alias.asname].add(alias.name)
+            else:
+                self.imported_modules.add(alias.name)
+
+    def _is_owner(self, boundary: NamedStoreBoundary) -> bool:
+        try:
+            relative = self.path.relative_to(self.repo_root)
+        except ValueError:
+            return False
+        if _starts_with(relative.parts, boundary.product_owner_prefix):
+            return True
+        return relative.as_posix() in boundary.persistence_owner_paths
+
+    def _add(
+        self,
+        node: ast.AST,
+        boundary: NamedStoreBoundary,
+        symbol: str,
+    ) -> None:
+        if self._is_owner(boundary):
+            return
+        qualified_symbol = f"{boundary.store_module}.{symbol}"
+        self.violations.append(
+            Violation(
+                rule_id="NAMED_CROSS_DOMAIN_WRITE",
+                path=self.path,
+                lineno=getattr(node, "lineno", 1),
+                message=(
+                    f"{qualified_symbol} is a protected {boundary.owner_label} "
+                    "store mutation; cross-domain callers must use "
+                    f"{boundary.owner_service_hint}"
+                ),
+            )
+        )
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        dotted = _dotted_name(node)
+        if dotted is not None and len(dotted) >= 2:
+            symbol = dotted[-1]
+            candidate_modules: set[str] = set()
+            if len(dotted) == 2:
+                candidate_modules.update(self.module_aliases.get(dotted[0], set()))
+            full_module = ".".join(dotted[:-1])
+            if full_module in self.imported_modules:
+                candidate_modules.add(full_module)
+
+            for module in sorted(candidate_modules):
+                boundary = NAMED_STORE_BOUNDARIES[module]
+                if symbol in boundary.protected_symbols:
+                    self._add(node, boundary, symbol)
+        self.generic_visit(node)
 
 
 def parse_source(path: Path) -> ast.Module:
@@ -613,6 +813,18 @@ def check_paths(paths: list[Path]) -> list[Violation]:
         tree = parse_source(path)
         checker.visit(tree)
         violations.extend(checker.violations)
+    return violations
+
+
+def check_named_cross_domain_writes(
+    paths: list[Path],
+    repo_root: Path = REPO_ROOT,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for path in paths:
+        tree = parse_source(path)
+        checker = NamedCrossDomainWriteChecker(path, repo_root)
+        violations.extend(checker.check(tree))
     return violations
 
 
@@ -758,9 +970,7 @@ def print_summary(
     violations: list[Violation],
     allowlist: dict[tuple[str, str], AllowlistEntry],
 ) -> None:
-    observed = Counter(
-        (violation.rule_id, violation.relative_path()) for violation in violations
-    )
+    observed = Counter((violation.rule_id, violation.relative_path()) for violation in violations)
     if not observed:
         return
     print("Observed server boundary debt:")
@@ -772,7 +982,7 @@ def print_summary(
 
 
 def reexec_with_python_312() -> None:
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 12):  # noqa: UP036 -- the CLI may start on Python 3.11
         return
     python_312 = shutil.which("python3.12")
     if python_312 is None:
@@ -784,13 +994,18 @@ def reexec_with_python_312() -> None:
 
 def main() -> int:
     reexec_with_python_312()
-    if sys.version_info < (3, 12):
+    if sys.version_info < (3, 12):  # noqa: UP036 -- fail clearly when 3.12 is absent
         print("Server boundary check requires Python 3.12+ to parse server source.")
         return 2
 
     paths = iter_target_files(REPO_ROOT)
+    named_write_paths = iter_named_write_target_files(REPO_ROOT)
     allowlist = load_allowlist()
-    violations = [*check_paths(paths), *check_structure(REPO_ROOT)]
+    violations = [
+        *check_paths(paths),
+        *check_named_cross_domain_writes(named_write_paths),
+        *check_structure(REPO_ROOT),
+    ]
     failing, stale = apply_allowlist(violations, allowlist)
 
     if not failing and not stale:

--- a/scripts/check_server_boundaries.py
+++ b/scripts/check_server_boundaries.py
@@ -784,6 +784,17 @@ class NamedCrossDomainWriteChecker(ast.NodeVisitor):
             )
         )
 
+    def _resolve_store_modules(self, node: ast.AST) -> set[str]:
+        dotted = _dotted_name(node)
+        if dotted is None:
+            return set()
+        if len(dotted) == 1:
+            return set(self.module_aliases.get(dotted[0], set()))
+        full_module = ".".join(dotted)
+        if full_module in self.imported_modules:
+            return {full_module}
+        return set()
+
     def visit_Attribute(self, node: ast.Attribute) -> None:
         dotted = _dotted_name(node)
         if dotted is not None and len(dotted) >= 2:
@@ -796,6 +807,21 @@ class NamedCrossDomainWriteChecker(ast.NodeVisitor):
                 candidate_modules.add(full_module)
 
             for module in sorted(candidate_modules):
+                boundary = NAMED_STORE_BOUNDARIES[module]
+                if symbol in boundary.protected_symbols:
+                    self._add(node, boundary, symbol)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            symbol = node.args[1].value
+            for module in sorted(self._resolve_store_modules(node.args[0])):
                 boundary = NAMED_STORE_BOUNDARIES[module]
                 if symbol in boundary.protected_symbols:
                     self._add(node, boundary, symbol)

--- a/server/tests/unit/test_server_boundary_checker.py
+++ b/server/tests/unit/test_server_boundary_checker.py
@@ -4,6 +4,38 @@ import importlib.util
 from pathlib import Path
 import sys
 
+import pytest
+
+
+PROTECTED_STORE_SYMBOLS = {
+    "proliferate.db.store.organizations": (
+        "acquire_membership_activation_lock",
+        "bind_team_checkout_session",
+        "cancel_team_checkout_intent",
+        "complete_team_checkout_activation",
+        "complete_team_checkout_activation_by_id",
+        "create_pending_team_checkout_intent",
+        "get_current_team_checkout_intent",
+        "load_team_checkout_activation_for_update",
+        "load_team_checkout_intent_for_update",
+        "mark_team_checkout_activating",
+        "mark_team_checkout_activating_by_id",
+        "mark_team_checkout_failed",
+        "mark_team_checkout_failed_by_id",
+    ),
+    "proliferate.db.store.organization_invitations": (
+        "accept_pending_invitation_for_organization_email",
+        "create_or_rotate_organization_invitation",
+        "mark_invitation_delivery",
+    ),
+    "proliferate.db.store.cloud_sandboxes": (
+        "accept_destroyed_cloud_sandbox_provider_observation",
+        "advance_cloud_sandbox_provider_observation_floor",
+        "apply_cloud_sandbox_provider_observation",
+        "mark_cloud_sandbox_provider_missing",
+    ),
+}
+
 
 def _load_checker_module():
     script_path = Path(__file__).resolve().parents[3] / "scripts" / "check_server_boundaries.py"
@@ -14,6 +46,316 @@ def _load_checker_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _check_named_source(
+    tmp_path: Path,
+    relative_path: str,
+    source: str,
+):
+    module = _load_checker_module()
+    path = tmp_path / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source)
+    return module, module.check_named_cross_domain_writes([path], tmp_path)
+
+
+def test_named_write_registry_matches_frozen_contract() -> None:
+    module = _load_checker_module()
+
+    actual = {
+        store_module: tuple(sorted(boundary.protected_symbols))
+        for store_module, boundary in module.NAMED_STORE_BOUNDARIES.items()
+    }
+    expected = {
+        store_module: tuple(sorted(symbols))
+        for store_module, symbols in PROTECTED_STORE_SYMBOLS.items()
+    }
+
+    assert actual == expected
+    assert {store_module: len(symbols) for store_module, symbols in actual.items()} == {
+        "proliferate.db.store.organizations": 13,
+        "proliferate.db.store.organization_invitations": 3,
+        "proliferate.db.store.cloud_sandboxes": 4,
+    }
+    assert sum(len(symbols) for symbols in actual.values()) == 20
+    organization_persistence = frozenset(
+        {
+            "server/proliferate/db/store/organization_invitations.py",
+            "server/proliferate/db/store/organizations.py",
+        }
+    )
+    for store_module in (
+        "proliferate.db.store.organizations",
+        "proliferate.db.store.organization_invitations",
+    ):
+        boundary = module.NAMED_STORE_BOUNDARIES[store_module]
+        assert boundary.product_owner_prefix == (
+            "server",
+            "proliferate",
+            "server",
+            "organizations",
+        )
+        assert boundary.persistence_owner_paths == organization_persistence
+        assert boundary.owner_service_hint == "proliferate.server.organizations.service"
+    cloud_boundary = module.NAMED_STORE_BOUNDARIES["proliferate.db.store.cloud_sandboxes"]
+    assert cloud_boundary.product_owner_prefix == (
+        "server",
+        "proliferate",
+        "server",
+        "cloud",
+    )
+    assert cloud_boundary.persistence_owner_paths == frozenset(
+        {"server/proliferate/db/store/cloud_sandboxes.py"}
+    )
+    assert cloud_boundary.owner_service_hint == "proliferate.server.cloud.cloud_sandboxes.service"
+
+
+@pytest.mark.parametrize(
+    ("store_module", "symbol"),
+    [
+        (store_module, symbol)
+        for store_module, symbols in PROTECTED_STORE_SYMBOLS.items()
+        for symbol in symbols
+    ],
+)
+@pytest.mark.parametrize("alias", ["", " as protected_alias"])
+def test_foreign_direct_import_rejects_every_protected_symbol(
+    tmp_path: Path,
+    store_module: str,
+    symbol: str,
+    alias: str,
+) -> None:
+    local_name = "protected_alias" if alias else symbol
+    _, violations = _check_named_source(
+        tmp_path,
+        "server/proliferate/server/billing/foreign.py",
+        f"from {store_module} import {symbol}{alias}\n{local_name}()\n",
+    )
+
+    assert len(violations) == 1
+    violation = violations[0]
+    assert violation.rule_id == "NAMED_CROSS_DOMAIN_WRITE"
+    assert violation.lineno == 1
+    assert f"{store_module}.{symbol}" in violation.message
+    expected_hint = (
+        "proliferate.server.cloud.cloud_sandboxes.service"
+        if store_module.endswith("cloud_sandboxes")
+        else "proliferate.server.organizations.service"
+    )
+    assert expected_hint in violation.message
+    assert violation.relative_path(tmp_path) == ("server/proliferate/server/billing/foreign.py")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from proliferate.db.store import organizations as organization_store\n"
+        "write = organization_store.bind_team_checkout_session\n",
+        "import proliferate.db.store.organizations as organization_store\n"
+        "write = organization_store.bind_team_checkout_session\n",
+    ],
+)
+def test_foreign_module_alias_access_is_rejected(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    _, violations = _check_named_source(
+        tmp_path,
+        "server/proliferate/server/billing/foreign.py",
+        source,
+    )
+
+    assert len(violations) == 1
+    assert violations[0].rule_id == "NAMED_CROSS_DOMAIN_WRITE"
+    assert "proliferate.db.store.organizations.bind_team_checkout_session" in violations[0].message
+
+
+def test_foreign_fully_qualified_reference_is_rejected_before_call(
+    tmp_path: Path,
+) -> None:
+    store_module = "proliferate.db.store.cloud_sandboxes"
+    symbol = "apply_cloud_sandbox_provider_observation"
+    _, violations = _check_named_source(
+        tmp_path,
+        "server/proliferate/server/billing/foreign.py",
+        f"import {store_module}\nwrite = {store_module}.{symbol}\nwrite()\n",
+    )
+
+    assert len(violations) == 1
+    assert violations[0].lineno == 2
+    assert f"{store_module}.{symbol}" in violations[0].message
+
+
+def test_foreign_star_import_rejects_each_protected_store_symbol(
+    tmp_path: Path,
+) -> None:
+    store_module = "proliferate.db.store.cloud_sandboxes"
+    _, violations = _check_named_source(
+        tmp_path,
+        "server/proliferate/server/billing/foreign.py",
+        f"from {store_module} import *\n",
+    )
+
+    assert len(violations) == 4
+    assert {item.rule_id for item in violations} == {"NAMED_CROSS_DOMAIN_WRITE"}
+    for symbol in PROTECTED_STORE_SYMBOLS[store_module]:
+        assert any(f"{store_module}.{symbol}" in item.message for item in violations)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "store_module", "symbol"),
+    [
+        (
+            "server/proliferate/server/organizations/invitation_delivery.py",
+            "proliferate.db.store.organization_invitations",
+            "mark_invitation_delivery",
+        ),
+        (
+            "server/proliferate/server/cloud/webhooks/service.py",
+            "proliferate.db.store.cloud_sandboxes",
+            "apply_cloud_sandbox_provider_observation",
+        ),
+    ],
+)
+def test_product_owner_may_access_its_protected_store(
+    tmp_path: Path,
+    relative_path: str,
+    store_module: str,
+    symbol: str,
+) -> None:
+    _, violations = _check_named_source(
+        tmp_path,
+        relative_path,
+        f"from {store_module} import {symbol}\n",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "store_module", "symbol"),
+    [
+        (
+            "server/proliferate/db/store/organizations.py",
+            "proliferate.db.store.organization_invitations",
+            "mark_invitation_delivery",
+        ),
+        (
+            "server/proliferate/db/store/organization_invitations.py",
+            "proliferate.db.store.organizations",
+            "mark_team_checkout_failed_by_id",
+        ),
+        (
+            "server/proliferate/db/store/cloud_sandboxes.py",
+            "proliferate.db.store.cloud_sandboxes",
+            "mark_cloud_sandbox_provider_missing",
+        ),
+    ],
+)
+def test_exact_persistence_owner_may_access_protected_store(
+    tmp_path: Path,
+    relative_path: str,
+    store_module: str,
+    symbol: str,
+) -> None:
+    _, violations = _check_named_source(
+        tmp_path,
+        relative_path,
+        f"from {store_module} import {symbol}\n",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "server/proliferate/db/store/unrelated.py",
+        "server/proliferate/server/organizations_external/service.py",
+    ],
+)
+def test_owner_lookalikes_may_not_access_protected_store(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    _, violations = _check_named_source(
+        tmp_path,
+        relative_path,
+        "from proliferate.db.store.organizations import bind_team_checkout_session\n",
+    )
+
+    assert len(violations) == 1
+    assert violations[0].rule_id == "NAMED_CROSS_DOMAIN_WRITE"
+
+
+def test_same_named_owner_service_calls_are_legal(tmp_path: Path) -> None:
+    _, violations = _check_named_source(
+        tmp_path,
+        "server/proliferate/server/billing/foreign.py",
+        "from proliferate.server.organizations import service as organization_service\n"
+        "from proliferate.server.cloud.cloud_sandboxes import service as cloud_service\n"
+        "organization_service.bind_team_checkout_session()\n"
+        "cloud_service.apply_cloud_sandbox_provider_observation()\n",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "source"),
+    [
+        (
+            "server/proliferate/auth/sso/user_resolution.py",
+            "from proliferate.db.store import organization_invitations as invitations\n"
+            "from proliferate.db.store import organizations as organizations\n"
+            "invitations.has_live_pending_invitation_for_organization_email()\n"
+            "organizations.get_active_membership()\n",
+        ),
+        (
+            "server/proliferate/server/billing/reconciler.py",
+            "from proliferate.db.store import cloud_sandboxes as sandboxes\n"
+            "sandboxes.load_cloud_sandbox_by_id()\n",
+        ),
+        (
+            "server/proliferate/server/billing/team_checkout/activation.py",
+            "from proliferate.db.store import billing_subscriptions as subscriptions\n"
+            "from proliferate.db.store import users as users\n"
+            "users.get_user_by_id()\n"
+            "subscriptions.upsert_billing_subscription()\n"
+            "unrelated.bind_team_checkout_session()\n",
+        ),
+    ],
+)
+def test_named_legal_reads_and_unrelated_same_named_method_are_legal(
+    tmp_path: Path,
+    relative_path: str,
+    source: str,
+) -> None:
+    _, violations = _check_named_source(tmp_path, relative_path, source)
+
+    assert violations == []
+
+
+def test_named_rule_scans_root_production_and_skips_migrations(
+    tmp_path: Path,
+) -> None:
+    module = _load_checker_module()
+    root_source = tmp_path / "server" / "proliferate" / "root_concern.py"
+    migration_source = tmp_path / "server" / "proliferate" / "db" / "migrations" / "revision.py"
+    alembic_source = tmp_path / "server" / "proliferate" / "alembic" / "versions" / "revision.py"
+    for path in (root_source, migration_source, alembic_source):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "from proliferate.db.store.organizations import cancel_team_checkout_intent\n"
+        )
+
+    targets = module.iter_named_write_target_files(tmp_path)
+    violations = module.check_named_cross_domain_writes(targets, tmp_path)
+
+    assert targets == [root_source]
+    assert len(violations) == 1
+    assert violations[0].path == root_source
 
 
 def test_api_allows_auth_user_import_only(tmp_path: Path) -> None:

--- a/server/tests/unit/test_server_boundary_checker.py
+++ b/server/tests/unit/test_server_boundary_checker.py
@@ -154,12 +154,15 @@ def test_foreign_direct_import_rejects_every_protected_symbol(
         "write = organization_store.bind_team_checkout_session\n",
         "import proliferate.db.store.organizations as organization_store\n"
         "write = organization_store.bind_team_checkout_session\n",
+        "from proliferate.db.store import organizations as organization_store\n"
+        "organization_store.bind_team_checkout_session()\n",
+        "from proliferate.db.store import organizations as organization_store\n"
+        'write = getattr(organization_store, "bind_team_checkout_session")\n',
+        "import proliferate.db.store.organizations as organization_store\n"
+        'write = getattr(organization_store, "bind_team_checkout_session")\n',
     ],
 )
-def test_foreign_module_alias_access_is_rejected(
-    tmp_path: Path,
-    source: str,
-) -> None:
+def test_module_alias_access_is_rejected(tmp_path: Path, source: str) -> None:
     _, violations = _check_named_source(
         tmp_path,
         "server/proliferate/server/billing/foreign.py",
@@ -171,15 +174,17 @@ def test_foreign_module_alias_access_is_rejected(
     assert "proliferate.db.store.organizations.bind_team_checkout_session" in violations[0].message
 
 
-def test_foreign_fully_qualified_reference_is_rejected_before_call(
-    tmp_path: Path,
-) -> None:
+@pytest.mark.parametrize("literal_getattr", [False, True])
+def test_qualified_reference_is_rejected(tmp_path: Path, literal_getattr: bool) -> None:
     store_module = "proliferate.db.store.cloud_sandboxes"
     symbol = "apply_cloud_sandbox_provider_observation"
+    reference = (
+        f'getattr({store_module}, "{symbol}")' if literal_getattr else f"{store_module}.{symbol}"
+    )
     _, violations = _check_named_source(
         tmp_path,
         "server/proliferate/server/billing/foreign.py",
-        f"import {store_module}\nwrite = {store_module}.{symbol}\nwrite()\n",
+        f"import {store_module}\nwrite = {reference}\nwrite()\n",
     )
 
     assert len(violations) == 1
@@ -187,9 +192,7 @@ def test_foreign_fully_qualified_reference_is_rejected_before_call(
     assert f"{store_module}.{symbol}" in violations[0].message
 
 
-def test_foreign_star_import_rejects_each_protected_store_symbol(
-    tmp_path: Path,
-) -> None:
+def test_star_import_rejects_each_protected_store_symbol(tmp_path: Path) -> None:
     store_module = "proliferate.db.store.cloud_sandboxes"
     _, violations = _check_named_source(
         tmp_path,
@@ -320,9 +323,13 @@ def test_same_named_owner_service_calls_are_legal(tmp_path: Path) -> None:
         (
             "server/proliferate/server/billing/team_checkout/activation.py",
             "from proliferate.db.store import billing_subscriptions as subscriptions\n"
+            "from proliferate.db.store import organizations as organizations\n"
             "from proliferate.db.store import users as users\n"
             "users.get_user_by_id()\n"
             "subscriptions.upsert_billing_subscription()\n"
+            'symbol_name = "bind_team_checkout_session"\n'
+            "getattr(organizations, symbol_name)\n"
+            'getattr(organizations, "get_active_membership")\n'
             "unrelated.bind_team_checkout_session()\n",
         ),
     ],


### PR DESCRIPTION
## Summary

- add a typed in-code registry for the exact 20 repaired Organization, invitation, and Cloud store write seams
- reject foreign direct imports, star imports, module-alias members, fully-qualified members, references, and literal getattr access
- scan every non-migration production Python file for this bounded rule without broadening existing layer or structure checks
- preserve legal foreign reads, same-owner persistence, service calls, and unlisted store access

## Temporary review topology

- depends on accepted draft repairs #1623, #1622, #1621, and #1627
- targets branch codex/server-grid-write-ownership-integration-base at exact head 07d7be55a8e31616f09500440f66fef47628d008
- that branch replays all four accepted patches with identical stable patch IDs and equal range-diffs
- this temporary target keeps the review diff to exactly two checker paths
- after dependencies land on main, rebase only this implementation onto then-current origin/main, retarget to main, prove the two-path diff, and rerun every acceptance command
- do not merge from the temporary base

## Review

- frozen Server Grid 18 Rev2
- independent review: ACCEPT after closing SG18-B01
- exact head: 9d09b06e725606c622d513125c7b448caf32f5fd
- no remaining findings

## Proof

- 76 focused boundary-checker tests passed
- targeted Ruff check and format passed
- production server-boundary checker passed across 584 named-rule targets with zero violations
- max-lines, design-attribution, and diff checks passed
- exact registry census is 13 + 3 + 4 = 20
- static probes: direct member call, alias literal getattr, and qualified literal getattr each emit one; computed and unlisted getattr emit zero
- all 48 pre-existing checker declarations remain unchanged by AST census
- no boundary allowlist, CI, docs, dependencies, or application source changed

Draft only. Never merge or mark ready from this temporary topology.

## Integration and landing

- PR #1614 must land before the final rebase, in addition to the dependency repairs already listed above.
- Once every dependency is on `main`, rebase only this implementation onto the final landed revision, retarget this PR to `main`, and rerun the complete acceptance proof.
- Preserve both Product Engagement worker-service checker enforcement and this PR's named-write registry when reconciling the checker.
- Refresh and review the historical checker-declaration census against the final landed tree; do not assume the current count of 48 remains authoritative.
- On that final base, reconcile the frozen two-path scope because the combined boundary-checker tests reach 749 lines: split named-write tests into an ownership-specific test leaf, or use an equivalent arrangement that keeps every file at or below 600 lines. Refresh max-lines proof and obtain independent re-review; do not add a 749-line allowlist entry.
- This temporary integration-base branch remains review-only: never merge from it.

