### PR TITLE
docs(server): reconcile Server Grid ownership model

### DIFF
--- a/specs/codebase/structures/server/README.md
+++ b/specs/codebase/structures/server/README.md
@@ -123,7 +123,7 @@ Use this as a routing map. The focused guides own the detailed rules.
 | App shell | `main.py`, `middleware/**` | FastAPI app construction, router mounting, exception handlers, cross-cutting request lifecycle. | This doc |
 | Settings and constants | `config.py`, `constants/<area>.py` | Env-derived runtime settings and shared hardcoded product/protocol values. | [guides/config.md](guides/config.md) |
 | Reusable cross-domain logic | `lib/infra/**`, `lib/product/**`, `lib/capabilities/**` | Generic machinery, cross-domain pure product logic, and reusable orchestration over integrations — owned by no single domain. | [guides/lib.md](guides/lib.md) |
-| Auth | `auth/**`, `permissions.py`, `server/<domain>/access.py`, `server/<domain>/domain/policy.py` | Actor authentication primitives (credentials, sessions, provider protocol, identity persistence, and transport-neutral failures), org-authorization factory deps and verdict types, resource-access deps, pure product-policy verdicts. | [guides/auth.md](guides/auth.md) |
+| Auth | `auth/**`, `permissions.py`, `server/<domain>/access.py`, `server/<domain>/domain/policy.py` | Actor authentication primitives, dependency-free authorization vocabulary, request-time owner/org resolution, resource-access deps, and pure product-policy verdicts. | [guides/auth.md](guides/auth.md) |
 | Accounts | `server/accounts/**` | Product account-entry routes and orchestration: user resolution/creation, identity placement, admin-email enforcement, SSO coordination, and product side effects. | [guides/auth.md](guides/auth.md) |
 | Database | `db/models/**`, `db/store/**` | ORM schema, query execution, transactions, row locks, ORM -> dataclass type boundary. | [guides/database.md](guides/database.md) |
 | Domain transport | `server/<domain>/api.py`, `server/<domain>/models.py` | HTTP route handling and Pydantic request/response schemas. | [guides/domains.md](guides/domains.md) |
@@ -171,14 +171,22 @@ Persistence rule:
   `integrations/`), and `lib/capabilities/` orchestrates integrations. No
   `lib/**` file imports `db/store` or `server/<domain>/**`. A concern enters
   `lib/` only at its second domain consumer.
-- Authorization is enforced at the endpoint via `Depends()`; services receive a
-  pre-authorized context and run no auth checks. All actor deps
-  (`current_active_user`, `current_product_user`) live in
-  `auth/dependencies.py`; the runtime-worker bearer dependency lives with the
-  Cloud runtime-worker domain; org-authorization factory deps and verdict types
-  (`require_org_role`, `require_org_membership`, `OwnerContext`, `PolicyVerdict`)
-  live in `permissions.py` at the server root; resource-access deps live in
-  `server/<domain>/access.py`; and product policy verdicts live in
+- New and refactored authorization paths enforce standing and resource access at
+  the endpoint via `Depends()`; services receive resolved context rather than
+  becoming a hidden permission layer. Existing inline checks are migration
+  debt, not a second recommended pattern. User actor deps
+  (`current_active_user`, `current_limited_user`, `current_product_user`, and
+  `current_organization_actor`) live in
+  [auth/dependencies.py](../../../../server/proliferate/auth/dependencies.py),
+  while the runtime-worker bearer dependency lives with the Cloud
+  runtime-worker domain. Dependency-free authorization vocabulary and the pure
+  `require_org_role(context, roles)` check live in
+  [auth/authorization.py](../../../../server/proliferate/auth/authorization.py).
+  [permissions.py](../../../../server/proliferate/permissions.py) re-exports that
+  vocabulary and owns request-time owner/org selection, membership resolution,
+  RLS context, `require_owner_role(*roles)`, and the `current_org_*` and
+  `current_path_org_*` dependencies. Resource-access deps live in
+  `server/<domain>/access.py`; product-policy verdicts live in
   `server/<domain>/domain/policy.py`.
 - Services raise product/domain errors. A global FastAPI exception handler
   translates `ProliferateError` subclasses to HTTP responses.
@@ -212,6 +220,8 @@ Persistence rule:
 Always start with this file. Then read the focused guide for the layer you are
 changing:
 
+- [guides/grid-ownership-model.md](guides/grid-ownership-model.md) — target
+  cross-layer ownership model and its explicit current gaps
 - [guides/domains.md](guides/domains.md)
 - [guides/database.md](guides/database.md)
 - [guides/auth.md](guides/auth.md)
@@ -250,11 +260,16 @@ only layer that imports SQLAlchemy query APIs. `integrations/**` is a leaf and
 does not import server domain code. `lib/**` is a leaf below the domains: it
 never imports `server/<domain>/**` or `db/store`, `lib/product/` never imports
 `integrations/`, and a concern enters `lib/` only at its second domain consumer.
