### PR TITLE
refactor(server): move Cloud Secrets access to route dependencies

### DIFF
--- a/server/proliferate/server/cloud/secrets/access.py
+++ b/server/proliferate/server/cloud/secrets/access.py
@@ -1,0 +1,89 @@
+"""Route dependencies for Cloud Secrets resource access."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.db.store import organizations as organization_store
+from proliferate.db.store import repositories as repositories_store
+from proliferate.server.cloud.errors import CloudApiError
+
+
+@dataclass(frozen=True)
+class OrganizationSecretsAccess:
+    actor_user_id: UUID
+    organization_id: UUID
+    membership_role: str
+
+
+@dataclass(frozen=True)
+class WorkspaceSecretsAccess:
+    actor_user_id: UUID
+    repo_environment_id: UUID
+
+
+async def organization_secrets_member_access(
+    organization_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> OrganizationSecretsAccess:
+    membership = await organization_store.get_active_membership(
+        db,
+        organization_id=organization_id,
+        user_id=user.id,
+    )
+    if membership is None:
+        raise CloudApiError(
+            "organization_secrets_not_found",
+            "Organization secrets not found.",
+            status_code=404,
+        )
+    return OrganizationSecretsAccess(
+        actor_user_id=user.id,
+        organization_id=organization_id,
+        membership_role=membership.role,
+    )
+
+
+async def organization_secrets_admin_access(
+    access: OrganizationSecretsAccess = Depends(organization_secrets_member_access),
+) -> OrganizationSecretsAccess:
+    if access.membership_role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
+        raise CloudApiError(
+            "organization_secrets_permission_denied",
+            "You do not have permission to manage organization secrets.",
+            status_code=403,
+        )
+    return access
+
+
+async def workspace_secrets_access(
+    git_owner: str,
+    git_repo_name: str,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> WorkspaceSecretsAccess:
+    environment = await repositories_store.get_cloud_repo_environment(
+        db,
+        user_id=user.id,
+        git_owner=git_owner,
+        git_repo_name=git_repo_name,
+    )
+    if environment is None:
+        raise CloudApiError(
+            "cloud_repo_environment_not_configured",
+            "Configure this GitHub repo for cloud before managing workspace secrets.",
+            status_code=404,
+        )
+    return WorkspaceSecretsAccess(
+        actor_user_id=user.id,
+        repo_environment_id=environment.id,
+    )

--- a/server/proliferate/server/cloud/secrets/api.py
+++ b/server/proliferate/server/cloud/secrets/api.py
@@ -12,7 +12,7 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.server.cloud.errors import CloudApiError
-from proliferate.server.cloud.secrets import service
+from proliferate.server.cloud.secrets import access, service
 from proliferate.server.cloud.secrets.models import (
     CloudSecretsResponse,
     DeleteCloudSecretFileRequest,
@@ -36,6 +36,41 @@ async def _read_uploaded_secret_file(file: UploadFile) -> str:
         ) from error
     finally:
         await file.close()
+
+
+async def _organization_secret_upload_access(
+    organization_id: UUID,
+    path: Annotated[str, Form()],
+    file: Annotated[UploadFile, File()],
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> tuple[str, str, access.OrganizationSecretsAccess]:
+    content = await _read_uploaded_secret_file(file)
+    member_access = await access.organization_secrets_member_access(
+        organization_id,
+        user=user,
+        db=db,
+    )
+    admin_access = await access.organization_secrets_admin_access(member_access)
+    return path, content, admin_access
+
+
+async def _workspace_secret_upload_access(
+    git_owner: str,
+    git_repo_name: str,
+    path: Annotated[str, Form()],
+    file: Annotated[UploadFile, File()],
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> tuple[str, str, access.WorkspaceSecretsAccess]:
+    content = await _read_uploaded_secret_file(file)
+    workspace_access = await access.workspace_secrets_access(
+        git_owner,
+        git_repo_name,
+        user=user,
+        db=db,
+    )
+    return path, content, workspace_access
 
 
 @router.get("/secrets/personal", response_model=CloudSecretsResponse)
@@ -124,14 +159,15 @@ async def delete_personal_secret_file_endpoint(
 
 @router.get("/organizations/{organization_id}/secrets", response_model=CloudSecretsResponse)
 async def get_organization_secrets_endpoint(
-    organization_id: UUID,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    organization_access: access.OrganizationSecretsAccess = Depends(
+        access.organization_secrets_member_access
+    ),
 ) -> CloudSecretsResponse:
     value, materialization = await service.get_organization_secrets(
         db,
-        user_id=user.id,
-        organization_id=organization_id,
+        user_id=organization_access.actor_user_id,
+        organization_id=organization_access.organization_id,
     )
     return cloud_secrets_payload(value, materialization=materialization)
 
@@ -141,16 +177,17 @@ async def get_organization_secrets_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def put_organization_secret_env_var_endpoint(
-    organization_id: UUID,
     name: str,
     body: PutCloudSecretEnvVarRequest,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    organization_access: access.OrganizationSecretsAccess = Depends(
+        access.organization_secrets_admin_access
+    ),
 ) -> CloudSecretsResponse:
     value, materialization = await service.set_organization_secret_env_var(
         db,
-        user_id=user.id,
-        organization_id=organization_id,
+        user_id=organization_access.actor_user_id,
+        organization_id=organization_access.organization_id,
         name=name,
         value=body.value,
     )
@@ -162,15 +199,16 @@ async def put_organization_secret_env_var_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def delete_organization_secret_env_var_endpoint(
-    organization_id: UUID,
     name: str,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    organization_access: access.OrganizationSecretsAccess = Depends(
+        access.organization_secrets_admin_access
+    ),
 ) -> CloudSecretsResponse:
     value, materialization = await service.delete_organization_secret_env_var(
         db,
-        user_id=user.id,
-        organization_id=organization_id,
+        user_id=organization_access.actor_user_id,
+        organization_id=organization_access.organization_id,
         name=name,
     )
     return cloud_secrets_payload(value, materialization=materialization)
@@ -181,15 +219,16 @@ async def delete_organization_secret_env_var_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def put_organization_secret_file_endpoint(
-    organization_id: UUID,
     body: PutCloudSecretFileRequest,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    organization_access: access.OrganizationSecretsAccess = Depends(
+        access.organization_secrets_admin_access
+    ),
 ) -> CloudSecretsResponse:
     value, materialization = await service.set_organization_secret_file(
         db,
-        user_id=user.id,
-        organization_id=organization_id,
+        user_id=organization_access.actor_user_id,
+        organization_id=organization_access.organization_id,
         path=body.path,
         content=body.content,
     )
@@ -201,18 +240,19 @@ async def put_organization_secret_file_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def upload_organization_secret_file_endpoint(
-    organization_id: UUID,
-    path: Annotated[str, Form()],
-    file: Annotated[UploadFile, File()],
+    upload: Annotated[
+        tuple[str, str, access.OrganizationSecretsAccess],
+        Depends(_organization_secret_upload_access),
+    ],
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
 ) -> CloudSecretsResponse:
+    path, content, organization_access = upload
     value, materialization = await service.set_organization_secret_file(
         db,
-        user_id=user.id,
-        organization_id=organization_id,
+        user_id=organization_access.actor_user_id,
+        organization_id=organization_access.organization_id,
         path=path,
-        content=await _read_uploaded_secret_file(file),
+        content=content,
     )
     return cloud_secrets_payload(value, materialization=materialization)
 
@@ -222,15 +262,16 @@ async def upload_organization_secret_file_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def delete_organization_secret_file_endpoint(
-    organization_id: UUID,
     body: DeleteCloudSecretFileRequest,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    organization_access: access.OrganizationSecretsAccess = Depends(
+        access.organization_secrets_admin_access
+    ),
 ) -> CloudSecretsResponse:
     value, materialization = await service.delete_organization_secret_file(
         db,
-        user_id=user.id,
-        organization_id=organization_id,
+        user_id=organization_access.actor_user_id,
+        organization_id=organization_access.organization_id,
         path=body.path,
     )
     return cloud_secrets_payload(value, materialization=materialization)
@@ -241,16 +282,13 @@ async def delete_organization_secret_file_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def get_workspace_secrets_endpoint(
-    git_owner: str,
-    git_repo_name: str,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    workspace_access: access.WorkspaceSecretsAccess = Depends(access.workspace_secrets_access),
 ) -> CloudSecretsResponse:
     value, materialization = await service.get_workspace_secrets(
         db,
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
+        user_id=workspace_access.actor_user_id,
+        repo_environment_id=workspace_access.repo_environment_id,
     )
     return cloud_secrets_payload(value, materialization=materialization)
 
@@ -260,18 +298,15 @@ async def get_workspace_secrets_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def put_workspace_secret_env_var_endpoint(
-    git_owner: str,
-    git_repo_name: str,
     name: str,
     body: PutCloudSecretEnvVarRequest,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    workspace_access: access.WorkspaceSecretsAccess = Depends(access.workspace_secrets_access),
 ) -> CloudSecretsResponse:
     value, materialization = await service.set_workspace_secret_env_var(
         db,
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
+        user_id=workspace_access.actor_user_id,
+        repo_environment_id=workspace_access.repo_environment_id,
         name=name,
         value=body.value,
     )
@@ -283,17 +318,14 @@ async def put_workspace_secret_env_var_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def delete_workspace_secret_env_var_endpoint(
-    git_owner: str,
-    git_repo_name: str,
     name: str,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    workspace_access: access.WorkspaceSecretsAccess = Depends(access.workspace_secrets_access),
 ) -> CloudSecretsResponse:
     value, materialization = await service.delete_workspace_secret_env_var(
         db,
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
+        user_id=workspace_access.actor_user_id,
+        repo_environment_id=workspace_access.repo_environment_id,
         name=name,
     )
     return cloud_secrets_payload(value, materialization=materialization)
@@ -304,17 +336,14 @@ async def delete_workspace_secret_env_var_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def put_workspace_secret_file_endpoint(
-    git_owner: str,
-    git_repo_name: str,
     body: PutCloudSecretFileRequest,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    workspace_access: access.WorkspaceSecretsAccess = Depends(access.workspace_secrets_access),
 ) -> CloudSecretsResponse:
     value, materialization = await service.set_workspace_secret_file(
         db,
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
+        user_id=workspace_access.actor_user_id,
+        repo_environment_id=workspace_access.repo_environment_id,
         path=body.path,
         content=body.content,
     )
@@ -326,20 +355,19 @@ async def put_workspace_secret_file_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def upload_workspace_secret_file_endpoint(
-    git_owner: str,
-    git_repo_name: str,
-    path: Annotated[str, Form()],
-    file: Annotated[UploadFile, File()],
+    upload: Annotated[
+        tuple[str, str, access.WorkspaceSecretsAccess],
+        Depends(_workspace_secret_upload_access),
+    ],
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
 ) -> CloudSecretsResponse:
+    path, content, workspace_access = upload
     value, materialization = await service.set_workspace_secret_file(
         db,
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
+        user_id=workspace_access.actor_user_id,
+        repo_environment_id=workspace_access.repo_environment_id,
         path=path,
-        content=await _read_uploaded_secret_file(file),
+        content=content,
     )
     return cloud_secrets_payload(value, materialization=materialization)
 
@@ -349,17 +377,14 @@ async def upload_workspace_secret_file_endpoint(
     response_model=CloudSecretsResponse,
 )
 async def delete_workspace_secret_file_endpoint(
-    git_owner: str,
-    git_repo_name: str,
     body: DeleteCloudSecretFileRequest,
     db: AsyncSession = Depends(get_async_session),
-    user: User = Depends(current_product_user),
+    workspace_access: access.WorkspaceSecretsAccess = Depends(access.workspace_secrets_access),
 ) -> CloudSecretsResponse:
     value, materialization = await service.delete_workspace_secret_file(
         db,
-        user_id=user.id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
+        user_id=workspace_access.actor_user_id,
+        repo_environment_id=workspace_access.repo_environment_id,
         path=body.path,
     )
     return cloud_secrets_payload(value, materialization=materialization)

--- a/server/proliferate/server/cloud/secrets/service.py
+++ b/server/proliferate/server/cloud/secrets/service.py
@@ -6,9 +6,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.constants.organizations import ORGANIZATION_ROLE_ADMIN, ORGANIZATION_ROLE_OWNER
 from proliferate.db.store import cloud_secrets as secret_store
-from proliferate.db.store import organizations as organization_store
 from proliferate.db.store.cloud_sandbox_secrets import (
     CloudSandboxSecretMaterializationValue,
     load_global_secret_materialization,
@@ -16,12 +14,6 @@ from proliferate.db.store.cloud_sandbox_secrets import (
 )
 from proliferate.db.store.cloud_sandboxes import load_personal_cloud_sandbox
 from proliferate.db.store.cloud_secrets import CloudSecretSetValue
-from proliferate.db.store.organization_records import MembershipRecord
-from proliferate.db.store.repositories import (
-    RepoEnvironmentValue,
-    get_cloud_repo_environment,
-)
-from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.materialization import service as materialization_service
 from proliferate.server.cloud.secrets.validation import (
     normalize_global_secret_file_path,
@@ -96,67 +88,6 @@ def _should_repair_stale_materialization(
     if materialization.status == "error":
         return False
     return not _materialization_ready_for_secret_set(value, materialization)
-
-
-async def _require_organization_member(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    organization_id: UUID,
-) -> MembershipRecord:
-    membership = await organization_store.get_active_membership(
-        db,
-        organization_id=organization_id,
-        user_id=user_id,
-    )
-    if membership is None:
-        raise CloudApiError(
-            "organization_secrets_not_found",
-            "Organization secrets not found.",
-            status_code=404,
-        )
-    return membership
-
-
-async def _require_organization_admin(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    organization_id: UUID,
-) -> None:
-    membership = await _require_organization_member(
-        db,
-        user_id=user_id,
-        organization_id=organization_id,
-    )
-    if membership.role not in {ORGANIZATION_ROLE_OWNER, ORGANIZATION_ROLE_ADMIN}:
-        raise CloudApiError(
-            "organization_secrets_permission_denied",
-            "You do not have permission to manage organization secrets.",
-            status_code=403,
-        )
-
-
-async def _load_workspace_repo_scope(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    git_owner: str,
-    git_repo_name: str,
-) -> RepoEnvironmentValue:
-    environment = await get_cloud_repo_environment(
-        db,
-        user_id=user_id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
-    if environment is None:
-        raise CloudApiError(
-            "cloud_repo_environment_not_configured",
-            "Configure this GitHub repo for cloud before managing workspace secrets.",
-            status_code=404,
-        )
-    return environment
 
 
 async def get_personal_secrets(
@@ -284,7 +215,6 @@ async def get_organization_secrets(
     user_id: UUID,
     organization_id: UUID,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    await _require_organization_member(db, user_id=user_id, organization_id=organization_id)
     value = await secret_store.get_or_create_organization_secret_set(
         db,
         organization_id=organization_id,
@@ -307,7 +237,6 @@ async def set_organization_secret_env_var(
     name: str,
     value: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    await _require_organization_admin(db, user_id=user_id, organization_id=organization_id)
     secret_set = await secret_store.get_or_create_organization_secret_set(
         db,
         organization_id=organization_id,
@@ -334,7 +263,6 @@ async def delete_organization_secret_env_var(
     organization_id: UUID,
     name: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    await _require_organization_admin(db, user_id=user_id, organization_id=organization_id)
     secret_set = await secret_store.get_or_create_organization_secret_set(
         db,
         organization_id=organization_id,
@@ -361,7 +289,6 @@ async def set_organization_secret_file(
     path: str,
     content: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    await _require_organization_admin(db, user_id=user_id, organization_id=organization_id)
     secret_set = await secret_store.get_or_create_organization_secret_set(
         db,
         organization_id=organization_id,
@@ -388,7 +315,6 @@ async def delete_organization_secret_file(
     organization_id: UUID,
     path: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    await _require_organization_admin(db, user_id=user_id, organization_id=organization_id)
     secret_set = await secret_store.get_or_create_organization_secret_set(
         db,
         organization_id=organization_id,
@@ -411,24 +337,17 @@ async def get_workspace_secrets(
     db: AsyncSession,
     *,
     user_id: UUID,
-    git_owner: str,
-    git_repo_name: str,
+    repo_environment_id: UUID,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    environment = await _load_workspace_repo_scope(
-        db,
-        user_id=user_id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
     value = await secret_store.get_or_create_workspace_secret_set(
         db,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
         actor_user_id=user_id,
     )
     materialization = await _load_workspace_materialization(
         db,
         user_id=user_id,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
     )
     if _should_repair_stale_materialization(value, materialization):
         await materialization_service.schedule_materialize_secret_set(
@@ -442,20 +361,13 @@ async def set_workspace_secret_env_var(
     db: AsyncSession,
     *,
     user_id: UUID,
-    git_owner: str,
-    git_repo_name: str,
+    repo_environment_id: UUID,
     name: str,
     value: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    environment = await _load_workspace_repo_scope(
-        db,
-        user_id=user_id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
         actor_user_id=user_id,
     )
     updated = await secret_store.upsert_secret_env_var(
@@ -472,7 +384,7 @@ async def set_workspace_secret_env_var(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
     )
 
 
@@ -480,19 +392,12 @@ async def delete_workspace_secret_env_var(
     db: AsyncSession,
     *,
     user_id: UUID,
-    git_owner: str,
-    git_repo_name: str,
+    repo_environment_id: UUID,
     name: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    environment = await _load_workspace_repo_scope(
-        db,
-        user_id=user_id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
         actor_user_id=user_id,
     )
     updated = await secret_store.delete_secret_env_var(
@@ -508,7 +413,7 @@ async def delete_workspace_secret_env_var(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
     )
 
 
@@ -516,20 +421,13 @@ async def set_workspace_secret_file(
     db: AsyncSession,
     *,
     user_id: UUID,
-    git_owner: str,
-    git_repo_name: str,
+    repo_environment_id: UUID,
     path: str,
     content: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    environment = await _load_workspace_repo_scope(
-        db,
-        user_id=user_id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
         actor_user_id=user_id,
     )
     updated = await secret_store.upsert_secret_file(
@@ -546,7 +444,7 @@ async def set_workspace_secret_file(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
     )
 
 
@@ -554,19 +452,12 @@ async def delete_workspace_secret_file(
     db: AsyncSession,
     *,
     user_id: UUID,
-    git_owner: str,
-    git_repo_name: str,
+    repo_environment_id: UUID,
     path: str,
 ) -> tuple[CloudSecretSetValue, CloudSandboxSecretMaterializationValue | None]:
-    environment = await _load_workspace_repo_scope(
-        db,
-        user_id=user_id,
-        git_owner=git_owner,
-        git_repo_name=git_repo_name,
-    )
     secret_set = await secret_store.get_or_create_workspace_secret_set(
         db,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
         actor_user_id=user_id,
     )
     updated = await secret_store.delete_secret_file(
@@ -582,5 +473,5 @@ async def delete_workspace_secret_file(
     return updated, await _load_workspace_materialization(
         db,
         user_id=user_id,
-        repo_environment_id=environment.id,
+        repo_environment_id=repo_environment_id,
     )

--- a/server/tests/unit/test_cloud_materialization_concurrency.py
+++ b/server/tests/unit/test_cloud_materialization_concurrency.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from proliferate.constants.organizations import ORGANIZATION_ROLE_OWNER
 from proliferate.db.store.cloud_secrets import CloudSecretSetPayload
 from proliferate.integrations import redis_lock
 from proliferate.server.cloud.materialization import locks, operation
@@ -68,9 +67,6 @@ async def test_personal_organization_secret_burst_schedules_each_mutation_once(
             return personal_after
         return organization_after
 
-    async def _membership(*_args: object, **_kwargs: object) -> object:
-        return SimpleNamespace(role=ORGANIZATION_ROLE_OWNER)
-
     async def _no_materialization(*_args: object, **_kwargs: object) -> None:
         return None
 
@@ -95,11 +91,6 @@ async def test_personal_organization_secret_burst_schedules_each_mutation_once(
         _organization,
     )
     monkeypatch.setattr(secrets_service.secret_store, "upsert_secret_env_var", _upsert)
-    monkeypatch.setattr(
-        secrets_service.organization_store,
-        "get_active_membership",
-        _membership,
-    )
     monkeypatch.setattr(
         secrets_service,
         "_load_user_global_materialization",

--- a/server/tests/unit/test_cloud_secrets_access.py
+++ b/server/tests/unit/test_cloud_secrets_access.py
@@ -1,0 +1,424 @@
+"""Cloud Secrets route-access ownership regressions."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.errors import ProliferateError
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.secrets import access, api, service
+from proliferate.server.cloud.secrets.models import CloudSecretsResponse
+
+
+def _assert_error(
+    error: CloudApiError,
+    *,
+    code: str,
+    message: str,
+    status_code: int,
+) -> None:
+    assert error.code == code
+    assert error.message == message
+    assert error.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_organization_member_access_returns_exact_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actor_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    db = SimpleNamespace()
+    calls: list[tuple[object, uuid.UUID, uuid.UUID]] = []
+
+    async def get_membership(
+        received_db: object,
+        *,
+        organization_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> object:
+        calls.append((received_db, organization_id, user_id))
+        return SimpleNamespace(role="member")
+
+    monkeypatch.setattr(access.organization_store, "get_active_membership", get_membership)
+    result = await access.organization_secrets_member_access(
+        organization_id,
+        user=SimpleNamespace(id=actor_id),  # type: ignore[arg-type]
+        db=db,  # type: ignore[arg-type]
+    )
+
+    assert result == access.OrganizationSecretsAccess(actor_id, organization_id, "member")
+    assert calls == [(db, organization_id, actor_id)]
+
+
+@pytest.mark.asyncio
+async def test_organization_member_access_preserves_missing_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def missing(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(access.organization_store, "get_active_membership", missing)
+    with pytest.raises(CloudApiError) as exc_info:
+        await access.organization_secrets_member_access(
+            uuid.uuid4(),
+            user=SimpleNamespace(id=uuid.uuid4()),  # type: ignore[arg-type]
+            db=SimpleNamespace(),  # type: ignore[arg-type]
+        )
+    _assert_error(
+        exc_info.value,
+        code="organization_secrets_not_found",
+        message="Organization secrets not found.",
+        status_code=404,
+    )
+
+
+@pytest.mark.asyncio
+async def test_organization_admin_access_is_pure_and_preserves_denial() -> None:
+    owner = access.OrganizationSecretsAccess(uuid.uuid4(), uuid.uuid4(), "owner")
+    admin = access.OrganizationSecretsAccess(uuid.uuid4(), uuid.uuid4(), "admin")
+    member = access.OrganizationSecretsAccess(uuid.uuid4(), uuid.uuid4(), "member")
+
+    assert await access.organization_secrets_admin_access(owner) is owner
+    assert await access.organization_secrets_admin_access(admin) is admin
+    with pytest.raises(CloudApiError) as exc_info:
+        await access.organization_secrets_admin_access(member)
+    _assert_error(
+        exc_info.value,
+        code="organization_secrets_permission_denied",
+        message="You do not have permission to manage organization secrets.",
+        status_code=403,
+    )
+
+
+@pytest.mark.asyncio
+async def test_workspace_access_resolves_exact_path_and_preserves_missing_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actor_id = uuid.uuid4()
+    environment_id = uuid.uuid4()
+    db = SimpleNamespace()
+    calls: list[tuple[object, uuid.UUID, str, str]] = []
+
+    async def configured(
+        received_db: object,
+        *,
+        user_id: uuid.UUID,
+        git_owner: str,
+        git_repo_name: str,
+    ) -> object:
+        calls.append((received_db, user_id, git_owner, git_repo_name))
+        return SimpleNamespace(id=environment_id)
+
+    monkeypatch.setattr(access.repositories_store, "get_cloud_repo_environment", configured)
+    result = await access.workspace_secrets_access(
+        "ExactOwner",
+        "ExactRepo",
+        user=SimpleNamespace(id=actor_id),  # type: ignore[arg-type]
+        db=db,  # type: ignore[arg-type]
+    )
+    assert result == access.WorkspaceSecretsAccess(actor_id, environment_id)
+    assert calls == [(db, actor_id, "ExactOwner", "ExactRepo")]
+
+    async def missing(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(access.repositories_store, "get_cloud_repo_environment", missing)
+    with pytest.raises(CloudApiError) as exc_info:
+        await access.workspace_secrets_access(
+            "ExactOwner",
+            "ExactRepo",
+            user=SimpleNamespace(id=actor_id),  # type: ignore[arg-type]
+            db=db,  # type: ignore[arg-type]
+        )
+    _assert_error(
+        exc_info.value,
+        code="cloud_repo_environment_not_configured",
+        message="Configure this GitHub repo for cloud before managing workspace secrets.",
+        status_code=404,
+    )
+
+
+def _response() -> CloudSecretsResponse:
+    return CloudSecretsResponse(
+        scope_kind="organization",
+        version=0,
+        env_vars=[],
+        files=[],
+        materialization=None,
+    )
+
+
+def _test_app(db: object) -> FastAPI:
+    app = FastAPI()
+
+    async def session() -> AsyncIterator[object]:
+        yield db
+
+    async def error_handler(_request: Request, error: ProliferateError) -> JSONResponse:
+        return JSONResponse(
+            status_code=error.status_code,
+            content={"detail": {"code": error.code, "message": error.message}},
+        )
+
+    app.include_router(api.router)
+    app.add_exception_handler(ProliferateError, error_handler)  # type: ignore[arg-type]
+    app.dependency_overrides[get_async_session] = session
+    return app
+
+
+@pytest.mark.asyncio
+async def test_router_passes_only_preauthorized_ids_and_same_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = SimpleNamespace()
+    app = _test_app(db)
+    actor_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    environment_id = uuid.uuid4()
+    events: list[tuple[str, dict[str, object]]] = []
+
+    async def organization_member() -> access.OrganizationSecretsAccess:
+        events.append(("organization_access", {}))
+        return access.OrganizationSecretsAccess(actor_id, organization_id, "member")
+
+    async def organization_admin() -> access.OrganizationSecretsAccess:
+        events.append(("organization_access", {}))
+        return access.OrganizationSecretsAccess(actor_id, organization_id, "admin")
+
+    async def workspace() -> access.WorkspaceSecretsAccess:
+        events.append(("workspace_access", {}))
+        return access.WorkspaceSecretsAccess(actor_id, environment_id)
+
+    async def observed(
+        event_name: str,
+        received_db: object,
+        **kwargs: object,
+    ) -> tuple[object, None]:
+        assert received_db is db
+        events.append((event_name, kwargs))
+        return object(), None
+
+    monkeypatch.setattr(
+        api.service,
+        "get_organization_secrets",
+        lambda received_db, **kwargs: observed("organization_get", received_db, **kwargs),
+    )
+    monkeypatch.setattr(
+        api.service,
+        "set_organization_secret_env_var",
+        lambda received_db, **kwargs: observed("organization_put", received_db, **kwargs),
+    )
+    monkeypatch.setattr(
+        api.service,
+        "get_workspace_secrets",
+        lambda received_db, **kwargs: observed("workspace_get", received_db, **kwargs),
+    )
+    monkeypatch.setattr(
+        api.service,
+        "set_workspace_secret_env_var",
+        lambda received_db, **kwargs: observed("workspace_put", received_db, **kwargs),
+    )
+    monkeypatch.setattr(api, "cloud_secrets_payload", lambda *_args, **_kwargs: _response())
+    app.dependency_overrides[access.organization_secrets_member_access] = organization_member
+    app.dependency_overrides[access.organization_secrets_admin_access] = organization_admin
+    app.dependency_overrides[access.workspace_secrets_access] = workspace
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        assert (await client.get(f"/organizations/{organization_id}/secrets")).status_code == 200
+        assert (
+            await client.put(
+                f"/organizations/{organization_id}/secrets/env-vars/KEY",
+                json={"value": "value"},
+            )
+        ).status_code == 200
+        assert (await client.get("/repos/ExactOwner/ExactRepo/secrets")).status_code == 200
+        assert (
+            await client.put(
+                "/repos/ExactOwner/ExactRepo/secrets/env-vars/KEY",
+                json={"value": "value"},
+            )
+        ).status_code == 200
+
+    assert events == [
+        ("organization_access", {}),
+        ("organization_get", {"user_id": actor_id, "organization_id": organization_id}),
+        ("organization_access", {}),
+        (
+            "organization_put",
+            {
+                "user_id": actor_id,
+                "organization_id": organization_id,
+                "name": "KEY",
+                "value": "value",
+            },
+        ),
+        ("workspace_access", {}),
+        ("workspace_get", {"user_id": actor_id, "repo_environment_id": environment_id}),
+        ("workspace_access", {}),
+        (
+            "workspace_put",
+            {
+                "user_id": actor_id,
+                "repo_environment_id": environment_id,
+                "name": "KEY",
+                "value": "value",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_denied_router_access_never_calls_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _test_app(SimpleNamespace())
+
+    async def denied() -> access.OrganizationSecretsAccess:
+        raise CloudApiError(
+            "organization_secrets_permission_denied",
+            "You do not have permission to manage organization secrets.",
+            status_code=403,
+        )
+
+    async def never(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("service must not run")
+
+    app.dependency_overrides[access.organization_secrets_admin_access] = denied
+    monkeypatch.setattr(api.service, "set_organization_secret_env_var", never)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.put(
+            f"/organizations/{uuid.uuid4()}/secrets/env-vars/KEY",
+            json={"value": "value"},
+        )
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": {
+            "code": "organization_secrets_permission_denied",
+            "message": "You do not have permission to manage organization secrets.",
+        }
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route", "access_name"),
+    [
+        ("/organizations/{resource}/secrets/files/upload", "organization"),
+        ("/repos/{resource}/repo/secrets/files/upload", "workspace"),
+    ],
+)
+async def test_multipart_invalid_utf8_precedes_resource_access(
+    monkeypatch: pytest.MonkeyPatch,
+    route: str,
+    access_name: str,
+) -> None:
+    db = SimpleNamespace()
+    app = _test_app(db)
+    events: list[str] = []
+    actor = SimpleNamespace(id=uuid.uuid4())
+
+    async def actor_dependency() -> object:
+        events.append("authenticate")
+        return actor
+
+    original_reader = api._read_uploaded_secret_file
+
+    async def observed_reader(file: object) -> str:
+        events.append("decode")
+        return await original_reader(file)  # type: ignore[arg-type]
+
+    async def forbidden_access(*_args: object, **_kwargs: object) -> Any:
+        events.append(f"{access_name}_access")
+        raise CloudApiError("denied", "Denied.", status_code=403)
+
+    app.dependency_overrides[current_product_user] = actor_dependency
+    monkeypatch.setattr(api, "_read_uploaded_secret_file", observed_reader)
+    if access_name == "organization":
+        monkeypatch.setattr(api.access, "organization_secrets_member_access", forbidden_access)
+    else:
+        monkeypatch.setattr(api.access, "workspace_secrets_access", forbidden_access)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.put(
+            route.format(resource=uuid.uuid4() if access_name == "organization" else "owner"),
+            data={"path": "/secret.txt"},
+            files={"file": ("secret.txt", b"\xff", "text/plain")},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_secret_file_upload"
+    assert events == ["authenticate", "decode"]
+
+    events.clear()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.put(
+            route.format(resource=uuid.uuid4() if access_name == "organization" else "owner"),
+            data={"path": "/secret.txt"},
+            files={"file": ("secret.txt", b"valid", "text/plain")},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "denied"
+    assert events == ["authenticate", "decode", f"{access_name}_access"]
+
+
+@pytest.mark.asyncio
+async def test_trusted_service_call_performs_no_access_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actor_id = uuid.uuid4()
+    organization_id = uuid.uuid4()
+    secret_set = SimpleNamespace(
+        id=uuid.uuid4(),
+        scope_kind="organization",
+        user_id=None,
+        organization_id=organization_id,
+        repo_environment_id=None,
+        version=0,
+        env_vars=(),
+        files=(),
+    )
+
+    async def get_secret_set(*_args: object, **_kwargs: object) -> object:
+        return secret_set
+
+    async def no_materialization(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        service.secret_store,
+        "get_or_create_organization_secret_set",
+        get_secret_set,
+    )
+    monkeypatch.setattr(service, "_load_user_global_materialization", no_materialization)
+
+    value, materialization = await service.get_organization_secrets(
+        SimpleNamespace(),  # type: ignore[arg-type]
+        user_id=actor_id,
+        organization_id=organization_id,
+    )
+    assert value is secret_set
+    assert materialization is None


### PR DESCRIPTION
## Summary

- move organization membership/admin checks into domain-owned Cloud Secrets route dependencies
- resolve workspace repository access before service orchestration and pass only authorized ids
- preserve multipart authentication -> UTF-8 decode -> resource-access failure ordering
- leave all personal routes and secret/materialization behavior unchanged

## Stack

- Base dependency: #1612 at `4e7c2516cb85d7600ba80380c89dc199f7cc72b1`
- This head: `1b897d368905db949c15463277f43301f5f3d276`
- Landing: #1612 first; then rebase only this slice onto landed main, retarget, re-prove, and re-review. Do not merge the stacked base.

## Frozen specification

Server Grid 27 revision 1  
SHA256 `ff5e6094f30df4be6f700afcd677fc864c6ec5261828e026d5dcba3f10ed707c`

## Proof

- 19 focused Secrets/access/model/validation/materialization tests passed
- Ruff check and format check passed
- Mypy passed on the three Secrets source files
- server boundaries, max-lines, design-attribution, and diff checks passed
- exact five-path/one-commit census and frozen negative checks passed
- independent review: ACCEPT, no SG27-Bxx findings

## Review state

Open draft only. Do not merge or mark ready until the dependency lands and the required rebase/reproof/re-review is complete.
