### PR TITLE
refactor(server): own Desktop Auth failures below HTTP

### DIFF
--- a/server/proliferate/auth/desktop/service.py
+++ b/server/proliferate/auth/desktop/service.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from uuid import UUID
 
-from fastapi import HTTPException, Request, status
+from fastapi import Request, status
 from fastapi.responses import HTMLResponse
 from fastapi_users import exceptions as fastapi_users_exceptions
 from fastapi_users.jwt import decode_jwt, generate_jwt
@@ -34,6 +34,7 @@ from proliferate.auth.desktop.pages import (
     make_browser_flow_page,
     make_desktop_handoff_page,
 )
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.providers import (
     parse_scope_string,
     token_expiry_from_timestamp,
@@ -154,12 +155,13 @@ def github_csrf_cookie_secure(request: Request) -> bool:
 def validate_desktop_redirect_uri(redirect_uri: str) -> None:
     parsed = urlparse(redirect_uri)
     if parsed.scheme not in DESKTOP_REDIRECT_SCHEMES:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
+        raise AuthFlowError(
+            "desktop_redirect_uri_not_allowed",
+            (
                 "redirect_uri must use a configured desktop scheme: "
                 f"{', '.join(sorted(DESKTOP_REDIRECT_SCHEMES))}"
             ),
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
 
@@ -207,9 +209,10 @@ async def mint_desktop_tokens(user: User) -> TokenResponse:
 async def get_active_user_or_400(db: AsyncSession, user_id: UUID) -> User:
     user = await get_active_user_by_id(db, user_id)
     if user is None:
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_user_not_found",
+            "User not found",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="User not found",
         )
     return user
 
@@ -260,11 +263,10 @@ async def create_desktop_auth_code(
     validate_desktop_redirect_uri(params.redirect_uri)
 
     if params.code_challenge_method not in SUPPORTED_CODE_CHALLENGE_METHODS:
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_code_challenge_method_unsupported",
+            (f"Unsupported code_challenge_method. Supported: {SUPPORTED_CODE_CHALLENGE_METHODS}"),
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Unsupported code_challenge_method. Supported: {SUPPORTED_CODE_CHALLENGE_METHODS}"
-            ),
         )
 
     auth_code = await create_auth_code(
@@ -468,9 +470,10 @@ async def poll_desktop_auth(
 ) -> TokenResponse | PendingTokenResponse:
     code_challenge = build_code_challenge(body.code_verifier)
     if code_challenge is None:
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_code_verifier_invalid",
+            "Invalid code_verifier",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid code_verifier",
         )
 
     auth_code = await consume_auth_code_for_state(
@@ -490,16 +493,18 @@ async def exchange_desktop_token(
     body: TokenRequest,
 ) -> TokenResponse:
     if body.grant_type != "authorization_code":
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_authorization_grant_type_invalid",
+            "grant_type must be 'authorization_code'",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="grant_type must be 'authorization_code'",
         )
 
     auth_code = await consume_auth_code(db, code=body.code)
     if auth_code is None:
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_auth_code_invalid",
+            "Invalid, expired, or already-consumed authorization code",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid, expired, or already-consumed authorization code",
         )
 
     if not verify_pkce(
@@ -507,9 +512,10 @@ async def exchange_desktop_token(
         auth_code.code_challenge,
         auth_code.code_challenge_method,
     ):
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_pkce_verification_failed",
+            "PKCE verification failed — code_verifier does not match code_challenge",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="PKCE verification failed — code_verifier does not match code_challenge",
         )
 
     user = await get_active_user_or_400(db, auth_code.user_id)
@@ -521,9 +527,10 @@ async def refresh_desktop_access_token(
     body: RefreshRequest,
 ) -> TokenResponse:
     if body.grant_type != "refresh_token":
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_refresh_grant_type_invalid",
+            "grant_type must be 'refresh_token'",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="grant_type must be 'refresh_token'",
         )
 
     try:
@@ -533,30 +540,34 @@ async def refresh_desktop_access_token(
             audience=[REFRESH_TOKEN_AUDIENCE],
         )
     except Exception as exc:
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_refresh_token_invalid",
+            "Invalid or expired refresh token",
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired refresh token",
         ) from exc
 
     user_id_str = payload.get("sub")
     if not user_id_str:
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_refresh_token_payload_invalid",
+            "Invalid refresh token payload",
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid refresh token payload",
         )
 
     try:
         user_id = UUID(user_id_str)
     except (ValueError, AttributeError):
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_refresh_token_payload_invalid",
+            "Invalid refresh token payload",
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid refresh token payload",
         ) from None
 
     user = await get_active_user_or_400(db, user_id)
     if claimed_token_generation(payload) != user_token_generation(user):
