### PR TITLE
refactor(server): own SSO Auth failures below HTTP

### DIFF
--- a/server/proliferate/auth/sso/api.py
+++ b/server/proliferate/auth/sso/api.py
@@ -108,7 +108,7 @@ async def oidc_sso_callback(
                 redirect_url = await complete_sso_error_callback(db, state=state, error=error)
                 await db.commit()
                 return _auth_redirect_response(redirect_url)
-            except HTTPException:
+            except AuthFlowError:
                 await db.rollback()
         return RedirectResponse(
             _auth_error_url("provider_error"), status_code=status.HTTP_302_FOUND
@@ -120,7 +120,7 @@ async def oidc_sso_callback(
     except WebBetaAccessDenied as exc:
         await db.rollback()
         return RedirectResponse(_auth_error_url(exc.code), status_code=status.HTTP_302_FOUND)
-    except HTTPException as exc:
+    except AuthFlowError as exc:
         await db.rollback()
         return RedirectResponse(
             _auth_error_url(_sso_callback_error_code(exc)), status_code=status.HTTP_302_FOUND
@@ -143,8 +143,8 @@ def _auth_error_url(code: str) -> str:
     return f"{base}/auth/error?{urlencode({'code': code})}"
 
 
-def _sso_callback_error_code(exc: HTTPException) -> str:
-    detail = exc.detail if isinstance(exc.detail, str) else None
+def _sso_callback_error_code(exc: AuthFlowError) -> str:
+    detail = exc.message if isinstance(exc.message, str) else None
     if detail is None:
         return "sso_callback_failed"
     return _SSO_CALLBACK_ERROR_CODES.get(detail, "sso_callback_failed")

--- a/server/proliferate/auth/sso/deployment_config.py
+++ b/server/proliferate/auth/sso/deployment_config.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException
-
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.sso.policy import normalize_domains, oidc_configuration_error
 from proliferate.auth.sso.types import (
     DEFAULT_OIDC_SCOPES,
@@ -88,9 +87,10 @@ def _deployment_login_policy() -> SsoLoginPolicy:
         SsoLoginPolicy.OPTIONAL,
     )
     if policy == SsoLoginPolicy.REQUIRED:
-        raise HTTPException(
+        raise AuthFlowError(
+            "sso_required_login_policy_unsupported",
+            "Required SSO login policy is not supported yet.",
             status_code=400,
-            detail="Required SSO login policy is not supported yet.",
         )
     return policy
 

--- a/server/proliferate/auth/sso/policy.py
+++ b/server/proliferate/auth/sso/policy.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
-from fastapi import HTTPException
-
 from proliferate.auth.sso.types import SsoConnectionSnapshot
 
 # Stable machine reasons for an incomplete OIDC connection, mapped to the human
@@ -18,6 +16,13 @@ OIDC_CONFIG_ERROR_MESSAGES: dict[str, str] = {
     "oidc_client_secret_missing": "OIDC client secret is required.",
     "oidc_endpoints_missing": "OIDC issuer or discovery URL is required.",
 }
+
+
+class SsoPolicyError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 def oidc_configuration_error(
@@ -86,16 +91,25 @@ def email_domain_allowed(email: str | None, allowed_domains: tuple[str, ...]) ->
 
 def require_email_domain_allowed(email: str | None, allowed_domains: tuple[str, ...]) -> None:
     if not email_domain_allowed(email, allowed_domains):
-        raise HTTPException(status_code=403, detail="Email domain is not allowed for this SSO.")
+        raise SsoPolicyError(
+            "sso_email_domain_not_allowed",
+            "Email domain is not allowed for this SSO.",
+        )
 
 
 def oidc_discovery_url(issuer_or_discovery_url: str) -> str:
     value = issuer_or_discovery_url.strip().rstrip("/")
     if not value:
-        raise HTTPException(status_code=400, detail="OIDC issuer URL is required.")
+        raise SsoPolicyError(
+            "sso_oidc_issuer_url_required",
+            "OIDC issuer URL is required.",
+        )
     parsed = urlparse(value)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise HTTPException(status_code=400, detail="OIDC issuer URL is invalid.")
+        raise SsoPolicyError(
+            "sso_oidc_issuer_url_invalid",
+            "OIDC issuer URL is invalid.",
+        )
     if value.endswith("/.well-known/openid-configuration"):
         return value
     return f"{value}/.well-known/openid-configuration"

--- a/server/proliferate/auth/sso/service.py
+++ b/server/proliferate/auth/sso/service.py
@@ -7,9 +7,10 @@ from datetime import UTC, datetime, timedelta
 from typing import NoReturn
 from uuid import UUID
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity import providers
 from proliferate.auth.identity.routing import auth_route_path_for_base
 from proliferate.auth.identity.service import (
@@ -200,9 +201,13 @@ async def start_sso_auth(
     user: User | None,
 ) -> SsoStart:
     if surface not in {"web", "mobile", "desktop"}:
-        raise HTTPException(status_code=404, detail="Unknown auth surface.")
+        raise AuthFlowError("sso_surface_unknown", "Unknown auth surface.", status_code=404)
     if code_challenge_method not in SUPPORTED_CODE_CHALLENGE_METHODS:
-        raise HTTPException(status_code=400, detail="Unsupported code challenge method.")
+        raise AuthFlowError(
+            "sso_code_challenge_method_unsupported",
+            "Unsupported code challenge method.",
+            status_code=400,
+        )
     validate_redirect_uri(surface, redirect_uri)
     connection = await _connection_for_start(
         db,
@@ -212,9 +217,17 @@ async def start_sso_auth(
         require_enabled=True,
     )
     if connection is None:
-        raise HTTPException(status_code=404, detail="SSO is not configured for this account.")
+        raise AuthFlowError(
+            "sso_not_configured",
+            "SSO is not configured for this account.",
+            status_code=404,
+        )
     if connection.protocol != SsoProtocol.OIDC:
-        raise HTTPException(status_code=400, detail="Only OIDC SSO is currently supported.")
+        raise AuthFlowError(
+            "sso_protocol_unsupported",
+            "Only OIDC SSO is currently supported.",
+            status_code=400,
+        )
     _require_oidc_configured(connection)
     try:
         metadata = await resolve_oidc_metadata(connection)
@@ -282,7 +295,11 @@ async def complete_oidc_sso_callback(
     challenge = await _consume_challenge(db, state=state)
     connection = await _connection_for_challenge(db, challenge)
     if connection.protocol != SsoProtocol.OIDC:
-        raise HTTPException(status_code=400, detail="SSO callback protocol mismatch.")
+        raise AuthFlowError(
+            "sso_protocol_mismatch",
+            "SSO callback protocol mismatch.",
+            status_code=400,
+        )
     try:
         metadata = await resolve_oidc_metadata(connection)
         token = await exchange_oidc_code(
@@ -322,7 +339,11 @@ async def test_oidc_connection(
     connection: SsoConnectionSnapshot,
 ) -> dict[str, str | None]:
     if connection.protocol != SsoProtocol.OIDC:
-        raise HTTPException(status_code=400, detail="Only OIDC connection tests are supported.")
+        raise AuthFlowError(
+            "sso_connection_test_protocol_unsupported",
+            "Only OIDC connection tests are supported.",
+            status_code=400,
+        )
     _require_oidc_configured(connection)
     try:
         metadata = await resolve_oidc_metadata(connection)
@@ -366,9 +387,17 @@ async def _connection_for_start(
     if connection is None:
         return None
     if require_enabled and connection.status != SsoStatus.ENABLED:
-        raise HTTPException(status_code=403, detail="SSO connection is not enabled.")
+        raise AuthFlowError(
+            "sso_connection_disabled",
+            "SSO connection is not enabled.",
+            status_code=403,
+        )
     if email and not _email_hint_allowed_for_discovery(email, connection.allowed_domains):
-        raise HTTPException(status_code=403, detail="Email domain is not allowed for this SSO.")
+        raise AuthFlowError(
+            "sso_email_domain_not_allowed",
+            "Email domain is not allowed for this SSO.",
+            status_code=403,
+        )
     return connection
 
 
@@ -380,15 +409,31 @@ async def _connection_for_challenge(
         connection = deployment_sso_connection()
     else:
         if challenge.connection_id is None:
-            raise HTTPException(status_code=400, detail="SSO challenge is missing connection.")
+            raise AuthFlowError(
+                "sso_challenge_connection_missing",
+                "SSO challenge is missing connection.",
+                status_code=400,
+            )
         record = await sso_store.get_sso_connection(db, connection_id=challenge.connection_id)
         connection = snapshot_from_sso_connection_record(record) if record is not None else None
     if connection is None:
-        raise HTTPException(status_code=400, detail="SSO connection is no longer available.")
+        raise AuthFlowError(
+            "sso_connection_unavailable",
+            "SSO connection is no longer available.",
+            status_code=400,
+        )
     if connection.status != SsoStatus.ENABLED:
-        raise HTTPException(status_code=403, detail="SSO connection is not enabled.")
+        raise AuthFlowError(
+            "sso_connection_disabled",
+            "SSO connection is not enabled.",
+            status_code=403,
+        )
     if connection.connection_key != challenge.connection_key:
-        raise HTTPException(status_code=400, detail="SSO callback state mismatch.")
+        raise AuthFlowError(
+            "sso_state_mismatch",
+            "SSO callback state mismatch.",
+            status_code=400,
+        )
     return connection
 
 
@@ -399,7 +444,11 @@ async def _consume_challenge(
 ) -> sso_store.SsoChallengeRecord:
     challenge = await sso_store.consume_sso_challenge(db, state_hash=hash_secret(state))
     if challenge is None:
-        raise HTTPException(status_code=400, detail="Invalid or expired SSO state.")
+        raise AuthFlowError(
+            "sso_state_invalid",
+            "Invalid or expired SSO state.",
+            status_code=400,
+        )
     return challenge
 
 
@@ -452,7 +501,11 @@ def _require_oidc_configured(
 ) -> None:
     error = oidc_configuration_error(connection, require_secret=require_secret)
     if error is not None:
-        raise HTTPException(status_code=400, detail=OIDC_CONFIG_ERROR_MESSAGES[error])
+        raise AuthFlowError(
+            f"sso_{error}",
+            OIDC_CONFIG_ERROR_MESSAGES[error],
+            status_code=400,
+        )
 
 
 def _email_hint_allowed_for_discovery(email: str, allowed_domains: tuple[str, ...]) -> bool:
@@ -462,7 +515,11 @@ def _email_hint_allowed_for_discovery(email: str, allowed_domains: tuple[str, ..
 
 
 def _raise_sso_integration_error(exc: SsoIntegrationError) -> NoReturn:
-    raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    raise AuthFlowError(
+        "sso_integration_failure",
+        exc.detail,
+        status_code=exc.status_code,
+    ) from exc
 
 
 def oidc_callback_url(request: Request) -> str:

--- a/server/proliferate/auth/sso/user_resolution.py
+++ b/server/proliferate/auth/sso/user_resolution.py
@@ -9,15 +9,15 @@ admin-removed instance membership; asserting the ADMIN_EMAILS floor at login).
 
 from __future__ import annotations
 
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.store import (
     create_auth_user,
     get_user_by_email,
     get_user_by_id,
 )
-from proliferate.auth.sso.policy import require_email_domain_allowed
+from proliferate.auth.sso.policy import SsoPolicyError, require_email_domain_allowed
 from proliferate.auth.sso.types import (
     SsoConnectionSnapshot,
     SsoJitPolicy,
@@ -70,7 +70,11 @@ async def _resolve_sso_user(
     if existing_identity is not None:
         user = await get_user_by_id(db, existing_identity.user_id)
         if user is None:
-            raise HTTPException(status_code=400, detail="Linked SSO user not found.")
+            raise AuthFlowError(
+                "sso_linked_user_not_found",
+                "Linked SSO user not found.",
+                status_code=400,
+            )
         _ensure_active_user(user)
         if connection.scope == SsoScope.ORGANIZATION:
             user = await _resolve_organization_sso_user(
@@ -85,7 +89,11 @@ async def _resolve_sso_user(
     user = await get_user_by_email(db, verified.email)
     if connection.scope == SsoScope.ORGANIZATION:
         if connection.organization_id is None:
-            raise HTTPException(status_code=400, detail="SSO organization is missing.")
+            raise AuthFlowError(
+                "sso_organization_missing",
+                "SSO organization is missing.",
+                status_code=400,
+            )
         user = await _resolve_organization_sso_user(
             db,
             connection=connection,
@@ -95,7 +103,11 @@ async def _resolve_sso_user(
     else:
         if user is None:
             if connection.jit_policy != SsoJitPolicy.CREATE_MEMBER:
-                raise HTTPException(status_code=403, detail="SSO user provisioning is disabled.")
+                raise AuthFlowError(
+                    "sso_jit_disabled",
+                    "SSO user provisioning is disabled.",
+                    status_code=403,
+                )
             user = await create_auth_user(
                 db,
                 email=verified.email,
@@ -103,7 +115,11 @@ async def _resolve_sso_user(
                 avatar_url=verified.avatar_url,
             )
         elif connection.jit_policy == SsoJitPolicy.DISABLED:
-            raise HTTPException(status_code=403, detail="SSO user provisioning is disabled.")
+            raise AuthFlowError(
+                "sso_jit_disabled",
+                "SSO user provisioning is disabled.",
+                status_code=403,
+            )
         _ensure_active_user(user)
         # Single-org mode honors the connection's default role for JIT
         # placement; hosted mode ignores it (personal org owner as always).
@@ -123,10 +139,21 @@ def _require_verified_allowed_email(
     verified: VerifiedSsoIdentity,
 ) -> None:
     if not verified.email:
-        raise HTTPException(status_code=400, detail="SSO did not return an email address.")
+        raise AuthFlowError(
+            "sso_email_missing",
+            "SSO did not return an email address.",
+            status_code=400,
+        )
     if not verified.email_verified:
-        raise HTTPException(status_code=403, detail="SSO email address is not verified.")
-    require_email_domain_allowed(verified.email, connection.allowed_domains)
+        raise AuthFlowError(
+            "sso_email_unverified",
+            "SSO email address is not verified.",
+            status_code=403,
+        )
+    try:
+        require_email_domain_allowed(verified.email, connection.allowed_domains)
+    except SsoPolicyError as exc:
+        raise AuthFlowError(exc.code, exc.message, status_code=403) from exc
 
 
 async def _resolve_organization_sso_user(
@@ -137,7 +164,11 @@ async def _resolve_organization_sso_user(
     user: User | None,
 ) -> User:
     if connection.organization_id is None:
-        raise HTTPException(status_code=400, detail="SSO organization is missing.")
+        raise AuthFlowError(
+            "sso_organization_missing",
+            "SSO organization is missing.",
+            status_code=400,
+        )
     has_pending_invitation = (
         await invitation_store.has_live_pending_invitation_for_organization_email(
             db,
@@ -147,7 +178,11 @@ async def _resolve_organization_sso_user(
     )
     if user is None:
         if connection.jit_policy != SsoJitPolicy.CREATE_MEMBER and not has_pending_invitation:
-            raise HTTPException(status_code=403, detail="SSO user is not a team member.")
+            raise AuthFlowError(
+                "sso_user_not_team_member",
+                "SSO user is not a team member.",
+                status_code=403,
+            )
         user = await create_auth_user(
             db,
             email=verified.email or "",
@@ -173,7 +208,11 @@ async def _resolve_organization_sso_user(
         if accepted is not None:
             return user
     if connection.jit_policy != SsoJitPolicy.CREATE_MEMBER:
-        raise HTTPException(status_code=403, detail="SSO user is not a team member.")
+        raise AuthFlowError(
+            "sso_user_not_team_member",
+            "SSO user is not a team member.",
+            status_code=403,
+        )
     # Single-org mode only (no-op in hosted mode): JIT must not silently
     # reactivate an instance-org membership an admin removed. ADMIN_EMAILS
     # listed emails are excepted; that floor is the documented
@@ -227,4 +266,4 @@ async def _attach_sso_identity(
 
 def _ensure_active_user(user: User) -> None:
     if not user.is_active:
-        raise HTTPException(status_code=403, detail="User is inactive.")
+        raise AuthFlowError("sso_user_inactive", "User is inactive.", status_code=403)

--- a/server/proliferate/integrations/sso/oidc.py
+++ b/server/proliferate/integrations/sso/oidc.py
@@ -14,7 +14,7 @@ from jose import JWTError, jwt
 
 from proliferate.auth.identity import providers
 from proliferate.auth.identity.service import hash_secret
-from proliferate.auth.sso.policy import oidc_discovery_url
+from proliferate.auth.sso.policy import SsoPolicyError, oidc_discovery_url
 from proliferate.auth.sso.types import SsoConnectionSnapshot, VerifiedSsoIdentity
 from proliferate.config import settings
 from proliferate.integrations.sso.errors import SsoIntegrationError
@@ -70,7 +70,10 @@ async def resolve_oidc_metadata(connection: SsoConnectionSnapshot) -> OidcMetada
     source_url = connection.oidc_discovery_url or connection.oidc_issuer_url
     if not source_url:
         raise SsoIntegrationError("OIDC issuer or discovery URL is required.")
-    discovery_url = oidc_discovery_url(source_url)
+    try:
+        discovery_url = oidc_discovery_url(source_url)
+    except SsoPolicyError as exc:
+        raise SsoIntegrationError(exc.message) from exc
     await _validate_oidc_url(discovery_url, "discovery_url")
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/server/proliferate/server/organizations/sso/service.py
+++ b/server/proliferate/server/organizations/sso/service.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from fastapi import HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.routing import auth_route_path_for_base
 from proliferate.auth.sso.policy import normalize_domains
 from proliferate.auth.sso.service import (
@@ -143,13 +144,13 @@ async def test_organization_sso_connection(
         raise NotFoundError("SSO connection not found.", code="sso_connection_not_found")
     try:
         discovered = await test_oidc_connection(db, connection=snapshot)
-    except HTTPException as exc:
+    except AuthFlowError as exc:
         updated = await sso_store.mark_sso_connection_test_result(
             db,
             connection_id=connection_id,
             organization_id=organization_id,
             success=False,
-            error=str(exc.detail),
+            error=exc.message,
             discovered=None,
             actor_user_id=actor_user_id,
         )

--- a/server/tests/integration/test_sso_auth_error_contract.py
+++ b/server/tests/integration/test_sso_auth_error_contract.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.errors import AuthFlowError
+from proliferate.auth.sso import service as sso_service
+from proliferate.auth.sso.types import (
+    DEFAULT_OIDC_SCOPES,
+    SsoConnectionSnapshot,
+    SsoJitPolicy,
+    SsoLoginPolicy,
+    SsoProtocol,
+    SsoScope,
+    SsoStatus,
+    VerifiedSsoIdentity,
+)
+from proliferate.config import settings
+from proliferate.db.models.auth import SsoChallenge, SsoConnection
+from proliferate.integrations.sso.errors import SsoIntegrationError
+from proliferate.integrations.sso.oidc import OidcMetadata, OidcTokenResponse
+from proliferate.utils.crypto import encrypt_text
+from tests.integration.test_organization_sso_membership import (
+    _create_organization_for_user,
+    _create_user_and_get_tokens,
+    _headers,
+)
+
+
+def _assert_error(response: Response, *, status_code: int, detail: str) -> None:
+    assert response.status_code == status_code
+    assert response.json() == {"detail": detail}
+    assert "retry-after" not in response.headers
+    assert "www-authenticate" not in response.headers
+    assert "sso_" not in response.text
+
+
+def _start_body(
+    *,
+    method: str = "S256",
+    email: str | None = None,
+) -> dict[str, str]:
+    body = {
+        "clientState": "client-state",
+        "codeChallenge": "pkce-challenge",
+        "codeChallengeMethod": method,
+        "redirectUri": settings.mobile_redirect_uri,
+    }
+    if email is not None:
+        body["email"] = email
+    return body
+
+
+def _connection() -> SsoConnectionSnapshot:
+    return SsoConnectionSnapshot(
+        id=None,
+        scope=SsoScope.DEPLOYMENT,
+        organization_id=None,
+        connection_key="deployment",
+        protocol=SsoProtocol.OIDC,
+        status=SsoStatus.ENABLED,
+        display_name="Company SSO",
+        login_policy=SsoLoginPolicy.OPTIONAL,
+        jit_policy=SsoJitPolicy.EXISTING_USER,
+        default_role="member",
+        allowed_domains=(),
+        oidc_issuer_url="https://idp.example.test",
+        oidc_discovery_url=None,
+        oidc_authorization_endpoint="https://idp.example.test/authorize",
+        oidc_token_endpoint="https://idp.example.test/token",
+        oidc_jwks_uri="https://idp.example.test/jwks",
+        oidc_userinfo_endpoint=None,
+        oidc_client_id="client-id",
+        oidc_client_secret="client-secret",
+        oidc_client_secret_configured=True,
+        oidc_scopes=DEFAULT_OIDC_SCOPES,
+        oidc_token_endpoint_auth_method="client_secret_basic",
+    )
+
+
+def _metadata() -> OidcMetadata:
+    return OidcMetadata(
+        issuer="https://idp.example.test",
+        authorization_endpoint="https://idp.example.test/authorize",
+        token_endpoint="https://idp.example.test/token",
+        jwks_uri="https://idp.example.test/jwks",
+        userinfo_endpoint=None,
+    )
+
+
+async def _start_sso(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> str:
+    monkeypatch.setattr(sso_service, "deployment_sso_connection", _connection)
+    monkeypatch.setattr(
+        sso_service,
+        "resolve_oidc_metadata",
+        AsyncMock(return_value=_metadata()),
+    )
+    response = await client.post("/auth/mobile/sso/start", json=_start_body())
+    assert response.status_code == 200
+    state = response.json()["state"]
+    assert isinstance(state, str)
+    return state
+
+
+async def _assert_challenge_consumed(
+    db: AsyncSession,
+    *,
+    state: str,
+    expected: bool,
+) -> None:
+    result = await db.execute(
+        select(SsoChallenge).where(SsoChallenge.state_hash == sso_service.hash_secret(state))
+    )
+    challenge = result.scalar_one()
+    assert (challenge.consumed_at is not None) is expected
+
+
+@pytest.mark.asyncio
+async def test_unknown_surface_and_challenge_method_preserve_raw_bodies(
+    client: AsyncClient,
+) -> None:
+    unknown = await client.post("/auth/unknown/sso/start", json=_start_body())
+    _assert_error(unknown, status_code=404, detail="Unknown auth surface.")
+
+    unsupported = await client.post(
+        "/auth/mobile/sso/start",
+        json=_start_body(method="plain"),
+    )
+    _assert_error(
+        unsupported,
+        status_code=400,
+        detail="Unsupported code challenge method.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_and_disabled_connections_preserve_raw_bodies(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sso_service, "deployment_sso_connection", lambda: None)
+    missing = await client.post("/auth/mobile/sso/start", json=_start_body())
+    _assert_error(
+        missing,
+        status_code=404,
+        detail="SSO is not configured for this account.",
+    )
+
+    disabled_connection = replace(_connection(), status=SsoStatus.DISABLED)
+    monkeypatch.setattr(
+        sso_service,
+        "deployment_sso_connection",
+        lambda: disabled_connection,
+    )
+    disabled = await client.post("/auth/mobile/sso/start", json=_start_body())
+    _assert_error(
+        disabled,
+        status_code=403,
+        detail="SSO connection is not enabled.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_domain_failure_preserves_raw_body(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    restricted = replace(_connection(), allowed_domains=("example.com",))
+    monkeypatch.setattr(sso_service, "deployment_sso_connection", lambda: restricted)
+
+    response = await client.post(
+        "/auth/mobile/sso/start",
+        json=_start_body(email="person@other.test"),
+    )
+
+    _assert_error(
+        response,
+        status_code=403,
+        detail="Email domain is not allowed for this SSO.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_incomplete_oidc_configuration_preserves_raw_body(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    incomplete = replace(_connection(), oidc_client_id=None)
+    monkeypatch.setattr(sso_service, "deployment_sso_connection", lambda: incomplete)
+
+    response = await client.post("/auth/mobile/sso/start", json=_start_body())
+
+    _assert_error(response, status_code=400, detail="OIDC client ID is required.")
+
+
+@pytest.mark.asyncio
+async def test_invalid_callback_state_preserves_redirect_mapping(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test")
+
+    response = await client.get(
+        "/auth/sso/oidc/callback",
+        params={"state": "missing-state", "code": "provider-code"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == (
+        "https://app.example.test/auth/error?code=sso_state_invalid"
+    )
+
+
+@pytest.mark.asyncio
+async def test_valid_provider_error_consumes_state_and_keeps_client_redirect(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _start_sso(client, monkeypatch)
+
+    response = await client.get(
+        "/auth/sso/oidc/callback",
+        params={"state": state, "error": "access_denied"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == (
+        "proliferate://auth/callback?error=access_denied&state=client-state"
+    )
+    await _assert_challenge_consumed(db_session, state=state, expected=True)
+
+
+@pytest.mark.asyncio
+async def test_integration_callback_failure_redirects_and_rolls_back_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test")
+    state = await _start_sso(client, monkeypatch)
+    monkeypatch.setattr(
+        sso_service,
+        "exchange_oidc_code",
+        AsyncMock(side_effect=SsoIntegrationError("OIDC token exchange failed.")),
+    )
+
+    response = await client.get(
+        "/auth/sso/oidc/callback",
+        params={"state": state, "code": "provider-code"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == (
+        "https://app.example.test/auth/error?code=sso_oidc_token_exchange_failed"
+    )
+    await _assert_challenge_consumed(db_session, state=state, expected=False)
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        ("sso_jit_disabled", "SSO user provisioning is disabled."),
+        ("sso_user_not_team_member", "SSO user is not a team member."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_jit_and_membership_callback_failures_redirect_and_roll_back(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    code: str,
+    message: str,
+) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test")
+    state = await _start_sso(client, monkeypatch)
+    monkeypatch.setattr(
+        sso_service,
+        "exchange_oidc_code",
+        AsyncMock(
+            return_value=OidcTokenResponse(
+                access_token="access-token",
+                id_token="id-token",
+                refresh_token=None,
+                expires_at=None,
+                scopes=frozenset(),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sso_service,
+        "verify_oidc_identity",
+        AsyncMock(
+            return_value=VerifiedSsoIdentity(
+                provider_subject="provider-subject",
+                email="person@example.com",
+                email_verified=True,
+                display_name=None,
+                avatar_url=None,
+                claims={},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        sso_service,
+        "resolve_sso_user",
+        AsyncMock(side_effect=AuthFlowError(code, message, status_code=403)),
+    )
+
+    response = await client.get(
+        "/auth/sso/oidc/callback",
+        params={"state": state, "code": "provider-code"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"https://app.example.test/auth/error?code={code}"
+    await _assert_challenge_consumed(db_session, state=state, expected=False)
+
+
+@pytest.mark.asyncio
+async def test_connection_test_preserves_integration_detail(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = await _create_user_and_get_tokens(client, email="sso-owner@example.com")
+    organization = await _create_organization_for_user(user_id=owner["user_id"])
+    organization_id = organization["organization_id"]
+
+    from proliferate.db import engine as engine_module
+
+    async with engine_module.async_session_factory() as db:
+        now = datetime.now(UTC)
+        connection = SsoConnection(
+            scope="organization",
+            organization_id=organization_id,
+            protocol="oidc",
+            status="draft",
+            display_name="Company SSO",
+            login_policy="optional",
+            jit_policy="existing_user",
+            default_role="member",
+            allowed_domains_json='["example.com"]',
+            oidc_issuer_url="https://idp.example.test",
+            oidc_authorization_endpoint="https://idp.example.test/authorize",
+            oidc_token_endpoint="https://idp.example.test/token",
+            oidc_jwks_uri="https://idp.example.test/jwks",
+            oidc_client_id="client-id",
+            oidc_client_secret_ciphertext=encrypt_text("client-secret"),
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(connection)
+        await db.commit()
+        connection_id = connection.id
+
+    monkeypatch.setattr(
+        sso_service,
+        "resolve_oidc_metadata",
+        AsyncMock(side_effect=SsoIntegrationError("OIDC discovery metadata is invalid.")),
+    )
+    response = await client.post(
+        f"/v1/organizations/{organization_id}/sso/connections/{connection_id}/test",
+        headers=_headers(owner),
+    )
+
+    _assert_error(
+        response,
+        status_code=400,
+        detail="OIDC discovery metadata is invalid.",
+    )

--- a/server/tests/integration/test_sso_auth_error_contract.py
+++ b/server/tests/integration/test_sso_auth_error_contract.py
@@ -222,6 +222,25 @@ async def test_invalid_callback_state_preserves_redirect_mapping(
 
 
 @pytest.mark.asyncio
+async def test_provider_error_with_invalid_state_uses_static_redirect(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test")
+
+    response = await client.get(
+        "/auth/sso/oidc/callback",
+        params={"state": "missing-state", "error": "access_denied"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["location"] == "https://app.example.test/auth/error?code=provider_error"
+    )
+
+
+@pytest.mark.asyncio
 async def test_valid_provider_error_consumes_state_and_keeps_client_redirect(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/server/tests/unit/auth/test_sso.py
+++ b/server/tests/unit/auth/test_sso.py
@@ -4,9 +4,10 @@ from dataclasses import replace
 from typing import cast
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.sso import api as sso_api
 from proliferate.auth.sso import service as sso_service
 from proliferate.auth.sso.branding import (
@@ -273,7 +274,11 @@ async def test_oidc_sso_callback_redirects_known_processing_http_errors(
     monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test/")
 
     async def fake_complete_oidc_sso_callback(*_args: object, **_kwargs: object) -> str:
-        raise HTTPException(status_code=400, detail="Invalid or expired SSO state.")
+        raise AuthFlowError(
+            "sso_state_invalid",
+            "Invalid or expired SSO state.",
+            status_code=400,
+        )
 
     monkeypatch.setattr(
         sso_api,
@@ -305,7 +310,11 @@ async def test_oidc_sso_callback_redirects_email_domain_errors(
     monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test/")
 
     async def fake_complete_oidc_sso_callback(*_args: object, **_kwargs: object) -> str:
-        raise HTTPException(status_code=403, detail="Email domain is not allowed for this SSO.")
+        raise AuthFlowError(
+            "sso_email_domain_not_allowed",
+            "Email domain is not allowed for this SSO.",
+            status_code=403,
+        )
 
     monkeypatch.setattr(
         sso_api,
@@ -337,7 +346,11 @@ async def test_oidc_sso_callback_redirects_org_membership_errors(
     monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test/")
 
     async def fake_complete_oidc_sso_callback(*_args: object, **_kwargs: object) -> str:
-        raise HTTPException(status_code=403, detail="SSO user is not a team member.")
+        raise AuthFlowError(
+            "sso_user_not_team_member",
+            "SSO user is not a team member.",
+            status_code=403,
+        )
 
     monkeypatch.setattr(
         sso_api,
@@ -369,7 +382,7 @@ async def test_oidc_sso_callback_keeps_generic_code_for_unknown_http_errors(
     monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test/")
 
     async def fake_complete_oidc_sso_callback(*_args: object, **_kwargs: object) -> str:
-        raise HTTPException(status_code=400, detail="Unexpected SSO failure.")
+        raise AuthFlowError("sso_unexpected", "Unexpected SSO failure.", status_code=400)
 
     monkeypatch.setattr(
         sso_api,
@@ -411,7 +424,7 @@ async def test_resolve_sso_user_rejects_unverified_email_before_identity_lookup(
         fake_get_sso_identity_by_connection_subject,
     )
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(AuthFlowError) as exc_info:
         await sso_service.resolve_sso_user(
             cast(AsyncSession, object()),
             connection=_connection(allowed_domains=("example.com",)),
@@ -425,7 +438,9 @@ async def test_resolve_sso_user_rejects_unverified_email_before_identity_lookup(
             ),
         )
 
+    assert exc_info.value.code == "sso_email_unverified"
     assert exc_info.value.status_code == 403
+    assert exc_info.value.message == "SSO email address is not verified."
     assert identity_lookup_called is False
 
 
@@ -446,7 +461,7 @@ async def test_resolve_sso_user_rechecks_allowed_domain_before_identity_lookup(
         fake_get_sso_identity_by_connection_subject,
     )
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(AuthFlowError) as exc_info:
         await sso_service.resolve_sso_user(
             cast(AsyncSession, object()),
             connection=_connection(allowed_domains=("example.com",)),
@@ -460,7 +475,9 @@ async def test_resolve_sso_user_rechecks_allowed_domain_before_identity_lookup(
             ),
         )
 
+    assert exc_info.value.code == "sso_email_domain_not_allowed"
     assert exc_info.value.status_code == 403
+    assert exc_info.value.message == "Email domain is not allowed for this SSO."
     assert identity_lookup_called is False
 
 

--- a/server/tests/unit/auth/test_sso_error_ownership.py
+++ b/server/tests/unit/auth/test_sso_error_ownership.py
@@ -67,6 +67,60 @@ def test_sso_policy_error_is_local_and_framework_free() -> None:
     )
 
 
+def test_sso_policy_error_callers_are_explicit_translation_boundaries() -> None:
+    production_root = Path(cast(str, user_resolution.__file__)).parents[2]
+    named_paths = {
+        path.relative_to(production_root).as_posix()
+        for path in production_root.rglob("*.py")
+        if "SsoPolicyError" in path.read_text()
+    }
+    assert named_paths == {
+        "auth/sso/policy.py",
+        "auth/sso/user_resolution.py",
+        "integrations/sso/oidc.py",
+    }
+
+    expected = {
+        user_resolution: (
+            "_require_verified_allowed_email",
+            "require_email_domain_allowed",
+        ),
+        oidc: ("resolve_oidc_metadata", "oidc_discovery_url"),
+    }
+    for module, (function_name, policy_call) in expected.items():
+        tree = _module_tree(module)
+        matching_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == policy_call
+        ]
+        assert len(matching_calls) == 1
+
+        translation_tries = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Try) and any(call in ast.walk(node) for call in matching_calls)
+        ]
+        assert len(translation_tries) == 1
+        handler_names = {
+            handler.type.id
+            for handler in translation_tries[0].handlers
+            if isinstance(handler.type, ast.Name)
+        }
+        assert handler_names == {"SsoPolicyError"}
+
+        parent_functions = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ]
+        assert len(parent_functions) == 1
+        assert matching_calls[0] in ast.walk(parent_functions[0])
+
+
 @pytest.mark.asyncio
 async def test_email_policy_translates_before_identity_lookup(
     monkeypatch: pytest.MonkeyPatch,

--- a/server/tests/unit/auth/test_sso_error_ownership.py
+++ b/server/tests/unit/auth/test_sso_error_ownership.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from dataclasses import replace
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.errors import AuthFlowError
+from proliferate.auth.sso import deployment_config, policy, service, user_resolution
+from proliferate.auth.sso.types import VerifiedSsoIdentity
+from proliferate.config import settings
+from proliferate.db.models.auth import User
+from proliferate.errors import ProliferateError
+from proliferate.integrations.sso import oidc
+from proliferate.integrations.sso.errors import SsoIntegrationError
+from tests.unit.auth.test_sso import _connection
+
+
+def _assert_auth_error(
+    exc_info: pytest.ExceptionInfo[AuthFlowError],
+    *,
+    code: str,
+    status_code: int,
+    message: str,
+) -> None:
+    assert (exc_info.value.code, exc_info.value.status_code, exc_info.value.message) == (
+        code,
+        status_code,
+        message,
+    )
+
+
+def test_sso_policy_error_is_local_and_framework_free() -> None:
+    error = policy.SsoPolicyError("sso_policy_failure", "Policy failed.")
+
+    assert error.code == "sso_policy_failure"
+    assert error.message == "Policy failed."
+    assert str(error) == "Policy failed."
+    assert isinstance(error, ValueError)
+    assert not isinstance(error, ProliferateError)
+
+    tree = _module_tree(policy)
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)}
+    banned_prefixes = (
+        "fastapi",
+        "starlette",
+        "proliferate.auth.errors",
+        "proliferate.auth.sso.service",
+        "proliferate.config",
+        "proliferate.db",
+        "proliferate.integrations",
+    )
+    assert not any(
+        imported.startswith(prefix) for imported in imported_modules for prefix in banned_prefixes
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_policy_translates_before_identity_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity_lookup = AsyncMock()
+    monkeypatch.setattr(
+        user_resolution.sso_store,
+        "get_sso_identity_by_connection_subject",
+        identity_lookup,
+    )
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        await user_resolution.resolve_sso_user(
+            cast(AsyncSession, object()),
+            connection=_connection(allowed_domains=("example.com",)),
+            verified=VerifiedSsoIdentity(
+                provider_subject="subject",
+                email="person@other.test",
+                email_verified=True,
+                display_name=None,
+                avatar_url=None,
+                claims={},
+            ),
+        )
+
+    _assert_auth_error(
+        exc_info,
+        code="sso_email_domain_not_allowed",
+        status_code=403,
+        message="Email domain is not allowed for this SSO.",
+    )
+    assert isinstance(exc_info.value.__cause__, policy.SsoPolicyError)
+    identity_lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oidc_url_policy_translates_to_integration_error() -> None:
+    connection = replace(
+        _connection(allowed_domains=()),
+        oidc_issuer_url=None,
+        oidc_discovery_url="not-a-url",
+    )
+
+    with pytest.raises(SsoIntegrationError) as exc_info:
+        await oidc.resolve_oidc_metadata(connection)
+
+    assert exc_info.value.detail == "OIDC issuer URL is invalid."
+    assert exc_info.value.status_code == 400
+    assert isinstance(exc_info.value.__cause__, policy.SsoPolicyError)
+    assert exc_info.value.__cause__.code == "sso_oidc_issuer_url_invalid"
+
+
+def test_integration_error_translates_to_auth_flow_error() -> None:
+    source_error = SsoIntegrationError("Provider unavailable.", status_code=503)
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        service._raise_sso_integration_error(source_error)
+
+    _assert_auth_error(
+        exc_info,
+        code="sso_integration_failure",
+        status_code=503,
+        message="Provider unavailable.",
+    )
+    assert exc_info.value.__cause__ is source_error
+
+
+def test_deployment_failure_uses_frozen_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "sso_login_policy", "required")
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        deployment_config._deployment_login_policy()
+
+    _assert_auth_error(
+        exc_info,
+        code="sso_required_login_policy_unsupported",
+        status_code=400,
+        message="Required SSO login policy is not supported yet.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_failure_uses_frozen_auth_error() -> None:
+    with pytest.raises(AuthFlowError) as exc_info:
+        await service.start_sso_auth(
+            cast(AsyncSession, object()),
+            cast(Request, object()),
+            surface="unknown",
+            client_state="state",
+            code_challenge="challenge",
+            code_challenge_method="S256",
+            redirect_uri="proliferate://auth/callback",
+            email=None,
+            organization_id=None,
+            connection_id=None,
+            prompt=None,
+            user=None,
+        )
+
+    _assert_auth_error(
+        exc_info,
+        code="sso_surface_unknown",
+        status_code=404,
+        message="Unknown auth surface.",
+    )
+
+
+def test_user_resolution_failure_uses_frozen_auth_error() -> None:
+    inactive_user = cast(User, SimpleNamespace(is_active=False))
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        user_resolution._ensure_active_user(inactive_user)
+
+    _assert_auth_error(
+        exc_info,
+        code="sso_user_inactive",
+        status_code=403,
+        message="User is inactive.",
+    )
+
+
+def _module_tree(module: ModuleType) -> ast.Module:
+    module_path = cast(str, module.__file__)
+    return ast.parse(Path(module_path).read_text())
+
+
+def _render(node: ast.expr) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    return ast.unparse(node)
+
+
+def _raise_descriptors(module: ModuleType) -> list[tuple[object, ...]]:
+    rows: list[tuple[object, ...]] = []
+    function_stack: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            function_stack.append(node.name)
+            self.generic_visit(node)
+            function_stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_Raise(self, node: ast.Raise) -> None:
+            call = node.exc
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id in {"AuthFlowError", "SsoPolicyError"}
+            ):
+                self.generic_visit(node)
+                return
+            keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+            rows.append(
+                (
+                    function_stack[-1],
+                    call.func.id,
+                    _render(call.args[0]),
+                    _render(call.args[1]),
+                    _render(keywords["status_code"]) if "status_code" in keywords else None,
+                )
+            )
+            self.generic_visit(node)
+
+    Visitor().visit(_module_tree(module))
+    return rows
+
+
+def test_all_frozen_sso_raise_sites_have_exact_mapping() -> None:
+    expected = {
+        deployment_config: [
+            (
+                "_deployment_login_policy",
+                "AuthFlowError",
+                "sso_required_login_policy_unsupported",
+                "Required SSO login policy is not supported yet.",
+                400,
+            ),
+        ],
+        policy: [
+            (
+                "require_email_domain_allowed",
+                "SsoPolicyError",
+                "sso_email_domain_not_allowed",
+                "Email domain is not allowed for this SSO.",
+                None,
+            ),
+            (
+                "oidc_discovery_url",
+                "SsoPolicyError",
+                "sso_oidc_issuer_url_required",
+                "OIDC issuer URL is required.",
+                None,
+            ),
+            (
+                "oidc_discovery_url",
+                "SsoPolicyError",
+                "sso_oidc_issuer_url_invalid",
+                "OIDC issuer URL is invalid.",
+                None,
+            ),
+        ],
+        service: [
+            (
+                "start_sso_auth",
+                "AuthFlowError",
+                "sso_surface_unknown",
+                "Unknown auth surface.",
+                404,
+            ),
+            (
+                "start_sso_auth",
+                "AuthFlowError",
+                "sso_code_challenge_method_unsupported",
+                "Unsupported code challenge method.",
+                400,
+            ),
+            (
+                "start_sso_auth",
+                "AuthFlowError",
+                "sso_not_configured",
+                "SSO is not configured for this account.",
+                404,
+            ),
+            (
+                "start_sso_auth",
+                "AuthFlowError",
+                "sso_protocol_unsupported",
+                "Only OIDC SSO is currently supported.",
+                400,
+            ),
+            (
+                "complete_oidc_sso_callback",
+                "AuthFlowError",
+                "sso_protocol_mismatch",
+                "SSO callback protocol mismatch.",
+                400,
+            ),
+            (
+                "test_oidc_connection",
+                "AuthFlowError",
+                "sso_connection_test_protocol_unsupported",
+                "Only OIDC connection tests are supported.",
+                400,
+            ),
+            (
+                "_connection_for_start",
+                "AuthFlowError",
+                "sso_connection_disabled",
+                "SSO connection is not enabled.",
+                403,
+            ),
+            (
+                "_connection_for_start",
+                "AuthFlowError",
+                "sso_email_domain_not_allowed",
+                "Email domain is not allowed for this SSO.",
+                403,
+            ),
+            (
+                "_connection_for_challenge",
+                "AuthFlowError",
+                "sso_challenge_connection_missing",
+                "SSO challenge is missing connection.",
+                400,
+            ),
+            (
+                "_connection_for_challenge",
+                "AuthFlowError",
+                "sso_connection_unavailable",
+                "SSO connection is no longer available.",
+                400,
+            ),
+            (
+                "_connection_for_challenge",
+                "AuthFlowError",
+                "sso_connection_disabled",
+                "SSO connection is not enabled.",
+                403,
+            ),
+            (
+                "_connection_for_challenge",
+                "AuthFlowError",
+                "sso_state_mismatch",
+                "SSO callback state mismatch.",
+                400,
+            ),
+            (
+                "_consume_challenge",
+                "AuthFlowError",
+                "sso_state_invalid",
+                "Invalid or expired SSO state.",
+                400,
+            ),
+            (
+                "_require_oidc_configured",
+                "AuthFlowError",
+                "f'sso_{error}'",
+                "OIDC_CONFIG_ERROR_MESSAGES[error]",
+                400,
+            ),
+            (
+                "_raise_sso_integration_error",
+                "AuthFlowError",
+                "sso_integration_failure",
+                "exc.detail",
+                "exc.status_code",
+            ),
+        ],
+        user_resolution: [
+            (
+                "_resolve_sso_user",
+                "AuthFlowError",
+                "sso_linked_user_not_found",
+                "Linked SSO user not found.",
+                400,
+            ),
+            (
+                "_resolve_sso_user",
+                "AuthFlowError",
+                "sso_organization_missing",
+                "SSO organization is missing.",
+                400,
+            ),
+            (
+                "_resolve_sso_user",
+                "AuthFlowError",
+                "sso_jit_disabled",
+                "SSO user provisioning is disabled.",
+                403,
+            ),
+            (
+                "_resolve_sso_user",
+                "AuthFlowError",
+                "sso_jit_disabled",
+                "SSO user provisioning is disabled.",
+                403,
+            ),
+            (
+                "_require_verified_allowed_email",
+                "AuthFlowError",
+                "sso_email_missing",
+                "SSO did not return an email address.",
+                400,
+            ),
+            (
+                "_require_verified_allowed_email",
+                "AuthFlowError",
+                "sso_email_unverified",
+                "SSO email address is not verified.",
+                403,
+            ),
+            (
+                "_require_verified_allowed_email",
+                "AuthFlowError",
+                "exc.code",
+                "exc.message",
+                403,
+            ),
+            (
+                "_resolve_organization_sso_user",
+                "AuthFlowError",
+                "sso_organization_missing",
+                "SSO organization is missing.",
+                400,
+            ),
+            (
+                "_resolve_organization_sso_user",
+                "AuthFlowError",
+                "sso_user_not_team_member",
+                "SSO user is not a team member.",
+                403,
+            ),
+            (
+                "_resolve_organization_sso_user",
+                "AuthFlowError",
+                "sso_user_not_team_member",
+                "SSO user is not a team member.",
+                403,
+            ),
+            (
+                "_ensure_active_user",
+                "AuthFlowError",
+                "sso_user_inactive",
+                "User is inactive.",
+                403,
+            ),
+        ],
+    }
+
+    for module, expected_rows in expected.items():
+        assert Counter(_raise_descriptors(module)) == Counter(expected_rows)
+        assert "HTTPException" not in Path(cast(str, module.__file__)).read_text()
+
+    all_rows = [row for rows in expected.values() for row in rows]
+    assert len(all_rows) == 30
+    assert sum(row[2] != "exc.code" for row in all_rows) == 29

--- a/server/tests/unit/auth/test_sso_selfhost.py
+++ b/server/tests/unit/auth/test_sso_selfhost.py
@@ -10,9 +10,10 @@ from dataclasses import replace
 from typing import cast
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.sso import api as sso_api
 from proliferate.auth.sso import service as sso_service
 from proliferate.auth.sso.types import SsoScope
@@ -143,7 +144,11 @@ async def test_oidc_sso_callback_maps_jit_disabled_to_specific_code(
     monkeypatch.setattr(settings, "frontend_base_url", "https://app.example.test/")
 
     async def fake_complete_oidc_sso_callback(*_args: object, **_kwargs: object) -> str:
-        raise HTTPException(status_code=403, detail="SSO user provisioning is disabled.")
+        raise AuthFlowError(
+            "sso_jit_disabled",
+            "SSO user provisioning is disabled.",
+            status_code=403,
+        )
 
     monkeypatch.setattr(
         sso_api,

--- a/server/tests/unit/auth/test_sso_service_security.py
+++ b/server/tests/unit/auth/test_sso_service_security.py
@@ -8,9 +8,9 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.sso import service as sso_service
 from proliferate.auth.sso import user_resolution as sso_user_resolution
 from proliferate.auth.sso.types import (
@@ -167,9 +167,11 @@ async def test_resolve_sso_user_rechecks_org_membership_for_existing_identity(
     )
 
     if not has_pending_invitation:
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthFlowError) as exc_info:
             await resolution
+        assert exc_info.value.code == "sso_user_not_team_member"
         assert exc_info.value.status_code == 403
+        assert exc_info.value.message == "SSO user is not a team member."
         attach_identity.assert_not_awaited()
         return
 
@@ -280,7 +282,7 @@ async def test_resolve_sso_user_rejects_unlinked_deployment_user_when_jit_disabl
     monkeypatch.setattr(sso_user_resolution, "get_user_by_email", fake_get_user_by_email)
     monkeypatch.setattr(sso_user_resolution, "_attach_sso_identity", fake_attach_sso_identity)
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(AuthFlowError) as exc_info:
         await sso_service.resolve_sso_user(
             cast(AsyncSession, object()),
             connection=replace(
@@ -297,7 +299,9 @@ async def test_resolve_sso_user_rejects_unlinked_deployment_user_when_jit_disabl
             ),
         )
 
+    assert exc_info.value.code == "sso_jit_disabled"
     assert exc_info.value.status_code == 403
+    assert exc_info.value.message == "SSO user provisioning is disabled."
     assert attach_called is False
 
 

--- a/server/tests/unit/test_organization_sso_error_catch.py
+++ b/server/tests/unit/test_organization_sso_error_catch.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.errors import AuthFlowError
+from proliferate.auth.sso.types import SsoConnectionSnapshot
+from proliferate.db.store.auth_sso_records import SsoConnectionRecord
+from proliferate.server.organizations.sso import service
+
+
+@pytest.mark.asyncio
+async def test_connection_test_records_and_reraises_auth_flow_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = cast(AsyncSession, object())
+    connection_id = uuid4()
+    organization_id = uuid4()
+    actor_user_id = uuid4()
+    record = cast(SsoConnectionRecord, object())
+    snapshot = cast(SsoConnectionSnapshot, object())
+    source_error = AuthFlowError(
+        "sso_integration_failure",
+        "OIDC discovery metadata could not be loaded.",
+        status_code=400,
+    )
+    get_connection = AsyncMock(return_value=record)
+    test_connection = AsyncMock(side_effect=source_error)
+    mark_result = AsyncMock(return_value=record)
+    monkeypatch.setattr(service.sso_store, "get_sso_connection", get_connection)
+    monkeypatch.setattr(service, "snapshot_from_sso_connection_record", lambda value: snapshot)
+    monkeypatch.setattr(service, "test_oidc_connection", test_connection)
+    monkeypatch.setattr(service.sso_store, "mark_sso_connection_test_result", mark_result)
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        await service.test_organization_sso_connection(
+            db,
+            actor_user_id=actor_user_id,
+            organization_id=organization_id,
+            connection_id=connection_id,
+        )
+
+    assert exc_info.value is source_error
+    get_connection.assert_awaited_once_with(
+        db,
+        connection_id=connection_id,
+        organization_id=organization_id,
+    )
+    test_connection.assert_awaited_once_with(db, connection=snapshot)
+    mark_result.assert_awaited_once_with(
+        db,
+        connection_id=connection_id,
+        organization_id=organization_id,
+        success=False,
+        error="OIDC discovery metadata could not be loaded.",
+        discovered=None,
+        actor_user_id=actor_user_id,
+    )


### PR DESCRIPTION
## Summary

- replace all 29 non-boundary SSO HTTPException raises with ownership-correct typed errors while preserving every shipped status, raw detail, callback code/location, header, transaction, and success behavior
- keep pure SSO policy framework-free, translate policy failures at the user-resolution and OIDC integration boundaries, and translate SsoIntegrationError once in SSO service
- preserve the two legal SSO API transport raises, the five excluded Organization SSO raises, and Server Grid 13 Organization-owned invitation acceptance and race-to-JIT path

## Scope

Frozen Server Grid 25 revision 5. Exact conversion census: 1 deployment-config site, 3 pure-policy sites, 15 SSO-service sites, and 10 user-resolution sites. The implementation diff is exactly the frozen seven production and six test paths. No handler, Identity/Desktop production, Organization invitation ownership, store, schema, migration, config, SDK/client, dependency, checker, allowlist, or repository-doc change is in scope.

## Accepted dependency receipts

- Server Grid 13 root: dc29ff9353ab569620b247ce292db577c5367233
- Server Grid 20 source/replay: e9dae29b513f1fe80df89eba58f246ac2aea4605 / 2b30f6355464ada2e780234ccc29e7a6ed16ad68, stable patch ID 8704a04e443e7631d8f3e07f353d8c4ec934c5b1
- Server Grid 24 main source/replay: a6bf199c63e7e33ee7efc13cf485c2dbb282eee6 / 9d393af4abc4c0c46b8d4d03b4210f47c9c4203b, stable patch ID 0e0493405c23b8a70e34c250717b7afa94071e72
- Server Grid 24 SG24-B01 repair source/replay: 2e5c2614df2193551d727f2567b73b57707b33b1 / 38a515f53d4282c75e15b6ec89a673b9343447e9, stable patch ID c137c5eaf71fb3f962b910c5ee5db6b14adf4f2b
- exact integrated prerequisite: 38a515f53d4282c75e15b6ec89a673b9343447e9

All four accepted Server Grid 13 paths remain blob-identical to dc29ff. This slice retains organization_service.try_accept_invitation, rejection/race fallthrough to the same JIT rule, and Organization-owned seat adjustment and enrollment follow-up.

## Proof

- frozen eleven-file pytest suite: 112 passed
- full combined server suite: 2,314 passed, 2 skipped in 16m29s
- Ruff check and format check across all thirteen paths: passed
- server boundaries, max-lines, design attribution, and diff checks: passed
- exact exception censuses: SSO 2 raises / 3 textual; complete Auth 10 legal raises / 13 textual; adjacent Organization SSO 5 raises / 6 textual
- AST classification: Desktop 3 + Identity 5 + SSO API 2
- test_sso_service_security.py remains 594 lines and accepted invitation/race/JIT assertions remain intact
- two independent reviews: ACCEPT with no unresolved SG25-Bxx findings

## Integration and landing

This draft temporarily targets codex/sso-auth-error-prerequisite-base at 38a515f53d4282c75e15b6ec89a673b9343447e9. That branch is a disposable review scaffold: never merge the temporary base or this PR in the temporary topology.

After PR #1623, PR #1633, and PR #1636 land through their required sequence, rebase only this Server Grid 25 implementation commit onto final landed main; do not carry replay commits forward. Retarget to main and rerun the complete proof before readiness or merge.

Frozen specification SHA256: 3a798efc3a844d57cf928b93b95616a4725be5c4331daca87d103ba5774fcda3. Repair head: 805cf2005f9dee5f1f1ef6f3a120b376cf060d7f.

## Review repair update (2026-08-05)

- Frozen specification: Server Grid 25 revision 5, SHA256 `3a798efc3a844d57cf928b93b95616a4725be5c4331daca87d103ba5774fcda3`.
- Repair head: `805cf2005f9dee5f1f1ef6f3a120b376cf060d7f`.
- Accepted findings closed: a missing-state plus provider-error callback is pinned to the exact static 302 response, and an exhaustive production-source guard proves the two explicit `SsoPolicyError` translation boundaries.
- `SsoPolicyError` remains a `ValueError`; Organization taxonomy and dead-artifact observations remain outside this slice.
- Repair proof: 20 focused SSO error tests plus Ruff, format, and diff checks passed.
- Downstream #1641 and #1642 were rebased onto this repair. This remains a temporary-topology draft. Independent re-review: ACCEPT with no findings. GitHub CI for the repair head is terminal green.
