### PR TITLE
refactor(server): own organization SSO errors

### DIFF
--- a/server/proliferate/server/organizations/errors.py
+++ b/server/proliferate/server/organizations/errors.py
@@ -16,6 +16,51 @@ class OrganizationServiceError(ProliferateError):
         self.extra_detail = dict(extra_detail or {})
 
 
+class OrganizationSsoConnectionEnableProtocolUnsupported(OrganizationServiceError):
+    def __init__(self) -> None:
+        super().__init__(
+            code="sso_connection_enable_protocol_unsupported",
+            message="Only OIDC SSO can be enabled right now.",
+            status_code=400,
+        )
+
+
+class OrganizationSsoDisplayNameRequired(OrganizationServiceError):
+    def __init__(self) -> None:
+        super().__init__(
+            code="sso_display_name_required",
+            message="SSO display name is required.",
+            status_code=400,
+        )
+
+
+class OrganizationSsoDisplayNameTooLong(OrganizationServiceError):
+    def __init__(self) -> None:
+        super().__init__(
+            code="sso_display_name_too_long",
+            message="SSO display name is too long.",
+            status_code=400,
+        )
+
+
+class OrganizationSsoJitDefaultRoleNotAllowed(OrganizationServiceError):
+    def __init__(self) -> None:
+        super().__init__(
+            code="sso_jit_default_role_not_allowed",
+            message="SSO JIT default role cannot be owner.",
+            status_code=400,
+        )
+
+
+class OrganizationSsoRequiredLoginPolicyUnsupported(OrganizationServiceError):
+    def __init__(self) -> None:
+        super().__init__(
+            code="sso_required_login_policy_unsupported",
+            message="Required SSO login policy is not supported yet.",
+            status_code=400,
+        )
+
+
 class InstanceOrganizationAlreadyClaimed(OrganizationServiceError):
     """Raised when the first-run claim path finds an instance org already exists."""
 