-        raise HTTPException(
+        raise AuthFlowError(
+            "desktop_refresh_token_revoked",
+            "Refresh token has been revoked",
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Refresh token has been revoked",
         )
     return await mint_desktop_tokens(user)

--- a/server/proliferate/auth/errors.py
+++ b/server/proliferate/auth/errors.py
@@ -1,0 +1,20 @@
+"""Typed product errors for authentication flows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from proliferate.errors import ProliferateError
+
+
+class AuthFlowError(ProliferateError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        super().__init__(message=message, code=code, status_code=status_code)
+        self.headers: dict[str, str] = dict(headers or {})

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -21,6 +21,7 @@ import proliferate.db.models.support  # noqa: F401
 import proliferate.db.models.workflows  # noqa: F401
 from proliferate.auth.api import router as auth_viewer_router
 from proliferate.auth.desktop.api import router as desktop_router
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.api import router as identity_auth_router
 from proliferate.auth.profile_api import router as user_profile_router
 from proliferate.auth.sso.api import router as sso_auth_router
@@ -195,13 +196,16 @@ async def _proliferate_error_handler(
     _request: Request,
     error: ProliferateError,
 ) -> JSONResponse:
-    detail = {
-        "code": error.code,
-        "message": error.message,
-    }
-    extra_detail = getattr(error, "extra_detail", None)
-    if isinstance(extra_detail, dict):
-        detail.update(extra_detail)
+    if isinstance(error, AuthFlowError):
+        detail: str | dict[str, object] = error.message
+    else:
+        detail = {
+            "code": error.code,
+            "message": error.message,
+        }
+        extra_detail = getattr(error, "extra_detail", None)
+        if isinstance(extra_detail, dict):
+            detail.update(extra_detail)
     return JSONResponse(
         status_code=error.status_code,
         content={"detail": detail},

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -7,13 +7,13 @@ from urllib.parse import parse_qs, urlparse
 from uuid import UUID
 
 import pytest
-from fastapi import HTTPException
 from fastapi_users.jwt import generate_jwt
 from httpx import AsyncClient
 from sqlalchemy import select
 
-from proliferate.auth.desktop.models import AuthorizeParams
 from proliferate.auth.desktop import service as desktop_service
+from proliferate.auth.desktop.models import AuthorizeParams
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity import providers as identity_providers
 from proliferate.auth.identity.sessions import WEB_CSRF_COOKIE
 from proliferate.auth.oauth import github_oauth_client, google_oauth_client
@@ -678,7 +678,9 @@ class TestDesktopPKCEFlow:
             },
         )
         assert resp.status_code == 400
-        assert "PKCE" in resp.json()["detail"]
+        assert resp.json()["detail"] == (
+            "PKCE verification failed — code_verifier does not match code_challenge"
+        )
 
     @pytest.mark.asyncio
     async def test_code_cannot_be_reused(self, client: AsyncClient) -> None:
@@ -728,14 +730,12 @@ class TestDesktopPKCEFlow:
     @pytest.mark.asyncio
     async def test_unsupported_challenge_method(self, client: AsyncClient) -> None:
         user_id = await _create_user_via_manager("badmethod@example.com")
-        with pytest.raises(HTTPException) as exc_info:
-            await _create_desktop_auth_code_for_user(
-                user_id=user_id,
-                state="state-3",
-                code_challenge="whatever",
-                code_challenge_method="plain",
-            )
-        assert exc_info.value.status_code == 400
+        args = dict(state="s", code_challenge="x", code_challenge_method="plain")
+        with pytest.raises(AuthFlowError) as exc_info:
+            await _create_desktop_auth_code_for_user(user_id=user_id, **args)
+        expected_message = "Unsupported code_challenge_method. Supported: frozenset({'S256'})"
+        actual = exc_info.value.code, exc_info.value.status_code, exc_info.value.message
+        assert actual == ("desktop_code_challenge_method_unsupported", 400, expected_message)
 
     @pytest.mark.asyncio
     async def test_debug_authorize_endpoint_disabled_outside_debug(

--- a/server/tests/integration/test_desktop_auth_error_contract.py
+++ b/server/tests/integration/test_desktop_auth_error_contract.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi_users.jwt import generate_jwt
+from httpx import AsyncClient, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.tokens import REFRESH_TOKEN_AUDIENCE
+from proliferate.config import settings
+from proliferate.constants.auth import REFRESH_TOKEN_LIFETIME_SECONDS
+from proliferate.db.models.auth import User
+
+
+def _signed_refresh_token(claims: dict[str, object]) -> str:
+    return generate_jwt(
+        data={"aud": REFRESH_TOKEN_AUDIENCE, **claims},
+        secret=settings.jwt_secret,
+        lifetime_seconds=REFRESH_TOKEN_LIFETIME_SECONDS,
+    )
+
+
+def _assert_desktop_error(response: Response, *, status_code: int, detail: str) -> None:
+    assert response.status_code == status_code
+    assert response.json() == {"detail": detail}
+    assert "www-authenticate" not in response.headers
+    assert "retry-after" not in response.headers
+
+
+async def _create_active_user(
+    db_session: AsyncSession,
+    *,
+    token_generation: int = 0,
+) -> User:
+    user = User(
+        email=f"desktop-error-{uuid4().hex}@proliferate.dev",
+        hashed_password="unused-oauth-only",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        token_generation=token_generation,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_invalid_poll_verifier_keeps_raw_detail(client: AsyncClient) -> None:
+    response = await client.post(
+        "/auth/desktop/poll",
+        json={"state": "desktop-error-state", "code_verifier": "not-ascii-☃"},
+    )
+
+    _assert_desktop_error(response, status_code=400, detail="Invalid code_verifier")
+
+
+@pytest.mark.asyncio
+async def test_wrong_authorization_grant_keeps_raw_detail(client: AsyncClient) -> None:
+    response = await client.post(
+        "/auth/desktop/token",
+        json={
+            "code": "unused-code",
+            "code_verifier": "unused-verifier",
+            "grant_type": "refresh_token",
+        },
+    )
+
+    _assert_desktop_error(
+        response,
+        status_code=400,
+        detail="grant_type must be 'authorization_code'",
+    )
+
+
+@pytest.mark.asyncio
+async def test_absent_authorization_code_keeps_raw_detail(client: AsyncClient) -> None:
+    response = await client.post(
+        "/auth/desktop/token",
+        json={
+            "code": "missing-code",
+            "code_verifier": "unused-verifier",
+            "grant_type": "authorization_code",
+        },
+    )
+
+    _assert_desktop_error(
+        response,
+        status_code=400,
+        detail="Invalid, expired, or already-consumed authorization code",
+    )
+
+
+@pytest.mark.asyncio
+async def test_wrong_refresh_grant_keeps_raw_detail(client: AsyncClient) -> None:
+    response = await client.post(
+        "/auth/desktop/refresh",
+        json={"refresh_token": "unused-token", "grant_type": "authorization_code"},
+    )
+
+    _assert_desktop_error(
+        response,
+        status_code=400,
+        detail="grant_type must be 'refresh_token'",
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_refresh_token_keeps_raw_detail(client: AsyncClient) -> None:
+    response = await client.post(
+        "/auth/desktop/refresh",
+        json={"refresh_token": "not-a-token", "grant_type": "refresh_token"},
+    )
+
+    _assert_desktop_error(
+        response,
+        status_code=401,
+        detail="Invalid or expired refresh token",
+    )
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [{}, {"sub": "not-a-uuid"}],
+    ids=["missing-subject", "malformed-subject"],
+)
+@pytest.mark.asyncio
+async def test_invalid_refresh_payload_keeps_raw_detail(
+    client: AsyncClient,
+    claims: dict[str, object],
+) -> None:
+    response = await client.post(
+        "/auth/desktop/refresh",
+        json={
+            "refresh_token": _signed_refresh_token(claims),
+            "grant_type": "refresh_token",
+        },
+    )
+
+    _assert_desktop_error(
+        response,
+        status_code=401,
+        detail="Invalid refresh token payload",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_refresh_generation_keeps_raw_detail(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    user = await _create_active_user(db_session, token_generation=2)
+    refresh_token = _signed_refresh_token({"sub": str(user.id), "token_generation": 1})
+
+    response = await client.post(
+        "/auth/desktop/refresh",
+        json={"refresh_token": refresh_token, "grant_type": "refresh_token"},
+    )
+
+    _assert_desktop_error(
+        response,
+        status_code=401,
+        detail="Refresh token has been revoked",
+    )

--- a/server/tests/unit/test_auth_errors.py
+++ b/server/tests/unit/test_auth_errors.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import Request
+
+from proliferate.auth.errors import AuthFlowError
+from proliferate.errors import InvalidRequest, ProliferateError
+from proliferate.main import _proliferate_error_handler
+
+
+class _InvalidRequestWithExtraDetail(InvalidRequest):
+    def __init__(self) -> None:
+        super().__init__("Input was invalid.", code="input_invalid")
+        self.extra_detail = {"field": "email"}
+
+
+def _request() -> Request:
+    return Request({"type": "http"})
+
+
+def test_auth_flow_error_is_typed_and_copies_headers() -> None:
+    headers = {"X-Auth-Contract": "preserved"}
+    error = AuthFlowError(
+        "desktop_auth_failed",
+        "Desktop auth failed.",
+        status_code=409,
+        headers=headers,
+    )
+    headers["X-Auth-Contract"] = "changed"
+
+    assert isinstance(error, ProliferateError)
+    assert error.code == "desktop_auth_failed"
+    assert error.message == "Desktop auth failed."
+    assert error.status_code == 409
+    assert isinstance(error.headers, dict)
+    assert error.headers is not headers
+    assert error.headers == {"X-Auth-Contract": "preserved"}
+    assert str(error) == "Desktop auth failed."
+
+
+@pytest.mark.asyncio
+async def test_global_handler_preserves_auth_flow_error_shape_and_headers() -> None:
+    error = AuthFlowError(
+        "desktop_auth_failed",
+        "Desktop auth failed.",
+        status_code=401,
+        headers={"X-Auth-Contract": "preserved"},
+    )
+
+    response = await _proliferate_error_handler(_request(), error)
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {"detail": "Desktop auth failed."}
+    assert response.headers["x-auth-contract"] == "preserved"
+
+
+@pytest.mark.asyncio
+async def test_global_handler_keeps_normal_product_error_envelope() -> None:
+    error = InvalidRequest("Input was invalid.", code="input_invalid")
+
+    response = await _proliferate_error_handler(_request(), error)
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "detail": {"code": "input_invalid", "message": "Input was invalid."}
+    }
+
+
+@pytest.mark.asyncio
+async def test_global_handler_keeps_normal_extra_detail() -> None:
+    error = _InvalidRequestWithExtraDetail()
+
+    response = await _proliferate_error_handler(_request(), error)
+
+    assert response.status_code == 400
+    assert json.loads(response.body) == {
+        "detail": {
+            "code": "input_invalid",
+            "message": "Input was invalid.",
+            "field": "email",
+        }
+    }

--- a/specs/codebase/structures/server/guides/errors.md
+++ b/specs/codebase/structures/server/guides/errors.md
@@ -135,6 +135,13 @@ Use the global handler instead:
 await service.do_work(...)
 ```
 
+`AuthFlowError` is a legacy Auth protocol compatibility exception translated by
+that same global handler. It preserves the already-shipped raw string
+`{"detail": "Client-facing message."}` response while keeping its stable
+internal code out of the public response. This exception exists only for
+compatibility with existing Auth clients; it is not a general shortcut for new
+product errors, which use the structured envelope above.
+
 ## Direct `HTTPException`
 
 Direct `HTTPException` is allowed only at actual HTTP boundaries:


### PR DESCRIPTION
## Summary

- add a typed AuthFlowError compatibility seam below the HTTP boundary
- convert all 12 Desktop Auth service HTTPException raises while retaining the three legal Desktop API boundary raises
- preserve every existing status code, raw string detail, header, exception chain, transaction order, and success response

## Compatibility boundary

Auth clients currently receive raw string details for these failures. The existing single ProliferateError handler now emits that legacy shape only for AuthFlowError; every other product error retains the normal structured code/message envelope and extra-detail behavior. No route-local catch or second handler was added.

## Scope and follow-ons

- exact current-main Auth census before this slice: 99 raises, comprising 10 legal API-boundary raises and 89 non-boundary raises
- this slice converts the 12 Desktop service raises; final head has 87 Auth raises and zero in Desktop service
- the remaining Identity and SSO surfaces are separately frozen as Server Grid 24 and 25 because they have independent provider/protocol and stacked-write-ownership risks
- no Auth lifecycle inversion, provider move, transaction change, callback HTML change, checker allowlist, or adjacent Organization SSO conversion

## Proof

- frozen focused suite: 86 passed
- Ruff check and format check: passed
- server boundaries, max-lines, documentation integrity, design attribution, and diff checks: passed
- exact seven-path scope and excluded-path guard: passed
- independent implementation review: ACCEPT with no unresolved findings

Frozen specification: Server Grid 20 revision 2. Base: current `main` at `1471d4f7e85549c4842b3fb4e69b43600f4509ed`. Draft only; rerun the frozen proof after any rebase.