-`auth/**` may be imported by every layer for authentication, and cross-domain
-authorization always comes from `proliferate.permissions` (a leaf importing
-neither `auth/**` nor `server/<domain>/**`). Background tasks call domain
-services; the relay is the only `background/**` module that touches a store, and
-only the outbox store.
+The dependency-free authorization types in
+[auth/authorization.py](../../../../server/proliferate/auth/authorization.py)
+sit below request composition. Domain code imports the public authorization
+seam from [permissions.py](../../../../server/proliferate/permissions.py), which
+is not an import-free leaf: it composes actor deps, stores, billing services,
+and request/RLS context. The rest of `auth/**` remains below product domains;
+product account-entry orchestration belongs to
+[server/accounts/**](../../../../server/proliferate/server/accounts). Background
+tasks call domain services; the relay is the only `background/**` module that
+touches a store, and only the outbox store.
 
 ## CI-Enforced Repo Shape
 

--- a/specs/codebase/structures/server/architecture.md
+++ b/specs/codebase/structures/server/architecture.md
@@ -33,8 +33,8 @@ server/proliferate/
   main.py · config.py · errors.py
   constants/<area>.py        # hardcoded policy values
   middleware/                # cross-cutting HTTP lifecycle
-  permissions.py             # org-authz factory deps + verdict types (leaf, imported everywhere)
-  auth/                      # actor authn deps + viewer/desktop/identity APIs + crypto utils
+  permissions.py             # request-time owner/org deps + public authorization seam
+  auth/                      # actor authn, dependency-free authz, identity/session/protocol leaf
   lib/                       # reusable cross-domain logic (leaf below domains)
     infra/ product/ capabilities/
   background/                # Celery substrate: app, config, beat, relay, tasks
@@ -91,7 +91,8 @@ ORM (db/models)  ──store returns──►  @dataclass(frozen=True)  ──mo
 api → service → store → models → SQLAlchemy        (nothing else imports SQLAlchemy)
 service → integrations / domain / other domains' public services (writes) or stores (reads)
 domain → pure (no FastAPI/SQLAlchemy/store/integrations/HTTP)
-auth/** → importable by every layer
+auth/authorization.py → dependency-free authorization vocabulary
+permissions.py → auth deps + stores/services needed for request owner/org context
 workers → call services, not stores; own the transaction at the entry
 ```
 
@@ -103,7 +104,8 @@ workers → call services, not stores; own the transaction at the entry
 ```text
 request → middleware → api handler
    Depends(current_product_user)        # authn (actor dep)
-   Depends(require_org_role(org_id, …)) # permissions.py: org standing → OwnerContext
+   Depends(current_path_org_admin)       # path org standing → CurrentOrgUser
+   Depends(require_owner_role("admin")) # selected owner standing → OwnerContext
    Depends(<domain>_user_can_<action>)  # access.py: lookup + check → resource or 403/404
    db = Depends(get_async_session)
    → service(db, …)
@@ -165,8 +167,8 @@ outbox row and let a worker do the call.
 ### `server/<domain>/access.py`
 - Resource-access route deps: look up the resource, check the user can touch it,
   return it (or raise 403/404). Read-only.
-- **Never:** mutating writes, business logic, inline authz helpers (compose the
-  `proliferate.permissions` factories).
+- **Never:** mutating writes, business logic, inline org-standing helpers
+  (compose the applicable dependency from `proliferate.permissions`).
 
 ### `server/<domain>/errors.py`
 - Domain error types subclassing the shared base, with a `code`. Types only.
@@ -190,17 +192,22 @@ outbox row and let a worker do the call.
   here; product domains orchestrate results.
 
 ### `auth/**` / `permissions.py`
-- Authorization is enforced at the endpoint via `Depends()`; services get a
-  pre-authorized context and run no auth checks. `auth/dependencies.py` owns
-  user actor deps (`current_active_user`, `current_product_user`); the Cloud
+- New and refactored paths enforce org standing and resource access at the
+  endpoint via `Depends()`; existing inline service checks remain migration
+  debt. [auth/dependencies.py](../../../../server/proliferate/auth/dependencies.py)
+  owns the user actor deps (`current_active_user`, `current_limited_user`,
+  `current_product_user`, and `current_organization_actor`); the Cloud
   runtime-worker domain owns its opaque-bearer `WorkerAuthContext` dependency.
-  `permissions.py` (server
-  root) = org-authorization factory deps (`require_org_role(org_id, roles)`,
-  `require_org_membership`) returning `OwnerContext`, plus `PolicyVerdict`. It is
-  a leaf importing neither `auth/**` nor `server/<domain>/**`; cross-domain authz
-  always comes from `proliferate.permissions`, never another service. `auth/` is
-  the authentication leaf for actor dependencies, credentials, sessions, provider
-  protocol, identity persistence, and crypto primitives. `server/accounts/**`
+  [auth/authorization.py](../../../../server/proliferate/auth/authorization.py)
+  owns dependency-free owner/policy vocabulary and the pure
+  `require_org_role(context, roles)` check.
+  [permissions.py](../../../../server/proliferate/permissions.py) re-exports that
+  vocabulary and owns request-time owner selection, membership resolution,
+  request/RLS context, `require_owner_role(*roles)`, and the `current_org_*` and
+  `current_path_org_*` dependencies. It is request composition, not an
+  import-free leaf. `auth/` remains below product domains for credentials,
+  sessions, provider protocol, identity persistence, and transport-neutral Auth
+  failures. [server/accounts/**](../../../../server/proliferate/server/accounts)
   owns the Desktop, Identity, and SSO account-entry surfaces and orchestration.
 
 ### `background/**` / `server/<domain>/worker/service.py`

--- a/specs/codebase/structures/server/guides/auth.md
+++ b/specs/codebase/structures/server/guides/auth.md
@@ -4,64 +4,87 @@ Server auth has four boundaries: **authentication** identifies the caller,
 **org authorization** decides whether that caller has the right standing in an
 organization, **resource access** checks whether the caller can touch a specific
 resource, and **product policy** decides whether the current resource state
-allows an action. Every one of them is enforced at the endpoint via `Depends()`.
-Services receive a resolved, pre-authorized context and contain **no auth
-checks** — they are never a hidden permission layer.
+allows an action. New and refactored paths enforce these boundaries at the
+endpoint via `Depends()`: services receive resolved context rather than becoming
+a hidden permission layer. Existing inline checks are migration work, not a
+second recommended pattern.
 
 ## Ownership
 
 | Boundary | Question | Lives in | Returns |
 |---|---|---|---|
 | **Authentication** | Who is the caller? | `auth/dependencies.py` for users; `server/cloud/runtime_workers/auth.py` for Workers | the actor (`User` / `WorkerAuthContext`) |
-| **Org authorization** | Does the caller have the right org standing? | `permissions.py` (factory deps) | `OwnerContext` |
+| **Org authorization** | Does the caller have the right org standing? | `permissions.py` (request deps and factories) | `OwnerContext` or `CurrentOrgUser` |
 | **Resource access** | Can this caller touch *this* resource? | `server/<domain>/access.py` | the resource snapshot, or raises 403/404 |
 | **Product rule** | Given this state, is the action permitted now? | `server/<domain>/domain/policy.py` | `PolicyVerdict` |
 
-Authorization currency — `OwnerContext`, `PolicyVerdict`, `require_org_role`,
-`require_org_membership` — lives in `server/proliferate/permissions.py`, not in
-`auth/`. It is product-wide vocabulary imported by ~every domain and has no
-auth-specific logic, so it sits at the server root next to `config.py` and
-`errors.py`. `auth/` is an importable leaf for credentials, sessions, provider
-protocols, identity persistence, and transport-neutral Auth failures. Product
-account-entry routes and orchestration live in `server/accounts/**`.
-In this guide, `auth/dependencies.py` centralizes **actor dependencies**, not
-every FastAPI dependency used by a route. Resource-specific dependencies stay in
-the domain that owns the resource.
+Dependency-free authorization currency — `ActorIdentity`, `AuthenticatedUser`,
+`OwnerScope`, `OwnerSelection`, `OwnerContext`, `PolicyAllowed`, `PolicyDenied`,
+`PolicyVerdict`, and the pure `require_org_role` check — is defined in
+[auth/authorization.py](../../../../../server/proliferate/auth/authorization.py).
+[permissions.py](../../../../../server/proliferate/permissions.py) re-exports
+that vocabulary as the public domain-facing seam and owns request-time
+organization selection, membership resolution, request/RLS context, and
+FastAPI dependencies. New and refactored domain code imports public names from
+`proliferate.permissions`; direct imports from `auth.authorization` are
+migration work, not a second public seam.
+
+[auth/dependencies.py](../../../../../server/proliferate/auth/dependencies.py)
+centralizes **actor dependencies**, not every FastAPI dependency used by a
+route. Resource-specific dependencies stay in the domain that owns the
+resource. [auth/**](../../../../../server/proliferate/auth) remains below product
+domains for credentials, sessions, provider protocols, identity persistence,
+and transport-neutral Auth failures. Product account-entry routes and
+orchestration live in
+[server/accounts/**](../../../../../server/proliferate/server/accounts). This
+split describes the current implementation; it does not make `permissions.py`
+an import-free leaf.
 
 ## The actor dependency hierarchy
 
 Authorization is a chain of `Depends()`, each one composing the one above it. An
-endpoint declares the *lowest actor it requires* and gets everything below it for
-free; nothing downstream re-checks.
+endpoint declares the lowest actor or organization context it requires.
 
 ```text
 anonymous
 └── current_active_user                    active user
-    └── current_product_user               + GitHub connected (hosted) / single-org bypass — default for product/cloud surfaces
-        ├── require_org_membership(org_id)  org member  -> OwnerContext
-        └── require_org_role(org_id, roles) org standing -> OwnerContext
+    └── current_limited_user               compatibility actor seam; currently no extra gate
+        ├── current_product_user           product readiness with the current single-org/SSO rules
+        └── current_organization_actor     organization-surface readiness
+
+current_product_user
+└── current_owner_context                  selected/default payer -> OwnerContext
+    ├── require_owner_role(*roles)         dependency factory -> OwnerContext
+    └── current_org_member/admin/owner     selected owner -> CurrentOrgUser
+
+current_organization_actor
+└── current_path_org_member                path organization -> CurrentOrgUser
+    ├── current_path_org_admin
+    └── current_path_org_owner
 
 authenticate_worker                       opaque worker bearer token -> WorkerAuthContext
 optional_current_active_user               maybe authenticated (public-with-extras)
 ```
 
-`require_org_membership` and `require_org_role` are **dependency factories**:
-called with the path's `org_id` (and, for role, the allowed roles), they return a
-`Depends` that resolves and returns an `OwnerContext`. Org standing is checked at
-the endpoint boundary — never inside a service. This is the whole centralized
-model: identity actors in `auth/dependencies.py`, org-authorization factories in
-`permissions.py`, both wired in at the route via `Depends()`.
+`require_owner_role(*roles)` is a dependency factory over the selected
+`OwnerContext`. `require_org_role(context, roles)` is instead a synchronous pure
+check over an already-resolved context. Path-organization routes use the
+`current_path_org_*` dependencies. There is no separate organization-membership
+factory. New and refactored paths resolve org standing at the endpoint boundary
+rather than hiding it inside a service.
 
 ## Shape
 
 ```text
 server/proliferate/
-  permissions.py             # OwnerContext, PolicyVerdict, require_org_role, require_org_membership
+  permissions.py             # request org deps + public authorization re-exports
 
   auth/
     __init__.py
-    dependencies.py          # user actor deps: current_active_user, current_product_user,
-                             #   optional_current_active_user
+    dependencies.py          # current_active_user, current_limited_user,
+                             # current_product_user, current_organization_actor,
+                             # optional_current_active_user
+    authorization.py         # dependency-free owner/policy vocabulary + pure role check
     users.py                 # UserManager (fastapi-users lifecycle plumbing)
     desktop/                 # leaf models and callback pages
     identity/                # provider protocol, stores, sessions, and credential primitives
@@ -92,7 +115,8 @@ resources or carry product rules.
 Use the question the code answers to decide where it lives:
 
 - "Who is calling?" belongs in `auth/dependencies.py`.
-- "What organization standing does the caller have?" belongs in `permissions.py`.
+- "What organization standing does the caller have?" is resolved by
+  `permissions.py` using vocabulary from `auth/authorization.py`.
 - "Can this caller touch this concrete route resource?" belongs in
   `server/<domain>/access.py`.
 - "Does the current product state allow this action?" belongs in
@@ -115,16 +139,14 @@ IDs or import product-domain stores.
 ```python
 # auth/dependencies.py
 async def current_product_user(
-    user: User = Depends(current_active_user),
+    user: User = Depends(current_limited_user),
     db: AsyncSession = Depends(get_async_session),
 ) -> User:
-    readiness = await get_account_readiness(db, user_id=user.id)
-    if not readiness.product_ready:
-        raise PermissionDenied(
-            "Connect GitHub before using Proliferate Cloud product surfaces.",
-            code="github_link_required",
-        )
-    return user
+    if settings.single_org_mode:
+        return user
+    if await user_has_active_organization_sso_membership(db, user_id=user.id):
+        return user
+    return await _require_product_ready(db, user)
 ```
 
 Use `server/<domain>/access.py` when a route needs a concrete resource already
@@ -136,27 +158,29 @@ snapshot the handler or service will use.
 # server/cloud/workspaces/access.py
 async def workspace_user_can_archive(
     workspace_id: UUID,
-    user: User = Depends(current_product_user),
+    owner: OwnerContext = Depends(current_owner_context),
     db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceSnapshot:
     workspace = await cloud_workspaces_store.get_workspace_snapshot(db, workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    role = await organizations_store.get_active_membership_role(
-        db,
-        organization_id=workspace.organization_id,
-        user_id=user.id,
-    )
+    if workspace.owner_scope != owner.owner_scope:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    if (
+        owner.owner_scope == "organization"
+        and workspace.organization_id != owner.organization_id
+    ):
+        raise HTTPException(status_code=404, detail="Workspace not found")
     verdict = policy.can_archive_workspace(
         workspace=workspace,
-        actor_user_id=user.id,
-        membership_role=role,
+        actor_user_id=owner.actor_user_id,
+        membership_role=owner.membership_role,
     )
     if isinstance(verdict, PolicyDenied):
         if verdict.code == "workspace_not_found":
-            raise HTTPException(status_code=404, detail=verdict.reason)
-        raise HTTPException(status_code=403, detail=verdict.reason)
+            raise HTTPException(status_code=404, detail=verdict.message)
+        raise HTTPException(status_code=403, detail=verdict.message)
     return workspace
 ```
 
@@ -177,13 +201,13 @@ def can_archive_workspace(
             return PolicyAllowed()
         return PolicyDenied(
             code="workspace_not_found",
-            reason="Workspace not found.",
+            message="Workspace not found.",
         )
 
     if workspace.organization_id is None:
         return PolicyDenied(
             code="workspace_not_found",
-            reason="Workspace not found.",
+            message="Workspace not found.",
         )
 
     if membership_role in {"owner", "admin"}:
@@ -191,7 +215,7 @@ def can_archive_workspace(
 
     return PolicyDenied(
         code="workspace_permission_denied",
-        reason="You do not have permission to archive this workspace.",
+        message="You do not have permission to archive this workspace.",
     )
 ```
 
@@ -204,11 +228,15 @@ token is part of that domain's enrollment lifecycle.
 | Dep | Gates |
 |---|---|
 | `current_active_user` | active user, no GitHub requirement |
-| `current_product_user` | active user **+ GitHub connected** — the default for product/cloud surfaces. Single-org (self-hosted) instances bypass the GitHub check for password-only accounts; hosted keeps it unconditionally. |
+| `current_limited_user` | compatibility actor seam over `current_active_user`; currently adds no gate |
+| `current_product_user` | active user plus current product readiness — the default for product/cloud surfaces. Single-org instances bypass the GitHub check; hosted users with an active organization SSO membership also pass, while other hosted users require account readiness. |
+| `current_organization_actor` | actor for organization-membership surfaces; applies the current hosted readiness gate and single-org bypass |
 | `optional_current_active_user` | maybe authenticated (public route with extra behavior when signed in) |
 
-There is no `current_limited_user`: it was a no-op wrapper over
-`current_active_user` and does not exist in this model.
+`current_limited_user` is live compatibility vocabulary used by actor and
+identity routes. It currently returns `current_active_user` unchanged. Do not
+create more no-op actor wrappers; removing or bypassing this one is a separate
+code migration, not an assumption a caller should make from this guide.
 
 ### Allowed
 
@@ -220,7 +248,7 @@ There is no `current_limited_user`: it was a no-op wrapper over
 ### Banned
 
 - Org-standing or resource-scoped checks. Org standing belongs in
-  `permissions.py` factory deps; resource checks belong in
+  `permissions.py` request deps; resource checks belong in
   `server/<domain>/access.py`.
 - Business logic.
 - ORM access beyond the actor lookup.
@@ -234,12 +262,20 @@ async def current_active_user(
 ) -> User:
     return user
 
-async def current_product_user(
+async def current_limited_user(
     user: User = Depends(current_active_user),
 ) -> User:
-    if not user.github_connected:
-        raise HTTPException(status_code=403, detail="GitHub connection required")
     return user
+
+async def current_product_user(
+    user: User = Depends(current_limited_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> User:
+    if settings.single_org_mode:
+        return user
+    if await user_has_active_organization_sso_membership(db, user_id=user.id):
+        return user
+    return await _require_product_ready(db, user)
 ```
 
 ### OAuth and account-entry surfaces
@@ -313,55 +349,79 @@ no mounted Worker control, command lease/result, or applied-revision endpoint.
 
 ## Org Authorization
 
-`server/proliferate/permissions.py` owns org-standing authorization and the
-shared verdict vocabulary, used by route deps, resource-access deps, and policy
-functions across every domain.
+[auth/authorization.py](../../../../../server/proliferate/auth/authorization.py)
+owns the dependency-free vocabulary: `ActorIdentity`, `AuthenticatedUser`,
+`OwnerScope`, `OwnerSelection`, `OwnerContext`, `PolicyAllowed`, `PolicyDenied`,
+`PolicyVerdict`, and `require_org_role`.
+[permissions.py](../../../../../server/proliferate/permissions.py) re-exports
+those names as the public domain-facing seam and owns request-time org-standing
+resolution.
 
 ### Allowed
 
-- `require_org_membership(org_id)` and `require_org_role(org_id, roles)` —
-  dependency factories that resolve and return an `OwnerContext`.
-- `OwnerContext` (and `OwnerSelection`) describing a caller's relationship to an
-  organization.
-- `PolicyVerdict` tagged union (`PolicyAllowed | PolicyDenied`).
+- `current_owner_context` and `require_owner_role(*roles)` for selected-owner
+  routes that receive an `OwnerContext`.
+- `current_path_org_member/admin/owner` for organization IDs carried by the
+  path, and `current_org_member/admin/owner` for a selected owner. These return
+  `CurrentOrgUser`.
+- Re-exporting `ActorIdentity`, `AuthenticatedUser`, `OwnerScope`,
+  `OwnerSelection`, `OwnerContext`, `PolicyAllowed`, `PolicyDenied`,
+  `PolicyVerdict`, and the pure `require_org_role(context, roles)` check from
+  `auth/authorization.py`.
+- Applying request and RLS organization context after membership resolution.
 
 ### Banned
 
 - Resource lookups. Those happen in `server/<domain>/access.py`.
-- Auth-flow logic. `permissions.py` is product authorization, not authentication.
-- Imports from `auth/**` or `server/<domain>/**`. It stays a leaf so every layer
-  can import it.
+- OAuth, session, or identity-flow logic. `permissions.py` composes actor
+  dependencies but does not own authentication.
+- Resource-specific product policy. The request seam resolves owner standing;
+  the owning domain resolves access to its concrete resource.
 
 ### Standard shapes
 
 ```python
-# server/proliferate/permissions.py
+# server/proliferate/auth/authorization.py
 @dataclass(frozen=True)
 class OwnerContext:
-    user_id: UUID
+    owner_scope: OwnerScope
+    actor_user_id: UUID
+    owner_user_id: UUID | None
     organization_id: UUID | None
-    role: str | None
+    membership_id: UUID | None
+    membership_role: str | None
+    billing_subject_id: UUID
 
-def require_org_role(org_id: UUID, roles: Iterable[str]):
-    async def _dep(
-        user: User = Depends(current_product_user),
-        db: AsyncSession = Depends(get_async_session),
-    ) -> OwnerContext:
-        context = await resolve_owner_context(db, org_id, user.id)
-        if context.role not in roles:
-            raise HTTPException(status_code=403, detail="Insufficient org role")
-        return context
-    return _dep
+def require_org_role(context: OwnerContext, roles: Iterable[str]) -> None:
+    if context.owner_scope != "organization" or context.membership_role is None:
+        raise NotFoundError("Organization not found.", code="organization_not_found")
+    if context.membership_role not in set(roles):
+        raise PermissionDenied(
+            "You do not have permission to manage this organization.",
+            code="organization_permission_denied",
+        )
 
 @dataclass(frozen=True)
-class PolicyAllowed: ...
+class PolicyAllowed:
+    allowed: Literal[True] = True
 
 @dataclass(frozen=True)
 class PolicyDenied:
     code: str
-    reason: str
+    message: str
+    status_code: int = 403
+    allowed: Literal[False] = False
 
 PolicyVerdict = PolicyAllowed | PolicyDenied
+
+# server/proliferate/permissions.py
+def require_owner_role(*roles: str):
+    async def dependency(
+        context: OwnerContext = Depends(current_owner_context),
+    ) -> OwnerContext:
+        require_org_role(context, roles)
+        return context
+    return dependency
 ```
 
 ## Resource-Access Route Deps
@@ -378,7 +438,8 @@ they may read stores and raise HTTP-shaped permission results, while
 - `async def` functions taking an actor + path/query params and returning a
   resource snapshot.
 - Calls to `db/store/**` for the lookup.
-- Composing `require_org_role`/`require_org_membership` from `permissions.py`.
+- Composing `current_path_org_member/admin/owner`, `current_owner_context`, or
+  `require_owner_role` from `permissions.py`.
 - Calls to `domain/policy.py` for state-based access checks.
 - Raising 404 for missing resources, 403 for forbidden.
 
@@ -386,7 +447,8 @@ they may read stores and raise HTTP-shaped permission results, while
 
 - Mutating writes. Access deps are read-only.
 - Business logic beyond access.
-- Inline org-authorization logic (compose the `permissions.py` factory).
+- Inline org-authorization logic (compose the applicable `permissions.py`
+  dependency).
 - Returning Pydantic. Return the dataclass snapshot.
 
 ### Standard shape
@@ -395,13 +457,13 @@ they may read stores and raise HTTP-shaped permission results, while
 # server/cloud/workspaces/access.py
 async def workspace_user_can_admin(
     workspace_id: UUID,
-    owner: OwnerContext = Depends(require_org_role(... , roles={OWNER, ADMIN})),
+    org_user: CurrentOrgUser = Depends(current_org_admin),
     db: AsyncSession = Depends(get_async_session),
 ) -> WorkspaceSnapshot:
     snapshot = await store.cloud_workspaces.get_workspace_snapshot(db, workspace_id)
     if snapshot is None:
         raise HTTPException(404, "Workspace not found")
-    if snapshot.owner_id != owner.organization_id:
+    if snapshot.organization_id != org_user.organization_id:
         raise HTTPException(403, "Workspace not in organization")
     return snapshot
 ```
@@ -414,9 +476,12 @@ the resource snapshot when access is granted.
 
 ### Resource-scoped vs platform admin
 
-When "admin" means "admin of *this* resource", compose `require_org_role` in
-`<domain>/access.py`. When it means "platform admin" (Proliferate staff,
-system-wide), use the platform-admin actor from `auth/dependencies.py`.
+When "admin" means "admin of *this* path organization", compose
+`current_path_org_admin` in `<domain>/access.py`. A resource-only route can
+compose selected-owner `current_org_admin` or
+`require_owner_role("owner", "admin")` instead. When it means "platform admin"
+(Proliferate staff, system-wide), use the platform-admin actor from
+`auth/dependencies.py`.
 
 ## Product Policy Rules
 
@@ -441,9 +506,9 @@ from proliferate.permissions import PolicyAllowed, PolicyDenied, PolicyVerdict
 
 def can_delete_workspace(workspace: WorkspaceSnapshot) -> PolicyVerdict:
     if workspace.status == WorkspaceStatus.DELETING:
-        return PolicyDenied(code="ALREADY_DELETING", reason="Already being deleted")
+        return PolicyDenied(code="ALREADY_DELETING", message="Already being deleted")
     if workspace.has_active_sessions:
-        return PolicyDenied(code="HAS_ACTIVE_SESSIONS", reason="Cancel sessions first")
+        return PolicyDenied(code="HAS_ACTIVE_SESSIONS", message="Cancel sessions first")
     return PolicyAllowed()
 ```
 
@@ -454,13 +519,14 @@ def can_delete_workspace(workspace: WorkspaceSnapshot) -> PolicyVerdict:
 async def delete_workspace(db: AsyncSession, *, workspace: WorkspaceSnapshot) -> None:
     verdict = policy.can_delete_workspace(workspace)
     if isinstance(verdict, PolicyDenied):
-        raise WorkspaceConflict(code=verdict.code, reason=verdict.reason)
+        raise WorkspaceConflict(verdict.message, code=verdict.code)
     await store.cloud_workspaces.mark_deleting(db, workspace.id)
 ```
 
 The service raises a domain error; the global handler maps it to an HTTP
-response. The service runs **no auth check** — admin standing was resolved by the
-endpoint's deps before `delete_workspace` was ever called.
+response. In the endpoint-composed shape, admin standing is resolved before
+`delete_workspace` is called. Existing services that still resolve standing
+inline are migration debt.
 
 ## End-to-End Example
 
@@ -478,7 +544,8 @@ async def delete_cloud_workspace(
 Each layer does one job, all before the service body runs:
 
 1. **`auth/dependencies.py`** — `current_product_user` (authentication).
-2. **`permissions.py`** — `require_org_role` (org standing → `OwnerContext`).
+2. **`permissions.py`** — the applicable path or selected-owner dependency
+   (org standing → `CurrentOrgUser` or `OwnerContext`).
 3. **`cloud/workspaces/access.py`** — `workspace_user_can_admin` (resource lookup
    + return snapshot).
 4. **`cloud/workspaces/domain/policy.py`** — `can_delete_workspace` (pure rule).
@@ -489,17 +556,18 @@ The handler is three lines and the service has no inline auth.
 ## Forbidden Patterns
 
 - Authorization checks inline in `api.py` route bodies. Use deps.
-- Org-standing checks buried in `service.py`. Resolve `OwnerContext` at the
-  endpoint via the `permissions.py` factory and pass it in.
+- Org-standing checks buried in `service.py`. New and refactored paths resolve
+  `CurrentOrgUser` or `OwnerContext` at the endpoint through `permissions.py`
+  and pass it in.
 - Product rules buried as `if not condition: raise HTTPException(403)` in
   `service.py`. Extract to pure verdicts in `domain/policy.py`.
 - Inline Worker bearer parsing in handlers or services. Authenticate once via
   the domain-owned `authenticate_worker` dependency.
-- Importing authorization helpers from a domain service
-  (`from organizations.service import require_org_role`) or from `auth/`. Always
-  import `OwnerContext`, `PolicyVerdict`, and the factories from
-  `proliferate.permissions`.
+- Importing authorization helpers from a domain service. Domain code imports
+  `OwnerContext`, `PolicyVerdict`, request dependencies, and factories from the
+  public `proliferate.permissions` seam.
 - Returning Pydantic from access deps. Return the dataclass snapshot.
-- A `current_limited_user`-style no-op wrapper. Use `current_active_user`.
+- New no-op actor wrappers. The existing `current_limited_user` compatibility
+  seam is not precedent for another.
 - Mixing authentication and authorization in one dep. Each does one job; compose
   via `Depends(... = Depends(...))`.

--- a/specs/codebase/structures/server/guides/domains.md
+++ b/specs/codebase/structures/server/guides/domains.md
@@ -4,6 +4,10 @@ Backend product domains keep transport, orchestration, wire models, pure rules,
 authorization deps, errors, and non-HTTP entry points in predictable homes. A
 domain folder answers "what product area owns this?"
 
+The placements below are the rule for new and refactored code. Remaining
+inline authorization and boundary exceptions are migration debt, not alternate
+patterns that new code may copy.
+
 ## Ownership
 
 A `server/<domain>/` folder is one product area's home. It owns:
@@ -201,7 +205,10 @@ Allowed:
   any path/query params.
 - `db: AsyncSession = Depends(get_async_session)` for the lookup.
 - Calls to `db/store/**` for the resource lookup.
-- Composing `proliferate.permissions` factory deps (`require_org_role`, etc.).
+- Composing request dependencies from
+  [permissions.py](../../../../../server/proliferate/permissions.py), such as
+  `current_path_org_admin`, `current_owner_context`, or
+  `require_owner_role("owner", "admin")`.
 - Calls to `domain/policy.py` for state-based access checks.
 - Returning the resource as a frozen dataclass.
 
@@ -209,7 +216,8 @@ Banned:
 
 - Mutating writes. Access deps are read-only.
 - Business logic beyond access.
-- Inline authorization helpers (compose the `proliferate.permissions` factories).
+- Inline org-standing helpers (compose the applicable dependency from the
+  public `proliferate.permissions` seam).
 
 ### `errors.py`
 
@@ -374,8 +382,11 @@ The owning service runs its own policy, invariants, and audit.
 - A service calling another domain's store *write* function directly.
 - Importing a service's private helpers (`from cloud.workspaces.service
   import _internal`). Public functions only.
-- Cross-domain imports for auth infrastructure. Always use
-  `proliferate.permissions`.
+- Cross-domain imports for authorization infrastructure. Domain code uses the
+  public names re-exported by
+  [permissions.py](../../../../../server/proliferate/permissions.py), while
+  [auth/authorization.py](../../../../../server/proliferate/auth/authorization.py)
+  remains the dependency-free definition owner.
 - Two domains both writing the same ORM resource. The resource has one
   owning domain whose service is the write boundary.
 

--- a/specs/codebase/structures/server/guides/grid-ownership-model.md
+++ b/specs/codebase/structures/server/guides/grid-ownership-model.md
@@ -66,8 +66,10 @@ entry; foreign writes go through the owner's public service.
 strings, and cryptography. Every layer may import it because it knows nothing
 about products, vendors, or persistence.
 
-**`lib/product`** contains cross-domain pure product logic. Only domain rows may
-import it; product policy never leaks into stores or integrations.
+**`lib/product`** contains cross-domain pure product logic. Its audience is the
+product-domain service, domain, and models coordinates, plus a domain's
+`worker/service.py`; API handlers, background task shims, stores, integrations,
+and other infrastructure do not import it.
 
 **`lib/capabilities`** contains reusable orchestration over integrations. Each
 capability has an explicit domain-consumer map. A concern enters `lib/**` only
@@ -119,8 +121,9 @@ and independently testable.
 pulls single-domain policy out of its owner prematurely.
 
 **Rule:** Infra is universal and product-blind; Product is pure and restricted
-to domain rows; Capabilities are consumer-mapped. Reuse requires at least two
-real consumers.
+to product-domain `service.py`, `domain/**`, `models.py`, and
+`worker/service.py`; Capabilities are consumer-mapped. Reuse requires at least
+two real consumers.
 
 **Result:** a library's import audience and allowed knowledge are obvious from
 its coordinate.
@@ -256,6 +259,19 @@ If every answer is yes or not applicable, the change aligns with the grid.
   [lib tree](../../../../../server/proliferate/lib) contains only a Product
   workspace-naming concern; `lib/infra` and `lib/capabilities` do not exist, and
   the server checker does not scan `lib/**` for audience or purity rules.
+- [ ] **Integration and raw-transport placement retain two exact exceptions.**
+  [integrations/sentry.py](../../../../../server/proliferate/integrations/sentry.py)
+  imports product-owned
+  [server/release.py](../../../../../server/proliferate/server/release.py) for
+  release tagging. The checker count-locks that debt as
+  `INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sentry.py 1` in
+  [server_boundaries_allowlist.txt](../../../../../scripts/server_boundaries_allowlist.txt).
+  [cloud/gateway/proxy.py](../../../../../server/proliferate/server/cloud/gateway/proxy.py)
+  owns raw HTTP and WebSocket proxy transport inside a product domain; its
+  `httpx` import is count-locked as
+  `PRODUCT_RAW_HTTP_IMPORT server/proliferate/server/cloud/gateway/proxy.py 1`
+  in the same allowlist. Both exceptions require ownership moves before the
+  integration-leaf and package-audience target can be enforced without debt.
 - [ ] **Service topology and package audiences are not gated.** Cloud Sandbox
   imports Gateway service in
   [cloud_sandboxes/service.py](../../../../../server/proliferate/server/cloud/cloud_sandboxes/service.py),

--- a/specs/codebase/structures/server/guides/grid-ownership-model.md
+++ b/specs/codebase/structures/server/guides/grid-ownership-model.md
@@ -1,0 +1,276 @@
+Status: target
+
+# Server Grid Ownership Model
+
+What an engineer needs to know to reason about the target server architecture.
+
+## Scope
+
+This document owns the cross-layer ownership model for the Python control plane
+under [server/proliferate](../../../../../server/proliferate). The current source
+router and enforced rules remain in [Server Standards](../README.md); the
+focused [domain](domains.md), [database](database.md), [auth](auth.md),
+[integration](integrations.md), [library](lib.md), [error](errors.md), and
+[background](background.md) guides own the detail for their rows. Product
+behavior remains in the owning platform or system document.
+
+## The Core Idea
+
+The server is a **grid**: columns are business domains such as Billing, Cloud,
+Workflows, Accounts, and Organizations; rows are technical layers such as API,
+service, domain, models, and stores. A piece of code lives at one coordinate.
+
+**Legality is a pure function of coordinates.** Whether code at `(service,
+billing)` can call code at `(store, cloud)` depends only on those coordinates
+and an explicit ownership declaration. It does not depend on review history or
+an undocumented exception. That makes the boundary searchable, testable, and
+enforceable in CI.
+
+Three principles hold the grid stable:
+
+1. **Ownership stops the blast radius.** Only an owning domain writes its
+   resources. Foreign reads exist only in a declared consumer ledger.
+2. **Import audiences are inverse to knowledge.** Code importable by everyone
+   knows nothing about product policy; code that knows product policy has a
+   narrow audience.
+3. **Layers own their seams.** A row answers one question—how data is loaded,
+   how access is resolved, or how an error crosses transport—and every column
+   uses that row's answer.
+
+## The Layers
+
+**API** is the HTTP boundary. It parses requests, receives authentication and
+access dependencies, calls services, and shapes responses. It contains no
+business logic, authorization decisions, or database operations.
+
+**Service** is orchestration. It calls its own stores, foreign public services,
+declared foreign-read stores, integrations, and allowed libraries. It receives
+resolved access context and returns domain-typed data.
+
+**Domain** is pure product policy. It performs no I/O. Its rules could move to a
+different runtime without changing their inputs or outputs.
+
+**Models** have two distinct audiences. Public models in a domain's `models.py`
+are wire vocabulary; models under `db/models/**` are private ORM shapes. The
+pipeline is ORM → frozen dataclass → Pydantic. A service never receives an ORM
+object.
+
+**Stores** are the only layer that knows SQL. A store receives the caller's
+session, returns frozen dataclasses, and never opens, commits, or rolls back a
+session. Each store has one owning domain. Foreign reads require an exact ledger
+entry; foreign writes go through the owner's public service.
+
+## Shared Coordinates
+
+**`lib/infra`** contains generic machinery: time, IDs, pagination, batching,
+strings, and cryptography. Every layer may import it because it knows nothing
+about products, vendors, or persistence.
+
+**`lib/product`** contains cross-domain pure product logic. Only domain rows may
+import it; product policy never leaks into stores or integrations.
+
+**`lib/capabilities`** contains reusable orchestration over integrations. Each
+capability has an explicit domain-consumer map. A concern enters `lib/**` only
+after a second real consumer exists.
+
+**Integrations** contain vendor mechanics: raw SDKs, HTTP, protocol models, and
+vendor errors. They are leaves below product domains. Services translate vendor
+failures into product meaning.
+
+**Seams** own cross-cutting request lifecycle. Authentication and
+dependency-free authorization vocabulary sit below product domains; request
+owner/org resolution composes at the endpoint; resource access remains in each
+owning domain; one global error handler translates product errors.
+
+**Background** has one durable execution model: thin Celery tasks fired by Beat
+or the transactional outbox. Domain worker services own the work. There are no
+domain schedulers, process-owned periodic loops, or `worker.py` entry points.
+Only the outbox relay below `background/**` reads a store directly.
+
+## Why Each Rule Exists
+
+### Store ownership (`SRV-STORE`)
+
+**Problem:** unrestricted foreign writes make responsibility and schema-change
+impact unknowable.
+
+**Rule:** writes cross domains only through the owner's public service. Reads
+cross only through an exact, reviewable consumer ledger.
+
+**Result:** a store owner can query every consumer before changing its contract,
+and invariant enforcement has one write boundary.
+
+### Error ownership (`SRV-ERR`)
+
+**Problem:** protocol-shaped errors scattered through services make response
+translation inconsistent and hard to test.
+
+**Rule:** services raise product errors; the global handler translates them to
+HTTP. `HTTPException` is legal only at authentication, org/resource-access, and
+explicitly declared non-JSON transport boundaries. Error codes are globally
+unique.
+
+**Result:** the HTTP format changes once, while product failures remain typed
+and independently testable.
+
+### Library purity (`SRV-LIB`)
+
+**Problem:** a shared folder that imports everything becomes a junk drawer and
+pulls single-domain policy out of its owner prematurely.
+
+**Rule:** Infra is universal and product-blind; Product is pure and restricted
+to domain rows; Capabilities are consumer-mapped. Reuse requires at least two
+real consumers.
+
+**Result:** a library's import audience and allowed knowledge are obvious from
+its coordinate.
+
+### Background unification (`SRV-BG`)
+
+**Problem:** domain-owned loops and schedulers create multiple restart,
+observability, and failure models.
+
+**Rule:** scheduled work is a Beat-fired Celery task; durable follow-up work is
+an outbox-fired Celery task. Tasks are thin and process state is disposable.
+
+**Result:** work is restartable, observable, and scalable through one runtime.
+
+### Auth as a seam (`SRV-SEAM`)
+
+**Problem:** authorization scattered through services hides access decisions
+and makes authentication changes cross domain boundaries.
+
+**Rule:** endpoints compose four orthogonal boundaries: actor authentication in
+[auth/dependencies.py](../../../../../server/proliferate/auth/dependencies.py),
+org standing through
+[permissions.py](../../../../../server/proliferate/permissions.py), concrete
+resource access in the owning domain's `access.py`, and pure product policy in
+the owning domain's `domain/policy.py`. Services receive the resolved result.
+
+**Result:** access is visible in route signatures, product policy is testable
+without FastAPI, and authentication mechanisms remain below product domains.
+
+## The Architecture in One Breath
+
+Columns are domains and rows are layers. Within a column, API calls service,
+service orchestrates, domain decides, and store persists. Public `models.py` is
+the wire handshake. Stores have one owner; writes cross through that owner's
+service and reads cross only when ledgered. Shared code has an explicit import
+audience. Integrations isolate vendors. Auth and errors are seams. Background
+work is a Celery task. Anything importable by every coordinate knows no product
+or persistence detail.
+
+## What the Grid Prevents
+
+| Failure mode | Grid rule | Prevention |
+| --- | --- | --- |
+| Foreign writes corrupt shared state | `SRV-STORE-3` | Only the owner's service writes |
+| Store changes surprise foreign readers | `SRV-STORE-2` | Exact consumer ledger makes reads queryable |
+| Errors vary by call site | `SRV-ERR-1` | Product errors plus one transport handler |
+| Shared code becomes a junk drawer | `SRV-LIB-2/4/5/6` | Three audiences, two-consumer entry ticket, and reverse ratchet |
+| Auth decisions hide in orchestration | `SRV-SEAM-1` | Four endpoint-composed boundaries |
+| Background work has divergent failure models | `SRV-BG-3` | One Celery execution model |
+| Service cycles block refactors | `SRV-TOPO-3` | Generated graph and acyclic-component gate |
+| Third-party packages leak into product code | `SRV-PKG-2` | Explicit package-audience map |
+
+## Foreign-Read Doctrine
+
+Foreign reads are legal only when the exact consumer and store operation appear
+in the ownership ledger. A ledger row grants no module-wide permission and
+stale rows fail the checker. If a required read is not declared, the caller must
+either add the reviewed read edge or consume an owner service contract.
+
+The small declaration cost makes schema-change blast radius queryable: the
+owner can answer “who reads this store?” without reconstructing history.
+
+## How to Reason About a Change
+
+Before code crosses domains or touches shared state, ask:
+
+1. **Store ownership:** Does this domain own the store? If not, is this exact
+   read ledgered, or is the write going through the owner's public service?
+2. **Audience:** May this coordinate import the library or package? Does the
+   imported code know more than its audience allows?
+3. **Error shape:** Is a transport error legal at this seam, or must the code
+   raise a product error?
+4. **Background:** Is this durable work represented as a Celery task, with Beat
+   or the outbox owning dispatch?
+5. **Auth:** Is the decision visible in an endpoint dependency or pure policy,
+   rather than buried in orchestration?
+
+If every answer is yes or not applicable, the change aligns with the grid.
+
+## Reading Order
+
+1. This document for the target mental model.
+2. [Server Standards](../README.md) for current source routing and enforced
+   rules.
+3. [Library ownership](lib.md) for import audiences.
+4. [Domain ownership](domains.md) for cross-domain coordination.
+5. [Auth ownership](auth.md) for the four authorization boundaries.
+6. [Background ownership](background.md) for task and transaction rules.
+
+## Current gaps
+
+- [ ] **Coordinate enforcement is not present.** Current CI runs the bounded,
+  path-classified
+  [check_server_boundaries.py](../../../../../scripts/check_server_boundaries.py)
+  from [ci.yml](../../../../../.github/workflows/ci.yml). There is no checked-in
+  TOML coordinate map, general `check_grid.py`, package-audience map, generated
+  service graph, or automatic owner/consumer map.
+- [ ] **Store ownership and foreign-read declarations are not generally
+  enforced.** The current [domain guide](domains.md#cross-domain-coordination)
+  permits foreign reads through stores, while the checker has no complete store
+  owner table or exact foreign-read ledger. Cross-domain write repair and
+  enforcement therefore remain bounded migrations rather than a repository-wide
+  coordinate law.
+- [ ] **The ORM → dataclass boundary is incomplete.** Current stores such as
+  [users.py](../../../../../server/proliferate/db/store/users.py) and
+  [billing_subjects.py](../../../../../server/proliferate/db/store/billing_subjects.py)
+  return ORM types. Accounts SSO also mutates a `User` and calls `db.flush()` in
+  [user_resolution.py](../../../../../server/proliferate/server/accounts/sso/user_resolution.py).
+- [ ] **Request transaction ownership is incomplete.** The migration allowlist
+  records 30 route-owned session calls across the Accounts
+  [Desktop](../../../../../server/proliferate/server/accounts/desktop/api.py),
+  [Identity](../../../../../server/proliferate/server/accounts/identity/api.py),
+  and [SSO](../../../../../server/proliferate/server/accounts/sso/api.py) APIs.
+  Their exact count locks live in
+  [server_boundaries_allowlist.txt](../../../../../scripts/server_boundaries_allowlist.txt).
+- [ ] **Authorization dependency adoption is partial.** The current
+  [Auth guide](auth.md) treats inline service checks as migration debt. Current
+  examples include Organization role gates in
+  [organizations/service.py](../../../../../server/proliferate/server/organizations/service.py),
+  Cloud integration admin checks in
+  [cloud/integrations/service.py](../../../../../server/proliferate/server/cloud/integrations/service.py),
+  and Agent Run Config visibility checks in
+  [agent_run_config/service.py](../../../../../server/proliferate/server/cloud/agent_run_config/service.py).
+  In addition, `permissions.py` currently composes actor deps, stores, billing
+  services, and request/RLS context; only `auth/authorization.py` is the
+  dependency-free authorization leaf.
+- [ ] **Error normalization is incomplete.** Organization SSO orchestration
+  still raises `HTTPException` in
+  [organizations/sso/service.py](../../../../../server/proliferate/server/organizations/sso/service.py),
+  and the current checker does not enforce globally unique error codes or ban
+  every non-boundary service raise.
+- [ ] **Library audiences are not represented or enforced.** The current
+  [lib tree](../../../../../server/proliferate/lib) contains only a Product
+  workspace-naming concern; `lib/infra` and `lib/capabilities` do not exist, and
+  the server checker does not scan `lib/**` for audience or purity rules.
+- [ ] **Service topology and package audiences are not gated.** Cloud Sandbox
+  imports Gateway service in
+  [cloud_sandboxes/service.py](../../../../../server/proliferate/server/cloud/cloud_sandboxes/service.py),
+  while Gateway imports Cloud Sandbox service in
+  [gateway/service.py](../../../../../server/proliferate/server/cloud/gateway/service.py).
+  No generated graph rejects that cycle, and no third-party package map limits
+  imports by coordinate.
+- [ ] **Background execution is not unified.** Periodic process loops remain in
+  [Billing reconciliation](../../../../../server/proliferate/server/billing/reconciler.py),
+  [anonymous telemetry](../../../../../server/proliferate/server/anonymous_telemetry/worker.py),
+  and the Agent Gateway
+  [worker](../../../../../server/proliferate/server/cloud/agent_gateway/worker.py),
+  [usage importer](../../../../../server/proliferate/server/cloud/agent_gateway/usage_import.py),
+  and [top-up worker](../../../../../server/proliferate/server/cloud/agent_gateway/topups.py).
+  The Customer.io task also performs SQL and vendor work directly in
+  [customerio_sync.py](../../../../../server/proliferate/background/tasks/customerio_sync.py).
+  These paths require a deployed, behavior-equivalent background plane before
+  loop removal can be safe.


### PR DESCRIPTION
## Summary

- reconcile the canonical Server README, architecture, Auth guide, and Domains guide with the real authorization API
- document Accounts as product account-entry owner and endpoint-composed access as partial adoption
- add one `Status: target` Server Grid mental model with an explicit, source-linked Current gaps checklist
- keep proposal-only TOML, foreign-read, package, topology, and background enforcement clearly separate from current CI law

## Corrected authorization truth

- `current_limited_user` exists
- `require_owner_role(*roles)` is the dependency factory
- `require_org_role(context, roles)` is a pure check
- `require_org_membership` does not exist
- `permissions.py` owns request-time composition and is not an import-free leaf
- `auth/authorization.py` owns dependency-free vocabulary
- `server/accounts/**` owns product account entry

## Stack

Depends directly on #1642 (`codex/sso-account-auth-leaf-inversion`) at `5bed2f85eca78cd5714ef1679dc16f67d57109f8`. This is a review topology, not the final landing topology. The landing rebase must preserve #1620's accepted current-auth correction and occur only after the prerequisite Server Grid stack plus the relevant follow-on fixes: #1645 (Organization SSO errors), #1649 (workspace naming ownership), and #1650 (Sentry release audience, after #1646). Re-run the complete gap census on that final tree and remove the Organization-error, workspace-naming, telemetry-product, Sentry-release, and any other entries closed by the landed stack.

## Verification

- independent review round 1 found SG34-B01/B02
- both findings repaired
- independent re-review: ACCEPT, no findings
- documentation integrity
- design attribution
- Server boundary checker
- repository-wide stale authorization-symbol census
- positive real-symbol/source-signature verification
- `git diff --check`

## Specification

Server Grid 34, Frozen revision 1.