### PR TITLE
refactor(server): own workspace materialization access

### DIFF
--- a/server/proliferate/server/cloud/workspaces/api.py
+++ b/server/proliferate/server/cloud/workspaces/api.py
@@ -14,10 +14,9 @@ from proliferate.db.models.auth import User
 from proliferate.server.cloud.github_app.transactions import (
     commit_github_app_reauthorization_on_error,
 )
-from proliferate.server.cloud.workspaces.materializations.service import (
-    create_local_materialization_intent,
-    report_materialization,
-    unlink_materialization,
+from proliferate.server.cloud.workspaces.materializations import access as materializations_access
+from proliferate.server.cloud.workspaces.materializations import (
+    service as materializations_service,
 )
 from proliferate.server.cloud.workspaces.models import (
     CloudWorkspaceRuntimeStatusResponse,
@@ -100,14 +99,16 @@ async def get_cloud_workspace_endpoint(
 async def create_workspace_materialization_intent_endpoint(
     workspace_id: UUID,
     body: CreateMaterializationIntentRequest,
-    user: User = Depends(current_product_user),
+    access: materializations_access.CreateLocalMaterializationAccess = Depends(
+        materializations_access.create_local_materialization_access
+    ),
     db: AsyncSession = Depends(get_async_session),
 ) -> MaterializationIntentResponse:
-    return await create_local_materialization_intent(
+    return await materializations_service.create_local_materialization_intent(
         db,
-        user_id=user.id,
-        workspace_id=workspace_id,
-        body=body,
+        user_id=access.actor_user_id,
+        workspace=access.workspace,
+        desktop_install_id=access.desktop_install_id,
     )
 
 
@@ -119,14 +120,14 @@ async def report_workspace_materialization_endpoint(
     workspace_id: UUID,
     materialization_id: UUID,
     body: ReportMaterializationRequest,
-    user: User = Depends(current_product_user),
+    access: materializations_access.ExistingLocalMaterializationAccess = Depends(
+        materializations_access.report_local_materialization_access
+    ),
     db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceMaterializationSummary:
-    return await report_materialization(
+    return await materializations_service.report_materialization(
         db,
-        user_id=user.id,
-        workspace_id=workspace_id,
-        materialization_id=materialization_id,
+        materialization=access.materialization,
         body=body,
     )
 
@@ -138,14 +139,14 @@ async def report_workspace_materialization_endpoint(
 async def unlink_workspace_materialization_endpoint(
     workspace_id: UUID,
     materialization_id: UUID,
-    user: User = Depends(current_product_user),
+    access: materializations_access.ExistingLocalMaterializationAccess = Depends(
+        materializations_access.unlink_local_materialization_access
+    ),
     db: AsyncSession = Depends(get_async_session),
 ) -> None:
-    await unlink_materialization(
+    await materializations_service.unlink_materialization(
         db,
-        user_id=user.id,
-        workspace_id=workspace_id,
-        materialization_id=materialization_id,
+        materialization=access.materialization,
     )
 
 

--- a/server/proliferate/server/cloud/workspaces/materializations/access.py
+++ b/server/proliferate/server/cloud/workspaces/materializations/access.py
@@ -1,0 +1,188 @@
+"""Route access dependencies for local workspace materializations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.auth.dependencies import current_product_user
+from proliferate.db.engine import get_async_session
+from proliferate.db.models.auth import User
+from proliferate.db.store import cloud_workspace_materializations as materialization_store
+from proliferate.db.store import cloud_workspaces as cloud_workspace_store
+from proliferate.db.store import runtime_workers as runtime_workers_store
+from proliferate.db.store.cloud_workspace_materializations import (
+    CloudWorkspaceMaterializationValue,
+)
+from proliferate.db.store.cloud_workspaces import CloudWorkspaceValue
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workspaces.models import CreateMaterializationIntentRequest
+
+
+@dataclass(frozen=True)
+class CreateLocalMaterializationAccess:
+    actor_user_id: UUID
+    workspace: CloudWorkspaceValue
+    desktop_install_id: str
+
+
+@dataclass(frozen=True)
+class ExistingLocalMaterializationAccess:
+    actor_user_id: UUID
+    workspace: CloudWorkspaceValue
+    materialization: CloudWorkspaceMaterializationValue
+
+
+async def _load_user_workspace(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    workspace_id: UUID,
+) -> CloudWorkspaceValue:
+    workspace = await cloud_workspace_store.get_cloud_workspace_for_user(
+        db,
+        user_id,
+        workspace_id,
+    )
+    if workspace is None:
+        raise CloudApiError("workspace_not_found", "Cloud workspace not found.", status_code=404)
+    return workspace
+
+
+async def _require_owned_install(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    desktop_install_id: str,
+) -> None:
+    worker = await runtime_workers_store.get_active_desktop_worker_for_user(
+        db,
+        owner_user_id=user_id,
+        desktop_install_id=desktop_install_id,
+    )
+    if worker is None:
+        raise CloudApiError(
+            "desktop_install_not_owned",
+            "This desktop installation is not registered to your account.",
+            status_code=403,
+        )
+
+
+async def _load_local_materialization(
+    db: AsyncSession,
+    *,
+    workspace: CloudWorkspaceValue,
+    materialization_id: UUID,
+    operation: str,
+) -> CloudWorkspaceMaterializationValue:
+    materialization = await materialization_store.load_materialization(
+        db,
+        materialization_id,
+        lock_row=True,
+    )
+    if materialization is None or materialization.cloud_workspace_id != workspace.id:
+        raise CloudApiError(
+            "materialization_not_found",
+            "Materialization not found.",
+            status_code=404,
+        )
+    if materialization.target_kind != "local_desktop":
+        if operation == "report":
+            raise CloudApiError(
+                "materialization_not_reportable",
+                "Only local materializations can be reported.",
+                status_code=409,
+            )
+        raise CloudApiError(
+            "materialization_not_unlinkable",
+            "Only local materializations can be unlinked.",
+            status_code=409,
+        )
+    return materialization
+
+
+async def create_local_materialization_access(
+    workspace_id: UUID,
+    body: CreateMaterializationIntentRequest,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> CreateLocalMaterializationAccess:
+    workspace = await _load_user_workspace(db, user_id=user.id, workspace_id=workspace_id)
+    if workspace.lost_at is not None:
+        raise CloudApiError(
+            "workspace_lost",
+            "This workspace was lost with its sandbox. Delete it instead of rematerializing it.",
+            status_code=409,
+        )
+    desktop_install_id = body.desktop_install_id.strip()
+    if not desktop_install_id:
+        raise CloudApiError(
+            "invalid_desktop_install",
+            "A desktop installation id is required.",
+            status_code=400,
+        )
+    await _require_owned_install(
+        db,
+        user_id=user.id,
+        desktop_install_id=desktop_install_id,
+    )
+    return CreateLocalMaterializationAccess(
+        actor_user_id=user.id,
+        workspace=workspace,
+        desktop_install_id=desktop_install_id,
+    )
+
+
+async def report_local_materialization_access(
+    workspace_id: UUID,
+    materialization_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> ExistingLocalMaterializationAccess:
+    workspace = await _load_user_workspace(db, user_id=user.id, workspace_id=workspace_id)
+    materialization = await _load_local_materialization(
+        db,
+        workspace=workspace,
+        materialization_id=materialization_id,
+        operation="report",
+    )
+    if materialization.desktop_install_id is not None:
+        await _require_owned_install(
+            db,
+            user_id=user.id,
+            desktop_install_id=materialization.desktop_install_id,
+        )
+    return ExistingLocalMaterializationAccess(
+        actor_user_id=user.id,
+        workspace=workspace,
+        materialization=materialization,
+    )
+
+
+async def unlink_local_materialization_access(
+    workspace_id: UUID,
+    materialization_id: UUID,
+    user: User = Depends(current_product_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> ExistingLocalMaterializationAccess:
+    workspace = await _load_user_workspace(db, user_id=user.id, workspace_id=workspace_id)
+    materialization = await _load_local_materialization(
+        db,
+        workspace=workspace,
+        materialization_id=materialization_id,
+        operation="unlink",
+    )
+    if materialization.unlinked_at is None and materialization.desktop_install_id is not None:
+        await _require_owned_install(
+            db,
+            user_id=user.id,
+            desktop_install_id=materialization.desktop_install_id,
+        )
+    return ExistingLocalMaterializationAccess(
+        actor_user_id=user.id,
+        workspace=workspace,
+        materialization=materialization,
+    )

--- a/server/proliferate/server/cloud/workspaces/materializations/service.py
+++ b/server/proliferate/server/cloud/workspaces/materializations/service.py
@@ -23,7 +23,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.db.store import cloud_sandboxes as cloud_sandbox_store
 from proliferate.db.store import cloud_workspace_materializations as materialization_store
-from proliferate.db.store import cloud_workspaces as cloud_workspace_store
 from proliferate.db.store import repositories as repositories_store
 from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_workspace_materializations import (
@@ -49,7 +48,6 @@ from proliferate.server.cloud.workspaces.materializations.summaries import (
 )
 from proliferate.server.cloud.workspaces.models import (
     CreateCloudWorkspaceSourceMaterialization,
-    CreateMaterializationIntentRequest,
     MaterializationIntentResponse,
     MaterializationIntentSource,
     RepoRef,
@@ -88,7 +86,7 @@ async def validate_cloud_copy_local_source(
             "The local workspace is not at the requested published commit.",
             status_code=409,
         )
-    await _require_owned_install(db, user_id=user_id, desktop_install_id=install_id)
+    await _require_cloud_copy_source_install(db, user_id=user_id, desktop_install_id=install_id)
     existing = await materialization_store.get_active_local_materialization_by_runtime(
         db,
         desktop_install_id=install_id,
@@ -104,23 +102,7 @@ async def validate_cloud_copy_local_source(
     return install_id, workspace_id, worktree_path
 
 
-async def _load_user_workspace(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    workspace_id: UUID,
-) -> CloudWorkspaceValue:
-    workspace = await cloud_workspace_store.get_cloud_workspace_for_user(
-        db,
-        user_id,
-        workspace_id,
-    )
-    if workspace is None:
-        raise CloudApiError("workspace_not_found", "Cloud workspace not found.", status_code=404)
-    return workspace
-
-
-async def _require_owned_install(
+async def _require_cloud_copy_source_install(
     db: AsyncSession,
     *,
     user_id: UUID,
@@ -284,25 +266,9 @@ async def create_local_materialization_intent(
     db: AsyncSession,
     *,
     user_id: UUID,
-    workspace_id: UUID,
-    body: CreateMaterializationIntentRequest,
+    workspace: CloudWorkspaceValue,
+    desktop_install_id: str,
 ) -> MaterializationIntentResponse:
-    workspace = await _load_user_workspace(db, user_id=user_id, workspace_id=workspace_id)
-    if workspace.lost_at is not None:
-        raise CloudApiError(
-            "workspace_lost",
-            "This workspace was lost with its sandbox. Delete it instead of rematerializing it.",
-            status_code=409,
-        )
-    desktop_install_id = body.desktop_install_id.strip()
-    if not desktop_install_id:
-        raise CloudApiError(
-            "invalid_desktop_install",
-            "A desktop installation id is required.",
-            status_code=400,
-        )
-    await _require_owned_install(db, user_id=user_id, desktop_install_id=desktop_install_id)
-
     # A repo-less workspace (no repository identity — e.g. a #1245 scratch
     # workspace) cannot resolve a source repo/branch/HEAD, so a local
     # materialization intent has no meaning. Reject it cleanly rather than
@@ -332,7 +298,7 @@ async def create_local_materialization_intent(
     # creates/observes the local row and commits before the second reads it.
     active = await materialization_store.lock_active_materializations_for_workspace(
         db,
-        cloud_workspace_id=workspace_id,
+        cloud_workspace_id=workspace.id,
     )
 
     existing_local = next(
@@ -420,7 +386,7 @@ async def create_local_materialization_intent(
     else:
         row = await materialization_store.create_local_desktop_intent(
             db,
-            cloud_workspace_id=workspace_id,
+            cloud_workspace_id=workspace.id,
             desktop_install_id=desktop_install_id,
             expected_head_sha=status.head_oid,
             observed_branch=source_branch,
@@ -432,7 +398,7 @@ async def create_local_materialization_intent(
             # than bumping — the concurrent-double-intent convergence case.
             existing = await materialization_store.get_active_local_materialization(
                 db,
-                cloud_workspace_id=workspace_id,
+                cloud_workspace_id=workspace.id,
                 desktop_install_id=desktop_install_id,
                 lock_row=True,
             )
@@ -479,39 +445,12 @@ async def create_local_materialization_intent(
 async def report_materialization(
     db: AsyncSession,
     *,
-    user_id: UUID,
-    workspace_id: UUID,
-    materialization_id: UUID,
+    materialization: CloudWorkspaceMaterializationValue,
     body: ReportMaterializationRequest,
 ) -> WorkspaceMaterializationSummary:
-    workspace = await _load_user_workspace(db, user_id=user_id, workspace_id=workspace_id)
-    row = await materialization_store.load_materialization(
-        db,
-        materialization_id,
-        lock_row=True,
-    )
-    if row is None or row.cloud_workspace_id != workspace.id:
-        raise CloudApiError(
-            "materialization_not_found",
-            "Materialization not found.",
-            status_code=404,
-        )
-    if row.target_kind != "local_desktop":
-        raise CloudApiError(
-            "materialization_not_reportable",
-            "Only local materializations can be reported.",
-            status_code=409,
-        )
-    if row.desktop_install_id is not None:
-        await _require_owned_install(
-            db,
-            user_id=user_id,
-            desktop_install_id=row.desktop_install_id,
-        )
-
     # A stale generation (including one bumped by a concurrent unlink) is
     # rejected without mutating state.
-    if body.generation != row.generation or row.unlinked_at is not None:
+    if body.generation != materialization.generation or materialization.unlinked_at is not None:
         raise CloudApiError(
             "stale_materialization_generation",
             "This materialization report is stale.",
@@ -521,13 +460,13 @@ async def report_materialization(
     observed_head_sha = (body.observed_head_sha or "").strip() or None
     observed_branch = (body.observed_branch or "").strip() or None
     if body.state == "hydrated":
-        if observed_head_sha is None or observed_head_sha != row.expected_head_sha:
+        if observed_head_sha is None or observed_head_sha != materialization.expected_head_sha:
             raise CloudApiError(
                 "materialization_sha_mismatch",
                 "The reported HEAD does not match the expected source commit.",
                 status_code=409,
             )
-        if observed_branch is None or observed_branch != row.observed_branch:
+        if observed_branch is None or observed_branch != materialization.observed_branch:
             raise CloudApiError(
                 "materialization_branch_mismatch",
                 "The reported branch does not match the expected source branch.",
@@ -536,7 +475,7 @@ async def report_materialization(
 
     updated = await materialization_store.apply_report(
         db,
-        materialization_id,
+        materialization.id,
         state=body.state,
         anyharness_workspace_id=(body.anyharness_workspace_id or "").strip() or None,
         worktree_path=(body.worktree_path or "").strip() or None,
@@ -560,35 +499,9 @@ async def report_materialization(
 async def unlink_materialization(
     db: AsyncSession,
     *,
-    user_id: UUID,
-    workspace_id: UUID,
-    materialization_id: UUID,
+    materialization: CloudWorkspaceMaterializationValue,
 ) -> None:
-    workspace = await _load_user_workspace(db, user_id=user_id, workspace_id=workspace_id)
-    row = await materialization_store.load_materialization(
-        db,
-        materialization_id,
-        lock_row=True,
-    )
-    if row is None or row.cloud_workspace_id != workspace.id:
-        raise CloudApiError(
-            "materialization_not_found",
-            "Materialization not found.",
-            status_code=404,
-        )
-    if row.target_kind != "local_desktop":
-        raise CloudApiError(
-            "materialization_not_unlinkable",
-            "Only local materializations can be unlinked.",
-            status_code=409,
-        )
-    if row.unlinked_at is not None:
+    if materialization.unlinked_at is not None:
         # Already unlinked — idempotent success.
         return
-    if row.desktop_install_id is not None:
-        await _require_owned_install(
-            db,
-            user_id=user_id,
-            desktop_install_id=row.desktop_install_id,
-        )
-    await materialization_store.unlink_materialization(db, materialization_id)
+    await materialization_store.unlink_materialization(db, materialization.id)

--- a/server/tests/integration/test_cloud_workspace_materialization_service.py
+++ b/server/tests/integration/test_cloud_workspace_materialization_service.py
@@ -27,13 +27,14 @@ from proliferate.integrations.anyharness.models import RemoteGitStatusSnapshot
 from proliferate.integrations.github.repos import GitHubRepoBranches
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.integrations.anyharness.models import ResolvedRemoteWorkspace
+from proliferate.db.store import cloud_workspace_materializations as materialization_store
+from proliferate.db.store import cloud_workspaces as cloud_workspace_store
 from proliferate.server.cloud.workspaces import service as workspaces_service
 from proliferate.server.cloud.workspaces.materializations import (
     service as materializations_service,
 )
 from proliferate.server.cloud.workspaces.models import (
     CreateCloudWorkspaceRequest,
-    CreateMaterializationIntentRequest,
     ReportMaterializationRequest,
 )
 
@@ -185,13 +186,42 @@ def _patch_preflight(
 
 
 async def _intent(db, seed, body_install: str = _INSTALL):
+    workspace = await cloud_workspace_store.get_cloud_workspace_for_user(
+        db, seed.user.id, seed.workspace.id
+    )
+    assert workspace is not None
     return await materializations_service.create_local_materialization_intent(
         db,
         user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        body=CreateMaterializationIntentRequest(
-            targetKind="local_desktop", desktopInstallId=body_install
-        ),
+        workspace=workspace,
+        desktop_install_id=body_install.strip(),
+    )
+
+
+async def _materialization(db: AsyncSession, materialization_id: uuid.UUID):
+    materialization = await materialization_store.load_materialization(
+        db, materialization_id, lock_row=True
+    )
+    assert materialization is not None
+    return materialization
+
+
+async def _report(
+    db: AsyncSession,
+    materialization_id: uuid.UUID,
+    body: ReportMaterializationRequest,
+):
+    return await materializations_service.report_materialization(
+        db,
+        materialization=await _materialization(db, materialization_id),
+        body=body,
+    )
+
+
+async def _unlink(db: AsyncSession, materialization_id: uuid.UUID) -> None:
+    await materializations_service.unlink_materialization(
+        db,
+        materialization=await _materialization(db, materialization_id),
     )
 
 
@@ -215,13 +245,34 @@ async def test_intent_success_clean_published_source(
 
 
 @pytest.mark.asyncio
-async def test_intent_rejects_lost_workspace(db_session: AsyncSession) -> None:
-    seed = await _seed(db_session, lost=True)
+async def test_intent_uses_pre_authorized_workspace_and_install(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed = await _seed(db_session, with_worker=False, lost=True)
+    await _seed_managed_materialization(db_session, seed)
+    _patch_preflight(monkeypatch, snapshot=_snapshot())
+    await _intent(db_session, seed)
 
-    with pytest.raises(CloudApiError) as excinfo:
-        await _intent(db_session, seed)
 
-    assert excinfo.value.code == "workspace_lost"
+@pytest.mark.asyncio
+async def test_report_uses_pre_authorized_locked_materialization(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed = await _seed(db_session, with_worker=False)
+    await _seed_managed_materialization(db_session, seed)
+    _patch_preflight(monkeypatch, snapshot=_snapshot())
+    intent = await _intent(db_session, seed)
+    updated = await _report(
+        db_session,
+        uuid.UUID(intent.materialization.id),
+        ReportMaterializationRequest(
+            generation=intent.materialization.generation,
+            state="hydrated",
+            observedHeadSha=_HEAD,
+            observedBranch=_BRANCH,
+        ),
+    )
+    assert updated.state == "hydrated"
 
 
 @pytest.mark.asyncio
@@ -276,19 +327,6 @@ async def test_intent_blocked_when_branch_absent_on_github(
     with pytest.raises(CloudApiError) as excinfo:
         await _intent(db_session, seed)
     assert excinfo.value.code == "materialization_source_blocked"
-
-
-@pytest.mark.asyncio
-async def test_intent_requires_owned_install(
-    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    seed = await _seed(db_session, with_worker=False)
-    await _seed_managed_materialization(db_session, seed)
-    _patch_preflight(monkeypatch, snapshot=_snapshot())
-
-    with pytest.raises(CloudApiError) as excinfo:
-        await _intent(db_session, seed)
-    assert excinfo.value.code == "desktop_install_not_owned"
 
 
 @pytest.mark.asyncio
@@ -367,12 +405,10 @@ async def test_reintent_after_hydrated_bumps_generation(
     _patch_preflight(monkeypatch, snapshot=_snapshot())
 
     first = await _intent(db_session, seed)
-    await materializations_service.report_materialization(
+    await _report(
         db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=uuid.UUID(first.materialization.id),
-        body=ReportMaterializationRequest(
+        uuid.UUID(first.materialization.id),
+        ReportMaterializationRequest(
             generation=first.materialization.generation,
             state="hydrated",
             observedHeadSha=_HEAD,
@@ -402,12 +438,10 @@ async def test_reintent_after_failed_bumps_generation(
     _patch_preflight(monkeypatch, snapshot=_snapshot())
 
     first = await _intent(db_session, seed)
-    await materializations_service.report_materialization(
+    await _report(
         db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=uuid.UUID(first.materialization.id),
-        body=ReportMaterializationRequest(
+        uuid.UUID(first.materialization.id),
+        ReportMaterializationRequest(
             generation=first.materialization.generation,
             state="failed",
             failureCode="clone_failed",
@@ -431,12 +465,10 @@ async def test_report_exact_sha_and_branch_hydrates(
     _patch_preflight(monkeypatch, snapshot=_snapshot())
     intent = await _intent(db_session, seed)
 
-    updated = await materializations_service.report_materialization(
+    updated = await _report(
         db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=uuid.UUID(intent.materialization.id),
-        body=ReportMaterializationRequest(
+        uuid.UUID(intent.materialization.id),
+        ReportMaterializationRequest(
             generation=intent.materialization.generation,
             state="hydrated",
             observedHeadSha=_HEAD,
@@ -459,12 +491,10 @@ async def test_report_wrong_sha_rejected(
     intent = await _intent(db_session, seed)
 
     with pytest.raises(CloudApiError) as excinfo:
-        await materializations_service.report_materialization(
+        await _report(
             db_session,
-            user_id=seed.user.id,
-            workspace_id=seed.workspace.id,
-            materialization_id=uuid.UUID(intent.materialization.id),
-            body=ReportMaterializationRequest(
+            uuid.UUID(intent.materialization.id),
+            ReportMaterializationRequest(
                 generation=intent.materialization.generation,
                 state="hydrated",
                 observedHeadSha="wrong",
@@ -484,12 +514,10 @@ async def test_report_wrong_branch_rejected(
     intent = await _intent(db_session, seed)
 
     with pytest.raises(CloudApiError) as excinfo:
-        await materializations_service.report_materialization(
+        await _report(
             db_session,
-            user_id=seed.user.id,
-            workspace_id=seed.workspace.id,
-            materialization_id=uuid.UUID(intent.materialization.id),
-            body=ReportMaterializationRequest(
+            uuid.UUID(intent.materialization.id),
+            ReportMaterializationRequest(
                 generation=intent.materialization.generation,
                 state="hydrated",
                 observedHeadSha=_HEAD,
@@ -509,12 +537,10 @@ async def test_report_stale_generation_rejected_without_mutation(
     intent = await _intent(db_session, seed)
 
     with pytest.raises(CloudApiError) as excinfo:
-        await materializations_service.report_materialization(
+        await _report(
             db_session,
-            user_id=seed.user.id,
-            workspace_id=seed.workspace.id,
-            materialization_id=uuid.UUID(intent.materialization.id),
-            body=ReportMaterializationRequest(
+            uuid.UUID(intent.materialization.id),
+            ReportMaterializationRequest(
                 generation=intent.materialization.generation - 1,
                 state="hydrated",
                 observedHeadSha=_HEAD,
@@ -541,21 +567,14 @@ async def test_completion_racing_unlink_loses_via_generation(
     stale_generation = intent.materialization.generation
 
     # Unlink bumps generation and soft-deletes.
-    await materializations_service.unlink_materialization(
-        db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=mat_id,
-    )
+    await _unlink(db_session, mat_id)
 
     # A completion report carrying the pre-unlink generation must lose.
     with pytest.raises(CloudApiError) as excinfo:
-        await materializations_service.report_materialization(
+        await _report(
             db_session,
-            user_id=seed.user.id,
-            workspace_id=seed.workspace.id,
-            materialization_id=mat_id,
-            body=ReportMaterializationRequest(
+            mat_id,
+            ReportMaterializationRequest(
                 generation=stale_generation,
                 state="hydrated",
                 observedHeadSha=_HEAD,
@@ -586,22 +605,7 @@ async def test_unlink_only_local_and_is_non_destructive(
     )
     assert managed is not None
 
-    # Managed rows cannot be unlinked through this action.
-    with pytest.raises(CloudApiError) as excinfo:
-        await materializations_service.unlink_materialization(
-            db_session,
-            user_id=seed.user.id,
-            workspace_id=seed.workspace.id,
-            materialization_id=managed.id,
-        )
-    assert excinfo.value.code == "materialization_not_unlinkable"
-
-    await materializations_service.unlink_materialization(
-        db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=uuid.UUID(intent.materialization.id),
-    )
+    await _unlink(db_session, uuid.UUID(intent.materialization.id))
     # Managed row and the workspace itself untouched.
     still_managed = await store.get_active_managed_cloud_materialization(
         db_session, cloud_workspace_id=seed.workspace.id
@@ -620,12 +624,10 @@ async def test_read_selection_and_redaction(
     _patch_preflight(monkeypatch, snapshot=_snapshot())
     intent = await _intent(db_session, seed)
     # Hydrate the local row so it is a healthy selection candidate.
-    await materializations_service.report_materialization(
+    await _report(
         db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=uuid.UUID(intent.materialization.id),
-        body=ReportMaterializationRequest(
+        uuid.UUID(intent.materialization.id),
+        ReportMaterializationRequest(
             generation=intent.materialization.generation,
             state="hydrated",
             observedHeadSha=_HEAD,
@@ -1081,12 +1083,6 @@ async def test_repo_less_workspace_reads_and_rejects_intent(
         "get_cloud_workspace_for_user",
         _repo_less_lookup,
     )
-    monkeypatch.setattr(
-        materializations_service.cloud_workspace_store,
-        "get_cloud_workspace_for_user",
-        _repo_less_lookup,
-    )
-
     # Read path: repo/repoEnvironmentId are null, no crash; managed row present.
     detail = await workspaces_service.get_cloud_workspace_detail(
         db_session, seed.user.id, seed.workspace.id
@@ -1098,7 +1094,13 @@ async def test_repo_less_workspace_reads_and_rejects_intent(
     # Intent path: cleanly rejected for a repo-less workspace.
     _patch_preflight(monkeypatch, snapshot=_snapshot())
     with pytest.raises(CloudApiError) as excinfo:
-        await _intent(db_session, seed)
+        # Production access supplies this exact pre-authorized snapshot.
+        await materializations_service.create_local_materialization_intent(
+            db_session,
+            user_id=seed.user.id,
+            workspace=repo_less,
+            desktop_install_id=_INSTALL,
+        )
     assert excinfo.value.code == "materialization_source_unavailable"
 
 
@@ -1117,12 +1119,10 @@ async def test_other_install_id_is_redacted(
     await _seed_managed_materialization(db_session, seed)
     _patch_preflight(monkeypatch, snapshot=_snapshot())
     intent = await _intent(db_session, seed)
-    await materializations_service.report_materialization(
+    await _report(
         db_session,
-        user_id=seed.user.id,
-        workspace_id=seed.workspace.id,
-        materialization_id=uuid.UUID(intent.materialization.id),
-        body=ReportMaterializationRequest(
+        uuid.UUID(intent.materialization.id),
+        ReportMaterializationRequest(
             generation=intent.materialization.generation,
             state="hydrated",
             observedHeadSha=_HEAD,

--- a/server/tests/unit/test_cloud_workspace_materialization_access.py
+++ b/server/tests/unit/test_cloud_workspace_materialization_access.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from proliferate.db.engine import get_async_session
+from proliferate.db.store.cloud_workspace_materializations import (
+    CloudWorkspaceMaterializationValue,
+)
+from proliferate.db.store.cloud_workspaces import CloudWorkspaceValue
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.workspaces import api
+from proliferate.server.cloud.workspaces.materializations import access
+from proliferate.server.cloud.workspaces.materializations import service
+from proliferate.server.cloud.workspaces.models import (
+    CreateMaterializationIntentRequest,
+    ReportMaterializationRequest,
+)
+
+
+def _workspace(*, lost: bool = False) -> CloudWorkspaceValue:
+    now = datetime.now(UTC)
+    return CloudWorkspaceValue(
+        id=uuid.uuid4(),
+        owner_user_id=uuid.uuid4(),
+        workspace_kind="repository_worktree",
+        repo_environment_id=uuid.uuid4(),
+        display_name="workspace",
+        git_branch="feature/access",
+        git_base_branch="main",
+        anyharness_workspace_id="managed-workspace",
+        created_at=now,
+        updated_at=now,
+        archived_at=None,
+        lost_at=now if lost else None,
+    )
+
+
+def _materialization(
+    workspace: CloudWorkspaceValue,
+    *,
+    target_kind: str = "local_desktop",
+    desktop_install_id: str | None = "desktop-a",
+    unlinked: bool = False,
+) -> CloudWorkspaceMaterializationValue:
+    now = datetime.now(UTC)
+    return CloudWorkspaceMaterializationValue(
+        id=uuid.uuid4(),
+        cloud_workspace_id=workspace.id,
+        target_kind=target_kind,
+        cloud_sandbox_id=None,
+        desktop_install_id=desktop_install_id,
+        anyharness_workspace_id=None,
+        worktree_path=None,
+        state="pending",
+        generation=1,
+        expected_head_sha="head",
+        observed_head_sha=None,
+        observed_branch="feature/access",
+        failure_code=None,
+        failure_detail=None,
+        last_reported_at=None,
+        unlinked_at=now if unlinked else None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _intent(install_id: str = "desktop-a") -> CreateMaterializationIntentRequest:
+    return CreateMaterializationIntentRequest(
+        targetKind="local_desktop", desktopInstallId=install_id
+    )
+
+
+def _assert_error(
+    excinfo: pytest.ExceptionInfo[CloudApiError],
+    *,
+    code: str,
+    message: str,
+    status_code: int,
+) -> None:
+    assert excinfo.value.code == code
+    assert excinfo.value.message == message
+    assert excinfo.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_missing_workspace_masks_access_and_stops_later_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    user = SimpleNamespace(id=uuid.uuid4())
+    workers = AsyncMock()
+    monkeypatch.setattr(
+        access.cloud_workspace_store,
+        "get_cloud_workspace_for_user",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        access.runtime_workers_store, "get_active_desktop_worker_for_user", workers
+    )
+
+    with pytest.raises(CloudApiError) as excinfo:
+        await access.create_local_materialization_access(uuid.uuid4(), _intent(), user, db)  # type: ignore[arg-type]
+
+    _assert_error(
+        excinfo,
+        code="workspace_not_found",
+        message="Cloud workspace not found.",
+        status_code=404,
+    )
+    workers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_access_preserves_failure_order_and_normalizes_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    user = SimpleNamespace(id=uuid.uuid4())
+    workers = AsyncMock(return_value=object())
+    monkeypatch.setattr(
+        access.runtime_workers_store, "get_active_desktop_worker_for_user", workers
+    )
+
+    lost = _workspace(lost=True)
+    monkeypatch.setattr(
+        access.cloud_workspace_store,
+        "get_cloud_workspace_for_user",
+        AsyncMock(return_value=lost),
+    )
+    with pytest.raises(CloudApiError) as lost_error:
+        await access.create_local_materialization_access(lost.id, _intent(""), user, db)  # type: ignore[arg-type]
+    _assert_error(
+        lost_error,
+        code="workspace_lost",
+        message=(
+            "This workspace was lost with its sandbox. Delete it instead of rematerializing it."
+        ),
+        status_code=409,
+    )
+    workers.assert_not_awaited()
+
+    workspace = _workspace()
+    monkeypatch.setattr(
+        access.cloud_workspace_store,
+        "get_cloud_workspace_for_user",
+        AsyncMock(return_value=workspace),
+    )
+    with pytest.raises(CloudApiError) as empty_error:
+        await access.create_local_materialization_access(workspace.id, _intent("  "), user, db)  # type: ignore[arg-type]
+    _assert_error(
+        empty_error,
+        code="invalid_desktop_install",
+        message="A desktop installation id is required.",
+        status_code=400,
+    )
+    workers.assert_not_awaited()
+
+    workers.return_value = None
+    with pytest.raises(CloudApiError) as ownership_error:
+        await access.create_local_materialization_access(
+            workspace.id, _intent(" desktop-a "), user, db
+        )  # type: ignore[arg-type]
+    _assert_error(
+        ownership_error,
+        code="desktop_install_not_owned",
+        message="This desktop installation is not registered to your account.",
+        status_code=403,
+    )
+    workers.assert_awaited_once_with(db, owner_user_id=user.id, desktop_install_id="desktop-a")
+
+    workers.reset_mock(return_value=True)
+    workers.return_value = object()
+    result = await access.create_local_materialization_access(
+        workspace.id,
+        _intent(" desktop-a "),
+        user,
+        db,  # type: ignore[arg-type]
+    )
+    assert result.actor_user_id == user.id
+    assert result.workspace is workspace
+    assert result.desktop_install_id == "desktop-a"
+    workers.assert_awaited_once_with(db, owner_user_id=user.id, desktop_install_id="desktop-a")
+
+
+@pytest.mark.asyncio
+async def test_report_access_locks_and_enforces_relation_target_and_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    user = SimpleNamespace(id=uuid.uuid4())
+    workspace = _workspace()
+    workers = AsyncMock(return_value=object())
+    monkeypatch.setattr(
+        access.cloud_workspace_store,
+        "get_cloud_workspace_for_user",
+        AsyncMock(return_value=workspace),
+    )
+    monkeypatch.setattr(
+        access.runtime_workers_store, "get_active_desktop_worker_for_user", workers
+    )
+
+    foreign = _materialization(_workspace())
+    loader = AsyncMock(return_value=foreign)
+    monkeypatch.setattr(access.materialization_store, "load_materialization", loader)
+    with pytest.raises(CloudApiError) as mismatch_error:
+        await access.report_local_materialization_access(workspace.id, foreign.id, user, db)  # type: ignore[arg-type]
+    _assert_error(
+        mismatch_error,
+        code="materialization_not_found",
+        message="Materialization not found.",
+        status_code=404,
+    )
+    loader.assert_awaited_once_with(db, foreign.id, lock_row=True)
+    workers.assert_not_awaited()
+
+    managed = _materialization(workspace, target_kind="managed_cloud")
+    loader.reset_mock(return_value=True)
+    loader.return_value = managed
+    with pytest.raises(CloudApiError) as target_error:
+        await access.report_local_materialization_access(workspace.id, managed.id, user, db)  # type: ignore[arg-type]
+    _assert_error(
+        target_error,
+        code="materialization_not_reportable",
+        message="Only local materializations can be reported.",
+        status_code=409,
+    )
+
+    row = _materialization(workspace)
+    loader.reset_mock(return_value=True)
+    loader.return_value = row
+    result = await access.report_local_materialization_access(workspace.id, row.id, user, db)  # type: ignore[arg-type]
+    assert result.workspace is workspace
+    assert result.materialization is row
+    workers.assert_awaited_once_with(db, owner_user_id=user.id, desktop_install_id="desktop-a")
+
+
+@pytest.mark.asyncio
+async def test_unlink_access_preserves_relation_target_and_replay_exemptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    user = SimpleNamespace(id=uuid.uuid4())
+    workspace = _workspace()
+    workers = AsyncMock(return_value=object())
+    monkeypatch.setattr(
+        access.cloud_workspace_store,
+        "get_cloud_workspace_for_user",
+        AsyncMock(return_value=workspace),
+    )
+    monkeypatch.setattr(
+        access.runtime_workers_store, "get_active_desktop_worker_for_user", workers
+    )
+    loader = AsyncMock()
+    monkeypatch.setattr(access.materialization_store, "load_materialization", loader)
+
+    managed = _materialization(workspace, target_kind="managed_cloud")
+    loader.return_value = managed
+    with pytest.raises(CloudApiError) as target_error:
+        await access.unlink_local_materialization_access(workspace.id, managed.id, user, db)  # type: ignore[arg-type]
+    _assert_error(
+        target_error,
+        code="materialization_not_unlinkable",
+        message="Only local materializations can be unlinked.",
+        status_code=409,
+    )
+
+    for row in (
+        _materialization(workspace, unlinked=True),
+        _materialization(workspace, desktop_install_id=None),
+    ):
+        loader.reset_mock(return_value=True)
+        loader.return_value = row
+        workers.reset_mock()
+        result = await access.unlink_local_materialization_access(workspace.id, row.id, user, db)  # type: ignore[arg-type]
+        assert result.materialization is row
+        loader.assert_awaited_once_with(db, row.id, lock_row=True)
+        workers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_routes_pass_exact_access_snapshots_and_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = object()
+    workspace = _workspace()
+    row = _materialization(workspace)
+    create = AsyncMock(return_value=object())
+    report = AsyncMock(return_value=object())
+    unlink = AsyncMock()
+    monkeypatch.setattr(service, "create_local_materialization_intent", create)
+    monkeypatch.setattr(service, "report_materialization", report)
+    monkeypatch.setattr(service, "unlink_materialization", unlink)
+    create_access = access.CreateLocalMaterializationAccess(uuid.uuid4(), workspace, "desktop-a")
+    existing_access = access.ExistingLocalMaterializationAccess(
+        create_access.actor_user_id, workspace, row
+    )
+    body = ReportMaterializationRequest(generation=1, state="failed")
+
+    await api.create_workspace_materialization_intent_endpoint(
+        workspace.id,
+        _intent(),
+        create_access,
+        db,  # type: ignore[arg-type]
+    )
+    await api.report_workspace_materialization_endpoint(
+        workspace.id,
+        row.id,
+        body,
+        existing_access,
+        db,  # type: ignore[arg-type]
+    )
+    await api.unlink_workspace_materialization_endpoint(
+        workspace.id,
+        row.id,
+        existing_access,
+        db,  # type: ignore[arg-type]
+    )
+
+    assert create.await_args.args[0] is db
+    assert create.await_args.kwargs["workspace"] is workspace
+    assert report.await_args.args[0] is db
+    assert report.await_args.kwargs["materialization"] is row
+    assert unlink.await_args.args[0] is db
+    assert unlink.await_args.kwargs["materialization"] is row
+
+
+@pytest.mark.asyncio
+async def test_denied_access_never_invokes_router_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(api.router, prefix="/v1/cloud")
+    service_call = AsyncMock()
+
+    async def denied_access() -> access.CreateLocalMaterializationAccess:
+        raise CloudApiError("workspace_not_found", "Cloud workspace not found.", status_code=404)
+
+    app.dependency_overrides[access.create_local_materialization_access] = denied_access
+    app.dependency_overrides[get_async_session] = lambda: object()
+    monkeypatch.setattr(service, "create_local_materialization_intent", service_call)
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/v1/cloud/workspaces/00000000-0000-0000-0000-000000000001/materializations",
+            json={"targetKind": "local_desktop", "desktopInstallId": "desktop-a"},
+        )
+
+    assert response.status_code == 500
+    service_call.assert_not_awaited()
+
+
+def test_access_module_has_only_the_frozen_read_seams() -> None:
+    source = inspect.getsource(access)
+    assert source.count("get_cloud_workspace_for_user") == 1
+    assert source.count("load_materialization") == 1
+    assert source.count("get_active_desktop_worker_for_user") == 1
+    for forbidden in (
+        "create_local_desktop_intent",
+        "refresh_local_desktop_intent",
+        "apply_report",
+        "unlink_materialization(",
+        "commit(",
+        "rollback(",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## Summary

- move organization and repository authorization for workspace materialization routes into the route dependency boundary
- hand services locked, pre-authorized workspace and materialization snapshots while preserving same-session transaction behavior
- retain the narrow exact-reference recovery helper and its single worker lookup for replay-safe reconciliation
- add focused access and concurrency characterization coverage

## Stack

Depends on #1612. To land after that prerequisite, rebase only this slice commit onto the accepted mainline, retarget, and rerun proof plus independent review.

## Verification

- serialized frozen focused pytest lane completed
- targeted repaired repo-less regression passed
- Ruff check and format check
- Mypy on changed server modules
- server boundary, max-lines, design-attribution, and diff checks
- independent SG30 review: ACCEPT, no findings

## Specification

Server Grid 30, Frozen revision 2, SHA256 1d0926d45142996629673a7572d31324e1052dcb3f7ff840d273dc67fe4d472f.