### PR TITLE
refactor(server): inject sentry release identity

### DIFF
--- a/scripts/server_boundaries_allowlist.txt
+++ b/scripts/server_boundaries_allowlist.txt
@@ -7,5 +7,4 @@
 # count, update this file in the same PR.
 
 DOMAIN_FORBIDDEN_IMPORT server/proliferate/server/cloud/agent_run_config/domain/resolve.py 1 transitional agent run config resolver imports product constants
-INTEGRATION_PRODUCT_IMPORT server/proliferate/integrations/sentry.py 1 sentry init reads server_version for release tagging; version helper pending move out of the product server layer
 PRODUCT_RAW_HTTP_IMPORT server/proliferate/server/cloud/gateway/proxy.py 1 managed sandbox gateway owns temporary HTTP/WS proxy transport until gateway access moves below product service layer

--- a/server/proliferate/integrations/sentry.py
+++ b/server/proliferate/integrations/sentry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Callable
 from typing import Any
 
 try:
@@ -16,7 +17,6 @@ except ImportError:  # pragma: no cover - optional dependency in local/test envs
     StarletteIntegration = None
 
 from proliferate.config import settings
-from proliferate.server.release import is_canonical_release_id, server_release_id
 
 _sentry_initialized = False
 
@@ -139,7 +139,12 @@ def _scrub_event(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any]
     return scrubbed
 
 
-def init_server_sentry(*, enabled: bool, telemetry_mode: str) -> None:
+def init_server_sentry(
+    *,
+    enabled: bool,
+    telemetry_mode: str,
+    release_resolver: Callable[[], str],
+) -> None:
     global _sentry_initialized
 
     if _sentry_initialized or not enabled or not settings.sentry_dsn or sentry_sdk is None:
@@ -151,17 +156,7 @@ def init_server_sentry(*, enabled: bool, telemetry_mode: str) -> None:
         level=logging.INFO,
         event_level=None,
     )
-
-    # Prefer a CI-stamped release only when it canonically names this component;
-    # otherwise fall back to the code-built `proliferate-server@<version>+<sha>`
-    # so a misconfigured `SENTRY_RELEASE` can never stamp the server's Sentry
-    # events with another component's (or a malformed) release.
-    configured_release = settings.sentry_release
-    release = (
-        configured_release
-        if is_canonical_release_id(configured_release, component="proliferate-server")
-        else server_release_id()
-    )
+    release = release_resolver()
 
     sentry_sdk.init(
         dsn=settings.sentry_dsn,

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -79,6 +79,7 @@ from proliferate.server.organizations.registration_pages import (
 )
 from proliferate.server.organizations.sso.api import router as organization_sso_router
 from proliferate.server.organizations.usage.api import router as organization_usage_router
+from proliferate.server.release import resolve_server_release_id
 from proliferate.server.setup.api import router as first_run_setup_router
 from proliferate.server.setup.lifecycle import ensure_first_run_setup_token
 from proliferate.server.support.api import router as support_router
@@ -260,6 +261,7 @@ def create_app() -> FastAPI:
     init_server_sentry(
         enabled=is_vendor_telemetry_enabled(),
         telemetry_mode=get_server_telemetry_mode(),
+        release_resolver=lambda: resolve_server_release_id(settings.sentry_release),
     )
     api_prefix = _normalize_api_prefix(settings.api_path_prefix)
 

--- a/server/proliferate/server/automations/worker/main.py
+++ b/server/proliferate/server/automations/worker/main.py
@@ -7,6 +7,7 @@ import asyncio
 import signal
 from collections.abc import Sequence
 
+from proliferate.config import settings
 from proliferate.db import engine as db_engine
 from proliferate.db.migrations import validate_database_schema
 from proliferate.integrations.sentry import (
@@ -19,6 +20,7 @@ from proliferate.lib.product.telemetry.mode import (
 )
 from proliferate.middleware.request_context import with_correlation_context
 from proliferate.server.automations.worker.scheduler import run_scheduler_loop
+from proliferate.server.release import resolve_server_release_id
 from proliferate.utils.logging import configure_server_logging
 
 
@@ -46,6 +48,7 @@ async def _amain(args: argparse.Namespace) -> None:
     init_server_sentry(
         enabled=is_vendor_telemetry_enabled(),
         telemetry_mode=get_server_telemetry_mode(),
+        release_resolver=lambda: resolve_server_release_id(settings.sentry_release),
     )
     stop_event = asyncio.Event()
     _install_signal_handlers(stop_event)

--- a/server/proliferate/server/release.py
+++ b/server/proliferate/server/release.py
@@ -181,3 +181,13 @@ def server_release_id() -> str:
         server_git_sha(),
         require=_release_identity_required(),
     )
+
+
+def resolve_server_release_id(configured_release: str | None) -> str:
+    """Resolve a configured Server release or build the canonical fallback."""
+    if configured_release is not None and is_canonical_release_id(
+        configured_release,
+        component="proliferate-server",
+    ):
+        return configured_release
+    return server_release_id()

--- a/server/tests/unit/test_release_identity.py
+++ b/server/tests/unit/test_release_identity.py
@@ -11,6 +11,7 @@ from proliferate.server.release import (
     build_release_id,
     is_canonical_release_id,
     normalize_git_sha,
+    resolve_server_release_id,
     sanitize_component_release_override,
     server_release_id,
 )
@@ -159,3 +160,32 @@ def test_server_release_id_production_rejects_dev_version(
     monkeypatch.setattr(release, "server_version", lambda: "0.0.0-dev")
     with pytest.raises(ReleaseIdentityError):
         server_release_id()
+
+
+def test_resolve_server_release_id_prefers_canonical_configured_release() -> None:
+    configured = f"proliferate-server@0.3.27+{_SHA12}"
+    assert resolve_server_release_id(configured) == configured
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [None, "", "not a release", f"anyharness@0.3.27+{_SHA12}"],
+)
+def test_resolve_server_release_id_builds_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str | None,
+) -> None:
+    monkeypatch.setenv("SERVER_GIT_SHA", _SHA40)
+    monkeypatch.setenv("SERVER_VERSION", "0.3.27")
+    monkeypatch.delenv("PROLIFERATE_REQUIRE_RELEASE_IDENTITY", raising=False)
+    assert resolve_server_release_id(configured) == f"proliferate-server@0.3.27+{_SHA12}"
+
+
+def test_resolve_server_release_id_fails_closed_for_invalid_production_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PROLIFERATE_REQUIRE_RELEASE_IDENTITY", "1")
+    monkeypatch.delenv("SERVER_GIT_SHA", raising=False)
+    monkeypatch.setenv("SERVER_VERSION", "0.3.27")
+    with pytest.raises(ReleaseIdentityError):
+        resolve_server_release_id("anyharness@0.3.27+3c2bbf20e215")

