### PR TITLE
fix(server): preserve allocated organization slug identity

### DIFF
--- a/server/proliferate/db/store/organizations.py
+++ b/server/proliferate/db/store/organizations.py
@@ -63,14 +63,14 @@ _SLUG_TRIM_CHAR = "-"
 _SLUG_NUMERIC_ATTEMPTS = 50
 
 
-def _slugify_organization(value: str | None) -> str:
+def _slugify_organization(value: str | None, *, truncate_base: bool = True) -> str:
+    end = ORGANIZATION_SLUG_MAX_LENGTH if truncate_base else None
     slug = _SLUG_ALLOWED.sub("-", (value or "").strip().lower()).strip(_SLUG_TRIM_CHAR)
-    return slug[:ORGANIZATION_SLUG_MAX_LENGTH].strip(_SLUG_TRIM_CHAR) or ORGANIZATION_SLUG_FALLBACK
+    return slug[:end].strip(_SLUG_TRIM_CHAR) or ORGANIZATION_SLUG_FALLBACK
 
 
 async def _slug_taken(db: AsyncSession, slug: str) -> bool:
-    existing = await db.scalar(select(Organization.id).where(Organization.slug == slug).limit(1))
-    return existing is not None
+    return bool(await db.scalar(select(Organization.id).where(Organization.slug == slug).limit(1)))
 
 
 async def allocate_organization_slug(db: AsyncSession, name: str) -> str:
@@ -95,7 +95,7 @@ async def allocate_organization_slug(db: AsyncSession, name: str) -> str:
 async def get_organization_by_slug(db: AsyncSession, slug: str) -> OrganizationRecord | None:
     result = await db.execute(
         select(Organization).where(
-            Organization.slug == _slugify_organization(slug),
+            Organization.slug == _slugify_organization(slug, truncate_base=False),
             Organization.status.in_(tuple(ORGANIZATION_CURRENT_STATUSES)),
         )
     )

