### PR TITLE
ci(server): gate boundary checker tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: astral-sh/setup-uv@v7
+
       - name: Check max source file length
         run: python3 scripts/check_max_lines.py
 
@@ -58,6 +60,12 @@ jobs:
 
       - name: Check frontend structure drift
         run: python3 scripts/report_frontend_structure.py --strict --summary-only
+
+      - name: Test server boundary checker
+        run: >-
+          uv run --python 3.12 --with pytest==9.1.1
+          pytest --noconftest -p no:cacheprovider -c /dev/null -q
+          server/tests/unit/test_server_boundary_checker.py
 
       - name: Check server layer boundaries
         run: python3 scripts/check_server_boundaries.py

--- a/scripts/ci-cd/server-boundary-checker-ci.test.mjs
+++ b/scripts/ci-cd/server-boundary-checker-ci.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const workflow = readFileSync(path.join(REPO_ROOT, ".github/workflows/ci.yml"), "utf8");
+
+function workflowStep(name) {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${name} workflow step`);
+  const nextStep = workflow.indexOf("\n      - ", start + marker.length);
+  return workflow.slice(start, nextStep === -1 ? workflow.length : nextStep);
+}
+
+test("repo-shape runs focused server boundary tests before enforcing the boundary", () => {
+  const testStep = workflowStep("Test server boundary checker");
+  const checkStep = workflowStep("Check server layer boundaries");
+
+  assert.match(testStep, /uv run --python 3\.12 --with pytest==9\.1\.1/);
+  assert.match(
+    testStep,
+    /pytest --noconftest [\s\S]*server\/tests\/unit\/test_server_boundary_checker\.py/,
+  );
+  assert.match(checkStep, /python3 scripts\/check_server_boundaries\.py/);
+  assert.ok(workflow.indexOf(testStep) < workflow.indexOf(checkStep));
+});
+
+test("the repo-shape workflow remains unfiltered for pull requests", () => {
+  const triggerBlock = workflow.slice(workflow.indexOf("on:\n"), workflow.indexOf("permissions:\n"));
+  assert.match(triggerBlock, /\n  pull_request:\n  workflow_dispatch:\n/);
+});


### PR DESCRIPTION
## Summary

- run the Server boundary checker's 76 focused unit tests in repo-shape CI before executing the production checker
- keep the test invocation isolated from Server application setup and the full Server suite
- add a workflow assertion that locks the command, ordering, and unfiltered pull-request trigger

## Stack

Depends directly on #1630 (`codex/bounded-cross-domain-write-enforcement`) at `9d09b06e725606c622d513125c7b448caf32f5fd`.

## Verification

- independent review: ACCEPT, no findings
- focused checker tests: 76 passed
- production boundary checker: passed
- workflow assertion: 2 passed
- complete CI/CD script suite: 172 passed
- workflow YAML parse
- max-lines and design attribution
- `git diff --check`

## Impact

Script-only checker and allowlist changes now exercise the checker's adversarial fixtures in pull-request CI without triggering a broad Server dependency install or application suite.

## Specification

Server Grid 32, Frozen revision 1.