--- a/server/tests/unit/test_sentry_integration.py
+++ b/server/tests/unit/test_sentry_integration.py
@@ -1,33 +1,34 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
+from proliferate import main as server_main
 from proliferate.config import settings
 from proliferate.integrations import sentry as sentry_integration
 
 
-def test_sentry_integration_does_not_import_product_policy() -> None:
+def test_sentry_integration_does_not_import_product_layers() -> None:
     source_path = Path(__file__).parents[2] / "proliferate/integrations/sentry.py"
     tree = ast.parse(source_path.read_text())
 
-    product_imports = []
+    forbidden_imports = []
+    forbidden_prefixes = ("proliferate.lib.product", "proliferate.server")
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
-            "proliferate.lib.product"
-        ):
-            product_imports.append((node.lineno, node.module))
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(forbidden_prefixes):
+            forbidden_imports.append((node.lineno, node.module))
         elif isinstance(node, ast.Import):
-            product_imports.extend(
+            forbidden_imports.extend(
                 (node.lineno, alias.name)
                 for alias in node.names
-                if alias.name.startswith("proliferate.lib.product")
+                if alias.name.startswith(forbidden_prefixes)
             )
 
-    assert product_imports == []
+    assert forbidden_imports == []
 
 
 @pytest.mark.parametrize(
@@ -248,6 +249,7 @@ def test_init_server_sentry_disables_logging_event_capture(
     sentry_integration.init_server_sentry(
         enabled=True,
         telemetry_mode="hosted_product",
+        release_resolver=lambda: "proliferate-server@0.3.27+3c2bbf20e215",
     )
 
     integrations = init_kwargs["integrations"]
@@ -264,6 +266,7 @@ def test_init_server_sentry_respects_injected_disabled_verdict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     init_calls: list[dict[str, object]] = []
+    release_calls = 0
 
     class _FakeInitSentrySdk:
         def init(self, **kwargs: object) -> None:
@@ -273,16 +276,23 @@ def test_init_server_sentry_respects_injected_disabled_verdict(
     monkeypatch.setattr(sentry_integration, "_sentry_initialized", False)
     monkeypatch.setattr(sentry_integration, "sentry_sdk", _FakeInitSentrySdk())
 
+    def resolve_release() -> str:
+        nonlocal release_calls
+        release_calls += 1
+        return "proliferate-server@0.3.27+3c2bbf20e215"
+
     sentry_integration.init_server_sentry(
         enabled=False,
         telemetry_mode="self_managed",
+        release_resolver=resolve_release,
     )
 
     assert init_calls == []
+    assert release_calls == 0
     assert sentry_integration._sentry_initialized is False
 
 
-def _init_and_capture_release(monkeypatch: pytest.MonkeyPatch) -> str:
+def _init_and_capture_release(monkeypatch: pytest.MonkeyPatch, release: str) -> str:
     init_kwargs: dict[str, object] = {}
 
     class _FakeInitSentrySdk:
@@ -302,10 +312,11 @@ def _init_and_capture_release(monkeypatch: pytest.MonkeyPatch) -> str:
     sentry_integration.init_server_sentry(
         enabled=True,
         telemetry_mode="hosted_product",
+        release_resolver=lambda: release,
     )
-    release = init_kwargs["release"]
-    assert isinstance(release, str)
-    return release
+    captured_release = init_kwargs["release"]
+    assert isinstance(captured_release, str)
+    return captured_release
 
 
 def test_scrub_event_preserves_top_level_deployment_environment() -> None:
@@ -337,20 +348,46 @@ def test_scrub_event_scrubs_preserved_environment_as_text() -> None:
     assert scrubbed["environment"] == "[redacted-token] [redacted-path]"
 
 
-def test_init_prefers_configured_canonical_server_release(
+def test_init_uses_exact_injected_server_release(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "sentry_release", "proliferate-server@0.3.27+3c2bbf20e215")
-    assert _init_and_capture_release(monkeypatch) == "proliferate-server@0.3.27+3c2bbf20e215"
+    release = "proliferate-server@0.3.27+3c2bbf20e215"
+    assert _init_and_capture_release(monkeypatch, release) == release
 
 
-def test_init_ignores_noncanonical_release_and_builds_server_release(
+def test_api_composition_injects_lazy_release_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # A misconfigured SENTRY_RELEASE (wrong component / malformed) must not
-    # stamp the server's events; fall back to the code-built server release.
-    monkeypatch.setattr(settings, "sentry_release", "anyharness@0.3.27+3c2bbf20e215")
-    monkeypatch.setenv("SERVER_VERSION", "0.3.27")
-    monkeypatch.setenv("SERVER_GIT_SHA", "3c2bbf20e21599aa11bb22cc33dd44ee55ff6600")
-    monkeypatch.delenv("PROLIFERATE_REQUIRE_RELEASE_IDENTITY", raising=False)
-    assert _init_and_capture_release(monkeypatch) == "proliferate-server@0.3.27+3c2bbf20e215"
+    captured: dict[str, object] = {}
+    configured = "proliferate-server@0.3.27+3c2bbf20e215"
+
+    def fake_init_server_sentry(
+        *,
+        enabled: bool,
+        telemetry_mode: str,
+        release_resolver: Callable[[], str],
+    ) -> None:
+        captured.update(
+            enabled=enabled,
+            telemetry_mode=telemetry_mode,
+            release=release_resolver(),
+        )
+
+    monkeypatch.setattr(server_main, "configure_server_logging", lambda: None)
+    monkeypatch.setattr(server_main, "is_vendor_telemetry_enabled", lambda: True)
+    monkeypatch.setattr(server_main, "get_server_telemetry_mode", lambda: "hosted_product")
+    monkeypatch.setattr(
+        server_main,
+        "resolve_server_release_id",
+        lambda value: f"resolved:{value}",
+    )
+    monkeypatch.setattr(server_main, "init_server_sentry", fake_init_server_sentry)
+    monkeypatch.setattr(settings, "sentry_release", configured)
+
+    server_main.create_app()
+
+    assert captured == {
+        "enabled": True,
+        "telemetry_mode": "hosted_product",
+        "release": f"resolved:{configured}",
+    }


### PR DESCRIPTION
## Summary

- Remove the Sentry vendor adapter's remaining upward import from product-owned Server release identity.
- Keep canonical/malformed release selection in `server/release.py` and inject a lazy resolver from the API and parked worker composition roots.
- Preserve initialization ordering and every early no-op: disabled telemetry, absent DSN, unavailable SDK, and already-initialized paths never resolve release identity.
- Remove the exact integration/product allowlist exception and add structural, resolver, strict-production, and composition tests.
- This draft is stacked after Server Grid 31 / #1646. Land and reconcile #1615, then #1646, before rebasing this implementation onto the resulting landed state; the current child topology is review evidence, not merge authority.

## Readiness

- [ ] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Independent focused suite: 98 tests passed across release identity, Sentry, API composition, checker, logging, and telemetry surfaces.
- Local focused suites: 82 tests and 61 post-repair tests passed.
- Ruff check and format pass on every changed Python file.
- Server boundary, max-lines, design-attribution, and diff checks pass.
- AST/negative census finds no `proliferate.server` or `proliferate.lib.product` import in `integrations/sentry.py`; its exact allowlist row is absent.
- Independent exact-head review: ACCEPT with no findings at `88158fa69dad7fe7bacbcaacda0f8564fae10e37`.