### PR TITLE
fix(composer): restore chat focus after model menu closes

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
@@ -109,6 +109,7 @@ export function ComposerModelOptionsSubmenu({
               group={group}
               currentKind={currentKind}
               showSeparator={index > 0}
+              onKeyboardSelect={onKeyboardSelect}
               onSelect={onSelect}
               highlightedKey={effectiveHighlightedKey}
               onHighlight={setHighlightedKey}
@@ -137,6 +138,7 @@ function ModelPickerGroup({
   group,
   currentKind,
   showSeparator,
+  onKeyboardSelect,
   onSelect,
   highlightedKey,
   onHighlight,
@@ -145,6 +147,7 @@ function ModelPickerGroup({
   group: ModelSelectorGroup;
   currentKind: string | null;
   showSeparator: boolean;
+  onKeyboardSelect: () => void;
   onSelect: (selection: ModelSelectorSelection) => void;
   highlightedKey: string | null;
   onHighlight: (key: string) => void;
@@ -194,6 +197,16 @@ function ModelPickerGroup({
             className={`items-start px-2.5 py-2 text-composer ${
               !model.isUnsupported && (model.isSelected || isHighlighted) ? "bg-hover" : ""
             }`}
+            // Keyboard submenu navigation focuses the rows themselves (the
+            // menu, not the search field, owns focus after a keyboard open),
+            // and the menu primitive turns Enter/Space on a focused row into a
+            // click-select. Mark the close as keyboard-driven before that
+            // conversion runs; onSelect cannot tell keyboard from pointer.
+            onKeyDown={(event) => {
+              if (event.target === event.currentTarget && (event.key === "Enter" || event.key === " ")) {
+                onKeyboardSelect();
+              }
+            }}
             onSelect={() => onSelect({ kind: group.kind, modelId: model.modelId })}
           >
             <ProviderIcon kind={group.kind} className="icon-compact mt-0.5 shrink-0 text-muted-foreground [font-size:var(--text-composer)]" />

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
@@ -26,11 +26,13 @@ export function ComposerModelOptionsSubmenu({
   groups,
   currentModel,
   currentModelLabel,
+  onEscapeKeyDown,
   onSelect,
 }: {
   groups: ModelSelectorGroup[];
   currentModel: ModelSelectorProps["currentModel"];
   currentModelLabel: string;
+  onEscapeKeyDown: () => void;
   onSelect: (selection: ModelSelectorSelection) => void;
 }) {
   const currentKind = currentModel?.kind ?? null;
@@ -79,6 +81,7 @@ export function ComposerModelOptionsSubmenu({
         sideOffset={4}
         alignOffset={-4}
         className="flex max-h-96 w-72 flex-col overflow-hidden p-0"
+        onEscapeKeyDown={onEscapeKeyDown}
       >
         <div className="shrink-0 border-b border-border">
           <PopoverSearchField

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelOptionsSubmenu.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
 import { splitProviderDisplayName } from "#product/lib/domain/chat/models/model-display-name-parts";
 import { orderModelGroupsActiveFirst } from "#product/lib/domain/chat/models/order-model-groups";
@@ -27,18 +27,24 @@ export function ComposerModelOptionsSubmenu({
   currentModel,
   currentModelLabel,
   onEscapeKeyDown,
+  onKeyboardSelect,
   onSelect,
 }: {
   groups: ModelSelectorGroup[];
   currentModel: ModelSelectorProps["currentModel"];
   currentModelLabel: string;
   onEscapeKeyDown: () => void;
+  onKeyboardSelect: () => void;
   onSelect: (selection: ModelSelectorSelection) => void;
 }) {
   const currentKind = currentModel?.kind ?? null;
   const orderedGroups = orderModelGroupsActiveFirst(groups, currentKind);
   const [search, setSearch] = useState("");
   const [open, setOpen] = useState(false);
+  const handleKeyboardSelect = useCallback((selection: ModelSelectorSelection) => {
+    onKeyboardSelect();
+    onSelect(selection);
+  }, [onKeyboardSelect, onSelect]);
 
   const filteredGroups = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -65,7 +71,7 @@ export function ComposerModelOptionsSubmenu({
     setHighlightedKey,
     setRowRef,
     handleSearchKeyDown,
-  } = useModelPickerKeyboardNav(filteredGroups, onSelect);
+  } = useModelPickerKeyboardNav(filteredGroups, handleKeyboardSelect);
 
   return (
     <DropdownMenuSub open={open} onOpenChange={setOpen}>

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
@@ -46,6 +46,7 @@ function createKeyboardModelSelectorProps(): ModelSelectorProps {
         providerDisplayName: "Claude Code",
         models: [
           { kind: "claude", modelId: "haiku", displayName: "Haiku 4.5", actionKind: "select", isSelected: true, isUnsupported: false },
+          { kind: "claude", modelId: "sonnet", displayName: "Sonnet 4.5", actionKind: "select", isSelected: false, isUnsupported: false },
         ],
       },
     ],
@@ -409,6 +410,52 @@ it("restores composer focus when Escape closes the model menu", async () => {
 
   fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
 
+  await waitFor(() => {
+    expect(
+      container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
+    ).toBe("closed");
+    expect(document.activeElement).toBe(prompt);
+  });
+  expect(prompt.selectionStart).toBe(4);
+  expect(prompt.selectionEnd).toBe(4);
+});
+
+it("restores composer focus after Return selects a model", async () => {
+  vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+  const props = createKeyboardModelSelectorProps();
+  const { container } = render(
+    <MemoryRouter>
+      <ShortcutDispatcher />
+      <div data-focus-zone="chat">
+        <textarea data-chat-composer-editor defaultValue="Keep typing" />
+        <ComposerModelSelectorControl
+          modelSelectorProps={props}
+          keyboardShortcutEnabled
+        />
+      </div>
+    </MemoryRouter>,
+  );
+  const prompt = container.querySelector<HTMLTextAreaElement>("[data-chat-composer-editor]")!;
+  prompt.focus();
+  prompt.setSelectionRange(4, 4);
+
+  fireEvent.keyDown(prompt, {
+    key: "M",
+    code: "KeyM",
+    ctrlKey: true,
+    shiftKey: true,
+  });
+  const modelMenu = document.querySelector<HTMLElement>("[data-composer-model-menu]")!;
+  modelMenu.focus();
+  fireEvent.keyDown(modelMenu, { key: "Enter", code: "Enter" });
+  const search = document.querySelector<HTMLInputElement>('input[placeholder="Search models"]')!;
+  search.focus();
+  expect(document.activeElement).toBe(search);
+
+  fireEvent.keyDown(search, { key: "ArrowDown", code: "ArrowDown" });
+  fireEvent.keyDown(search, { key: "Enter", code: "Enter" });
+
+  expect(props.onSelect).toHaveBeenCalledWith({ kind: "claude", modelId: "sonnet" });
   await waitFor(() => {
     expect(
       container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
@@ -466,6 +466,57 @@ it("restores composer focus after Return selects a model", async () => {
   expect(prompt.selectionEnd).toBe(4);
 });
 
+// The all-keyboard flow moves focus onto the model rows rather than the search
+// field. Regression coverage for Return activating a focused row on that path.
+it("restores composer focus after Return activates a focused model row", async () => {
+  vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+  const props = createKeyboardModelSelectorProps();
+  const { container } = render(
+    <MemoryRouter>
+      <ShortcutDispatcher />
+      <div data-focus-zone="chat">
+        <textarea data-chat-composer-editor defaultValue="Keep typing" />
+        <ComposerModelSelectorControl
+          modelSelectorProps={props}
+          keyboardShortcutEnabled
+        />
+      </div>
+    </MemoryRouter>,
+  );
+  const prompt = container.querySelector<HTMLTextAreaElement>("[data-chat-composer-editor]")!;
+  prompt.focus();
+  prompt.setSelectionRange(4, 4);
+
+  fireEvent.keyDown(prompt, {
+    key: "M",
+    code: "KeyM",
+    ctrlKey: true,
+    shiftKey: true,
+  });
+  const modelMenu = document.querySelector<HTMLElement>("[data-composer-model-menu]")!;
+  modelMenu.focus();
+  fireEvent.keyDown(modelMenu, { key: "Enter", code: "Enter" });
+
+  await waitFor(() => {
+    expect(document.activeElement?.getAttribute("data-model-option")).toBe("haiku");
+  });
+  fireEvent.keyDown(document.activeElement!, { key: "ArrowDown", code: "ArrowDown" });
+  await waitFor(() => {
+    expect(document.activeElement?.getAttribute("data-model-option")).toBe("sonnet");
+  });
+  fireEvent.keyDown(document.activeElement!, { key: "Enter", code: "Enter" });
+
+  expect(props.onSelect).toHaveBeenCalledWith({ kind: "claude", modelId: "sonnet" });
+  await waitFor(() => {
+    expect(
+      container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
+    ).toBe("closed");
+    expect(document.activeElement).toBe(prompt);
+  });
+  expect(prompt.selectionStart).toBe(4);
+  expect(prompt.selectionEnd).toBe(4);
+});
+
 it("does not restore Escape focus to a composer hidden behind another route", async () => {
   const props = createKeyboardModelSelectorProps();
   const { container } = render(

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, expect, it, vi } from "vitest";
 import { ComposerModelSelectorControl } from "#product/components/workspace/chat/input/ComposerModelSelectorControl";
@@ -34,6 +34,25 @@ function openModelOptions(container: HTMLElement) {
     ctrlKey: false,
   });
   fireEvent.click(document.querySelector<HTMLElement>("[data-composer-model-menu]")!);
+}
+
+function createKeyboardModelSelectorProps(): ModelSelectorProps {
+  return {
+    connectionState: "healthy",
+    currentModel: { kind: "claude", displayName: "Haiku 4.5", pendingState: null },
+    groups: [
+      {
+        kind: "claude",
+        providerDisplayName: "Claude Code",
+        models: [
+          { kind: "claude", modelId: "haiku", displayName: "Haiku 4.5", actionKind: "select", isSelected: true, isUnsupported: false },
+        ],
+      },
+    ],
+    hasAgents: true,
+    isLoading: false,
+    onSelect: vi.fn(),
+  };
 }
 
 it("identifies model rows by both harness kind and model id", () => {
@@ -255,24 +274,9 @@ it("opens the picker when a refusal asks for it, and again on the next refusal",
   expect(menuState()).toBe("open");
 });
 
-it("toggles model options from the active macOS workspace, not a background route", () => {
+it("toggles model options from the active macOS workspace and restores composer focus", async () => {
   vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
-  const props: ModelSelectorProps = {
-    connectionState: "healthy",
-    currentModel: { kind: "claude", displayName: "Haiku 4.5", pendingState: null },
-    groups: [
-      {
-        kind: "claude",
-        providerDisplayName: "Claude Code",
-        models: [
-          { kind: "claude", modelId: "haiku", displayName: "Haiku 4.5", actionKind: "select", isSelected: true, isUnsupported: false },
-        ],
-      },
-    ],
-    hasAgents: true,
-    isLoading: false,
-    onSelect: vi.fn(),
-  };
+  const props = createKeyboardModelSelectorProps();
   const reasoningControl: LiveSessionControlDescriptor = {
     key: "effort",
     label: "Reasoning effort",
@@ -291,15 +295,19 @@ it("toggles model options from the active macOS workspace, not a background rout
   const { container, unmount } = render(
     <MemoryRouter>
       <ShortcutDispatcher />
-      <ComposerModelSelectorControl
-        modelSelectorProps={props}
-        reasoningControl={reasoningControl}
-        keyboardShortcutEnabled
-      />
+      <div data-focus-zone="chat">
+        <textarea data-chat-composer-editor defaultValue="Keep typing" />
+        <ComposerModelSelectorControl
+          modelSelectorProps={props}
+          reasoningControl={reasoningControl}
+          keyboardShortcutEnabled
+        />
+      </div>
     </MemoryRouter>,
   );
-  const prompt = document.createElement("textarea");
-  document.body.append(prompt);
+  const prompt = container.querySelector<HTMLTextAreaElement>("[data-chat-composer-editor]")!;
+  prompt.focus();
+  prompt.setSelectionRange(4, 4);
   const shortcut = new KeyboardEvent("keydown", {
     key: "M",
     code: "KeyM",
@@ -334,7 +342,11 @@ it("toggles model options from the active macOS workspace, not a background rout
   expect(
     container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
   ).toBe("closed");
-  prompt.remove();
+  await waitFor(() => {
+    expect(document.activeElement).toBe(prompt);
+  });
+  expect(prompt.selectionStart).toBe(4);
+  expect(prompt.selectionEnd).toBe(4);
 
   unmount();
   const hidden = render(
@@ -367,4 +379,71 @@ it("toggles model options from the active macOS workspace, not a background rout
     hidden.container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
   ).toBe("closed");
   settingsPrompt.remove();
+});
+
+it("restores composer focus when Escape closes the model menu", async () => {
+  vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+  const props = createKeyboardModelSelectorProps();
+
+  const { container } = render(
+    <MemoryRouter>
+      <ShortcutDispatcher />
+      <div data-focus-zone="chat">
+        <textarea data-chat-composer-editor defaultValue="Keep typing" />
+        <ComposerModelSelectorControl
+          modelSelectorProps={props}
+          keyboardShortcutEnabled
+        />
+      </div>
+    </MemoryRouter>,
+  );
+  const prompt = container.querySelector<HTMLTextAreaElement>("[data-chat-composer-editor]")!;
+  prompt.focus();
+  prompt.setSelectionRange(4, 4);
+
+  openModelOptions(container);
+  expect(
+    container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
+  ).toBe("open");
+  expect(document.querySelector("[data-model-option]")).not.toBeNull();
+
+  fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+
+  await waitFor(() => {
+    expect(
+      container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
+    ).toBe("closed");
+    expect(document.activeElement).toBe(prompt);
+  });
+  expect(prompt.selectionStart).toBe(4);
+  expect(prompt.selectionEnd).toBe(4);
+});
+
+it("does not restore Escape focus to a composer hidden behind another route", async () => {
+  const props = createKeyboardModelSelectorProps();
+  const { container } = render(
+    <MemoryRouter initialEntries={["/settings"]}>
+      <div aria-hidden="true">
+        <div data-focus-zone="chat">
+          <textarea data-chat-composer-editor defaultValue="Hidden draft" />
+          <ComposerModelSelectorControl
+            modelSelectorProps={props}
+            keyboardShortcutEnabled
+          />
+        </div>
+      </div>
+    </MemoryRouter>,
+  );
+  const prompt = container.querySelector<HTMLTextAreaElement>("[data-chat-composer-editor]")!;
+  prompt.focus();
+
+  openModelOptions(container);
+  fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+
+  await waitFor(() => {
+    expect(
+      container.querySelector("[data-composer-model-trigger]")?.getAttribute("data-state"),
+    ).toBe("closed");
+  });
+  expect(document.activeElement).not.toBe(prompt);
 });

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -83,7 +83,7 @@ export function ComposerModelSelectorControl({
     enabled: keyboardFocusRestoreEnabled && selectorEnabled,
     priority: "contextual",
   });
-  const handleEscapeKeyDown = useCallback(() => {
+  const handleKeyboardClose = useCallback(() => {
     if (keyboardFocusRestoreEnabled) {
       restoreComposerFocusOnCloseRef.current = true;
     }
@@ -180,7 +180,7 @@ export function ComposerModelSelectorControl({
           align="start"
           sideOffset={2}
           className="w-56 min-w-56"
-          onEscapeKeyDown={handleEscapeKeyDown}
+          onEscapeKeyDown={handleKeyboardClose}
           onCloseAutoFocus={(event) => {
             event.preventDefault();
             const shouldRestoreComposerFocus = restoreComposerFocusOnCloseRef.current;
@@ -196,7 +196,8 @@ export function ComposerModelSelectorControl({
             currentModelLabel={triggerLabel}
             reasoningControl={reasoningControl}
             fastModeControl={fastModeControl}
-            onEscapeKeyDown={handleEscapeKeyDown}
+            onEscapeKeyDown={handleKeyboardClose}
+            onKeyboardSelect={handleKeyboardClose}
             onSelect={(selection) => {
               onSelect(selection);
               setPickerOpen(false);
@@ -233,6 +234,7 @@ function ComposerModelPickerMenu({
   reasoningControl,
   fastModeControl,
   onEscapeKeyDown,
+  onKeyboardSelect,
   onSelect,
   onAddProvider,
   onSettings,
@@ -243,6 +245,7 @@ function ComposerModelPickerMenu({
   reasoningControl: LiveSessionControlDescriptor | null;
   fastModeControl: LiveSessionControlDescriptor | null;
   onEscapeKeyDown: () => void;
+  onKeyboardSelect: () => void;
   onSelect: (selection: ModelSelectorSelection) => void;
   onAddProvider: () => void;
   onSettings: () => void;
@@ -254,6 +257,7 @@ function ComposerModelPickerMenu({
         currentModel={currentModel}
         currentModelLabel={currentModelLabel}
         onEscapeKeyDown={onEscapeKeyDown}
+        onKeyboardSelect={onKeyboardSelect}
         onSelect={onSelect}
       />
       <ComposerModelTuningControls

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { APP_ROUTES } from "#product/config/app-routes";
 import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
@@ -31,6 +31,7 @@ import { useModelSupportStore } from "#product/stores/chat/model-support-store";
 import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import { ComposerModelTuningControls } from "#product/components/workspace/chat/input/ComposerModelTuningControls";
 import { ComposerModelOptionsSubmenu } from "#product/components/workspace/chat/input/ComposerModelOptionsSubmenu";
+import { focusChatInput } from "#product/lib/domain/focus-zone";
 
 interface ComposerModelSelectorControlProps {
   modelSelectorProps: ModelSelectorProps;
@@ -64,6 +65,9 @@ export function ComposerModelSelectorControl({
   // each reopen it, and nothing has to reset a flag.
   const pickerRequestNonce = useModelSupportStore((state) => state.pickerRequestNonce);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const restoreComposerFocusOnCloseRef = useRef(false);
+  const keyboardFocusRestoreEnabled = keyboardShortcutEnabled
+    && location.pathname === APP_ROUTES.home;
   useEffect(() => {
     if (pickerRequestNonce === 0) {
       return;
@@ -71,13 +75,19 @@ export function ComposerModelSelectorControl({
     setPickerOpen(true);
   }, [pickerRequestNonce]);
   useShortcutHandler("workspace.open-model-selector", () => {
+    if (pickerOpen && keyboardFocusRestoreEnabled) {
+      restoreComposerFocusOnCloseRef.current = true;
+    }
     setPickerOpen((open) => !open);
   }, {
-    enabled: keyboardShortcutEnabled
-      && selectorEnabled
-      && location.pathname === APP_ROUTES.home,
+    enabled: keyboardFocusRestoreEnabled && selectorEnabled,
     priority: "contextual",
   });
+  const handleEscapeKeyDown = useCallback(() => {
+    if (keyboardFocusRestoreEnabled) {
+      restoreComposerFocusOnCloseRef.current = true;
+    }
+  }, [keyboardFocusRestoreEnabled]);
   const triggerLabel = resolveTriggerLabel(modelSelectorProps);
   const selectedReasoningOption = reasoningControl?.options.find((option) => option.selected) ?? null;
   const reasoningLabel = resolveReasoningEffortPresentation(
@@ -170,7 +180,15 @@ export function ComposerModelSelectorControl({
           align="start"
           sideOffset={2}
           className="w-56 min-w-56"
-          onCloseAutoFocus={(event) => event.preventDefault()}
+          onEscapeKeyDown={handleEscapeKeyDown}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            const shouldRestoreComposerFocus = restoreComposerFocusOnCloseRef.current;
+            restoreComposerFocusOnCloseRef.current = false;
+            if (shouldRestoreComposerFocus && keyboardFocusRestoreEnabled) {
+              focusChatInput();
+            }
+          }}
         >
           <ComposerModelPickerMenu
             groups={groups}
@@ -178,6 +196,7 @@ export function ComposerModelSelectorControl({
             currentModelLabel={triggerLabel}
             reasoningControl={reasoningControl}
             fastModeControl={fastModeControl}
+            onEscapeKeyDown={handleEscapeKeyDown}
             onSelect={(selection) => {
               onSelect(selection);
               setPickerOpen(false);
@@ -213,6 +232,7 @@ function ComposerModelPickerMenu({
   currentModelLabel,
   reasoningControl,
   fastModeControl,
+  onEscapeKeyDown,
   onSelect,
   onAddProvider,
   onSettings,
@@ -222,6 +242,7 @@ function ComposerModelPickerMenu({
   currentModelLabel: string;
   reasoningControl: LiveSessionControlDescriptor | null;
   fastModeControl: LiveSessionControlDescriptor | null;
+  onEscapeKeyDown: () => void;
   onSelect: (selection: ModelSelectorSelection) => void;
   onAddProvider: () => void;
   onSettings: () => void;
@@ -232,15 +253,18 @@ function ComposerModelPickerMenu({
         groups={groups}
         currentModel={currentModel}
         currentModelLabel={currentModelLabel}
+        onEscapeKeyDown={onEscapeKeyDown}
         onSelect={onSelect}
       />
       <ComposerModelTuningControls
         reasoningControl={reasoningControl}
         fastModeControl={fastModeControl}
+        onEscapeKeyDown={onEscapeKeyDown}
       />
       <DropdownMenuSeparator />
       <AdvancedOptionsSubmenu
         onAddProvider={onAddProvider}
+        onEscapeKeyDown={onEscapeKeyDown}
         onSettings={onSettings}
       />
     </>
@@ -249,9 +273,11 @@ function ComposerModelPickerMenu({
 
 function AdvancedOptionsSubmenu({
   onAddProvider,
+  onEscapeKeyDown,
   onSettings,
 }: {
   onAddProvider: () => void;
+  onEscapeKeyDown: () => void;
   onSettings: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -264,7 +290,12 @@ function AdvancedOptionsSubmenu({
       >
         Advanced
       </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent sideOffset={4} alignOffset={-4} className="w-56">
+      <DropdownMenuSubContent
+        sideOffset={4}
+        alignOffset={-4}
+        className="w-56"
+        onEscapeKeyDown={onEscapeKeyDown}
+      >
         <DropdownMenuItem onSelect={onAddProvider}>
           <Plus className="icon-compact shrink-0" />
           <span>Add provider</span>

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelTuningControls.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelTuningControls.tsx
@@ -13,6 +13,7 @@ import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/sess
 interface ComposerModelTuningControlsProps {
   reasoningControl: LiveSessionControlDescriptor | null;
   fastModeControl: LiveSessionControlDescriptor | null;
+  onEscapeKeyDown: () => void;
 }
 
 interface TuningOption {
@@ -24,6 +25,7 @@ interface TuningOption {
 export function ComposerModelTuningControls({
   reasoningControl,
   fastModeControl,
+  onEscapeKeyDown,
 }: ComposerModelTuningControlsProps) {
   const reasoningOptions = reasoningControl?.options.map((option) => ({
     value: option.value,
@@ -48,6 +50,7 @@ export function ComposerModelTuningControls({
           label="Effort"
           control={reasoningControl}
           options={reasoningOptions}
+          onEscapeKeyDown={onEscapeKeyDown}
         />
       )}
       {fastModeControl && (
@@ -55,6 +58,7 @@ export function ComposerModelTuningControls({
           label="Speed"
           control={fastModeControl}
           options={speedOptions}
+          onEscapeKeyDown={onEscapeKeyDown}
         />
       )}
     </>
@@ -65,10 +69,12 @@ function TuningSubmenu({
   label,
   control,
   options,
+  onEscapeKeyDown,
 }: {
   label: "Effort" | "Speed";
   control: LiveSessionControlDescriptor;
   options: TuningOption[];
+  onEscapeKeyDown: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const selectedOption = options.find((option) => option.selected) ?? null;
@@ -86,7 +92,12 @@ function TuningSubmenu({
           {selectedOption?.label ?? control.detail}
         </span>
       </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent sideOffset={4} alignOffset={-4} className="w-56">
+      <DropdownMenuSubContent
+        sideOffset={4}
+        alignOffset={-4}
+        className="w-56"
+        onEscapeKeyDown={onEscapeKeyDown}
+      >
         {options.map((option) => (
           <DropdownMenuItem
             key={option.value}

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -169,10 +169,10 @@ Rules:
 - `Ctrl+Shift+M` toggles the active compact root menu open and closed, including
   while the composer editor is focused. It does nothing while that selector is
   unavailable.
-- Closing the active root menu with `Ctrl+Shift+M` or Escape returns focus to
-  the active composer editor without changing its draft or caret. Pointer
-  dismissal and model selectors outside an active composer keep their own focus
-  behavior.
+- Closing the active root menu with `Ctrl+Shift+M`, Escape, or a keyboard model
+  selection returns focus to the active composer editor without changing its
+  draft or caret. Pointer dismissal and model selectors outside an active
+  composer keep their own focus behavior.
 - Preserve authored catalog effort labels (`Extra High`, `Max`, `Ultra`, and
   so on); do not rewrite distinct values to internal spellings such as
   `Xhigh`.

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -169,6 +169,10 @@ Rules:
 - `Ctrl+Shift+M` toggles the active compact root menu open and closed, including
   while the composer editor is focused. It does nothing while that selector is
   unavailable.
+- Closing the active root menu with `Ctrl+Shift+M` or Escape returns focus to
+  the active composer editor without changing its draft or caret. Pointer
+  dismissal and model selectors outside an active composer keep their own focus
+  behavior.
 - Preserve authored catalog effort labels (`Extra High`, `Max`, `Ultra`, and
   so on); do not rewrite distinct values to internal spellings such as
   `Xhigh`.


### PR DESCRIPTION
## Summary

- Restore the active chat composer focus after closing model controls with `Ctrl+Shift+M`, Escape, or a keyboard model selection.
- Cover both keyboard selection paths: Enter in the model search field, and Return/Space on a focused model row — the path keyboard navigation actually takes, because a keyboard-opened submenu focuses the menu itself rather than the search field.
- Carry keyboard-close intent through nested Model, Effort, Speed, and Advanced menus while leaving pointer dismissal and non-composer selectors unchanged.
- Preserve the draft and caret, and document the shared Desktop/Web behavior.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship applies, and no tracker, report, user, support ID, or private source data appears in this PR.

## Verification

- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx --reporter=verbose` (11 tests passed; the new row-activation test fails without the fix)
- `pnpm --filter @proliferate/product-client exec vitest run --exclude src/app/authenticated-markdown-cascade.test.ts --reporter=dot` (656 files, 4,186 tests passed)
- `python3 scripts/check_docs.py` (227 Markdown files passed)
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/report_frontend_structure.py --strict` (0 violations)
- `python3 scripts/check_design_attribution.py`
- `git diff --check`

The unfiltered package suite also invokes `authenticated-markdown-cascade.test.ts`; that browser fixture could not run because this host has no system Chrome, and installing Chrome requires an unavailable administrator credential.