--- a/server/tests/integration/test_organization_slug_resolution.py
+++ b/server/tests/integration/test_organization_slug_resolution.py
@@ -1,0 +1,95 @@
+"""Persisted organization slugs retain exact identity during SSO discovery."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.sso import service as sso_service
+from proliferate.db.models.auth import SsoConnection
+from proliferate.db.models.organizations import Organization
+from proliferate.db.store import organizations as organization_store
+
+
+@pytest.mark.asyncio
+async def test_long_collision_slugs_preserve_identity_and_sso_routing(
+    db_session: AsyncSession,
+) -> None:
+    base = "a" * 48
+    first_slug = await organization_store.allocate_organization_slug(db_session, "A" * 49)
+    first = Organization(name="A" * 49, slug=first_slug, status="active")
+    db_session.add(first)
+    await db_session.flush()
+
+    second_slug = await organization_store.allocate_organization_slug(db_session, "A" * 48)
+    second = Organization(name="A" * 48, slug=second_slug, status="active")
+    random_form = Organization(
+        name="Random suffix organization",
+        slug=f"{base}-abcdef",
+        status="active",
+    )
+    db_session.add_all((second, random_form))
+    await db_session.flush()
+
+    assert first.slug == base
+    assert second.slug == f"{base}-2"
+    assert (await organization_store.get_organization_by_slug(db_session, base)).id == first.id
+    assert (
+        await organization_store.get_organization_by_slug(db_session, f"{base}-2")
+    ).id == second.id
+    assert (
+        await organization_store.get_organization_by_slug(db_session, f"{base}-abcdef")
+    ).id == random_form.id
+    assert (
+        await organization_store.get_organization_by_slug(
+            db_session,
+            f"  !!!{base.upper()}-2???  ",
+        )
+    ).id == second.id
+
+    unmatched = f"{base}-2-{'x' * 20}"
+    assert len(unmatched) > 64
+    assert await organization_store.get_organization_by_slug(db_session, unmatched) is None
+
+    first_connection = SsoConnection(
+        scope="organization",
+        organization_id=first.id,
+        protocol="oidc",
+        status="enabled",
+        display_name="First organization SSO",
+        login_policy="optional",
+        jit_policy="create_member",
+        default_role="member",
+        allowed_domains_json="[]",
+        oidc_issuer_url="https://first.example.test",
+        oidc_client_id="first-client-id",
+        oidc_token_endpoint_auth_method="none",
+    )
+    second_connection = SsoConnection(
+        scope="organization",
+        organization_id=second.id,
+        protocol="oidc",
+        status="enabled",
+        display_name="Second organization SSO",
+        login_policy="optional",
+        jit_policy="create_member",
+        default_role="member",
+        allowed_domains_json="[]",
+        oidc_issuer_url="https://second.example.test",
+        oidc_client_id="second-client-id",
+        oidc_token_endpoint_auth_method="none",
+    )
+    db_session.add_all((first_connection, second_connection))
+    await db_session.flush()
+
+    discovery = await sso_service.discover_sso(db_session, email=None, slug=second_slug)
+    assert discovery.enabled is True
+    assert discovery.organization_id == second.id
+    assert discovery.connection_id == second_connection.id
+    assert discovery.connection_id != first_connection.id
+
+    unavailable = await sso_service.discover_sso(db_session, email=None, slug=unmatched)
+    assert unavailable.enabled is False
+    assert unavailable.organization_id is None
+    assert unavailable.connection_id is None
+    assert unavailable.reason == "not_available"

--- a/server/tests/integration/test_schema_migrations.py
+++ b/server/tests/integration/test_schema_migrations.py
@@ -80,7 +80,9 @@ async def test_organization_slug_migration_preserves_frozen_backfill_policy() ->
                 "created_at": base_time + timedelta(seconds=offset),
                 "updated_at": base_time + timedelta(seconds=offset),
             }
-            for offset, name in enumerate(("Acme Inc", " ACME---INC! ", "!!!", "é", "A" * 49))
+            for offset, name in enumerate(
+                ("Acme Inc", " ACME---INC! ", "!!!", "é", "A" * 49, "A" * 48)
+            )
         ]
         seed_engine = create_async_engine(database_url, echo=False)
         try:
@@ -121,6 +123,7 @@ async def test_organization_slug_migration_preserves_frozen_backfill_policy() ->
                 "org",
                 "org-2",
                 "a" * 48,
+                "a" * 48 + "-2",
             ]
             slug_index = next(
                 index for index in indexes if index["name"] == "ux_organization_slug"

--- a/server/tests/unit/test_organization_slugs.py
+++ b/server/tests/unit/test_organization_slugs.py
@@ -32,6 +32,24 @@ def test_slugify_organization_preserves_frozen_normalization(
     assert organization_store._slugify_organization(value) == expected
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("A" * 48 + "-2", "a" * 48 + "-2"),
+        ("A" * 48 + "-abcdef", "a" * 48 + "-abcdef"),
+        ("A" * 46 + "-20", "a" * 46 + "-20"),
+        ("  Acme, Inc.  ", "acme-inc"),
+        ("!!!", "org"),
+        ("A" * 72, "a" * 72),
+    ],
+)
+def test_slugify_organization_preserves_complete_lookup_identity(
+    value: str,
+    expected: str,
+) -> None:
+    assert organization_store._slugify_organization(value, truncate_base=False) == expected
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("taken", "expected"),
@@ -87,3 +105,33 @@ async def test_allocate_organization_slug_uses_random_suffix_after_numeric_limit
         *(f"acme-{suffix}" for suffix in range(2, 51)),
         "acme-abcdef",
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exhaust_numeric", [False, True])
+async def test_allocate_long_organization_slug_preserves_suffix_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    exhaust_numeric: bool,
+) -> None:
+    base = "a" * 48
+    taken = {base}
+    if exhaust_numeric:
+        taken.update(f"{base}-{suffix}" for suffix in range(2, 51))
+
+    async def fake_slug_taken(_db: AsyncSession, slug: str) -> bool:
+        return slug in taken
+
+    def fake_token_hex(byte_count: int) -> str:
+        assert byte_count == 3
+        return "abcdef"
+
+    monkeypatch.setattr(organization_store, "_slug_taken", fake_slug_taken)
+    monkeypatch.setattr(organization_store.secrets, "token_hex", fake_token_hex)
+
+    actual = await organization_store.allocate_organization_slug(
+        cast(AsyncSession, object()),
+        "A" * 49,
+    )
+
+    expected = f"{base}-abcdef" if exhaust_numeric else f"{base}-2"
+    assert actual == expected


### PR DESCRIPTION
## Summary

- preserve the complete identity of allocated Organization slugs during lookup while retaining the existing 48-character allocation base cap
- prevent a suffixed or random long-collision slug from being truncated back to another tenant's base slug during SSO discovery
- characterize exact base, numeric-suffix, random-suffix, overlong-unmatched, migration, and distinct-tenant SSO routing behavior

## Security behavior

Previously, allocation could persist a slug longer than 48 characters, such as a 48-character base plus `-2`, while lookup normalized and truncated the supplied slug back to the base. That could resolve the wrong Organization before SSO discovery. Lookup normalization now preserves the complete normalized handle and still applies the existing current-Organization status filter; an unmatched overlong input returns the generic unavailable result without tenant or connection identifiers.

## Stack and landing

- stacked on draft PR #1618 (`codex/organization-slug-utility-ownership`), exact repaired base `26f588d787d0e49056768a2da71fe411ad5c1075`
- draft only; do not merge this temporary stacked topology independently
- after #1618 lands, rebase this implementation onto its merge revision, retarget to `main`, and rerun the frozen proof

## Proof

- focused Postgres, SSO, migration, and unit suite: 34 passed
- focused Ruff check and format check: passed
- server boundaries, max-lines, migration heads, and diff checks: passed
- Organization store remains exactly 732 lines under the repaired parent's reviewed allowance
- production uncapped lookup census: exactly one call, in `get_organization_by_slug`
- exact four-path scope; forbidden-path diff is empty

Frozen specification: Server Grid 19 revision 2, SHA256 `a4e003550bdd8939ef77e24e5b9fdd09f57a9ee07029ffb3c1e74133e9ec7223`. Independent specification audit and implementation review both accepted with no unresolved findings.

## Parent repair propagation (2026-08-05)

- Rebased head: `5826d75f0f6b2b58842e96b449a3564c2cfcc57b`, on repaired #1618 at `26f588d787d0e49056768a2da71fe411ad5c1075`.
- Downstream reconciliation: Yellow. SG19 revision 2 records the repaired 732-line parent allowance and migration application-import ratchet; no identity/security design changed.
- Integrated proof: 31 focused slug, migration, and real-Postgres tests passed; the four-path SG19 diff and whitespace checks remain exact.
- The earlier 34-test acceptance receipt belongs to the superseded head. Fresh independent re-review: ACCEPT with no findings for this rewritten head. GitHub CI is terminal green for this head.
