### PR TITLE
refactor(server): own Identity Auth failures below HTTP

### DIFF
--- a/server/proliferate/auth/desktop/api.py
+++ b/server/proliferate/auth/desktop/api.py
@@ -47,6 +47,7 @@ from proliferate.auth.desktop.service import (
 from proliferate.auth.desktop.service import (
     poll_desktop_auth as poll_desktop_auth_service,
 )
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.models import PasswordLoginRequest
 from proliferate.auth.identity.password import (
     authenticate_password_user,
@@ -104,7 +105,7 @@ async def desktop_password_login(
             password=body.password,
             client_ip=request_client_ip(request),
         )
-    except HTTPException:
+    except AuthFlowError:
         # Persist rate-limit failure counters before surfacing the error.
         await db.commit()
         raise

--- a/server/proliferate/auth/identity/api.py
+++ b/server/proliferate/auth/identity/api.py
@@ -20,6 +20,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import current_limited_user, optional_current_active_user
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.models import (
     AppleMobileCompleteRequest,
     AuthRefreshRequest,
@@ -153,7 +154,7 @@ async def oauth_callback(
                 )
                 await db.commit()
                 return RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
-            except HTTPException:
+            except AuthFlowError:
                 await db.rollback()
         return RedirectResponse(_auth_error_url(error), status_code=status.HTTP_302_FOUND)
     if state is None or code is None:
@@ -197,7 +198,7 @@ async def oauth_shared_provider_callback(
                 )
                 await db.commit()
                 return RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
-            except HTTPException:
+            except AuthFlowError:
                 await db.rollback()
         return RedirectResponse(_auth_error_url(error), status_code=status.HTTP_302_FOUND)
     if state is None or code is None:
@@ -290,7 +291,7 @@ async def web_password_login(
     except WebBetaAccessDenied:
         await db.rollback()
         raise
-    except HTTPException:
+    except AuthFlowError:
         await db.commit()
         raise
     await db.commit()
@@ -311,7 +312,7 @@ async def mobile_password_login(
             password=body.password,
             client_ip=request_client_ip(request),
         )
-    except HTTPException:
+    except AuthFlowError:
         await db.commit()
         raise
     await db.commit()

--- a/server/proliferate/auth/identity/password.py
+++ b/server/proliferate/auth/identity/password.py
@@ -7,9 +7,10 @@ import hmac
 from datetime import UTC, datetime
 from ipaddress import ip_address, ip_network
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.models import PasswordCredentialResponse
 from proliferate.auth.identity.types import AuthSession
 from proliferate.auth.models import AuthPasswordCredential
@@ -90,7 +91,11 @@ def ensure_password_auth_enabled() -> None:
     operator disables password auth, no path may verify or create a password.
     """
     if not settings.password_auth_enabled:
-        raise HTTPException(status_code=404, detail="Email sign-in is not enabled.")
+        raise AuthFlowError(
+            "identity_password_auth_disabled",
+            "Email sign-in is not enabled.",
+            status_code=404,
+        )
 
 
 def password_login_buckets(
@@ -154,18 +159,30 @@ async def authenticate_password_user(
     buckets = password_login_buckets(email=normalized_email, client_ip=client_ip)
     now = datetime.now(UTC)
     if await active_password_login_blocks(db, buckets=buckets, now=now):
-        raise HTTPException(status_code=429, detail=PASSWORD_RATE_LIMIT_MESSAGE)
+        raise AuthFlowError(
+            "identity_password_rate_limited",
+            PASSWORD_RATE_LIMIT_MESSAGE,
+            status_code=429,
+        )
 
     user = await get_user_by_normalized_email(db, normalized_email)
     if user is None or not user.is_active or user.password_set_at is None:
         harden_password_failure(password)
         await record_password_login_failure(db, buckets=buckets, now=now)
-        raise HTTPException(status_code=401, detail=PASSWORD_BAD_CREDENTIALS_MESSAGE)
+        raise AuthFlowError(
+            "identity_password_credentials_invalid",
+            PASSWORD_BAD_CREDENTIALS_MESSAGE,
+            status_code=401,
+        )
 
     verification = verify_password(password, user.hashed_password)
     if not verification.verified:
         await record_password_login_failure(db, buckets=buckets, now=now)
-        raise HTTPException(status_code=401, detail=PASSWORD_BAD_CREDENTIALS_MESSAGE)
+        raise AuthFlowError(
+            "identity_password_credentials_invalid",
+            PASSWORD_BAD_CREDENTIALS_MESSAGE,
+            status_code=401,
+        )
 
     if verification.updated_hash is not None:
         updated = await update_user_password_hash(
@@ -207,15 +224,27 @@ async def set_password_credential(
     is_password_change = user.password_set_at is not None
     if is_password_change:
         if not current_password:
-            raise HTTPException(status_code=400, detail="Current password is required.")
+            raise AuthFlowError(
+                "identity_current_password_required",
+                "Current password is required.",
+                status_code=400,
+            )
         verification = verify_password(current_password, user.hashed_password)
         if not verification.verified:
-            raise HTTPException(status_code=401, detail="Current password is incorrect.")
+            raise AuthFlowError(
+                "identity_current_password_invalid",
+                "Current password is incorrect.",
+                status_code=401,
+            )
 
     try:
         validate_new_password(new_password)
     except PasswordValidationError as exc:
-        raise HTTPException(status_code=400, detail=exc.reason) from exc
+        raise AuthFlowError(
+            "identity_password_invalid",
+            exc.reason,
+            status_code=400,
+        ) from exc
 
     now = datetime.now(UTC)
     updated_user = await update_user_password_hash(
@@ -225,7 +254,11 @@ async def set_password_credential(
         password_set_at=now,
     )
     if updated_user is None:
-        raise HTTPException(status_code=400, detail="User not found.")
+        raise AuthFlowError(
+            "identity_password_user_not_found",
+            "User not found.",
+            status_code=400,
+        )
 
     if not is_password_change:
         return password_credential_response(updated_user), None

--- a/server/proliferate/auth/identity/providers.py
+++ b/server/proliferate/auth/identity/providers.py
@@ -6,10 +6,10 @@ import hashlib
 import secrets
 import time
 from datetime import UTC, datetime
+from typing import Protocol
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import HTTPException, Request, status
 from httpx_oauth.exceptions import GetIdEmailError, GetProfileError
 from httpx_oauth.oauth2 import GetAccessTokenError
 from jose import JWTError, jwt
@@ -30,8 +30,20 @@ APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
 APPLE_ISSUER = "https://appleid.apple.com"
 
 
+class _RequestWithBaseUrl(Protocol):
+    @property
+    def base_url(self) -> object: ...
+
+
 class OAuthProviderTokenRejectedError(Exception):
     """The provider rejected the callback grant during identity verification."""
+
+
+class ProviderVerificationError(Exception):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 def parse_scope_string(value: object) -> frozenset[str]:
@@ -158,9 +170,9 @@ async def verify_oauth_callback(
             # sign-in working; the provider subject is the durable identity.
             account_email = f"{account_id}+{provider_login}@users.noreply.github.com"
         if account_email is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="GitHub did not return an email address.",
+            raise ProviderVerificationError(
+                "identity_github_email_missing",
+                "GitHub did not return an email address.",
             )
         return VerifiedProviderIdentity(
             provider="github",
@@ -191,19 +203,19 @@ async def verify_oauth_callback(
         if isinstance(id_token, str) and id_token:
             try:
                 return await _verified_google_identity_from_id_token(token, id_token)
-            except HTTPException:
+            except ProviderVerificationError:
                 return await _verified_google_identity_from_userinfo(token)
         try:
             account_id, account_email = await google_oauth_client.get_id_email(access_token)
         except GetIdEmailError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Google did not return a usable account profile.",
+            raise ProviderVerificationError(
+                "identity_google_profile_unusable",
+                "Google did not return a usable account profile.",
             ) from exc
         if account_email is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Google did not return an email address.",
+            raise ProviderVerificationError(
+                "identity_google_email_missing",
+                "Google did not return an email address.",
             )
         return VerifiedProviderIdentity(
             provider="google",
@@ -222,9 +234,9 @@ async def verify_oauth_callback(
             scopes=parse_scope_string(token.get("scope")),
         )
 
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail="Unsupported OAuth provider.",
+    raise ProviderVerificationError(
+        "identity_oauth_provider_unsupported",
+        "Unsupported OAuth provider.",
     )
 
 
@@ -250,15 +262,15 @@ def _verified_google_identity_from_claims(
 ) -> VerifiedProviderIdentity:
     subject = claims.get("sub")
     if not isinstance(subject, str) or not subject:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Google subject is missing.",
+        raise ProviderVerificationError(
+            "identity_google_subject_missing",
+            "Google subject is missing.",
         )
     email = claims.get("email") if isinstance(claims.get("email"), str) else None
     if not email:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Google did not return an email address.",
+        raise ProviderVerificationError(
+            "identity_google_email_missing",
+            "Google did not return an email address.",
         )
     email_verified = claims.get("email_verified")
     display_name = claims.get("name") if isinstance(claims.get("name"), str) else None
@@ -292,15 +304,15 @@ async def _fetch_google_userinfo(access_token: str) -> dict[str, object]:
             response.raise_for_status()
             payload = response.json()
     except (ValueError, httpx.HTTPError) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Google did not return a usable account profile.",
+        raise ProviderVerificationError(
+            "identity_google_profile_unusable",
+            "Google did not return a usable account profile.",
         ) from exc
 
     if not isinstance(payload, dict):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Google did not return a usable account profile.",
+        raise ProviderVerificationError(
+            "identity_google_profile_unusable",
+            "Google did not return a usable account profile.",
         )
     return payload
 
@@ -310,9 +322,9 @@ async def _decode_google_id_token(id_token: str) -> dict[str, object]:
         jwks = (await client.get(GOOGLE_JWKS_URL)).json()
     keys = jwks.get("keys")
     if not isinstance(keys, list):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Google JWKS is invalid.",
+        raise ProviderVerificationError(
+            "identity_google_jwks_invalid",
+            "Google JWKS is invalid.",
         )
 
     last_error: Exception | None = None
@@ -332,9 +344,9 @@ async def _decode_google_id_token(id_token: str) -> dict[str, object]:
             return dict(claims)
         except JWTError as exc:
             last_error = exc
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail="Google identity token could not be verified.",
+    raise ProviderVerificationError(
+        "identity_google_identity_token_unverified",
+        "Google identity token could not be verified.",
     ) from last_error
 
 
@@ -353,9 +365,9 @@ async def verify_apple_identity_token(
     )
     subject = claims.get("sub")
     if not isinstance(subject, str) or not subject:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Apple subject is missing.",
+        raise ProviderVerificationError(
+            "identity_apple_subject_missing",
+            "Apple subject is missing.",
         )
     signed_email = claims.get("email") if isinstance(claims.get("email"), str) else None
     email_verified = claims.get("email_verified")
@@ -385,9 +397,9 @@ async def _decode_apple_identity_token(
         jwks = (await client.get(APPLE_JWKS_URL)).json()
     keys = jwks.get("keys")
     if not isinstance(keys, list):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Apple JWKS is invalid.",
+        raise ProviderVerificationError(
+            "identity_apple_jwks_invalid",
+            "Apple JWKS is invalid.",
         )
 
     allowed_audience = apple_client_id_for_surface(surface)
@@ -407,24 +419,24 @@ async def _decode_apple_identity_token(
             return dict(claims)
         except JWTError as exc:
             last_error = exc
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail="Apple identity token could not be verified.",
+    raise ProviderVerificationError(
+        "identity_apple_identity_token_unverified",
+        "Apple identity token could not be verified.",
     ) from last_error
 
 
 def _validate_apple_nonce(claims: dict[str, object], expected_nonce: str) -> None:
     claim_nonce = claims.get("nonce")
     if not isinstance(claim_nonce, str):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Apple nonce is missing.",
+        raise ProviderVerificationError(
+            "identity_apple_nonce_missing",
+            "Apple nonce is missing.",
         )
     expected_hash = hashlib.sha256(expected_nonce.encode("utf-8")).hexdigest()
     if claim_nonce not in {expected_nonce, expected_hash}:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Apple nonce mismatch.",
+        raise ProviderVerificationError(
+            "identity_apple_nonce_mismatch",
+            "Apple nonce mismatch.",
         )
 
 
@@ -445,7 +457,12 @@ def build_apple_client_secret(*, surface: str) -> str:
     )
 
 
-def provider_callback_url(request: Request, *, provider: AuthProviderName, surface: str) -> str:
+def provider_callback_url(
+    request: _RequestWithBaseUrl,
+    *,
+    provider: AuthProviderName,
+    surface: str,
+) -> str:
     base = settings.api_base_url.strip().rstrip("/")
     if not base:
         base = str(request.base_url).rstrip("/")

--- a/server/proliferate/auth/identity/service.py
+++ b/server/proliferate/auth/identity/service.py
@@ -6,9 +6,10 @@ import hashlib
 from datetime import UTC, datetime, timedelta
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity import providers
 from proliferate.auth.identity.sessions import mint_auth_session
 from proliferate.auth.identity.store import (
@@ -61,7 +62,11 @@ def append_query(base_url: str, **params: str) -> str:
 def validate_redirect_uri(surface: str, redirect_uri: str) -> None:
     if surface == "mobile":
         if redirect_uri != settings.mobile_redirect_uri:
-            raise HTTPException(status_code=400, detail="Mobile redirect URI is not allowed.")
+            raise AuthFlowError(
+                "identity_mobile_redirect_uri_not_allowed",
+                "Mobile redirect URI is not allowed.",
+                status_code=400,
+            )
         return
     if surface == "desktop":
         parsed = urlparse(redirect_uri)
@@ -70,13 +75,23 @@ def validate_redirect_uri(surface: str, redirect_uri: str) -> None:
             detail = (
                 f"Desktop redirect URI must use a configured desktop scheme: {desktop_schemes}."
             )
-            raise HTTPException(status_code=400, detail=detail)
+            raise AuthFlowError(
+                "identity_desktop_redirect_uri_not_allowed",
+                detail,
+                status_code=400,
+            )
         return
     if surface == "web":
         if not _is_allowed_web_redirect_uri(redirect_uri):
-            raise HTTPException(status_code=400, detail="Web redirect URI origin is not allowed.")
+            raise AuthFlowError(
+                "identity_web_redirect_uri_not_allowed",
+                "Web redirect URI origin is not allowed.",
+                status_code=400,
+            )
         return
-    raise HTTPException(status_code=400, detail="Unsupported auth surface.")
+    raise AuthFlowError(
+        "identity_surface_unsupported", "Unsupported auth surface.", status_code=400
+    )
 
 
 def _is_allowed_web_redirect_uri(redirect_uri: str) -> bool:
@@ -118,7 +133,7 @@ def _loopback_origin_aliases(scheme: str, hostname: str | None, port: int | None
 
 def _ensure_active_user(user: User) -> None:
     if not user.is_active:
-        raise HTTPException(status_code=403, detail="User is inactive.")
+        raise AuthFlowError("identity_user_inactive", "User is inactive.", status_code=403)
 
 
 async def start_provider_auth(
@@ -136,16 +151,29 @@ async def start_provider_auth(
     user: User | None,
 ) -> tuple[str | None, str, str, datetime]:
     if provider not in {"github", "google", "apple"}:
-        raise HTTPException(status_code=404, detail="Unknown auth provider.")
+        raise AuthFlowError(
+            "identity_provider_unknown",
+            "Unknown auth provider.",
+            status_code=404,
+        )
     if not providers.provider_enabled(provider, surface=surface):
-        raise HTTPException(status_code=503, detail=f"{provider} sign-in is not configured.")
+        raise AuthFlowError(
+            "identity_provider_not_configured",
+            f"{provider} sign-in is not configured.",
+            status_code=503,
+        )
     if purpose != "login" and user is None:
-        raise HTTPException(
+        raise AuthFlowError(
+            "identity_provider_link_auth_required",
+            "Authentication is required to link providers.",
             status_code=401,
-            detail="Authentication is required to link providers.",
         )
     if code_challenge_method not in SUPPORTED_CODE_CHALLENGE_METHODS:
-        raise HTTPException(status_code=400, detail="Unsupported code challenge method.")
+        raise AuthFlowError(
+            "identity_code_challenge_method_unsupported",
+            "Unsupported code challenge method.",
+            status_code=400,
+        )
     validate_redirect_uri(surface, redirect_uri)
 
     state = providers.new_secret()
@@ -212,6 +240,8 @@ async def complete_oauth_provider_callback(
             error="provider_error",
             state=challenge.client_state,
         )
+    except providers.ProviderVerificationError as exc:
+        raise AuthFlowError(exc.code, exc.message, status_code=400) from exc
     if callback_surface == "web" and challenge.purpose == "login":
         beta_email = await _beta_email_for_provider_login(db, verified=verified)
         ensure_web_beta_email_allowed(beta_email)
@@ -321,13 +351,16 @@ async def complete_apple_mobile_login(
         provider="apple",
         surface="mobile",
     )
-    verified = await providers.verify_apple_identity_token(
-        identity_token=identity_token,
-        expected_nonce=_nonce_unavailable_marker(challenge),
-        surface=challenge.surface,
-        email_hint=email,
-        display_name_hint=display_name,
-    )
+    try:
+        verified = await providers.verify_apple_identity_token(
+            identity_token=identity_token,
+            expected_nonce=_nonce_unavailable_marker(challenge),
+            surface=challenge.surface,
+            email_hint=email,
+            display_name_hint=display_name,
+        )
+    except providers.ProviderVerificationError as exc:
+        raise AuthFlowError(exc.code, exc.message, status_code=400) from exc
     user = await resolve_provider_user(db, verified=verified, challenge=challenge)
     schedule_agent_gateway_user_enrollment(user.id, db=db)
     return await mint_auth_session(db, user=user)
@@ -347,13 +380,16 @@ async def complete_apple_web_callback(
         provider="apple",
         surface="web",
     )
-    verified = await providers.verify_apple_identity_token(
-        identity_token=identity_token,
-        expected_nonce=_nonce_unavailable_marker(challenge),
-        surface=challenge.surface,
-        email_hint=email,
-        display_name_hint=display_name,
-    )
+    try:
+        verified = await providers.verify_apple_identity_token(
+            identity_token=identity_token,
+            expected_nonce=_nonce_unavailable_marker(challenge),
+            surface=challenge.surface,
+            email_hint=email,
+            display_name_hint=display_name,
+        )
+    except providers.ProviderVerificationError as exc:
+        raise AuthFlowError(exc.code, exc.message, status_code=400) from exc
     if challenge.purpose == "login":
         beta_email = await _beta_email_for_provider_login(db, verified=verified)
         ensure_web_beta_email_allowed(beta_email)
@@ -411,7 +447,11 @@ async def _consume_challenge_for_callback(
         or challenge.provider != provider
         or (surface is not None and challenge.surface != surface)
     ):
-        raise HTTPException(status_code=400, detail="Invalid or expired auth state.")
+        raise AuthFlowError(
+            "identity_auth_state_invalid",
+            "Invalid or expired auth state.",
+            status_code=400,
+        )
     return challenge
 
 
@@ -444,12 +484,20 @@ async def _resolve_provider_user(
 
     if challenge.purpose != "login":
         if challenge.user_id is None:
-            raise HTTPException(status_code=401, detail="Authentication is required.")
+            raise AuthFlowError(
+                "identity_authentication_required",
+                "Authentication is required.",
+                status_code=401,
+            )
         if existing_identity is not None and existing_identity.user_id != challenge.user_id:
             current_user = await get_user_by_id(db, challenge.user_id)
             linked_user = await get_user_by_id(db, existing_identity.user_id)
             if current_user is None or linked_user is None:
-                raise HTTPException(status_code=400, detail="Linked user not found.")
+                raise AuthFlowError(
+                    "identity_linked_user_not_found",
+                    "Linked user not found.",
+                    status_code=400,
+                )
             _ensure_active_user(current_user)
             _ensure_active_user(linked_user)
             current_readiness = await get_account_readiness(db, user_id=current_user.id)
@@ -474,10 +522,18 @@ async def _resolve_provider_user(
                 )
                 await attach_verified_identity(db, user=current_user, verified=verified)
                 return current_user
-            raise HTTPException(status_code=409, detail="Provider identity already linked.")
+            raise AuthFlowError(
+                "identity_provider_already_linked",
+                "Provider identity already linked.",
+                status_code=409,
+            )
         user = await get_user_by_id(db, challenge.user_id)
         if user is None:
-            raise HTTPException(status_code=400, detail="User not found.")
+            raise AuthFlowError(
+                "identity_user_not_found",
+                "User not found.",
+                status_code=400,
+            )
         _ensure_active_user(user)
         await attach_verified_identity(db, user=user, verified=verified)
         return user
@@ -485,7 +541,11 @@ async def _resolve_provider_user(
     if existing_identity is not None:
         user = await get_user_by_id(db, existing_identity.user_id)
         if user is None:
-            raise HTTPException(status_code=400, detail="Linked user not found.")
+            raise AuthFlowError(
+                "identity_linked_user_not_found",
+                "Linked user not found.",
+                status_code=400,
+            )
         _ensure_active_user(user)
         await attach_verified_identity(db, user=user, verified=verified)
         return user
@@ -498,9 +558,10 @@ async def _resolve_provider_user(
             await attach_verified_identity(db, user=existing_email_user, verified=verified)
             return existing_email_user
     if verified.email and await get_user_by_email(db, verified.email) is not None:
-        raise HTTPException(
+        raise AuthFlowError(
+            "identity_email_account_conflict",
+            "An account already exists for this email. Sign in with GitHub to link it.",
             status_code=409,
-            detail="An account already exists for this email. Sign in with GitHub to link it.",
         )
     user = await create_auth_user(
         db,

--- a/server/proliferate/auth/identity/sessions.py
+++ b/server/proliferate/auth/identity/sessions.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from fastapi import HTTPException
 from fastapi_users.jwt import decode_jwt, generate_jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity import providers
 from proliferate.auth.identity.models import AccountReadinessResponse, AuthSessionResponse
 from proliferate.auth.identity.password import auth_password_credential
@@ -55,7 +55,11 @@ WEB_CSRF_HEADER = "x-proliferate-csrf"
 
 def _ensure_active_user(user: User) -> None:
     if not user.is_active:
-        raise HTTPException(status_code=403, detail="User is inactive.")
+        raise AuthFlowError(
+            "identity_user_inactive",
+            "User is inactive.",
+            status_code=403,
+        )
 
 
 async def exchange_auth_code(
@@ -66,18 +70,34 @@ async def exchange_auth_code(
 ) -> AuthSession:
     auth_code = await consume_auth_code(db, code=code)
     if auth_code is None:
-        raise HTTPException(status_code=400, detail="Invalid, expired, or consumed auth code.")
+        raise AuthFlowError(
+            "identity_auth_code_invalid",
+            "Invalid, expired, or consumed auth code.",
+            status_code=400,
+        )
     if not verify_pkce(
         code_verifier,
         auth_code.code_challenge,
         auth_code.code_challenge_method,
     ):
-        raise HTTPException(status_code=400, detail="PKCE verification failed.")
+        raise AuthFlowError(
+            "identity_pkce_verification_failed",
+            "PKCE verification failed.",
+            status_code=400,
+        )
     if _auth_code_expired(auth_code.created_at):
-        raise HTTPException(status_code=400, detail="Auth code expired.")
+        raise AuthFlowError(
+            "identity_auth_code_expired",
+            "Auth code expired.",
+            status_code=400,
+        )
     user = await get_user_by_id(db, auth_code.user_id)
     if user is None:
-        raise HTTPException(status_code=400, detail="User not found.")
+        raise AuthFlowError(
+            "identity_auth_code_user_not_found",
+            "User not found.",
+            status_code=400,
+        )
     return await mint_auth_session(db, user=user)
 
 
@@ -123,15 +143,31 @@ async def refresh_auth_session(db: AsyncSession, *, refresh_token: str) -> AuthS
             audience=[REFRESH_TOKEN_AUDIENCE],
         )
     except Exception as exc:
-        raise HTTPException(status_code=401, detail="Invalid or expired refresh token.") from exc
+        raise AuthFlowError(
+            "identity_refresh_token_invalid",
+            "Invalid or expired refresh token.",
+            status_code=401,
+        ) from exc
     user_id = payload.get("sub")
     if not isinstance(user_id, str):
-        raise HTTPException(status_code=401, detail="Invalid refresh token payload.")
+        raise AuthFlowError(
+            "identity_refresh_token_payload_invalid",
+            "Invalid refresh token payload.",
+            status_code=401,
+        )
     user = await get_user_by_id(db, UUID(user_id))
     if user is None:
-        raise HTTPException(status_code=401, detail="User not found.")
+        raise AuthFlowError(
+            "identity_refresh_token_user_not_found",
+            "User not found.",
+            status_code=401,
+        )
     if claimed_token_generation(payload) != user_token_generation(user):
-        raise HTTPException(status_code=401, detail="Refresh token has been revoked.")
+        raise AuthFlowError(
+            "identity_refresh_token_revoked",
+            "Refresh token has been revoked.",
+            status_code=401,
+        )
     return await mint_auth_session(db, user=user)
 
 

--- a/server/proliferate/auth/sso/api.py
+++ b/server/proliferate/auth/sso/api.py
@@ -10,6 +10,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.dependencies import optional_current_active_user
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.service import validate_redirect_uri
 from proliferate.auth.identity.web_beta import WebBetaAccessDenied
 from proliferate.auth.sso.models import (
@@ -185,7 +186,7 @@ def _validated_auth_redirect_url(redirect_url: str) -> str:
     for surface in ("web", "mobile", "desktop"):
         try:
             validate_redirect_uri(surface, redirect_url)
-        except HTTPException:
+        except AuthFlowError:
             continue
         return redirect_url
     raise HTTPException(status_code=400, detail="Auth redirect URI is not allowed.")

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -1935,9 +1935,9 @@ class TestWebMobileProductAuthFlow:
             raise AssertionError("Google legacy profile endpoint should not be used.")
 
         async def fake_decode_google_id_token(_id_token: str) -> dict[str, object]:
-            raise identity_providers.HTTPException(
-                status_code=400,
-                detail="Google identity token could not be verified.",
+            raise identity_providers.ProviderVerificationError(
+                "identity_google_identity_token_unverified",
+                "Google identity token could not be verified.",
             )
 
         async def fake_fetch_google_userinfo(access_token: str) -> dict[str, object]:

--- a/server/tests/integration/test_identity_auth_error_contract.py
+++ b/server/tests/integration/test_identity_auth_error_contract.py
@@ -14,6 +14,7 @@ from proliferate.auth.identity.password import hash_password_login_bucket
 from proliferate.auth.identity.types import VerifiedProviderIdentity
 from proliferate.auth.oauth import google_oauth_client
 from proliferate.auth.passwords import hash_password
+from proliferate.auth.sso.api import _validated_auth_redirect_url
 from proliferate.auth.tokens import REFRESH_TOKEN_AUDIENCE
 from proliferate.config import settings
 from proliferate.constants.auth import (
@@ -94,6 +95,12 @@ async def _refresh(client: AsyncClient, token: str) -> Response:
     return await client.post(
         "/auth/mobile/session/refresh",
         json={"refreshToken": token, "grantType": "refresh_token"},
+    )
+
+
+def test_sso_redirect_probe_accepts_later_identity_surface() -> None:
+    assert (
+        _validated_auth_redirect_url(settings.mobile_redirect_uri) == settings.mobile_redirect_uri
     )
 
 

--- a/server/tests/integration/test_identity_auth_error_contract.py
+++ b/server/tests/integration/test_identity_auth_error_contract.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi_users.jwt import generate_jwt
+from httpx import AsyncClient, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.identity import providers, service
+from proliferate.auth.identity.password import hash_password_login_bucket
+from proliferate.auth.identity.types import VerifiedProviderIdentity
+from proliferate.auth.oauth import google_oauth_client
+from proliferate.auth.passwords import hash_password
+from proliferate.auth.tokens import REFRESH_TOKEN_AUDIENCE
+from proliferate.config import settings
+from proliferate.constants.auth import (
+    PASSWORD_LOGIN_EMAIL_BUCKET,
+    PASSWORD_LOGIN_FAILURE_LIMIT,
+    REFRESH_TOKEN_LIFETIME_SECONDS,
+)
+from proliferate.db.models.auth import AuthChallenge, PasswordLoginAttempt, User
+from tests.helpers.desktop_auth import create_desktop_auth_code, make_pkce_pair
+
+
+def _assert_error(response: Response, *, status_code: int, detail: str) -> None:
+    assert response.status_code == status_code
+    assert response.json() == {"detail": detail}
+    assert "retry-after" not in response.headers
+    assert "www-authenticate" not in response.headers
+
+
+def _start_body(*, redirect_uri: str | None = None) -> dict[str, str]:
+    return {
+        "purpose": "login",
+        "clientState": "client-state",
+        "codeChallenge": "pkce-challenge",
+        "codeChallengeMethod": "S256",
+        "redirectUri": redirect_uri or settings.mobile_redirect_uri,
+    }
+
+
+async def _create_user(
+    db: AsyncSession,
+    *,
+    email: str,
+    password: str | None = None,
+    is_active: bool = True,
+    token_generation: int = 0,
+) -> User:
+    user = User(
+        email=email,
+        hashed_password=hash_password(password) if password else "unused-oauth-only",
+        password_set_at=datetime.now(UTC) if password else None,
+        is_active=is_active,
+        is_superuser=False,
+        is_verified=True,
+        token_generation=token_generation,
+    )
+    db.add(user)
+    await db.commit()
+    return user
+
+
+async def _start_google(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> str:
+    monkeypatch.setattr(settings, "google_oauth_client_id", "google-client")
+    monkeypatch.setattr(settings, "google_oauth_client_secret", "google-secret")
+    monkeypatch.setattr(
+        google_oauth_client,
+        "get_authorization_url",
+        AsyncMock(return_value="https://accounts.example.test/authorize"),
+    )
+    response = await client.post("/auth/mobile/google/start", json=_start_body())
+    assert response.status_code == 200
+    state = response.json()["state"]
+    assert isinstance(state, str)
+    return state
+
+
+def _refresh_token(**claims: object) -> str:
+    return generate_jwt(
+        data={"aud": REFRESH_TOKEN_AUDIENCE, **claims},
+        secret=settings.jwt_secret,
+        lifetime_seconds=REFRESH_TOKEN_LIFETIME_SECONDS,
+    )
+
+
+async def _refresh(client: AsyncClient, token: str) -> Response:
+    return await client.post(
+        "/auth/mobile/session/refresh",
+        json={"refreshToken": token, "grantType": "refresh_token"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_password_disabled_preserves_404_contract(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "password_auth_enabled", False)
+
+    response = await client.post(
+        "/auth/mobile/password/login",
+        json={"email": "disabled@example.com", "password": "irrelevant password"},
+    )
+
+    _assert_error(
+        response,
+        status_code=404,
+        detail="Email sign-in is not enabled.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_not_configured_preserves_503_contract(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "google_oauth_client_id", "")
+    monkeypatch.setattr(settings, "google_oauth_client_secret", "")
+
+    response = await client.post("/auth/mobile/google/start", json=_start_body())
+
+    _assert_error(
+        response,
+        status_code=503,
+        detail="google sign-in is not configured.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mobile_redirect_rejection_preserves_400_contract(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "google_oauth_client_id", "google-client")
+    monkeypatch.setattr(settings, "google_oauth_client_secret", "google-secret")
+
+    response = await client.post(
+        "/auth/mobile/google/start",
+        json=_start_body(redirect_uri="wrong://auth/callback"),
+    )
+
+    _assert_error(
+        response,
+        status_code=400,
+        detail="Mobile redirect URI is not allowed.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_password_failures_commit_counters_and_rate_limit_without_header(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "password_auth_enabled", True)
+    email = "rate-limit@example.com"
+    await _create_user(db_session, email=email, password="correct horse battery staple")
+
+    for _ in range(PASSWORD_LOGIN_FAILURE_LIMIT):
+        response = await client.post(
+            "/auth/mobile/password/login",
+            json={"email": email, "password": "wrong horse battery staple"},
+        )
+        _assert_error(
+            response,
+            status_code=401,
+            detail="Email or password is incorrect.",
+        )
+
+    bucket_key = hash_password_login_bucket(PASSWORD_LOGIN_EMAIL_BUCKET, email)
+    result = await db_session.execute(
+        select(PasswordLoginAttempt).where(
+            PasswordLoginAttempt.bucket_kind == PASSWORD_LOGIN_EMAIL_BUCKET,
+            PasswordLoginAttempt.bucket_key == bucket_key,
+        )
+    )
+    attempt = result.scalar_one()
+    assert attempt.failure_count == PASSWORD_LOGIN_FAILURE_LIMIT
+    assert attempt.blocked_until is not None
+
+    response = await client.post(
+        "/auth/mobile/password/login",
+        json={"email": email, "password": "wrong horse battery staple"},
+    )
+    _assert_error(
+        response,
+        status_code=429,
+        detail="Too many attempts. Wait a moment, then try again.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_and_consumed_auth_state_preserve_400_contract(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invalid = await client.post(
+        "/auth/mobile/apple/complete",
+        json={"state": "missing-state", "identityToken": "apple-token"},
+    )
+    _assert_error(
+        invalid,
+        status_code=400,
+        detail="Invalid or expired auth state.",
+    )
+
+    state = await _start_google(client, monkeypatch)
+    result = await db_session.execute(
+        select(AuthChallenge).where(AuthChallenge.state_hash == service.hash_secret(state))
+    )
+    challenge = result.scalar_one()
+    challenge.consumed_at = datetime.now(UTC)
+    await db_session.commit()
+
+    consumed = await client.get(
+        "/auth/mobile/google/callback",
+        params={"state": state, "code": "google-code"},
+    )
+    _assert_error(
+        consumed,
+        status_code=400,
+        detail="Invalid or expired auth state.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_code_and_pkce_failures_preserve_details_and_rollback(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    invalid = await client.post(
+        "/auth/mobile/token",
+        json={
+            "code": "missing-code",
+            "codeVerifier": "missing-verifier",
+            "grantType": "authorization_code",
+        },
+    )
+    _assert_error(
+        invalid,
+        status_code=400,
+        detail="Invalid, expired, or consumed auth code.",
+    )
+
+    user = await _create_user(db_session, email="pkce@example.com")
+    verifier, challenge = make_pkce_pair()
+    code = await create_desktop_auth_code(
+        user_id=user.id,
+        state="pkce-state",
+        code_challenge=challenge,
+    )
+    rejected = await client.post(
+        "/auth/mobile/token",
+        json={
+            "code": code,
+            "codeVerifier": "wrong-verifier",
+            "grantType": "authorization_code",
+        },
+    )
+    _assert_error(
+        rejected,
+        status_code=400,
+        detail="PKCE verification failed.",
+    )
+
+    retried = await client.post(
+        "/auth/mobile/token",
+        json={
+            "code": code,
+            "codeVerifier": verifier,
+            "grantType": "authorization_code",
+        },
+    )
+    assert retried.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_refresh_decode_and_payload_failures_preserve_401_contract(
+    client: AsyncClient,
+) -> None:
+    decoded = await _refresh(client, "not-a-refresh-token")
+    _assert_error(
+        decoded,
+        status_code=401,
+        detail="Invalid or expired refresh token.",
+    )
+
+    payload = await _refresh(client, _refresh_token())
+    _assert_error(
+        payload,
+        status_code=401,
+        detail="Invalid refresh token payload.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_revoked_refresh_generation_preserves_401_contract(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    user = await _create_user(
+        db_session,
+        email="revoked@example.com",
+        token_generation=2,
+    )
+
+    response = await _refresh(
+        client,
+        _refresh_token(sub=str(user.id), token_generation=1),
+    )
+
+    _assert_error(
+        response,
+        status_code=401,
+        detail="Refresh token has been revoked.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_inactive_user_preserves_403_contract(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    user = await _create_user(
+        db_session,
+        email="inactive@example.com",
+        is_active=False,
+    )
+
+    response = await _refresh(
+        client,
+        _refresh_token(sub=str(user.id), token_generation=0),
+    )
+
+    _assert_error(response, status_code=403, detail="User is inactive.")
+
+
+@pytest.mark.asyncio
+async def test_provider_verification_failure_is_raw_and_rolls_back_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _start_google(client, monkeypatch)
+    source_error = providers.ProviderVerificationError(
+        "identity_google_email_missing",
+        "Google did not return an email address.",
+    )
+    monkeypatch.setattr(
+        providers,
+        "verify_oauth_callback",
+        AsyncMock(side_effect=source_error),
+    )
+
+    response = await client.get(
+        "/auth/mobile/google/callback",
+        params={"state": state, "code": "google-code"},
+    )
+
+    _assert_error(
+        response,
+        status_code=400,
+        detail="Google did not return an email address.",
+    )
+    assert source_error.code not in response.text
+    result = await db_session.execute(
+        select(AuthChallenge).where(AuthChallenge.state_hash == service.hash_secret(state))
+    )
+    assert result.scalar_one().consumed_at is None
+
+
+@pytest.mark.asyncio
+async def test_provider_email_conflict_preserves_409_contract(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    email = "existing@example.com"
+    await _create_user(db_session, email=email)
+    state = await _start_google(client, monkeypatch)
+    monkeypatch.setattr(
+        providers,
+        "verify_oauth_callback",
+        AsyncMock(
+            return_value=VerifiedProviderIdentity(
+                provider="google",
+                provider_subject="new-google-subject",
+                email=email,
+                email_verified=True,
+                display_name=None,
+                provider_login=None,
+                avatar_url=None,
+                access_token="google-token",
+                refresh_token=None,
+                expires_at=None,
+                expires_at_timestamp=None,
+                scopes=frozenset(),
+            )
+        ),
+    )
+
+    response = await client.get(
+        "/auth/mobile/google/callback",
+        params={"state": state, "code": "google-code"},
+    )
+
+    _assert_error(
+        response,
+        status_code=409,
+        detail="An account already exists for this email. Sign in with GitHub to link it.",
+    )

--- a/server/tests/unit/auth/test_identity_error_ownership.py
+++ b/server/tests/unit/auth/test_identity_error_ownership.py
@@ -1,0 +1,600 @@
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import Request
+from httpx_oauth.exceptions import GetIdEmailError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.errors import AuthFlowError
+from proliferate.auth.identity import password, providers, service, sessions
+from proliferate.auth.identity.types import (
+    AuthChallengeSnapshot,
+    AuthProviderName,
+    VerifiedProviderIdentity,
+)
+from proliferate.auth.oauth import github_oauth_client, google_oauth_client
+from proliferate.config import settings
+from proliferate.errors import ProliferateError
+from proliferate.integrations.github import GitHubIntegrationError
+
+
+def _assert_provider_error(
+    exc_info: pytest.ExceptionInfo[providers.ProviderVerificationError],
+    *,
+    code: str,
+    message: str,
+) -> None:
+    assert (exc_info.value.code, exc_info.value.message, str(exc_info.value)) == (
+        code,
+        message,
+        message,
+    )
+
+
+def _assert_auth_error(
+    exc_info: pytest.ExceptionInfo[AuthFlowError],
+    *,
+    code: str,
+    status_code: int,
+    message: str,
+) -> None:
+    assert (exc_info.value.code, exc_info.value.status_code, exc_info.value.message) == (
+        code,
+        status_code,
+        message,
+    )
+
+
+def _provider_response(status_code: int = 400) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        request=httpx.Request("GET", "https://provider.example.test/profile"),
+    )
+
+
+class _JsonResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def _install_json_response(monkeypatch: pytest.MonkeyPatch, payload: object) -> None:
+    response = _JsonResponse(payload)
+
+    class _Client:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            del args
+
+        async def get(self, *args: object, **kwargs: object) -> _JsonResponse:
+            del args, kwargs
+            return response
+
+    monkeypatch.setattr(providers.httpx, "AsyncClient", _Client)
+
+
+def _verified_identity(
+    *, provider: str = "google", email: str | None = None
+) -> VerifiedProviderIdentity:
+    return VerifiedProviderIdentity(
+        provider=cast(AuthProviderName, provider),
+        provider_subject="provider-subject",
+        email=email,
+        email_verified=email is not None,
+        display_name=None,
+        provider_login=None,
+        avatar_url=None,
+        access_token="provider-token",
+        refresh_token=None,
+        expires_at=None,
+        expires_at_timestamp=None,
+        scopes=frozenset(),
+    )
+
+
+def _challenge(*, provider: str = "google", surface: str = "web") -> AuthChallengeSnapshot:
+    return AuthChallengeSnapshot(
+        id=uuid4(),
+        provider=cast(AuthProviderName, provider),
+        surface=surface,
+        purpose="login",
+        user_id=None,
+        client_state="client-state",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+        redirect_uri="https://client.example.test/callback",
+        nonce_hash="nonce-hash",
+    )
+
+
+async def _verify_oauth(provider: AuthProviderName = "google") -> VerifiedProviderIdentity:
+    return await providers.verify_oauth_callback(
+        provider=provider,
+        surface="web",
+        code="code",
+        provider_callback_url=f"https://api.example.test/auth/web/{provider}/callback",
+    )
+
+
+def test_provider_verification_error_is_provider_local() -> None:
+    error = providers.ProviderVerificationError("provider_invalid", "Provider invalid.")
+
+    assert error.code == "provider_invalid"
+    assert error.message == "Provider invalid."
+    assert str(error) == "Provider invalid."
+    assert not isinstance(error, ProliferateError)
+
+
+@pytest.mark.asyncio
+async def test_identity_lower_layers_use_typed_auth_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "password_auth_enabled", False)
+    with pytest.raises(AuthFlowError) as password_error:
+        password.ensure_password_auth_enabled()
+    _assert_auth_error(
+        password_error,
+        code="identity_password_auth_disabled",
+        status_code=404,
+        message="Email sign-in is not enabled.",
+    )
+
+    monkeypatch.setattr(settings, "mobile_redirect_uri", "proliferate://auth/callback")
+    with pytest.raises(AuthFlowError) as service_error:
+        service.validate_redirect_uri("mobile", "wrong://auth/callback")
+    _assert_auth_error(
+        service_error,
+        code="identity_mobile_redirect_uri_not_allowed",
+        status_code=400,
+        message="Mobile redirect URI is not allowed.",
+    )
+
+    monkeypatch.setattr(sessions, "consume_auth_code", AsyncMock(return_value=None))
+    with pytest.raises(AuthFlowError) as session_error:
+        await sessions.exchange_auth_code(
+            cast(AsyncSession, object()),
+            code="missing",
+            code_verifier="verifier",
+        )
+    _assert_auth_error(
+        session_error,
+        code="identity_auth_code_invalid",
+        status_code=400,
+        message="Invalid, expired, or consumed auth code.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_missing_email_has_provider_local_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        github_oauth_client,
+        "get_access_token",
+        AsyncMock(return_value={"access_token": "github-token"}),
+    )
+    monkeypatch.setattr(
+        github_oauth_client,
+        "get_id_email",
+        AsyncMock(return_value=("github-subject", None)),
+    )
+    monkeypatch.setattr(
+        providers,
+        "get_github_user_profile",
+        AsyncMock(side_effect=GitHubIntegrationError("profile unavailable")),
+    )
+
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await _verify_oauth("github")
+
+    _assert_provider_error(
+        exc_info,
+        code="identity_github_email_missing",
+        message="GitHub did not return an email address.",
+    )
+
+
+def _install_google_legacy_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        google_oauth_client,
+        "get_access_token",
+        AsyncMock(return_value={"access_token": "google-token"}),
+    )
+
+
+@pytest.mark.parametrize(
+    ("profile", "code", "message"),
+    [
+        (
+            GetIdEmailError(response=_provider_response()),
+            "identity_google_profile_unusable",
+            "Google did not return a usable account profile.",
+        ),
+        (
+            ("google-subject", None),
+            "identity_google_email_missing",
+            "Google did not return an email address.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_google_legacy_failures_have_provider_local_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: object,
+    code: str,
+    message: str,
+) -> None:
+    _install_google_legacy_token(monkeypatch)
+    get_id_email = AsyncMock()
+    if isinstance(profile, Exception):
+        get_id_email.side_effect = profile
+    else:
+        get_id_email.return_value = profile
+    monkeypatch.setattr(
+        google_oauth_client,
+        "get_id_email",
+        get_id_email,
+    )
+
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await _verify_oauth()
+
+    _assert_provider_error(exc_info, code=code, message=message)
+    if isinstance(profile, Exception):
+        assert exc_info.value.__cause__ is profile
+
+
+@pytest.mark.asyncio
+async def test_unsupported_oauth_provider_has_provider_local_code() -> None:
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await _verify_oauth("apple")
+
+    _assert_provider_error(
+        exc_info,
+        code="identity_oauth_provider_unsupported",
+        message="Unsupported OAuth provider.",
+    )
+
+
+@pytest.mark.parametrize(
+    ("claims", "code", "message"),
+    [
+        (
+            {"email": "google@example.com"},
+            "identity_google_subject_missing",
+            "Google subject is missing.",
+        ),
+        (
+            {"sub": "google-subject"},
+            "identity_google_email_missing",
+            "Google did not return an email address.",
+        ),
+    ],
+)
+def test_google_claim_failures_have_provider_local_codes(
+    claims: dict[str, object],
+    code: str,
+    message: str,
+) -> None:
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        providers._verified_google_identity_from_claims(
+            {"access_token": "google-token"},
+            claims,
+        )
+
+    _assert_provider_error(exc_info, code=code, message=message)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [ValueError("invalid JSON"), ["not", "an", "object"]],
+)
+@pytest.mark.asyncio
+async def test_google_userinfo_failures_have_provider_local_code(
+    monkeypatch: pytest.MonkeyPatch, payload: object
+) -> None:
+    _install_json_response(monkeypatch, payload)
+
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await providers._fetch_google_userinfo("google-token")
+
+    _assert_provider_error(
+        exc_info,
+        code="identity_google_profile_unusable",
+        message="Google did not return a usable account profile.",
+    )
+    if isinstance(payload, Exception):
+        assert exc_info.value.__cause__ is payload
+
+
+@pytest.mark.parametrize(
+    ("payload", "code", "message"),
+    [
+        ({}, "identity_google_jwks_invalid", "Google JWKS is invalid."),
+        (
+            {"keys": []},
+            "identity_google_identity_token_unverified",
+            "Google identity token could not be verified.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_google_jwks_failures_have_provider_local_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+    code: str,
+    message: str,
+) -> None:
+    _install_json_response(monkeypatch, payload)
+
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await providers._decode_google_id_token("google-id-token")
+
+    _assert_provider_error(exc_info, code=code, message=message)
+
+
+@pytest.mark.asyncio
+async def test_apple_missing_subject_has_provider_local_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        providers,
+        "_decode_apple_identity_token",
+        AsyncMock(return_value={}),
+    )
+
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await providers.verify_apple_identity_token(
+            identity_token="apple-token",
+            expected_nonce="nonce",
+            surface="mobile",
+            email_hint=None,
+            display_name_hint=None,
+        )
+
+    _assert_provider_error(
+        exc_info,
+        code="identity_apple_subject_missing",
+        message="Apple subject is missing.",
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "code", "message"),
+    [
+        ({}, "identity_apple_jwks_invalid", "Apple JWKS is invalid."),
+        (
+            {"keys": []},
+            "identity_apple_identity_token_unverified",
+            "Apple identity token could not be verified.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_apple_jwks_failures_have_provider_local_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+    code: str,
+    message: str,
+) -> None:
+    _install_json_response(monkeypatch, payload)
+
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        await providers._decode_apple_identity_token(
+            identity_token="apple-token",
+            expected_nonce="nonce",
+            surface="mobile",
+        )
+
+    _assert_provider_error(exc_info, code=code, message=message)
+
+
+@pytest.mark.parametrize(
+    ("claims", "code", "message"),
+    [
+        ({}, "identity_apple_nonce_missing", "Apple nonce is missing."),
+        ({"nonce": "wrong"}, "identity_apple_nonce_mismatch", "Apple nonce mismatch."),
+    ],
+)
+def test_apple_nonce_failures_have_provider_local_codes(
+    claims: dict[str, object],
+    code: str,
+    message: str,
+) -> None:
+    with pytest.raises(providers.ProviderVerificationError) as exc_info:
+        providers._validate_apple_nonce(claims, "expected")
+
+    _assert_provider_error(exc_info, code=code, message=message)
+
+
+@pytest.mark.asyncio
+async def test_google_id_token_verification_error_falls_back_to_userinfo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = _verified_identity(email="google@example.com")
+    monkeypatch.setattr(
+        google_oauth_client,
+        "get_access_token",
+        AsyncMock(return_value={"access_token": "google-token", "id_token": "id-token"}),
+    )
+    monkeypatch.setattr(
+        providers,
+        "_verified_google_identity_from_id_token",
+        AsyncMock(
+            side_effect=providers.ProviderVerificationError(
+                "identity_google_identity_token_unverified",
+                "Google identity token could not be verified.",
+            )
+        ),
+    )
+    userinfo = AsyncMock(return_value=expected)
+    monkeypatch.setattr(providers, "_verified_google_identity_from_userinfo", userinfo)
+
+    actual = await _verify_oauth()
+
+    assert actual is expected
+    userinfo.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_google_id_token_nonclassified_error_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_error = RuntimeError("unexpected verification failure")
+    monkeypatch.setattr(
+        google_oauth_client,
+        "get_access_token",
+        AsyncMock(return_value={"access_token": "google-token", "id_token": "id-token"}),
+    )
+    monkeypatch.setattr(
+        providers,
+        "_verified_google_identity_from_id_token",
+        AsyncMock(side_effect=source_error),
+    )
+    userinfo = AsyncMock()
+    monkeypatch.setattr(providers, "_verified_google_identity_from_userinfo", userinfo)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await _verify_oauth()
+
+    assert exc_info.value is source_error
+    userinfo.assert_not_awaited()
+
+
+def _install_challenge(monkeypatch: pytest.MonkeyPatch, challenge: AuthChallengeSnapshot) -> None:
+    monkeypatch.setattr(
+        service,
+        "_consume_challenge_for_callback",
+        AsyncMock(return_value=challenge),
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_service_translates_provider_verification_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_challenge(monkeypatch, _challenge())
+    monkeypatch.setattr(
+        providers,
+        "provider_callback_url",
+        lambda *args, **kwargs: "https://api.example.test/auth/web/google/callback",
+    )
+    source_error = providers.ProviderVerificationError(
+        "identity_google_email_missing",
+        "Google did not return an email address.",
+    )
+    monkeypatch.setattr(
+        providers,
+        "verify_oauth_callback",
+        AsyncMock(side_effect=source_error),
+    )
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        await service.complete_oauth_provider_callback(
+            cast(AsyncSession, object()),
+            cast(Request, object()),
+            provider="google",
+            surface="web",
+            state="state",
+            code="code",
+        )
+
+    _assert_auth_error(
+        exc_info,
+        code="identity_google_email_missing",
+        status_code=400,
+        message="Google did not return an email address.",
+    )
+    assert exc_info.value.__cause__ is source_error
+
+
+@pytest.mark.parametrize(("surface", "callback"), [("mobile", "mobile"), ("web", "web")])
+@pytest.mark.asyncio
+async def test_apple_services_translate_provider_verification_error(
+    monkeypatch: pytest.MonkeyPatch,
+    surface: str,
+    callback: str,
+) -> None:
+    _install_challenge(monkeypatch, _challenge(provider="apple", surface=surface))
+    source_error = providers.ProviderVerificationError(
+        "identity_apple_nonce_mismatch",
+        "Apple nonce mismatch.",
+    )
+    monkeypatch.setattr(
+        providers,
+        "verify_apple_identity_token",
+        AsyncMock(side_effect=source_error),
+    )
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        if callback == "mobile":
+            await service.complete_apple_mobile_login(
+                cast(AsyncSession, object()),
+                state="state",
+                identity_token="token",
+                email=None,
+                display_name=None,
+            )
+        else:
+            await service.complete_apple_web_callback(
+                cast(AsyncSession, object()),
+                state="state",
+                identity_token="token",
+                email=None,
+                display_name=None,
+            )
+
+    _assert_auth_error(
+        exc_info,
+        code="identity_apple_nonce_mismatch",
+        status_code=400,
+        message="Apple nonce mismatch.",
+    )
+    assert exc_info.value.__cause__ is source_error
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_token_rejection_keeps_redirect_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_challenge(monkeypatch, _challenge())
+    monkeypatch.setattr(
+        providers,
+        "provider_callback_url",
+        lambda *args, **kwargs: "https://api.example.test/auth/web/google/callback",
+    )
+    monkeypatch.setattr(
+        providers,
+        "verify_oauth_callback",
+        AsyncMock(side_effect=providers.OAuthProviderTokenRejectedError()),
+    )
+
+    redirect = await service.complete_oauth_provider_callback(
+        cast(AsyncSession, object()),
+        cast(Request, object()),
+        provider="google",
+        surface="web",
+        state="state",
+        code="code",
+    )
+
+    assert (
+        redirect == "https://client.example.test/callback?error=provider_error&state=client-state"
+    )

--- a/server/tests/unit/test_auth_identity_service.py
+++ b/server/tests/unit/test_auth_identity_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import HTTPException
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.service import validate_redirect_uri
 from proliferate.config import settings
 
@@ -16,8 +16,9 @@ def test_web_redirect_uri_allows_configured_loopback_alias(
     validate_redirect_uri("web", "http://localhost:5175/auth/callback")
     validate_redirect_uri("web", "http://127.0.0.1:5175/auth/callback")
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(AuthFlowError) as exc_info:
         validate_redirect_uri("web", "http://127.0.0.1:5176/auth/callback")
 
+    assert exc_info.value.code == "identity_web_redirect_uri_not_allowed"
     assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == "Web redirect URI origin is not allowed."
+    assert exc_info.value.message == "Web redirect URI origin is not allowed."


### PR DESCRIPTION
## Summary

- convert all 48 Identity non-boundary HTTPException raises to typed ownership
- keep provider verification local until the three Identity service translation points
- atomically update the one SSO redirect-surface consumer of the shared Identity validator
- preserve the five legal Identity API raises, legacy raw-detail wire shape, semantic catches, and transaction order

## Compatibility boundary

Provider adapters now raise ProviderVerificationError with exact code and message values. Identity service translates that local error to AuthFlowError at exactly three entry points. Password, service, and session layers raise AuthFlowError directly. The single compatibility handler introduced by the prerequisite keeps all existing status codes and raw string details unchanged.

The shared redirect validator now raises AuthFlowError. Its SSO surface-probing consumer catches that exact type so a redirect valid for mobile or Desktop is not rejected merely because the earlier web probe failed. The final legal invalid-redirect HTTPException remains unchanged.

## Scope

- exact eleven-path implementation boundary
- 8 password, 15 provider, 16 service, and 9 session sites converted
- final Identity census: 5 legal raises and 6 textual occurrences
- final sequenced Auth census at this stack: 39 raises and 49 textual occurrences
- no SSO failure conversion, handler change, provider behavior change, transaction redesign, checker allowlist, or public envelope migration

## Proof

- frozen focused suite: 109 passed
- focused later-surface SSO redirect regression: passed
- Ruff check and format check: passed
- server boundaries, max-lines, design attribution, AST classification, exact census, and diff checks: passed
- independent review: SG24-B01 was found by tier-2 intent CI, repaired at head 2e5c2614df2193551d727f2567b73b57707b33b1, and independently re-reviewed ACCEPT with no unresolved findings

## Integration and landing

This draft is intentionally stacked on draft PR #1633 at exact prerequisite head e9dae29b513f1fe80df89eba58f246ac2aea4605. Do not merge it in the current stacked topology. After #1633 lands, rebase this implementation onto the final main revision, retarget to main, and rerun the complete frozen proof before readiness or merge.

Frozen specification: Server Grid 24 revision 3, SHA256 4b1ca04066c973107fbde832af49d2fe84324b5d1430a976992b2139bb27f170. Implementation head: 2e5c2614df2193551d727f2567b73b57707b33b1.