--- a/server/proliferate/server/organizations/sso/service.py
+++ b/server/proliferate/server/organizations/sso/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.auth.errors import AuthFlowError
@@ -17,6 +17,13 @@ from proliferate.server.accounts.sso.service import (
     oidc_callback_url,
     snapshot_from_sso_connection_record,
     test_oidc_connection,
+)
+from proliferate.server.organizations.errors import (
+    OrganizationSsoConnectionEnableProtocolUnsupported,
+    OrganizationSsoDisplayNameRequired,
+    OrganizationSsoDisplayNameTooLong,
+    OrganizationSsoJitDefaultRoleNotAllowed,
+    OrganizationSsoRequiredLoginPolicyUnsupported,
 )
 from proliferate.server.organizations.sso.models import (
     OrganizationSsoConnectionRequest,
@@ -188,7 +195,7 @@ async def enable_organization_sso_connection(
         connection_id=connection_id,
     )
     if tested.protocol != "oidc":
-        raise HTTPException(status_code=400, detail="Only OIDC SSO can be enabled right now.")
+        raise OrganizationSsoConnectionEnableProtocolUnsupported()
     enabled = await sso_store.set_sso_connection_status(
         db,
         connection_id=connection_id,
@@ -264,9 +271,9 @@ def organization_sso_urls(request: Request, connection_id: UUID) -> tuple[str, s
 def _clean_display_name(value: str | None) -> str:
     cleaned = (value or "").strip()
     if not cleaned:
-        raise HTTPException(status_code=400, detail="SSO display name is required.")
+        raise OrganizationSsoDisplayNameRequired()
     if len(cleaned) > 255:
-        raise HTTPException(status_code=400, detail="SSO display name is too long.")
+        raise OrganizationSsoDisplayNameTooLong()
     return cleaned
 
 
@@ -279,17 +286,11 @@ def _clean_optional(value: str | None) -> str | None:
 
 def _clean_default_role(value: str) -> str:
     if value == "owner":
-        raise HTTPException(
-            status_code=400,
-            detail="SSO JIT default role cannot be owner.",
-        )
+        raise OrganizationSsoJitDefaultRoleNotAllowed()
     return value
 
 
 def _clean_login_policy(value: str) -> str:
     if value == "required":
-        raise HTTPException(
-            status_code=400,
-            detail="Required SSO login policy is not supported yet.",
-        )
+        raise OrganizationSsoRequiredLoginPolicyUnsupported()
     return value

--- a/server/tests/integration/test_sso_auth_error_contract.py
+++ b/server/tests/integration/test_sso_auth_error_contract.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 from httpx import AsyncClient, Response
@@ -26,6 +28,7 @@ from proliferate.config import settings
 from proliferate.db.models.auth import SsoChallenge, SsoConnection, User
 from proliferate.integrations.sso.errors import SsoIntegrationError
 from proliferate.integrations.sso.oidc import OidcMetadata, OidcTokenResponse
+from proliferate.server.organizations.sso import service as organization_sso_service
 from proliferate.utils.crypto import encrypt_text
 from tests.integration.test_organization_sso_membership import (
     _create_organization_for_user,
@@ -40,6 +43,19 @@ def _assert_error(response: Response, *, status_code: int, detail: str) -> None:
     assert "retry-after" not in response.headers
     assert "www-authenticate" not in response.headers
     assert "sso_" not in response.text
+
+
+def _assert_product_error(
+    response: Response,
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+) -> None:
+    assert response.status_code == status_code
+    assert response.json() == {"detail": {"code": code, "message": message}}
+    assert "retry-after" not in response.headers
+    assert "www-authenticate" not in response.headers
 
 
 def _start_body(
@@ -460,3 +476,98 @@ async def test_connection_test_preserves_integration_detail(
         status_code=400,
         detail="OIDC discovery metadata is invalid.",
     )
+
+
+@pytest.mark.asyncio
+async def test_organization_sso_validation_errors_use_structured_contract(
+    client: AsyncClient,
+) -> None:
+    owner = await _create_user_and_get_tokens(client, email="sso-validation-owner@example.com")
+    organization = await _create_organization_for_user(user_id=owner["user_id"])
+    organization_id = organization["organization_id"]
+    cases = [
+        (
+            {"displayName": " "},
+            "sso_display_name_required",
+            "SSO display name is required.",
+        ),
+        (
+            {"displayName": "x" * 256},
+            "sso_display_name_too_long",
+            "SSO display name is too long.",
+        ),
+        (
+            {"loginPolicy": "required"},
+            "sso_required_login_policy_unsupported",
+            "Required SSO login policy is not supported yet.",
+        ),
+        (
+            {"defaultRole": "owner"},
+            "sso_jit_default_role_not_allowed",
+            "SSO JIT default role cannot be owner.",
+        ),
+        (
+            {
+                "displayName": " ",
+                "loginPolicy": "required",
+                "defaultRole": "owner",
+            },
+            "sso_display_name_required",
+            "SSO display name is required.",
+        ),
+        (
+            {"loginPolicy": "required", "defaultRole": "owner"},
+            "sso_required_login_policy_unsupported",
+            "Required SSO login policy is not supported yet.",
+        ),
+    ]
+
+    for body, code, message in cases:
+        response = await client.post(
+            f"/v1/organizations/{organization_id}/sso/connections",
+            headers=_headers(owner),
+            json=body,
+        )
+
+        _assert_product_error(
+            response,
+            status_code=400,
+            code=code,
+            message=message,
+        )
+
+
+@pytest.mark.asyncio
+async def test_organization_sso_enable_protocol_error_uses_structured_contract(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = await _create_user_and_get_tokens(client, email="sso-enable-owner@example.com")
+    organization = await _create_organization_for_user(user_id=owner["user_id"])
+    organization_id = organization["organization_id"]
+    test_connection = AsyncMock(return_value=SimpleNamespace(protocol="saml"))
+    set_status = AsyncMock()
+    monkeypatch.setattr(
+        organization_sso_service,
+        "test_organization_sso_connection",
+        test_connection,
+    )
+    monkeypatch.setattr(
+        organization_sso_service.sso_store,
+        "set_sso_connection_status",
+        set_status,
+    )
+
+    response = await client.post(
+        f"/v1/organizations/{organization_id}/sso/connections/{uuid4()}/enable",
+        headers=_headers(owner),
+    )
+
+    _assert_product_error(
+        response,
+        status_code=400,
+        code="sso_connection_enable_protocol_unsupported",
+        message="Only OIDC SSO can be enabled right now.",
+    )
+    test_connection.assert_awaited_once()
+    set_status.assert_not_awaited()

--- a/server/tests/unit/test_organization_sso_error_catch.py
+++ b/server/tests/unit/test_organization_sso_error_catch.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import ast
+from collections import Counter
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -10,7 +15,214 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.sso.types import SsoConnectionSnapshot
 from proliferate.db.store.auth_sso_records import SsoConnectionRecord
+from proliferate.server.organizations.errors import (
+    OrganizationServiceError,
+    OrganizationSsoConnectionEnableProtocolUnsupported,
+    OrganizationSsoDisplayNameRequired,
+    OrganizationSsoDisplayNameTooLong,
+    OrganizationSsoJitDefaultRoleNotAllowed,
+    OrganizationSsoRequiredLoginPolicyUnsupported,
+)
 from proliferate.server.organizations.sso import service
+from proliferate.server.organizations.sso.models import (
+    OrganizationSsoConnectionRequest,
+    OrganizationSsoConnectionUpdateRequest,
+)
+
+
+@pytest.mark.parametrize(
+    ("validator", "value", "error_type", "code", "message"),
+    [
+        (
+            service._clean_display_name,
+            " ",
+            OrganizationSsoDisplayNameRequired,
+            "sso_display_name_required",
+            "SSO display name is required.",
+        ),
+        (
+            service._clean_display_name,
+            "x" * 256,
+            OrganizationSsoDisplayNameTooLong,
+            "sso_display_name_too_long",
+            "SSO display name is too long.",
+        ),
+        (
+            service._clean_default_role,
+            "owner",
+            OrganizationSsoJitDefaultRoleNotAllowed,
+            "sso_jit_default_role_not_allowed",
+            "SSO JIT default role cannot be owner.",
+        ),
+        (
+            service._clean_login_policy,
+            "required",
+            OrganizationSsoRequiredLoginPolicyUnsupported,
+            "sso_required_login_policy_unsupported",
+            "Required SSO login policy is not supported yet.",
+        ),
+    ],
+)
+def test_organization_sso_validation_uses_stable_product_errors(
+    validator: Callable[[str], str],
+    value: str,
+    error_type: type[OrganizationServiceError],
+    code: str,
+    message: str,
+) -> None:
+    with pytest.raises(error_type) as exc_info:
+        validator(value)
+
+    assert (exc_info.value.code, exc_info.value.status_code, exc_info.value.message) == (
+        code,
+        400,
+        message,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_mixed_failures_preserve_display_name_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    create_connection = AsyncMock()
+    monkeypatch.setattr(service.sso_store, "create_sso_connection", create_connection)
+
+    with pytest.raises(OrganizationSsoDisplayNameRequired):
+        await service.create_organization_sso_connection(
+            cast(AsyncSession, object()),
+            actor_user_id=uuid4(),
+            organization_id=uuid4(),
+            body=OrganizationSsoConnectionRequest(
+                display_name=" ",
+                login_policy="required",
+                default_role="owner",
+            ),
+        )
+
+    create_connection.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_mixed_failures_preserve_login_policy_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    update_connection = AsyncMock()
+    monkeypatch.setattr(service.sso_store, "update_sso_connection", update_connection)
+
+    with pytest.raises(OrganizationSsoRequiredLoginPolicyUnsupported):
+        await service.update_organization_sso_connection(
+            cast(AsyncSession, object()),
+            actor_user_id=uuid4(),
+            organization_id=uuid4(),
+            connection_id=uuid4(),
+            body=OrganizationSsoConnectionUpdateRequest(
+                login_policy="required",
+                default_role="owner",
+            ),
+        )
+
+    update_connection.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enable_protocol_failure_uses_stable_product_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_connection = AsyncMock(return_value=SimpleNamespace(protocol="saml"))
+    set_status = AsyncMock()
+    monkeypatch.setattr(service, "test_organization_sso_connection", test_connection)
+    monkeypatch.setattr(service.sso_store, "set_sso_connection_status", set_status)
+
+    with pytest.raises(OrganizationSsoConnectionEnableProtocolUnsupported) as exc_info:
+        await service.enable_organization_sso_connection(
+            cast(AsyncSession, object()),
+            actor_user_id=uuid4(),
+            organization_id=uuid4(),
+            connection_id=uuid4(),
+        )
+
+    assert (
+        exc_info.value.code,
+        exc_info.value.status_code,
+        exc_info.value.message,
+    ) == (
+        "sso_connection_enable_protocol_unsupported",
+        400,
+        "Only OIDC SSO can be enabled right now.",
+    )
+    test_connection.assert_awaited_once()
+    set_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enable_preserves_connection_test_failure_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_error = AuthFlowError(
+        "sso_connection_test_failed",
+        "Connection test failed.",
+        status_code=400,
+    )
+    test_connection = AsyncMock(side_effect=source_error)
+    set_status = AsyncMock()
+    monkeypatch.setattr(service, "test_organization_sso_connection", test_connection)
+    monkeypatch.setattr(service.sso_store, "set_sso_connection_status", set_status)
+
+    with pytest.raises(AuthFlowError) as exc_info:
+        await service.enable_organization_sso_connection(
+            cast(AsyncSession, object()),
+            actor_user_id=uuid4(),
+            organization_id=uuid4(),
+            connection_id=uuid4(),
+        )
+
+    assert exc_info.value is source_error
+    test_connection.assert_awaited_once()
+    set_status.assert_not_awaited()
+
+
+def test_all_organization_sso_product_error_sites_have_exact_mapping() -> None:
+    source_path = Path(cast(str, service.__file__))
+    tree = ast.parse(source_path.read_text())
+    rows: list[tuple[str, str]] = []
+    function_stack: list[str] = []
+
+    class RaiseVisitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            function_stack.append(node.name)
+            self.generic_visit(node)
+            function_stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+        def visit_Raise(self, node: ast.Raise) -> None:
+            call = node.exc
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id.startswith("OrganizationSso")
+            ):
+                rows.append((function_stack[-1], call.func.id))
+            self.generic_visit(node)
+
+    RaiseVisitor().visit(tree)
+
+    assert Counter(rows) == Counter(
+        {
+            (
+                "enable_organization_sso_connection",
+                "OrganizationSsoConnectionEnableProtocolUnsupported",
+            ): 1,
+            ("_clean_display_name", "OrganizationSsoDisplayNameRequired"): 1,
+            ("_clean_display_name", "OrganizationSsoDisplayNameTooLong"): 1,
+            ("_clean_default_role", "OrganizationSsoJitDefaultRoleNotAllowed"): 1,
+            (
+                "_clean_login_policy",
+                "OrganizationSsoRequiredLoginPolicyUnsupported",
+            ): 1,
+        }
+    )
+    assert "HTTPException" not in source_path.read_text()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace the five remaining Organization SSO service-layer `HTTPException` raises with Organization-owned product errors
- preserve exact status, message, validation precedence, connection-test ordering, and no-write-on-failure behavior
- retain the separate legacy `AuthFlowError` raw-string wire contract unchanged

## Stack

Depends directly on #1642 (`codex/sso-account-auth-leaf-inversion`) at `5bed2f85eca78cd5714ef1679dc16f67d57109f8`. Land/reconcile that prerequisite first, then rebase this single implementation commit, rerun proof, and obtain fresh review.

## Verification

- independent review: ACCEPT, no findings
- Organization unit/error contracts: 11 passed
- full SSO Auth HTTP contract: 14 passed
- independent focused review lane: 24 passed
- SSO ownership/global Auth contracts: 13 passed
- Ruff check and format check
- Server boundary checker
- diff checks

## Compatibility

The five Organization-admin failures now use the standard structured product envelope with stable codes. Status and human messages are unchanged. The Cloud SDK accepts both string and structured detail. Auth's compatibility response remains unchanged.

## Specification

Server Grid 33, Frozen revision 1.